### PR TITLE
Prepare v0.5.0-rc4 managed zccache patch

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -90,15 +90,16 @@ For `soldr cargo ...`:
 
 1. Resolve real `cargo` via `rustup`
 2. Resolve matching real `rustc` via `rustup`
-3. Set `RUSTC_WRAPPER=soldr`
-4. Delegate to Cargo with unchanged user flags
+3. Set `RUSTC_WRAPPER` to the current soldr binary
+4. Start managed zccache and pass its binary/session state through the environment
+5. Delegate to Cargo with unchanged user flags
 
 For wrapper mode:
 
 1. Detect `rustc` invocation shape
 2. Resolve the real `rustc`
-3. Perform cache logic when implemented
-4. Fall through to the real compiler
+3. Delegate cache-enabled builds into the managed zccache binary
+4. Fall through to the real compiler when caching is disabled or unavailable
 
 ---
 
@@ -174,9 +175,10 @@ all resolve quickly from cache or pre-built binaries.
 
 Done when:
 
-- wrapper mode hashes compiler inputs
-- cache hits avoid recompilation
-- daemon behavior is stable across platforms
+- `soldr cargo ...` enables managed zccache by default
+- `soldr --no-cache cargo ...` cleanly bypasses the cache path
+- wrapper mode routes cache-enabled builds into managed zccache instead of pure pass-through
+- cache commands report and manage real zccache state
 
 ### Phase 4: Bootstrap Validation
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ soldr aims for the same outcome in the Rust toolchain world.
 
 Current release line:
 
-- `0.5.x` is the secure front-door and tool-fetch release line
-- `1.0.0-rc` remains reserved for the point where the built-in zccache integration and cache command surface are fully rounded out
+- `0.5.x` is the secure front-door, tool-fetch, and built-in zccache-backed cache release line
+- `1.0.0-rc` remains reserved for broader release hardening and bootstrap validation
 
 ## Why soldr exists
 
@@ -67,7 +67,8 @@ soldr rustfmt src/main.rs
 soldr cargo build --release
   +-- resolve the real cargo binary
   +-- fetch/start managed zccache when cache is enabled
-  +-- set zccache as the compiler wrapper for this build
+  +-- set soldr as the compiler wrapper for this build
+  +-- have soldr wrapper mode delegate to managed zccache
   +-- delegate to cargo with your existing flags
 
 soldr maturin build --release
@@ -80,6 +81,7 @@ soldr maturin build --release
 - **One obvious command**: Fetch tools, pick the right Windows target, and run through managed zccache through the same entry point.
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
 - **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
+- **Real cache controls**: `soldr status`, `soldr cache`, and `soldr clean` report and manage the soldr-managed zccache state instead of placeholder behavior.
 - **One cache boundary, eventually**: soldr keeps its own tools and zccache session state in `~/.soldr/`. Current zccache artifacts still live in zccache's default cache root until upstream exposes a supported cache-dir override.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,7 +37,7 @@ The remaining work before the attested secure `0.5` release is operational rathe
 - finish policy decisions around SBOMs, reproducibility, and hermeticity
 - register the existing `soldr` PyPI project for Trusted Publishing if hardened wheel upload is in scope for `0.5.0`
 
-`1.0.0-rc` is intentionally reserved for the point where the zccache-style compilation cache is actually integrated rather than merely planned.
+`1.0.0-rc` remains intentionally reserved for broader release hardening and bootstrap validation beyond the `0.5.x` built-in zccache release line.
 
 crates.io publication is not part of the current release direction. `soldr` is being released as a hardened binary tool, not as a promised Rust library API surface.
 

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -23,6 +23,10 @@ pub const CACHE_DISABLED_VALUE: &str = "0";
 /// Per-build session identifier recognized by zccache.
 pub const ZCCACHE_SESSION_ID_ENV_VAR: &str = "ZCCACHE_SESSION_ID";
 
