### PR TITLE
Add release operations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Built on lessons from:
 ## Security And Verification
 
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
+- [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,179 @@
+# Release Guide
+
+This document memorializes the intended high-security release flow for `soldr`.
+
+It is written for two audiences:
+
+- the repository owner, who must configure the GitHub-side controls
+- a future agent, who must understand what the release workflow is supposed to enforce
+
+## Goal
+
+The release model should satisfy all of these properties:
+
+- releases are triggered intentionally by the owner
+- the machine validates the exact release commit before publication
+- release tags such as `v1.2.3` are minted only by trusted automation
+- humans cannot manually create, move, or delete release tags
+- published release assets are immutable, attestable, and verifiable
+
+## Current State
+
+These controls are already in place:
+
+- `main` is protected with required CI and e2e checks
+- the `release` environment exists and requires approval from `@zackees`
+- immutable GitHub Releases are enabled
+- GitHub Actions requires full-SHA pinning for third-party actions
+- the validated release workflow exists in `.github/workflows/release.yml`
+
+The remaining gap is protected workflow-only release tags.
+
+## Recommended Final Model
+
+The strongest GitHub-native model for this repository is:
+
+1. A human starts the release intentionally.
+2. The workflow validates an exact commit on the protected `release` branch.
+3. The workflow reruns lint, build, tests, integration, and e2e gates.
+4. The owner approves the `release` environment.
+5. A dedicated GitHub App creates the `v*.*.*` tag and GitHub Release.
+6. Humans are blocked from minting or retargeting release tags directly.
+
+`workflow_dispatch` is the release authorization step.
+
+The GitHub App is the machine identity that performs the irreversible tag-creation step.
+
+## Why A GitHub App Is Needed
+
+On this personal repository, GitHub would not let the built-in `github-actions` integration be used as the bypass actor for a release-tag ruleset.
+
+That means:
+
+- `GITHUB_TOKEN` is not enough for workflow-only protected tags here
+- a personal access token is not acceptable for the target trust model
+- a dedicated GitHub App is the recommended machine identity
+
+## Owner Setup Checklist
+
+These are the concrete steps the owner must perform in GitHub.
+
+### 1. Create A Protected `release` Branch
+
+The branch should be the only branch from which release commits are promoted.
+
+Desired branch policy:
+
+- no direct human pushes
+- pull-request or automation-only updates
+- linear history enabled
+- force pushes disabled
+- deletions disabled
+- required checks enabled
+
+The release workflow should later validate that the target SHA is on `release`.
+
+### 2. Create A Dedicated GitHub App
+
+Create a private GitHub App under the owner account and install it only on `zackees/soldr`.
+
+Use it only for release automation.
+
+Start with minimal permissions:
+
+- `Metadata: Read`
+- `Contents: Read and write`
+
+If GitHub Release creation needs an additional narrow permission during implementation, add only that permission and document it.
+
+### 3. Generate And Store App Credentials
+
+Create a private key for the GitHub App and store the App identity in GitHub configuration.
+
+Suggested configuration:
+
+- secret: `RELEASE_APP_PRIVATE_KEY`
+- variable: `RELEASE_APP_ID`
+
+Store these on the `release` environment if possible, not as broad repository-wide secrets.
+
+### 4. Install The App On This Repository
+
+Install the App only on `zackees/soldr`.
+
+Avoid broad installation scope.
+
+### 5. Create A Tag Ruleset For Release Tags
+
+Protect `refs/tags/v*.*.*` with a ruleset that blocks:
+
+- tag creation
+- tag update
+- tag deletion
+
+The only bypass actor should be the dedicated GitHub App.
+
+Do not use:
+
+- a maintainer-user bypass
+- a PAT-backed workflow
+- a generic human admin exception and call it equivalent
+
+Those weaken the trust model.
+
+### 6. Keep The `release` Environment As The Human Approval Gate
+
+The owner should remain the required reviewer for the `release` environment.
+
+That means the human decides when a release is authorized, while the machine identity performs tag issuance and publication.
+
+## Future Workflow Changes
+
+Once the GitHub App exists, the release workflow should be updated to do this:
+
+1. Accept a version and exact commit SHA.
+2. Verify the commit SHA is on `release`.
+3. Rerun the full release gate on that exact commit.
+4. Pause on the `release` environment for approval.
+5. Mint a GitHub App installation token inside the workflow.
+6. Use that App token to create the tag.
+7. Use that same App token to create the GitHub Release.
+8. Attach checksums and build provenance attestations.
+
+The release workflow must not use:
+
+- a PAT for tag creation
+- manual tag creation outside automation
+
+## Future Agent Instructions
+
+If a future agent is asked to finish the maximum-security release flow, the agent should:
+
+1. Read this file.
+2. Check issue `#18` for the release-tag governance problem.
+3. Confirm whether the GitHub App has been created and installed.
+4. Confirm whether the `release` branch exists and is protected.
+5. Confirm whether a tag ruleset protects `v*.*.*` and only the App may bypass it.
+6. Only then modify `.github/workflows/release.yml` to use the App token for tag and release creation.
+
+If the GitHub App or ruleset is missing, the agent should stop and report the missing GitHub-side prerequisites instead of faking the policy in code.
+
+## Verification Checklist
+
+After the final setup is complete, verify all of these:
+
+- a human cannot manually create `v1.2.3`
+- a human cannot move `v1.2.3` to a different commit
+- the release workflow can create `v1.2.3` after approval
+- the workflow refuses SHAs not on `release`
+- published release assets are immutable
+- checksums and provenance attestations are attached
+
+## Related Documents
+
+- [README.md](./README.md)
+- [SECURITY.md](./SECURITY.md)
+- [docs/RELEASE_GOVERNANCE_CHECKLIST.md](./docs/RELEASE_GOVERNANCE_CHECKLIST.md)
+- [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md)
+- [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md)
+


### PR DESCRIPTION
## Summary
- add a repo-root RELEASE.md that memorializes the intended maximum-security release flow
- spell out the owner-side GitHub setup needed for a protected release branch and GitHub App based tag issuance
- link the guide from the README so future agents and maintainers can find it quickly

## Testing
- docs only
