### PR TITLE
Add soldr cargo front door and bootstrap e2e workflows

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -1,0 +1,111 @@
+name: _Bootstrap E2E
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      target:
+        required: true
+        type: string
+      binary_name:
+        required: true
+        type: string
+      soldr_toolchain:
+        required: false
+        type: string
+        default: "1.94.1"
+      third_party_repo:
+        required: false
+        type: string
+        default: "zackees/running-process"
+      third_party_ref:
+        required: false
+        type: string
+        default: "b4e005318ce320bcbd652df3aa8381f4ab95fea7"
+      third_party_path:
+        required: false
+        type: string
+        default: "third_party/running-process"
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap-e2e:
+    name: Build soldr and bootstrap third-party app
+    runs-on: ${{ inputs.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: soldr
+
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.third_party_repo }}
+          ref: ${{ inputs.third_party_ref }}
+          path: ${{ inputs.third_party_path }}
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ inputs.soldr_toolchain }}
+          targets: ${{ inputs.target }}
+
+      - name: Install musl tools
+        if: contains(inputs.target, 'musl')
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            soldr -> target
+            ${{ inputs.third_party_path }} -> target
+
+      - name: Build soldr-cli
+        shell: pwsh
+        working-directory: soldr
+        run: |
+          cargo build --package soldr-cli --release --locked --target "${{ inputs.target }}"
+
+      - name: Resolve third-party toolchain
+        id: third_party_toolchain
+        shell: pwsh
+        run: |
+          $toolchainFile = Join-Path $env:GITHUB_WORKSPACE "${{ inputs.third_party_path }}/rust-toolchain.toml"
+          $channelLine = Select-String -Path $toolchainFile -Pattern '^channel = "(.*)"$' | Select-Object -First 1
+          if (-not $channelLine) {
+            throw "failed to resolve third-party Rust toolchain from $toolchainFile"
+          }
+          $channel = $channelLine.Matches[0].Groups[1].Value
+          rustup toolchain install $channel --profile minimal
+          rustup target add --toolchain $channel "${{ inputs.target }}"
+          "channel=$channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Resolve soldr binary path
+        id: soldr_binary
+        shell: pwsh
+        run: |
+          $soldrPath = Join-Path $env:GITHUB_WORKSPACE "soldr/target/${{ inputs.target }}/release/${{ inputs.binary_name }}"
+          "path=$soldrPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Show soldr version
+        shell: pwsh
+        run: |
+          & "${{ steps.soldr_binary.outputs.path }}" --version
+
+      - name: Build third-party app through soldr
+        shell: pwsh
+        working-directory: ${{ inputs.third_party_path }}
+        run: |
+          & "${{ steps.soldr_binary.outputs.path }}" cargo build --locked --target "${{ inputs.target }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: soldr-${{ inputs.target }}
+          path: ${{ steps.soldr_binary.outputs.path }}

--- a/.github/workflows/build-linux-arm64-musl.yml
+++ b/.github/workflows/build-linux-arm64-musl.yml
@@ -1,0 +1,17 @@
+name: Build Linux ARM64 musl
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-musl
+      binary_name: soldr
+

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -1,0 +1,17 @@
+name: Build Linux ARM64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-gnu
+      binary_name: soldr
+

--- a/.github/workflows/build-linux-x64-musl.yml
+++ b/.github/workflows/build-linux-x64-musl.yml
@@ -1,0 +1,17 @@
+name: Build Linux x64 musl
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-musl
+      binary_name: soldr
+

--- a/.github/workflows/build-linux-x64.yml
+++ b/.github/workflows/build-linux-x64.yml
@@ -1,0 +1,17 @@
+name: Build Linux x64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-gnu
+      binary_name: soldr
+

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -1,0 +1,17 @@
+name: Build macOS ARM64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15
+      target: aarch64-apple-darwin
+      binary_name: soldr
+

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -1,0 +1,17 @@
+name: Build macOS x64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15-intel
+      target: x86_64-apple-darwin
+      binary_name: soldr
+

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -1,0 +1,16 @@
+name: Build Windows ARM64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-11-arm
+      target: aarch64-pc-windows-msvc
+      binary_name: soldr.exe

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -1,0 +1,17 @@
+name: Build Windows x64
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-2025
+      target: x86_64-pc-windows-msvc
+      binary_name: soldr.exe
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.85
+      - uses: dtolnay/rust-toolchain@1.94.1
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.85
+      - uses: dtolnay/rust-toolchain@1.94.1
 
       - uses: Swatinem/rust-cache@v2
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ cargo fmt --all -- --check             # Check Rust formatting
 
 # Python (linting/testing the PyPI wrapper)
 ./lint                                 # ruff, black, isort, flake8, pylint, mypy
-./test                                 # pytest -n auto
+./test                                 # full build + test pipeline
 
 # Maturin (Python+Rust packaging)
 uv run maturin develop                 # Build & install in venv

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,250 +1,216 @@
-# DESIGN.md — soldr Implementation Guide
+# soldr Implementation Guide
 
-This document is the guiding light for implementing soldr. Every PR, every code review, every architecture decision should trace back to something in here. For the full CLI specification, see [docs/API.md](docs/API.md).
+This document defines the implementation direction for soldr.
+
+For user-facing command behavior, see [docs/API.md](docs/API.md).
 
 ---
 
 ## What soldr is
 
-One binary. Two jobs:
+One binary. Two visible jobs. One internal job.
 
