### PR TITLE
Avoid release artifact name collisions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: soldr-${{ matrix.target }}
+          name: release-soldr-${{ matrix.target }}
           path: dist/soldr-*
 
   publish:
@@ -324,7 +324,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
-          pattern: soldr-*
+          pattern: release-soldr-*
           merge-multiple: true
 
       - name: Create GitHub App token


### PR DESCRIPTION
Fixes the artifact upload collision uncovered by the first release dry run. The build matrix now uploads artifacts under elease-soldr-* so they do not conflict with the e2e artifacts uploaded earlier in the same workflow run.