### PR TITLE
Make badge checks target-specific for governance

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   bootstrap-e2e:
-    name: Build soldr and bootstrap third-party app
+    name: Build soldr and bootstrap third-party app (${{ inputs.target }})
     runs-on: ${{ inputs.runner }}
 
     steps:


### PR DESCRIPTION
## Summary
- make the reusable bootstrap e2e job name include the target triple
- give branch protection and ruleset configuration unique check contexts to reference
- support the release governance work tracked in #11

## Testing
- GitHub Actions
