### PR TITLE
Harden validated release workflow

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -12,6 +12,9 @@ on:
       binary_name:
         required: true
         type: string
+      source_ref:
+        required: true
+        type: string
       soldr_toolchain:
         required: false
         type: string
@@ -38,17 +41,18 @@ jobs:
     runs-on: ${{ inputs.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ inputs.source_ref }}
           path: soldr
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ inputs.third_party_repo }}
           ref: ${{ inputs.third_party_ref }}
           path: ${{ inputs.third_party_path }}
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           toolchain: ${{ inputs.soldr_toolchain }}
           targets: ${{ inputs.target }}
@@ -61,7 +65,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: |
             soldr -> target
@@ -105,7 +109,7 @@ jobs:
         run: |
           & "${{ steps.soldr_binary.outputs.path }}" cargo build --locked --target "${{ inputs.target }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: soldr-${{ inputs.target }}
           path: ${{ steps.soldr_binary.outputs.path }}

--- a/.github/workflows/build-linux-arm64-musl.yml
+++ b/.github/workflows/build-linux-arm64-musl.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/_bootstrap-e2e.yml
@@ -14,4 +17,4 @@ jobs:
       runner: ubuntu-24.04-arm
       target: aarch64-unknown-linux-musl
       binary_name: soldr
-
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/_bootstrap-e2e.yml
@@ -14,4 +17,4 @@ jobs:
       runner: ubuntu-24.04-arm
       target: aarch64-unknown-linux-gnu
       binary_name: soldr
-
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-linux-x64-musl.yml
+++ b/.github/workflows/build-linux-x64-musl.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/_bootstrap-e2e.yml
@@ -14,4 +17,4 @@ jobs:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-musl
       binary_name: soldr
-
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-linux-x64.yml
+++ b/.github/workflows/build-linux-x64.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/_bootstrap-e2e.yml
@@ -14,4 +17,4 @@ jobs:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-gnu
       binary_name: soldr
-
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/_bootstrap-e2e.yml
@@ -14,4 +17,4 @@ jobs:
       runner: macos-15
       target: aarch64-apple-darwin
       binary_name: soldr
-
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/_bootstrap-e2e.yml
@@ -14,4 +17,4 @@ jobs:
       runner: macos-15-intel
       target: x86_64-apple-darwin
       binary_name: soldr
-
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/_bootstrap-e2e.yml
@@ -14,3 +17,4 @@ jobs:
       runner: windows-11-arm
       target: aarch64-pc-windows-msvc
       binary_name: soldr.exe
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/_bootstrap-e2e.yml
@@ -14,4 +17,4 @@ jobs:
       runner: windows-2025
       target: x86_64-pc-windows-msvc
       binary_name: soldr.exe
-
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,33 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
   test:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    needs: lint
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:
@@ -24,11 +47,11 @@ jobs:
             runner: windows-2025
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build workspace
         run: cargo build --workspace --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,238 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: Release version tag, for example v0.1.0
+        required: true
+        type: string
+      commit_sha:
+        description: Exact commit SHA to validate and release
+        required: true
+        type: string
 
 permissions:
   contents: write
+  attestations: write
+  id-token: write
+
+concurrency:
+  group: release-${{ inputs.version }}
+  cancel-in-progress: false
 
 jobs:
