### PR TITLE
Add trusted PyPI publishing release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ on:
         required: false
         default: true
         type: boolean
+      publish_pypi:
+        description: Build hardened wheel artifacts and publish them to PyPI via Trusted Publishing
+        required: false
+        default: false
+        type: boolean
+      pypi_repository_url:
+        description: Optional alternate upload endpoint such as https://test.pypi.org/legacy/
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -49,6 +59,8 @@ jobs:
           set -euo pipefail
           version='${{ inputs.version }}'
           commit_sha='${{ inputs.commit_sha }}'
+          publish_pypi='${{ inputs.publish_pypi }}'
+          pypi_repository_url='${{ inputs.pypi_repository_url }}'
 
           if [[ "${GITHUB_REF_NAME}" != "release" ]]; then
             echo "validated releases must be dispatched from release" >&2
@@ -62,6 +74,11 @@ jobs:
 
           if [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "commit_sha must be a full 40-character commit SHA" >&2
+            exit 1
+          fi
+
+          if [[ "$publish_pypi" != "true" && -n "$pypi_repository_url" ]]; then
+            echo "pypi_repository_url requires publish_pypi=true" >&2
             exit 1
           fi
 
@@ -312,6 +329,115 @@ jobs:
           name: release-soldr-${{ matrix.target }}
           path: dist/soldr-*
 
+  build-pypi:
+    name: PyPI ${{ matrix.name }}
+    if: ${{ inputs.publish_pypi }}
+    needs:
+      - prepare
+      - lint
+      - test
+      - e2e-linux-x64
+      - e2e-linux-arm64
+      - e2e-linux-x64-musl
+      - e2e-linux-arm64-musl
+      - e2e-macos-x64
+      - e2e-macos-arm64
+      - e2e-windows-x64
+      - e2e-windows-arm64
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - name: Linux ARM64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS x64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - name: macOS ARM64
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - name: Windows x64
+            runner: windows-2025
+            target: x86_64-pc-windows-msvc
+          - name: Windows ARM64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Install maturin
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "maturin>=1.7,<2"
+
+      - name: Install maturin
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m pip install --upgrade pip
+          py -3 -m pip install "maturin>=1.7,<2"
+
+      - name: Build hardened wheel
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m maturin build \
+            --release \
+            --locked \
+            --compatibility pypi \
+            --target "${{ matrix.target }}" \
+            --out dist
+
+      - name: Build hardened wheel
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m maturin build `
+            --release `
+            --locked `
+            --compatibility pypi `
+            --target "${{ matrix.target }}" `
+            --out dist
+
+      - name: Smoke test wheel
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m venv .venv
+          . .venv/bin/activate
+          python -m pip install dist/*.whl
+          soldr --version
+
+      - name: Smoke test wheel
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m venv .venv
+          .\.venv\Scripts\python.exe -m pip install dist\*.whl
+          .\.venv\Scripts\soldr.exe --version
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pypi-soldr-${{ matrix.target }}
+          path: dist/*.whl
+
   publish:
     name: Attest and publish release assets
     needs:
@@ -370,6 +496,7 @@ jobs:
         run: |
           set -euo pipefail
           gh release create "${{ needs.prepare.outputs.version }}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
             --draft \
             --generate-notes \
             --target "${{ needs.prepare.outputs.commit_sha }}" \
@@ -382,4 +509,42 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh release edit "${{ needs.prepare.outputs.version }}" --draft=false
+          gh release edit "${{ needs.prepare.outputs.version }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --draft=false
+
+  publish-pypi:
+    name: Publish hardened PyPI wheels
+    if: ${{ inputs.publish_pypi && !inputs.dry_run }}
+    needs:
+      - prepare
+      - build-pypi
+      - publish
+    runs-on: ubuntu-24.04
+    environment: release
+
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          pattern: pypi-soldr-*
+          merge-multiple: true
+
+      - name: Show Python distributions
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -1 dist
+
+      - name: Publish wheel set to PyPI
+        if: ${{ inputs.pypi_repository_url == '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
+
+      - name: Publish wheel set to alternate index
+        if: ${{ inputs.pypi_repository_url != '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          repository-url: ${{ inputs.pypi_repository_url }}
+          packages-dir: dist

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Built on lessons from:
 
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
 - [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md) defines the supported machine-facing integration boundary.
+- [docs/PYPI_TRUSTED_PUBLISHING.md](./docs/PYPI_TRUSTED_PUBLISHING.md) describes the optional Trusted Publishing path for hardened PyPI wheels.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.

--- a/docs/PYPI_TRUSTED_PUBLISHING.md
+++ b/docs/PYPI_TRUSTED_PUBLISHING.md
@@ -1,0 +1,88 @@
+# PyPI Trusted Publishing
+
+This document describes the repo-side and owner-side steps needed to publish `soldr` wheels to PyPI using GitHub Actions OIDC Trusted Publishing.
+
+It is intentionally PyPI-only. crates.io publication is not part of the current `0.5.x` release direction.
+
+## Current State
+
+As of April 14, 2026:
+
+- the release workflow can build hardened `soldr` wheels when `publish_pypi=true`
+- the workflow can publish those wheels through `pypa/gh-action-pypi-publish` in a dedicated OIDC job
+- the existing PyPI project `soldr` already exists
+- the current public PyPI `0.1.0` file details say `Uploaded using Trusted Publishing? No`
+
+The next secure PyPI release should replace that stale packaging path with the real wheel set built from the validated release workflow.
+
+## Why This Uses Trusted Publishing
+
+PyPI Trusted Publishing avoids long-lived API tokens.
+
+The workflow receives a short-lived upload credential from PyPI using the GitHub Actions OIDC identity for a specific repository, workflow file, and optional environment.
+
+For `soldr`, the intended trusted identity is:
+
+- owner: `zackees`
+- repository: `soldr`
+- workflow: `.github/workflows/release.yml`
+- environment: `release`
+
+Using the existing `release` environment keeps the PyPI publish step behind the same manual approval gate as the immutable GitHub release path.
+
+## Owner Setup On PyPI
+
+These steps must be performed in the PyPI web UI by a maintainer of the `soldr` project.
+
+1. Open the `soldr` project on PyPI.
+2. Click `Manage`.
+3. Open the `Publishing` page in the project sidebar.
+4. Add a new GitHub Actions publisher with:
+   - repository owner: `zackees`
+   - repository name: `soldr`
+   - workflow filename: `.github/workflows/release.yml`
+   - environment name: `release`
+
+The environment field is optional in PyPI, but it should be filled in here because the repo already uses `release` as the human approval boundary.
+
+## Repo-Side Workflow Inputs
+
+The release workflow supports these PyPI-related inputs:
+
+- `publish_pypi=true`
+- `pypi_repository_url=...` for alternate endpoints such as TestPyPI
+
+If `publish_pypi=false`, the workflow keeps its GitHub-release-only behavior.
+
+If `publish_pypi=true`, the workflow:
+
+1. Builds hardened wheels on the supported platform runners.
+2. Smoke-tests the built wheel on each runner by installing it and running `soldr --version`.
+3. Publishes the GitHub Release.
+4. Publishes the wheel set to PyPI from a dedicated Linux job with `id-token: write`.
+
+No source distribution is published in this path. The current design is wheel-only because the project is prioritizing hardened binary distribution rather than source release through package registries.
+
+## Recommended Rehearsal
+
+Before enabling real PyPI publishing, rehearse against TestPyPI.
+
+Recommended command:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=false \
+  -f publish_pypi=true \
+  -f pypi_repository_url=https://test.pypi.org/legacy/
+```
+
+This uses a real publish path instead of `dry_run=true`, because the OIDC publisher exchange only happens in the real publish job.
+
+## Expected Manual Stop
+
+The repo-side work can be completed without additional secrets.
+
+If the PyPI trusted publisher has not been registered yet, that PyPI-side publisher registration is the remaining manual stop. Until that is done, the PyPI publish job will not be able to mint a trusted upload token.


### PR DESCRIPTION
## Summary
- add optional `publish_pypi` and `pypi_repository_url` inputs to the validated release workflow
- build and smoke-test hardened wheels on the release platform matrix when PyPI publishing is requested
- publish those wheels through PyPI Trusted Publishing in a dedicated OIDC job
- add the missing PyPI Trusted Publishing operations doc and link it from the README

Closes #30.

## Verification
- `git diff --check`
- parsed `.github/workflows/release.yml` with Python `yaml.safe_load(...)`
- could not run a local wheel build on this machine because the C: drive was temporarily out of space and Rust builds failed with `os error 112`; GitHub CI is the real validation for the workflow changes