### PR TITLE
Fix release publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,6 +370,7 @@ jobs:
         run: |
           set -euo pipefail
           gh release create "${{ needs.prepare.outputs.version }}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
             --draft \
             --generate-notes \
             --target "${{ needs.prepare.outputs.commit_sha }}" \
@@ -382,4 +383,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh release edit "${{ needs.prepare.outputs.version }}" --draft=false
+          gh release edit "${{ needs.prepare.outputs.version }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --draft=false


### PR DESCRIPTION
## Summary
- pass `--repo $GITHUB_REPOSITORY` to `gh release create`
- pass `--repo $GITHUB_REPOSITORY` to `gh release edit`
- keep the publish job working without a checkout step

## Testing
- dry-run release workflow 24378223921 succeeded on release@3bc820270447673eff104c301a89259587a31ffb
- real release workflow 24378387798 failed in publish job because `gh release create` ran outside a git checkout