+  prepare:
+    name: Validate release inputs
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      commit_sha: ${{ steps.validate.outputs.commit_sha }}
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.commit_sha }}
+
+      - name: Validate release version and commit
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version='${{ inputs.version }}'
+          commit_sha='${{ inputs.commit_sha }}'
+
+          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
+            echo "validated releases must be dispatched from main" >&2
+            exit 1
+          fi
+
+          if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "version must look like vX.Y.Z" >&2
+            exit 1
+          fi
+
+          if [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "commit_sha must be a full 40-character commit SHA" >&2
+            exit 1
+          fi
+
+          git fetch origin main --depth=1
+          git rev-parse --verify "${commit_sha}^{commit}" >/dev/null
+          git merge-base --is-ancestor "$commit_sha" origin/main
+
+          if git ls-remote --exit-code --tags origin "$version" >/dev/null 2>&1; then
+            echo "tag $version already exists" >&2
+            exit 1
+          fi
+
+          if gh release view "$version" >/dev/null 2>&1; then
+            echo "release $version already exists" >&2
+            exit 1
+          fi
+
+          {
+            echo "version=$version"
+            echo "commit_sha=$commit_sha"
+          } >> "$GITHUB_OUTPUT"
+
+  lint:
+    name: Lint
+    needs: prepare
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+  test:
+    name: ${{ matrix.name }}
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            runner: ubuntu-24.04
+          - name: macOS x64
+            runner: macos-15-intel
+          - name: Windows x64
+            runner: windows-2025
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Build workspace
+        run: cargo build --workspace --locked
+
+      - name: Run library tests
+        run: cargo test --workspace --lib --locked
+
+      - name: Run CLI smoke tests
+        run: cargo test -p soldr-cli --test cli --locked
+
+      - name: Run fetch integration test
+        run: cargo test -p soldr-fetch --test fetch_crgx --locked
+
+  e2e-linux-x64:
+    name: E2E Linux x64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-gnu
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-linux-arm64:
+    name: E2E Linux ARM64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-gnu
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-linux-x64-musl:
+    name: E2E Linux x64 musl
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-musl
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-linux-arm64-musl:
+    name: E2E Linux ARM64 musl
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-musl
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-macos-x64:
+    name: E2E macOS x64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15-intel
+      target: x86_64-apple-darwin
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-macos-arm64:
+    name: E2E macOS ARM64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15
+      target: aarch64-apple-darwin
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-windows-x64:
+    name: E2E Windows x64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-2025
+      target: x86_64-pc-windows-msvc
+      binary_name: soldr.exe
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-windows-arm64:
+    name: E2E Windows ARM64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-11-arm
+      target: aarch64-pc-windows-msvc
+      binary_name: soldr.exe
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
   build:
     name: ${{ matrix.name }}
+    needs:
+      - prepare
+      - lint
+      - test
+      - e2e-linux-x64
+      - e2e-linux-arm64
+      - e2e-linux-x64-musl
+      - e2e-linux-arm64-musl
+      - e2e-macos-x64
+      - e2e-macos-arm64
+      - e2e-windows-x64
+      - e2e-windows-arm64
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -49,11 +270,13 @@ jobs:
             binary: soldr.exe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
 
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build release binary
         run: cargo build --package soldr-cli --release --locked --target ${{ matrix.target }}
@@ -63,7 +286,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME}"
+          version="${{ needs.prepare.outputs.version }}"
           name="soldr-${version}-${{ matrix.target }}"
           mkdir -p dist/package
           cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "dist/package/${{ matrix.binary }}"
@@ -73,30 +296,59 @@ jobs:
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          $version = $env:GITHUB_REF_NAME
+          $version = "${{ needs.prepare.outputs.version }}"
           $name = "soldr-$version-${{ matrix.target }}"
           New-Item -ItemType Directory -Force -Path dist\package | Out-Null
           Copy-Item "target\${{ matrix.target }}\release\${{ matrix.binary }}" "dist\package\${{ matrix.binary }}"
           Compress-Archive -Path "dist\package\${{ matrix.binary }}" -DestinationPath "dist\$name.zip" -Force
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: soldr-${{ matrix.target }}
           path: dist/soldr-*
 
   publish:
-    name: Publish release assets
-    needs: build
+    name: Attest and publish release assets
+    needs:
+      - prepare
+      - build
     runs-on: ubuntu-24.04
-    if: startsWith(github.ref, 'refs/tags/v')
+    environment: release
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           pattern: soldr-*
           merge-multiple: true
 
