### PR TITLE
Document release verification and trust boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Built on lessons from:
 - [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) - pre-built binary resolution
 - [sccache](https://github.com/mozilla/sccache) - the original Rust compilation cache
 
+## Security And Verification
+
+- [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
+- [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
+- [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts.
+
 ## License
 
 BSD-3-Clause

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,11 @@
 
 This document describes the current hardening posture and the policy direction for future work tracked in issue [#7](https://github.com/zackees/soldr/issues/7).
 
+Related documentation:
+
+- [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md)
+- [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md)
+
 ## Current hardening
 
 The repository currently enforces several baseline controls:
@@ -70,6 +75,7 @@ Current state:
 - release assets are published to GitHub Releases with a generated checksum manifest
 - release assets are attested in GitHub Actions prior to publication
 - immutable releases and protected tag settings still depend on repository configuration outside the git tree
+- current user-facing verification guidance is checksum verification plus `gh attestation verify`
 
 Planned state, tracked in issue `#7`:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -54,10 +54,12 @@ soldr maturin@1.7.0 build
 Resolution order:
 
 1. Local cache in `~/.soldr/bin/`
-2. Binstall metadata
-3. GitHub Releases
-4. QuickInstall registry
-5. `cargo install` as a last resort
+2. crates.io repository lookup
+3. GitHub Releases for that repository
+
+Current implementation note:
+
+- the broader binstall/QuickInstall/`cargo install` fallback chain is planned behavior, not the current shipped fetch path
 
 ### Mode 3: Internal Wrapper Mode
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -1,0 +1,113 @@
+# Release Verification
+
+This document describes how to verify a published `soldr` release today.
+
+It is intentionally limited to what the repository currently implements.
+
+## What The Current Release Flow Guarantees
+
+For a normal `soldr` release:
+
+- the release workflow is started manually with an explicit version and exact commit SHA
+- that exact commit must be reachable from `main`
+- the workflow re-runs lint, workspace build, tests, integration, and all supported e2e bootstrap jobs for that exact commit
+- release archives are built from that exact commit
+- a SHA-256 checksum manifest is published with the release assets
+- GitHub build provenance attestations are generated for the published assets
+
+## What It Does Not Guarantee Yet
+
+The current release flow does not yet claim all of the following:
+
+- immutable GitHub Releases
+- protected release-tag rulesets enforced outside the git tree
+- SBOM publication
+- independently reproduced builds by a second builder
+- fully hermetic inputs for rustup, crates.io, OS packages, or third-party test inputs
+
+Those follow-up items are tracked in issues [#11](https://github.com/zackees/soldr/issues/11), [#12](https://github.com/zackees/soldr/issues/12), and [#13](https://github.com/zackees/soldr/issues/13).
+
+## Release Asset Names
+
+Current release assets follow this shape:
+
+- `soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz`
+- `soldr-vX.Y.Z-aarch64-unknown-linux-gnu.tar.gz`
+- `soldr-vX.Y.Z-x86_64-apple-darwin.tar.gz`
+- `soldr-vX.Y.Z-aarch64-apple-darwin.tar.gz`
+- `soldr-vX.Y.Z-x86_64-pc-windows-msvc.zip`
+- `soldr-vX.Y.Z-aarch64-pc-windows-msvc.zip`
+- `soldr-vX.Y.Z-SHA256SUMS.txt`
+
+## Step 1: Verify The Checksum
+
+Download the release artifact you want and the matching `SHA256SUMS` file.
+
+On Linux or macOS:
+
+```bash
+sha256sum -c soldr-vX.Y.Z-SHA256SUMS.txt --ignore-missing
+```
+
+On Windows PowerShell:
+
+```powershell
+$expected = Select-String -Path soldr-vX.Y.Z-SHA256SUMS.txt -Pattern 'soldr-vX.Y.Z-x86_64-pc-windows-msvc.zip' |
+  ForEach-Object { ($_ -split '\s+')[0] }
+$actual = (Get-FileHash .\soldr-vX.Y.Z-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash.ToLower()
+if ($expected -ne $actual) { throw "checksum mismatch" }
+```
+
+The checksum step tells you the file you downloaded matches the checksum manifest attached to the release.
+
+## Step 2: Verify The Artifact Attestation
+
+Use GitHub CLI's attestation support to verify the artifact provenance:
+
+```bash
+gh attestation verify soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz \
+  --repo zackees/soldr
+```
+
+For stricter identity validation, also pin the signer workflow:
+
+```bash
+gh attestation verify soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz \
+  --repo zackees/soldr \
+  --signer-workflow zackees/soldr/.github/workflows/release.yml
+```
+
+This validates that GitHub has a matching attestation for the artifact and that the attestation was produced by the expected repository and workflow.
+
+## Step 3: Understand What Was Verified
+
+`gh attestation verify` validates:
+
+- the artifact digest
+- the GitHub repository identity
+- the workflow identity if you provide `--signer-workflow`
+- the provenance attestation type
+
+It does not, by itself, prove that every external input used during the build was mirrored or hermetic. For the current trust boundary inventory, see [TRUST_BOUNDARIES.md](./TRUST_BOUNDARIES.md).
+
+## Optional: Offline Verification
+
+GitHub CLI also supports downloading attestation bundles and verifying them offline.
+
+Relevant commands:
+
+```bash
+gh attestation download soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz --repo zackees/soldr
+gh attestation trusted-root
+```
+
+Offline verification is not yet the primary documented path for `soldr`, but it remains available if you want to archive bundles and trusted roots alongside release artifacts.
+
+## About `gh release verify`
+
+GitHub CLI also has `gh release verify`, which verifies release-level attestations.
+
+We do not currently document that as the primary verification path for `soldr` because immutable releases and the surrounding release-governance settings are still tracked separately. Today, the repository's strongest implemented verification path is:
+
+1. checksum verification
+2. artifact attestation verification with `gh attestation verify`

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -1,0 +1,90 @@
+# Trust Boundaries
+
+This document describes the current external trust boundaries for `soldr`.
+
+It is a factual inventory of what the project trusts today, not a claim that every trust edge is already ideal.
+
+## Controlled Inputs
+
+The repository directly controls:
+
+- the source tree at the released commit SHA
+- the Cargo dependency graph recorded in `Cargo.lock`
+- the workflow definitions committed in `.github/workflows/`
+- the action revisions pinned by full commit SHA in those workflows
+- the exact third-party Git commit used by the current bootstrap e2e workflow
+
+## Release-Time External Dependencies
+
+Even with a validated release workflow, the release path still depends on external systems:
+
+- GitHub-hosted runners
+  - The repo trusts the runner images provided by GitHub Actions.
+- Rust toolchains from `rustup`
+  - The workflows install Rust toolchains during CI and release.
+- crates.io
+  - The build downloads crate metadata and crate archives from the crates.io ecosystem.
+  - Published crate versions are immutable, but the transport and index are still external.
+- GitHub APIs and GitHub Releases
+  - The release workflow uses GitHub services to create releases, publish assets, and store attestations.
+
+## E2E Validation External Dependencies
+
+The bootstrap e2e jobs currently trust additional external systems:
+
+- Ubuntu package repositories
+  - musl validation jobs install `musl-tools` from live `apt` repositories
+- third-party source repository hosting
+  - the e2e workflow checks out a pinned commit of `zackees/running-process` from GitHub
+- third-party Rust toolchain installation
+  - the e2e workflow reads the third-party project's `rust-toolchain.toml` and installs that toolchain through `rustup`
+
+These inputs are pinned where possible, but they are not yet mirrored or fully hermetic.
+
+## Runtime Tool-Fetch Trust Boundaries
+
+The current `soldr-fetch` implementation resolves tools using this live network chain:
+
+1. local cache in `~/.soldr/bin`
+2. crates.io API lookup for the crate's repository URL
+3. GitHub release metadata for the crate's repository
+4. GitHub release asset download for the selected platform archive
+
+That means the runtime tool-fetch path currently trusts:
+
+- crates.io metadata for crate existence and repository linkage
+- GitHub repository ownership and release contents for the target tool
+- HTTPS transport to those services
+
+It does not yet enforce:
+
+- maintainer allowlists
+- per-tool checksums committed in this repo
+- upstream signatures
+- upstream artifact attestations
+- mirrored internal copies of third-party tool binaries
+
+## Current Policy Direction
+
+Current repo policy is:
+
+- pin what we can inside the git tree
+- make external trust edges explicit in documentation
+- treat floating workflow refs as unacceptable
+- prefer exact commit or version selection where possible
+
+Open follow-up decisions are tracked in:
+
+- [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
+- [#12](https://github.com/zackees/soldr/issues/12) for verification and reproducibility policy
+- [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust hardening
+
+## Practical Reading Of This Document
+
+If you are deciding whether to trust a published `soldr` release:
+
+- trust the validated GitHub workflow run and artifact attestation for the released commit
+- separately evaluate whether the remaining external build inputs are acceptable for your threat model
+- separately evaluate whether `soldr` fetching third-party tool binaries at runtime is acceptable for your threat model
+
+Those are related but distinct trust decisions.


### PR DESCRIPTION
## Summary
- add a release verification doc that explains the current checksum + attestation verification path
- add a trust-boundary doc that inventories current release-time, e2e, and runtime external dependencies
- link those docs from the README and SECURITY policy, and tighten the API doc so it matches the shipped fetch path

## Testing
- `git diff --check`

Related:
- closes the documentation parts of #12
- closes the inventory/documentation parts of #13