### PR TITLE
Bring managed zccache cache flow to main

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -90,15 +90,16 @@ For `soldr cargo ...`:
 
 1. Resolve real `cargo` via `rustup`
 2. Resolve matching real `rustc` via `rustup`
-3. Set `RUSTC_WRAPPER=soldr`
-4. Delegate to Cargo with unchanged user flags
+3. Set `RUSTC_WRAPPER` to the current soldr binary
+4. Start managed zccache and pass its binary/session state through the environment
+5. Delegate to Cargo with unchanged user flags
 
 For wrapper mode:
 
 1. Detect `rustc` invocation shape
 2. Resolve the real `rustc`
-3. Perform cache logic when implemented
-4. Fall through to the real compiler
+3. Delegate cache-enabled builds into the managed zccache binary
+4. Fall through to the real compiler when caching is disabled or unavailable
 
 ---
 
@@ -174,9 +175,10 @@ all resolve quickly from cache or pre-built binaries.
 
 Done when:
 
-- wrapper mode hashes compiler inputs
-- cache hits avoid recompilation
-- daemon behavior is stable across platforms
+- `soldr cargo ...` enables managed zccache by default
+- `soldr --no-cache cargo ...` cleanly bypasses the cache path
+- wrapper mode routes cache-enabled builds into managed zccache instead of pure pass-through
+- cache commands report and manage real zccache state
 
 ### Phase 4: Bootstrap Validation
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ soldr aims for the same outcome in the Rust toolchain world.
 
 Current release line:
 
-- `0.5.x` is the secure front-door and tool-fetch release line
-- `1.0.0-rc` remains reserved for the point where the built-in zccache integration and cache command surface are fully rounded out
+- `0.5.x` is the secure front-door, tool-fetch, and built-in zccache-backed cache release line
+- `1.0.0-rc` remains reserved for broader release hardening and bootstrap validation
+
 ## Why soldr exists
 
 On Windows, the real problem is not "how do I cache builds?" or "how do I download a tool binary?" in isolation.
@@ -66,7 +67,8 @@ soldr rustfmt src/main.rs
 soldr cargo build --release
   +-- resolve the real cargo binary
   +-- fetch/start managed zccache when cache is enabled
-  +-- set zccache as the compiler wrapper for this build
+  +-- set soldr as the compiler wrapper for this build
+  +-- have soldr wrapper mode delegate to managed zccache
   +-- delegate to cargo with your existing flags
 
 soldr maturin build --release
@@ -79,6 +81,7 @@ soldr maturin build --release
 - **One obvious command**: Fetch tools, pick the right Windows target, and run through managed zccache through the same entry point.
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
 - **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
+- **Real cache controls**: `soldr status`, `soldr cache`, and `soldr clean` report and manage the soldr-managed zccache state instead of placeholder behavior.
 - **One cache boundary, eventually**: soldr keeps its own tools and zccache session state in `~/.soldr/`. Current zccache artifacts still live in zccache's default cache root until upstream exposes a supported cache-dir override.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
@@ -94,7 +97,7 @@ soldr/
 |   |-- soldr-fetch/     # Binary resolution + download (the crgx half)
 |   |-- soldr-cache/     # Compilation caching (the zccache half)
 |   `-- soldr-cli/       # CLI entry point + daemon
-|-- src/soldr/           # Python package (PyO3 bindings)
+|-- src/soldr/           # Python package (maturin bin bindings)
 `-- tests/
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ That is the same reason [uv](https://github.com/astral-sh/uv) is compelling. uv 
 
 soldr aims for the same outcome in the Rust toolchain world.
 
+Current release line:
+
+- `0.5.x` is the secure front-door and tool-fetch release line
+- `1.0.0-rc` remains reserved for the point where the built-in zccache integration and cache command surface are fully rounded out
 ## Why soldr exists
 
 On Windows, the real problem is not "how do I cache builds?" or "how do I download a tool binary?" in isolation.
@@ -36,13 +40,13 @@ When you run `soldr`, the tool should do the obvious thing:
 - pick MSVC on Windows by default
 - fetch the tool you asked for
 - cache it locally
-- carry `zccache` along for transparent `rustc` caching without manual wrapper setup
+- fetch and manage zccache so Rust builds get transparent caching without manual wrapper setup
 
 If soldr solves that one problem well, it becomes a super tool: the command you reach for first, because it makes the rest of the stack behave.
 
 - **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse.
 
-- **Compilation caching** (the zccache half): When your build invokes `rustc` hundreds of times, soldr caches every compilation unit. Second builds finish in milliseconds, not minutes.
+- **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring; zccache's artifact store still uses its current default cache root.
 
 ```bash
 # Build through soldr's front door:
@@ -61,7 +65,8 @@ soldr rustfmt src/main.rs
 ```text
 soldr cargo build --release
   +-- resolve the real cargo binary
-  +-- wire soldr's wrapper path internally
+  +-- fetch/start managed zccache when cache is enabled
+  +-- set zccache as the compiler wrapper for this build
   +-- delegate to cargo with your existing flags
 
 soldr maturin build --release
@@ -71,10 +76,10 @@ soldr maturin build --release
 
 ## Design goals
 
-- **One obvious command**: Fetch tools, pick the right Windows target, and enable build caching through the same entry point.
+- **One obvious command**: Fetch tools, pick the right Windows target, and run through managed zccache through the same entry point.
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
-- **Invisible caching**: soldr wires its build-assistance internals for you. No manual `RUSTC_WRAPPER` setup in the common case.
-- **One cache**: Tools and compilation artifacts in a single `~/.soldr/` directory.
+- **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
+- **One cache boundary, eventually**: soldr keeps its own tools and zccache session state in `~/.soldr/`. Current zccache artifacts still live in zccache's default cache root until upstream exposes a supported cache-dir override.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
 - **Cross-platform**: Linux, macOS, Windows (x86_64 + aarch64).
@@ -97,8 +102,8 @@ soldr/
 |---|---|
 | `soldr-core` | Cache paths, config, version types |
 | `soldr-fetch` | Resolve crate binaries from binstall metadata, GitHub Releases, QuickInstall. Download, verify, cache. |
-| `soldr-cache` | Wrap rustc, hash inputs, store/retrieve compiled artifacts. The compilation cache daemon. |
-| `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`), tool fetch dispatch. |
+| `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
+| `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
 
 ## Prior art
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 # Build through soldr's front door:
 soldr cargo build --release
 soldr cargo test
+soldr cargo --no-cache test
 
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 # Build through soldr's front door:
 soldr cargo build --release
 soldr cargo test
-soldr cargo --no-cache test
+soldr --no-cache cargo test
 
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -23,6 +23,10 @@ pub const CACHE_DISABLED_VALUE: &str = "0";
 /// Per-build session identifier recognized by zccache.
 pub const ZCCACHE_SESSION_ID_ENV_VAR: &str = "ZCCACHE_SESSION_ID";
 