+/// Managed zccache binary path propagated from the soldr front door into
+/// wrapper-mode children.
+pub const ZCCACHE_BINARY_ENV_VAR: &str = "SOLDR_ZCCACHE_BIN";
+
 pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
     if enabled {
         CACHE_ENABLED_VALUE

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -2,6 +2,10 @@ use clap::{Parser, Subcommand};
 use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 
+const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
+const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
+const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
+
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
 struct Cli {
@@ -61,7 +65,6 @@ async fn run() -> Result<(), SoldrError> {
             println!("soldr {}", soldr_core::version());
             let target = soldr_core::TargetTriple::detect()?;
             let paths = soldr_core::SoldrPaths::new()?;
-            let zccache_dir = soldr_cache::zccache_dir(&paths);
             println!("target: {target}");
             println!("root dir: {}", paths.root.display());
             println!("cache dir: {}", paths.cache.display());
@@ -71,7 +74,6 @@ async fn run() -> Result<(), SoldrError> {
                 if cache_enabled { "enabled" } else { "disabled" }
             );
             println!("zccache version: {}", soldr_fetch::MANAGED_ZCCACHE_VERSION);
-            println!("soldr zccache state dir: {}", zccache_dir.display());
             print_zccache_status(&paths)?;
         }
         Commands::Clean => {
@@ -121,17 +123,21 @@ fn report_and_exit(error: SoldrError) -> i32 {
 }
 
 fn is_rustc_path(arg: &str) -> bool {
-    arg == "rustc"
-        || arg.ends_with("/rustc")
-        || arg.ends_with("\\rustc")
-        || arg.ends_with("rustc.exe")
+    if arg == "rustc" {
+        return true;
+    }
+
+    std::path::Path::new(arg)
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        == Some("rustc")
 }
 
 fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     if soldr_cache::cache_enabled_in_current_process() {
-        // The actual artifact cache will slot in here in a follow-up slice.
-        // For now, cache-enabled and cache-disabled wrapper mode both
-        // delegate to the real rustc without modifying outputs.
+        if let Some(zccache) = zccache_binary_override() {
+            return run_wrapper_through_zccache(raw_args, &zccache);
+        }
     }
 
     let rustc = raw_args
@@ -145,6 +151,17 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
 
     let status = std::process::Command::new(rustc)
         .args(&raw_args[2..])
+        .status()?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+fn run_wrapper_through_zccache(
+    raw_args: &[String],
+    zccache: &std::path::Path,
+) -> Result<i32, SoldrError> {
+    let status = std::process::Command::new(zccache)
+        .args(&raw_args[1..])
         .status()?;
 
     Ok(status.code().unwrap_or(1))
@@ -245,6 +262,10 @@ fn prepend_path(
 }
 
 fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError> {
+    if let Some(path) = toolchain_binary_override(tool) {
+        return Ok(path);
+    }
+
     let output = std::process::Command::new("rustup")
         .args(["which", tool])
         .output()?;
@@ -283,7 +304,7 @@ async fn prepare_zccache_build(
     cargo: &mut std::process::Command,
     paths: &SoldrPaths,
 ) -> Result<ZccacheBuildSession, SoldrError> {
-    let fetch = soldr_fetch::fetch_zccache_with_paths(paths).await?;
+    let fetch = fetch_managed_zccache(paths).await?;
     let zccache_dir = soldr_cache::zccache_dir(paths);
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
@@ -315,7 +336,8 @@ async fn prepare_zccache_build(
             ))
         })?;
 
-    cargo.env("RUSTC_WRAPPER", &fetch.binary_path);
+    cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
+    cargo.env(soldr_cache::ZCCACHE_BINARY_ENV_VAR, &fetch.binary_path);
     cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
 
     Ok(ZccacheBuildSession {
@@ -336,10 +358,20 @@ fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError>
 
 fn clear_zccache_cache() -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
-    if let Some(fetch) = soldr_fetch::cached_zccache_binary(&paths)? {
+    let zccache_dir = soldr_cache::zccache_dir(&paths);
+    let mut cleared_anything = false;
+
+    if let Some(fetch) = cached_managed_zccache(&paths)? {
         let _ = run_zccache_command(&fetch.binary_path, &["clear"])?;
-        println!("cleared zccache cache");
-    } else {
+        println!("cleared zccache artifact cache");
+        cleared_anything = true;
+    }
+    if zccache_dir.exists() {
+        std::fs::remove_dir_all(&zccache_dir)?;
+        println!("removed soldr zccache state dir: {}", zccache_dir.display());
+        cleared_anything = true;
+    }
+    if !cleared_anything {
         println!(
             "managed zccache {} not fetched yet",
             soldr_fetch::MANAGED_ZCCACHE_VERSION
@@ -349,7 +381,20 @@ fn clear_zccache_cache() -> Result<(), SoldrError> {
 }
 
 fn print_zccache_status(paths: &SoldrPaths) -> Result<(), SoldrError> {
-    match soldr_fetch::cached_zccache_binary(paths)? {
+    let zccache_dir = soldr_cache::zccache_dir(paths);
+    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    println!("soldr zccache state dir: {}", zccache_dir.display());
+    println!(
+        "last session journal: {} ({})",
+        journal_path.display(),
+        if journal_path.exists() {
+            "present"
+        } else {
+            "missing"
+        }
+    );
+
+    match cached_managed_zccache(paths)? {
         Some(fetch) => {
             println!("zccache binary: {}", fetch.binary_path.display());
             let output = run_zccache_command(&fetch.binary_path, &["status"])?;
@@ -392,6 +437,58 @@ fn run_zccache_command(
     Ok(CommandOutput {
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
     })
+}
+
+fn toolchain_binary_override(tool: &str) -> Option<std::path::PathBuf> {
+    let env_var = match tool {
+        "cargo" => TEST_CARGO_BIN_ENV_VAR,
+        "rustc" => TEST_RUSTC_BIN_ENV_VAR,
+        _ => return None,
+    };
+    non_empty_env_path(env_var)
+}
+
+fn zccache_binary_override() -> Option<std::path::PathBuf> {
+    non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR)
+        .or_else(|| non_empty_env_path(soldr_cache::ZCCACHE_BINARY_ENV_VAR))
+}
+
+fn non_empty_env_path(env_var: &str) -> Option<std::path::PathBuf> {
+    let value = std::env::var_os(env_var)?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.into())
+}
+
+fn current_soldr_binary() -> Result<std::path::PathBuf, SoldrError> {
+    std::env::current_exe().map_err(SoldrError::from)
+}
+
+async fn fetch_managed_zccache(paths: &SoldrPaths) -> Result<soldr_fetch::FetchResult, SoldrError> {
+    if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
+        return Ok(soldr_fetch::FetchResult {
+            binary_path,
+            version: soldr_fetch::MANAGED_ZCCACHE_VERSION.to_string(),
+            cached: true,
+        });
+    }
+
+    soldr_fetch::fetch_zccache_with_paths(paths).await
+}
+
+fn cached_managed_zccache(
+    paths: &SoldrPaths,
+) -> Result<Option<soldr_fetch::FetchResult>, SoldrError> {
+    if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
+        return Ok(Some(soldr_fetch::FetchResult {
+            binary_path,
+            version: soldr_fetch::MANAGED_ZCCACHE_VERSION.to_string(),
+            cached: true,
+        }));
+    }
+
+    soldr_fetch::cached_zccache_binary(paths)
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -26,6 +26,169 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     dir
 }
 
+fn fake_script_path(dir: &PathBuf, name: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        return dir.join(format!("{name}.cmd"));
+    }
+    #[cfg(not(windows))]
+    {
+        dir.join(name)
+    }
+}
+
+fn write_fake_script(path: &PathBuf, body: &str) {
+    #[cfg(windows)]
+    {
+        fs::write(path, body.replace('\n', "\r\n")).expect("failed to write fake script");
+    }
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::write(path, body).expect("failed to write fake script");
+        let mut perms = fs::metadata(path)
+            .expect("failed to stat fake script")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("failed to chmod fake script");
+    }
+}
+
+fn fake_cargo_script(log_path: &PathBuf) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID%>>\"{}\"\n\
+             if defined RUSTC_WRAPPER (\n\
+             call \"%RUSTC_WRAPPER%\" \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
+             ) else (\n\
+             call \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
+             )\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}}\" >> \"{}\"\n\
+             if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\
+               \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
+             else\n\
+               \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
+             fi\n",
+            log_path.display()
+        )
+    }
+}
+
+fn fake_rustc_script(log_path: &PathBuf) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo rustc %*>>\"{}\"\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"rustc $*\" >> \"{}\"\n",
+            log_path.display()
+        )
+    }
+}
+
+fn fake_zccache_script(log_path: &PathBuf) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             if \"%~1\"==\"start\" (\n\
+               echo zccache start>>\"{0}\"\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"session-start\" (\n\
+               echo zccache session-start>>\"{0}\"\n\
+               if not \"%~4\"==\"\" type nul > \"%~4\"\n\
+               echo {{\"session_id\":\"test-session\"}}\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"session-end\" (\n\
+               echo zccache session-end %~2>>\"{0}\"\n\
+               echo hits: 1\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"status\" (\n\
+               echo hits=7\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"clear\" (\n\
+               echo zccache clear>>\"{0}\"\n\
+               exit /b 0\n\
+             )\n\
+             set \"rustc=%~1\"\n\
+             shift\n\
+             echo zccache wrapper %rustc% %*>>\"{0}\"\n\
+             call \"%rustc%\" %*\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             case \"$1\" in\n\
+               start)\n\
+                 echo \"zccache start\" >> \"{0}\"\n\
+                 exit 0\n\
+                 ;;\n\
+               session-start)\n\
+                 echo \"zccache session-start\" >> \"{0}\"\n\
+                 : > \"$4\"\n\
+                 echo '{{\"session_id\":\"test-session\"}}'\n\
+                 exit 0\n\
+                 ;;\n\
+               session-end)\n\
+                 echo \"zccache session-end $2\" >> \"{0}\"\n\
+                 echo 'hits: 1'\n\
+                 exit 0\n\
+                 ;;\n\
+               status)\n\
+                 echo 'hits=7'\n\
+                 exit 0\n\
+                 ;;\n\
+               clear)\n\
+                 echo \"zccache clear\" >> \"{0}\"\n\
+                 exit 0\n\
+                 ;;\n\
+             esac\n\
+             rustc=\"$1\"\n\
+             shift\n\
+             echo \"zccache wrapper $rustc $*\" >> \"{0}\"\n\
+             \"$rustc\" \"$@\"\n",
+            log_path.display()
+        )
+    }
+}
+
+fn install_fake_toolchain(log_path: &PathBuf) -> (PathBuf, PathBuf, PathBuf) {
+    let dir = unique_temp_dir("fake-toolchain");
+    let cargo = fake_script_path(&dir, "cargo");
+    let rustc = fake_script_path(&dir, "rustc");
+    let zccache = fake_script_path(&dir, "zccache");
+    write_fake_script(&cargo, &fake_cargo_script(log_path));
+    write_fake_script(&rustc, &fake_rustc_script(log_path));
+    write_fake_script(&zccache, &fake_zccache_script(log_path));
+    (cargo, rustc, zccache)
+}
+
 #[test]
 fn version_command_prints_workspace_version() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -133,6 +296,119 @@ fn cargo_subcommand_rejects_no_cache_flag() {
 }
 
 #[test]
+fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
+    let cache_root = unique_temp_dir("cargo-default-cache");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cargo build with fake zccache");
+
+    assert!(
+        output.status.success(),
+        "cache-enabled front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cargo wrapper="),
+        "fake cargo did not record wrapper env: {log}"
+    );
+    assert!(
+        log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "soldr should own the wrapper slot in cache-enabled mode: {log}"
+    );
+    assert!(
+        log.contains("cache=1"),
+        "cache-enabled front door should propagate cache flag: {log}"
+    );
+    assert!(
+        log.contains("zccache start"),
+        "managed zccache should be started for cache-enabled builds: {log}"
+    );
+    assert!(
+        log.contains("zccache session-start"),
+        "managed zccache session should start before cargo runs: {log}"
+    );
+    assert!(
+        log.contains("zccache wrapper"),
+        "wrapper mode should dispatch into zccache on cache-enabled builds: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "real rustc invocation should still happen through the wrapper path: {log}"
+    );
+    assert!(
+        log.contains("zccache session-end test-session"),
+        "managed zccache session should end after cargo finishes: {log}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("soldr: zccache session summary"),
+        "expected zccache session summary in stderr: {stderr}"
+    );
+
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    assert!(
+        journal.exists(),
+        "expected session journal at {}",
+        journal.display()
+    );
+}
+
+#[test]
+fn no_cache_bypasses_wrapper_and_zccache() {
+    let cache_root = unique_temp_dir("cargo-no-cache-fake");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["--no-cache", "cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr --no-cache cargo build with fake tools");
+
+    assert!(
+        output.status.success(),
+        "no-cache front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cache=0"),
+        "no-cache front door should propagate cache disable flag: {log}"
+    );
+    assert!(
+        !log.contains("zccache start"),
+        "no-cache front door should not start zccache: {log}"
+    );
+    assert!(
+        !log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "no-cache front door should not set soldr as wrapper: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "no-cache front door should call rustc directly: {log}"
+    );
+}
+
+#[test]
 fn rustc_wrapper_mode_passes_through_to_rustc() {
     let rustc = rustup_which("rustc");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -177,6 +453,90 @@ fn status_reports_cache_control_defaults() {
     assert!(
         stdout.contains("not fetched yet"),
         "status should explain unfetched managed zccache state: {stdout}"
+    );
+}
+
+#[test]
+fn cache_command_reports_managed_zccache_status() {
+    let cache_root = unique_temp_dir("cache-command");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("cache")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache");
+
+    assert!(output.status.success(), "cache command failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("soldr zccache state dir:"),
+        "cache command missing state dir: {stdout}"
+    );
+    assert!(
+        stdout.contains("last session journal:"),
+        "cache command missing journal path: {stdout}"
+    );
+    assert!(
+        stdout.contains("(present)"),
+        "cache command should report present journal: {stdout}"
+    );
+    assert!(
+        stdout.contains("zccache: hits=7"),
+        "cache command should surface managed zccache status output: {stdout}"
+    );
+}
+
+#[test]
+fn clean_clears_managed_zccache_and_state_dir() {
+    let cache_root = unique_temp_dir("clean-command");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let state_dir = cache_root.join("cache").join("zccache");
+    let journal = state_dir.join("logs").join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("clean")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr clean");
+
+    assert!(output.status.success(), "clean command failed");
+    assert!(
+        !state_dir.exists(),
+        "clean should remove soldr zccache state dir at {}",
+        state_dir.display()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cleared zccache artifact cache"),
+        "clean should report artifact cache cleanup: {stdout}"
+    );
+    assert!(
+        stdout.contains("removed soldr zccache state dir:"),
+        "clean should report state dir cleanup: {stdout}"
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("zccache clear"),
+        "clean should call managed zccache clear: {log}"
     );
 }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,9 +1,7 @@
-#[cfg(windows)]
-use std::path::Path;
 use std::process::Command;
 use std::{
     fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -26,7 +24,7 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     dir
 }
 
-fn fake_script_path(dir: &PathBuf, name: &str) -> PathBuf {
+fn fake_script_path(dir: &Path, name: &str) -> PathBuf {
     #[cfg(windows)]
     {
         return dir.join(format!("{name}.cmd"));
@@ -37,7 +35,7 @@ fn fake_script_path(dir: &PathBuf, name: &str) -> PathBuf {
     }
 }
 
-fn write_fake_script(path: &PathBuf, body: &str) {
+fn write_fake_script(path: &Path, body: &str) {
     #[cfg(windows)]
     {
         fs::write(path, body.replace('\n', "\r\n")).expect("failed to write fake script");
@@ -55,7 +53,7 @@ fn write_fake_script(path: &PathBuf, body: &str) {
     }
 }
 
-fn fake_cargo_script(log_path: &PathBuf) -> String {
+fn fake_cargo_script(log_path: &Path) -> String {
     #[cfg(windows)]
     {
         format!(
@@ -85,7 +83,7 @@ fn fake_cargo_script(log_path: &PathBuf) -> String {
     }
 }
 
-fn fake_rustc_script(log_path: &PathBuf) -> String {
+fn fake_rustc_script(log_path: &Path) -> String {
     #[cfg(windows)]
     {
         format!(
@@ -104,7 +102,7 @@ fn fake_rustc_script(log_path: &PathBuf) -> String {
     }
 }
 
-fn fake_zccache_script(log_path: &PathBuf) -> String {
+fn fake_zccache_script(log_path: &Path) -> String {
     #[cfg(windows)]
     {
         format!(
@@ -178,7 +176,7 @@ fn fake_zccache_script(log_path: &PathBuf) -> String {
     }
 }
 
-fn install_fake_toolchain(log_path: &PathBuf) -> (PathBuf, PathBuf, PathBuf) {
+fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
     let dir = unique_temp_dir("fake-toolchain");
     let cargo = fake_script_path(&dir, "cargo");
     let rustc = fake_script_path(&dir, "rustc");

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,7 +33,8 @@ Behavior:
 - Resolve the real `cargo` binary through `rustup`
 - Resolve the matching real `rustc` binary through `rustup`
 - Fetch a pinned managed `zccache` release when caching is enabled
-- Set `RUSTC_WRAPPER` to the managed `zccache` binary
+- Set `RUSTC_WRAPPER` to the current soldr binary
+- Pass the managed `zccache` binary path into wrapper mode through the environment
 - Start a per-build zccache session on zccache's current default daemon endpoint
 - Delegate to Cargo with the exact flags the user passed
 
@@ -86,8 +87,9 @@ In this mode, soldr should act as the transparent build-assistance layer around 
 
 Current implementation status:
 
-- Wrapper-mode passthrough to real `rustc` exists
-- The normal cache-enabled build path uses managed `zccache` instead of soldr wrapper mode
+- Wrapper mode still transparently resolves the real `rustc`
+- The normal cache-enabled build path now runs through soldr wrapper mode and delegates into managed `zccache`
+- If caching is disabled, wrapper mode falls through to real `rustc` without zccache involvement
 
 ---
 
@@ -121,7 +123,7 @@ Show cache and target information.
 
 ### `soldr clean`
 
-Clear the managed local zccache artifact cache.
+Clear the managed local zccache artifact cache and remove soldr's zccache session state directory.
 
 ### `soldr config`
 
@@ -161,6 +163,7 @@ Commands:
 |---|---|---|
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
 | `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
+| `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `SOLDR_LOG` | Log level | `warn` |
@@ -204,5 +207,6 @@ For bootstrap verification of another Rust project:
 The key design rule is simple:
 
 - users build through `soldr cargo ...`
-- soldr uses managed zccache internally for cache-enabled Rust builds
+- soldr owns the wrapper slot on the common path
+- soldr delegates cache-enabled wrapper invocations into managed zccache
 - users do not need to manually wire `RUSTC_WRAPPER` for the common path

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -18,7 +18,7 @@ Decide what `0.5` means for the user-facing CLI.
 Required decision:
 
 - the `0.5` release line is the front-door build and tool-fetch line
-- compilation caching is explicitly out of scope for `0.5`
+- built-in zccache-backed compilation caching is part of the front-door `0.5.x` line
 - `status`, `clean`, `config`, and `cache` must not be presented as complete features unless implemented
 
 Do not ship `0.5` with placeholder commands presented as finished behavior.
@@ -172,8 +172,8 @@ Ship `v0.5.0` only when all of these are true:
 
 Do not cut `1.0.0-rc` until:
 
-- zccache-style compilation caching is actually integrated
-- the wrapper does real cache lookup and store work
-- the public cache commands describe real behavior instead of placeholders
+- `soldr cargo ...` enables managed zccache by default with `--no-cache` as the explicit opt-out
+- the cache-enabled wrapper path delegates through managed zccache instead of acting as pure rustc pass-through
+- the public cache commands describe and manage real behavior instead of placeholders
 
 If those are not true, stay on the `0.5.x` line.


### PR DESCRIPTION
## Summary
Prepare `v0.5.0-rc4` by replaying the managed `zccache` wrapper-path fix onto `release`.

This updates the actual build path so:
- `soldr` owns `RUSTC_WRAPPER`
- cache-enabled wrapper invocations delegate into managed `zccache`
- `--no-cache` cleanly bypasses the cache path
- `status`, `cache`, and `clean` report real managed-cache state

## Validation
- `cargo test --workspace`

## Tracking
- Closes #48