### PR TITLE
Ignore README-only changes in GitHub Actions triggers

### DIFF
--- a/.github/workflows/build-linux-arm64-musl.yml
+++ b/.github/workflows/build-linux-arm64-musl.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-linux-x64-musl.yml
+++ b/.github/workflows/build-linux-x64-musl.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-linux-x64.yml
+++ b/.github/workflows/build-linux-x64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add \README.md\ to \paths-ignore\ for \push\ and \pull_request\ in \ci.yml\
- add the same exclusion to each platform-specific \uild-*.yml\ workflow
- keep \workflow_dispatch\ unchanged so manual runs still work

## Testing
- verified the workflow diffs locally
- did not execute GitHub Actions runs