### PR TITLE
Move no-cache to top-level soldr flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 # Build through soldr's front door:
 soldr cargo build --release
 soldr cargo test
-soldr cargo --no-cache test
+soldr --no-cache cargo test
 
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -5,6 +5,9 @@ use soldr_fetch::VersionSpec;
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
 struct Cli {
+    /// Disable soldr's compilation cache for this invocation
+    #[arg(long)]
+    no_cache: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -13,9 +16,6 @@ struct Cli {
 enum Commands {
     /// Run Cargo through soldr's front door
     Cargo {
-        /// Disable soldr's compilation cache for this invocation
-        #[arg(long)]
-        no_cache: bool,
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -51,10 +51,11 @@ async fn main() {
 
 async fn run() -> Result<(), SoldrError> {
     let cli = Cli::parse();
+    let cache_enabled = !cli.no_cache;
 
     match cli.command {
-        Commands::Cargo { no_cache, args } => {
-            std::process::exit(run_cargo_front_door(&args, !no_cache)?);
+        Commands::Cargo { args } => {
+            std::process::exit(run_cargo_front_door(&args, cache_enabled)?);
         }
         Commands::Status => {
             println!("soldr {}", soldr_core::version());
@@ -65,11 +66,7 @@ async fn run() -> Result<(), SoldrError> {
             println!("cache default: enabled");
             println!(
                 "cache mode: {}",
-                if soldr_cache::cache_enabled_in_current_process() {
-                    "enabled"
-                } else {
-                    "disabled"
-                }
+                if cache_enabled { "enabled" } else { "disabled" }
             );
             println!("build cache: control plane wired; artifact cache not yet implemented");
         }

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -73,13 +73,13 @@ fn cargo_front_door_runs_real_cargo() {
 #[test]
 fn cargo_front_door_consumes_no_cache_flag() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "--no-cache", "--version"])
+        .args(["--no-cache", "cargo", "--version"])
         .output()
-        .expect("failed to run soldr cargo --no-cache --version");
+        .expect("failed to run soldr --no-cache cargo --version");
 
     assert!(
         output.status.success(),
-        "cargo front door with --no-cache failed\nstdout:\n{}\nstderr:\n{}",
+        "cargo front door with top-level --no-cache failed\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -93,6 +93,25 @@ fn cargo_front_door_consumes_no_cache_flag() {
     assert!(
         !stderr.contains("unexpected argument '--no-cache'"),
         "--no-cache should be consumed by soldr, not forwarded to cargo: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_subcommand_rejects_no_cache_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "--no-cache", "--version"])
+        .output()
+        .expect("failed to run soldr cargo --no-cache --version");
+
+    assert!(
+        !output.status.success(),
+        "cargo subcommand form should no longer accept --no-cache"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unexpected argument '--no-cache'"),
+        "expected clap to reject cargo-level --no-cache: {stderr}"
     );
 }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -110,8 +110,8 @@ fn cargo_subcommand_rejects_no_cache_flag() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("unexpected argument '--no-cache'"),
-        "expected clap to reject cargo-level --no-cache: {stderr}"
+        stderr.contains("--no-cache"),
+        "expected cargo-subcommand form to fail mentioning --no-cache: {stderr}"
     );
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,7 +25,7 @@ The primary user experience is `soldr cargo ...`.
 soldr cargo build --release
 soldr cargo test
 soldr cargo run -- --help
-soldr cargo --no-cache build
+soldr --no-cache cargo build
 ```
 
 Behavior:
@@ -39,7 +39,7 @@ Behavior:
 Current cache-control behavior:
 
 - caching is enabled by default for `soldr cargo ...`
-- `soldr cargo --no-cache ...` disables soldr's compilation-cache path for that invocation
+- `soldr --no-cache cargo ...` disables soldr's compilation-cache path for that invocation
 - wrapper mode still falls through to real `rustc` while artifact caching is implemented in follow-up work
 
 This is the normal build entry point.
@@ -109,7 +109,7 @@ Run Cargo through soldr's front door.
 soldr cargo build --release
 soldr cargo test --workspace
 soldr cargo check -p soldr-cli
-soldr cargo --no-cache test
+soldr --no-cache cargo test
 ```
 
 ### `soldr status`


### PR DESCRIPTION
## Summary
- move cache opt-out to a top-level soldr flag
- reject the cargo-subcommand form with no compatibility alias
- update docs and tests to match the intended UX

## Testing
- cargo fmt --all
- cargo test --workspace --locked
