### PR TITLE
Define soldr hermeticity and runtime trust policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ When you run `soldr`, the tool should do the obvious thing:
 
 If soldr solves that one problem well, it becomes a super tool: the command you reach for first, because it makes the rest of the stack behave.
 
-- **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse.
+- **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse. On `0.5.x`, this is still an upstream trust decision rather than a repo-side trust guarantee; see [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md).
 
 - **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring; zccache's artifact store still uses its current default cache root.
 
@@ -104,7 +104,7 @@ soldr/
 | Crate | Role |
 |---|---|
 | `soldr-core` | Cache paths, config, version types |
-| `soldr-fetch` | Resolve crate binaries from binstall metadata, GitHub Releases, QuickInstall. Download, verify, cache. |
+| `soldr-fetch` | Resolve crate binaries from crates.io metadata and GitHub Releases. Download and cache. |
 | `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
 | `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
 
@@ -121,7 +121,7 @@ Built on lessons from:
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
-- [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts.
+- [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ The repository currently enforces several baseline controls:
 
 These controls reduce drift, but they do not make the full release pipeline hermetic.
 
+The current `0.5.x` line does not claim hermetic builds, and it does not claim that third-party binaries fetched later by `soldr` are repository-verified just because `soldr` downloaded them.
+
 ## What is pinned
 
 The repo aims to pin security-relevant inputs wherever practical:
@@ -86,6 +88,14 @@ Current verification policy:
 - SBOM publication is not currently required for the release line
 - reproducible-build claims are not currently made for `soldr`
 - no extra signed release metadata is currently published beyond `SHA256SUMS` and GitHub provenance attestations
+
+Current hermeticity and runtime-trust policy:
+
+- `0.5.x` release verification covers published `soldr` artifacts, not every external input used during CI
+- `0.5.x` does not claim hermetic builds; documented dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt`, and the pinned bootstrap test repository remain acceptable for this release line
+- Cargo/toolchain/package mirroring or vendoring is deferred hardening tracked in issue [#41](https://github.com/zackees/soldr/issues/41)
+- runtime third-party binary fetches are a convenience/bootstrap path on `0.5.x`, not a repository-side trust guarantee
+- stronger trust enforcement for fetched binaries is tracked in issue [#42](https://github.com/zackees/soldr/issues/42)
 
 Planned state, tracked in issue `#7`:
 

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -28,15 +28,15 @@ Do not ship `0.5` with placeholder commands presented as finished behavior.
 Confirm the documented policy decisions in:
 
 - issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
-- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
+- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy, with implementation follow-up in [#41](https://github.com/zackees/soldr/issues/41) and [#42](https://github.com/zackees/soldr/issues/42)
 
 Current decisions for `0.5`:
 
 - checksum plus `gh attestation verify` is the official user-facing verification story
 - SBOM generation is not required for `0.5`
 - reproducible-build claims are out of scope for `0.5`
-- whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
-- what trust statement applies to third-party binaries fetched by `soldr` at runtime
+- `0.5.x` does not claim hermetic builds; vendoring or mirroring Cargo, toolchain, OS-package, and pinned bootstrap-test inputs is deferred hardening tracked in [#41](https://github.com/zackees/soldr/issues/41)
+- third-party binaries fetched by `soldr` at runtime remain an upstream trust decision on `0.5.x`, not a repository-side trust guarantee; stronger enforcement is tracked in [#42](https://github.com/zackees/soldr/issues/42)
 
 ## 3. Rehearse The Release Path
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -38,7 +38,7 @@ The current release flow does not yet claim all of the following:
 - independently reproduced builds by a second builder
 - fully hermetic inputs for rustup, crates.io, OS packages, or third-party test inputs
 
-The release-governance and hermetic-input follow-up items remain tracked in issues [#11](https://github.com/zackees/soldr/issues/11) and [#13](https://github.com/zackees/soldr/issues/13). SBOM publication and independently reproduced builds are intentionally outside the current release claim.
+The release-governance and hermetic-input follow-up items remain tracked in issues [#11](https://github.com/zackees/soldr/issues/11), [#41](https://github.com/zackees/soldr/issues/41), and [#42](https://github.com/zackees/soldr/issues/42). SBOM publication and independently reproduced builds are intentionally outside the current release claim.
 
 ## Release Asset Names
 

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -2,7 +2,7 @@
 
 This document describes the current external trust boundaries for `soldr`.
 
-It is a factual inventory of what the project trusts today, not a claim that every trust edge is already ideal.
+It records both the factual inventory of what the project trusts today and the current repo policy for which of those trust edges are acceptable on the `0.5.x` line.
 
 ## Controlled Inputs
 
@@ -27,6 +27,16 @@ Even with a validated release workflow, the release path still depends on extern
   - Published crate versions are immutable, but the transport and index are still external.
 - GitHub APIs and GitHub Releases
   - The release workflow uses GitHub services to create releases, publish assets, and store attestations.
+
+## Audit: What The Published Release Artifacts Depend On
+
+Based on the committed release workflow in `.github/workflows/release.yml`:
+
+- the published `soldr` release archives are built from the repository source tree plus Rust dependencies resolved through Cargo
+- the workflow does not explicitly download and repackage third-party release binaries into the published `soldr` archives
+- the release path still depends on external services and package sources such as GitHub-hosted runners, `rustup`, crates.io, and GitHub APIs
+- the live `apt` install and pinned third-party repository checkout are part of release-gating validation, not packaged release contents
+- the managed `zccache` download path is runtime behavior in `soldr`, not an input to building the published `soldr` release artifacts
 
 ## E2E Validation External Dependencies
 
@@ -64,7 +74,7 @@ It does not yet enforce:
 - upstream artifact attestations
 - mirrored internal copies of third-party tool binaries
 
-## Current Policy Direction
+## Current Policy Decisions
 
 Current repo policy is:
 
@@ -72,11 +82,27 @@ Current repo policy is:
 - make external trust edges explicit in documentation
 - treat floating workflow refs as unacceptable
 - prefer exact commit or version selection where possible
+- `0.5.x` does not claim hermetic builds
+- the documented release-time dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt` in the bootstrap e2e path, and the pinned third-party bootstrap repository are acceptable for `0.5.x`
+- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are accepted future hardening work, but they are not blockers for the current `0.5.x` release line
+- the pinned third-party bootstrap checkout is acceptable for current validation, but it must not be described as mirrored or hermetic
+- release verification for `soldr` covers the published `soldr` artifacts and their provenance, not every external input used during CI
 
-Open follow-up decisions are tracked in:
+## Current Runtime Fetch Policy
+
+Current `0.5.x` policy for runtime-fetched binaries is:
+
+- `soldr` fetching a third-party tool is a convenience/bootstrap path, not a repository-side trust guarantee
+- a successful fetch currently means crates.io metadata and GitHub Releases produced a matching archive for the selected target and `soldr` extracted it successfully
+- `soldr` does not currently enforce maintainer allowlists, repo-managed checksums, upstream signatures, upstream attestations, or mirrored copies before executing a fetched tool
+- the managed `zccache` path is pinned to a repo-chosen version, but it still uses the same direct GitHub Release download model and is not independently checksum- or attestation-verified by `soldr` itself today
+- stronger runtime trust enforcement is accepted follow-up work, but it is not part of the current `0.5.x` trust claim
+
+Open follow-up implementation issues are tracked in:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
-- [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust hardening
+- [#41](https://github.com/zackees/soldr/issues/41) for reducing live external release inputs
+- [#42](https://github.com/zackees/soldr/issues/42) for fetched-binary trust enforcement
 
 ## Practical Reading Of This Document
 
@@ -84,6 +110,6 @@ If you are deciding whether to trust a published `soldr` release:
 
 - trust the validated GitHub workflow run and artifact attestation for the released commit
 - separately evaluate whether the remaining external build inputs are acceptable for your threat model
-- separately evaluate whether `soldr` fetching third-party tool binaries at runtime is acceptable for your threat model
+- separately evaluate whether `soldr` fetching third-party tool binaries at runtime is acceptable for your threat model, because that remains an upstream trust decision on `0.5.x`
 
 Those are related but distinct trust decisions.


### PR DESCRIPTION
## Summary
- define the explicit `0.5.x` policy for hermeticity and runtime third-party trust
- document that `0.5.x` release verification covers published `soldr` artifacts, not a fully hermetic build claim
- document that runtime fetched binaries remain an upstream trust decision on `0.5.x`
- add concrete follow-up issues for future hardening: #41 and #42

Closes #13.

## Testing
- docs only
- `git diff --check`