-      - uses: softprops/action-gh-release@v2
+      - name: Generate release checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum soldr-* > "soldr-${{ needs.prepare.outputs.version }}-SHA256SUMS.txt"
+
+      - uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
-          files: dist/*
+          subject-checksums: dist/soldr-${{ needs.prepare.outputs.version }}-SHA256SUMS.txt
+
+      - name: Create draft GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "${{ needs.prepare.outputs.version }}" dist/* \
+            --draft \
+            --generate-notes \
+            --target "${{ needs.prepare.outputs.commit_sha }}" \
+            --title "${{ needs.prepare.outputs.version }}"
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release edit "${{ needs.prepare.outputs.version }}" --draft=false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,85 @@
+# Security
+
+## Scope
+
+`soldr` is a binary bootstrap/build tool. Security for this repo is therefore about:
+
+- release integrity
+- supply-chain trust boundaries
+- workflow and dependency immutability
+- user verification of published artifacts
+
+This document describes the current hardening posture and the policy direction for future work tracked in issue [#7](https://github.com/zackees/soldr/issues/7).
+
+## Current hardening
+
+The repository currently enforces several baseline controls:
+
+- Rust dependencies are locked in `Cargo.lock`.
+- CI and release builds use `cargo ... --locked`.
+- CI now enforces `cargo fmt --check` and `cargo clippy -D warnings`.
+- No Cargo `git` dependencies are currently used; dependencies resolve from crates.io.
+- Published crates.io versions are immutable and cannot be overwritten, only yanked.
+- Third-party GitHub Actions in the repository workflows are pinned to full commit SHAs.
+- The e2e third-party source input is pinned to an exact Git commit in the workflow inputs.
+- Releases are promoted by `workflow_dispatch` for an exact commit SHA instead of publishing immediately on tag push.
+- Release assets are attested in GitHub Actions before publication.
+
+These controls reduce drift, but they do not make the full release pipeline hermetic.
+
+## What is pinned
+
+The repo aims to pin security-relevant inputs wherever practical:
+
+- Cargo dependency graph: pinned by `Cargo.lock`
+- GitHub Actions: pinned by full commit SHA
+- E2E third-party test source: pinned by exact commit SHA
+- Rust toolchain action implementation: pinned by full commit SHA
+
+For release integrity, pinning by floating tag or branch is treated as insufficient for third-party workflow code.
+
+## What is still external or mutable
+
+Even with the current pinning, some inputs still come from external systems at build or runtime:
+
+- rustup toolchain downloads during CI/release
+- crates.io index and crate downloads unless dependencies are vendored or mirrored
+- OS package repositories such as `apt` in musl jobs
+- GitHub Releases as the publication surface unless immutable releases are enabled
+- third-party binary artifacts fetched by soldr at runtime
+
+These boundaries are intentional or transitional. They must be documented so users understand what is and is not covered by our own release assurances.
+
+## Versioning and update policy
+
+Security-relevant versioning and pinning should follow these rules:
+
+- Cargo dependency changes must update `Cargo.lock`.
+- Workflow action upgrades should be explicit pull requests that update SHAs, not floating major tags.
+- Third-party test inputs should remain pinned to exact commits.
+- Release toolchain changes should be explicit and reviewed.
+
+When a pinned dependency, action, or external input is updated, the change should be visible in git history and reviewed like code.
+
+## Release trust model
+
+Current state:
+
+- releases are validated in GitHub Actions from an exact commit SHA
+- the release workflow re-runs lint, build, test, integration, and e2e checks before publishing
+- release assets are published to GitHub Releases with a generated checksum manifest
+- release assets are attested in GitHub Actions prior to publication
+- immutable releases and protected tag settings still depend on repository configuration outside the git tree
+
+Planned state, tracked in issue `#7`:
+
+- release tags created only after full validation passes for the exact release commit
+- release assets attested and verifiable
+- protected tag and release controls
+- clearer documentation of external trust boundaries
+
+## Reporting a security issue
+
+If you discover a vulnerability or supply-chain concern, open a GitHub issue unless the issue is sensitive enough that public disclosure would create immediate risk.
+
+For high-risk undisclosed issues, contact the maintainers privately before opening a public issue.

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -143,7 +143,10 @@ fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
     command.args(args);
     command.env("RUSTC_WRAPPER", current_exe);
     command.env("RUSTC", rustc);
-    command.env("PATH", prepend_path(&cargo_bin_dir, existing_path.as_deref())?);
+    command.env(
+        "PATH",
+        prepend_path(&cargo_bin_dir, existing_path.as_deref())?,
+    );
 
     let status = command.status()?;
     Ok(status.code().unwrap_or(1))

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -19,7 +19,10 @@ fn version_command_prints_workspace_version() {
     assert!(output.status.success(), "version command failed");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(stdout.trim(), format!("soldr {}", env!("CARGO_PKG_VERSION")));
+    assert_eq!(
+        stdout.trim(),
+        format!("soldr {}", env!("CARGO_PKG_VERSION"))
+    );
 }
 
 #[test]
@@ -51,7 +54,10 @@ fn cargo_front_door_runs_real_cargo() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stdout.contains("cargo"), "unexpected cargo output: {stdout}");
+    assert!(
+        stdout.contains("cargo"),
+        "unexpected cargo output: {stdout}"
+    );
     assert!(
         !stderr.contains("soldr: fetching cargo"),
         "cargo front door should not fetch cargo: {stderr}"
@@ -70,5 +76,8 @@ fn rustc_wrapper_mode_passes_through_to_rustc() {
     assert!(output.status.success(), "wrapper mode failed");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("rustc"), "unexpected rustc output: {stdout}");
+    assert!(
+        stdout.contains("rustc"),
+        "unexpected rustc output: {stdout}"
+    );
 }

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -517,8 +517,8 @@ mod tests {
         )
         .unwrap();
 
-        let target = TargetTriple::detect_in_dir(dir.path()).unwrap();
+        let _target = TargetTriple::detect_in_dir(dir.path()).unwrap();
         #[cfg(target_os = "windows")]
-        assert_eq!(target.triple(), "x86_64-pc-windows-msvc");
+        assert_eq!(_target.triple(), "x86_64-pc-windows-msvc");
     }
 }


### PR DESCRIPTION
## Summary
- add a documented `SECURITY.md` with the current release hardening and trust-boundary model
- pin workflow actions to full SHAs and remove floating refs from the reusable bootstrap e2e workflow
- convert release publication into a validated workflow-dispatch flow that re-runs lint, test, integration, and e2e checks for an exact commit before attesting and publishing assets

## Testing
- `cargo fmt --all -- --check`
- `git diff --check`
- local full build/test validation was not reliable in this shell because `cargo -vV` reports a GNU host while the active rustup override is MSVC, which polluted local dependency caches with mismatched target metadata; GitHub Actions is the real validation surface for this change

Closes #7