### PR TITLE
Add PyPI trusted publishing release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ on:
         required: false
         default: true
         type: boolean
+      publish_pypi:
+        description: Build hardened wheel artifacts and publish them to PyPI via Trusted Publishing
+        required: false
+        default: false
+        type: boolean
+      pypi_repository_url:
+        description: Optional alternate upload endpoint such as https://test.pypi.org/legacy/
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -49,6 +59,8 @@ jobs:
           set -euo pipefail
           version='${{ inputs.version }}'
           commit_sha='${{ inputs.commit_sha }}'
+          publish_pypi='${{ inputs.publish_pypi }}'
+          pypi_repository_url='${{ inputs.pypi_repository_url }}'
 
           if [[ "${GITHUB_REF_NAME}" != "release" ]]; then
             echo "validated releases must be dispatched from release" >&2
@@ -62,6 +74,11 @@ jobs:
 
           if [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "commit_sha must be a full 40-character commit SHA" >&2
+            exit 1
+          fi
+
+          if [[ "$publish_pypi" != "true" && -n "$pypi_repository_url" ]]; then
+            echo "pypi_repository_url requires publish_pypi=true" >&2
             exit 1
           fi
 
@@ -312,11 +329,121 @@ jobs:
           name: release-soldr-${{ matrix.target }}
           path: dist/soldr-*
 
+  build-pypi:
+    name: PyPI ${{ matrix.name }}
+    if: ${{ inputs.publish_pypi }}
+    needs:
+      - prepare
+      - lint
+      - test
+      - e2e-linux-x64
+      - e2e-linux-arm64
+      - e2e-linux-x64-musl
+      - e2e-linux-arm64-musl
+      - e2e-macos-x64
+      - e2e-macos-arm64
+      - e2e-windows-x64
+      - e2e-windows-arm64
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - name: Linux ARM64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS x64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - name: macOS ARM64
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - name: Windows x64
+            runner: windows-2025
+            target: x86_64-pc-windows-msvc
+          - name: Windows ARM64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Install maturin
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "maturin>=1.7,<2"
+
+      - name: Install maturin
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m pip install --upgrade pip
+          py -3 -m pip install "maturin>=1.7,<2"
+
+      - name: Build hardened wheel
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m maturin build \
+            --release \
+            --locked \
+            --compatibility pypi \
+            --target "${{ matrix.target }}" \
+            --out dist
+
+      - name: Build hardened wheel
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m maturin build `
+            --release `
+            --locked `
+            --compatibility pypi `
+            --target "${{ matrix.target }}" `
+            --out dist
+
+      - name: Smoke test wheel
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m venv .venv
+          . .venv/bin/activate
+          python -m pip install dist/*.whl
+          soldr --version
+
+      - name: Smoke test wheel
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m venv .venv
+          .\.venv\Scripts\python.exe -m pip install dist\*.whl
+          .\.venv\Scripts\soldr.exe --version
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pypi-soldr-${{ matrix.target }}
+          path: dist/*.whl
+
   publish:
     name: Attest and publish release assets
     needs:
       - prepare
       - build
+      - build-pypi
     runs-on: ubuntu-24.04
     environment: release
 
@@ -386,3 +513,43 @@ jobs:
           gh release edit "${{ needs.prepare.outputs.version }}" \
             --repo "${GITHUB_REPOSITORY}" \
             --draft=false
+
+  publish-pypi:
+    name: Publish hardened PyPI wheels
+    if: ${{ inputs.publish_pypi && !inputs.dry_run }}
+    needs:
+      - prepare
+      - build-pypi
+      - publish
+    runs-on: ubuntu-24.04
+    environment:
+      name: release
+      url: https://pypi.org/project/soldr/
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          pattern: pypi-soldr-*
+          merge-multiple: true
+
+      - name: Show Python distributions
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -1 dist
+
+      - name: Publish wheel set to PyPI
+        if: ${{ inputs.pypi_repository_url == '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
+
+      - name: Publish wheel set to alternate index
+        if: ${{ inputs.pypi_repository_url != '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          repository-url: ${{ inputs.pypi_repository_url }}
+          packages-dir: dist

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ soldr/
 |   |-- soldr-fetch/     # Binary resolution + download (the crgx half)
 |   |-- soldr-cache/     # Compilation caching (the zccache half)
 |   `-- soldr-cli/       # CLI entry point + daemon
-|-- src/soldr/           # Python package (PyO3 bindings)
+|-- src/soldr/           # Python package (maturin bin bindings)
 `-- tests/
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,8 +35,11 @@ The remaining work before the attested secure `0.5` release is operational rathe
 - exercise the full release path with a rehearsal and first release candidate
 - verify that humans cannot mint, move, or delete release tags in practice
 - finish policy decisions around SBOMs, reproducibility, and hermeticity
+- register the existing `soldr` PyPI project for Trusted Publishing if hardened wheel upload is in scope for `0.5.0`
 
 `1.0.0-rc` is intentionally reserved for the point where the zccache-style compilation cache is actually integrated rather than merely planned.
+
+crates.io publication is not part of the current release direction. `soldr` is being released as a hardened binary tool, not as a promised Rust library API surface.
 
 ## Recommended Final Model
 
@@ -148,6 +151,7 @@ The release workflow now does this:
 6. Use that App token to create the tag.
 7. Use that same App token to create the GitHub Release.
 8. Attach checksums and build provenance attestations.
+9. Optionally build hardened platform wheels and publish them to PyPI through OIDC Trusted Publishing.
 
 The release workflow must not use:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,6 @@ The repository currently enforces several baseline controls:
 - CI and release builds use `cargo ... --locked`.
 - CI now enforces `cargo fmt --check` and `cargo clippy -D warnings`.
 - No Cargo `git` dependencies are currently used; dependencies resolve from crates.io.
-- Published crates.io versions are immutable and cannot be overwritten, only yanked.
 - Third-party GitHub Actions in the repository workflows are pinned to full commit SHAs.
 - The e2e third-party source input is pinned to an exact Git commit in the workflow inputs.
 - Releases are promoted by `workflow_dispatch` for an exact commit SHA instead of publishing immediately on tag push.
@@ -80,8 +79,11 @@ Current state:
 - release tags are created through a GitHub App-backed workflow path
 - release assets are published to GitHub Releases with a generated checksum manifest
 - release assets are attested in GitHub Actions prior to publication
+- the release workflow can also build hardened PyPI wheels, but enabling PyPI upload still requires Trusted Publisher registration on the existing `soldr` PyPI project
 - immutable releases and protected tag settings still depend on repository configuration outside the git tree
 - current user-facing verification guidance is checksum verification plus `gh attestation verify`
+
+The current distribution direction for `0.5.x` is GitHub Releases plus optional PyPI wheels. crates.io publication is intentionally out of scope because the project is not promising a stable Rust source/library API.
 
 Remaining follow-up decisions before the attested secure `0.5` release, tracked in issues `#12` and `#13`:
 

--- a/docs/PYPI_TRUSTED_PUBLISHING.md
+++ b/docs/PYPI_TRUSTED_PUBLISHING.md
@@ -1,0 +1,88 @@
+# PyPI Trusted Publishing
+
+This document describes the repo-side and owner-side steps needed to publish `soldr` wheels to PyPI using GitHub Actions OIDC Trusted Publishing.
+
+It is intentionally PyPI-only. crates.io publication is not part of the current `0.5.x` release direction.
+
+## Current State
+
+As of April 14, 2026:
+
+- the release workflow can build hardened `soldr` wheels when `publish_pypi=true`
+- the workflow can publish those wheels through `pypa/gh-action-pypi-publish` in a dedicated OIDC job
+- the existing PyPI project `soldr` already exists
+- that PyPI project currently shows a stale `0.1.0` upload that predates Trusted Publishing
+
+The next secure PyPI release should replace that stale packaging path with the real wheel set built from the validated release workflow.
+
+## Why This Uses Trusted Publishing
+
+PyPI Trusted Publishing avoids long-lived API tokens.
+
+The workflow receives a short-lived upload credential from PyPI using the GitHub Actions OIDC identity for a specific repository, workflow file, and optional environment.
+
+For `soldr`, the intended trusted identity is:
+
+- owner: `zackees`
+- repository: `soldr`
+- workflow: `.github/workflows/release.yml`
+- environment: `release`
+
+Using the existing `release` environment keeps the PyPI publish step behind the same manual approval gate as the immutable GitHub release path.
+
+## Owner Setup On PyPI
+
+These steps must be performed in the PyPI web UI by a maintainer of the `soldr` project.
+
+1. Open the `soldr` project on PyPI.
+2. Click `Manage`.
+3. Open the `Publishing` page in the project sidebar.
+4. Add a new GitHub Actions publisher with:
+   - repository owner: `zackees`
+   - repository name: `soldr`
+   - workflow filename: `.github/workflows/release.yml`
+   - environment name: `release`
+
+The environment field is optional in PyPI, but it should be filled in here because the repo already uses `release` as the human approval boundary.
+
+## Repo-Side Workflow Inputs
+
+The release workflow now supports these PyPI-related inputs:
+
+- `publish_pypi=true`
+- `pypi_repository_url=...` for alternate endpoints such as TestPyPI
+
+If `publish_pypi=false`, the workflow keeps its previous GitHub-release-only behavior.
+
+If `publish_pypi=true`, the workflow:
+
+1. Builds hardened wheels on the supported platform runners.
+2. Smoke-tests the built wheel on each runner by installing it and running `soldr --version`.
+3. Publishes the GitHub Release.
+4. Publishes the wheel set to PyPI from a dedicated Linux job with `id-token: write`.
+
+No source distribution is published in this path. The current design is wheel-only because the project is prioritizing hardened binary distribution rather than source release through package registries.
+
+## Recommended Rehearsal
+
+Before enabling real PyPI publishing, rehearse against TestPyPI.
+
+Recommended command:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=false \
+  -f publish_pypi=true \
+  -f pypi_repository_url=https://test.pypi.org/legacy/
+```
+
+This uses a real publish path instead of `dry_run=true`, because the OIDC publisher exchange only happens in the real publish job.
+
+## Expected Manual Stop
+
+The repo-side work can be completed without additional secrets.
+
+The first unavoidable manual stop is PyPI-side publisher registration on the existing `soldr` project. Until that is done, the PyPI publish job will not be able to mint a trusted upload token.

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -101,7 +101,38 @@ Required checks after publication:
 - a human cannot create, move, or delete the release tag manually
 - the release cannot be mutated after publication because immutable releases are enabled
 
-Recommended verification commands:
+## 6. Enable Trusted PyPI Publishing If `0.5.0` Will Ship Wheels
+
+If PyPI is part of `0.5.0`, configure the existing `soldr` project for Trusted Publishing before the final release.
+
+Required setup:
+
+- add the GitHub Actions trusted publisher on PyPI for:
+  - owner: `zackees`
+  - repository: `soldr`
+  - workflow: `.github/workflows/release.yml`
+  - environment: `release`
+- confirm the existing `soldr` PyPI project is the correct project and that stale pre-Trusted-Publishing metadata will be superseded by the next upload
+
+Recommended rehearsal:
+
+- use TestPyPI first with the same workflow and `publish_pypi=true`
+- pass `pypi_repository_url=https://test.pypi.org/legacy/`
+- treat this as a real publish rehearsal, not a `dry_run`, because OIDC publish cannot be fully exercised in the workflow's dry-run path
+
+Recommended command path:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=false \
+  -f publish_pypi=true \
+  -f pypi_repository_url=https://test.pypi.org/legacy/
+```
+
+Recommended GitHub-release verification commands:
 
 ```bash
 gh release view v0.5.0-rc1 --repo zackees/soldr
@@ -110,13 +141,14 @@ gh attestation verify soldr-v0.5.0-rc1-x86_64-unknown-linux-gnu.tar.gz \
   --signer-workflow zackees/soldr/.github/workflows/release.yml
 ```
 
-## 6. Audit The First Published Release
+## 7. Audit The First Published Release
 
 After `v0.5.0-rc1`, confirm that reality matches the docs:
 
 - [RELEASE.md](../RELEASE.md)
 - [RELEASE_VERIFICATION.md](./RELEASE_VERIFICATION.md)
 - [RELEASE_GOVERNANCE_CHECKLIST.md](./RELEASE_GOVERNANCE_CHECKLIST.md)
+- [PYPI_TRUSTED_PUBLISHING.md](./PYPI_TRUSTED_PUBLISHING.md)
 - [TRUST_BOUNDARIES.md](./TRUST_BOUNDARIES.md)
 
 Anything discovered during the RC must become either:
@@ -125,7 +157,7 @@ Anything discovered during the RC must become either:
 - a GitHub settings fix
 - an explicit documented limitation
 
-## 7. Decide Go Or No-Go For `v0.5.0`
+## 8. Decide Go Or No-Go For `v0.5.0`
 
 Ship `v0.5.0` only when all of these are true:
 
@@ -133,9 +165,10 @@ Ship `v0.5.0` only when all of these are true:
 - the release workflow has passed in dry-run and real-release modes
 - the first RC was verified with checksums and attestations
 - the protected-tag and immutable-release controls behaved as expected
+- if PyPI is in scope, Trusted Publishing was exercised successfully against TestPyPI or PyPI with the hardened wheel set
 - the remaining policy questions are closed or explicitly deferred in writing
 
-## 8. Gate `1.0.0-rc`
+## 9. Gate `1.0.0-rc`
 
 Do not cut `1.0.0-rc` until:
 

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -27,6 +27,9 @@ Even with a validated release workflow, the release path still depends on extern
   - Published crate versions are immutable, but the transport and index are still external.
 - GitHub APIs and GitHub Releases
   - The release workflow uses GitHub services to create releases, publish assets, and store attestations.
+- PyPI
+  - Optional hardened wheel publication relies on PyPI's Trusted Publishing and package hosting.
+  - The project already has an existing `soldr` PyPI record whose ownership and publisher settings live outside this repository.
 
 ## E2E Validation External Dependencies
 


### PR DESCRIPTION
## Summary
- add an optional PyPI Trusted Publishing path to the validated release workflow
- build and smoke-test hardened platform wheels before publishing them
- document the exact PyPI publisher registration handoff and narrow tracking to PyPI only

## Details
- adds `publish_pypi` and `pypi_repository_url` workflow inputs to `.github/workflows/release.yml`
- builds wheel artifacts via `maturin` on the supported platform runners and smoke-tests `soldr --version`
- publishes wheel artifacts in a dedicated OIDC job using `pypa/gh-action-pypi-publish`
- adds `docs/PYPI_TRUSTED_PUBLISHING.md`
- updates release/security docs to make crates.io explicitly out of scope for `0.5.x`

## Validation
- `cargo test --workspace --locked`
- `maturin build --release`
- `maturin build --release --compatibility pypi`
- installed the built wheel locally and verified `soldr --version`

Closes #30