-1. **Fetch any Rust tool instantly** — download pre-built binaries from GitHub Releases, never compile from source unless forced. Like crgx/npx but with correct Windows target detection.
+1. Build front door
+   `soldr cargo ...` is the primary user experience for Rust builds.
+2. Tool fetcher
+   `soldr <tool> ...` fetches and runs Rust CLI tools.
+3. Internal wrapper
+   soldr participates in builds by sitting in the `RUSTC_WRAPPER` slot after `soldr cargo ...` wires it up.
 
-2. **Cache every rustc invocation transparently** — sit in the `RUSTC_WRAPPER` slot, hash inputs, return cached artifacts on hit. Like sccache/zccache but with auto-start daemon and unified cache.
+The important product rule is that users should think in terms of `soldr cargo ...`, not in terms of manually exporting `RUSTC_WRAPPER`.
 
-These are detected automatically. No mode flags.
+## What soldr is not
 
-## What soldr is NOT
+- Not a separate build language
+- Not a project scaffolder
+- Not a Rust toolchain manager
 
-- **Not a cargo wrapper.** soldr never wraps `cargo build`. It wraps `rustc`. The user runs cargo directly with all the flags they know. soldr is invisible. (See: "Why no `soldr build`" below.)
-
-- **Not a task runner.** No `soldr lint`, `soldr test`, `soldr build`. Those are scope creep that creates flag-forwarding nightmares. cargo has dozens of flags; reimplementing or proxying them is a trap.
-
-- **Not a project scaffolder.** No `soldr init`. Templates baked into binaries rot when CI syntax changes. Use `cargo init` or `cargo generate` with a template repo.
-
-- **Not a version manager.** soldr doesn't manage Rust toolchains. That's rustup's job. soldr fetches _tool binaries_ (maturin, cargo-dylint, etc.), not the Rust compiler itself.
+soldr can delegate to Cargo, but it should not try to replace Cargo's flags, profiles, or dependency model.
 
 ---
 
 ## Core Principles
 
-### 1. Invisible by default
+### 1. Front-door UX first
 
-The compilation cache should require zero thought. `RUSTC_WRAPPER` defaults to `zccache` if not explicitly set — no configuration needed. The daemon auto-starts on first invocation, auto-evicts old entries, and never prompts.
+The normal build path is:
 
-### 2. Pre-built first, always
+```bash
+soldr cargo build
+soldr cargo test
+soldr cargo check
+```
 
-When fetching a tool, try every pre-built source before touching `cargo install`:
+If the user has to understand `RUSTC_WRAPPER` just to get value from soldr, the product shape is wrong.
 
-1. Local cache (`~/.soldr/bin/`)
-2. Binstall metadata (`[package.metadata.binstall]` in Cargo.toml on crates.io)
-3. GitHub Releases (standard naming patterns)
-4. QuickInstall registry
-5. `cargo install` (last resort — slow, requires full toolchain)
+### 2. Cargo compatibility
 
-### 3. MSVC on Windows, always
+The front door must preserve normal Cargo arguments. soldr should delegate to real Cargo, not reimplement Cargo semantics.
 
-On Windows, assume `x86_64-pc-windows-msvc` (or `aarch64-pc-windows-msvc`). Period. Unless `rust-toolchain.toml` explicitly says GNU. MSVC links against `vcruntime140.dll` (always present). GNU requires shipping `libgcc_s_seh-1.dll` and `libwinpthread-1.dll` — extra baggage for no benefit.
+### 3. Wrapper mode is an implementation detail
 
-crgx gets this wrong by baking the target at compile time. soldr resolves it at runtime.
+Wrapper mode still matters, but it exists to support the front door. It is not the primary mental model.
 
-### 4. Bootstrapping tool — version doesn't matter (mostly)
+### 4. Pre-built tools first
 
-soldr is like uv: users install it once and it just works. They don't care about the version. `pip install soldr` gets latest. The bash one-liner gets latest. But CI pipelines _should_ pin: `pip install soldr==0.1.0`. Support `--version` in every install path.
+When users run `soldr <tool> ...`, prefer pre-built binaries before any source build path.
 
-### 5. Frozen built-in command list
+### 5. MSVC by default on Windows
 
-The built-in commands are: `status`, `clean`, `config`, `cache`, `version`, `help`. This list is **frozen**. Every other first argument is treated as a tool name to fetch-and-run. This prevents namespace collisions with real tools. Do not add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, or `publish` as built-in commands — ever.
+On Windows, soldr should prefer MSVC targets unless the project explicitly requires GNU.
+
+### 6. Bootstrapper mindset
+
+soldr should prove it can build:
+
+- itself
+- other Rust software
+
+That bootstrap story is a first-class requirement, not a side effect.
 
 ---
 
-## Why no `soldr build`
+## Command Model
 
