### PR TITLE
Add soldr cache control plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 # Build through soldr's front door:
 soldr cargo build --release
 soldr cargo test
+soldr cargo --no-cache test
 
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -1,4 +1,79 @@
-//! Compilation caching.
+//! Compilation caching control plane.
 //!
-//! Wraps rustc invocations, hashes inputs, and stores/retrieves
-//! compiled artifacts (.o, .rlib, .rmeta) for cache hits.
+//! The actual artifact cache is not implemented yet, but this crate owns the
+//! cache policy surface so the CLI and wrapper agree on whether caching is
+//! enabled for a given invocation.
+
+use std::ffi::OsStr;
+
+/// Environment variable used to carry cache enable/disable state from the
+/// front-door cargo command into wrapper mode.
+pub const CACHE_ENABLED_ENV_VAR: &str = "SOLDR_CACHE_ENABLED";
+
+/// Encoded environment value for an enabled cache invocation.
+pub const CACHE_ENABLED_VALUE: &str = "1";
+
+/// Encoded environment value for a disabled cache invocation.
+pub const CACHE_DISABLED_VALUE: &str = "0";
+
+pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
+    if enabled {
+        CACHE_ENABLED_VALUE
+    } else {
+        CACHE_DISABLED_VALUE
+    }
+}
+
+pub fn cache_enabled_from_env_var(value: Option<&OsStr>) -> bool {
+    match value.and_then(OsStr::to_str) {
+        None => true,
+        Some(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+    }
+}
+
+pub fn cache_enabled_in_current_process() -> bool {
+    cache_enabled_from_env_var(std::env::var_os(CACHE_ENABLED_ENV_VAR).as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cache_enabled_env_value, cache_enabled_from_env_var, CACHE_DISABLED_VALUE,
+        CACHE_ENABLED_VALUE,
+    };
+    use std::ffi::OsStr;
+
+    #[test]
+    fn cache_defaults_to_enabled_when_env_is_missing() {
+        assert!(cache_enabled_from_env_var(None));
+    }
+
+    #[test]
+    fn cache_control_parses_common_false_values() {
+        for value in ["0", "false", "FALSE", "no", "off", ""] {
+            assert!(
+                !cache_enabled_from_env_var(Some(OsStr::new(value))),
+                "expected {value:?} to disable cache"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_control_treats_other_values_as_enabled() {
+        for value in ["1", "true", "yes", "unexpected"] {
+            assert!(
+                cache_enabled_from_env_var(Some(OsStr::new(value))),
+                "expected {value:?} to enable cache"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_control_serializes_boolean_state() {
+        assert_eq!(cache_enabled_env_value(true), CACHE_ENABLED_VALUE);
+        assert_eq!(cache_enabled_env_value(false), CACHE_DISABLED_VALUE);
+    }
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -13,6 +13,9 @@ struct Cli {
 enum Commands {
     /// Run Cargo through soldr's front door
     Cargo {
+        /// Disable soldr's compilation cache for this invocation
+        #[arg(long)]
+        no_cache: bool,
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -50,14 +53,25 @@ async fn run() -> Result<(), SoldrError> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Cargo { args } => {
-            std::process::exit(run_cargo_front_door(&args)?);
+        Commands::Cargo { no_cache, args } => {
+            std::process::exit(run_cargo_front_door(&args, !no_cache)?);
         }
         Commands::Status => {
             println!("soldr {}", soldr_core::version());
             let target = soldr_core::TargetTriple::detect()?;
+            let paths = soldr_core::SoldrPaths::new()?;
             println!("target: {target}");
-            println!("(status not yet implemented)");
+            println!("cache dir: {}", paths.cache.display());
+            println!("cache default: enabled");
+            println!(
+                "cache mode: {}",
+                if soldr_cache::cache_enabled_in_current_process() {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            );
+            println!("build cache: control plane wired; artifact cache not yet implemented");
         }
         Commands::Clean => {
             println!("(clean not yet implemented)");
@@ -113,6 +127,12 @@ fn is_rustc_path(arg: &str) -> bool {
 }
 
 fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
+    if soldr_cache::cache_enabled_in_current_process() {
+        // The actual artifact cache will slot in here in a follow-up slice.
+        // For now, cache-enabled and cache-disabled wrapper mode both
+        // delegate to the real rustc without modifying outputs.
+    }
+
     let rustc = raw_args
         .get(1)
         .ok_or_else(|| SoldrError::Other("missing rustc path in wrapper mode".into()))?;
@@ -129,7 +149,7 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     Ok(status.code().unwrap_or(1))
 }
 
-fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
+fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {
     let cargo = resolve_toolchain_binary("cargo")?;
     let rustc = resolve_toolchain_binary("rustc")?;
     let current_exe = std::env::current_exe()?;
@@ -143,6 +163,10 @@ fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
     command.args(args);
     command.env("RUSTC_WRAPPER", current_exe);
     command.env("RUSTC", rustc);
+    command.env(
+        soldr_cache::CACHE_ENABLED_ENV_VAR,
+        soldr_cache::cache_enabled_env_value(cache_enabled),
+    );
     command.env(
         "PATH",
         prepend_path(&cargo_bin_dir, existing_path.as_deref())?,
@@ -224,7 +248,8 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
 
 #[cfg(test)]
 mod tests {
-    use super::cargo_args_specify_target;
+    use super::{cargo_args_specify_target, parse_tool_spec};
+    use soldr_fetch::VersionSpec;
 
     #[test]
     fn cargo_args_detect_explicit_target_flag() {
@@ -247,5 +272,12 @@ mod tests {
             "--target".into(),
             "ignored".into(),
         ]));
+    }
+
+    #[test]
+    fn parse_tool_spec_defaults_to_latest_version() {
+        let (tool, version) = parse_tool_spec("maturin");
+        assert_eq!(tool, "maturin");
+        assert!(matches!(version, VersionSpec::Latest));
     }
 }

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -71,6 +71,32 @@ fn cargo_front_door_runs_real_cargo() {
 }
 
 #[test]
+fn cargo_front_door_consumes_no_cache_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "--no-cache", "--version"])
+        .output()
+        .expect("failed to run soldr cargo --no-cache --version");
+
+    assert!(
+        output.status.success(),
+        "cargo front door with --no-cache failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("cargo"),
+        "unexpected cargo output with --no-cache: {stdout}"
+    );
+    assert!(
+        !stderr.contains("unexpected argument '--no-cache'"),
+        "--no-cache should be consumed by soldr, not forwarded to cargo: {stderr}"
+    );
+}
+
+#[test]
 fn rustc_wrapper_mode_passes_through_to_rustc() {
     let rustc = rustup_which("rustc");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -85,6 +111,26 @@ fn rustc_wrapper_mode_passes_through_to_rustc() {
     assert!(
         stdout.contains("rustc"),
         "unexpected rustc output: {stdout}"
+    );
+}
+
+#[test]
+fn status_reports_cache_control_defaults() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("status")
+        .output()
+        .expect("failed to run soldr status");
+
+    assert!(output.status.success(), "status command failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cache dir:"),
+        "status missing cache dir: {stdout}"
+    );
+    assert!(
+        stdout.contains("cache default: enabled"),
+        "status missing cache default: {stdout}"
     );
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,6 +25,7 @@ The primary user experience is `soldr cargo ...`.
 soldr cargo build --release
 soldr cargo test
 soldr cargo run -- --help
+soldr cargo --no-cache build
 ```
 
 Behavior:
@@ -32,7 +33,14 @@ Behavior:
 - Resolve the real `cargo` binary through `rustup`
 - Resolve the matching real `rustc` binary through `rustup`
 - Set `RUSTC_WRAPPER` to the current `soldr` executable
+- Enable the soldr compilation-cache path by default
 - Delegate to Cargo with the exact flags the user passed
+
+Current cache-control behavior:
+
+- caching is enabled by default for `soldr cargo ...`
+- `soldr cargo --no-cache ...` disables soldr's compilation-cache path for that invocation
+- wrapper mode still falls through to real `rustc` while artifact caching is implemented in follow-up work
 
 This is the normal build entry point.
 
@@ -101,6 +109,7 @@ Run Cargo through soldr's front door.
 soldr cargo build --release
 soldr cargo test --workspace
 soldr cargo check -p soldr-cli
+soldr cargo --no-cache test
 ```
 
 ### `soldr status`
@@ -148,6 +157,7 @@ Commands:
 | Variable | Purpose | Default |
 |---|---|---|
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
+| `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |


### PR DESCRIPTION
## Summary
- add a first-class --no-cache flag to the soldr cargo front door
- propagate cache-enabled state into wrapper mode via a stable env contract
- document and test the new cache-control behavior

## Testing
- cargo fmt --all
- cargo test --workspace --locked
