### PR TITLE
Prepare attested secure 0.5.0 release

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -15,10 +15,6 @@ on:
       source_ref:
         required: true
         type: string
-      soldr_toolchain:
-        required: false
-        type: string
-        default: "1.94.1"
       third_party_repo:
         required: false
         type: string
@@ -54,7 +50,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
-          toolchain: ${{ inputs.soldr_toolchain }}
           targets: ${{ inputs.target }}
 
       - name: Install musl tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
         description: Exact commit SHA to validate and release
         required: true
         type: string
+      dry_run:
+        description: Validate the full release flow without creating a release tag or publishing assets
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -45,8 +50,8 @@ jobs:
           version='${{ inputs.version }}'
           commit_sha='${{ inputs.commit_sha }}'
 
-          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
-            echo "validated releases must be dispatched from main" >&2
+          if [[ "${GITHUB_REF_NAME}" != "release" ]]; then
+            echo "validated releases must be dispatched from release" >&2
             exit 1
           fi
 
@@ -60,9 +65,9 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main --depth=1
+          git fetch origin release --depth=1
           git rev-parse --verify "${commit_sha}^{commit}" >/dev/null
-          git merge-base --is-ancestor "$commit_sha" origin/main
+          git merge-base --is-ancestor "$commit_sha" origin/release
 
           if git ls-remote --exit-code --tags origin "$version" >/dev/null 2>&1; then
             echo "tag $version already exists" >&2
@@ -322,6 +327,23 @@ jobs:
           pattern: soldr-*
           merge-multiple: true
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: soldr
+
+      - name: Verify GitHub App token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}" --jq '.full_name'
+
       - name: Generate release checksums
         shell: bash
         run: |
@@ -333,9 +355,17 @@ jobs:
         with:
           subject-checksums: dist/soldr-${{ needs.prepare.outputs.version }}-SHA256SUMS.txt
 
+      - name: Stop after dry run validation
+        if: inputs.dry_run
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "dry run complete: release gating, artifact build, attestation, and GitHub App authentication all succeeded"
+
       - name: Create draft GitHub Release
+        if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -346,8 +376,9 @@ jobs:
             --title "${{ needs.prepare.outputs.version }}"
 
       - name: Publish GitHub Release
+        if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: soldr-${{ matrix.target }}
+          name: release-soldr-${{ matrix.target }}
           path: dist/soldr-*
 
   publish:
@@ -324,7 +324,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
-          pattern: soldr-*
+          pattern: release-soldr-*
           merge-multiple: true
 
       - name: Create GitHub App token

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.2.0-beta"
+version = "0.5.0"
 dependencies = [
  "blake3",
  "serde",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.2.0-beta"
+version = "0.5.0"
 dependencies = [
  "clap",
  "soldr-cache",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.2.0-beta"
+version = "0.5.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.2.0-beta"
+version = "0.5.0"
 dependencies = [
  "flate2",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0-beta"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.2.0-beta" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.2.0-beta" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.2.0-beta" }
+soldr-core = { path = "crates/soldr-core", version = "0.5.0" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.5.0" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.5.0" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ That is the same reason [uv](https://github.com/astral-sh/uv) is compelling. uv 
 
 soldr aims for the same outcome in the Rust toolchain world.
 
+Current release line:
+
+- `0.5.x` is the secure front-door and tool-fetch release line
+- `1.0.0-rc` is reserved for the point where the zccache-style compilation cache is actually integrated
+
 ## Why soldr exists
 
 On Windows, the real problem is not "how do I cache builds?" or "how do I download a tool binary?" in isolation.
@@ -36,13 +41,13 @@ When you run `soldr`, the tool should do the obvious thing:
 - pick MSVC on Windows by default
 - fetch the tool you asked for
 - cache it locally
-- carry `zccache` along for transparent `rustc` caching without manual wrapper setup
+- prepare the front door that will eventually carry zccache-style transparent `rustc` caching without manual wrapper setup
 
 If soldr solves that one problem well, it becomes a super tool: the command you reach for first, because it makes the rest of the stack behave.
 
 - **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse.
 
-- **Compilation caching** (the zccache half): When your build invokes `rustc` hundreds of times, soldr caches every compilation unit. Second builds finish in milliseconds, not minutes.
+- **Compilation caching** (the zccache half): planned, but not integrated yet in the current `0.5.x` line.
 
 ```bash
 # Build through soldr's front door:
@@ -70,9 +75,9 @@ soldr maturin build --release
 
 ## Design goals
 
-- **One obvious command**: Fetch tools, pick the right Windows target, and enable build caching through the same entry point.
+- **One obvious command**: Fetch tools, pick the right Windows target, and eventually enable build caching through the same entry point.
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
-- **Invisible caching**: soldr wires its build-assistance internals for you. No manual `RUSTC_WRAPPER` setup in the common case.
+- **Invisible caching**: the wrapper plumbing exists now; actual compilation cache behavior is still future work.
 - **One cache**: Tools and compilation artifacts in a single `~/.soldr/` directory.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
@@ -96,7 +101,7 @@ soldr/
 |---|---|
 | `soldr-core` | Cache paths, config, version types |
 | `soldr-fetch` | Resolve crate binaries from binstall metadata, GitHub Releases, QuickInstall. Download, verify, cache. |
-| `soldr-cache` | Wrap rustc, hash inputs, store/retrieve compiled artifacts. The compilation cache daemon. |
+| `soldr-cache` | Reserved for the future compilation-cache implementation; not yet integrated in the current release line. |
 | `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`), tool fetch dispatch. |
 
 ## Prior art

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,12 +22,21 @@ The release model should satisfy all of these properties:
 These controls are already in place:
 
 - `main` is protected with required CI and e2e checks
+- `release` is protected with the same required validation gates
 - the `release` environment exists and requires approval from `@zackees`
 - immutable GitHub Releases are enabled
 - GitHub Actions requires full-SHA pinning for third-party actions
 - the validated release workflow exists in `.github/workflows/release.yml`
+- a dedicated GitHub App is used for release publication
+- release tags matching `refs/tags/v*.*.*` are protected by a repository ruleset whose only bypass actor is the release GitHub App
 
-The remaining gap is protected workflow-only release tags.
+The remaining work before the attested secure `0.5` release is operational rather than architectural:
+
+- exercise the full release path with a rehearsal and first release candidate
+- verify that humans cannot mint, move, or delete release tags in practice
+- finish policy decisions around SBOMs, reproducibility, and hermeticity
+
+`1.0.0-rc` is intentionally reserved for the point where the zccache-style compilation cache is actually integrated rather than merely planned.
 
 ## Recommended Final Model
 
@@ -127,9 +136,9 @@ The owner should remain the required reviewer for the `release` environment.
 
 That means the human decides when a release is authorized, while the machine identity performs tag issuance and publication.
 
-## Future Workflow Changes
+## Current Workflow Behavior
 
-Once the GitHub App exists, the release workflow should be updated to do this:
+The release workflow now does this:
 
 1. Accept a version and exact commit SHA.
 2. Verify the commit SHA is on `release`.
@@ -147,16 +156,17 @@ The release workflow must not use:
 
 ## Future Agent Instructions
 
-If a future agent is asked to finish the maximum-security release flow, the agent should:
+If a future agent is asked to audit or extend the release flow, the agent should:
 
 1. Read this file.
-2. Check issue `#18` for the release-tag governance problem.
-3. Confirm whether the GitHub App has been created and installed.
-4. Confirm whether the `release` branch exists and is protected.
-5. Confirm whether a tag ruleset protects `v*.*.*` and only the App may bypass it.
-6. Only then modify `.github/workflows/release.yml` to use the App token for tag and release creation.
+2. Audit the live GitHub-side controls before trusting the checked-in docs.
+3. Confirm whether the GitHub App remains installed and scoped only to this repository.
+4. Confirm whether `release` still exists and is protected.
+5. Confirm whether a tag ruleset still protects `v*.*.*` and only the App may bypass it.
+6. Check issues `#12` and `#13` for the remaining `0.5` policy decisions.
+7. Only then modify `.github/workflows/release.yml` or the verification docs.
 
-If the GitHub App or ruleset is missing, the agent should stop and report the missing GitHub-side prerequisites instead of faking the policy in code.
+If the live GitHub-side controls drift from the documented trust model, the agent should stop and report the drift instead of assuming the release posture is still intact.
 
 ## Verification Checklist
 
@@ -173,7 +183,7 @@ After the final setup is complete, verify all of these:
 
 - [README.md](./README.md)
 - [SECURITY.md](./SECURITY.md)
+- [docs/RELEASE_0_5_CHECKLIST.md](./docs/RELEASE_0_5_CHECKLIST.md)
 - [docs/RELEASE_GOVERNANCE_CHECKLIST.md](./docs/RELEASE_GOVERNANCE_CHECKLIST.md)
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md)
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md)
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@
 - workflow and dependency immutability
 - user verification of published artifacts
 
-This document describes the current hardening posture and the policy direction for future work tracked in issue [#7](https://github.com/zackees/soldr/issues/7).
+This document describes the current hardening posture for the `0.5.x` line and the remaining policy work before the first attested secure release.
 
 Related documentation:
 
@@ -30,6 +30,9 @@ The repository currently enforces several baseline controls:
 - The e2e third-party source input is pinned to an exact Git commit in the workflow inputs.
 - Releases are promoted by `workflow_dispatch` for an exact commit SHA instead of publishing immediately on tag push.
 - Release assets are attested in GitHub Actions before publication.
+- Release publication uses a dedicated GitHub App instead of `GITHUB_TOKEN` or a PAT.
+- Release tags matching `v*.*.*` are protected by a repository ruleset.
+- Immutable GitHub Releases are enabled.
 
 These controls reduce drift, but they do not make the full release pipeline hermetic.
 
@@ -51,7 +54,7 @@ Even with the current pinning, some inputs still come from external systems at b
 - rustup toolchain downloads during CI/release
 - crates.io index and crate downloads unless dependencies are vendored or mirrored
 - OS package repositories such as `apt` in musl jobs
-- GitHub Releases as the publication surface unless immutable releases are enabled
+- GitHub Releases as the publication surface, even though immutable releases are enabled
 - third-party binary artifacts fetched by soldr at runtime
 
 These boundaries are intentional or transitional. They must be documented so users understand what is and is not covered by our own release assurances.
@@ -73,17 +76,21 @@ Current state:
 
 - releases are validated in GitHub Actions from an exact commit SHA
 - the release workflow re-runs lint, build, test, integration, and e2e checks before publishing
+- the release commit must be reachable from the protected `release` branch
+- release tags are created through a GitHub App-backed workflow path
 - release assets are published to GitHub Releases with a generated checksum manifest
 - release assets are attested in GitHub Actions prior to publication
 - immutable releases and protected tag settings still depend on repository configuration outside the git tree
 - current user-facing verification guidance is checksum verification plus `gh attestation verify`
 
-Planned state, tracked in issue `#7`:
+Remaining follow-up decisions before the attested secure `0.5` release, tracked in issues `#12` and `#13`:
 
-- release tags created only after full validation passes for the exact release commit
-- release assets attested and verifiable
-- protected tag and release controls
-- clearer documentation of external trust boundaries
+- whether `0.5` should publish SBOMs in addition to provenance attestations
+- whether `0.5` should claim reproducible builds and how that would be validated
+- whether release-time dependencies should be vendored or mirrored
+- what trust policy should apply to third-party binaries fetched by `soldr` at runtime
+
+`1.0.0-rc` remains gated on actual compilation-cache integration rather than release hardening alone.
 
 ## Reporting a security issue
 

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.2.0-beta");
+        assert_eq!(version(), "0.5.0");
     }
 
     #[test]

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -1,0 +1,146 @@
+# Release 0.5 Checklist
+
+This document is the concrete execution list for the first attested secure `soldr 0.5` release.
+
+It assumes the current repository state on April 13, 2026:
+
+- the validated release workflow exists in `.github/workflows/release.yml`
+- the workflow requires an exact commit SHA on `release`
+- publication uses a dedicated GitHub App
+- `v*.*.*` tags are protected by repository rulesets
+- immutable GitHub Releases are enabled
+- `main` and `release` are protected
+
+## 1. Freeze The `0.5` Product Surface
+
+Decide what `0.5` means for the user-facing CLI.
+
+Required decision:
+
+- the `0.5` release line is the front-door build and tool-fetch line
+- compilation caching is explicitly out of scope for `0.5`
+- `status`, `clean`, `config`, and `cache` must not be presented as complete features unless implemented
+
+Do not ship `0.5` with placeholder commands presented as finished behavior.
+
+## 2. Freeze The `0.5` Security Claim
+
+Resolve the open policy questions in:
+
+- issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
+- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
+
+Minimum decisions needed before `0.5`:
+
+- whether checksum plus `gh attestation verify` is the official verification story
+- whether SBOM generation is required for `0.5`
+- whether reproducible-build claims are in scope for `0.5`
+- whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
+- what trust statement applies to third-party binaries fetched by `soldr` at runtime
+
+## 3. Rehearse The Release Path
+
+Before the first public `0.5` tag, run a dry-run rehearsal from `release`.
+
+Inputs to choose:
+
+- candidate version such as `v0.5.0-rc1`
+- exact commit SHA on `release`
+
+Required checks:
+
+- the workflow rejects SHAs not reachable from `release`
+- the workflow completes lint, test, packaging, and e2e gates for the exact SHA
+- the `release` environment approval gate triggers as expected
+- the GitHub App token step succeeds
+- checksums and provenance attestation steps succeed
+
+Recommended command path:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=true
+```
+
+## 4. Verify The Governance Controls Manually
+
+Before the first real release, verify the controls that live outside the git tree.
+
+```bash
+gh api repos/zackees/soldr/rulesets
+gh api repos/zackees/soldr/environments
+gh api repos/zackees/soldr/branches/main/protection
+gh api repos/zackees/soldr/branches/release/protection
+gh api repos/zackees/soldr/immutable-releases
+```
+
+Success criteria:
+
+- the `v*.*.*` tag ruleset is active
+- only the release GitHub App can bypass that ruleset
+- `release` still requires approval from `@zackees`
+- `main` and `release` still require the expected checks
+- immutable releases remain enabled
+
+## 5. Cut A Real Release Candidate
+
+After the dry run passes, create the first real release candidate through the workflow.
+
+Recommended first tag:
+
+- `v0.5.0-rc1`
+
+Required checks after publication:
+
+- the GitHub Release contains all expected platform archives
+- the `SHA256SUMS` manifest is present
+- `gh attestation verify` succeeds for at least one downloaded archive
+- a human cannot create, move, or delete the release tag manually
+- the release cannot be mutated after publication because immutable releases are enabled
+
+Recommended verification commands:
+
+```bash
+gh release view v0.5.0-rc1 --repo zackees/soldr
+gh attestation verify soldr-v0.5.0-rc1-x86_64-unknown-linux-gnu.tar.gz \
+  --repo zackees/soldr \
+  --signer-workflow zackees/soldr/.github/workflows/release.yml
+```
+
+## 6. Audit The First Published Release
+
+After `v0.5.0-rc1`, confirm that reality matches the docs:
+
+- [RELEASE.md](../RELEASE.md)
+- [RELEASE_VERIFICATION.md](./RELEASE_VERIFICATION.md)
+- [RELEASE_GOVERNANCE_CHECKLIST.md](./RELEASE_GOVERNANCE_CHECKLIST.md)
+- [TRUST_BOUNDARIES.md](./TRUST_BOUNDARIES.md)
+
+Anything discovered during the RC must become either:
+
+- a code fix
+- a GitHub settings fix
+- an explicit documented limitation
+
+## 7. Decide Go Or No-Go For `v0.5.0`
+
+Ship `v0.5.0` only when all of these are true:
+
+- the intended `0.5` CLI surface is clearly scoped and honestly documented
+- the release workflow has passed in dry-run and real-release modes
+- the first RC was verified with checksums and attestations
+- the protected-tag and immutable-release controls behaved as expected
+- the remaining policy questions are closed or explicitly deferred in writing
+
+## 8. Gate `1.0.0-rc`
+
+Do not cut `1.0.0-rc` until:
+
+- zccache-style compilation caching is actually integrated
+- the wrapper does real cache lookup and store work
+- the public cache commands describe real behavior instead of placeholders
+
+If those are not true, stay on the `0.5.x` line.

--- a/docs/RELEASE_GOVERNANCE_CHECKLIST.md
+++ b/docs/RELEASE_GOVERNANCE_CHECKLIST.md
@@ -26,9 +26,12 @@ The intended release-governance state is:
 
 Observed on April 13, 2026 via GitHub API:
 
-- no repository rulesets for release tags
+- an active repository tag ruleset protects `refs/tags/v*.*.*`
+- the release-tag ruleset blocks tag creation, update, and deletion
+- the release GitHub App is the only bypass actor for that ruleset
 - the `release` environment exists and requires approval from `@zackees`
 - `main` branch protection requires pull requests, conversation resolution, linear history, and the current CI plus per-target e2e checks
+- `release` branch protection requires the same validation gate before promotion
 - immutable GitHub Releases are enabled
 - GitHub Actions requires full-SHA pinning for third-party actions
 - no published GitHub Releases yet
@@ -37,14 +40,16 @@ Those observations were produced with:
 
 ```bash
 gh api repos/zackees/soldr/rulesets
+gh api repos/zackees/soldr/rulesets/15033379
 gh api repos/zackees/soldr/environments
 gh api repos/zackees/soldr/branches/main/protection
+gh api repos/zackees/soldr/branches/release/protection
 gh api repos/zackees/soldr/actions/permissions
 gh api repos/zackees/soldr/immutable-releases
 gh api repos/zackees/soldr/releases?per_page=5
 ```
 
-The tag-ruleset query still returns an empty list. That is intentional for now: GitHub rejected a repository-ruleset bypass entry for the built-in `github-actions` integration on this personal repository, which means a true workflow-only tag rule needs either a different repository ownership model or a dedicated installed GitHub App.
+The ruleset now exists and is active. The critical detail is not just that a tag ruleset exists, but that the only bypass actor is the dedicated release GitHub App rather than a human maintainer or a PAT-backed workaround.
 
 ## Audit Steps
 
@@ -59,14 +64,17 @@ gh api repos/zackees/soldr/rulesets
 What to look for:
 
 - a ruleset that applies to release tag patterns such as `v*`
+- the ruleset is active
+- tag creation, update, and deletion are all blocked by default
+- the only bypass actor is the dedicated release GitHub App
 - protection against moving or deleting release tags
 - restrictions that make the validated workflow the normal release path
 
-Current limitation:
+Current constraint:
 
-- On this personal repository, GitHub rejected a bypass actor for the built-in `github-actions` integration when attempting to create a workflow-only release-tag ruleset.
-- Do not replace this with a maintainer-user bypass or PAT-backed workaround and call it equivalent. That would weaken the workflow-only release intent.
-- If strict workflow-only tags are required, solve this with repository-ownership changes or a dedicated installed GitHub App whose token is used by the release workflow.
+- On this personal repository, the built-in `github-actions` integration was not suitable as the bypass actor for a workflow-only tag rule.
+- The current secure model uses a dedicated installed GitHub App instead.
+- Do not replace the App bypass with a maintainer-user bypass or PAT-backed workaround and call it equivalent.
 
 ### 2. Check The Release Environment
 
@@ -86,15 +94,17 @@ The validated release workflow already targets `environment: release`, so this e
 
 ### 3. Check Branch Protection Or Equivalent Rulesets
 
-Confirm that the default branch is protected either by branch protection or a ruleset-based equivalent:
+Confirm that both `main` and `release` are protected either by branch protection or a ruleset-based equivalent:
 
 ```bash
 gh api repos/zackees/soldr/branches/main/protection
+gh api repos/zackees/soldr/branches/release/protection
 ```
 
 What to look for:
 
 - pull requests are required for `main`
+- `release` is also protected and requires the same validation gate
 - the required-check list includes:
   - `Lint`
   - `Linux x64`

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -9,9 +9,11 @@ It is intentionally limited to what the repository currently implements.
 For a normal `soldr` release:
 
 - the release workflow is started manually with an explicit version and exact commit SHA
-- that exact commit must be reachable from `main`
+- that exact commit must be reachable from the protected `release` branch
 - the workflow re-runs lint, workspace build, tests, integration, and all supported e2e bootstrap jobs for that exact commit
 - release archives are built from that exact commit
+- the version tag is protected by repository rulesets and created through the release workflow path
+- the published GitHub Release is immutable once published
 - a SHA-256 checksum manifest is published with the release assets
 - GitHub build provenance attestations are generated for the published assets
 
@@ -19,13 +21,11 @@ For a normal `soldr` release:
 
 The current release flow does not yet claim all of the following:
 
-- immutable GitHub Releases
-- protected release-tag rulesets enforced outside the git tree
 - SBOM publication
 - independently reproduced builds by a second builder
 - fully hermetic inputs for rustup, crates.io, OS packages, or third-party test inputs
 
-Those follow-up items are tracked in issues [#11](https://github.com/zackees/soldr/issues/11), [#12](https://github.com/zackees/soldr/issues/12), and [#13](https://github.com/zackees/soldr/issues/13).
+Those follow-up items are tracked in issues [#12](https://github.com/zackees/soldr/issues/12) and [#13](https://github.com/zackees/soldr/issues/13).
 
 ## Release Asset Names
 
@@ -107,7 +107,9 @@ Offline verification is not yet the primary documented path for `soldr`, but it 
 
 GitHub CLI also has `gh release verify`, which verifies release-level attestations.
 
-We do not currently document that as the primary verification path for `soldr` because immutable releases and the surrounding release-governance settings are still tracked separately. Today, the repository's strongest implemented verification path is:
+Because `soldr` now uses protected release tags and immutable GitHub Releases, `gh release verify` is a reasonable supplementary check.
+
+We still document per-artifact verification as the primary path because it validates the exact archive you downloaded. Today, the strongest explicit verification path for `soldr` is:
 
 1. checksum verification
 2. artifact attestation verification with `gh attestation verify`


### PR DESCRIPTION
## Summary
- bump the workspace release line to 0.5.0
- document that 0.5.x is the secure front-door/tool-fetch line and reserve 1.0.0-rc for real cache integration
- refresh release docs and add the 0.5 release checklist
- remove the invalid \\	oolchain\\ input from the reusable e2e workflow to eliminate dry-run warnings

## Verification
- cargo test --workspace
- cargo test --workspace --locked
- dry-run release rehearsal completed successfully on the current release workflow