### PR TITLE
Add versioned JSON CLI output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,8 @@ name = "soldr-cli"
 version = "0.2.0-beta"
 dependencies = [
  "clap",
+ "serde",
+ "serde_json",
  "soldr-cache",
  "soldr-core",
  "soldr-fetch",

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -12,9 +12,14 @@ soldr-core = { workspace = true }
 soldr-fetch = { workspace = true }
 soldr-cache = { workspace = true }
 clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [[bin]]
 name = "soldr"

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,10 +1,12 @@
 use clap::{Parser, Subcommand};
+use serde::Serialize;
 use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 
 const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
 const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
+const JSON_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
@@ -24,15 +26,27 @@ enum Commands {
         args: Vec<String>,
     },
     /// Show cache status and tool info
-    Status,
+    Status {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
+    },
     /// Clear caches
     Clean,
     /// Show or set configuration
     Config,
     /// Inspect the compilation cache
-    Cache,
+    Cache {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
+    },
     /// Show version
-    Version,
+    Version {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
+    },
     /// Anything else is a tool to fetch and run
     #[command(external_subcommand)]
     External(Vec<String>),
@@ -61,20 +75,13 @@ async fn run() -> Result<(), SoldrError> {
         Commands::Cargo { args } => {
             std::process::exit(run_cargo_front_door(&args, cache_enabled).await?);
         }
-        Commands::Status => {
-            println!("soldr {}", soldr_core::version());
-            let target = soldr_core::TargetTriple::detect()?;
-            let paths = soldr_core::SoldrPaths::new()?;
-            println!("target: {target}");
-            println!("root dir: {}", paths.root.display());
-            println!("cache dir: {}", paths.cache.display());
-            println!("cache default: enabled");
-            println!(
-                "cache mode: {}",
-                if cache_enabled { "enabled" } else { "disabled" }
-            );
-            println!("zccache version: {}", soldr_fetch::MANAGED_ZCCACHE_VERSION);
-            print_zccache_status(&paths)?;
+        Commands::Status { json } => {
+            let output = collect_status_output(cache_enabled)?;
+            if json {
+                print_json(&output)?;
+            } else {
+                print_status_output(&output);
+            }
         }
         Commands::Clean => {
             clear_zccache_cache()?;
@@ -82,11 +89,21 @@ async fn run() -> Result<(), SoldrError> {
         Commands::Config => {
             println!("(config not yet implemented)");
         }
-        Commands::Cache => {
-            print_zccache_status(&SoldrPaths::new()?)?;
+        Commands::Cache { json } => {
+            let output = collect_cache_output()?;
+            if json {
+                print_json(&output)?;
+            } else {
+                print_cache_output(&output);
+            }
         }
-        Commands::Version => {
-            println!("soldr {}", soldr_core::version());
+        Commands::Version { json } => {
+            let output = version_output();
+            if json {
+                print_json(&output)?;
+            } else {
+                println!("soldr {}", output.soldr_version);
+            }
         }
         Commands::External(args) => {
             if args.is_empty() {
@@ -380,40 +397,170 @@ fn clear_zccache_cache() -> Result<(), SoldrError> {
     Ok(())
 }
 
-fn print_zccache_status(paths: &SoldrPaths) -> Result<(), SoldrError> {
+#[derive(Serialize)]
+struct VersionOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+}
+
+#[derive(Serialize)]
+struct StatusOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+    target: String,
+    root_dir: String,
+    cache_dir: String,
+    cache_default_enabled: bool,
+    cache_enabled_for_invocation: bool,
+    managed_zccache_version: &'static str,
+    zccache: ZccacheStatusSnapshot,
+}
+
+#[derive(Serialize)]
+struct CacheOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+    managed_zccache_version: &'static str,
+    zccache: ZccacheStatusSnapshot,
+}
+
+#[derive(Serialize)]
+struct ZccacheStatusSnapshot {
+    state_dir: String,
+    journal_path: String,
+    journal_present: bool,
+    binary_path: Option<String>,
+    binary_fetched: bool,
+    status_lines: Vec<String>,
+    status_empty: bool,
+}
+
+fn version_output() -> VersionOutput {
+    VersionOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "version",
+        soldr_version: soldr_core::version().to_string(),
+    }
+}
+
+fn collect_status_output(cache_enabled: bool) -> Result<StatusOutput, SoldrError> {
+    let target = soldr_core::TargetTriple::detect()?;
+    let paths = SoldrPaths::new()?;
+    Ok(StatusOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "status",
+        soldr_version: soldr_core::version().to_string(),
+        target: target.to_string(),
+        root_dir: paths.root.display().to_string(),
+        cache_dir: paths.cache.display().to_string(),
+        cache_default_enabled: true,
+        cache_enabled_for_invocation: cache_enabled,
+        managed_zccache_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+        zccache: collect_zccache_status(&paths)?,
+    })
+}
+
+fn collect_cache_output() -> Result<CacheOutput, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    Ok(CacheOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "cache",
+        soldr_version: soldr_core::version().to_string(),
+        managed_zccache_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+        zccache: collect_zccache_status(&paths)?,
+    })
+}
+
+fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, SoldrError> {
     let zccache_dir = soldr_cache::zccache_dir(paths);
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
-    println!("soldr zccache state dir: {}", zccache_dir.display());
+    let journal_present = journal_path.exists();
+
+    match cached_managed_zccache(paths)? {
+        Some(fetch) => {
+            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
+            let stdout = output.stdout.trim();
+            let status_lines = stdout.lines().map(str::to_owned).collect();
+            Ok(ZccacheStatusSnapshot {
+                state_dir: zccache_dir.display().to_string(),
+                journal_path: journal_path.display().to_string(),
+                journal_present,
+                binary_path: Some(fetch.binary_path.display().to_string()),
+                binary_fetched: true,
+                status_lines,
+                status_empty: stdout.is_empty(),
+            })
+        }
+        None => Ok(ZccacheStatusSnapshot {
+            state_dir: zccache_dir.display().to_string(),
+            journal_path: journal_path.display().to_string(),
+            journal_present,
+            binary_path: None,
+            binary_fetched: false,
+            status_lines: Vec::new(),
+            status_empty: false,
+        }),
+    }
+}
+
+fn print_status_output(output: &StatusOutput) {
+    println!("soldr {}", output.soldr_version);
+    println!("target: {}", output.target);
+    println!("root dir: {}", output.root_dir);
+    println!("cache dir: {}", output.cache_dir);
+    println!("cache default: enabled");
+    println!(
+        "cache mode: {}",
+        if output.cache_enabled_for_invocation {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+    println!("zccache version: {}", output.managed_zccache_version);
+    print_zccache_status_snapshot(&output.zccache);
+}
+
+fn print_cache_output(output: &CacheOutput) {
+    print_zccache_status_snapshot(&output.zccache);
+}
+
+fn print_zccache_status_snapshot(snapshot: &ZccacheStatusSnapshot) {
+    println!("soldr zccache state dir: {}", snapshot.state_dir);
     println!(
         "last session journal: {} ({})",
-        journal_path.display(),
-        if journal_path.exists() {
+        snapshot.journal_path,
+        if snapshot.journal_present {
             "present"
         } else {
             "missing"
         }
     );
 
-    match cached_managed_zccache(paths)? {
-        Some(fetch) => {
-            println!("zccache binary: {}", fetch.binary_path.display());
-            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
-            let stdout = output.stdout.trim();
-            if stdout.is_empty() {
-                println!("zccache status: no output");
-            } else {
-                for line in stdout.lines() {
-                    println!("zccache: {line}");
-                }
+    if let Some(binary_path) = &snapshot.binary_path {
+        println!("zccache binary: {binary_path}");
+        if snapshot.status_empty {
+            println!("zccache status: no output");
+        } else {
+            for line in &snapshot.status_lines {
+                println!("zccache: {line}");
             }
         }
-        None => {
-            println!(
-                "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
-                soldr_fetch::MANAGED_ZCCACHE_VERSION
-            );
-        }
+    } else {
+        println!(
+            "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
     }
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<(), SoldrError> {
+    serde_json::to_writer_pretty(std::io::stdout(), value)
+        .map_err(|e| SoldrError::Other(format!("failed to serialize JSON output: {e}")))?;
+    println!();
     Ok(())
 }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,3 +1,4 @@
+use serde_json::Value;
 use std::process::Command;
 use std::{
     fs,
@@ -201,6 +202,22 @@ fn version_command_prints_workspace_version() {
         stdout.trim(),
         format!("soldr {}", env!("CARGO_PKG_VERSION"))
     );
+}
+
+#[test]
+fn version_command_emits_versioned_json() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["version", "--json"])
+        .output()
+        .expect("failed to run soldr version --json");
+
+    assert!(output.status.success(), "version --json command failed");
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("version --json did not return JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "version");
+    assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
 }
 
 #[test]
@@ -455,6 +472,38 @@ fn status_reports_cache_control_defaults() {
 }
 
 #[test]
+fn status_json_reports_stable_machine_fields() {
+    let cache_root = unique_temp_dir("status-json");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["status", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr status --json");
+
+    assert!(output.status.success(), "status --json command failed");
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("status --json did not return JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "status");
+    assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(json["cache_default_enabled"], true);
+    assert_eq!(json["cache_enabled_for_invocation"], true);
+    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["root_dir"], cache_root.display().to_string());
+    assert_eq!(
+        json["cache_dir"],
+        cache_root.join("cache").display().to_string()
+    );
+    assert_eq!(json["zccache"]["binary_fetched"], false);
+    assert_eq!(json["zccache"]["journal_present"], false);
+    assert!(
+        json["target"].as_str().is_some(),
+        "status JSON missing target"
+    );
+}
+
+#[test]
 fn cache_command_reports_managed_zccache_status() {
     let cache_root = unique_temp_dir("cache-command");
     let log_path = cache_root.join("tool.log");
@@ -497,6 +546,46 @@ fn cache_command_reports_managed_zccache_status() {
 }
 
 #[test]
+fn cache_json_reports_managed_zccache_status() {
+    let cache_root = unique_temp_dir("cache-command-json");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache --json");
+
+    assert!(output.status.success(), "cache --json command failed");
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "cache");
+    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["zccache"]["journal_present"], true);
+    assert_eq!(json["zccache"]["binary_fetched"], true);
+    assert_eq!(
+        json["zccache"]["journal_path"],
+        journal.display().to_string()
+    );
+    assert_eq!(
+        json["zccache"]["status_lines"][0],
+        Value::String("hits=7".to_string())
+    );
+}
+
+#[test]
 fn clean_clears_managed_zccache_and_state_dir() {
     let cache_root = unique_temp_dir("clean-command");
     let log_path = cache_root.join("tool.log");
@@ -535,6 +624,25 @@ fn clean_clears_managed_zccache_and_state_dir() {
     assert!(
         log.contains("zccache clear"),
         "clean should call managed zccache clear: {log}"
+    );
+}
+
+#[test]
+fn clean_rejects_json_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["clean", "--json"])
+        .output()
+        .expect("failed to run soldr clean --json");
+
+    assert!(
+        !output.status.success(),
+        "clean --json should be rejected because JSON is not supported there"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--json"),
+        "expected clap to reject clean --json: {stderr}"
     );
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,8 @@ Current support policy:
 - the supported external integration surface is invoking the `soldr` executable through documented commands and flags
 - the internal Rust crates are not a supported public API
 - wrapper mode and internal environment variables are operational mechanics, not a general-purpose API contract
-- human-oriented command output is not yet the stable machine-facing protocol; explicit structured output is future work tracked in [#44](https://github.com/zackees/soldr/issues/44)
+- human-oriented command output is not the stable machine-facing protocol
+- the first stable machine-facing protocol is the JSON mode on selected commands documented below
 
 ---
 
@@ -134,6 +135,12 @@ soldr --no-cache cargo test
 
 Show cache and target information.
 
+Stable machine-facing mode:
+
+```bash
+soldr status --json
+```
+
 ### `soldr clean`
 
 Clear the managed local zccache artifact cache and remove soldr's zccache session state directory.
@@ -146,9 +153,57 @@ Show or set configuration.
 
 Inspect managed zccache status.
 
+Stable machine-facing mode:
+
+```bash
+soldr cache --json
+```
+
 ### `soldr version`
 
 Print soldr version.
+
+Stable machine-facing mode:
+
+```bash
+soldr version --json
+```
+
+---
+
+## Structured JSON Output
+
+The supported JSON protocol currently exists on:
+
+- `soldr status --json`
+- `soldr cache --json`
+- `soldr version --json`
+
+The JSON response always includes:
+
+- `schema_version`
+- `command`
+
+Current schema version:
+
+- `schema_version: 1`
+
+Compatibility rules for schema version `1`:
+
+- existing fields keep their current meaning
+- fields may be added in later releases without changing `schema_version`
+- removing a field, renaming a field, or changing the meaning/type of an existing field requires a new schema version
+- human-readable stdout for commands without `--json` is not covered by this compatibility promise
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "command": "version",
+  "soldr_version": "0.2.0-beta"
+}
+```
 
 ---
 

--- a/docs/API_BOUNDARY.md
+++ b/docs/API_BOUNDARY.md
@@ -10,7 +10,7 @@ Current repo policy is:
 - the supported external surface is the `soldr` executable, not the internal Rust workspace crates
 - there is no supported public Rust crate API, C ABI, or FFI surface
 - there is no supported long-running daemon or local service protocol today
-- the first future machine-facing API should be explicit CLI commands with structured JSON output, tracked in [#44](https://github.com/zackees/soldr/issues/44)
+- the first supported machine-facing API is explicit CLI commands with structured JSON output on selected commands
 
 ## What Is Supported Today
 
@@ -19,9 +19,12 @@ Supported use today means invoking the `soldr` binary as a subprocess through do
 - `soldr cargo ...`
 - `soldr <tool>[@version] ...`
 - `soldr status`
+- `soldr status --json`
 - `soldr cache`
+- `soldr cache --json`
 - `soldr clean`
 - `soldr version`
+- `soldr version --json`
 
 The current CLI reference lives in [API.md](./API.md).
 
@@ -34,13 +37,14 @@ The following are implementation details and may change without a semver promise
 - undocumented environment variables or wrapper-mode conventions
 - the exact on-disk cache/session layout beyond what is explicitly documented for users
 - human-oriented stdout/stderr wording unless a command is explicitly documented as structured and stable
+- commands that do not explicitly document `--json` as a supported protocol surface
 
 ## Future Direction
 
 The intended progression is:
 
 1. Keep `soldr` binary-first.
-2. Add explicit JSON output for selected commands that need automation support.
+2. Expand explicit JSON output only for selected commands that need automation support.
 3. Version that structured output as an external protocol.
 4. Only consider a daemon or other long-running local protocol if a real use case appears that the CLI cannot serve cleanly.
 


### PR DESCRIPTION
## Summary
- add the first stable machine-facing JSON output modes for soldr status, soldr cache, and soldr version
- document schema version 1 and the compatibility rules for additive evolution
- add CLI tests covering JSON output shape and unsupported --json use on non-protocol commands

## Testing
- cargo fmt --all
- cargo test -p soldr-cli --test cli --locked
- cargo build --workspace --locked
- cargo test --workspace --lib --locked

Closes #44