### PR TITLE
Fix release publish when PyPI build is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,6 +448,13 @@ jobs:
 
   publish:
     name: Attest and publish release assets
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.result == 'success' &&
+        needs.build.result == 'success' &&
+        (needs.build-pypi.result == 'success' || needs.build-pypi.result == 'skipped')
+      }}
     needs:
       - prepare
       - build


### PR DESCRIPTION
## Summary
Fix `release.yml` so the GitHub Release publish job still runs when `publish_pypi=false` and `build-pypi` is skipped.

## Why
The attempted real `v0.5.0-rc4` run (`24424875022`) passed all validation and build jobs but skipped `Attest and publish release assets`, which meant:
- no `v0.5.0-rc4` tag was created
- no GitHub Release was published

The root cause is that `publish` depended on `build-pypi`, and GitHub skipped `publish` when `build-pypi` was skipped.

## Fix
Allow `publish` to run when:
- `build` succeeded, and
- `build-pypi` is either `success` or `skipped`

## Tracking
- Related to #48