-This is the most important design decision. An expert review ([conversation record](https://github.com/zackees/soldr/issues/1)) identified this as the biggest risk:
+### Primary commands
 
-> `soldr build` wrapping `cargo build` creates a flag forwarding nightmare. Cargo has `--release`, `--target`, `--features`, `--no-default-features`, `--manifest-path`, `--jobs`, `--profile`, `--timings`, `-p`, `--workspace`, `--exclude`, `--bin`, `--lib`, `--example`, `--test`, `--bench`, and dozens more. You either forward everything (maintenance hell) or support a subset (users hit walls).
-
-sccache solved this correctly: it's a `RUSTC_WRAPPER`, not a cargo wrapper. The user runs `cargo build` with all the flags they already know. The cache is invisible.
-
-**The rule:** soldr wraps `rustc`, not `cargo`. Cargo owns the build orchestration. soldr owns the per-unit caching.
-
----
-
-## Mode Detection
-
-When soldr's `main()` runs:
-
-```
-if argv[1] looks like a path to rustc (ends with "/rustc" or "\rustc" or "rustc.exe")
-    or argv[1] == "rustc":
-    → RUSTC_WRAPPER mode: act as compilation cache
-
-else if argv[1] is in BUILT_IN_COMMANDS:
-    → run the built-in command
-
-else:
-    → tool fetch mode: parse argv[1] as "crate[@version]", fetch binary, exec with remaining args
+```text
+soldr cargo <cargo-args...>
+soldr <tool>[@version] [tool-args...]
+soldr status
+soldr clean
+soldr config
+soldr cache
+soldr version
 ```
 
-This is clean and unambiguous. No flags, no env var sniffing for mode selection.
+### Internal execution model
+
+For `soldr cargo ...`:
+
+1. Resolve real `cargo` via `rustup`
+2. Resolve matching real `rustc` via `rustup`
+3. Set `RUSTC_WRAPPER=soldr`
+4. Delegate to Cargo with unchanged user flags
+
+For wrapper mode:
+
+1. Detect `rustc` invocation shape
+2. Resolve the real `rustc`
+3. Perform cache logic when implemented
+4. Fall through to the real compiler
 
 ---
 
 ## Architecture
 
-```
+```text
 crates/
-├── soldr-core/       # Config, paths, cache layout, target resolution, errors
-├── soldr-fetch/      # Binary resolution chain: cache → binstall → github → quickinstall → cargo install
-├── soldr-cache/      # RUSTC_WRAPPER logic: hash inputs, check cache, store artifacts, daemon IPC
-└── soldr-cli/        # main(), mode detection, clap for built-ins, exec for tool fetch
+|-- soldr-core
+|-- soldr-fetch
+|-- soldr-cache
+`-- soldr-cli
 ```
 
 ### soldr-core
 
 Owns:
-- `~/.soldr/` directory layout and creation
-- `config.toml` parsing and defaults
-- Target triple resolution (runtime, not compile-time; MSVC default on Windows)
-- Version types (`Latest`, `Exact(semver)`, `Pinned`)
-- Shared error types
 
-Does not own: any I/O beyond config file reading.
+- configuration
+- target detection
+- cache paths
+- shared error types
 
 ### soldr-fetch
 
 Owns:
-- Crate metadata fetching from crates.io (reads `[package.metadata.binstall]`)
-- GitHub Release asset discovery (tries standard naming patterns)
-- QuickInstall registry queries
-- Archive download, extraction, verification
-- Tool cache management (`~/.soldr/bin/`)
-- Fallback to `cargo install` when no pre-built binary found
 
-Key types:
-```rust
-pub struct FetchRequest {
-    pub crate_name: String,
-    pub version: VersionSpec,     // Latest | Exact("1.2.3") | LatestForce
-    pub target: TargetTriple,
-}
-
-pub enum FetchResult {
-    Cached(PathBuf),              // Already in ~/.soldr/bin/
-    Downloaded(PathBuf),          // Fetched from remote, now cached
-    BuiltFromSource(PathBuf),     // cargo install fallback
-    NotFound(FetchError),
-}
-```
+- tool resolution
+- archive download and extraction
+- tool cache management
 
 ### soldr-cache
 
 Owns:
-- RUSTC_WRAPPER entry point (called by cargo with rustc args)
-- Input hashing (source files, compiler flags, dependency fingerprints, rustc version)
-- Artifact storage and retrieval (`~/.soldr/cache/`)
-- Cache daemon (IPC server for concurrent builds)
-- Auto-start daemon on first invocation
-- LRU eviction when cache exceeds `max_size`
-- Cache statistics tracking
 
-Key flow:
-```
-cargo calls: soldr rustc --crate-name foo --edition 2021 -C opt-level=3 ...
-  1. Hash all inputs → cache key
-  2. Ask daemon: have this key?
-     YES → write cached artifacts to expected output paths, exit 0
-     NO  → invoke real rustc, capture outputs, store in cache, exit with rustc's code
-```
+- wrapper behavior around `rustc`
+- cache keying
+- artifact storage
+- daemon and IPC work
 
 ### soldr-cli
 
 Owns:
-- `main()` with mode detection (see above)
-- Built-in command dispatch via clap
-- Tool fetch mode: parse `crate[@version]`, call soldr-fetch, exec the binary
-- Process lifecycle: exec/spawn the fetched tool, forward exit code
 
-Does not own: any business logic. This is a thin dispatch layer.
+- mode detection
+- command dispatch
+- Cargo delegation
+- fetched-tool process execution
 
 ---
 
 ## Implementation Phases
 
-### Phase 1: Tool Fetcher (MVP)
+### Phase 1: Cargo Front Door
 
-The fastest path to a useful tool. No compilation caching yet.
+Done when:
 
-1. **soldr-core**: config, paths, target resolution
-2. **soldr-fetch**: local cache check → GitHub Releases download → exec
-3. **soldr-cli**: mode detection, `soldr <tool> [args]`, `soldr version`, `soldr help`
-4. **Install scripts**: `install.sh` (curl one-liner), `pyproject.toml` (pip)
-5. **CI**: build matrix for 6 platforms, publish to PyPI + GitHub Releases
+- `soldr cargo build` works
+- `soldr cargo test` works
+- wrapper mode is wired automatically
+- users no longer need manual `RUSTC_WRAPPER` setup for the common case
 
-**Done when:** `soldr maturin build --release` works on all 6 platforms, downloading maturin from GitHub Releases in <3 seconds.
+### Phase 2: Tool Fetching
 
-### Phase 2: Compilation Cache
+Done when:
 
-Port the zccache compilation cache into soldr-cache.
+- `soldr maturin build`
+- `soldr cargo-dylint check`
+- `soldr rustfmt ...`
 
-1. **soldr-cache**: RUSTC_WRAPPER entry point, input hashing, artifact storage
-2. **Daemon**: auto-start, IPC (Unix domain socket / Windows named pipe)
-3. **soldr-cli**: `soldr status`, `soldr clean`, `soldr cache list`
+all resolve quickly from cache or pre-built binaries.
 
-**Done when:** `RUSTC_WRAPPER=soldr cargo build` on a warm cache is 2x+ faster than without, across all 6 platforms.
+### Phase 3: Build Cache
 
-### Phase 3: Full Resolution Chain
+Done when:
 
-Flesh out the fetch resolution to match cargo-binstall's maturity.
+- wrapper mode hashes compiler inputs
+- cache hits avoid recompilation
+- daemon behavior is stable across platforms
 
-1. **Binstall metadata**: read `[package.metadata.binstall]` from crates.io
-2. **QuickInstall**: query the quickinstall registry as fallback
-3. **cargo install fallback**: build from source when no binary found
-4. **soldr config**: expose all config knobs
-5. **soldr cache export/import**: share caches across CI runners
+### Phase 4: Bootstrap Validation
 
-### Phase 4: Distribution
+Done when:
 
-1. **npm package**: thin wrapper that downloads the platform binary (like esbuild)
-2. **cargo binstall support**: `[package.metadata.binstall]` in soldr-cli's Cargo.toml
-3. **soldr.dev**: landing page with install instructions
-4. **GitHub Action**: (probably just `curl | sh` + `RUSTC_WRAPPER=soldr`, no custom action needed)
+- soldr can build itself per target
+- soldr can build a pinned third-party Rust project per target
+- CI exposes one workflow per badge target
 
 ---
 
-## Target Platforms
+## CI Expectations
 
-| Target | Runner | Priority |
-|---|---|---|
-| `x86_64-unknown-linux-gnu` | ubuntu-24.04 | P0 |
-| `aarch64-unknown-linux-gnu` | ubuntu-24.04-arm | P0 |
-| `x86_64-apple-darwin` | macos-14 | P0 |
-| `aarch64-apple-darwin` | macos-15 | P0 |
-| `x86_64-pc-windows-msvc` | windows-2025 | P0 |
-| `aarch64-pc-windows-msvc` | windows-2025 | P1 |
+The repository should verify two things independently:
 
----
+1. soldr builds on each supported target
+2. soldr can bootstrap and build another Rust project on each supported target
 
-## What we learned building zccache
+Badge visibility matters, so these should be separate workflow entry points rather than a single hidden matrix.
 
-These hard-won lessons should be carried into soldr:
-
-1. **CARGO_MAKEFLAGS jobserver FDs don't survive deep process chains.** When running through `uv → maturin → cargo → wrapper`, the daemon's jobserver FDs (8,9) become invalid. Workaround: don't set CARGO_MAKEFLAGS, or detect when FDs are dead.
-
-2. **GitHub Releases need standard naming.** The binstall ecosystem expects `{name}-{version}-{target}.tar.gz`. Don't invent a custom scheme.
-
-3. **`pip install` is the universal fallback.** Every CI runner has Python. When the binary download fails, `pip install` always works. Keep this fallback.
-
-4. **The daemon must auto-start.** Requiring `soldr start` before builds is friction. The first RUSTC_WRAPPER call should start the daemon transparently.
-
-5. **Cache save on PR builds wastes budget.** GHA cache is limited. PR builds should restore but not save. Push-to-main builds save.
-
-6. **`cargo publish` must happen in dependency order.** The workspace has internal dependencies. Publish leaf crates first, wait for crates.io propagation, then publish dependents.
+Reusable workflow templates are fine, but the public workflows should remain one file per badge target.
 
 ---
 
-## Files to reference
+## Design Guardrails
 
-- [docs/API.md](docs/API.md) — Full CLI specification, environment variables, cache layout
-- [README.md](README.md) — User-facing description and motivation
-- This file — Implementation guide and architecture decisions
+- Do not regress to a `RUSTC_WRAPPER`-first UX in docs or examples.
+- Do not proxy Cargo by reimplementing Cargo flags.
+- Do not require users to learn internal wrapper mechanics for the happy path.
+- Keep the wrapper contract compatible with normal Cargo execution.
+
+---
+
+## References
+
+- [README.md](README.md)
+- [docs/API.md](docs/API.md)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ When you run `soldr`, the tool should do the obvious thing:
 - pick MSVC on Windows by default
 - fetch the tool you asked for
 - cache it locally
-- carry `zccache` along for transparent `rustc` caching
+- carry `zccache` along for transparent `rustc` caching without manual wrapper setup
 
 If soldr solves that one problem well, it becomes a super tool: the command you reach for first, because it makes the rest of the stack behave.
 
@@ -45,37 +45,37 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 - **Compilation caching** (the zccache half): When your build invokes `rustc` hundreds of times, soldr caches every compilation unit. Second builds finish in milliseconds, not minutes.
 
 ```bash
+# Build through soldr's front door:
+soldr cargo build --release
+soldr cargo test
+
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release
 soldr cargo-dylint check
 soldr rustfmt src/main.rs
-
-# Transparent compilation caching (invisible to you):
-export RUSTC_WRAPPER=soldr
-cargo build --release            # soldr caches every rustc call
 ```
 
 ## How it works
 
-```
+```text
+soldr cargo build --release
+  +-- resolve the real cargo binary
+  +-- wire soldr's wrapper path internally
+  +-- delegate to cargo with your existing flags
+
 soldr maturin build --release
   +-- maturin cached? --> run instantly
   +-- not cached?     --> download pre-built binary (2s) --> run
-
-RUSTC_WRAPPER=soldr cargo build
-  +-- rustc invocation #1 -> cache miss -> compile -> store artifact
-  +-- rustc invocation #2 -> cache hit  -> return cached .rlib (1ms)
-  +-- rustc invocation #N -> cache hit  -> return cached .o (1ms)
-  +-- Done. (1.6s warm, 9.8s cold)
 ```
 
 ## Design goals
 
 - **One obvious command**: Fetch tools, pick the right Windows target, and enable build caching through the same entry point.
-- **Invisible caching**: `RUSTC_WRAPPER` defaults to `zccache` if not set. Daemon auto-starts. No manual setup.
+- **Front-door builds**: `soldr cargo ...` is the primary build UX.
+- **Invisible caching**: soldr wires its build-assistance internals for you. No manual `RUSTC_WRAPPER` setup in the common case.
 - **One cache**: Tools and compilation artifacts in a single `~/.soldr/` directory.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
-- **No cargo wrapping**: soldr wraps `rustc`, not `cargo`. You keep all your cargo flags. No flag-forwarding nightmares.
+- **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
 - **Cross-platform**: Linux, macOS, Windows (x86_64 + aarch64).
 - **MSVC by default on Windows**: Always targets `x86_64-pc-windows-msvc` (or `aarch64-pc-windows-msvc`) unless `rust-toolchain.toml` explicitly says otherwise. MSVC links against `vcruntime140.dll` which ships with every modern Windows install. The GNU target requires shipping `libgcc_s_seh-1.dll` and `libwinpthread-1.dll` with every binary, which is extra baggage for no benefit. This matches the Rust ecosystem default: rustup, cargo-binstall, and nearly all published release binaries target MSVC. crgx gets this wrong by baking the target at compile time, causing it to look for GNU binaries when compiled under MSYS2.
 
@@ -97,7 +97,7 @@ soldr/
 | `soldr-core` | Cache paths, config, version types |
 | `soldr-fetch` | Resolve crate binaries from binstall metadata, GitHub Releases, QuickInstall. Download, verify, cache. |
 | `soldr-cache` | Wrap rustc, hash inputs, store/retrieve compiled artifacts. The compilation cache daemon. |
-| `soldr-cli` | Mode detection, built-in commands (`status`, `clean`, `config`), tool fetch dispatch. |
+| `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`), tool fetch dispatch. |
 
 ## Prior art
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -11,6 +11,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Run Cargo through soldr's front door
+    Cargo {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Show cache status and tool info
     Status,
     /// Clear caches
@@ -32,8 +37,7 @@ async fn main() {
     // Must be checked before clap parsing.
     let raw_args: Vec<String> = std::env::args().collect();
     if raw_args.len() > 1 && is_rustc_path(&raw_args[1]) {
-        eprintln!("soldr: RUSTC_WRAPPER mode (not yet implemented)");
-        std::process::exit(1);
+        std::process::exit(run_rustc_wrapper(&raw_args).unwrap_or_else(report_and_exit));
     }
 
     if let Err(e) = run().await {
@@ -46,6 +50,9 @@ async fn run() -> Result<(), SoldrError> {
     let cli = Cli::parse();
 
     match cli.command {
+        Commands::Cargo { args } => {
+            std::process::exit(run_cargo_front_door(&args)?);
+        }
         Commands::Status => {
             println!("soldr {}", soldr_core::version());
             let target = soldr_core::TargetTriple::detect()?;
@@ -93,11 +100,86 @@ async fn run() -> Result<(), SoldrError> {
     Ok(())
 }
 
+fn report_and_exit(error: SoldrError) -> i32 {
+    eprintln!("soldr: {error}");
+    1
+}
+
 fn is_rustc_path(arg: &str) -> bool {
     arg == "rustc"
         || arg.ends_with("/rustc")
         || arg.ends_with("\\rustc")
         || arg.ends_with("rustc.exe")
+}
+
+fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
+    let rustc = raw_args
+        .get(1)
+        .ok_or_else(|| SoldrError::Other("missing rustc path in wrapper mode".into()))?;
+    let rustc = if rustc == "rustc" {
+        resolve_toolchain_binary("rustc")?
+    } else {
+        rustc.into()
+    };
+
+    let status = std::process::Command::new(rustc)
+        .args(&raw_args[2..])
+        .status()?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
+    let cargo = resolve_toolchain_binary("cargo")?;
+    let rustc = resolve_toolchain_binary("rustc")?;
+    let current_exe = std::env::current_exe()?;
+    let cargo_bin_dir = cargo
+        .parent()
+        .ok_or_else(|| SoldrError::Other("failed to resolve cargo bin directory".into()))?
+        .to_path_buf();
+    let existing_path = std::env::var_os("PATH");
+
+    let mut command = std::process::Command::new(cargo);
+    command.args(args);
+    command.env("RUSTC_WRAPPER", current_exe);
+    command.env("RUSTC", rustc);
+    command.env("PATH", prepend_path(&cargo_bin_dir, existing_path.as_deref())?);
+
+    let status = command.status()?;
+    Ok(status.code().unwrap_or(1))
+}
+
+fn prepend_path(
+    dir: &std::path::Path,
+    existing_path: Option<&std::ffi::OsStr>,
+) -> Result<std::ffi::OsString, SoldrError> {
+    let mut paths = vec![dir.to_path_buf()];
+    if let Some(existing_path) = existing_path {
+        paths.extend(std::env::split_paths(existing_path));
+    }
+    std::env::join_paths(paths).map_err(|e| SoldrError::Other(format!("invalid PATH: {e}")))
+}
+
+fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError> {
+    let output = std::process::Command::new("rustup")
+        .args(["which", tool])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(SoldrError::Other(format!(
+            "failed to resolve {tool} via rustup: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        return Err(SoldrError::Other(format!(
+            "rustup did not return a path for {tool}"
+        )));
+    }
+
+    Ok(path.into())
 }
 
 fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,5 +1,14 @@
 use std::process::Command;
 
+fn rustup_which(tool: &str) -> String {
+    let output = Command::new("rustup")
+        .args(["which", tool])
+        .output()
+        .expect("failed to resolve tool with rustup");
+    assert!(output.status.success(), "rustup which failed for {tool}");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
 #[test]
 fn version_command_prints_workspace_version() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -28,4 +37,38 @@ fn help_lists_phase_one_command_surface() {
     assert!(stdout.contains("config"), "help output missing config");
     assert!(stdout.contains("cache"), "help output missing cache");
     assert!(stdout.contains("version"), "help output missing version");
+    assert!(stdout.contains("cargo"), "help output missing cargo");
+}
+
+#[test]
+fn cargo_front_door_runs_real_cargo() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "--version"])
+        .output()
+        .expect("failed to run soldr cargo --version");
+
+    assert!(output.status.success(), "cargo front door failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.contains("cargo"), "unexpected cargo output: {stdout}");
+    assert!(
+        !stderr.contains("soldr: fetching cargo"),
+        "cargo front door should not fetch cargo: {stderr}"
+    );
+}
+
+#[test]
+fn rustc_wrapper_mode_passes_through_to_rustc() {
+    let rustc = rustup_which("rustc");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg(rustc)
+        .arg("--version")
+        .output()
+        .expect("failed to run soldr in wrapper mode");
+
+    assert!(output.status.success(), "wrapper mode failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("rustc"), "unexpected rustc output: {stdout}");
 }

--- a/crates/soldr-fetch/tests/fetch_crgx.rs
+++ b/crates/soldr-fetch/tests/fetch_crgx.rs
@@ -11,8 +11,10 @@ use soldr_fetch::{fetch_tool, VersionSpec};
 
 #[tokio::test]
 async fn fetch_crgx_and_run() {
-    // Fetch crgx (latest) for the current platform
-    let result = fetch_tool("crgx", &VersionSpec::Latest)
+    const CRGX_VERSION: &str = "0.1.0";
+
+    // Fetch a pinned crgx release for the current platform.
+    let result = fetch_tool("crgx", &VersionSpec::Exact(CRGX_VERSION.into()))
         .await
         .expect("failed to fetch crgx");
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,224 +2,142 @@
 
 ## Overview
 
-soldr is two things in one binary:
+soldr is a single front door for Rust tool execution and Rust builds.
 
-1. **A tool fetcher**: `soldr <tool> [args]` downloads and runs any crate binary instantly
-2. **A compilation cache**: `RUSTC_WRAPPER=soldr` makes cargo cache every rustc invocation
+It has three invocation modes:
 
-These two roles are detected automatically based on how soldr is invoked.
+1. `soldr cargo ...`
+   Delegates to the real Cargo binary while wiring soldr into the build path.
+2. `soldr <tool> [args...]`
+   Fetches and runs a Rust CLI tool binary.
+3. `soldr rustc ...`
+   Internal wrapper mode used during builds after `soldr cargo ...` sets `RUSTC_WRAPPER=soldr`.
+
+The primary user experience is `soldr cargo ...`.
 
 ---
 
 ## Invocation Modes
 
-### Mode 1: Tool Fetcher (default)
+### Mode 1: Cargo Front Door
 
+```bash
+soldr cargo build --release
+soldr cargo test
+soldr cargo run -- --help
 ```
+
+Behavior:
+
+- Resolve the real `cargo` binary through `rustup`
+- Resolve the matching real `rustc` binary through `rustup`
+- Set `RUSTC_WRAPPER` to the current `soldr` executable
+- Delegate to Cargo with the exact flags the user passed
+
+This is the normal build entry point.
+
+### Mode 2: Tool Fetcher
+
+```bash
 soldr <tool>[@<version>] [tool-args...]
 ```
 
-Fetch a pre-built binary for `<tool>` and execute it with `[tool-args...]`.
+Examples:
 
 ```bash
-soldr maturin build --release          # fetch maturin, run it
-soldr cargo-dylint                      # fetch cargo-dylint, run it
-soldr rustfmt src/main.rs              # fetch rustfmt, run it
-soldr maturin@1.7.0 build              # fetch specific version
+soldr maturin build --release
+soldr cargo-dylint check
+soldr rustfmt src/main.rs
+soldr maturin@1.7.0 build
 ```
 
-**Resolution order:**
-1. Local cache (`~/.soldr/bin/`) — instant if previously fetched
-2. Binstall metadata from crate's `Cargo.toml` (`[package.metadata.binstall]`)
-3. GitHub Releases (standard naming conventions)
+Resolution order:
+
+1. Local cache in `~/.soldr/bin/`
+2. Binstall metadata
+3. GitHub Releases
 4. QuickInstall registry
-5. `cargo install` from source (last resort, requires Rust toolchain)
+5. `cargo install` as a last resort
 
-**Target resolution (Windows):**
-- Always `x86_64-pc-windows-msvc` (or `aarch64-pc-windows-msvc`)
-- Unless `rust-toolchain.toml` explicitly specifies a GNU target
-- Never baked at compile time; always resolved at runtime
+### Mode 3: Internal Wrapper Mode
 
-**Caching:**
-- `soldr tool` — fetches latest, checks for updates every 24h
-- `soldr tool@1.2.3` — exact version, cached forever
-- `soldr tool@latest` — force re-check for latest version
+Wrapper mode is entered when Cargo invokes soldr as the configured `RUSTC_WRAPPER`.
 
-### Mode 2: Compilation Cache (RUSTC_WRAPPER)
+Typical shape:
 
-```bash
-export RUSTC_WRAPPER=soldr
-cargo build --release
+```text
+soldr /path/to/rustc --crate-name foo ...
 ```
 
-When cargo sets `RUSTC_WRAPPER=soldr`, cargo invokes `soldr rustc <args>` for every compilation unit. soldr detects this (first arg is a path ending in `rustc` or equals `rustc`) and acts as a transparent compilation cache:
+In this mode, soldr should act as the transparent build-assistance layer around `rustc`.
 
-1. Hash the inputs (source files, flags, dependencies, rustc version)
-2. Check `~/.soldr/cache/` for a matching artifact
-3. Cache hit → return cached `.o` / `.rlib` / `.rmeta` (~1ms)
-4. Cache miss → invoke real `rustc`, store output, return it
+Current implementation status:
 
-**This is invisible to the user.** No flag forwarding, no cargo wrapping. Cargo does its thing, soldr silently caches. Exactly how sccache works.
+- Wrapper-mode passthrough to real `rustc` exists
+- Cache and daemon behavior are still being implemented
 
-**Auto-start daemon:** The first RUSTC_WRAPPER invocation starts the cache daemon if it's not running. No manual `soldr start` needed.
+---
 
-### Mode Detection
+## Mode Detection
 
-When soldr is invoked, it determines its mode:
+When soldr starts, it decides its mode in this order:
 
-```
-argv[1] ends with "rustc" or is "rustc"
-  → Mode 2: Compilation cache (RUSTC_WRAPPER)
-
-argv[1] is a built-in command (status, clean, config, cache, version, help)
-  → Run built-in
-
-argv[1] is anything else
-  → Mode 1: Tool fetcher (fetch + run)
-```
+1. If `argv[1]` looks like `rustc` or a path to `rustc`, enter wrapper mode.
+2. Otherwise, parse CLI commands with Clap.
+3. `cargo` is a first-class built-in subcommand.
+4. Any unknown first argument is treated as a tool name to fetch and run.
 
 ---
 
 ## Built-in Commands
 
+### `soldr cargo`
+
+Run Cargo through soldr's front door.
+
+```bash
+soldr cargo build --release
+soldr cargo test --workspace
+soldr cargo check -p soldr-cli
+```
+
 ### `soldr status`
 
-Show cache statistics and daemon state.
-
-```
-$ soldr status
-soldr 0.1.0
-
-Daemon:        running (pid 12345)
-Tool cache:    ~/.soldr/bin/ (14 tools, 89 MB)
-Build cache:   ~/.soldr/cache/ (2,341 artifacts, 412 MB)
-
-Recent tools:
-  maturin 1.7.4      (cached 2h ago)
-  cargo-dylint 3.1.0  (cached 5d ago)
-  rustfmt 1.7.1       (cached 12d ago)
-
-Build cache hit rate: 94% (last 24h)
-```
+Show cache and target information.
 
 ### `soldr clean`
 
 Clear caches.
 
-```bash
-soldr clean              # clear everything (tools + build cache)
-soldr clean --tools      # clear only tool cache
-soldr clean --cache      # clear only build cache
-soldr clean --older 30d  # clear entries older than 30 days
-```
-
 ### `soldr config`
 
-View or set configuration.
-
-```bash
-soldr config                          # show current config
-soldr config set cache-dir /tmp/soldr # override cache directory
-soldr config set max-cache-size 2GB   # limit build cache size
-```
-
-**Config file:** `~/.soldr/config.toml`
-
-```toml
-[cache]
-dir = "~/.soldr"
-max_size = "2GB"
-eviction = "lru"
-
-[fetch]
-# Registries to search for pre-built binaries
-registries = ["github", "quickinstall"]
-# Allow source compilation as fallback
-allow_build = true
-
-[daemon]
-# Auto-start daemon on first RUSTC_WRAPPER invocation
-auto_start = true
-```
+Show or set configuration.
 
 ### `soldr cache`
 
-Direct cache inspection (for debugging).
-
-```bash
-soldr cache list                   # list cached artifacts
-soldr cache inspect <hash>         # show details for a cached artifact
-soldr cache export <path>          # export cache for sharing/CI
-soldr cache import <path>          # import cache from another machine
-```
+Inspect build-cache state.
 
 ### `soldr version`
 
-```
-$ soldr version
-soldr 0.1.0
-```
-
-### `soldr help`
-
-```
-$ soldr help
-soldr — Instant tools. Instant builds.
-
-Usage:
-  soldr <tool>[@version] [args...]   Fetch and run a crate binary
-  RUSTC_WRAPPER=soldr cargo build    Transparent compilation caching
-
-Commands:
-  status    Show cache stats and daemon state
-  clean     Clear caches
-  config    View or set configuration
-  cache     Inspect and manage build cache
-  version   Print version
-  help      Show this help
-
-Examples:
-  soldr maturin build --release      Fetch maturin, run it
-  soldr rustfmt src/main.rs          Fetch rustfmt, run it
-  soldr maturin@1.7.0 build          Pin to a specific version
-  soldr clean --older 30d            Evict stale cache entries
-
-Cache directory: ~/.soldr/
-Config file:     ~/.soldr/config.toml
-```
+Print soldr version.
 
 ---
 
-## Install
+## Help Surface
 
-```bash
-# One-liner (Linux/macOS)
-curl -fsSL https://soldr.dev/install.sh | sh
+```text
+Usage:
+  soldr <COMMAND>
+  soldr <TOOL>[@version] [args...]
 
-# One-liner (Windows PowerShell)
-irm https://soldr.dev/install.ps1 | iex
-
-# pip (all platforms)
-pip install soldr
-
-# npm (all platforms)
-npm install -g soldr
-
-# Cargo (from source)
-cargo install soldr-cli
-
-# cargo-binstall (pre-built binary)
-cargo binstall soldr-cli
+Commands:
+  cargo    Run Cargo through soldr
+  status   Show cache status and tool info
+  clean    Clear caches
+  config   Show or set configuration
+  cache    Inspect the compilation cache
+  version  Show version
 ```
-
-All install methods support `--version`:
-```bash
-curl -fsSL https://soldr.dev/install.sh | sh -s -- --version 0.1.0
-pip install soldr==0.1.0
-npm install -g soldr@0.1.0
-```
-
-Default: latest. CI pipelines should pin.
 
 ---
 
@@ -227,59 +145,48 @@ Default: latest. CI pipelines should pin.
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `RUSTC_WRAPPER` | Set to `soldr` to enable compilation caching | `zccache` |
+| `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
-| `SOLDR_MAX_CACHE_SIZE` | Maximum build cache size | `2GB` |
-| `SOLDR_LOG` | Log level (`error`, `warn`, `info`, `debug`, `trace`) | `warn` |
-| `SOLDR_NO_DAEMON` | Disable daemon, run cache in-process | `false` |
-| `SOLDR_OFFLINE` | No network access, only use local cache | `false` |
+| `SOLDR_LOG` | Log level | `warn` |
+| `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
+
+`RUSTC_WRAPPER=soldr cargo build` remains a valid low-level integration path, but it is no longer the preferred user-facing workflow.
 
 ---
 
-## Cache Directory Layout
+## Cache Layout
 
-```
+```text
 ~/.soldr/
-├── config.toml              # User configuration
-├── bin/                     # Fetched tool binaries
-│   ├── maturin-1.7.4/       # One dir per tool@version
-│   │   └── maturin(.exe)
-│   ├── cargo-dylint-3.1.0/
-│   │   └── cargo-dylint(.exe)
-│   └── ...
-├── cache/                   # Compilation artifacts
-│   ├── ab/cd/ef012345...    # Content-addressed by input hash
-│   └── ...
-├── daemon.pid               # Daemon PID file
-└── daemon.sock              # Daemon IPC socket (Unix) / named pipe (Windows)
+|-- bin/
+|   `-- <tool>-<version>/
+|-- cache/
+|-- config.toml
+`-- daemon.*
 ```
 
 ---
 
-## GitHub Action
+## GitHub Actions
 
 ```yaml
-- name: Setup soldr
-  run: curl -fsSL https://soldr.dev/install.sh | sh
-
-- name: Build with caching
-  env:
-    RUSTC_WRAPPER: soldr
-  run: cargo build --release
+- name: Build through soldr
+  run: soldr cargo build --release
 ```
 
-No separate action needed. Just install + set the env var. Cargo does the rest, soldr caches invisibly.
+For bootstrap verification of another Rust project:
+
+```yaml
+- name: Build third-party project through soldr
+  run: soldr cargo build --locked --target ${{ matrix.target }}
+```
 
 ---
 
-## Comparison
+## Summary
 
-| Feature | soldr | sccache | crgx | cargo-binstall |
-|---|---|---|---|---|
-| Compilation caching | Yes (RUSTC_WRAPPER) | Yes | No | No |
-| Tool fetching | Yes (first-class) | No | Yes | Yes |
-| Pre-built binary download | Yes | No | Yes | Yes |
-| Daemon auto-start | Yes | Manual | N/A | N/A |
-| MSVC default on Windows | Yes | N/A | No (compile-time) | Yes (tries both) |
-| Single cache directory | Yes | Separate | Separate | Separate |
-| pip/npm install | Yes | No | No | No |
+The key design rule is simple:
+
+- users build through `soldr cargo ...`
+- soldr uses wrapper mode internally
+- users do not need to manually wire `RUSTC_WRAPPER` for the common path

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85"
+channel = "1.94.1"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/test
+++ b/test
@@ -1,5 +1,18 @@
 #!/bin/bash
 
-set -e
-echo "Running unittests"
-uv run pytest -n auto tests -v --durations=0
+set -euo pipefail
+
+run_step() {
+  local name="$1"
+  shift
+  printf '\n==> %s\n' "$name"
+  "$@"
+}
+
+run_step "Build workspace" cargo build --workspace --locked
+run_step "Run library tests" cargo test --workspace --lib --locked
+run_step "Run CLI smoke tests" cargo test -p soldr-cli --test cli --locked
+run_step "Run fetch integration test" cargo test -p soldr-fetch --test fetch_crgx --locked
+run_step "Run Python wrapper tests" uv run pytest -n auto tests -v --durations=0
+
+printf '\nPipeline complete.\n'


### PR DESCRIPTION
## Summary

- make `soldr cargo ...` the primary build front door
- keep wrapper mode as the internal rustc path instead of the primary UX
- update docs and toolchain/CI pins to match the new direction
- add reusable bootstrap e2e workflow plus one badge workflow per target

## Validation

- forced-MSVC local CLI tests for `soldr-cli` passed
- local `soldr cargo build --locked --target x86_64-pc-windows-msvc` succeeded against the pinned `running-process` checkout

Fixes #3
Fixes #4