### PR TITLE
Define soldr machine-facing API boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Current release line:
 
 - `0.5.x` is the secure front-door, tool-fetch, and built-in zccache-backed cache release line
 - `1.0.0-rc` remains reserved for broader release hardening and bootstrap validation
+- the supported external integration boundary remains the `soldr` executable, not the internal Rust crates; see [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md)
 
 ## Why soldr exists
 
@@ -96,7 +97,7 @@ soldr/
 |   |-- soldr-core/      # Shared types, config, cache directory layout
 |   |-- soldr-fetch/     # Binary resolution + download (the crgx half)
 |   |-- soldr-cache/     # Compilation caching (the zccache half)
-|   `-- soldr-cli/       # CLI entry point + daemon
+|   `-- soldr-cli/       # CLI entry point + wrapper mode
 |-- src/soldr/           # Python package (maturin bin bindings)
 `-- tests/
 ```
@@ -107,6 +108,8 @@ soldr/
 | `soldr-fetch` | Resolve crate binaries from crates.io metadata and GitHub Releases. Download and cache. |
 | `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
 | `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
+
+These workspace crates are implementation details. They are not a supported public Rust library API.
 
 ## Prior art
 
@@ -119,6 +122,7 @@ Built on lessons from:
 ## Security And Verification
 
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
+- [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md) defines the supported machine-facing integration boundary.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,9 @@
 # soldr API Reference
 
+This file is the CLI reference for `soldr`.
+
+For the product-level support contract about what counts as a supported external API, see [API_BOUNDARY.md](./API_BOUNDARY.md).
+
 ## Overview
 
 soldr is a single front door for Rust tool execution and Rust builds.
@@ -14,6 +18,15 @@ It has three invocation modes:
    Low-level passthrough wrapper mode for explicit `RUSTC_WRAPPER=soldr` usage.
 
 The primary user experience is `soldr cargo ...`.
+
+## Machine-Facing Support Level
+
+Current support policy:
+
+- the supported external integration surface is invoking the `soldr` executable through documented commands and flags
+- the internal Rust crates are not a supported public API
+- wrapper mode and internal environment variables are operational mechanics, not a general-purpose API contract
+- human-oriented command output is not yet the stable machine-facing protocol; explicit structured output is future work tracked in [#44](https://github.com/zackees/soldr/issues/44)
 
 ---
 

--- a/docs/API_BOUNDARY.md
+++ b/docs/API_BOUNDARY.md
@@ -1,0 +1,56 @@
+# Machine-Facing API Boundary
+
+This document defines the supported external integration boundary for `soldr`.
+
+## Decision Summary
+
+Current repo policy is:
+
+- `soldr` is a binary-first product
+- the supported external surface is the `soldr` executable, not the internal Rust workspace crates
+- there is no supported public Rust crate API, C ABI, or FFI surface
+- there is no supported long-running daemon or local service protocol today
+- the first future machine-facing API should be explicit CLI commands with structured JSON output, tracked in [#44](https://github.com/zackees/soldr/issues/44)
+
+## What Is Supported Today
+
+Supported use today means invoking the `soldr` binary as a subprocess through documented commands and flags such as:
+
+- `soldr cargo ...`
+- `soldr <tool>[@version] ...`
+- `soldr status`
+- `soldr cache`
+- `soldr clean`
+- `soldr version`
+
+The current CLI reference lives in [API.md](./API.md).
+
+## What Is Not A Supported Public API
+
+The following are implementation details and may change without a semver promise to automation consumers:
+
+- the internal Rust crates in `crates/`
+- direct use of `soldr-core`, `soldr-fetch`, `soldr-cache`, or `soldr-cli` as library dependencies
+- undocumented environment variables or wrapper-mode conventions
+- the exact on-disk cache/session layout beyond what is explicitly documented for users
+- human-oriented stdout/stderr wording unless a command is explicitly documented as structured and stable
+
+## Future Direction
+
+The intended progression is:
+
+1. Keep `soldr` binary-first.
+2. Add explicit JSON output for selected commands that need automation support.
+3. Version that structured output as an external protocol.
+4. Only consider a daemon or other long-running local protocol if a real use case appears that the CLI cannot serve cleanly.
+
+If a daemon or other protocol is ever added, it should be documented and versioned as a separate external interface. It should not expose the internal Rust crate graph and call that the supported API.
+
+## Non-Goals
+
+This repo is not currently pursuing:
+
+- a stable public Rust library API
+- a stable embeddable C ABI
+- undocumented machine parsing of human help/status text
+- a background service that third parties are expected to integrate with by default


### PR DESCRIPTION
## Summary
- define the supported machine-facing boundary as the `soldr` executable, not the internal Rust crates
- add a dedicated API-boundary decision doc
- clarify that daemon/protocol and FFI surfaces are not supported today
- point the future structured automation path at follow-up issue #44

Closes #10.

## Testing
- docs only
- `git diff --check`