+/// Managed zccache binary path propagated from the soldr front door into
+/// wrapper-mode children.
+pub const ZCCACHE_BINARY_ENV_VAR: &str = "SOLDR_ZCCACHE_BIN";
+
 pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
     if enabled {
         CACHE_ENABLED_VALUE

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -1,13 +1,17 @@
-//! Compilation caching control plane.
+//! zccache integration surface for soldr.
 //!
-//! The actual artifact cache is not implemented yet, but this crate owns the
-//! cache policy surface so the CLI and wrapper agree on whether caching is
-//! enabled for a given invocation.
+//! soldr owns the build UX and cache policy, while zccache provides the actual
+//! compiler-cache engine and daemon.
 
-use std::ffi::OsStr;
+use serde::Deserialize;
+use soldr_core::SoldrPaths;
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 
 /// Environment variable used to carry cache enable/disable state from the
-/// front-door cargo command into wrapper mode.
+/// front-door cargo command into child processes.
 pub const CACHE_ENABLED_ENV_VAR: &str = "SOLDR_CACHE_ENABLED";
 
 /// Encoded environment value for an enabled cache invocation.
@@ -15,6 +19,9 @@ pub const CACHE_ENABLED_VALUE: &str = "1";
 
 /// Encoded environment value for a disabled cache invocation.
 pub const CACHE_DISABLED_VALUE: &str = "0";
+
+/// Per-build session identifier recognized by zccache.
+pub const ZCCACHE_SESSION_ID_ENV_VAR: &str = "ZCCACHE_SESSION_ID";
 
 pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
     if enabled {
@@ -38,13 +45,58 @@ pub fn cache_enabled_in_current_process() -> bool {
     cache_enabled_from_env_var(std::env::var_os(CACHE_ENABLED_ENV_VAR).as_deref())
 }
 
+pub fn zccache_dir(paths: &SoldrPaths) -> PathBuf {
+    paths.cache.join("zccache")
+}
+
+pub fn parse_zccache_session_id(stdout: &str) -> Option<String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(response) = serde_json::from_str::<SessionStartResponse>(trimmed) {
+        if !response.session_id.trim().is_empty() {
+            return Some(response.session_id);
+        }
+    }
+
+    for line in trimmed.lines() {
+        let line = line.trim();
+        for prefix in [
+            "ZCCACHE_SESSION_ID=",
+            "export ZCCACHE_SESSION_ID=",
+            "$env:ZCCACHE_SESSION_ID=",
+        ] {
+            if let Some(value) = line.strip_prefix(prefix) {
+                let value = value.trim().trim_matches('"').trim_matches('\'');
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+pub fn session_journal_path(zccache_dir: &Path) -> PathBuf {
+    zccache_dir.join("logs").join("last-session.jsonl")
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionStartResponse {
+    session_id: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_enabled_env_value, cache_enabled_from_env_var, CACHE_DISABLED_VALUE,
-        CACHE_ENABLED_VALUE,
+        cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id,
+        session_journal_path, zccache_dir, CACHE_DISABLED_VALUE, CACHE_ENABLED_VALUE,
     };
-    use std::ffi::OsStr;
+    use soldr_core::SoldrPaths;
+    use std::{ffi::OsStr, path::Path};
 
     #[test]
     fn cache_defaults_to_enabled_when_env_is_missing() {
@@ -75,5 +127,47 @@ mod tests {
     fn cache_control_serializes_boolean_state() {
         assert_eq!(cache_enabled_env_value(true), CACHE_ENABLED_VALUE);
         assert_eq!(cache_enabled_env_value(false), CACHE_DISABLED_VALUE);
+    }
+
+    #[test]
+    fn zccache_dir_lives_under_soldr_cache_root() {
+        let paths = SoldrPaths::with_root(Path::new("C:\\soldr-root").to_path_buf());
+        assert_eq!(
+            zccache_dir(&paths),
+            paths.root.join("cache").join("zccache")
+        );
+    }
+
+    #[test]
+    fn parses_json_session_start_output() {
+        let session_id = parse_zccache_session_id(
+            r#"{"session_id":"08f063c0-5f01-4c92-aec1-3f304d9224d0","started_at":1776141813}"#,
+        );
+        assert_eq!(
+            session_id.as_deref(),
+            Some("08f063c0-5f01-4c92-aec1-3f304d9224d0")
+        );
+    }
+
+    #[test]
+    fn parses_shell_style_session_start_output() {
+        let session_id = parse_zccache_session_id(
+            "export ZCCACHE_SESSION_ID=08f063c0-5f01-4c92-aec1-3f304d9224d0",
+        );
+        assert_eq!(
+            session_id.as_deref(),
+            Some("08f063c0-5f01-4c92-aec1-3f304d9224d0")
+        );
+    }
+
+    #[test]
+    fn session_journal_path_uses_logs_directory() {
+        let path = session_journal_path(Path::new("C:\\soldr-root\\cache\\zccache"));
+        assert_eq!(
+            path,
+            Path::new("C:\\soldr-root\\cache\\zccache")
+                .join("logs")
+                .join("last-session.jsonl")
+        );
     }
 }

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -1,4 +1,79 @@
-//! Compilation caching.
+//! Compilation caching control plane.
 //!
-//! Wraps rustc invocations, hashes inputs, and stores/retrieves
-//! compiled artifacts (.o, .rlib, .rmeta) for cache hits.
+//! The actual artifact cache is not implemented yet, but this crate owns the
+//! cache policy surface so the CLI and wrapper agree on whether caching is
+//! enabled for a given invocation.
+
+use std::ffi::OsStr;
+
+/// Environment variable used to carry cache enable/disable state from the
+/// front-door cargo command into wrapper mode.
+pub const CACHE_ENABLED_ENV_VAR: &str = "SOLDR_CACHE_ENABLED";
+
+/// Encoded environment value for an enabled cache invocation.
+pub const CACHE_ENABLED_VALUE: &str = "1";
+
+/// Encoded environment value for a disabled cache invocation.
+pub const CACHE_DISABLED_VALUE: &str = "0";
+
+pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
+    if enabled {
+        CACHE_ENABLED_VALUE
+    } else {
+        CACHE_DISABLED_VALUE
+    }
+}
+
+pub fn cache_enabled_from_env_var(value: Option<&OsStr>) -> bool {
+    match value.and_then(OsStr::to_str) {
+        None => true,
+        Some(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+    }
+}
+
+pub fn cache_enabled_in_current_process() -> bool {
+    cache_enabled_from_env_var(std::env::var_os(CACHE_ENABLED_ENV_VAR).as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cache_enabled_env_value, cache_enabled_from_env_var, CACHE_DISABLED_VALUE,
+        CACHE_ENABLED_VALUE,
+    };
+    use std::ffi::OsStr;
+
+    #[test]
+    fn cache_defaults_to_enabled_when_env_is_missing() {
+        assert!(cache_enabled_from_env_var(None));
+    }
+
+    #[test]
+    fn cache_control_parses_common_false_values() {
+        for value in ["0", "false", "FALSE", "no", "off", ""] {
+            assert!(
+                !cache_enabled_from_env_var(Some(OsStr::new(value))),
+                "expected {value:?} to disable cache"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_control_treats_other_values_as_enabled() {
+        for value in ["1", "true", "yes", "unexpected"] {
+            assert!(
+                cache_enabled_from_env_var(Some(OsStr::new(value))),
+                "expected {value:?} to enable cache"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_control_serializes_boolean_state() {
+        assert_eq!(cache_enabled_env_value(true), CACHE_ENABLED_VALUE);
+        assert_eq!(cache_enabled_env_value(false), CACHE_DISABLED_VALUE);
+    }
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -13,6 +13,9 @@ struct Cli {
 enum Commands {
     /// Run Cargo through soldr's front door
     Cargo {
+        /// Disable soldr's compilation cache for this invocation
+        #[arg(long)]
+        no_cache: bool,
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -50,14 +53,25 @@ async fn run() -> Result<(), SoldrError> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Cargo { args } => {
-            std::process::exit(run_cargo_front_door(&args)?);
+        Commands::Cargo { no_cache, args } => {
+            std::process::exit(run_cargo_front_door(&args, !no_cache)?);
         }
         Commands::Status => {
             println!("soldr {}", soldr_core::version());
             let target = soldr_core::TargetTriple::detect()?;
+            let paths = soldr_core::SoldrPaths::new()?;
             println!("target: {target}");
-            println!("(status not yet implemented)");
+            println!("cache dir: {}", paths.cache.display());
+            println!("cache default: enabled");
+            println!(
+                "cache mode: {}",
+                if soldr_cache::cache_enabled_in_current_process() {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            );
+            println!("build cache: control plane wired; artifact cache not yet implemented");
         }
         Commands::Clean => {
             println!("(clean not yet implemented)");
@@ -113,6 +127,12 @@ fn is_rustc_path(arg: &str) -> bool {
 }
 
 fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
+    if soldr_cache::cache_enabled_in_current_process() {
+        // The actual artifact cache will slot in here in a follow-up slice.
+        // For now, cache-enabled and cache-disabled wrapper mode both
+        // delegate to the real rustc without modifying outputs.
+    }
+
     let rustc = raw_args
         .get(1)
         .ok_or_else(|| SoldrError::Other("missing rustc path in wrapper mode".into()))?;
@@ -129,7 +149,7 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     Ok(status.code().unwrap_or(1))
 }
 
-fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
+fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {
     let cargo = resolve_toolchain_binary("cargo")?;
     let rustc = resolve_toolchain_binary("rustc")?;
     let current_exe = std::env::current_exe()?;
@@ -143,6 +163,10 @@ fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
     command.args(args);
     command.env("RUSTC_WRAPPER", current_exe);
     command.env("RUSTC", rustc);
+    command.env(
+        soldr_cache::CACHE_ENABLED_ENV_VAR,
+        soldr_cache::cache_enabled_env_value(cache_enabled),
+    );
     command.env(
         "PATH",
         prepend_path(&cargo_bin_dir, existing_path.as_deref())?,
@@ -224,7 +248,8 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
 
 #[cfg(test)]
 mod tests {
-    use super::cargo_args_specify_target;
+    use super::{cargo_args_specify_target, parse_tool_spec};
+    use soldr_fetch::VersionSpec;
 
     #[test]
     fn cargo_args_detect_explicit_target_flag() {
@@ -247,5 +272,12 @@ mod tests {
             "--target".into(),
             "ignored".into(),
         ]));
+    }
+
+    #[test]
+    fn parse_tool_spec_defaults_to_latest_version() {
+        let (tool, version) = parse_tool_spec("maturin");
+        assert_eq!(tool, "maturin");
+        assert!(matches!(version, VersionSpec::Latest));
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -5,6 +5,9 @@ use soldr_fetch::VersionSpec;
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
 struct Cli {
+    /// Disable soldr's compilation cache for this invocation
+    #[arg(long)]
+    no_cache: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -13,9 +16,6 @@ struct Cli {
 enum Commands {
     /// Run Cargo through soldr's front door
     Cargo {
-        /// Disable soldr's compilation cache for this invocation
-        #[arg(long)]
-        no_cache: bool,
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -51,10 +51,11 @@ async fn main() {
 
 async fn run() -> Result<(), SoldrError> {
     let cli = Cli::parse();
+    let cache_enabled = !cli.no_cache;
 
     match cli.command {
-        Commands::Cargo { no_cache, args } => {
-            std::process::exit(run_cargo_front_door(&args, !no_cache)?);
+        Commands::Cargo { args } => {
+            std::process::exit(run_cargo_front_door(&args, cache_enabled)?);
         }
         Commands::Status => {
             println!("soldr {}", soldr_core::version());
@@ -65,11 +66,7 @@ async fn run() -> Result<(), SoldrError> {
             println!("cache default: enabled");
             println!(
                 "cache mode: {}",
-                if soldr_cache::cache_enabled_in_current_process() {
-                    "enabled"
-                } else {
-                    "disabled"
-                }
+                if cache_enabled { "enabled" } else { "disabled" }
             );
             println!("build cache: control plane wired; artifact cache not yet implemented");
         }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use soldr_core::SoldrError;
+use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 
 #[derive(Parser)]
@@ -55,29 +55,33 @@ async fn run() -> Result<(), SoldrError> {
 
     match cli.command {
         Commands::Cargo { args } => {
-            std::process::exit(run_cargo_front_door(&args, cache_enabled)?);
+            std::process::exit(run_cargo_front_door(&args, cache_enabled).await?);
         }
         Commands::Status => {
             println!("soldr {}", soldr_core::version());
             let target = soldr_core::TargetTriple::detect()?;
             let paths = soldr_core::SoldrPaths::new()?;
+            let zccache_dir = soldr_cache::zccache_dir(&paths);
             println!("target: {target}");
+            println!("root dir: {}", paths.root.display());
             println!("cache dir: {}", paths.cache.display());
             println!("cache default: enabled");
             println!(
                 "cache mode: {}",
                 if cache_enabled { "enabled" } else { "disabled" }
             );
-            println!("build cache: control plane wired; artifact cache not yet implemented");
+            println!("zccache version: {}", soldr_fetch::MANAGED_ZCCACHE_VERSION);
+            println!("soldr zccache state dir: {}", zccache_dir.display());
+            print_zccache_status(&paths)?;
         }
         Commands::Clean => {
-            println!("(clean not yet implemented)");
+            clear_zccache_cache()?;
         }
         Commands::Config => {
             println!("(config not yet implemented)");
         }
         Commands::Cache => {
-            println!("(cache not yet implemented)");
+            print_zccache_status(&SoldrPaths::new()?)?;
         }
         Commands::Version => {
             println!("soldr {}", soldr_core::version());
@@ -146,19 +150,25 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     Ok(status.code().unwrap_or(1))
 }
 
-fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {
+async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {
+    if cargo_args_use_reserved_no_cache(args) {
+        return Err(SoldrError::Other(
+            "`--no-cache` must appear before `cargo`, as in `soldr --no-cache cargo build`".into(),
+        ));
+    }
+
     let cargo = resolve_toolchain_binary("cargo")?;
     let rustc = resolve_toolchain_binary("rustc")?;
-    let current_exe = std::env::current_exe()?;
     let cargo_bin_dir = cargo
         .parent()
         .ok_or_else(|| SoldrError::Other("failed to resolve cargo bin directory".into()))?
         .to_path_buf();
     let existing_path = std::env::var_os("PATH");
+    let paths = SoldrPaths::new()?;
+    paths.ensure_dirs()?;
 
     let mut command = std::process::Command::new(cargo);
     command.args(args);
-    command.env("RUSTC_WRAPPER", current_exe);
     command.env("RUSTC", rustc);
     command.env(
         soldr_cache::CACHE_ENABLED_ENV_VAR,
@@ -172,7 +182,16 @@ fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, Sol
         command.env("CARGO_BUILD_TARGET", target);
     }
 
+    let session = if cache_enabled {
+        Some(prepare_zccache_build(&mut command, &paths).await?)
+    } else {
+        None
+    };
+
     let status = command.status()?;
+    if let Some(session) = session {
+        finish_zccache_build(&session)?;
+    }
     Ok(status.code().unwrap_or(1))
 }
 
@@ -196,6 +215,18 @@ fn cargo_args_specify_target(args: &[String]) -> bool {
             return true;
         }
         if arg.starts_with("--target=") {
+            return true;
+        }
+    }
+    false
+}
+
+fn cargo_args_use_reserved_no_cache(args: &[String]) -> bool {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--no-cache" {
             return true;
         }
     }
@@ -243,9 +274,129 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
     }
 }
 
+struct ZccacheBuildSession {
+    binary_path: std::path::PathBuf,
+    session_id: String,
+}
+
+async fn prepare_zccache_build(
+    cargo: &mut std::process::Command,
+    paths: &SoldrPaths,
+) -> Result<ZccacheBuildSession, SoldrError> {
+    let fetch = soldr_fetch::fetch_zccache_with_paths(paths).await?;
+    let zccache_dir = soldr_cache::zccache_dir(paths);
+    std::fs::create_dir_all(&zccache_dir)?;
+    std::fs::create_dir_all(zccache_dir.join("logs"))?;
+    if fetch.cached {
+        eprintln!(
+            "soldr: using managed zccache {}",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    } else {
+        eprintln!(
+            "soldr: fetched managed zccache {}",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    }
+
+    run_zccache_command(&fetch.binary_path, &["start"])?;
+
+    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    let journal_path = journal_path.display().to_string();
+    let session_json = run_zccache_command(
+        &fetch.binary_path,
+        &["session-start", "--stats", "--journal", &journal_path],
+    )?;
+    let session_id =
+        soldr_cache::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
+            SoldrError::Other(format!(
+                "failed to parse zccache session id from output: {}",
+                session_json.stdout.trim()
+            ))
+        })?;
+
+    cargo.env("RUSTC_WRAPPER", &fetch.binary_path);
+    cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
+
+    Ok(ZccacheBuildSession {
+        binary_path: fetch.binary_path,
+        session_id,
+    })
+}
+
+fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
+    let output = run_zccache_command(&session.binary_path, &["session-end", &session.session_id])?;
+    let stdout = output.stdout.trim();
+    if !stdout.is_empty() {
+        eprintln!("soldr: zccache session summary");
+        eprintln!("{stdout}");
+    }
+    Ok(())
+}
+
+fn clear_zccache_cache() -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    if let Some(fetch) = soldr_fetch::cached_zccache_binary(&paths)? {
+        let _ = run_zccache_command(&fetch.binary_path, &["clear"])?;
+        println!("cleared zccache cache");
+    } else {
+        println!(
+            "managed zccache {} not fetched yet",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    }
+    Ok(())
+}
+
+fn print_zccache_status(paths: &SoldrPaths) -> Result<(), SoldrError> {
+    match soldr_fetch::cached_zccache_binary(paths)? {
+        Some(fetch) => {
+            println!("zccache binary: {}", fetch.binary_path.display());
+            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
+            let stdout = output.stdout.trim();
+            if stdout.is_empty() {
+                println!("zccache status: no output");
+            } else {
+                for line in stdout.lines() {
+                    println!("zccache: {line}");
+                }
+            }
+        }
+        None => {
+            println!(
+                "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
+                soldr_fetch::MANAGED_ZCCACHE_VERSION
+            );
+        }
+    }
+    Ok(())
+}
+
+struct CommandOutput {
+    stdout: String,
+}
+
+fn run_zccache_command(
+    binary: &std::path::Path,
+    args: &[&str],
+) -> Result<CommandOutput, SoldrError> {
+    let output = std::process::Command::new(binary).args(args).output()?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(format!(
+            "zccache {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    Ok(CommandOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{cargo_args_specify_target, parse_tool_spec};
+    use super::{cargo_args_specify_target, cargo_args_use_reserved_no_cache, parse_tool_spec};
     use soldr_fetch::VersionSpec;
 
     #[test]
@@ -268,6 +419,19 @@ mod tests {
             "--".into(),
             "--target".into(),
             "ignored".into(),
+        ]));
+    }
+
+    #[test]
+    fn cargo_args_reject_reserved_no_cache_before_passthrough_separator() {
+        assert!(cargo_args_use_reserved_no_cache(&[
+            "build".into(),
+            "--no-cache".into(),
+        ]));
+        assert!(!cargo_args_use_reserved_no_cache(&[
+            "test".into(),
+            "--".into(),
+            "--no-cache".into(),
         ]));
     }
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -2,6 +2,10 @@ use clap::{Parser, Subcommand};
 use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 
+const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
+const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
+const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
+
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
 struct Cli {
@@ -61,7 +65,6 @@ async fn run() -> Result<(), SoldrError> {
             println!("soldr {}", soldr_core::version());
             let target = soldr_core::TargetTriple::detect()?;
             let paths = soldr_core::SoldrPaths::new()?;
-            let zccache_dir = soldr_cache::zccache_dir(&paths);
             println!("target: {target}");
             println!("root dir: {}", paths.root.display());
             println!("cache dir: {}", paths.cache.display());
@@ -71,7 +74,6 @@ async fn run() -> Result<(), SoldrError> {
                 if cache_enabled { "enabled" } else { "disabled" }
             );
             println!("zccache version: {}", soldr_fetch::MANAGED_ZCCACHE_VERSION);
-            println!("soldr zccache state dir: {}", zccache_dir.display());
             print_zccache_status(&paths)?;
         }
         Commands::Clean => {
@@ -121,17 +123,21 @@ fn report_and_exit(error: SoldrError) -> i32 {
 }
 
 fn is_rustc_path(arg: &str) -> bool {
-    arg == "rustc"
-        || arg.ends_with("/rustc")
-        || arg.ends_with("\\rustc")
-        || arg.ends_with("rustc.exe")
+    if arg == "rustc" {
+        return true;
+    }
+
+    std::path::Path::new(arg)
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        == Some("rustc")
 }
 
 fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     if soldr_cache::cache_enabled_in_current_process() {
-        // The actual artifact cache will slot in here in a follow-up slice.
-        // For now, cache-enabled and cache-disabled wrapper mode both
-        // delegate to the real rustc without modifying outputs.
+        if let Some(zccache) = zccache_binary_override() {
+            return run_wrapper_through_zccache(raw_args, &zccache);
+        }
     }
 
     let rustc = raw_args
@@ -145,6 +151,17 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
 
     let status = std::process::Command::new(rustc)
         .args(&raw_args[2..])
+        .status()?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+fn run_wrapper_through_zccache(
+    raw_args: &[String],
+    zccache: &std::path::Path,
+) -> Result<i32, SoldrError> {
+    let status = std::process::Command::new(zccache)
+        .args(&raw_args[1..])
         .status()?;
 
     Ok(status.code().unwrap_or(1))
@@ -245,6 +262,10 @@ fn prepend_path(
 }
 
 fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError> {
+    if let Some(path) = toolchain_binary_override(tool) {
+        return Ok(path);
+    }
+
     let output = std::process::Command::new("rustup")
         .args(["which", tool])
         .output()?;
@@ -283,7 +304,7 @@ async fn prepare_zccache_build(
     cargo: &mut std::process::Command,
     paths: &SoldrPaths,
 ) -> Result<ZccacheBuildSession, SoldrError> {
-    let fetch = soldr_fetch::fetch_zccache_with_paths(paths).await?;
+    let fetch = fetch_managed_zccache(paths).await?;
     let zccache_dir = soldr_cache::zccache_dir(paths);
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
@@ -315,7 +336,8 @@ async fn prepare_zccache_build(
             ))
         })?;
 
-    cargo.env("RUSTC_WRAPPER", &fetch.binary_path);
+    cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
+    cargo.env(soldr_cache::ZCCACHE_BINARY_ENV_VAR, &fetch.binary_path);
     cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
 
     Ok(ZccacheBuildSession {
@@ -336,10 +358,20 @@ fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError>
 
 fn clear_zccache_cache() -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
-    if let Some(fetch) = soldr_fetch::cached_zccache_binary(&paths)? {
+    let zccache_dir = soldr_cache::zccache_dir(&paths);
+    let mut cleared_anything = false;
+
+    if let Some(fetch) = cached_managed_zccache(&paths)? {
         let _ = run_zccache_command(&fetch.binary_path, &["clear"])?;
-        println!("cleared zccache cache");
-    } else {
+        println!("cleared zccache artifact cache");
+        cleared_anything = true;
+    }
+    if zccache_dir.exists() {
+        std::fs::remove_dir_all(&zccache_dir)?;
+        println!("removed soldr zccache state dir: {}", zccache_dir.display());
+        cleared_anything = true;
+    }
+    if !cleared_anything {
         println!(
             "managed zccache {} not fetched yet",
             soldr_fetch::MANAGED_ZCCACHE_VERSION
@@ -349,7 +381,20 @@ fn clear_zccache_cache() -> Result<(), SoldrError> {
 }
 
 fn print_zccache_status(paths: &SoldrPaths) -> Result<(), SoldrError> {
-    match soldr_fetch::cached_zccache_binary(paths)? {
+    let zccache_dir = soldr_cache::zccache_dir(paths);
+    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    println!("soldr zccache state dir: {}", zccache_dir.display());
+    println!(
+        "last session journal: {} ({})",
+        journal_path.display(),
+        if journal_path.exists() {
+            "present"
+        } else {
+            "missing"
+        }
+    );
+
+    match cached_managed_zccache(paths)? {
         Some(fetch) => {
             println!("zccache binary: {}", fetch.binary_path.display());
             let output = run_zccache_command(&fetch.binary_path, &["status"])?;
@@ -392,6 +437,58 @@ fn run_zccache_command(
     Ok(CommandOutput {
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
     })
+}
+
+fn toolchain_binary_override(tool: &str) -> Option<std::path::PathBuf> {
+    let env_var = match tool {
+        "cargo" => TEST_CARGO_BIN_ENV_VAR,
+        "rustc" => TEST_RUSTC_BIN_ENV_VAR,
+        _ => return None,
+    };
+    non_empty_env_path(env_var)
+}
+
+fn zccache_binary_override() -> Option<std::path::PathBuf> {
+    non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR)
+        .or_else(|| non_empty_env_path(soldr_cache::ZCCACHE_BINARY_ENV_VAR))
+}
+
+fn non_empty_env_path(env_var: &str) -> Option<std::path::PathBuf> {
+    let value = std::env::var_os(env_var)?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.into())
+}
+
+fn current_soldr_binary() -> Result<std::path::PathBuf, SoldrError> {
+    std::env::current_exe().map_err(SoldrError::from)
+}
+
+async fn fetch_managed_zccache(paths: &SoldrPaths) -> Result<soldr_fetch::FetchResult, SoldrError> {
+    if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
+        return Ok(soldr_fetch::FetchResult {
+            binary_path,
+            version: soldr_fetch::MANAGED_ZCCACHE_VERSION.to_string(),
+            cached: true,
+        });
+    }
+
+    soldr_fetch::fetch_zccache_with_paths(paths).await
+}
+
+fn cached_managed_zccache(
+    paths: &SoldrPaths,
+) -> Result<Option<soldr_fetch::FetchResult>, SoldrError> {
+    if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
+        return Ok(Some(soldr_fetch::FetchResult {
+            binary_path,
+            version: soldr_fetch::MANAGED_ZCCACHE_VERSION.to_string(),
+            cached: true,
+        }));
+    }
+
+    soldr_fetch::cached_zccache_binary(paths)
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -26,6 +26,169 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     dir
 }
 
+fn fake_script_path(dir: &PathBuf, name: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        return dir.join(format!("{name}.cmd"));
+    }
+    #[cfg(not(windows))]
+    {
+        dir.join(name)
+    }
+}
+
+fn write_fake_script(path: &PathBuf, body: &str) {
+    #[cfg(windows)]
+    {
+        fs::write(path, body.replace('\n', "\r\n")).expect("failed to write fake script");
+    }
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::write(path, body).expect("failed to write fake script");
+        let mut perms = fs::metadata(path)
+            .expect("failed to stat fake script")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("failed to chmod fake script");
+    }
+}
+
+fn fake_cargo_script(log_path: &PathBuf) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID%>>\"{}\"\n\
+             if defined RUSTC_WRAPPER (\n\
+             call \"%RUSTC_WRAPPER%\" \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
+             ) else (\n\
+             call \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
+             )\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}}\" >> \"{}\"\n\
+             if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\
+               \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
+             else\n\
+               \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
+             fi\n",
+            log_path.display()
+        )
+    }
+}
+
+fn fake_rustc_script(log_path: &PathBuf) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo rustc %*>>\"{}\"\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"rustc $*\" >> \"{}\"\n",
+            log_path.display()
+        )
+    }
+}
+
+fn fake_zccache_script(log_path: &PathBuf) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             if \"%~1\"==\"start\" (\n\
+               echo zccache start>>\"{0}\"\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"session-start\" (\n\
+               echo zccache session-start>>\"{0}\"\n\
+               if not \"%~4\"==\"\" type nul > \"%~4\"\n\
+               echo {{\"session_id\":\"test-session\"}}\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"session-end\" (\n\
+               echo zccache session-end %~2>>\"{0}\"\n\
+               echo hits: 1\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"status\" (\n\
+               echo hits=7\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"clear\" (\n\
+               echo zccache clear>>\"{0}\"\n\
+               exit /b 0\n\
+             )\n\
+             set \"rustc=%~1\"\n\
+             shift\n\
+             echo zccache wrapper %rustc% %*>>\"{0}\"\n\
+             call \"%rustc%\" %*\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             case \"$1\" in\n\
+               start)\n\
+                 echo \"zccache start\" >> \"{0}\"\n\
+                 exit 0\n\
+                 ;;\n\
+               session-start)\n\
+                 echo \"zccache session-start\" >> \"{0}\"\n\
+                 : > \"$4\"\n\
+                 echo '{{\"session_id\":\"test-session\"}}'\n\
+                 exit 0\n\
+                 ;;\n\
+               session-end)\n\
+                 echo \"zccache session-end $2\" >> \"{0}\"\n\
+                 echo 'hits: 1'\n\
+                 exit 0\n\
+                 ;;\n\
+               status)\n\
+                 echo 'hits=7'\n\
+                 exit 0\n\
+                 ;;\n\
+               clear)\n\
+                 echo \"zccache clear\" >> \"{0}\"\n\
+                 exit 0\n\
+                 ;;\n\
+             esac\n\
+             rustc=\"$1\"\n\
+             shift\n\
+             echo \"zccache wrapper $rustc $*\" >> \"{0}\"\n\
+             \"$rustc\" \"$@\"\n",
+            log_path.display()
+        )
+    }
+}
+
+fn install_fake_toolchain(log_path: &PathBuf) -> (PathBuf, PathBuf, PathBuf) {
+    let dir = unique_temp_dir("fake-toolchain");
+    let cargo = fake_script_path(&dir, "cargo");
+    let rustc = fake_script_path(&dir, "rustc");
+    let zccache = fake_script_path(&dir, "zccache");
+    write_fake_script(&cargo, &fake_cargo_script(log_path));
+    write_fake_script(&rustc, &fake_rustc_script(log_path));
+    write_fake_script(&zccache, &fake_zccache_script(log_path));
+    (cargo, rustc, zccache)
+}
+
 #[test]
 fn version_command_prints_workspace_version() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -133,6 +296,119 @@ fn cargo_subcommand_rejects_no_cache_flag() {
 }
 
 #[test]
+fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
+    let cache_root = unique_temp_dir("cargo-default-cache");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cargo build with fake zccache");
+
+    assert!(
+        output.status.success(),
+        "cache-enabled front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cargo wrapper="),
+        "fake cargo did not record wrapper env: {log}"
+    );
+    assert!(
+        log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "soldr should own the wrapper slot in cache-enabled mode: {log}"
+    );
+    assert!(
+        log.contains("cache=1"),
+        "cache-enabled front door should propagate cache flag: {log}"
+    );
+    assert!(
+        log.contains("zccache start"),
+        "managed zccache should be started for cache-enabled builds: {log}"
+    );
+    assert!(
+        log.contains("zccache session-start"),
+        "managed zccache session should start before cargo runs: {log}"
+    );
+    assert!(
+        log.contains("zccache wrapper"),
+        "wrapper mode should dispatch into zccache on cache-enabled builds: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "real rustc invocation should still happen through the wrapper path: {log}"
+    );
+    assert!(
+        log.contains("zccache session-end test-session"),
+        "managed zccache session should end after cargo finishes: {log}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("soldr: zccache session summary"),
+        "expected zccache session summary in stderr: {stderr}"
+    );
+
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    assert!(
+        journal.exists(),
+        "expected session journal at {}",
+        journal.display()
+    );
+}
+
+#[test]
+fn no_cache_bypasses_wrapper_and_zccache() {
+    let cache_root = unique_temp_dir("cargo-no-cache-fake");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["--no-cache", "cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr --no-cache cargo build with fake tools");
+
+    assert!(
+        output.status.success(),
+        "no-cache front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cache=0"),
+        "no-cache front door should propagate cache disable flag: {log}"
+    );
+    assert!(
+        !log.contains("zccache start"),
+        "no-cache front door should not start zccache: {log}"
+    );
+    assert!(
+        !log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "no-cache front door should not set soldr as wrapper: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "no-cache front door should call rustc directly: {log}"
+    );
+}
+
+#[test]
 fn rustc_wrapper_mode_passes_through_to_rustc() {
     let rustc = rustup_which("rustc");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -177,6 +453,90 @@ fn status_reports_cache_control_defaults() {
     assert!(
         stdout.contains("not fetched yet"),
         "status should explain unfetched managed zccache state: {stdout}"
+    );
+}
+
+#[test]
+fn cache_command_reports_managed_zccache_status() {
+    let cache_root = unique_temp_dir("cache-command");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("cache")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache");
+
+    assert!(output.status.success(), "cache command failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("soldr zccache state dir:"),
+        "cache command missing state dir: {stdout}"
+    );
+    assert!(
+        stdout.contains("last session journal:"),
+        "cache command missing journal path: {stdout}"
+    );
+    assert!(
+        stdout.contains("(present)"),
+        "cache command should report present journal: {stdout}"
+    );
+    assert!(
+        stdout.contains("zccache: hits=7"),
+        "cache command should surface managed zccache status output: {stdout}"
+    );
+}
+
+#[test]
+fn clean_clears_managed_zccache_and_state_dir() {
+    let cache_root = unique_temp_dir("clean-command");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let state_dir = cache_root.join("cache").join("zccache");
+    let journal = state_dir.join("logs").join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("clean")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr clean");
+
+    assert!(output.status.success(), "clean command failed");
+    assert!(
+        !state_dir.exists(),
+        "clean should remove soldr zccache state dir at {}",
+        state_dir.display()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cleared zccache artifact cache"),
+        "clean should report artifact cache cleanup: {stdout}"
+    );
+    assert!(
+        stdout.contains("removed soldr zccache state dir:"),
+        "clean should report state dir cleanup: {stdout}"
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("zccache clear"),
+        "clean should call managed zccache clear: {log}"
     );
 }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,8 +1,9 @@
-use std::process::Command;
 #[cfg(windows)]
+use std::path::Path;
+use std::process::Command;
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -13,6 +14,16 @@ fn rustup_which(tool: &str) -> String {
         .expect("failed to resolve tool with rustup");
     assert!(output.status.success(), "rustup which failed for {tool}");
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
+    fs::create_dir_all(&dir).expect("failed to create temp dir");
+    dir
 }
 
 #[test]
@@ -51,8 +62,10 @@ fn help_lists_phase_one_command_surface() {
 
 #[test]
 fn cargo_front_door_runs_real_cargo() {
+    let cache_root = unique_temp_dir("cargo-version");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "--version"])
+        .args(["--no-cache", "cargo", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr cargo --version");
 
@@ -72,8 +85,10 @@ fn cargo_front_door_runs_real_cargo() {
 
 #[test]
 fn cargo_front_door_consumes_no_cache_flag() {
+    let cache_root = unique_temp_dir("cargo-no-cache");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["--no-cache", "cargo", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr --no-cache cargo --version");
 
@@ -98,8 +113,10 @@ fn cargo_front_door_consumes_no_cache_flag() {
 
 #[test]
 fn cargo_subcommand_rejects_no_cache_flag() {
+    let cache_root = unique_temp_dir("cargo-subcommand-no-cache");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["cargo", "--no-cache", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr cargo --no-cache --version");
 
@@ -135,8 +152,10 @@ fn rustc_wrapper_mode_passes_through_to_rustc() {
 
 #[test]
 fn status_reports_cache_control_defaults() {
+    let cache_root = unique_temp_dir("status");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .arg("status")
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr status");
 
@@ -151,17 +170,14 @@ fn status_reports_cache_control_defaults() {
         stdout.contains("cache default: enabled"),
         "status missing cache default: {stdout}"
     );
-}
-
-#[cfg(windows)]
-fn unique_temp_dir(label: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("time went backwards")
-        .as_nanos();
-    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
-    fs::create_dir_all(&dir).expect("failed to create temp dir");
-    dir
+    assert!(
+        stdout.contains("zccache version:"),
+        "status missing zccache version: {stdout}"
+    );
+    assert!(
+        stdout.contains("not fetched yet"),
+        "status should explain unfetched managed zccache state: {stdout}"
+    );
 }
 
 #[cfg(windows)]
@@ -193,10 +209,11 @@ fn cargo_front_door_forces_msvc_target_even_with_polluted_path() {
         .join("fixtures")
         .join("windows-msvc-default");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "build"])
+        .args(["--no-cache", "cargo", "build"])
         .current_dir(&fixture)
         .env("PATH", prepend_to_path(&fake_tools))
         .env("CARGO_TARGET_DIR", &target_dir)
+        .env("SOLDR_CACHE_DIR", unique_temp_dir("msvc-cache-root"))
         .output()
         .expect("failed to run soldr cargo build");
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -71,6 +71,32 @@ fn cargo_front_door_runs_real_cargo() {
 }
 
 #[test]
+fn cargo_front_door_consumes_no_cache_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "--no-cache", "--version"])
+        .output()
+        .expect("failed to run soldr cargo --no-cache --version");
+
+    assert!(
+        output.status.success(),
+        "cargo front door with --no-cache failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("cargo"),
+        "unexpected cargo output with --no-cache: {stdout}"
+    );
+    assert!(
+        !stderr.contains("unexpected argument '--no-cache'"),
+        "--no-cache should be consumed by soldr, not forwarded to cargo: {stderr}"
+    );
+}
+
+#[test]
 fn rustc_wrapper_mode_passes_through_to_rustc() {
     let rustc = rustup_which("rustc");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -85,6 +111,26 @@ fn rustc_wrapper_mode_passes_through_to_rustc() {
     assert!(
         stdout.contains("rustc"),
         "unexpected rustc output: {stdout}"
+    );
+}
+
+#[test]
+fn status_reports_cache_control_defaults() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("status")
+        .output()
+        .expect("failed to run soldr status");
+
+    assert!(output.status.success(), "status command failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cache dir:"),
+        "status missing cache dir: {stdout}"
+    );
+    assert!(
+        stdout.contains("cache default: enabled"),
+        "status missing cache default: {stdout}"
     );
 }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -73,13 +73,13 @@ fn cargo_front_door_runs_real_cargo() {
 #[test]
 fn cargo_front_door_consumes_no_cache_flag() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "--no-cache", "--version"])
+        .args(["--no-cache", "cargo", "--version"])
         .output()
-        .expect("failed to run soldr cargo --no-cache --version");
+        .expect("failed to run soldr --no-cache cargo --version");
 
     assert!(
         output.status.success(),
-        "cargo front door with --no-cache failed\nstdout:\n{}\nstderr:\n{}",
+        "cargo front door with top-level --no-cache failed\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -93,6 +93,25 @@ fn cargo_front_door_consumes_no_cache_flag() {
     assert!(
         !stderr.contains("unexpected argument '--no-cache'"),
         "--no-cache should be consumed by soldr, not forwarded to cargo: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_subcommand_rejects_no_cache_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "--no-cache", "--version"])
+        .output()
+        .expect("failed to run soldr cargo --no-cache --version");
+
+    assert!(
+        !output.status.success(),
+        "cargo subcommand form should no longer accept --no-cache"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--no-cache"),
+        "expected cargo-subcommand form to fail mentioning --no-cache: {stderr}"
     );
 }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,9 +1,7 @@
-#[cfg(windows)]
-use std::path::Path;
 use std::process::Command;
 use std::{
     fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -26,7 +24,7 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     dir
 }
 
-fn fake_script_path(dir: &PathBuf, name: &str) -> PathBuf {
+fn fake_script_path(dir: &Path, name: &str) -> PathBuf {
     #[cfg(windows)]
     {
         return dir.join(format!("{name}.cmd"));
@@ -37,7 +35,7 @@ fn fake_script_path(dir: &PathBuf, name: &str) -> PathBuf {
     }
 }
 
-fn write_fake_script(path: &PathBuf, body: &str) {
+fn write_fake_script(path: &Path, body: &str) {
     #[cfg(windows)]
     {
         fs::write(path, body.replace('\n', "\r\n")).expect("failed to write fake script");
@@ -55,7 +53,7 @@ fn write_fake_script(path: &PathBuf, body: &str) {
     }
 }
 
-fn fake_cargo_script(log_path: &PathBuf) -> String {
+fn fake_cargo_script(log_path: &Path) -> String {
     #[cfg(windows)]
     {
         format!(
@@ -85,7 +83,7 @@ fn fake_cargo_script(log_path: &PathBuf) -> String {
     }
 }
 
-fn fake_rustc_script(log_path: &PathBuf) -> String {
+fn fake_rustc_script(log_path: &Path) -> String {
     #[cfg(windows)]
     {
         format!(
@@ -104,7 +102,7 @@ fn fake_rustc_script(log_path: &PathBuf) -> String {
     }
 }
 
-fn fake_zccache_script(log_path: &PathBuf) -> String {
+fn fake_zccache_script(log_path: &Path) -> String {
     #[cfg(windows)]
     {
         format!(
@@ -178,7 +176,7 @@ fn fake_zccache_script(log_path: &PathBuf) -> String {
     }
 }
 
-fn install_fake_toolchain(log_path: &PathBuf) -> (PathBuf, PathBuf, PathBuf) {
+fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
     let dir = unique_temp_dir("fake-toolchain");
     let cargo = fake_script_path(&dir, "cargo");
     let rustc = fake_script_path(&dir, "rustc");

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -1,5 +1,8 @@
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 use thiserror::Error;
 
 // ---------------------------------------------------------------------------
@@ -304,6 +307,8 @@ fn compile_time_fallback_triple() -> Result<String, SoldrError> {
 // Paths - ~/.soldr/ layout
 // ---------------------------------------------------------------------------
 
+pub const SOLDR_CACHE_DIR_ENV_VAR: &str = "SOLDR_CACHE_DIR";
+
 pub struct SoldrPaths {
     pub root: PathBuf,
     pub bin: PathBuf,
@@ -313,7 +318,8 @@ pub struct SoldrPaths {
 
 impl SoldrPaths {
     pub fn new() -> Result<Self, SoldrError> {
-        let root = home_dir()?.join(".soldr");
+        let root = soldr_root_from_env_var(std::env::var_os(SOLDR_CACHE_DIR_ENV_VAR).as_deref())
+            .unwrap_or_else(|| home_dir().map(|home| home.join(".soldr")))?;
         Ok(Self::with_root(root))
     }
 
@@ -331,6 +337,14 @@ impl SoldrPaths {
         std::fs::create_dir_all(&self.cache)?;
         Ok(())
     }
+}
+
+fn soldr_root_from_env_var(value: Option<&OsStr>) -> Option<Result<PathBuf, SoldrError>> {
+    let value = value?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(Ok(PathBuf::from(value)))
 }
 
 fn home_dir() -> Result<PathBuf, SoldrError> {
@@ -437,6 +451,19 @@ mod tests {
         assert!(paths.root.ends_with(".soldr"));
         assert!(paths.bin.ends_with("bin"));
         assert!(paths.cache.ends_with("cache"));
+    }
+
+    #[test]
+    fn soldr_root_override_uses_env_path() {
+        let root = soldr_root_from_env_var(Some(OsStr::new("C:\\temp\\soldr-cache-root")))
+            .unwrap()
+            .unwrap();
+        assert_eq!(root, PathBuf::from("C:\\temp\\soldr-cache-root"));
+    }
+
+    #[test]
+    fn soldr_root_override_ignores_empty_env() {
+        assert!(soldr_root_from_env_var(Some(OsStr::new(""))).is_none());
     }
 
     #[test]

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -34,6 +34,8 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.8";
+
 /// Fetch a tool binary for the current platform.
 pub async fn fetch_tool(
     crate_name: &str,
@@ -50,36 +52,95 @@ pub async fn fetch_tool_with_paths(
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
-    let target = TargetTriple::detect()?;
+    let repo = resolve_repo(crate_name).await?;
+    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, paths).await
+}
 
-    // 1. Check local cache (exact version only)
+pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    fetch_zccache_with_paths(&paths).await
+}
+
+pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
+    paths.ensure_dirs()?;
+    let target = TargetTriple::detect()?;
+    let binary_names = ["zccache", "zccache-daemon", "zccache-fp"];
+
+    if let Some(result) = check_cache(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &binary_names,
+        &target,
+    )? {
+        return Ok(result);
+    }
+
+    let download_url = managed_zccache_download_url(MANAGED_ZCCACHE_VERSION, &target);
+    let binary_path = download_and_extract(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &download_url,
+        &target,
+        &binary_names,
+    )
+    .await?;
+
+    Ok(FetchResult {
+        binary_path,
+        version: MANAGED_ZCCACHE_VERSION.to_string(),
+        cached: false,
+    })
+}
+
+pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, SoldrError> {
+    let target = TargetTriple::detect()?;
+    check_cache(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &["zccache", "zccache-daemon", "zccache-fp"],
+        &target,
+    )
+}
+
+async fn fetch_repo_binary_with_paths(
+    cache_name: &str,
+    binary_names: &[&str],
+    repo: &RepoInfo,
+    version: &VersionSpec,
+    paths: &SoldrPaths,
+) -> Result<FetchResult, SoldrError> {
+    paths.ensure_dirs()?;
+    let target = TargetTriple::detect()?;
+    if binary_names.is_empty() {
+        return Err(SoldrError::Other(format!(
+            "no binary names configured for {cache_name}"
+        )));
+    }
+
     if let VersionSpec::Exact(ref v) = version {
-        if let Some(r) = check_cache(paths, crate_name, v, &target)? {
+        if let Some(r) = check_cache(paths, cache_name, v, binary_names, &target)? {
             return Ok(r);
         }
     }
 
-    // 2. Resolve repository from crates.io
-    let repo = resolve_repo(crate_name).await?;
+    let release = fetch_release(repo, version).await?;
 
-    // 3. Get release metadata from GitHub
-    let release = fetch_release(&repo, version).await?;
-
-    // 4. Check cache for the resolved version (handles Latest -> concrete version)
-    if let Some(r) = check_cache(paths, crate_name, &release.version, &target)? {
+    if let Some(r) = check_cache(paths, cache_name, &release.version, binary_names, &target)? {
         return Ok(r);
     }
 
-    // 5. Find matching asset for our target
     let asset = match_asset(&release.assets, &target)?;
 
-    // 6. Download and extract
     let binary_path = download_and_extract(
         paths,
-        crate_name,
+        cache_name,
         &release.version,
         &asset.download_url,
         &target,
+        binary_names,
     )
     .await?;
 
@@ -96,15 +157,28 @@ pub async fn fetch_tool_with_paths(
 
 fn check_cache(
     paths: &SoldrPaths,
-    crate_name: &str,
+    cache_name: &str,
     version: &str,
+    binary_names: &[&str],
     target: &TargetTriple,
 ) -> Result<Option<FetchResult>, SoldrError> {
-    let bin_name = format!("{crate_name}{}", target.binary_ext());
-    let tool_dir = paths.bin.join(format!("{crate_name}-{version}"));
+    let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
+    let bin_name = format!(
+        "{}{}",
+        binary_names
+            .first()
+            .ok_or_else(|| SoldrError::Other(format!(
+                "no binary names configured for {cache_name}"
+            )))?,
+        target.binary_ext()
+    );
     let binary_path = tool_dir.join(&bin_name);
 
-    if binary_path.exists() {
+    if binary_names.iter().all(|binary_name| {
+        tool_dir
+            .join(format!("{binary_name}{}", target.binary_ext()))
+            .exists()
+    }) {
         Ok(Some(FetchResult {
             binary_path,
             version: version.to_string(),
@@ -204,21 +278,25 @@ async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<Release
             fetch_release_value(&client, repo, &url).await?
         }
         VersionSpec::Exact(v) => {
-            let tag = if v.starts_with('v') {
-                v.clone()
-            } else {
-                format!("v{v}")
-            };
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/releases/tags/{tag}",
-                repo.owner, repo.repo
-            );
-            match fetch_release_value(&client, repo, &url).await {
-                Ok(release) => release,
-                Err(SoldrError::ToolNotFound(_)) => {
-                    fetch_release_by_listing(&client, repo, &tag).await?
+            let candidate_tags = release_tag_candidates(v);
+            let mut found = None;
+            for tag in &candidate_tags {
+                let url = format!(
+                    "https://api.github.com/repos/{}/{}/releases/tags/{tag}",
+                    repo.owner, repo.repo
+                );
+                match fetch_release_value(&client, repo, &url).await {
+                    Ok(release) => {
+                        found = Some(release);
+                        break;
+                    }
+                    Err(SoldrError::ToolNotFound(_)) => continue,
+                    Err(err) => return Err(err),
                 }
-                Err(err) => return Err(err),
+            }
+            match found {
+                Some(release) => release,
+                None => fetch_release_by_listing(&client, repo, &candidate_tags).await?,
             }
         }
     };
@@ -253,7 +331,7 @@ async fn fetch_release_value(
 async fn fetch_release_by_listing(
     client: &reqwest::Client,
     repo: &RepoInfo,
-    tag: &str,
+    tags: &[String],
 ) -> Result<serde_json::Value, SoldrError> {
     let url = format!(
         "https://api.github.com/repos/{}/{}/releases?per_page=30",
@@ -283,7 +361,7 @@ async fn fetch_release_by_listing(
             items.iter().find(|release| {
                 release["tag_name"]
                     .as_str()
-                    .map(|release_tag| release_tag == tag)
+                    .map(|release_tag| tags.iter().any(|tag| release_tag == tag))
                     .unwrap_or(false)
             })
         })
@@ -292,6 +370,32 @@ async fn fetch_release_by_listing(
     matched.ok_or_else(|| {
         SoldrError::ToolNotFound(format!("no release found for {}/{}", repo.owner, repo.repo))
     })
+}
+
+fn release_tag_candidates(version: &str) -> Vec<String> {
+    let mut tags = Vec::with_capacity(2);
+    let raw = version.trim();
+    if raw.is_empty() {
+        return tags;
+    }
+    tags.push(raw.to_string());
+    if let Some(stripped) = raw.strip_prefix('v') {
+        if !stripped.is_empty() {
+            tags.push(stripped.to_string());
+        }
+    } else {
+        tags.push(format!("v{raw}"));
+    }
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
+fn managed_zccache_download_url(version: &str, target: &TargetTriple) -> String {
+    format!(
+        "https://github.com/zackees/zccache/releases/download/{version}/zccache-{version}-{}.tar.gz",
+        target.triple()
+    )
 }
 
 fn parse_release_info(body: serde_json::Value) -> Result<ReleaseInfo, SoldrError> {
@@ -411,10 +515,11 @@ fn match_asset<'a>(
 
 async fn download_and_extract(
     paths: &SoldrPaths,
-    crate_name: &str,
+    cache_name: &str,
     version: &str,
     url: &str,
     target: &TargetTriple,
+    binary_names: &[&str],
 ) -> Result<PathBuf, SoldrError> {
     let client = http_client()?;
 
@@ -436,18 +541,27 @@ async fn download_and_extract(
         .await
         .map_err(|e| SoldrError::Network(e.to_string()))?;
 
-    let tool_dir = paths.bin.join(format!("{crate_name}-{version}"));
+    let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
+    let desired_binaries = desired_binary_names(binary_names, target);
     std::fs::create_dir_all(&tool_dir)?;
 
-    let bin_name = format!("{crate_name}{}", target.binary_ext());
-    let binary_path = tool_dir.join(&bin_name);
+    let main_binary_name = desired_binaries
+        .first()
+        .cloned()
+        .ok_or_else(|| SoldrError::Other(format!("no binary names configured for {cache_name}")))?;
+    let binary_path = tool_dir.join(&main_binary_name);
 
     if url.ends_with(".zip") {
-        extract_zip(&bytes, &binary_path, &bin_name)?;
+        extract_zip(&bytes, &tool_dir, &desired_binaries)?;
     } else if url.ends_with(".tar.gz") || url.ends_with(".tgz") {
-        extract_tar_gz(&bytes, &binary_path, &bin_name)?;
+        extract_tar_gz(&bytes, &tool_dir, &desired_binaries)?;
     } else {
         // Assume raw binary.
+        if desired_binaries.len() != 1 {
+            return Err(SoldrError::Archive(format!(
+                "cannot extract multiple binaries from raw asset for {cache_name}"
+            )));
+        }
         std::fs::write(&binary_path, &bytes)?;
     }
 
@@ -455,18 +569,29 @@ async fn download_and_extract(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&binary_path)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&binary_path, perms)?;
+        for binary_name in &desired_binaries {
+            let binary_path = tool_dir.join(binary_name);
+            let mut perms = std::fs::metadata(&binary_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&binary_path, perms)?;
+        }
     }
 
     Ok(binary_path)
 }
 
-fn extract_zip(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrError> {
+fn desired_binary_names(binary_names: &[&str], target: &TargetTriple) -> Vec<String> {
+    binary_names
+        .iter()
+        .map(|binary_name| format!("{binary_name}{}", target.binary_ext()))
+        .collect()
+}
+
+fn extract_zip(data: &[u8], dest_dir: &Path, binary_names: &[String]) -> Result<(), SoldrError> {
     let reader = std::io::Cursor::new(data);
     let mut archive =
         zip::ZipArchive::new(reader).map_err(|e| SoldrError::Archive(e.to_string()))?;
+    let mut found = std::collections::BTreeSet::new();
 
     for i in 0..archive.len() {
         let mut file = archive
@@ -482,23 +607,25 @@ fn extract_zip(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrErro
             .and_then(|f| f.to_str())
             .unwrap_or("");
 
-        if file_name == bin_name || file_name == bin_name.trim_end_matches(".exe") {
-            let mut out = std::fs::File::create(dest)?;
+        let wanted = binary_names.iter().find(|binary_name| {
+            file_name == *binary_name || file_name == binary_name.trim_end_matches(".exe")
+        });
+
+        if let Some(binary_name) = wanted {
+            let mut out = std::fs::File::create(dest_dir.join(binary_name))?;
             std::io::copy(&mut file, &mut out)?;
-            return Ok(());
+            found.insert(binary_name.clone());
         }
     }
 
-    Err(SoldrError::Archive(format!(
-        "{bin_name} not found in zip archive"
-    )))
+    ensure_all_binaries_found(binary_names, &found)
 }
 
-fn extract_tar_gz(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrError> {
+fn extract_tar_gz(data: &[u8], dest_dir: &Path, binary_names: &[String]) -> Result<(), SoldrError> {
     let reader = std::io::Cursor::new(data);
     let gz = flate2::read::GzDecoder::new(reader);
     let mut archive = tar::Archive::new(gz);
-    let base_name = bin_name.trim_end_matches(".exe");
+    let mut found = std::collections::BTreeSet::new();
 
     for entry in archive
         .entries()
@@ -511,16 +638,37 @@ fn extract_tar_gz(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrE
 
         let file_name = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
 
-        if file_name == bin_name || file_name == base_name {
-            let mut out = std::fs::File::create(dest)?;
+        let wanted = binary_names.iter().find(|binary_name| {
+            file_name == *binary_name || file_name == binary_name.trim_end_matches(".exe")
+        });
+
+        if let Some(binary_name) = wanted {
+            let mut out = std::fs::File::create(dest_dir.join(binary_name))?;
             std::io::copy(&mut entry, &mut out)?;
-            return Ok(());
+            found.insert(binary_name.clone());
         }
     }
 
-    Err(SoldrError::Archive(format!(
-        "{bin_name} not found in tar.gz archive"
-    )))
+    ensure_all_binaries_found(binary_names, &found)
+}
+
+fn ensure_all_binaries_found(
+    binary_names: &[String],
+    found: &std::collections::BTreeSet<String>,
+) -> Result<(), SoldrError> {
+    let missing = binary_names
+        .iter()
+        .filter(|binary_name| !found.contains(*binary_name))
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(SoldrError::Archive(format!(
+            "missing binaries in archive: {}",
+            missing.join(", ")
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -580,5 +728,30 @@ mod tests {
 
         let selected = match_asset(&assets, &target).unwrap();
         assert_eq!(selected.name, "tool-x86_64-unknown-linux-musl.tar.gz");
+    }
+
+    #[test]
+    fn release_tag_candidates_support_plain_and_v_prefixed_tags() {
+        assert_eq!(
+            release_tag_candidates("1.2.8"),
+            vec!["1.2.8".to_string(), "v1.2.8".to_string()]
+        );
+        assert_eq!(
+            release_tag_candidates("v1.2.8"),
+            vec!["1.2.8".to_string(), "v1.2.8".to_string()]
+        );
+    }
+
+    #[test]
+    fn managed_zccache_download_url_uses_target_triple() {
+        let target = TargetTriple {
+            arch: Arch::Aarch64,
+            os: Os::MacOs,
+            env: Env::None,
+        };
+        assert_eq!(
+            managed_zccache_download_url("1.2.8", &target),
+            "https://github.com/zackees/zccache/releases/download/1.2.8/zccache-1.2.8-aarch64-apple-darwin.tar.gz"
+        );
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,7 +25,7 @@ The primary user experience is `soldr cargo ...`.
 soldr cargo build --release
 soldr cargo test
 soldr cargo run -- --help
-soldr cargo --no-cache build
+soldr --no-cache cargo build
 ```
 
 Behavior:
@@ -39,7 +39,7 @@ Behavior:
 Current cache-control behavior:
 
 - caching is enabled by default for `soldr cargo ...`
-- `soldr cargo --no-cache ...` disables soldr's compilation-cache path for that invocation
+- `soldr --no-cache cargo ...` disables soldr's compilation-cache path for that invocation
 - wrapper mode still falls through to real `rustc` while artifact caching is implemented in follow-up work
 
 This is the normal build entry point.
@@ -109,7 +109,7 @@ Run Cargo through soldr's front door.
 soldr cargo build --release
 soldr cargo test --workspace
 soldr cargo check -p soldr-cli
-soldr cargo --no-cache test
+soldr --no-cache cargo test
 ```
 
 ### `soldr status`

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,7 +33,8 @@ Behavior:
 - Resolve the real `cargo` binary through `rustup`
 - Resolve the matching real `rustc` binary through `rustup`
 - Fetch a pinned managed `zccache` release when caching is enabled
-- Set `RUSTC_WRAPPER` to the managed `zccache` binary
+- Set `RUSTC_WRAPPER` to the current soldr binary
+- Pass the managed `zccache` binary path into wrapper mode through the environment
 - Start a per-build zccache session on zccache's current default daemon endpoint
 - Delegate to Cargo with the exact flags the user passed
 
@@ -86,8 +87,9 @@ In this mode, soldr should act as the transparent build-assistance layer around 
 
 Current implementation status:
 
-- Wrapper-mode passthrough to real `rustc` exists
-- The normal cache-enabled build path uses managed `zccache` instead of soldr wrapper mode
+- Wrapper mode still transparently resolves the real `rustc`
+- The normal cache-enabled build path now runs through soldr wrapper mode and delegates into managed `zccache`
+- If caching is disabled, wrapper mode falls through to real `rustc` without zccache involvement
 
 ---
 
@@ -121,7 +123,7 @@ Show cache and target information.
 
 ### `soldr clean`
 
-Clear the managed local zccache artifact cache.
+Clear the managed local zccache artifact cache and remove soldr's zccache session state directory.
 
 ### `soldr config`
 
@@ -161,6 +163,7 @@ Commands:
 |---|---|---|
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
 | `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
+| `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `SOLDR_LOG` | Log level | `warn` |
@@ -204,5 +207,6 @@ For bootstrap verification of another Rust project:
 The key design rule is simple:
 
 - users build through `soldr cargo ...`
-- soldr uses managed zccache internally for cache-enabled Rust builds
+- soldr owns the wrapper slot on the common path
+- soldr delegates cache-enabled wrapper invocations into managed zccache
 - users do not need to manually wire `RUSTC_WRAPPER` for the common path

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,6 +25,7 @@ The primary user experience is `soldr cargo ...`.
 soldr cargo build --release
 soldr cargo test
 soldr cargo run -- --help
+soldr cargo --no-cache build
 ```
 
 Behavior:
@@ -32,7 +33,14 @@ Behavior:
 - Resolve the real `cargo` binary through `rustup`
 - Resolve the matching real `rustc` binary through `rustup`
 - Set `RUSTC_WRAPPER` to the current `soldr` executable
+- Enable the soldr compilation-cache path by default
 - Delegate to Cargo with the exact flags the user passed
+
+Current cache-control behavior:
+
+- caching is enabled by default for `soldr cargo ...`
+- `soldr cargo --no-cache ...` disables soldr's compilation-cache path for that invocation
+- wrapper mode still falls through to real `rustc` while artifact caching is implemented in follow-up work
 
 This is the normal build entry point.
 
@@ -101,6 +109,7 @@ Run Cargo through soldr's front door.
 soldr cargo build --release
 soldr cargo test --workspace
 soldr cargo check -p soldr-cli
+soldr cargo --no-cache test
 ```
 
 ### `soldr status`
@@ -148,6 +157,7 @@ Commands:
 | Variable | Purpose | Default |
 |---|---|---|
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
+| `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,11 +7,11 @@ soldr is a single front door for Rust tool execution and Rust builds.
 It has three invocation modes:
 
 1. `soldr cargo ...`
-   Delegates to the real Cargo binary while wiring soldr into the build path.
+   Delegates to the real Cargo binary while wiring soldr-managed zccache into the build path.
 2. `soldr <tool> [args...]`
    Fetches and runs a Rust CLI tool binary.
 3. `soldr rustc ...`
-   Internal wrapper mode used during builds after `soldr cargo ...` sets `RUSTC_WRAPPER=soldr`.
+   Low-level passthrough wrapper mode for explicit `RUSTC_WRAPPER=soldr` usage.
 
 The primary user experience is `soldr cargo ...`.
 
@@ -32,15 +32,18 @@ Behavior:
 
 - Resolve the real `cargo` binary through `rustup`
 - Resolve the matching real `rustc` binary through `rustup`
-- Set `RUSTC_WRAPPER` to the current `soldr` executable
-- Enable the soldr compilation-cache path by default
+- Fetch a pinned managed `zccache` release when caching is enabled
+- Set `RUSTC_WRAPPER` to the managed `zccache` binary
+- Start a per-build zccache session on zccache's current default daemon endpoint
 - Delegate to Cargo with the exact flags the user passed
 
 Current cache-control behavior:
 
 - caching is enabled by default for `soldr cargo ...`
 - `soldr --no-cache cargo ...` disables soldr's compilation-cache path for that invocation
-- wrapper mode still falls through to real `rustc` while artifact caching is implemented in follow-up work
+- `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
+- zccache integration currently targets Rust builds through the cargo front door
+- zccache's current artifact store and daemon endpoint remain on zccache's default paths; soldr currently manages the session lifecycle and logs
 
 This is the normal build entry point.
 
@@ -84,7 +87,7 @@ In this mode, soldr should act as the transparent build-assistance layer around 
 Current implementation status:
 
 - Wrapper-mode passthrough to real `rustc` exists
-- Cache and daemon behavior are still being implemented
+- The normal cache-enabled build path uses managed `zccache` instead of soldr wrapper mode
 
 ---
 
@@ -118,7 +121,7 @@ Show cache and target information.
 
 ### `soldr clean`
 
-Clear caches.
+Clear the managed local zccache artifact cache.
 
 ### `soldr config`
 
@@ -126,7 +129,7 @@ Show or set configuration.
 
 ### `soldr cache`
 
-Inspect build-cache state.
+Inspect managed zccache status.
 
 ### `soldr version`
 
@@ -159,10 +162,11 @@ Commands:
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
 | `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
+| `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 
-`RUSTC_WRAPPER=soldr cargo build` remains a valid low-level integration path, but it is no longer the preferred user-facing workflow.
+`RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 
 ---
 
@@ -200,5 +204,5 @@ For bootstrap verification of another Rust project:
 The key design rule is simple:
 
 - users build through `soldr cargo ...`
-- soldr uses wrapper mode internally
+- soldr uses managed zccache internally for cache-enabled Rust builds
 - users do not need to manually wire `RUSTC_WRAPPER` for the common path

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -1,0 +1,179 @@
+# Release 0.5 Checklist
+
+This document is the concrete execution list for the first attested secure `soldr 0.5` release.
+
+It assumes the current repository state on April 13, 2026:
+
+- the validated release workflow exists in `.github/workflows/release.yml`
+- the workflow requires an exact commit SHA on `release`
+- publication uses a dedicated GitHub App
+- `v*.*.*` tags are protected by repository rulesets
+- immutable GitHub Releases are enabled
+- `main` and `release` are protected
+
+## 1. Freeze The `0.5` Product Surface
+
+Decide what `0.5` means for the user-facing CLI.
+
+Required decision:
+
+- the `0.5` release line is the front-door build and tool-fetch line
+- built-in zccache-backed compilation caching is part of the front-door `0.5.x` line
+- `status`, `clean`, `config`, and `cache` must not be presented as complete features unless implemented
+
+Do not ship `0.5` with placeholder commands presented as finished behavior.
+
+## 2. Freeze The `0.5` Security Claim
+
+Resolve the open policy questions in:
+
+- issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
+- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
+
+Minimum decisions needed before `0.5`:
+
+- whether checksum plus `gh attestation verify` is the official verification story
+- whether SBOM generation is required for `0.5`
+- whether reproducible-build claims are in scope for `0.5`
+- whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
+- what trust statement applies to third-party binaries fetched by `soldr` at runtime
+
+## 3. Rehearse The Release Path
+
+Before the first public `0.5` tag, run a dry-run rehearsal from `release`.
+
+Inputs to choose:
+
+- candidate version such as `v0.5.0-rc1`
+- exact commit SHA on `release`
+
+Required checks:
+
+- the workflow rejects SHAs not reachable from `release`
+- the workflow completes lint, test, packaging, and e2e gates for the exact SHA
+- the `release` environment approval gate triggers as expected
+- the GitHub App token step succeeds
+- checksums and provenance attestation steps succeed
+
+Recommended command path:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=true
+```
+
+## 4. Verify The Governance Controls Manually
+
+Before the first real release, verify the controls that live outside the git tree.
+
+```bash
+gh api repos/zackees/soldr/rulesets
+gh api repos/zackees/soldr/environments
+gh api repos/zackees/soldr/branches/main/protection
+gh api repos/zackees/soldr/branches/release/protection
+gh api repos/zackees/soldr/immutable-releases
+```
+
+Success criteria:
+
+- the `v*.*.*` tag ruleset is active
+- only the release GitHub App can bypass that ruleset
+- `release` still requires approval from `@zackees`
+- `main` and `release` still require the expected checks
+- immutable releases remain enabled
+
+## 5. Cut A Real Release Candidate
+
+After the dry run passes, create the first real release candidate through the workflow.
+
+Recommended first tag:
+
+- `v0.5.0-rc1`
+
+Required checks after publication:
+
+- the GitHub Release contains all expected platform archives
+- the `SHA256SUMS` manifest is present
+- `gh attestation verify` succeeds for at least one downloaded archive
+- a human cannot create, move, or delete the release tag manually
+- the release cannot be mutated after publication because immutable releases are enabled
+
+## 6. Enable Trusted PyPI Publishing If `0.5.0` Will Ship Wheels
+
+If PyPI is part of `0.5.0`, configure the existing `soldr` project for Trusted Publishing before the final release.
+
+Required setup:
+
+- add the GitHub Actions trusted publisher on PyPI for:
+  - owner: `zackees`
+  - repository: `soldr`
+  - workflow: `.github/workflows/release.yml`
+  - environment: `release`
+- confirm the existing `soldr` PyPI project is the correct project and that stale pre-Trusted-Publishing metadata will be superseded by the next upload
+
+Recommended rehearsal:
+
+- use TestPyPI first with the same workflow and `publish_pypi=true`
+- pass `pypi_repository_url=https://test.pypi.org/legacy/`
+- treat this as a real publish rehearsal, not a `dry_run`, because OIDC publish cannot be fully exercised in the workflow's dry-run path
+
+Recommended command path:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=false \
+  -f publish_pypi=true \
+  -f pypi_repository_url=https://test.pypi.org/legacy/
+```
+
+Recommended GitHub-release verification commands:
+
+```bash
+gh release view v0.5.0-rc1 --repo zackees/soldr
+gh attestation verify soldr-v0.5.0-rc1-x86_64-unknown-linux-gnu.tar.gz \
+  --repo zackees/soldr \
+  --signer-workflow zackees/soldr/.github/workflows/release.yml
+```
+
+## 7. Audit The First Published Release
+
+After `v0.5.0-rc1`, confirm that reality matches the docs:
+
+- [RELEASE.md](../RELEASE.md)
+- [RELEASE_VERIFICATION.md](./RELEASE_VERIFICATION.md)
+- [RELEASE_GOVERNANCE_CHECKLIST.md](./RELEASE_GOVERNANCE_CHECKLIST.md)
+- [PYPI_TRUSTED_PUBLISHING.md](./PYPI_TRUSTED_PUBLISHING.md)
+- [TRUST_BOUNDARIES.md](./TRUST_BOUNDARIES.md)
+
+Anything discovered during the RC must become either:
+
+- a code fix
+- a GitHub settings fix
+- an explicit documented limitation
+
+## 8. Decide Go Or No-Go For `v0.5.0`
+
+Ship `v0.5.0` only when all of these are true:
+
+- the intended `0.5` CLI surface is clearly scoped and honestly documented
+- the release workflow has passed in dry-run and real-release modes
+- the first RC was verified with checksums and attestations
+- the protected-tag and immutable-release controls behaved as expected
+- if PyPI is in scope, Trusted Publishing was exercised successfully against TestPyPI or PyPI with the hardened wheel set
+- the remaining policy questions are closed or explicitly deferred in writing
+
+## 9. Gate `1.0.0-rc`
+
+Do not cut `1.0.0-rc` until:
+
+- `soldr cargo ...` enables managed zccache by default with `--no-cache` as the explicit opt-out
+- the cache-enabled wrapper path delegates through managed zccache instead of acting as pure rustc pass-through
+- the public cache commands describe and manage real behavior instead of placeholders
+
+If those are not true, stay on the `0.5.x` line.


### PR DESCRIPTION
## Summary
- port the release-side cache control, --no-cache, and managed zccache front-door work onto main
- route cache-enabled builds through the soldr wrapper and delegate wrapper-mode rustc calls into managed zccache
- add CLI coverage for wrapper ownership, cache status/clean behavior, and the managed zccache test harness
- refresh the README/API/release checklist docs to match the real cache behavior

## Testing
- cargo fmt --all
- cargo build --workspace --locked
- cargo test --workspace --lib --locked
- cargo test -p soldr-cli --test cli
- cargo test -p soldr-fetch --test fetch_crgx --locked

## Notes
- local cargo clippy on this machine is affected by a GNU/MSVC host toolchain split, so the authoritative lint result will come from GitHub Actions