### PR TITLE
Integrate managed zccache into soldr cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ soldr aims for the same outcome in the Rust toolchain world.
 Current release line:
 
 - `0.5.x` is the secure front-door and tool-fetch release line
-- `1.0.0-rc` is reserved for the point where the zccache-style compilation cache is actually integrated
+- `1.0.0-rc` remains reserved for the point where the built-in zccache integration and cache command surface are fully rounded out
 
 ## Why soldr exists
 
@@ -41,13 +41,13 @@ When you run `soldr`, the tool should do the obvious thing:
 - pick MSVC on Windows by default
 - fetch the tool you asked for
 - cache it locally
-- prepare the front door that will eventually carry zccache-style transparent `rustc` caching without manual wrapper setup
+- fetch and manage zccache so Rust builds get transparent caching without manual wrapper setup
 
 If soldr solves that one problem well, it becomes a super tool: the command you reach for first, because it makes the rest of the stack behave.
 
 - **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse.
 
-- **Compilation caching** (the zccache half): planned, but not integrated yet in the current `0.5.x` line.
+- **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring; zccache's artifact store still uses its current default cache root.
 
 ```bash
 # Build through soldr's front door:
@@ -66,7 +66,8 @@ soldr rustfmt src/main.rs
 ```text
 soldr cargo build --release
   +-- resolve the real cargo binary
-  +-- wire soldr's wrapper path internally
+  +-- fetch/start managed zccache when cache is enabled
+  +-- set zccache as the compiler wrapper for this build
   +-- delegate to cargo with your existing flags
 
 soldr maturin build --release
@@ -76,10 +77,10 @@ soldr maturin build --release
 
 ## Design goals
 
-- **One obvious command**: Fetch tools, pick the right Windows target, and eventually enable build caching through the same entry point.
+- **One obvious command**: Fetch tools, pick the right Windows target, and run through managed zccache through the same entry point.
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
-- **Invisible caching**: the wrapper plumbing exists now; actual compilation cache behavior is still future work.
-- **One cache**: Tools and compilation artifacts in a single `~/.soldr/` directory.
+- **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
+- **One cache boundary, eventually**: soldr keeps its own tools and zccache session state in `~/.soldr/`. Current zccache artifacts still live in zccache's default cache root until upstream exposes a supported cache-dir override.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
 - **Cross-platform**: Linux, macOS, Windows (x86_64 + aarch64).
@@ -102,8 +103,8 @@ soldr/
 |---|---|
 | `soldr-core` | Cache paths, config, version types |
 | `soldr-fetch` | Resolve crate binaries from binstall metadata, GitHub Releases, QuickInstall. Download, verify, cache. |
