### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "serde",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "clap",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "flate2",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0-beta"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.2.0-beta" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.2.0-beta" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.2.0-beta" }
+soldr-core = { path = "crates/soldr-core", version = "0.6.0" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.6.0" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.6.0" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.2.0-beta");
+        assert_eq!(version(), "0.6.0");
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.2.0-beta"
+  "soldr_version": "0.6.0"
 }
 ```
 


### PR DESCRIPTION
## Summary

- Bump workspace version from `0.2.0-beta` to `0.6.0` for PyPI release
- Includes toolchain subcommands and clippy-driver fix from #73

## Files changed

- `Cargo.toml` — workspace version + dependency versions
- `Cargo.lock` — lockfile update
- `crates/soldr-core/src/lib.rs` — version test assertion
- `docs/API.md` — example JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)