### PR TITLE
Define soldr release verification policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,15 @@ Current state:
 - immutable releases and protected tag settings still depend on repository configuration outside the git tree
 - current user-facing verification guidance is checksum verification plus `gh attestation verify`
 
+Current verification policy:
+
+- checksum verification plus `gh attestation verify` is the official user-facing verification story
+- GitHub CLI is the primary documented attestation-verification tool
+- offline attestation bundles may be archived, but separate Sigstore tooling is not required for the normal verification path
+- SBOM publication is not currently required for the release line
+- reproducible-build claims are not currently made for `soldr`
+- no extra signed release metadata is currently published beyond `SHA256SUMS` and GitHub provenance attestations
+
 Planned state, tracked in issue `#7`:
 
 - release tags created only after full validation passes for the exact release commit

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -25,16 +25,16 @@ Do not ship `0.5` with placeholder commands presented as finished behavior.
 
 ## 2. Freeze The `0.5` Security Claim
 
-Resolve the open policy questions in:
+Confirm the documented policy decisions in:
 
 - issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
 - issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
 
-Minimum decisions needed before `0.5`:
+Current decisions for `0.5`:
 
-- whether checksum plus `gh attestation verify` is the official verification story
-- whether SBOM generation is required for `0.5`
-- whether reproducible-build claims are in scope for `0.5`
+- checksum plus `gh attestation verify` is the official user-facing verification story
+- SBOM generation is not required for `0.5`
+- reproducible-build claims are out of scope for `0.5`
 - whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
 - what trust statement applies to third-party binaries fetched by `soldr` at runtime
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -4,6 +4,19 @@ This document describes how to verify a published `soldr` release today.
 
 It is intentionally limited to what the repository currently implements.
 
+## Verification Policy
+
+The current `soldr` verification policy is:
+
+- the official user-facing verification path is checksum verification plus `gh attestation verify`
+- GitHub CLI is the primary documented tool for attestation verification
+- Sigstore-compatible offline verification remains possible through downloaded attestation bundles, but it is not the primary documented path
+- `soldr` does not currently require or publish SBOMs for the release line
+- `soldr` does not currently claim independently reproducible builds
+- `soldr` does not currently publish extra signed metadata beyond the checksum manifest and GitHub provenance attestations
+
+Those positions are deliberate. They may be revisited later, but they are the current release policy rather than open questions.
+
 ## What The Current Release Flow Guarantees
 
 For a normal `soldr` release:
@@ -25,7 +38,7 @@ The current release flow does not yet claim all of the following:
 - independently reproduced builds by a second builder
 - fully hermetic inputs for rustup, crates.io, OS packages, or third-party test inputs
 
-Those follow-up items are tracked in issues [#11](https://github.com/zackees/soldr/issues/11), [#12](https://github.com/zackees/soldr/issues/12), and [#13](https://github.com/zackees/soldr/issues/13).
+The release-governance and hermetic-input follow-up items remain tracked in issues [#11](https://github.com/zackees/soldr/issues/11) and [#13](https://github.com/zackees/soldr/issues/13). SBOM publication and independently reproduced builds are intentionally outside the current release claim.
 
 ## Release Asset Names
 
@@ -62,7 +75,9 @@ The checksum step tells you the file you downloaded matches the checksum manifes
 
 ## Step 2: Verify The Artifact Attestation
 
-Use GitHub CLI's attestation support to verify the artifact provenance:
+Use GitHub CLI's attestation support to verify the artifact provenance.
+
+This is the primary documented verification path for `soldr`:
 
 ```bash
 gh attestation verify soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz \
@@ -90,7 +105,7 @@ This validates that GitHub has a matching attestation for the artifact and that 
 
 It does not, by itself, prove that every external input used during the build was mirrored or hermetic. For the current trust boundary inventory, see [TRUST_BOUNDARIES.md](./TRUST_BOUNDARIES.md).
 
-## Optional: Offline Verification
+## Optional: Offline Verification And Sigstore-Compatible Bundles
 
 GitHub CLI also supports downloading attestation bundles and verifying them offline.
 
@@ -101,13 +116,15 @@ gh attestation download soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz --repo zack
 gh attestation trusted-root
 ```
 
-Offline verification is not yet the primary documented path for `soldr`, but it remains available if you want to archive bundles and trusted roots alongside release artifacts.
+Offline verification is not the primary documented path for `soldr`, but it remains available if you want to archive bundles and trusted roots alongside release artifacts.
+
+This is also the nearest current equivalent to a Sigstore-style workflow for this repository. We do not require users to install separate Sigstore tooling as part of the normal `soldr` verification story.
 
 ## About `gh release verify`
 
 GitHub CLI also has `gh release verify`, which verifies release-level attestations.
 
-We do not currently document that as the primary verification path for `soldr` because immutable releases and the surrounding release-governance settings are still tracked separately. Today, the repository's strongest implemented verification path is:
+We do not currently document that as the primary verification path for `soldr` because immutable releases and the surrounding release-governance settings are still tracked separately. Today, the repository's official verification path is:
 
 1. checksum verification
 2. artifact attestation verification with `gh attestation verify`

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -76,7 +76,6 @@ Current repo policy is:
 Open follow-up decisions are tracked in:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
-- [#12](https://github.com/zackees/soldr/issues/12) for verification and reproducibility policy
 - [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust hardening
 
 ## Practical Reading Of This Document


### PR DESCRIPTION
## Summary
- define the official release verification path as checksums plus \gh attestation verify\
- record the current project policy on SBOMs, reproducible builds, Sigstore tooling, and extra signed metadata
- update the release checklist and trust-boundary docs so these points are no longer framed as unresolved questions

## Testing
- documentation-only change
- did not run code tests locally