-| `soldr-cache` | Reserved for the future compilation-cache implementation; not yet integrated in the current release line. |
-| `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`), tool fetch dispatch. |
+| `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
+| `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
 
 ## Prior art
 

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -132,7 +132,10 @@ mod tests {
     #[test]
     fn zccache_dir_lives_under_soldr_cache_root() {
         let paths = SoldrPaths::with_root(Path::new("C:\\soldr-root").to_path_buf());
-        assert_eq!(zccache_dir(&paths), paths.root.join("cache").join("zccache"));
+        assert_eq!(
+            zccache_dir(&paths),
+            paths.root.join("cache").join("zccache")
+        );
     }
 
     #[test]
@@ -160,6 +163,11 @@ mod tests {
     #[test]
     fn session_journal_path_uses_logs_directory() {
         let path = session_journal_path(Path::new("C:\\soldr-root\\cache\\zccache"));
-        assert_eq!(path, Path::new("C:\\soldr-root\\cache\\zccache").join("logs").join("last-session.jsonl"));
+        assert_eq!(
+            path,
+            Path::new("C:\\soldr-root\\cache\\zccache")
+                .join("logs")
+                .join("last-session.jsonl")
+        );
     }
 }

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -132,10 +132,7 @@ mod tests {
     #[test]
     fn zccache_dir_lives_under_soldr_cache_root() {
         let paths = SoldrPaths::with_root(Path::new("C:\\soldr-root").to_path_buf());
-        assert_eq!(
-            zccache_dir(&paths),
-            Path::new("C:\\soldr-root\\cache\\zccache")
-        );
+        assert_eq!(zccache_dir(&paths), paths.root.join("cache").join("zccache"));
     }
 
     #[test]
@@ -163,9 +160,6 @@ mod tests {
     #[test]
     fn session_journal_path_uses_logs_directory() {
         let path = session_journal_path(Path::new("C:\\soldr-root\\cache\\zccache"));
-        assert_eq!(
-            path,
-            Path::new("C:\\soldr-root\\cache\\zccache\\logs\\last-session.jsonl")
-        );
+        assert_eq!(path, Path::new("C:\\soldr-root\\cache\\zccache").join("logs").join("last-session.jsonl"));
     }
 }

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -1,13 +1,17 @@
-//! Compilation caching control plane.
+//! zccache integration surface for soldr.
 //!
-//! The actual artifact cache is not implemented yet, but this crate owns the
-//! cache policy surface so the CLI and wrapper agree on whether caching is
-//! enabled for a given invocation.
+//! soldr owns the build UX and cache policy, while zccache provides the actual
+//! compiler-cache engine and daemon.
 
-use std::ffi::OsStr;
+use serde::Deserialize;
+use soldr_core::SoldrPaths;
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 
 /// Environment variable used to carry cache enable/disable state from the
-/// front-door cargo command into wrapper mode.
+/// front-door cargo command into child processes.
 pub const CACHE_ENABLED_ENV_VAR: &str = "SOLDR_CACHE_ENABLED";
 
 /// Encoded environment value for an enabled cache invocation.
@@ -15,6 +19,9 @@ pub const CACHE_ENABLED_VALUE: &str = "1";
 
 /// Encoded environment value for a disabled cache invocation.
 pub const CACHE_DISABLED_VALUE: &str = "0";
+
+/// Per-build session identifier recognized by zccache.
+pub const ZCCACHE_SESSION_ID_ENV_VAR: &str = "ZCCACHE_SESSION_ID";
 
 pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
     if enabled {
@@ -38,13 +45,58 @@ pub fn cache_enabled_in_current_process() -> bool {
     cache_enabled_from_env_var(std::env::var_os(CACHE_ENABLED_ENV_VAR).as_deref())
 }
 
+pub fn zccache_dir(paths: &SoldrPaths) -> PathBuf {
+    paths.cache.join("zccache")
+}
+
+pub fn parse_zccache_session_id(stdout: &str) -> Option<String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(response) = serde_json::from_str::<SessionStartResponse>(trimmed) {
+        if !response.session_id.trim().is_empty() {
+            return Some(response.session_id);
+        }
+    }
+
+    for line in trimmed.lines() {
+        let line = line.trim();
+        for prefix in [
+            "ZCCACHE_SESSION_ID=",
+            "export ZCCACHE_SESSION_ID=",
+            "$env:ZCCACHE_SESSION_ID=",
+        ] {
+            if let Some(value) = line.strip_prefix(prefix) {
+                let value = value.trim().trim_matches('"').trim_matches('\'');
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+pub fn session_journal_path(zccache_dir: &Path) -> PathBuf {
+    zccache_dir.join("logs").join("last-session.jsonl")
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionStartResponse {
+    session_id: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_enabled_env_value, cache_enabled_from_env_var, CACHE_DISABLED_VALUE,
-        CACHE_ENABLED_VALUE,
+        cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id,
+        session_journal_path, zccache_dir, CACHE_DISABLED_VALUE, CACHE_ENABLED_VALUE,
     };
-    use std::ffi::OsStr;
+    use soldr_core::SoldrPaths;
+    use std::{ffi::OsStr, path::Path};
 
     #[test]
     fn cache_defaults_to_enabled_when_env_is_missing() {
@@ -75,5 +127,45 @@ mod tests {
     fn cache_control_serializes_boolean_state() {
         assert_eq!(cache_enabled_env_value(true), CACHE_ENABLED_VALUE);
         assert_eq!(cache_enabled_env_value(false), CACHE_DISABLED_VALUE);
+    }
+
+    #[test]
+    fn zccache_dir_lives_under_soldr_cache_root() {
+        let paths = SoldrPaths::with_root(Path::new("C:\\soldr-root").to_path_buf());
+        assert_eq!(
+            zccache_dir(&paths),
+            Path::new("C:\\soldr-root\\cache\\zccache")
+        );
+    }
+
+    #[test]
+    fn parses_json_session_start_output() {
+        let session_id = parse_zccache_session_id(
+            r#"{"session_id":"08f063c0-5f01-4c92-aec1-3f304d9224d0","started_at":1776141813}"#,
+        );
+        assert_eq!(
+            session_id.as_deref(),
+            Some("08f063c0-5f01-4c92-aec1-3f304d9224d0")
+        );
+    }
+
+    #[test]
+    fn parses_shell_style_session_start_output() {
+        let session_id = parse_zccache_session_id(
+            "export ZCCACHE_SESSION_ID=08f063c0-5f01-4c92-aec1-3f304d9224d0",
+        );
+        assert_eq!(
+            session_id.as_deref(),
+            Some("08f063c0-5f01-4c92-aec1-3f304d9224d0")
+        );
+    }
+
+    #[test]
+    fn session_journal_path_uses_logs_directory() {
+        let path = session_journal_path(Path::new("C:\\soldr-root\\cache\\zccache"));
+        assert_eq!(
+            path,
+            Path::new("C:\\soldr-root\\cache\\zccache\\logs\\last-session.jsonl")
+        );
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use soldr_core::SoldrError;
+use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 
 #[derive(Parser)]
@@ -55,29 +55,33 @@ async fn run() -> Result<(), SoldrError> {
 
     match cli.command {
         Commands::Cargo { args } => {
-            std::process::exit(run_cargo_front_door(&args, cache_enabled)?);
+            std::process::exit(run_cargo_front_door(&args, cache_enabled).await?);
         }
         Commands::Status => {
             println!("soldr {}", soldr_core::version());
             let target = soldr_core::TargetTriple::detect()?;
             let paths = soldr_core::SoldrPaths::new()?;
+            let zccache_dir = soldr_cache::zccache_dir(&paths);
             println!("target: {target}");
+            println!("root dir: {}", paths.root.display());
             println!("cache dir: {}", paths.cache.display());
             println!("cache default: enabled");
             println!(
                 "cache mode: {}",
                 if cache_enabled { "enabled" } else { "disabled" }
             );
-            println!("build cache: control plane wired; artifact cache not yet implemented");
+            println!("zccache version: {}", soldr_fetch::MANAGED_ZCCACHE_VERSION);
+            println!("soldr zccache state dir: {}", zccache_dir.display());
+            print_zccache_status(&paths)?;
         }
         Commands::Clean => {
-            println!("(clean not yet implemented)");
+            clear_zccache_cache()?;
         }
         Commands::Config => {
             println!("(config not yet implemented)");
         }
         Commands::Cache => {
-            println!("(cache not yet implemented)");
+            print_zccache_status(&SoldrPaths::new()?)?;
         }
         Commands::Version => {
             println!("soldr {}", soldr_core::version());
@@ -146,19 +150,25 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     Ok(status.code().unwrap_or(1))
 }
 
-fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {
+async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {
+    if cargo_args_use_reserved_no_cache(args) {
+        return Err(SoldrError::Other(
+            "`--no-cache` must appear before `cargo`, as in `soldr --no-cache cargo build`".into(),
+        ));
+    }
+
     let cargo = resolve_toolchain_binary("cargo")?;
     let rustc = resolve_toolchain_binary("rustc")?;
-    let current_exe = std::env::current_exe()?;
     let cargo_bin_dir = cargo
         .parent()
         .ok_or_else(|| SoldrError::Other("failed to resolve cargo bin directory".into()))?
         .to_path_buf();
     let existing_path = std::env::var_os("PATH");
+    let paths = SoldrPaths::new()?;
+    paths.ensure_dirs()?;
 
     let mut command = std::process::Command::new(cargo);
     command.args(args);
-    command.env("RUSTC_WRAPPER", current_exe);
     command.env("RUSTC", rustc);
     command.env(
         soldr_cache::CACHE_ENABLED_ENV_VAR,
@@ -172,7 +182,16 @@ fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, Sol
         command.env("CARGO_BUILD_TARGET", target);
     }
 
+    let session = if cache_enabled {
+        Some(prepare_zccache_build(&mut command, &paths).await?)
+    } else {
+        None
+    };
+
     let status = command.status()?;
+    if let Some(session) = session {
+        finish_zccache_build(&session)?;
+    }
     Ok(status.code().unwrap_or(1))
 }
 
@@ -196,6 +215,18 @@ fn cargo_args_specify_target(args: &[String]) -> bool {
             return true;
         }
         if arg.starts_with("--target=") {
+            return true;
+        }
+    }
+    false
+}
+
+fn cargo_args_use_reserved_no_cache(args: &[String]) -> bool {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--no-cache" {
             return true;
         }
     }
@@ -243,9 +274,129 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
     }
 }
 
+struct ZccacheBuildSession {
+    binary_path: std::path::PathBuf,
+    session_id: String,
+}
+
+async fn prepare_zccache_build(
+    cargo: &mut std::process::Command,
+    paths: &SoldrPaths,
+) -> Result<ZccacheBuildSession, SoldrError> {
+    let fetch = soldr_fetch::fetch_zccache_with_paths(paths).await?;
+    let zccache_dir = soldr_cache::zccache_dir(paths);
+    std::fs::create_dir_all(&zccache_dir)?;
+    std::fs::create_dir_all(zccache_dir.join("logs"))?;
+    if fetch.cached {
+        eprintln!(
+            "soldr: using managed zccache {}",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    } else {
+        eprintln!(
+            "soldr: fetched managed zccache {}",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    }
+
+    run_zccache_command(&fetch.binary_path, &["start"])?;
+
+    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    let journal_path = journal_path.display().to_string();
+    let session_json = run_zccache_command(
+        &fetch.binary_path,
+        &["session-start", "--stats", "--journal", &journal_path],
+    )?;
+    let session_id =
+        soldr_cache::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
+            SoldrError::Other(format!(
+                "failed to parse zccache session id from output: {}",
+                session_json.stdout.trim()
+            ))
+        })?;
+
+    cargo.env("RUSTC_WRAPPER", &fetch.binary_path);
+    cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
+
+    Ok(ZccacheBuildSession {
+        binary_path: fetch.binary_path,
+        session_id,
+    })
+}
+
+fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
+    let output = run_zccache_command(&session.binary_path, &["session-end", &session.session_id])?;
+    let stdout = output.stdout.trim();
+    if !stdout.is_empty() {
+        eprintln!("soldr: zccache session summary");
+        eprintln!("{stdout}");
+    }
+    Ok(())
+}
+
+fn clear_zccache_cache() -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    if let Some(fetch) = soldr_fetch::cached_zccache_binary(&paths)? {
+        let _ = run_zccache_command(&fetch.binary_path, &["clear"])?;
+        println!("cleared zccache cache");
+    } else {
+        println!(
+            "managed zccache {} not fetched yet",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    }
+    Ok(())
+}
+
+fn print_zccache_status(paths: &SoldrPaths) -> Result<(), SoldrError> {
+    match soldr_fetch::cached_zccache_binary(paths)? {
+        Some(fetch) => {
+            println!("zccache binary: {}", fetch.binary_path.display());
+            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
+            let stdout = output.stdout.trim();
+            if stdout.is_empty() {
+                println!("zccache status: no output");
+            } else {
+                for line in stdout.lines() {
+                    println!("zccache: {line}");
+                }
+            }
+        }
+        None => {
+            println!(
+                "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
+                soldr_fetch::MANAGED_ZCCACHE_VERSION
+            );
+        }
+    }
+    Ok(())
+}
+
+struct CommandOutput {
+    stdout: String,
+}
+
+fn run_zccache_command(
+    binary: &std::path::Path,
+    args: &[&str],
+) -> Result<CommandOutput, SoldrError> {
+    let output = std::process::Command::new(binary).args(args).output()?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(format!(
+            "zccache {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    Ok(CommandOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{cargo_args_specify_target, parse_tool_spec};
+    use super::{cargo_args_specify_target, cargo_args_use_reserved_no_cache, parse_tool_spec};
     use soldr_fetch::VersionSpec;
 
     #[test]
@@ -268,6 +419,19 @@ mod tests {
             "--".into(),
             "--target".into(),
             "ignored".into(),
+        ]));
+    }
+
+    #[test]
+    fn cargo_args_reject_reserved_no_cache_before_passthrough_separator() {
+        assert!(cargo_args_use_reserved_no_cache(&[
+            "build".into(),
+            "--no-cache".into(),
+        ]));
+        assert!(!cargo_args_use_reserved_no_cache(&[
+            "test".into(),
+            "--".into(),
+            "--no-cache".into(),
         ]));
     }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-#[cfg(windows)]
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -13,6 +12,16 @@ fn rustup_which(tool: &str) -> String {
         .expect("failed to resolve tool with rustup");
     assert!(output.status.success(), "rustup which failed for {tool}");
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
+    fs::create_dir_all(&dir).expect("failed to create temp dir");
+    dir
 }
 
 #[test]
@@ -51,8 +60,10 @@ fn help_lists_phase_one_command_surface() {
 
 #[test]
 fn cargo_front_door_runs_real_cargo() {
+    let cache_root = unique_temp_dir("cargo-version");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "--version"])
+        .args(["--no-cache", "cargo", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr cargo --version");
 
@@ -72,8 +83,10 @@ fn cargo_front_door_runs_real_cargo() {
 
 #[test]
 fn cargo_front_door_consumes_no_cache_flag() {
+    let cache_root = unique_temp_dir("cargo-no-cache");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["--no-cache", "cargo", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr --no-cache cargo --version");
 
@@ -98,8 +111,10 @@ fn cargo_front_door_consumes_no_cache_flag() {
 
 #[test]
 fn cargo_subcommand_rejects_no_cache_flag() {
+    let cache_root = unique_temp_dir("cargo-subcommand-no-cache");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["cargo", "--no-cache", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr cargo --no-cache --version");
 
@@ -135,8 +150,10 @@ fn rustc_wrapper_mode_passes_through_to_rustc() {
 
 #[test]
 fn status_reports_cache_control_defaults() {
+    let cache_root = unique_temp_dir("status");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .arg("status")
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr status");
 
@@ -151,17 +168,14 @@ fn status_reports_cache_control_defaults() {
         stdout.contains("cache default: enabled"),
         "status missing cache default: {stdout}"
     );
-}
-
-#[cfg(windows)]
-fn unique_temp_dir(label: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("time went backwards")
-        .as_nanos();
-    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
-    fs::create_dir_all(&dir).expect("failed to create temp dir");
-    dir
+    assert!(
+        stdout.contains("zccache version:"),
+        "status missing zccache version: {stdout}"
+    );
+    assert!(
+        stdout.contains("not fetched yet"),
+        "status should explain unfetched managed zccache state: {stdout}"
+    );
 }
 
 #[cfg(windows)]
@@ -193,10 +207,11 @@ fn cargo_front_door_forces_msvc_target_even_with_polluted_path() {
         .join("fixtures")
         .join("windows-msvc-default");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "build"])
+        .args(["--no-cache", "cargo", "build"])
         .current_dir(&fixture)
         .env("PATH", prepend_to_path(&fake_tools))
         .env("CARGO_TARGET_DIR", &target_dir)
+        .env("SOLDR_CACHE_DIR", unique_temp_dir("msvc-cache-root"))
         .output()
         .expect("failed to run soldr cargo build");
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,9 +1,11 @@
 use std::process::Command;
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
 };
+#[cfg(windows)]
+use std::path::Path;
 
 fn rustup_which(tool: &str) -> String {
     let output = Command::new("rustup")

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,11 +1,11 @@
+#[cfg(windows)]
+use std::path::Path;
 use std::process::Command;
 use std::{
     fs,
     path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
 };
-#[cfg(windows)]
-use std::path::Path;
 
 fn rustup_which(tool: &str) -> String {
     let output = Command::new("rustup")

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -1,5 +1,8 @@
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 use thiserror::Error;
 
 // ---------------------------------------------------------------------------
@@ -304,6 +307,8 @@ fn compile_time_fallback_triple() -> Result<String, SoldrError> {
 // Paths - ~/.soldr/ layout
 // ---------------------------------------------------------------------------
 
+pub const SOLDR_CACHE_DIR_ENV_VAR: &str = "SOLDR_CACHE_DIR";
+
 pub struct SoldrPaths {
     pub root: PathBuf,
     pub bin: PathBuf,
@@ -313,7 +318,8 @@ pub struct SoldrPaths {
 
 impl SoldrPaths {
     pub fn new() -> Result<Self, SoldrError> {
-        let root = home_dir()?.join(".soldr");
+        let root = soldr_root_from_env_var(std::env::var_os(SOLDR_CACHE_DIR_ENV_VAR).as_deref())
+            .unwrap_or_else(|| home_dir().map(|home| home.join(".soldr")))?;
         Ok(Self::with_root(root))
     }
 
@@ -331,6 +337,14 @@ impl SoldrPaths {
         std::fs::create_dir_all(&self.cache)?;
         Ok(())
     }
+}
+
+fn soldr_root_from_env_var(value: Option<&OsStr>) -> Option<Result<PathBuf, SoldrError>> {
+    let value = value?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(Ok(PathBuf::from(value)))
 }
 
 fn home_dir() -> Result<PathBuf, SoldrError> {
@@ -437,6 +451,19 @@ mod tests {
         assert!(paths.root.ends_with(".soldr"));
         assert!(paths.bin.ends_with("bin"));
         assert!(paths.cache.ends_with("cache"));
+    }
+
+    #[test]
+    fn soldr_root_override_uses_env_path() {
+        let root = soldr_root_from_env_var(Some(OsStr::new("C:\\temp\\soldr-cache-root")))
+            .unwrap()
+            .unwrap();
+        assert_eq!(root, PathBuf::from("C:\\temp\\soldr-cache-root"));
+    }
+
+    #[test]
+    fn soldr_root_override_ignores_empty_env() {
+        assert!(soldr_root_from_env_var(Some(OsStr::new(""))).is_none());
     }
 
     #[test]

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -62,18 +62,36 @@ pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
 }
 
 pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
-    let repo = RepoInfo {
-        owner: "zackees".to_string(),
-        repo: "zccache".to_string(),
-    };
-    fetch_repo_binary_with_paths(
-        "zccache",
-        &["zccache", "zccache-daemon", "zccache-fp"],
-        &repo,
-        &VersionSpec::Exact(MANAGED_ZCCACHE_VERSION.into()),
+    paths.ensure_dirs()?;
+    let target = TargetTriple::detect()?;
+    let binary_names = ["zccache", "zccache-daemon", "zccache-fp"];
+
+    if let Some(result) = check_cache(
         paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &binary_names,
+        &target,
+    )? {
+        return Ok(result);
+    }
+
+    let download_url = managed_zccache_download_url(MANAGED_ZCCACHE_VERSION, &target);
+    let binary_path = download_and_extract(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &download_url,
+        &target,
+        &binary_names,
     )
-    .await
+    .await?;
+
+    Ok(FetchResult {
+        binary_path,
+        version: MANAGED_ZCCACHE_VERSION.to_string(),
+        cached: false,
+    })
 }
 
 pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, SoldrError> {
@@ -108,7 +126,7 @@ async fn fetch_repo_binary_with_paths(
         }
     }
 
-    let release = fetch_release(&repo, version).await?;
+    let release = fetch_release(repo, version).await?;
 
     if let Some(r) = check_cache(paths, cache_name, &release.version, binary_names, &target)? {
         return Ok(r);
@@ -371,6 +389,13 @@ fn release_tag_candidates(version: &str) -> Vec<String> {
     tags.sort();
     tags.dedup();
     tags
+}
+
+fn managed_zccache_download_url(version: &str, target: &TargetTriple) -> String {
+    format!(
+        "https://github.com/zackees/zccache/releases/download/{version}/zccache-{version}-{}.tar.gz",
+        target.triple()
+    )
 }
 
 fn parse_release_info(body: serde_json::Value) -> Result<ReleaseInfo, SoldrError> {
@@ -714,6 +739,19 @@ mod tests {
         assert_eq!(
             release_tag_candidates("v1.2.8"),
             vec!["1.2.8".to_string(), "v1.2.8".to_string()]
+        );
+    }
+
+    #[test]
+    fn managed_zccache_download_url_uses_target_triple() {
+        let target = TargetTriple {
+            arch: Arch::Aarch64,
+            os: Os::MacOs,
+            env: Env::None,
+        };
+        assert_eq!(
+            managed_zccache_download_url("1.2.8", &target),
+            "https://github.com/zackees/zccache/releases/download/1.2.8/zccache-1.2.8-aarch64-apple-darwin.tar.gz"
         );
     }
 }

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -34,6 +34,8 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.8";
+
 /// Fetch a tool binary for the current platform.
 pub async fn fetch_tool(
     crate_name: &str,
@@ -50,36 +52,77 @@ pub async fn fetch_tool_with_paths(
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
-    let target = TargetTriple::detect()?;
+    let repo = resolve_repo(crate_name).await?;
+    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, paths).await
+}
 
-    // 1. Check local cache (exact version only)
+pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    fetch_zccache_with_paths(&paths).await
+}
+
+pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
+    let repo = RepoInfo {
+        owner: "zackees".to_string(),
+        repo: "zccache".to_string(),
+    };
+    fetch_repo_binary_with_paths(
+        "zccache",
+        &["zccache", "zccache-daemon", "zccache-fp"],
+        &repo,
+        &VersionSpec::Exact(MANAGED_ZCCACHE_VERSION.into()),
+        paths,
+    )
+    .await
+}
+
+pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, SoldrError> {
+    let target = TargetTriple::detect()?;
+    check_cache(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &["zccache", "zccache-daemon", "zccache-fp"],
+        &target,
+    )
+}
+
+async fn fetch_repo_binary_with_paths(
+    cache_name: &str,
+    binary_names: &[&str],
+    repo: &RepoInfo,
+    version: &VersionSpec,
+    paths: &SoldrPaths,
+) -> Result<FetchResult, SoldrError> {
+    paths.ensure_dirs()?;
+    let target = TargetTriple::detect()?;
+    if binary_names.is_empty() {
+        return Err(SoldrError::Other(format!(
+            "no binary names configured for {cache_name}"
+        )));
+    }
+
     if let VersionSpec::Exact(ref v) = version {
-        if let Some(r) = check_cache(paths, crate_name, v, &target)? {
+        if let Some(r) = check_cache(paths, cache_name, v, binary_names, &target)? {
             return Ok(r);
         }
     }
 
-    // 2. Resolve repository from crates.io
-    let repo = resolve_repo(crate_name).await?;
-
-    // 3. Get release metadata from GitHub
     let release = fetch_release(&repo, version).await?;
 
-    // 4. Check cache for the resolved version (handles Latest -> concrete version)
-    if let Some(r) = check_cache(paths, crate_name, &release.version, &target)? {
+    if let Some(r) = check_cache(paths, cache_name, &release.version, binary_names, &target)? {
         return Ok(r);
     }
 
-    // 5. Find matching asset for our target
     let asset = match_asset(&release.assets, &target)?;
 
-    // 6. Download and extract
     let binary_path = download_and_extract(
         paths,
-        crate_name,
+        cache_name,
         &release.version,
         &asset.download_url,
         &target,
+        binary_names,
     )
     .await?;
 
@@ -96,15 +139,28 @@ pub async fn fetch_tool_with_paths(
 
 fn check_cache(
     paths: &SoldrPaths,
-    crate_name: &str,
+    cache_name: &str,
     version: &str,
+    binary_names: &[&str],
     target: &TargetTriple,
 ) -> Result<Option<FetchResult>, SoldrError> {
-    let bin_name = format!("{crate_name}{}", target.binary_ext());
-    let tool_dir = paths.bin.join(format!("{crate_name}-{version}"));
+    let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
+    let bin_name = format!(
+        "{}{}",
+        binary_names
+            .first()
+            .ok_or_else(|| SoldrError::Other(format!(
+                "no binary names configured for {cache_name}"
+            )))?,
+        target.binary_ext()
+    );
     let binary_path = tool_dir.join(&bin_name);
 
-    if binary_path.exists() {
+    if binary_names.iter().all(|binary_name| {
+        tool_dir
+            .join(format!("{binary_name}{}", target.binary_ext()))
+            .exists()
+    }) {
         Ok(Some(FetchResult {
             binary_path,
             version: version.to_string(),
@@ -204,21 +260,25 @@ async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<Release
             fetch_release_value(&client, repo, &url).await?
         }
         VersionSpec::Exact(v) => {
-            let tag = if v.starts_with('v') {
-                v.clone()
-            } else {
-                format!("v{v}")
-            };
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/releases/tags/{tag}",
-                repo.owner, repo.repo
-            );
-            match fetch_release_value(&client, repo, &url).await {
-                Ok(release) => release,
-                Err(SoldrError::ToolNotFound(_)) => {
-                    fetch_release_by_listing(&client, repo, &tag).await?
+            let candidate_tags = release_tag_candidates(v);
+            let mut found = None;
+            for tag in &candidate_tags {
+                let url = format!(
+                    "https://api.github.com/repos/{}/{}/releases/tags/{tag}",
+                    repo.owner, repo.repo
+                );
+                match fetch_release_value(&client, repo, &url).await {
+                    Ok(release) => {
+                        found = Some(release);
+                        break;
+                    }
+                    Err(SoldrError::ToolNotFound(_)) => continue,
+                    Err(err) => return Err(err),
                 }
-                Err(err) => return Err(err),
+            }
+            match found {
+                Some(release) => release,
+                None => fetch_release_by_listing(&client, repo, &candidate_tags).await?,
             }
         }
     };
@@ -253,7 +313,7 @@ async fn fetch_release_value(
 async fn fetch_release_by_listing(
     client: &reqwest::Client,
     repo: &RepoInfo,
-    tag: &str,
+    tags: &[String],
 ) -> Result<serde_json::Value, SoldrError> {
     let url = format!(
         "https://api.github.com/repos/{}/{}/releases?per_page=30",
@@ -283,7 +343,7 @@ async fn fetch_release_by_listing(
             items.iter().find(|release| {
                 release["tag_name"]
                     .as_str()
-                    .map(|release_tag| release_tag == tag)
+                    .map(|release_tag| tags.iter().any(|tag| release_tag == tag))
                     .unwrap_or(false)
             })
         })
@@ -292,6 +352,25 @@ async fn fetch_release_by_listing(
     matched.ok_or_else(|| {
         SoldrError::ToolNotFound(format!("no release found for {}/{}", repo.owner, repo.repo))
     })
+}
+
+fn release_tag_candidates(version: &str) -> Vec<String> {
+    let mut tags = Vec::with_capacity(2);
+    let raw = version.trim();
+    if raw.is_empty() {
+        return tags;
+    }
+    tags.push(raw.to_string());
+    if let Some(stripped) = raw.strip_prefix('v') {
+        if !stripped.is_empty() {
+            tags.push(stripped.to_string());
+        }
+    } else {
+        tags.push(format!("v{raw}"));
+    }
+    tags.sort();
+    tags.dedup();
+    tags
 }
 
 fn parse_release_info(body: serde_json::Value) -> Result<ReleaseInfo, SoldrError> {
@@ -411,10 +490,11 @@ fn match_asset<'a>(
 
 async fn download_and_extract(
     paths: &SoldrPaths,
-    crate_name: &str,
+    cache_name: &str,
     version: &str,
     url: &str,
     target: &TargetTriple,
+    binary_names: &[&str],
 ) -> Result<PathBuf, SoldrError> {
     let client = http_client()?;
 
@@ -436,18 +516,27 @@ async fn download_and_extract(
         .await
         .map_err(|e| SoldrError::Network(e.to_string()))?;
 
-    let tool_dir = paths.bin.join(format!("{crate_name}-{version}"));
+    let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
+    let desired_binaries = desired_binary_names(binary_names, target);
     std::fs::create_dir_all(&tool_dir)?;
 
-    let bin_name = format!("{crate_name}{}", target.binary_ext());
-    let binary_path = tool_dir.join(&bin_name);
+    let main_binary_name = desired_binaries
+        .first()
+        .cloned()
+        .ok_or_else(|| SoldrError::Other(format!("no binary names configured for {cache_name}")))?;
+    let binary_path = tool_dir.join(&main_binary_name);
 
     if url.ends_with(".zip") {
-        extract_zip(&bytes, &binary_path, &bin_name)?;
+        extract_zip(&bytes, &tool_dir, &desired_binaries)?;
     } else if url.ends_with(".tar.gz") || url.ends_with(".tgz") {
-        extract_tar_gz(&bytes, &binary_path, &bin_name)?;
+        extract_tar_gz(&bytes, &tool_dir, &desired_binaries)?;
     } else {
         // Assume raw binary.
+        if desired_binaries.len() != 1 {
+            return Err(SoldrError::Archive(format!(
+                "cannot extract multiple binaries from raw asset for {cache_name}"
+            )));
+        }
         std::fs::write(&binary_path, &bytes)?;
     }
 
@@ -455,18 +544,29 @@ async fn download_and_extract(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&binary_path)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&binary_path, perms)?;
+        for binary_name in &desired_binaries {
+            let binary_path = tool_dir.join(binary_name);
+            let mut perms = std::fs::metadata(&binary_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&binary_path, perms)?;
+        }
     }
 
     Ok(binary_path)
 }
 
-fn extract_zip(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrError> {
+fn desired_binary_names(binary_names: &[&str], target: &TargetTriple) -> Vec<String> {
+    binary_names
+        .iter()
+        .map(|binary_name| format!("{binary_name}{}", target.binary_ext()))
+        .collect()
+}
+
+fn extract_zip(data: &[u8], dest_dir: &Path, binary_names: &[String]) -> Result<(), SoldrError> {
     let reader = std::io::Cursor::new(data);
     let mut archive =
         zip::ZipArchive::new(reader).map_err(|e| SoldrError::Archive(e.to_string()))?;
+    let mut found = std::collections::BTreeSet::new();
 
     for i in 0..archive.len() {
         let mut file = archive
@@ -482,23 +582,25 @@ fn extract_zip(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrErro
             .and_then(|f| f.to_str())
             .unwrap_or("");
 
-        if file_name == bin_name || file_name == bin_name.trim_end_matches(".exe") {
-            let mut out = std::fs::File::create(dest)?;
+        let wanted = binary_names.iter().find(|binary_name| {
+            file_name == *binary_name || file_name == binary_name.trim_end_matches(".exe")
+        });
+
+        if let Some(binary_name) = wanted {
+            let mut out = std::fs::File::create(dest_dir.join(binary_name))?;
             std::io::copy(&mut file, &mut out)?;
-            return Ok(());
+            found.insert(binary_name.clone());
         }
     }
 
-    Err(SoldrError::Archive(format!(
-        "{bin_name} not found in zip archive"
-    )))
+    ensure_all_binaries_found(binary_names, &found)
 }
 
-fn extract_tar_gz(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrError> {
+fn extract_tar_gz(data: &[u8], dest_dir: &Path, binary_names: &[String]) -> Result<(), SoldrError> {
     let reader = std::io::Cursor::new(data);
     let gz = flate2::read::GzDecoder::new(reader);
     let mut archive = tar::Archive::new(gz);
-    let base_name = bin_name.trim_end_matches(".exe");
+    let mut found = std::collections::BTreeSet::new();
 
     for entry in archive
         .entries()
@@ -511,16 +613,37 @@ fn extract_tar_gz(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrE
 
         let file_name = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
 
-        if file_name == bin_name || file_name == base_name {
-            let mut out = std::fs::File::create(dest)?;
+        let wanted = binary_names.iter().find(|binary_name| {
+            file_name == *binary_name || file_name == binary_name.trim_end_matches(".exe")
+        });
+
+        if let Some(binary_name) = wanted {
+            let mut out = std::fs::File::create(dest_dir.join(binary_name))?;
             std::io::copy(&mut entry, &mut out)?;
-            return Ok(());
+            found.insert(binary_name.clone());
         }
     }
 
-    Err(SoldrError::Archive(format!(
-        "{bin_name} not found in tar.gz archive"
-    )))
+    ensure_all_binaries_found(binary_names, &found)
+}
+
+fn ensure_all_binaries_found(
+    binary_names: &[String],
+    found: &std::collections::BTreeSet<String>,
+) -> Result<(), SoldrError> {
+    let missing = binary_names
+        .iter()
+        .filter(|binary_name| !found.contains(*binary_name))
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(SoldrError::Archive(format!(
+            "missing binaries in archive: {}",
+            missing.join(", ")
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -580,5 +703,17 @@ mod tests {
 
         let selected = match_asset(&assets, &target).unwrap();
         assert_eq!(selected.name, "tool-x86_64-unknown-linux-musl.tar.gz");
+    }
+
+    #[test]
+    fn release_tag_candidates_support_plain_and_v_prefixed_tags() {
+        assert_eq!(
+            release_tag_candidates("1.2.8"),
+            vec!["1.2.8".to_string(), "v1.2.8".to_string()]
+        );
+        assert_eq!(
+            release_tag_candidates("v1.2.8"),
+            vec!["1.2.8".to_string(), "v1.2.8".to_string()]
+        );
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,11 +7,11 @@ soldr is a single front door for Rust tool execution and Rust builds.
 It has three invocation modes:
 
 1. `soldr cargo ...`
-   Delegates to the real Cargo binary while wiring soldr into the build path.
+   Delegates to the real Cargo binary while wiring soldr-managed zccache into the build path.
 2. `soldr <tool> [args...]`
    Fetches and runs a Rust CLI tool binary.
 3. `soldr rustc ...`
-   Internal wrapper mode used during builds after `soldr cargo ...` sets `RUSTC_WRAPPER=soldr`.
+   Low-level passthrough wrapper mode for explicit `RUSTC_WRAPPER=soldr` usage.
 
 The primary user experience is `soldr cargo ...`.
 
@@ -32,15 +32,18 @@ Behavior:
 
 - Resolve the real `cargo` binary through `rustup`
 - Resolve the matching real `rustc` binary through `rustup`
-- Set `RUSTC_WRAPPER` to the current `soldr` executable
-- Enable the soldr compilation-cache path by default
+- Fetch a pinned managed `zccache` release when caching is enabled
+- Set `RUSTC_WRAPPER` to the managed `zccache` binary
+- Start a per-build zccache session on zccache's current default daemon endpoint
 - Delegate to Cargo with the exact flags the user passed
 
 Current cache-control behavior:
 
 - caching is enabled by default for `soldr cargo ...`
 - `soldr --no-cache cargo ...` disables soldr's compilation-cache path for that invocation
-- wrapper mode still falls through to real `rustc` while artifact caching is implemented in follow-up work
+- `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
+- zccache integration currently targets Rust builds through the cargo front door
+- zccache's current artifact store and daemon endpoint remain on zccache's default paths; soldr currently manages the session lifecycle and logs
 
 This is the normal build entry point.
 
@@ -84,7 +87,7 @@ In this mode, soldr should act as the transparent build-assistance layer around 
 Current implementation status:
 
 - Wrapper-mode passthrough to real `rustc` exists
-- Cache and daemon behavior are still being implemented
+- The normal cache-enabled build path uses managed `zccache` instead of soldr wrapper mode
 
 ---
 
@@ -118,7 +121,7 @@ Show cache and target information.
 
 ### `soldr clean`
 
-Clear caches.
+Clear the managed local zccache artifact cache.
 
 ### `soldr config`
 
@@ -126,7 +129,7 @@ Show or set configuration.
 
 ### `soldr cache`
 
-Inspect build-cache state.
+Inspect managed zccache status.
 
 ### `soldr version`
 
@@ -159,10 +162,11 @@ Commands:
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
 | `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
+| `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 
-`RUSTC_WRAPPER=soldr cargo build` remains a valid low-level integration path, but it is no longer the preferred user-facing workflow.
+`RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 
 ---
 
@@ -200,5 +204,5 @@ For bootstrap verification of another Rust project:
 The key design rule is simple:
 
 - users build through `soldr cargo ...`
-- soldr uses wrapper mode internally
+- soldr uses managed zccache internally for cache-enabled Rust builds
 - users do not need to manually wire `RUSTC_WRAPPER` for the common path


### PR DESCRIPTION
## Summary
- fetch and manage a pinned zccache release for cache-enabled soldr cargo ... builds
- use zccache sessions for the cargo front door, wire real status/clean behavior, and reject misplaced --no-cache
- fix exact-version GitHub release fetches for non-v tags and extract zccache companion binaries

## Verification
- cargo test --workspace --locked
- cargo build -p soldr-cli
- manual build through target/debug/soldr.exe against crates/soldr-cli/tests/fixtures/windows-msvc-default

Closes #33