### PR TITLE
Fix PyPI release workflow runner setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,22 +382,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 -m pip install --upgrade pip
-          python3 -m pip install "maturin>=1.7,<2"
+          python3 -m venv .build-venv
+          . .build-venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install "maturin>=1.7,<2"
 
       - name: Install maturin
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          py -3 -m pip install --upgrade pip
-          py -3 -m pip install "maturin>=1.7,<2"
+          py -3 -m venv .build-venv
+          .\.build-venv\Scripts\python.exe -m pip install --upgrade pip
+          .\.build-venv\Scripts\python.exe -m pip install "maturin>=1.7,<2"
 
       - name: Build hardened wheel
         if: runner.os != 'Windows'
         shell: bash
         run: |
           set -euo pipefail
-          python3 -m maturin build \
+          . .build-venv/bin/activate
+          python -m maturin build \
             --release \
             --locked \
             --compatibility pypi \
@@ -408,7 +412,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          py -3 -m maturin build `
+          .\.build-venv\Scripts\python.exe -m maturin build `
             --release `
             --locked `
             --compatibility pypi `
@@ -430,7 +434,11 @@ jobs:
         shell: pwsh
         run: |
           py -3 -m venv .venv
-          .\.venv\Scripts\python.exe -m pip install dist\*.whl
+          $wheel = (Get-ChildItem dist\*.whl | Select-Object -First 1).FullName
+          if (-not $wheel) {
+            throw "No wheel found in dist"
+          }
+          .\.venv\Scripts\python.exe -m pip install $wheel
           .\.venv\Scripts\soldr.exe --version
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Summary
- install maturin inside a dedicated build venv on all runners
- use that venv for wheel builds to avoid externally-managed Python failures on macOS
- resolve the concrete wheel path in Windows smoke tests before installing

## Testing
- python yaml parse for .github/workflows/release.yml
- git diff --check
