### PR TITLE
chore: sync release branch for v0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
         description: Exact commit SHA to validate and release
         required: true
         type: string
+      dry_run:
+        description: Validate the full release flow without creating a release tag or publishing assets
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -45,8 +50,8 @@ jobs:
           version='${{ inputs.version }}'
           commit_sha='${{ inputs.commit_sha }}'
 
-          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
-            echo "validated releases must be dispatched from main" >&2
+          if [[ "${GITHUB_REF_NAME}" != "release" ]]; then
+            echo "validated releases must be dispatched from release" >&2
             exit 1
           fi
 
@@ -60,9 +65,9 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main --depth=1
+          git fetch origin release --depth=1
           git rev-parse --verify "${commit_sha}^{commit}" >/dev/null
-          git merge-base --is-ancestor "$commit_sha" origin/main
+          git merge-base --is-ancestor "$commit_sha" origin/release
 
           if git ls-remote --exit-code --tags origin "$version" >/dev/null 2>&1; then
             echo "tag $version already exists" >&2
@@ -322,6 +327,23 @@ jobs:
           pattern: soldr-*
           merge-multiple: true
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: soldr
+
+      - name: Verify GitHub App token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}" --jq '.full_name'
+
       - name: Generate release checksums
         shell: bash
         run: |
@@ -333,9 +355,17 @@ jobs:
         with:
           subject-checksums: dist/soldr-${{ needs.prepare.outputs.version }}-SHA256SUMS.txt
 
+      - name: Stop after dry run validation
+        if: inputs.dry_run
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "dry run complete: release gating, artifact build, attestation, and GitHub App authentication all succeeded"
+
       - name: Create draft GitHub Release
+        if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -346,8 +376,9 @@ jobs:
             --title "${{ needs.prepare.outputs.version }}"
 
       - name: Publish GitHub Release
+        if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: soldr-${{ matrix.target }}
+          name: release-soldr-${{ matrix.target }}
           path: dist/soldr-*
 
   publish:
@@ -324,7 +324,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
-          pattern: soldr-*
+          pattern: release-soldr-*
           merge-multiple: true
 
       - name: Create GitHub App token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ on:
         required: false
         default: true
         type: boolean
+      publish_pypi:
+        description: Build hardened wheel artifacts and publish them to PyPI via Trusted Publishing
+        required: false
+        default: false
+        type: boolean
+      pypi_repository_url:
+        description: Optional alternate upload endpoint such as https://test.pypi.org/legacy/
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -49,6 +59,8 @@ jobs:
           set -euo pipefail
           version='${{ inputs.version }}'
           commit_sha='${{ inputs.commit_sha }}'
+          publish_pypi='${{ inputs.publish_pypi }}'
+          pypi_repository_url='${{ inputs.pypi_repository_url }}'
 
           if [[ "${GITHUB_REF_NAME}" != "release" ]]; then
             echo "validated releases must be dispatched from release" >&2
@@ -62,6 +74,11 @@ jobs:
 
           if [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "commit_sha must be a full 40-character commit SHA" >&2
+            exit 1
+          fi
+
+          if [[ "$publish_pypi" != "true" && -n "$pypi_repository_url" ]]; then
+            echo "pypi_repository_url requires publish_pypi=true" >&2
             exit 1
           fi
 
@@ -312,6 +329,115 @@ jobs:
           name: release-soldr-${{ matrix.target }}
           path: dist/soldr-*
 
+  build-pypi:
+    name: PyPI ${{ matrix.name }}
+    if: ${{ inputs.publish_pypi }}
+    needs:
+      - prepare
+      - lint
+      - test
+      - e2e-linux-x64
+      - e2e-linux-arm64
+      - e2e-linux-x64-musl
+      - e2e-linux-arm64-musl
+      - e2e-macos-x64
+      - e2e-macos-arm64
+      - e2e-windows-x64
+      - e2e-windows-arm64
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - name: Linux ARM64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS x64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - name: macOS ARM64
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - name: Windows x64
+            runner: windows-2025
+            target: x86_64-pc-windows-msvc
+          - name: Windows ARM64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Install maturin
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "maturin>=1.7,<2"
+
+      - name: Install maturin
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m pip install --upgrade pip
+          py -3 -m pip install "maturin>=1.7,<2"
+
+      - name: Build hardened wheel
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m maturin build \
+            --release \
+            --locked \
+            --compatibility pypi \
+            --target "${{ matrix.target }}" \
+            --out dist
+
+      - name: Build hardened wheel
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m maturin build `
+            --release `
+            --locked `
+            --compatibility pypi `
+            --target "${{ matrix.target }}" `
+            --out dist
+
+      - name: Smoke test wheel
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m venv .venv
+          . .venv/bin/activate
+          python -m pip install dist/*.whl
+          soldr --version
+
+      - name: Smoke test wheel
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m venv .venv
+          .\.venv\Scripts\python.exe -m pip install dist\*.whl
+          .\.venv\Scripts\soldr.exe --version
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pypi-soldr-${{ matrix.target }}
+          path: dist/*.whl
+
   publish:
     name: Attest and publish release assets
     needs:
@@ -370,6 +496,7 @@ jobs:
         run: |
           set -euo pipefail
           gh release create "${{ needs.prepare.outputs.version }}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
             --draft \
             --generate-notes \
             --target "${{ needs.prepare.outputs.commit_sha }}" \
@@ -382,4 +509,42 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh release edit "${{ needs.prepare.outputs.version }}" --draft=false
+          gh release edit "${{ needs.prepare.outputs.version }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --draft=false
+
+  publish-pypi:
+    name: Publish hardened PyPI wheels
+    if: ${{ inputs.publish_pypi && !inputs.dry_run }}
+    needs:
+      - prepare
+      - build-pypi
+      - publish
+    runs-on: ubuntu-24.04
+    environment: release
+
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          pattern: pypi-soldr-*
+          merge-multiple: true
+
+      - name: Show Python distributions
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -1 dist
+
+      - name: Publish wheel set to PyPI
+        if: ${{ inputs.pypi_repository_url == '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
+
+      - name: Publish wheel set to alternate index
+        if: ${{ inputs.pypi_repository_url != '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          repository-url: ${{ inputs.pypi_repository_url }}
+          packages-dir: dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "serde",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "clap",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "flate2",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,8 @@ name = "soldr-cli"
 version = "0.2.0-beta"
 dependencies = [
  "clap",
+ "serde",
+ "serde_json",
  "soldr-cache",
  "soldr-core",
  "soldr-fetch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0-beta"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.2.0-beta" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.2.0-beta" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.2.0-beta" }
+soldr-core = { path = "crates/soldr-core", version = "0.6.0" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.6.0" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.6.0" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -90,15 +90,16 @@ For `soldr cargo ...`:
 
 1. Resolve real `cargo` via `rustup`
 2. Resolve matching real `rustc` via `rustup`
-3. Set `RUSTC_WRAPPER=soldr`
-4. Delegate to Cargo with unchanged user flags
+3. Set `RUSTC_WRAPPER` to the current soldr binary
+4. Start managed zccache and pass its binary/session state through the environment
+5. Delegate to Cargo with unchanged user flags
 
 For wrapper mode:
 
 1. Detect `rustc` invocation shape
 2. Resolve the real `rustc`
-3. Perform cache logic when implemented
-4. Fall through to the real compiler
+3. Delegate cache-enabled builds into the managed zccache binary
+4. Fall through to the real compiler when caching is disabled or unavailable
 
 ---
 
@@ -174,9 +175,10 @@ all resolve quickly from cache or pre-built binaries.
 
 Done when:
 
-- wrapper mode hashes compiler inputs
-- cache hits avoid recompilation
-- daemon behavior is stable across platforms
+- `soldr cargo ...` enables managed zccache by default
+- `soldr --no-cache cargo ...` cleanly bypasses the cache path
+- wrapper mode routes cache-enabled builds into managed zccache instead of pure pass-through
+- cache commands report and manage real zccache state
 
 ### Phase 4: Bootstrap Validation
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Current release line:
 
 - `0.5.x` is the secure front-door, tool-fetch, and built-in zccache-backed cache release line
 - `1.0.0-rc` remains reserved for broader release hardening and bootstrap validation
+- the supported external integration boundary remains the `soldr` executable, not the internal Rust crates; see [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md)
 
 ## Why soldr exists
 
@@ -96,7 +97,7 @@ soldr/
 |   |-- soldr-core/      # Shared types, config, cache directory layout
 |   |-- soldr-fetch/     # Binary resolution + download (the crgx half)
 |   |-- soldr-cache/     # Compilation caching (the zccache half)
-|   `-- soldr-cli/       # CLI entry point + daemon
+|   `-- soldr-cli/       # CLI entry point + wrapper mode
 |-- src/soldr/           # Python package (maturin bin bindings)
 `-- tests/
 ```
@@ -107,6 +108,8 @@ soldr/
 | `soldr-fetch` | Resolve crate binaries from crates.io metadata and GitHub Releases. Download and cache. |
 | `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
 | `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
+
+These workspace crates are implementation details. They are not a supported public Rust library API.
 
 ## Prior art
 
@@ -119,6 +122,7 @@ Built on lessons from:
 ## Security And Verification
 
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
+- [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md) defines the supported machine-facing integration boundary.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Built on lessons from:
 
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
 - [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md) defines the supported machine-facing integration boundary.
+- [docs/PYPI_TRUSTED_PUBLISHING.md](./docs/PYPI_TRUSTED_PUBLISHING.md) describes the optional Trusted Publishing path for hardened PyPI wheels.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ When you run `soldr`, the tool should do the obvious thing:
 
 If soldr solves that one problem well, it becomes a super tool: the command you reach for first, because it makes the rest of the stack behave.
 
-- **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse.
+- **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse. On `0.5.x`, this is still an upstream trust decision rather than a repo-side trust guarantee; see [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md).
 
 - **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring; zccache's artifact store still uses its current default cache root.
 
@@ -104,7 +104,7 @@ soldr/
 | Crate | Role |
 |---|---|
 | `soldr-core` | Cache paths, config, version types |
-| `soldr-fetch` | Resolve crate binaries from binstall metadata, GitHub Releases, QuickInstall. Download, verify, cache. |
+| `soldr-fetch` | Resolve crate binaries from crates.io metadata and GitHub Releases. Download and cache. |
 | `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
 | `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
 
@@ -121,7 +121,7 @@ Built on lessons from:
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
-- [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts.
+- [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ That is the same reason [uv](https://github.com/astral-sh/uv) is compelling. uv 
 
 soldr aims for the same outcome in the Rust toolchain world.
 
+Current release line:
+
+- `0.5.x` is the secure front-door, tool-fetch, and built-in zccache-backed cache release line
+- `1.0.0-rc` remains reserved for broader release hardening and bootstrap validation
+
 ## Why soldr exists
 
 On Windows, the real problem is not "how do I cache builds?" or "how do I download a tool binary?" in isolation.
@@ -36,18 +41,19 @@ When you run `soldr`, the tool should do the obvious thing:
 - pick MSVC on Windows by default
 - fetch the tool you asked for
 - cache it locally
-- carry `zccache` along for transparent `rustc` caching without manual wrapper setup
+- fetch and manage zccache so Rust builds get transparent caching without manual wrapper setup
 
 If soldr solves that one problem well, it becomes a super tool: the command you reach for first, because it makes the rest of the stack behave.
 
 - **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse.
 
-- **Compilation caching** (the zccache half): When your build invokes `rustc` hundreds of times, soldr caches every compilation unit. Second builds finish in milliseconds, not minutes.
+- **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring; zccache's artifact store still uses its current default cache root.
 
 ```bash
 # Build through soldr's front door:
 soldr cargo build --release
 soldr cargo test
+soldr --no-cache cargo test
 
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release
@@ -60,7 +66,9 @@ soldr rustfmt src/main.rs
 ```text
 soldr cargo build --release
   +-- resolve the real cargo binary
-  +-- wire soldr's wrapper path internally
+  +-- fetch/start managed zccache when cache is enabled
+  +-- set soldr as the compiler wrapper for this build
+  +-- have soldr wrapper mode delegate to managed zccache
   +-- delegate to cargo with your existing flags
 
 soldr maturin build --release
@@ -70,10 +78,11 @@ soldr maturin build --release
 
 ## Design goals
 
-- **One obvious command**: Fetch tools, pick the right Windows target, and enable build caching through the same entry point.
+- **One obvious command**: Fetch tools, pick the right Windows target, and run through managed zccache through the same entry point.
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
-- **Invisible caching**: soldr wires its build-assistance internals for you. No manual `RUSTC_WRAPPER` setup in the common case.
-- **One cache**: Tools and compilation artifacts in a single `~/.soldr/` directory.
+- **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
+- **Real cache controls**: `soldr status`, `soldr cache`, and `soldr clean` report and manage the soldr-managed zccache state instead of placeholder behavior.
+- **One cache boundary, eventually**: soldr keeps its own tools and zccache session state in `~/.soldr/`. Current zccache artifacts still live in zccache's default cache root until upstream exposes a supported cache-dir override.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
 - **Cross-platform**: Linux, macOS, Windows (x86_64 + aarch64).
@@ -88,7 +97,7 @@ soldr/
 |   |-- soldr-fetch/     # Binary resolution + download (the crgx half)
 |   |-- soldr-cache/     # Compilation caching (the zccache half)
 |   `-- soldr-cli/       # CLI entry point + daemon
-|-- src/soldr/           # Python package (PyO3 bindings)
+|-- src/soldr/           # Python package (maturin bin bindings)
 `-- tests/
 ```
 
@@ -96,8 +105,8 @@ soldr/
 |---|---|
 | `soldr-core` | Cache paths, config, version types |
 | `soldr-fetch` | Resolve crate binaries from binstall metadata, GitHub Releases, QuickInstall. Download, verify, cache. |
-| `soldr-cache` | Wrap rustc, hash inputs, store/retrieve compiled artifacts. The compilation cache daemon. |
-| `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`), tool fetch dispatch. |
+| `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
+| `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
 
 ## Prior art
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,15 @@ Current state:
 - immutable releases and protected tag settings still depend on repository configuration outside the git tree
 - current user-facing verification guidance is checksum verification plus `gh attestation verify`
 
+Current verification policy:
+
+- checksum verification plus `gh attestation verify` is the official user-facing verification story
+- GitHub CLI is the primary documented attestation-verification tool
+- offline attestation bundles may be archived, but separate Sigstore tooling is not required for the normal verification path
+- SBOM publication is not currently required for the release line
+- reproducible-build claims are not currently made for `soldr`
+- no extra signed release metadata is currently published beyond `SHA256SUMS` and GitHub provenance attestations
+
 Planned state, tracked in issue `#7`:
 
 - release tags created only after full validation passes for the exact release commit

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ The repository currently enforces several baseline controls:
 
 These controls reduce drift, but they do not make the full release pipeline hermetic.
 
+The current `0.5.x` line does not claim hermetic builds, and it does not claim that third-party binaries fetched later by `soldr` are repository-verified just because `soldr` downloaded them.
+
 ## What is pinned
 
 The repo aims to pin security-relevant inputs wherever practical:
@@ -86,6 +88,14 @@ Current verification policy:
 - SBOM publication is not currently required for the release line
 - reproducible-build claims are not currently made for `soldr`
 - no extra signed release metadata is currently published beyond `SHA256SUMS` and GitHub provenance attestations
+
+Current hermeticity and runtime-trust policy:
+
+- `0.5.x` release verification covers published `soldr` artifacts, not every external input used during CI
+- `0.5.x` does not claim hermetic builds; documented dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt`, and the pinned bootstrap test repository remain acceptable for this release line
+- Cargo/toolchain/package mirroring or vendoring is deferred hardening tracked in issue [#41](https://github.com/zackees/soldr/issues/41)
+- runtime third-party binary fetches are a convenience/bootstrap path on `0.5.x`, not a repository-side trust guarantee
+- stronger trust enforcement for fetched binaries is tracked in issue [#42](https://github.com/zackees/soldr/issues/42)
 
 Planned state, tracked in issue `#7`:
 

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -1,4 +1,177 @@
-//! Compilation caching.
+//! zccache integration surface for soldr.
 //!
-//! Wraps rustc invocations, hashes inputs, and stores/retrieves
-//! compiled artifacts (.o, .rlib, .rmeta) for cache hits.
+//! soldr owns the build UX and cache policy, while zccache provides the actual
+//! compiler-cache engine and daemon.
+
+use serde::Deserialize;
+use soldr_core::SoldrPaths;
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+/// Environment variable used to carry cache enable/disable state from the
+/// front-door cargo command into child processes.
+pub const CACHE_ENABLED_ENV_VAR: &str = "SOLDR_CACHE_ENABLED";
+
+/// Encoded environment value for an enabled cache invocation.
+pub const CACHE_ENABLED_VALUE: &str = "1";
+
+/// Encoded environment value for a disabled cache invocation.
+pub const CACHE_DISABLED_VALUE: &str = "0";
+
+/// Per-build session identifier recognized by zccache.
+pub const ZCCACHE_SESSION_ID_ENV_VAR: &str = "ZCCACHE_SESSION_ID";
+
+/// Managed zccache binary path propagated from the soldr front door into
+/// wrapper-mode children.
+pub const ZCCACHE_BINARY_ENV_VAR: &str = "SOLDR_ZCCACHE_BIN";
+
+pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
+    if enabled {
+        CACHE_ENABLED_VALUE
+    } else {
+        CACHE_DISABLED_VALUE
+    }
+}
+
+pub fn cache_enabled_from_env_var(value: Option<&OsStr>) -> bool {
+    match value.and_then(OsStr::to_str) {
+        None => true,
+        Some(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+    }
+}
+
+pub fn cache_enabled_in_current_process() -> bool {
+    cache_enabled_from_env_var(std::env::var_os(CACHE_ENABLED_ENV_VAR).as_deref())
+}
+
+pub fn zccache_dir(paths: &SoldrPaths) -> PathBuf {
+    paths.cache.join("zccache")
+}
+
+pub fn parse_zccache_session_id(stdout: &str) -> Option<String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(response) = serde_json::from_str::<SessionStartResponse>(trimmed) {
+        if !response.session_id.trim().is_empty() {
+            return Some(response.session_id);
+        }
+    }
+
+    for line in trimmed.lines() {
+        let line = line.trim();
+        for prefix in [
+            "ZCCACHE_SESSION_ID=",
+            "export ZCCACHE_SESSION_ID=",
+            "$env:ZCCACHE_SESSION_ID=",
+        ] {
+            if let Some(value) = line.strip_prefix(prefix) {
+                let value = value.trim().trim_matches('"').trim_matches('\'');
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+pub fn session_journal_path(zccache_dir: &Path) -> PathBuf {
+    zccache_dir.join("logs").join("last-session.jsonl")
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionStartResponse {
+    session_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id,
+        session_journal_path, zccache_dir, CACHE_DISABLED_VALUE, CACHE_ENABLED_VALUE,
+    };
+    use soldr_core::SoldrPaths;
+    use std::{ffi::OsStr, path::Path};
+
+    #[test]
+    fn cache_defaults_to_enabled_when_env_is_missing() {
+        assert!(cache_enabled_from_env_var(None));
+    }
+
+    #[test]
+    fn cache_control_parses_common_false_values() {
+        for value in ["0", "false", "FALSE", "no", "off", ""] {
+            assert!(
+                !cache_enabled_from_env_var(Some(OsStr::new(value))),
+                "expected {value:?} to disable cache"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_control_treats_other_values_as_enabled() {
+        for value in ["1", "true", "yes", "unexpected"] {
+            assert!(
+                cache_enabled_from_env_var(Some(OsStr::new(value))),
+                "expected {value:?} to enable cache"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_control_serializes_boolean_state() {
+        assert_eq!(cache_enabled_env_value(true), CACHE_ENABLED_VALUE);
+        assert_eq!(cache_enabled_env_value(false), CACHE_DISABLED_VALUE);
+    }
+
+    #[test]
+    fn zccache_dir_lives_under_soldr_cache_root() {
+        let paths = SoldrPaths::with_root(Path::new("C:\\soldr-root").to_path_buf());
+        assert_eq!(
+            zccache_dir(&paths),
+            paths.root.join("cache").join("zccache")
+        );
+    }
+
+    #[test]
+    fn parses_json_session_start_output() {
+        let session_id = parse_zccache_session_id(
+            r#"{"session_id":"08f063c0-5f01-4c92-aec1-3f304d9224d0","started_at":1776141813}"#,
+        );
+        assert_eq!(
+            session_id.as_deref(),
+            Some("08f063c0-5f01-4c92-aec1-3f304d9224d0")
+        );
+    }
+
+    #[test]
+    fn parses_shell_style_session_start_output() {
+        let session_id = parse_zccache_session_id(
+            "export ZCCACHE_SESSION_ID=08f063c0-5f01-4c92-aec1-3f304d9224d0",
+        );
+        assert_eq!(
+            session_id.as_deref(),
+            Some("08f063c0-5f01-4c92-aec1-3f304d9224d0")
+        );
+    }
+
+    #[test]
+    fn session_journal_path_uses_logs_directory() {
+        let path = session_journal_path(Path::new("C:\\soldr-root\\cache\\zccache"));
+        assert_eq!(
+            path,
+            Path::new("C:\\soldr-root\\cache\\zccache")
+                .join("logs")
+                .join("last-session.jsonl")
+        );
+    }
+}

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -12,9 +12,14 @@ soldr-core = { workspace = true }
 soldr-fetch = { workspace = true }
 soldr-cache = { workspace = true }
 clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [[bin]]
 name = "soldr"

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,10 +1,17 @@
 use clap::{Parser, Subcommand};
-use soldr_core::SoldrError;
+use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
+
+const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
+const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
+const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
 struct Cli {
+    /// Disable soldr's compilation cache for this invocation
+    #[arg(long)]
+    no_cache: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -48,25 +55,35 @@ async fn main() {
 
 async fn run() -> Result<(), SoldrError> {
     let cli = Cli::parse();
+    let cache_enabled = !cli.no_cache;
 
     match cli.command {
         Commands::Cargo { args } => {
-            std::process::exit(run_cargo_front_door(&args)?);
+            std::process::exit(run_cargo_front_door(&args, cache_enabled).await?);
         }
         Commands::Status => {
             println!("soldr {}", soldr_core::version());
             let target = soldr_core::TargetTriple::detect()?;
+            let paths = soldr_core::SoldrPaths::new()?;
             println!("target: {target}");
-            println!("(status not yet implemented)");
+            println!("root dir: {}", paths.root.display());
+            println!("cache dir: {}", paths.cache.display());
+            println!("cache default: enabled");
+            println!(
+                "cache mode: {}",
+                if cache_enabled { "enabled" } else { "disabled" }
+            );
+            println!("zccache version: {}", soldr_fetch::MANAGED_ZCCACHE_VERSION);
+            print_zccache_status(&paths)?;
         }
         Commands::Clean => {
-            println!("(clean not yet implemented)");
+            clear_zccache_cache()?;
         }
         Commands::Config => {
             println!("(config not yet implemented)");
         }
         Commands::Cache => {
-            println!("(cache not yet implemented)");
+            print_zccache_status(&SoldrPaths::new()?)?;
         }
         Commands::Version => {
             println!("soldr {}", soldr_core::version());
@@ -106,13 +123,23 @@ fn report_and_exit(error: SoldrError) -> i32 {
 }
 
 fn is_rustc_path(arg: &str) -> bool {
-    arg == "rustc"
-        || arg.ends_with("/rustc")
-        || arg.ends_with("\\rustc")
-        || arg.ends_with("rustc.exe")
+    if arg == "rustc" {
+        return true;
+    }
+
+    std::path::Path::new(arg)
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        == Some("rustc")
 }
 
 fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
+    if soldr_cache::cache_enabled_in_current_process() {
+        if let Some(zccache) = zccache_binary_override() {
+            return run_wrapper_through_zccache(raw_args, &zccache);
+        }
+    }
+
     let rustc = raw_args
         .get(1)
         .ok_or_else(|| SoldrError::Other("missing rustc path in wrapper mode".into()))?;
@@ -129,20 +156,41 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     Ok(status.code().unwrap_or(1))
 }
 
-fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
+fn run_wrapper_through_zccache(
+    raw_args: &[String],
+    zccache: &std::path::Path,
+) -> Result<i32, SoldrError> {
+    let status = std::process::Command::new(zccache)
+        .args(&raw_args[1..])
+        .status()?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {
+    if cargo_args_use_reserved_no_cache(args) {
+        return Err(SoldrError::Other(
+            "`--no-cache` must appear before `cargo`, as in `soldr --no-cache cargo build`".into(),
+        ));
+    }
+
     let cargo = resolve_toolchain_binary("cargo")?;
     let rustc = resolve_toolchain_binary("rustc")?;
-    let current_exe = std::env::current_exe()?;
     let cargo_bin_dir = cargo
         .parent()
         .ok_or_else(|| SoldrError::Other("failed to resolve cargo bin directory".into()))?
         .to_path_buf();
     let existing_path = std::env::var_os("PATH");
+    let paths = SoldrPaths::new()?;
+    paths.ensure_dirs()?;
 
     let mut command = std::process::Command::new(cargo);
     command.args(args);
-    command.env("RUSTC_WRAPPER", current_exe);
     command.env("RUSTC", rustc);
+    command.env(
+        soldr_cache::CACHE_ENABLED_ENV_VAR,
+        soldr_cache::cache_enabled_env_value(cache_enabled),
+    );
     command.env(
         "PATH",
         prepend_path(&cargo_bin_dir, existing_path.as_deref())?,
@@ -151,7 +199,16 @@ fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
         command.env("CARGO_BUILD_TARGET", target);
     }
 
+    let session = if cache_enabled {
+        Some(prepare_zccache_build(&mut command, &paths).await?)
+    } else {
+        None
+    };
+
     let status = command.status()?;
+    if let Some(session) = session {
+        finish_zccache_build(&session)?;
+    }
     Ok(status.code().unwrap_or(1))
 }
 
@@ -181,6 +238,18 @@ fn cargo_args_specify_target(args: &[String]) -> bool {
     false
 }
 
+fn cargo_args_use_reserved_no_cache(args: &[String]) -> bool {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--no-cache" {
+            return true;
+        }
+    }
+    false
+}
+
 fn prepend_path(
     dir: &std::path::Path,
     existing_path: Option<&std::ffi::OsStr>,
@@ -193,6 +262,10 @@ fn prepend_path(
 }
 
 fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError> {
+    if let Some(path) = toolchain_binary_override(tool) {
+        return Ok(path);
+    }
+
     let output = std::process::Command::new("rustup")
         .args(["which", tool])
         .output()?;
@@ -222,9 +295,206 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
     }
 }
 
+struct ZccacheBuildSession {
+    binary_path: std::path::PathBuf,
+    session_id: String,
+}
+
+async fn prepare_zccache_build(
+    cargo: &mut std::process::Command,
+    paths: &SoldrPaths,
+) -> Result<ZccacheBuildSession, SoldrError> {
+    let fetch = fetch_managed_zccache(paths).await?;
+    let zccache_dir = soldr_cache::zccache_dir(paths);
+    std::fs::create_dir_all(&zccache_dir)?;
+    std::fs::create_dir_all(zccache_dir.join("logs"))?;
+    if fetch.cached {
+        eprintln!(
+            "soldr: using managed zccache {}",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    } else {
+        eprintln!(
+            "soldr: fetched managed zccache {}",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    }
+
+    run_zccache_command(&fetch.binary_path, &["start"])?;
+
+    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    let journal_path = journal_path.display().to_string();
+    let session_json = run_zccache_command(
+        &fetch.binary_path,
+        &["session-start", "--stats", "--journal", &journal_path],
+    )?;
+    let session_id =
+        soldr_cache::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
+            SoldrError::Other(format!(
+                "failed to parse zccache session id from output: {}",
+                session_json.stdout.trim()
+            ))
+        })?;
+
+    cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
+    cargo.env(soldr_cache::ZCCACHE_BINARY_ENV_VAR, &fetch.binary_path);
+    cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
+
+    Ok(ZccacheBuildSession {
+        binary_path: fetch.binary_path,
+        session_id,
+    })
+}
+
+fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
+    let output = run_zccache_command(&session.binary_path, &["session-end", &session.session_id])?;
+    let stdout = output.stdout.trim();
+    if !stdout.is_empty() {
+        eprintln!("soldr: zccache session summary");
+        eprintln!("{stdout}");
+    }
+    Ok(())
+}
+
+fn clear_zccache_cache() -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let zccache_dir = soldr_cache::zccache_dir(&paths);
+    let mut cleared_anything = false;
+
+    if let Some(fetch) = cached_managed_zccache(&paths)? {
+        let _ = run_zccache_command(&fetch.binary_path, &["clear"])?;
+        println!("cleared zccache artifact cache");
+        cleared_anything = true;
+    }
+    if zccache_dir.exists() {
+        std::fs::remove_dir_all(&zccache_dir)?;
+        println!("removed soldr zccache state dir: {}", zccache_dir.display());
+        cleared_anything = true;
+    }
+    if !cleared_anything {
+        println!(
+            "managed zccache {} not fetched yet",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    }
+    Ok(())
+}
+
+fn print_zccache_status(paths: &SoldrPaths) -> Result<(), SoldrError> {
+    let zccache_dir = soldr_cache::zccache_dir(paths);
+    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    println!("soldr zccache state dir: {}", zccache_dir.display());
+    println!(
+        "last session journal: {} ({})",
+        journal_path.display(),
+        if journal_path.exists() {
+            "present"
+        } else {
+            "missing"
+        }
+    );
+
+    match cached_managed_zccache(paths)? {
+        Some(fetch) => {
+            println!("zccache binary: {}", fetch.binary_path.display());
+            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
+            let stdout = output.stdout.trim();
+            if stdout.is_empty() {
+                println!("zccache status: no output");
+            } else {
+                for line in stdout.lines() {
+                    println!("zccache: {line}");
+                }
+            }
+        }
+        None => {
+            println!(
+                "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
+                soldr_fetch::MANAGED_ZCCACHE_VERSION
+            );
+        }
+    }
+    Ok(())
+}
+
+struct CommandOutput {
+    stdout: String,
+}
+
+fn run_zccache_command(
+    binary: &std::path::Path,
+    args: &[&str],
+) -> Result<CommandOutput, SoldrError> {
+    let output = std::process::Command::new(binary).args(args).output()?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(format!(
+            "zccache {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    Ok(CommandOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+    })
+}
+
+fn toolchain_binary_override(tool: &str) -> Option<std::path::PathBuf> {
+    let env_var = match tool {
+        "cargo" => TEST_CARGO_BIN_ENV_VAR,
+        "rustc" => TEST_RUSTC_BIN_ENV_VAR,
+        _ => return None,
+    };
+    non_empty_env_path(env_var)
+}
+
+fn zccache_binary_override() -> Option<std::path::PathBuf> {
+    non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR)
+        .or_else(|| non_empty_env_path(soldr_cache::ZCCACHE_BINARY_ENV_VAR))
+}
+
+fn non_empty_env_path(env_var: &str) -> Option<std::path::PathBuf> {
+    let value = std::env::var_os(env_var)?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.into())
+}
+
+fn current_soldr_binary() -> Result<std::path::PathBuf, SoldrError> {
+    std::env::current_exe().map_err(SoldrError::from)
+}
+
+async fn fetch_managed_zccache(paths: &SoldrPaths) -> Result<soldr_fetch::FetchResult, SoldrError> {
+    if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
+        return Ok(soldr_fetch::FetchResult {
+            binary_path,
+            version: soldr_fetch::MANAGED_ZCCACHE_VERSION.to_string(),
+            cached: true,
+        });
+    }
+
+    soldr_fetch::fetch_zccache_with_paths(paths).await
+}
+
+fn cached_managed_zccache(
+    paths: &SoldrPaths,
+) -> Result<Option<soldr_fetch::FetchResult>, SoldrError> {
+    if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
+        return Ok(Some(soldr_fetch::FetchResult {
+            binary_path,
+            version: soldr_fetch::MANAGED_ZCCACHE_VERSION.to_string(),
+            cached: true,
+        }));
+    }
+
+    soldr_fetch::cached_zccache_binary(paths)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::cargo_args_specify_target;
+    use super::{cargo_args_specify_target, cargo_args_use_reserved_no_cache, parse_tool_spec};
+    use soldr_fetch::VersionSpec;
 
     #[test]
     fn cargo_args_detect_explicit_target_flag() {
@@ -247,5 +517,25 @@ mod tests {
             "--target".into(),
             "ignored".into(),
         ]));
+    }
+
+    #[test]
+    fn cargo_args_reject_reserved_no_cache_before_passthrough_separator() {
+        assert!(cargo_args_use_reserved_no_cache(&[
+            "build".into(),
+            "--no-cache".into(),
+        ]));
+        assert!(!cargo_args_use_reserved_no_cache(&[
+            "test".into(),
+            "--".into(),
+            "--no-cache".into(),
+        ]));
+    }
+
+    #[test]
+    fn parse_tool_spec_defaults_to_latest_version() {
+        let (tool, version) = parse_tool_spec("maturin");
+        assert_eq!(tool, "maturin");
+        assert!(matches!(version, VersionSpec::Latest));
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,10 +1,12 @@
 use clap::{Parser, Subcommand};
+use serde::Serialize;
 use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 
 const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
 const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
+const JSON_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
@@ -24,15 +26,27 @@ enum Commands {
         args: Vec<String>,
     },
     /// Show cache status and tool info
-    Status,
+    Status {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
+    },
     /// Clear caches
     Clean,
     /// Show or set configuration
     Config,
     /// Inspect the compilation cache
-    Cache,
+    Cache {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
+    },
     /// Show version
-    Version,
+    Version {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
+    },
     /// Anything else is a tool to fetch and run
     #[command(external_subcommand)]
     External(Vec<String>),
@@ -61,20 +75,13 @@ async fn run() -> Result<(), SoldrError> {
         Commands::Cargo { args } => {
             std::process::exit(run_cargo_front_door(&args, cache_enabled).await?);
         }
-        Commands::Status => {
-            println!("soldr {}", soldr_core::version());
-            let target = soldr_core::TargetTriple::detect()?;
-            let paths = soldr_core::SoldrPaths::new()?;
-            println!("target: {target}");
-            println!("root dir: {}", paths.root.display());
-            println!("cache dir: {}", paths.cache.display());
-            println!("cache default: enabled");
-            println!(
-                "cache mode: {}",
-                if cache_enabled { "enabled" } else { "disabled" }
-            );
-            println!("zccache version: {}", soldr_fetch::MANAGED_ZCCACHE_VERSION);
-            print_zccache_status(&paths)?;
+        Commands::Status { json } => {
+            let output = collect_status_output(cache_enabled)?;
+            if json {
+                print_json(&output)?;
+            } else {
+                print_status_output(&output);
+            }
         }
         Commands::Clean => {
             clear_zccache_cache()?;
@@ -82,11 +89,21 @@ async fn run() -> Result<(), SoldrError> {
         Commands::Config => {
             println!("(config not yet implemented)");
         }
-        Commands::Cache => {
-            print_zccache_status(&SoldrPaths::new()?)?;
+        Commands::Cache { json } => {
+            let output = collect_cache_output()?;
+            if json {
+                print_json(&output)?;
+            } else {
+                print_cache_output(&output);
+            }
         }
-        Commands::Version => {
-            println!("soldr {}", soldr_core::version());
+        Commands::Version { json } => {
+            let output = version_output();
+            if json {
+                print_json(&output)?;
+            } else {
+                println!("soldr {}", output.soldr_version);
+            }
         }
         Commands::External(args) => {
             if args.is_empty() {
@@ -380,40 +397,170 @@ fn clear_zccache_cache() -> Result<(), SoldrError> {
     Ok(())
 }
 
-fn print_zccache_status(paths: &SoldrPaths) -> Result<(), SoldrError> {
+#[derive(Serialize)]
+struct VersionOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+}
+
+#[derive(Serialize)]
+struct StatusOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+    target: String,
+    root_dir: String,
+    cache_dir: String,
+    cache_default_enabled: bool,
+    cache_enabled_for_invocation: bool,
+    managed_zccache_version: &'static str,
+    zccache: ZccacheStatusSnapshot,
+}
+
+#[derive(Serialize)]
+struct CacheOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+    managed_zccache_version: &'static str,
+    zccache: ZccacheStatusSnapshot,
+}
+
+#[derive(Serialize)]
+struct ZccacheStatusSnapshot {
+    state_dir: String,
+    journal_path: String,
+    journal_present: bool,
+    binary_path: Option<String>,
+    binary_fetched: bool,
+    status_lines: Vec<String>,
+    status_empty: bool,
+}
+
+fn version_output() -> VersionOutput {
+    VersionOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "version",
+        soldr_version: soldr_core::version().to_string(),
+    }
+}
+
+fn collect_status_output(cache_enabled: bool) -> Result<StatusOutput, SoldrError> {
+    let target = soldr_core::TargetTriple::detect()?;
+    let paths = SoldrPaths::new()?;
+    Ok(StatusOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "status",
+        soldr_version: soldr_core::version().to_string(),
+        target: target.to_string(),
+        root_dir: paths.root.display().to_string(),
+        cache_dir: paths.cache.display().to_string(),
+        cache_default_enabled: true,
+        cache_enabled_for_invocation: cache_enabled,
+        managed_zccache_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+        zccache: collect_zccache_status(&paths)?,
+    })
+}
+
+fn collect_cache_output() -> Result<CacheOutput, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    Ok(CacheOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "cache",
+        soldr_version: soldr_core::version().to_string(),
+        managed_zccache_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+        zccache: collect_zccache_status(&paths)?,
+    })
+}
+
+fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, SoldrError> {
     let zccache_dir = soldr_cache::zccache_dir(paths);
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
-    println!("soldr zccache state dir: {}", zccache_dir.display());
+    let journal_present = journal_path.exists();
+
+    match cached_managed_zccache(paths)? {
+        Some(fetch) => {
+            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
+            let stdout = output.stdout.trim();
+            let status_lines = stdout.lines().map(str::to_owned).collect();
+            Ok(ZccacheStatusSnapshot {
+                state_dir: zccache_dir.display().to_string(),
+                journal_path: journal_path.display().to_string(),
+                journal_present,
+                binary_path: Some(fetch.binary_path.display().to_string()),
+                binary_fetched: true,
+                status_lines,
+                status_empty: stdout.is_empty(),
+            })
+        }
+        None => Ok(ZccacheStatusSnapshot {
+            state_dir: zccache_dir.display().to_string(),
+            journal_path: journal_path.display().to_string(),
+            journal_present,
+            binary_path: None,
+            binary_fetched: false,
+            status_lines: Vec::new(),
+            status_empty: false,
+        }),
+    }
+}
+
+fn print_status_output(output: &StatusOutput) {
+    println!("soldr {}", output.soldr_version);
+    println!("target: {}", output.target);
+    println!("root dir: {}", output.root_dir);
+    println!("cache dir: {}", output.cache_dir);
+    println!("cache default: enabled");
+    println!(
+        "cache mode: {}",
+        if output.cache_enabled_for_invocation {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+    println!("zccache version: {}", output.managed_zccache_version);
+    print_zccache_status_snapshot(&output.zccache);
+}
+
+fn print_cache_output(output: &CacheOutput) {
+    print_zccache_status_snapshot(&output.zccache);
+}
+
+fn print_zccache_status_snapshot(snapshot: &ZccacheStatusSnapshot) {
+    println!("soldr zccache state dir: {}", snapshot.state_dir);
     println!(
         "last session journal: {} ({})",
-        journal_path.display(),
-        if journal_path.exists() {
+        snapshot.journal_path,
+        if snapshot.journal_present {
             "present"
         } else {
             "missing"
         }
     );
 
-    match cached_managed_zccache(paths)? {
-        Some(fetch) => {
-            println!("zccache binary: {}", fetch.binary_path.display());
-            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
-            let stdout = output.stdout.trim();
-            if stdout.is_empty() {
-                println!("zccache status: no output");
-            } else {
-                for line in stdout.lines() {
-                    println!("zccache: {line}");
-                }
+    if let Some(binary_path) = &snapshot.binary_path {
+        println!("zccache binary: {binary_path}");
+        if snapshot.status_empty {
+            println!("zccache status: no output");
+        } else {
+            for line in &snapshot.status_lines {
+                println!("zccache: {line}");
             }
         }
-        None => {
-            println!(
-                "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
-                soldr_fetch::MANAGED_ZCCACHE_VERSION
-            );
-        }
+    } else {
+        println!(
+            "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
     }
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<(), SoldrError> {
+    serde_json::to_writer_pretty(std::io::stdout(), value)
+        .map_err(|e| SoldrError::Other(format!("failed to serialize JSON output: {e}")))?;
+    println!();
     Ok(())
 }
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -25,6 +25,45 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Run rustc from the active toolchain
+    Rustc {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rustfmt from the active toolchain
+    Rustfmt {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run clippy-driver from the active toolchain
+    #[command(name = "clippy-driver")]
+    ClippyDriver {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rustdoc from the active toolchain
+    Rustdoc {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rust-gdb from the active toolchain
+    #[command(name = "rust-gdb")]
+    RustGdb {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rust-lldb from the active toolchain
+    #[command(name = "rust-lldb")]
+    RustLldb {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rust-analyzer from the active toolchain
+    #[command(name = "rust-analyzer")]
+    RustAnalyzer {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Show cache status and tool info
     Status {
         /// Emit the stable machine-facing JSON form for this command
@@ -57,7 +96,7 @@ async fn main() {
     // RUSTC_WRAPPER mode: cargo passes `soldr /path/to/rustc <args...>`
     // Must be checked before clap parsing.
     let raw_args: Vec<String> = std::env::args().collect();
-    if raw_args.len() > 1 && is_rustc_path(&raw_args[1]) {
+    if raw_args.len() > 1 && is_wrapper_invocation(&raw_args[1]) {
         std::process::exit(run_rustc_wrapper(&raw_args).unwrap_or_else(report_and_exit));
     }
 
@@ -74,6 +113,27 @@ async fn run() -> Result<(), SoldrError> {
     match cli.command {
         Commands::Cargo { args } => {
             std::process::exit(run_cargo_front_door(&args, cache_enabled).await?);
+        }
+        Commands::Rustc { args } => {
+            std::process::exit(run_toolchain_passthrough("rustc", &args)?);
+        }
+        Commands::Rustfmt { args } => {
+            std::process::exit(run_toolchain_passthrough("rustfmt", &args)?);
+        }
+        Commands::ClippyDriver { args } => {
+            std::process::exit(run_toolchain_passthrough("clippy-driver", &args)?);
+        }
+        Commands::Rustdoc { args } => {
+            std::process::exit(run_toolchain_passthrough("rustdoc", &args)?);
+        }
+        Commands::RustGdb { args } => {
+            std::process::exit(run_toolchain_passthrough("rust-gdb", &args)?);
+        }
+        Commands::RustLldb { args } => {
+            std::process::exit(run_toolchain_passthrough("rust-lldb", &args)?);
+        }
+        Commands::RustAnalyzer { args } => {
+            std::process::exit(run_toolchain_passthrough("rust-analyzer", &args)?);
         }
         Commands::Status { json } => {
             let output = collect_status_output(cache_enabled)?;
@@ -139,37 +199,57 @@ fn report_and_exit(error: SoldrError) -> i32 {
     1
 }
 
-fn is_rustc_path(arg: &str) -> bool {
-    if arg == "rustc" {
-        return true;
-    }
+/// Known toolchain binaries that cargo may invoke through RUSTC_WRAPPER
+/// or RUSTC_WORKSPACE_WRAPPER. When soldr is set as a wrapper, cargo
+/// passes: `soldr <toolchain-binary> <rustc-args...>`
+const WRAPPER_PASSTHROUGH_TOOLS: &[&str] = &["rustc", "clippy-driver"];
 
-    std::path::Path::new(arg)
+fn is_wrapper_invocation(arg: &str) -> bool {
+    let stem = std::path::Path::new(arg)
         .file_stem()
         .and_then(std::ffi::OsStr::to_str)
-        == Some("rustc")
+        .unwrap_or(arg);
+
+    WRAPPER_PASSTHROUGH_TOOLS.contains(&stem)
 }
 
 fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
-    if soldr_cache::cache_enabled_in_current_process() {
+    let tool_arg = raw_args
+        .get(1)
+        .ok_or_else(|| SoldrError::Other("missing tool path in wrapper mode".into()))?;
+
+    let tool_stem = std::path::Path::new(tool_arg.as_str())
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or(tool_arg);
+
+    // Only route through zccache for actual rustc invocations, not
+    // clippy-driver or other workspace wrappers.
+    if tool_stem == "rustc" && soldr_cache::cache_enabled_in_current_process() {
         if let Some(zccache) = zccache_binary_override() {
             return run_wrapper_through_zccache(raw_args, &zccache);
         }
     }
 
-    let rustc = raw_args
-        .get(1)
-        .ok_or_else(|| SoldrError::Other("missing rustc path in wrapper mode".into()))?;
-    let rustc = if rustc == "rustc" {
-        resolve_toolchain_binary("rustc")?
+    // Resolve the tool binary. If it's already a full path, use it
+    // directly. Otherwise resolve via rustup.
+    let tool_path: std::path::PathBuf = if std::path::Path::new(tool_arg.as_str()).is_absolute() {
+        tool_arg.into()
     } else {
-        rustc.into()
+        resolve_toolchain_binary(tool_stem)?
     };
 
-    let status = std::process::Command::new(rustc)
+    let status = std::process::Command::new(tool_path)
         .args(&raw_args[2..])
         .status()?;
 
+    Ok(status.code().unwrap_or(1))
+}
+
+/// Run a rustup-managed toolchain binary with pass-through args.
+fn run_toolchain_passthrough(tool: &str, args: &[String]) -> Result<i32, SoldrError> {
+    let binary = resolve_toolchain_binary(tool)?;
+    let status = std::process::Command::new(binary).args(args).status()?;
     Ok(status.code().unwrap_or(1))
 }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-#[cfg(windows)]
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -13,6 +12,179 @@ fn rustup_which(tool: &str) -> String {
         .expect("failed to resolve tool with rustup");
     assert!(output.status.success(), "rustup which failed for {tool}");
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
+    fs::create_dir_all(&dir).expect("failed to create temp dir");
+    dir
+}
+
+fn fake_script_path(dir: &Path, name: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        return dir.join(format!("{name}.cmd"));
+    }
+    #[cfg(not(windows))]
+    {
+        dir.join(name)
+    }
+}
+
+fn write_fake_script(path: &Path, body: &str) {
+    #[cfg(windows)]
+    {
+        fs::write(path, body.replace('\n', "\r\n")).expect("failed to write fake script");
+    }
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::write(path, body).expect("failed to write fake script");
+        let mut perms = fs::metadata(path)
+            .expect("failed to stat fake script")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("failed to chmod fake script");
+    }
+}
+
+fn fake_cargo_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID%>>\"{}\"\n\
+             if defined RUSTC_WRAPPER (\n\
+             call \"%RUSTC_WRAPPER%\" \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
+             ) else (\n\
+             call \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
+             )\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}}\" >> \"{}\"\n\
+             if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\
+               \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
+             else\n\
+               \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
+             fi\n",
+            log_path.display()
+        )
+    }
+}
+
+fn fake_rustc_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo rustc %*>>\"{}\"\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"rustc $*\" >> \"{}\"\n",
+            log_path.display()
+        )
+    }
+}
+
+fn fake_zccache_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             if \"%~1\"==\"start\" (\n\
+               echo zccache start>>\"{0}\"\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"session-start\" (\n\
+               echo zccache session-start>>\"{0}\"\n\
+               if not \"%~4\"==\"\" type nul > \"%~4\"\n\
+               echo {{\"session_id\":\"test-session\"}}\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"session-end\" (\n\
+               echo zccache session-end %~2>>\"{0}\"\n\
+               echo hits: 1\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"status\" (\n\
+               echo hits=7\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"clear\" (\n\
+               echo zccache clear>>\"{0}\"\n\
+               exit /b 0\n\
+             )\n\
+             set \"rustc=%~1\"\n\
+             shift\n\
+             echo zccache wrapper %rustc% %*>>\"{0}\"\n\
+             call \"%rustc%\" %*\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             case \"$1\" in\n\
+               start)\n\
+                 echo \"zccache start\" >> \"{0}\"\n\
+                 exit 0\n\
+                 ;;\n\
+               session-start)\n\
+                 echo \"zccache session-start\" >> \"{0}\"\n\
+                 : > \"$4\"\n\
+                 echo '{{\"session_id\":\"test-session\"}}'\n\
+                 exit 0\n\
+                 ;;\n\
+               session-end)\n\
+                 echo \"zccache session-end $2\" >> \"{0}\"\n\
+                 echo 'hits: 1'\n\
+                 exit 0\n\
+                 ;;\n\
+               status)\n\
+                 echo 'hits=7'\n\
+                 exit 0\n\
+                 ;;\n\
+               clear)\n\
+                 echo \"zccache clear\" >> \"{0}\"\n\
+                 exit 0\n\
+                 ;;\n\
+             esac\n\
+             rustc=\"$1\"\n\
+             shift\n\
+             echo \"zccache wrapper $rustc $*\" >> \"{0}\"\n\
+             \"$rustc\" \"$@\"\n",
+            log_path.display()
+        )
+    }
+}
+
+fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let dir = unique_temp_dir("fake-toolchain");
+    let cargo = fake_script_path(&dir, "cargo");
+    let rustc = fake_script_path(&dir, "rustc");
+    let zccache = fake_script_path(&dir, "zccache");
+    write_fake_script(&cargo, &fake_cargo_script(log_path));
+    write_fake_script(&rustc, &fake_rustc_script(log_path));
+    write_fake_script(&zccache, &fake_zccache_script(log_path));
+    (cargo, rustc, zccache)
 }
 
 #[test]
@@ -51,8 +223,10 @@ fn help_lists_phase_one_command_surface() {
 
 #[test]
 fn cargo_front_door_runs_real_cargo() {
+    let cache_root = unique_temp_dir("cargo-version");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "--version"])
+        .args(["--no-cache", "cargo", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr cargo --version");
 
@@ -67,6 +241,168 @@ fn cargo_front_door_runs_real_cargo() {
     assert!(
         !stderr.contains("soldr: fetching cargo"),
         "cargo front door should not fetch cargo: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_front_door_consumes_no_cache_flag() {
+    let cache_root = unique_temp_dir("cargo-no-cache");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["--no-cache", "cargo", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr --no-cache cargo --version");
+
+    assert!(
+        output.status.success(),
+        "cargo front door with top-level --no-cache failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("cargo"),
+        "unexpected cargo output with --no-cache: {stdout}"
+    );
+    assert!(
+        !stderr.contains("unexpected argument '--no-cache'"),
+        "--no-cache should be consumed by soldr, not forwarded to cargo: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_subcommand_rejects_no_cache_flag() {
+    let cache_root = unique_temp_dir("cargo-subcommand-no-cache");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "--no-cache", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr cargo --no-cache --version");
+
+    assert!(
+        !output.status.success(),
+        "cargo subcommand form should no longer accept --no-cache"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--no-cache"),
+        "expected cargo-subcommand form to fail mentioning --no-cache: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
+    let cache_root = unique_temp_dir("cargo-default-cache");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cargo build with fake zccache");
+
+    assert!(
+        output.status.success(),
+        "cache-enabled front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cargo wrapper="),
+        "fake cargo did not record wrapper env: {log}"
+    );
+    assert!(
+        log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "soldr should own the wrapper slot in cache-enabled mode: {log}"
+    );
+    assert!(
+        log.contains("cache=1"),
+        "cache-enabled front door should propagate cache flag: {log}"
+    );
+    assert!(
+        log.contains("zccache start"),
+        "managed zccache should be started for cache-enabled builds: {log}"
+    );
+    assert!(
+        log.contains("zccache session-start"),
+        "managed zccache session should start before cargo runs: {log}"
+    );
+    assert!(
+        log.contains("zccache wrapper"),
+        "wrapper mode should dispatch into zccache on cache-enabled builds: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "real rustc invocation should still happen through the wrapper path: {log}"
+    );
+    assert!(
+        log.contains("zccache session-end test-session"),
+        "managed zccache session should end after cargo finishes: {log}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("soldr: zccache session summary"),
+        "expected zccache session summary in stderr: {stderr}"
+    );
+
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    assert!(
+        journal.exists(),
+        "expected session journal at {}",
+        journal.display()
+    );
+}
+
+#[test]
+fn no_cache_bypasses_wrapper_and_zccache() {
+    let cache_root = unique_temp_dir("cargo-no-cache-fake");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["--no-cache", "cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr --no-cache cargo build with fake tools");
+
+    assert!(
+        output.status.success(),
+        "no-cache front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cache=0"),
+        "no-cache front door should propagate cache disable flag: {log}"
+    );
+    assert!(
+        !log.contains("zccache start"),
+        "no-cache front door should not start zccache: {log}"
+    );
+    assert!(
+        !log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "no-cache front door should not set soldr as wrapper: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "no-cache front door should call rustc directly: {log}"
     );
 }
 
@@ -88,15 +424,118 @@ fn rustc_wrapper_mode_passes_through_to_rustc() {
     );
 }
 
-#[cfg(windows)]
-fn unique_temp_dir(label: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("time went backwards")
-        .as_nanos();
-    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
-    fs::create_dir_all(&dir).expect("failed to create temp dir");
-    dir
+#[test]
+fn status_reports_cache_control_defaults() {
+    let cache_root = unique_temp_dir("status");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("status")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr status");
+
+    assert!(output.status.success(), "status command failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cache dir:"),
+        "status missing cache dir: {stdout}"
+    );
+    assert!(
+        stdout.contains("cache default: enabled"),
+        "status missing cache default: {stdout}"
+    );
+    assert!(
+        stdout.contains("zccache version:"),
+        "status missing zccache version: {stdout}"
+    );
+    assert!(
+        stdout.contains("not fetched yet"),
+        "status should explain unfetched managed zccache state: {stdout}"
+    );
+}
+
+#[test]
+fn cache_command_reports_managed_zccache_status() {
+    let cache_root = unique_temp_dir("cache-command");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("cache")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache");
+
+    assert!(output.status.success(), "cache command failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("soldr zccache state dir:"),
+        "cache command missing state dir: {stdout}"
+    );
+    assert!(
+        stdout.contains("last session journal:"),
+        "cache command missing journal path: {stdout}"
+    );
+    assert!(
+        stdout.contains("(present)"),
+        "cache command should report present journal: {stdout}"
+    );
+    assert!(
+        stdout.contains("zccache: hits=7"),
+        "cache command should surface managed zccache status output: {stdout}"
+    );
+}
+
+#[test]
+fn clean_clears_managed_zccache_and_state_dir() {
+    let cache_root = unique_temp_dir("clean-command");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let state_dir = cache_root.join("cache").join("zccache");
+    let journal = state_dir.join("logs").join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("clean")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr clean");
+
+    assert!(output.status.success(), "clean command failed");
+    assert!(
+        !state_dir.exists(),
+        "clean should remove soldr zccache state dir at {}",
+        state_dir.display()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cleared zccache artifact cache"),
+        "clean should report artifact cache cleanup: {stdout}"
+    );
+    assert!(
+        stdout.contains("removed soldr zccache state dir:"),
+        "clean should report state dir cleanup: {stdout}"
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("zccache clear"),
+        "clean should call managed zccache clear: {log}"
+    );
 }
 
 #[cfg(windows)]
@@ -128,10 +567,11 @@ fn cargo_front_door_forces_msvc_target_even_with_polluted_path() {
         .join("fixtures")
         .join("windows-msvc-default");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "build"])
+        .args(["--no-cache", "cargo", "build"])
         .current_dir(&fixture)
         .env("PATH", prepend_to_path(&fake_tools))
         .env("CARGO_TARGET_DIR", &target_dir)
+        .env("SOLDR_CACHE_DIR", unique_temp_dir("msvc-cache-root"))
         .output()
         .expect("failed to run soldr cargo build");
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,3 +1,4 @@
+use serde_json::Value;
 use std::process::Command;
 use std::{
     fs,
@@ -201,6 +202,22 @@ fn version_command_prints_workspace_version() {
         stdout.trim(),
         format!("soldr {}", env!("CARGO_PKG_VERSION"))
     );
+}
+
+#[test]
+fn version_command_emits_versioned_json() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["version", "--json"])
+        .output()
+        .expect("failed to run soldr version --json");
+
+    assert!(output.status.success(), "version --json command failed");
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("version --json did not return JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "version");
+    assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
 }
 
 #[test]
@@ -455,6 +472,38 @@ fn status_reports_cache_control_defaults() {
 }
 
 #[test]
+fn status_json_reports_stable_machine_fields() {
+    let cache_root = unique_temp_dir("status-json");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["status", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr status --json");
+
+    assert!(output.status.success(), "status --json command failed");
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("status --json did not return JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "status");
+    assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(json["cache_default_enabled"], true);
+    assert_eq!(json["cache_enabled_for_invocation"], true);
+    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["root_dir"], cache_root.display().to_string());
+    assert_eq!(
+        json["cache_dir"],
+        cache_root.join("cache").display().to_string()
+    );
+    assert_eq!(json["zccache"]["binary_fetched"], false);
+    assert_eq!(json["zccache"]["journal_present"], false);
+    assert!(
+        json["target"].as_str().is_some(),
+        "status JSON missing target"
+    );
+}
+
+#[test]
 fn cache_command_reports_managed_zccache_status() {
     let cache_root = unique_temp_dir("cache-command");
     let log_path = cache_root.join("tool.log");
@@ -497,6 +546,46 @@ fn cache_command_reports_managed_zccache_status() {
 }
 
 #[test]
+fn cache_json_reports_managed_zccache_status() {
+    let cache_root = unique_temp_dir("cache-command-json");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache --json");
+
+    assert!(output.status.success(), "cache --json command failed");
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "cache");
+    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["zccache"]["journal_present"], true);
+    assert_eq!(json["zccache"]["binary_fetched"], true);
+    assert_eq!(
+        json["zccache"]["journal_path"],
+        journal.display().to_string()
+    );
+    assert_eq!(
+        json["zccache"]["status_lines"][0],
+        Value::String("hits=7".to_string())
+    );
+}
+
+#[test]
 fn clean_clears_managed_zccache_and_state_dir() {
     let cache_root = unique_temp_dir("clean-command");
     let log_path = cache_root.join("tool.log");
@@ -535,6 +624,25 @@ fn clean_clears_managed_zccache_and_state_dir() {
     assert!(
         log.contains("zccache clear"),
         "clean should call managed zccache clear: {log}"
+    );
+}
+
+#[test]
+fn clean_rejects_json_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["clean", "--json"])
+        .output()
+        .expect("failed to run soldr clean --json");
+
+    assert!(
+        !output.status.success(),
+        "clean --json should be rejected because JSON is not supported there"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--json"),
+        "expected clap to reject clean --json: {stderr}"
     );
 }
 

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -1,5 +1,8 @@
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 use thiserror::Error;
 
 // ---------------------------------------------------------------------------
@@ -304,6 +307,8 @@ fn compile_time_fallback_triple() -> Result<String, SoldrError> {
 // Paths - ~/.soldr/ layout
 // ---------------------------------------------------------------------------
 
+pub const SOLDR_CACHE_DIR_ENV_VAR: &str = "SOLDR_CACHE_DIR";
+
 pub struct SoldrPaths {
     pub root: PathBuf,
     pub bin: PathBuf,
@@ -313,7 +318,8 @@ pub struct SoldrPaths {
 
 impl SoldrPaths {
     pub fn new() -> Result<Self, SoldrError> {
-        let root = home_dir()?.join(".soldr");
+        let root = soldr_root_from_env_var(std::env::var_os(SOLDR_CACHE_DIR_ENV_VAR).as_deref())
+            .unwrap_or_else(|| home_dir().map(|home| home.join(".soldr")))?;
         Ok(Self::with_root(root))
     }
 
@@ -331,6 +337,14 @@ impl SoldrPaths {
         std::fs::create_dir_all(&self.cache)?;
         Ok(())
     }
+}
+
+fn soldr_root_from_env_var(value: Option<&OsStr>) -> Option<Result<PathBuf, SoldrError>> {
+    let value = value?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(Ok(PathBuf::from(value)))
 }
 
 fn home_dir() -> Result<PathBuf, SoldrError> {
@@ -437,6 +451,19 @@ mod tests {
         assert!(paths.root.ends_with(".soldr"));
         assert!(paths.bin.ends_with("bin"));
         assert!(paths.cache.ends_with("cache"));
+    }
+
+    #[test]
+    fn soldr_root_override_uses_env_path() {
+        let root = soldr_root_from_env_var(Some(OsStr::new("C:\\temp\\soldr-cache-root")))
+            .unwrap()
+            .unwrap();
+        assert_eq!(root, PathBuf::from("C:\\temp\\soldr-cache-root"));
+    }
+
+    #[test]
+    fn soldr_root_override_ignores_empty_env() {
+        assert!(soldr_root_from_env_var(Some(OsStr::new(""))).is_none());
     }
 
     #[test]

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.2.0-beta");
+        assert_eq!(version(), "0.6.0");
     }
 
     #[test]

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -34,6 +34,8 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.8";
+
 /// Fetch a tool binary for the current platform.
 pub async fn fetch_tool(
     crate_name: &str,
@@ -50,36 +52,95 @@ pub async fn fetch_tool_with_paths(
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
-    let target = TargetTriple::detect()?;
+    let repo = resolve_repo(crate_name).await?;
+    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, paths).await
+}
 
-    // 1. Check local cache (exact version only)
+pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    fetch_zccache_with_paths(&paths).await
+}
+
+pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
+    paths.ensure_dirs()?;
+    let target = TargetTriple::detect()?;
+    let binary_names = ["zccache", "zccache-daemon", "zccache-fp"];
+
+    if let Some(result) = check_cache(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &binary_names,
+        &target,
+    )? {
+        return Ok(result);
+    }
+
+    let download_url = managed_zccache_download_url(MANAGED_ZCCACHE_VERSION, &target);
+    let binary_path = download_and_extract(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &download_url,
+        &target,
+        &binary_names,
+    )
+    .await?;
+
+    Ok(FetchResult {
+        binary_path,
+        version: MANAGED_ZCCACHE_VERSION.to_string(),
+        cached: false,
+    })
+}
+
+pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, SoldrError> {
+    let target = TargetTriple::detect()?;
+    check_cache(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &["zccache", "zccache-daemon", "zccache-fp"],
+        &target,
+    )
+}
+
+async fn fetch_repo_binary_with_paths(
+    cache_name: &str,
+    binary_names: &[&str],
+    repo: &RepoInfo,
+    version: &VersionSpec,
+    paths: &SoldrPaths,
+) -> Result<FetchResult, SoldrError> {
+    paths.ensure_dirs()?;
+    let target = TargetTriple::detect()?;
+    if binary_names.is_empty() {
+        return Err(SoldrError::Other(format!(
+            "no binary names configured for {cache_name}"
+        )));
+    }
+
     if let VersionSpec::Exact(ref v) = version {
-        if let Some(r) = check_cache(paths, crate_name, v, &target)? {
+        if let Some(r) = check_cache(paths, cache_name, v, binary_names, &target)? {
             return Ok(r);
         }
     }
 
-    // 2. Resolve repository from crates.io
-    let repo = resolve_repo(crate_name).await?;
+    let release = fetch_release(repo, version).await?;
 
-    // 3. Get release metadata from GitHub
-    let release = fetch_release(&repo, version).await?;
-
-    // 4. Check cache for the resolved version (handles Latest -> concrete version)
-    if let Some(r) = check_cache(paths, crate_name, &release.version, &target)? {
+    if let Some(r) = check_cache(paths, cache_name, &release.version, binary_names, &target)? {
         return Ok(r);
     }
 
-    // 5. Find matching asset for our target
     let asset = match_asset(&release.assets, &target)?;
 
-    // 6. Download and extract
     let binary_path = download_and_extract(
         paths,
-        crate_name,
+        cache_name,
         &release.version,
         &asset.download_url,
         &target,
+        binary_names,
     )
     .await?;
 
@@ -96,15 +157,28 @@ pub async fn fetch_tool_with_paths(
 
 fn check_cache(
     paths: &SoldrPaths,
-    crate_name: &str,
+    cache_name: &str,
     version: &str,
+    binary_names: &[&str],
     target: &TargetTriple,
 ) -> Result<Option<FetchResult>, SoldrError> {
-    let bin_name = format!("{crate_name}{}", target.binary_ext());
-    let tool_dir = paths.bin.join(format!("{crate_name}-{version}"));
+    let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
+    let bin_name = format!(
+        "{}{}",
+        binary_names
+            .first()
+            .ok_or_else(|| SoldrError::Other(format!(
+                "no binary names configured for {cache_name}"
+            )))?,
+        target.binary_ext()
+    );
     let binary_path = tool_dir.join(&bin_name);
 
-    if binary_path.exists() {
+    if binary_names.iter().all(|binary_name| {
+        tool_dir
+            .join(format!("{binary_name}{}", target.binary_ext()))
+            .exists()
+    }) {
         Ok(Some(FetchResult {
             binary_path,
             version: version.to_string(),
@@ -204,21 +278,25 @@ async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<Release
             fetch_release_value(&client, repo, &url).await?
         }
         VersionSpec::Exact(v) => {
-            let tag = if v.starts_with('v') {
-                v.clone()
-            } else {
-                format!("v{v}")
-            };
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/releases/tags/{tag}",
-                repo.owner, repo.repo
-            );
-            match fetch_release_value(&client, repo, &url).await {
-                Ok(release) => release,
-                Err(SoldrError::ToolNotFound(_)) => {
-                    fetch_release_by_listing(&client, repo, &tag).await?
+            let candidate_tags = release_tag_candidates(v);
+            let mut found = None;
+            for tag in &candidate_tags {
+                let url = format!(
+                    "https://api.github.com/repos/{}/{}/releases/tags/{tag}",
+                    repo.owner, repo.repo
+                );
+                match fetch_release_value(&client, repo, &url).await {
+                    Ok(release) => {
+                        found = Some(release);
+                        break;
+                    }
+                    Err(SoldrError::ToolNotFound(_)) => continue,
+                    Err(err) => return Err(err),
                 }
-                Err(err) => return Err(err),
+            }
+            match found {
+                Some(release) => release,
+                None => fetch_release_by_listing(&client, repo, &candidate_tags).await?,
             }
         }
     };
@@ -253,7 +331,7 @@ async fn fetch_release_value(
 async fn fetch_release_by_listing(
     client: &reqwest::Client,
     repo: &RepoInfo,
-    tag: &str,
+    tags: &[String],
 ) -> Result<serde_json::Value, SoldrError> {
     let url = format!(
         "https://api.github.com/repos/{}/{}/releases?per_page=30",
@@ -283,7 +361,7 @@ async fn fetch_release_by_listing(
             items.iter().find(|release| {
                 release["tag_name"]
                     .as_str()
-                    .map(|release_tag| release_tag == tag)
+                    .map(|release_tag| tags.iter().any(|tag| release_tag == tag))
                     .unwrap_or(false)
             })
         })
@@ -292,6 +370,32 @@ async fn fetch_release_by_listing(
     matched.ok_or_else(|| {
         SoldrError::ToolNotFound(format!("no release found for {}/{}", repo.owner, repo.repo))
     })
+}
+
+fn release_tag_candidates(version: &str) -> Vec<String> {
+    let mut tags = Vec::with_capacity(2);
+    let raw = version.trim();
+    if raw.is_empty() {
+        return tags;
+    }
+    tags.push(raw.to_string());
+    if let Some(stripped) = raw.strip_prefix('v') {
+        if !stripped.is_empty() {
+            tags.push(stripped.to_string());
+        }
+    } else {
+        tags.push(format!("v{raw}"));
+    }
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
+fn managed_zccache_download_url(version: &str, target: &TargetTriple) -> String {
+    format!(
+        "https://github.com/zackees/zccache/releases/download/{version}/zccache-{version}-{}.tar.gz",
+        target.triple()
+    )
 }
 
 fn parse_release_info(body: serde_json::Value) -> Result<ReleaseInfo, SoldrError> {
@@ -411,10 +515,11 @@ fn match_asset<'a>(
 
 async fn download_and_extract(
     paths: &SoldrPaths,
-    crate_name: &str,
+    cache_name: &str,
     version: &str,
     url: &str,
     target: &TargetTriple,
+    binary_names: &[&str],
 ) -> Result<PathBuf, SoldrError> {
     let client = http_client()?;
 
@@ -436,18 +541,27 @@ async fn download_and_extract(
         .await
         .map_err(|e| SoldrError::Network(e.to_string()))?;
 
-    let tool_dir = paths.bin.join(format!("{crate_name}-{version}"));
+    let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
+    let desired_binaries = desired_binary_names(binary_names, target);
     std::fs::create_dir_all(&tool_dir)?;
 
-    let bin_name = format!("{crate_name}{}", target.binary_ext());
-    let binary_path = tool_dir.join(&bin_name);
+    let main_binary_name = desired_binaries
+        .first()
+        .cloned()
+        .ok_or_else(|| SoldrError::Other(format!("no binary names configured for {cache_name}")))?;
+    let binary_path = tool_dir.join(&main_binary_name);
 
     if url.ends_with(".zip") {
-        extract_zip(&bytes, &binary_path, &bin_name)?;
+        extract_zip(&bytes, &tool_dir, &desired_binaries)?;
     } else if url.ends_with(".tar.gz") || url.ends_with(".tgz") {
-        extract_tar_gz(&bytes, &binary_path, &bin_name)?;
+        extract_tar_gz(&bytes, &tool_dir, &desired_binaries)?;
     } else {
         // Assume raw binary.
+        if desired_binaries.len() != 1 {
+            return Err(SoldrError::Archive(format!(
+                "cannot extract multiple binaries from raw asset for {cache_name}"
+            )));
+        }
         std::fs::write(&binary_path, &bytes)?;
     }
 
@@ -455,18 +569,29 @@ async fn download_and_extract(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&binary_path)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&binary_path, perms)?;
+        for binary_name in &desired_binaries {
+            let binary_path = tool_dir.join(binary_name);
+            let mut perms = std::fs::metadata(&binary_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&binary_path, perms)?;
+        }
     }
 
     Ok(binary_path)
 }
 
-fn extract_zip(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrError> {
+fn desired_binary_names(binary_names: &[&str], target: &TargetTriple) -> Vec<String> {
+    binary_names
+        .iter()
+        .map(|binary_name| format!("{binary_name}{}", target.binary_ext()))
+        .collect()
+}
+
+fn extract_zip(data: &[u8], dest_dir: &Path, binary_names: &[String]) -> Result<(), SoldrError> {
     let reader = std::io::Cursor::new(data);
     let mut archive =
         zip::ZipArchive::new(reader).map_err(|e| SoldrError::Archive(e.to_string()))?;
+    let mut found = std::collections::BTreeSet::new();
 
     for i in 0..archive.len() {
         let mut file = archive
@@ -482,23 +607,25 @@ fn extract_zip(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrErro
             .and_then(|f| f.to_str())
             .unwrap_or("");
 
-        if file_name == bin_name || file_name == bin_name.trim_end_matches(".exe") {
-            let mut out = std::fs::File::create(dest)?;
+        let wanted = binary_names.iter().find(|binary_name| {
+            file_name == *binary_name || file_name == binary_name.trim_end_matches(".exe")
+        });
+
+        if let Some(binary_name) = wanted {
+            let mut out = std::fs::File::create(dest_dir.join(binary_name))?;
             std::io::copy(&mut file, &mut out)?;
-            return Ok(());
+            found.insert(binary_name.clone());
         }
     }
 
-    Err(SoldrError::Archive(format!(
-        "{bin_name} not found in zip archive"
-    )))
+    ensure_all_binaries_found(binary_names, &found)
 }
 
-fn extract_tar_gz(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrError> {
+fn extract_tar_gz(data: &[u8], dest_dir: &Path, binary_names: &[String]) -> Result<(), SoldrError> {
     let reader = std::io::Cursor::new(data);
     let gz = flate2::read::GzDecoder::new(reader);
     let mut archive = tar::Archive::new(gz);
-    let base_name = bin_name.trim_end_matches(".exe");
+    let mut found = std::collections::BTreeSet::new();
 
     for entry in archive
         .entries()
@@ -511,16 +638,37 @@ fn extract_tar_gz(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrE
 
         let file_name = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
 
-        if file_name == bin_name || file_name == base_name {
-            let mut out = std::fs::File::create(dest)?;
+        let wanted = binary_names.iter().find(|binary_name| {
+            file_name == *binary_name || file_name == binary_name.trim_end_matches(".exe")
+        });
+
+        if let Some(binary_name) = wanted {
+            let mut out = std::fs::File::create(dest_dir.join(binary_name))?;
             std::io::copy(&mut entry, &mut out)?;
-            return Ok(());
+            found.insert(binary_name.clone());
         }
     }
 
-    Err(SoldrError::Archive(format!(
-        "{bin_name} not found in tar.gz archive"
-    )))
+    ensure_all_binaries_found(binary_names, &found)
+}
+
+fn ensure_all_binaries_found(
+    binary_names: &[String],
+    found: &std::collections::BTreeSet<String>,
+) -> Result<(), SoldrError> {
+    let missing = binary_names
+        .iter()
+        .filter(|binary_name| !found.contains(*binary_name))
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(SoldrError::Archive(format!(
+            "missing binaries in archive: {}",
+            missing.join(", ")
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -580,5 +728,30 @@ mod tests {
 
         let selected = match_asset(&assets, &target).unwrap();
         assert_eq!(selected.name, "tool-x86_64-unknown-linux-musl.tar.gz");
+    }
+
+    #[test]
+    fn release_tag_candidates_support_plain_and_v_prefixed_tags() {
+        assert_eq!(
+            release_tag_candidates("1.2.8"),
+            vec!["1.2.8".to_string(), "v1.2.8".to_string()]
+        );
+        assert_eq!(
+            release_tag_candidates("v1.2.8"),
+            vec!["1.2.8".to_string(), "v1.2.8".to_string()]
+        );
+    }
+
+    #[test]
+    fn managed_zccache_download_url_uses_target_triple() {
+        let target = TargetTriple {
+            arch: Arch::Aarch64,
+            os: Os::MacOs,
+            env: Env::None,
+        };
+        assert_eq!(
+            managed_zccache_download_url("1.2.8", &target),
+            "https://github.com/zackees/zccache/releases/download/1.2.8/zccache-1.2.8-aarch64-apple-darwin.tar.gz"
+        );
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,8 @@ Current support policy:
 - the supported external integration surface is invoking the `soldr` executable through documented commands and flags
 - the internal Rust crates are not a supported public API
 - wrapper mode and internal environment variables are operational mechanics, not a general-purpose API contract
-- human-oriented command output is not yet the stable machine-facing protocol; explicit structured output is future work tracked in [#44](https://github.com/zackees/soldr/issues/44)
+- human-oriented command output is not the stable machine-facing protocol
+- the first stable machine-facing protocol is the JSON mode on selected commands documented below
 
 ---
 
@@ -134,6 +135,12 @@ soldr --no-cache cargo test
 
 Show cache and target information.
 
+Stable machine-facing mode:
+
+```bash
+soldr status --json
+```
+
 ### `soldr clean`
 
 Clear the managed local zccache artifact cache and remove soldr's zccache session state directory.
@@ -146,9 +153,57 @@ Show or set configuration.
 
 Inspect managed zccache status.
 
+Stable machine-facing mode:
+
+```bash
+soldr cache --json
+```
+
 ### `soldr version`
 
 Print soldr version.
+
+Stable machine-facing mode:
+
+```bash
+soldr version --json
+```
+
+---
+
+## Structured JSON Output
+
+The supported JSON protocol currently exists on:
+
+- `soldr status --json`
+- `soldr cache --json`
+- `soldr version --json`
+
+The JSON response always includes:
+
+- `schema_version`
+- `command`
+
+Current schema version:
+
+- `schema_version: 1`
+
+Compatibility rules for schema version `1`:
+
+- existing fields keep their current meaning
+- fields may be added in later releases without changing `schema_version`
+- removing a field, renaming a field, or changing the meaning/type of an existing field requires a new schema version
+- human-readable stdout for commands without `--json` is not covered by this compatibility promise
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "command": "version",
+  "soldr_version": "0.2.0-beta"
+}
+```
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.2.0-beta"
+  "soldr_version": "0.6.0"
 }
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,9 @@
 # soldr API Reference
 
+This file is the CLI reference for `soldr`.
+
+For the product-level support contract about what counts as a supported external API, see [API_BOUNDARY.md](./API_BOUNDARY.md).
+
 ## Overview
 
 soldr is a single front door for Rust tool execution and Rust builds.
@@ -14,6 +18,15 @@ It has three invocation modes:
    Low-level passthrough wrapper mode for explicit `RUSTC_WRAPPER=soldr` usage.
 
 The primary user experience is `soldr cargo ...`.
+
+## Machine-Facing Support Level
+
+Current support policy:
+
+- the supported external integration surface is invoking the `soldr` executable through documented commands and flags
+- the internal Rust crates are not a supported public API
+- wrapper mode and internal environment variables are operational mechanics, not a general-purpose API contract
+- human-oriented command output is not yet the stable machine-facing protocol; explicit structured output is future work tracked in [#44](https://github.com/zackees/soldr/issues/44)
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,11 +7,11 @@ soldr is a single front door for Rust tool execution and Rust builds.
 It has three invocation modes:
 
 1. `soldr cargo ...`
-   Delegates to the real Cargo binary while wiring soldr into the build path.
+   Delegates to the real Cargo binary while wiring soldr-managed zccache into the build path.
 2. `soldr <tool> [args...]`
    Fetches and runs a Rust CLI tool binary.
 3. `soldr rustc ...`
-   Internal wrapper mode used during builds after `soldr cargo ...` sets `RUSTC_WRAPPER=soldr`.
+   Low-level passthrough wrapper mode for explicit `RUSTC_WRAPPER=soldr` usage.
 
 The primary user experience is `soldr cargo ...`.
 
@@ -25,14 +25,26 @@ The primary user experience is `soldr cargo ...`.
 soldr cargo build --release
 soldr cargo test
 soldr cargo run -- --help
+soldr --no-cache cargo build
 ```
 
 Behavior:
 
 - Resolve the real `cargo` binary through `rustup`
 - Resolve the matching real `rustc` binary through `rustup`
-- Set `RUSTC_WRAPPER` to the current `soldr` executable
+- Fetch a pinned managed `zccache` release when caching is enabled
+- Set `RUSTC_WRAPPER` to the current soldr binary
+- Pass the managed `zccache` binary path into wrapper mode through the environment
+- Start a per-build zccache session on zccache's current default daemon endpoint
 - Delegate to Cargo with the exact flags the user passed
+
+Current cache-control behavior:
+
+- caching is enabled by default for `soldr cargo ...`
+- `soldr --no-cache cargo ...` disables soldr's compilation-cache path for that invocation
+- `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
+- zccache integration currently targets Rust builds through the cargo front door
+- zccache's current artifact store and daemon endpoint remain on zccache's default paths; soldr currently manages the session lifecycle and logs
 
 This is the normal build entry point.
 
@@ -75,8 +87,9 @@ In this mode, soldr should act as the transparent build-assistance layer around 
 
 Current implementation status:
 
-- Wrapper-mode passthrough to real `rustc` exists
-- Cache and daemon behavior are still being implemented
+- Wrapper mode still transparently resolves the real `rustc`
+- The normal cache-enabled build path now runs through soldr wrapper mode and delegates into managed `zccache`
+- If caching is disabled, wrapper mode falls through to real `rustc` without zccache involvement
 
 ---
 
@@ -101,6 +114,7 @@ Run Cargo through soldr's front door.
 soldr cargo build --release
 soldr cargo test --workspace
 soldr cargo check -p soldr-cli
+soldr --no-cache cargo test
 ```
 
 ### `soldr status`
@@ -109,7 +123,7 @@ Show cache and target information.
 
 ### `soldr clean`
 
-Clear caches.
+Clear the managed local zccache artifact cache and remove soldr's zccache session state directory.
 
 ### `soldr config`
 
@@ -117,7 +131,7 @@ Show or set configuration.
 
 ### `soldr cache`
 
-Inspect build-cache state.
+Inspect managed zccache status.
 
 ### `soldr version`
 
@@ -148,11 +162,14 @@ Commands:
 | Variable | Purpose | Default |
 |---|---|---|
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
+| `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
+| `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
+| `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 
-`RUSTC_WRAPPER=soldr cargo build` remains a valid low-level integration path, but it is no longer the preferred user-facing workflow.
+`RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 
 ---
 
@@ -190,5 +207,6 @@ For bootstrap verification of another Rust project:
 The key design rule is simple:
 
 - users build through `soldr cargo ...`
-- soldr uses wrapper mode internally
+- soldr owns the wrapper slot on the common path
+- soldr delegates cache-enabled wrapper invocations into managed zccache
 - users do not need to manually wire `RUSTC_WRAPPER` for the common path

--- a/docs/API_BOUNDARY.md
+++ b/docs/API_BOUNDARY.md
@@ -10,7 +10,7 @@ Current repo policy is:
 - the supported external surface is the `soldr` executable, not the internal Rust workspace crates
 - there is no supported public Rust crate API, C ABI, or FFI surface
 - there is no supported long-running daemon or local service protocol today
-- the first future machine-facing API should be explicit CLI commands with structured JSON output, tracked in [#44](https://github.com/zackees/soldr/issues/44)
+- the first supported machine-facing API is explicit CLI commands with structured JSON output on selected commands
 
 ## What Is Supported Today
 
@@ -19,9 +19,12 @@ Supported use today means invoking the `soldr` binary as a subprocess through do
 - `soldr cargo ...`
 - `soldr <tool>[@version] ...`
 - `soldr status`
+- `soldr status --json`
 - `soldr cache`
+- `soldr cache --json`
 - `soldr clean`
 - `soldr version`
+- `soldr version --json`
 
 The current CLI reference lives in [API.md](./API.md).
 
@@ -34,13 +37,14 @@ The following are implementation details and may change without a semver promise
 - undocumented environment variables or wrapper-mode conventions
 - the exact on-disk cache/session layout beyond what is explicitly documented for users
 - human-oriented stdout/stderr wording unless a command is explicitly documented as structured and stable
+- commands that do not explicitly document `--json` as a supported protocol surface
 
 ## Future Direction
 
 The intended progression is:
 
 1. Keep `soldr` binary-first.
-2. Add explicit JSON output for selected commands that need automation support.
+2. Expand explicit JSON output only for selected commands that need automation support.
 3. Version that structured output as an external protocol.
 4. Only consider a daemon or other long-running local protocol if a real use case appears that the CLI cannot serve cleanly.
 

--- a/docs/API_BOUNDARY.md
+++ b/docs/API_BOUNDARY.md
@@ -1,0 +1,56 @@
+# Machine-Facing API Boundary
+
+This document defines the supported external integration boundary for `soldr`.
+
+## Decision Summary
+
+Current repo policy is:
+
+- `soldr` is a binary-first product
+- the supported external surface is the `soldr` executable, not the internal Rust workspace crates
+- there is no supported public Rust crate API, C ABI, or FFI surface
+- there is no supported long-running daemon or local service protocol today
+- the first future machine-facing API should be explicit CLI commands with structured JSON output, tracked in [#44](https://github.com/zackees/soldr/issues/44)
+
+## What Is Supported Today
+
+Supported use today means invoking the `soldr` binary as a subprocess through documented commands and flags such as:
+
+- `soldr cargo ...`
+- `soldr <tool>[@version] ...`
+- `soldr status`
+- `soldr cache`
+- `soldr clean`
+- `soldr version`
+
+The current CLI reference lives in [API.md](./API.md).
+
+## What Is Not A Supported Public API
+
+The following are implementation details and may change without a semver promise to automation consumers:
+
+- the internal Rust crates in `crates/`
+- direct use of `soldr-core`, `soldr-fetch`, `soldr-cache`, or `soldr-cli` as library dependencies
+- undocumented environment variables or wrapper-mode conventions
+- the exact on-disk cache/session layout beyond what is explicitly documented for users
+- human-oriented stdout/stderr wording unless a command is explicitly documented as structured and stable
+
+## Future Direction
+
+The intended progression is:
+
+1. Keep `soldr` binary-first.
+2. Add explicit JSON output for selected commands that need automation support.
+3. Version that structured output as an external protocol.
+4. Only consider a daemon or other long-running local protocol if a real use case appears that the CLI cannot serve cleanly.
+
+If a daemon or other protocol is ever added, it should be documented and versioned as a separate external interface. It should not expose the internal Rust crate graph and call that the supported API.
+
+## Non-Goals
+
+This repo is not currently pursuing:
+
+- a stable public Rust library API
+- a stable embeddable C ABI
+- undocumented machine parsing of human help/status text
+- a background service that third parties are expected to integrate with by default

--- a/docs/PYPI_TRUSTED_PUBLISHING.md
+++ b/docs/PYPI_TRUSTED_PUBLISHING.md
@@ -1,0 +1,88 @@
+# PyPI Trusted Publishing
+
+This document describes the repo-side and owner-side steps needed to publish `soldr` wheels to PyPI using GitHub Actions OIDC Trusted Publishing.
+
+It is intentionally PyPI-only. crates.io publication is not part of the current `0.5.x` release direction.
+
+## Current State
+
+As of April 14, 2026:
+
+- the release workflow can build hardened `soldr` wheels when `publish_pypi=true`
+- the workflow can publish those wheels through `pypa/gh-action-pypi-publish` in a dedicated OIDC job
+- the existing PyPI project `soldr` already exists
+- the current public PyPI `0.1.0` file details say `Uploaded using Trusted Publishing? No`
+
+The next secure PyPI release should replace that stale packaging path with the real wheel set built from the validated release workflow.
+
+## Why This Uses Trusted Publishing
+
+PyPI Trusted Publishing avoids long-lived API tokens.
+
+The workflow receives a short-lived upload credential from PyPI using the GitHub Actions OIDC identity for a specific repository, workflow file, and optional environment.
+
+For `soldr`, the intended trusted identity is:
+
+- owner: `zackees`
+- repository: `soldr`
+- workflow: `.github/workflows/release.yml`
+- environment: `release`
+
+Using the existing `release` environment keeps the PyPI publish step behind the same manual approval gate as the immutable GitHub release path.
+
+## Owner Setup On PyPI
+
+These steps must be performed in the PyPI web UI by a maintainer of the `soldr` project.
+
+1. Open the `soldr` project on PyPI.
+2. Click `Manage`.
+3. Open the `Publishing` page in the project sidebar.
+4. Add a new GitHub Actions publisher with:
+   - repository owner: `zackees`
+   - repository name: `soldr`
+   - workflow filename: `.github/workflows/release.yml`
+   - environment name: `release`
+
+The environment field is optional in PyPI, but it should be filled in here because the repo already uses `release` as the human approval boundary.
+
+## Repo-Side Workflow Inputs
+
+The release workflow supports these PyPI-related inputs:
+
+- `publish_pypi=true`
+- `pypi_repository_url=...` for alternate endpoints such as TestPyPI
+
+If `publish_pypi=false`, the workflow keeps its GitHub-release-only behavior.
+
+If `publish_pypi=true`, the workflow:
+
+1. Builds hardened wheels on the supported platform runners.
+2. Smoke-tests the built wheel on each runner by installing it and running `soldr --version`.
+3. Publishes the GitHub Release.
+4. Publishes the wheel set to PyPI from a dedicated Linux job with `id-token: write`.
+
+No source distribution is published in this path. The current design is wheel-only because the project is prioritizing hardened binary distribution rather than source release through package registries.
+
+## Recommended Rehearsal
+
+Before enabling real PyPI publishing, rehearse against TestPyPI.
+
+Recommended command:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=false \
+  -f publish_pypi=true \
+  -f pypi_repository_url=https://test.pypi.org/legacy/
+```
+
+This uses a real publish path instead of `dry_run=true`, because the OIDC publisher exchange only happens in the real publish job.
+
+## Expected Manual Stop
+
+The repo-side work can be completed without additional secrets.
+
+If the PyPI trusted publisher has not been registered yet, that PyPI-side publisher registration is the remaining manual stop. Until that is done, the PyPI publish job will not be able to mint a trusted upload token.

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -1,0 +1,179 @@
+# Release 0.5 Checklist
+
+This document is the concrete execution list for the first attested secure `soldr 0.5` release.
+
+It assumes the current repository state on April 13, 2026:
+
+- the validated release workflow exists in `.github/workflows/release.yml`
+- the workflow requires an exact commit SHA on `release`
+- publication uses a dedicated GitHub App
+- `v*.*.*` tags are protected by repository rulesets
+- immutable GitHub Releases are enabled
+- `main` and `release` are protected
+
+## 1. Freeze The `0.5` Product Surface
+
+Decide what `0.5` means for the user-facing CLI.
+
+Required decision:
+
+- the `0.5` release line is the front-door build and tool-fetch line
+- built-in zccache-backed compilation caching is part of the front-door `0.5.x` line
+- `status`, `clean`, `config`, and `cache` must not be presented as complete features unless implemented
+
+Do not ship `0.5` with placeholder commands presented as finished behavior.
+
+## 2. Freeze The `0.5` Security Claim
+
+Resolve the open policy questions in:
+
+- issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
+- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
+
+Minimum decisions needed before `0.5`:
+
+- whether checksum plus `gh attestation verify` is the official verification story
+- whether SBOM generation is required for `0.5`
+- whether reproducible-build claims are in scope for `0.5`
+- whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
+- what trust statement applies to third-party binaries fetched by `soldr` at runtime
+
+## 3. Rehearse The Release Path
+
+Before the first public `0.5` tag, run a dry-run rehearsal from `release`.
+
+Inputs to choose:
+
+- candidate version such as `v0.5.0-rc1`
+- exact commit SHA on `release`
+
+Required checks:
+
+- the workflow rejects SHAs not reachable from `release`
+- the workflow completes lint, test, packaging, and e2e gates for the exact SHA
+- the `release` environment approval gate triggers as expected
+- the GitHub App token step succeeds
+- checksums and provenance attestation steps succeed
+
+Recommended command path:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=true
+```
+
+## 4. Verify The Governance Controls Manually
+
+Before the first real release, verify the controls that live outside the git tree.
+
+```bash
+gh api repos/zackees/soldr/rulesets
+gh api repos/zackees/soldr/environments
+gh api repos/zackees/soldr/branches/main/protection
+gh api repos/zackees/soldr/branches/release/protection
+gh api repos/zackees/soldr/immutable-releases
+```
+
+Success criteria:
+
+- the `v*.*.*` tag ruleset is active
+- only the release GitHub App can bypass that ruleset
+- `release` still requires approval from `@zackees`
+- `main` and `release` still require the expected checks
+- immutable releases remain enabled
+
+## 5. Cut A Real Release Candidate
+
+After the dry run passes, create the first real release candidate through the workflow.
+
+Recommended first tag:
+
+- `v0.5.0-rc1`
+
+Required checks after publication:
+
+- the GitHub Release contains all expected platform archives
+- the `SHA256SUMS` manifest is present
+- `gh attestation verify` succeeds for at least one downloaded archive
+- a human cannot create, move, or delete the release tag manually
+- the release cannot be mutated after publication because immutable releases are enabled
+
+## 6. Enable Trusted PyPI Publishing If `0.5.0` Will Ship Wheels
+
+If PyPI is part of `0.5.0`, configure the existing `soldr` project for Trusted Publishing before the final release.
+
+Required setup:
+
+- add the GitHub Actions trusted publisher on PyPI for:
+  - owner: `zackees`
+  - repository: `soldr`
+  - workflow: `.github/workflows/release.yml`
+  - environment: `release`
+- confirm the existing `soldr` PyPI project is the correct project and that stale pre-Trusted-Publishing metadata will be superseded by the next upload
+
+Recommended rehearsal:
+
+- use TestPyPI first with the same workflow and `publish_pypi=true`
+- pass `pypi_repository_url=https://test.pypi.org/legacy/`
+- treat this as a real publish rehearsal, not a `dry_run`, because OIDC publish cannot be fully exercised in the workflow's dry-run path
+
+Recommended command path:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=false \
+  -f publish_pypi=true \
+  -f pypi_repository_url=https://test.pypi.org/legacy/
+```
+
+Recommended GitHub-release verification commands:
+
+```bash
+gh release view v0.5.0-rc1 --repo zackees/soldr
+gh attestation verify soldr-v0.5.0-rc1-x86_64-unknown-linux-gnu.tar.gz \
+  --repo zackees/soldr \
+  --signer-workflow zackees/soldr/.github/workflows/release.yml
+```
+
+## 7. Audit The First Published Release
+
+After `v0.5.0-rc1`, confirm that reality matches the docs:
+
+- [RELEASE.md](../RELEASE.md)
+- [RELEASE_VERIFICATION.md](./RELEASE_VERIFICATION.md)
+- [RELEASE_GOVERNANCE_CHECKLIST.md](./RELEASE_GOVERNANCE_CHECKLIST.md)
+- [PYPI_TRUSTED_PUBLISHING.md](./PYPI_TRUSTED_PUBLISHING.md)
+- [TRUST_BOUNDARIES.md](./TRUST_BOUNDARIES.md)
+
+Anything discovered during the RC must become either:
+
+- a code fix
+- a GitHub settings fix
+- an explicit documented limitation
+
+## 8. Decide Go Or No-Go For `v0.5.0`
+
+Ship `v0.5.0` only when all of these are true:
+
+- the intended `0.5` CLI surface is clearly scoped and honestly documented
+- the release workflow has passed in dry-run and real-release modes
+- the first RC was verified with checksums and attestations
+- the protected-tag and immutable-release controls behaved as expected
+- if PyPI is in scope, Trusted Publishing was exercised successfully against TestPyPI or PyPI with the hardened wheel set
+- the remaining policy questions are closed or explicitly deferred in writing
+
+## 9. Gate `1.0.0-rc`
+
+Do not cut `1.0.0-rc` until:
+
+- `soldr cargo ...` enables managed zccache by default with `--no-cache` as the explicit opt-out
+- the cache-enabled wrapper path delegates through managed zccache instead of acting as pure rustc pass-through
+- the public cache commands describe and manage real behavior instead of placeholders
+
+If those are not true, stay on the `0.5.x` line.

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -28,15 +28,15 @@ Do not ship `0.5` with placeholder commands presented as finished behavior.
 Confirm the documented policy decisions in:
 
 - issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
-- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
+- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy, with implementation follow-up in [#41](https://github.com/zackees/soldr/issues/41) and [#42](https://github.com/zackees/soldr/issues/42)
 
 Current decisions for `0.5`:
 
 - checksum plus `gh attestation verify` is the official user-facing verification story
 - SBOM generation is not required for `0.5`
 - reproducible-build claims are out of scope for `0.5`
-- whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
-- what trust statement applies to third-party binaries fetched by `soldr` at runtime
+- `0.5.x` does not claim hermetic builds; vendoring or mirroring Cargo, toolchain, OS-package, and pinned bootstrap-test inputs is deferred hardening tracked in [#41](https://github.com/zackees/soldr/issues/41)
+- third-party binaries fetched by `soldr` at runtime remain an upstream trust decision on `0.5.x`, not a repository-side trust guarantee; stronger enforcement is tracked in [#42](https://github.com/zackees/soldr/issues/42)
 
 ## 3. Rehearse The Release Path
 

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -25,16 +25,16 @@ Do not ship `0.5` with placeholder commands presented as finished behavior.
 
 ## 2. Freeze The `0.5` Security Claim
 
-Resolve the open policy questions in:
+Confirm the documented policy decisions in:
 
 - issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
 - issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
 
-Minimum decisions needed before `0.5`:
+Current decisions for `0.5`:
 
-- whether checksum plus `gh attestation verify` is the official verification story
-- whether SBOM generation is required for `0.5`
-- whether reproducible-build claims are in scope for `0.5`
+- checksum plus `gh attestation verify` is the official user-facing verification story
+- SBOM generation is not required for `0.5`
+- reproducible-build claims are out of scope for `0.5`
 - whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
 - what trust statement applies to third-party binaries fetched by `soldr` at runtime
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -38,7 +38,7 @@ The current release flow does not yet claim all of the following:
 - independently reproduced builds by a second builder
 - fully hermetic inputs for rustup, crates.io, OS packages, or third-party test inputs
 
-The release-governance and hermetic-input follow-up items remain tracked in issues [#11](https://github.com/zackees/soldr/issues/11) and [#13](https://github.com/zackees/soldr/issues/13). SBOM publication and independently reproduced builds are intentionally outside the current release claim.
+The release-governance and hermetic-input follow-up items remain tracked in issues [#11](https://github.com/zackees/soldr/issues/11), [#41](https://github.com/zackees/soldr/issues/41), and [#42](https://github.com/zackees/soldr/issues/42). SBOM publication and independently reproduced builds are intentionally outside the current release claim.
 
 ## Release Asset Names
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -4,6 +4,19 @@ This document describes how to verify a published `soldr` release today.
 
 It is intentionally limited to what the repository currently implements.
 
+## Verification Policy
+
+The current `soldr` verification policy is:
+
+- the official user-facing verification path is checksum verification plus `gh attestation verify`
+- GitHub CLI is the primary documented tool for attestation verification
+- Sigstore-compatible offline verification remains possible through downloaded attestation bundles, but it is not the primary documented path
+- `soldr` does not currently require or publish SBOMs for the release line
+- `soldr` does not currently claim independently reproducible builds
+- `soldr` does not currently publish extra signed metadata beyond the checksum manifest and GitHub provenance attestations
+
+Those positions are deliberate. They may be revisited later, but they are the current release policy rather than open questions.
+
 ## What The Current Release Flow Guarantees
 
 For a normal `soldr` release:
@@ -25,7 +38,7 @@ The current release flow does not yet claim all of the following:
 - independently reproduced builds by a second builder
 - fully hermetic inputs for rustup, crates.io, OS packages, or third-party test inputs
 
-Those follow-up items are tracked in issues [#11](https://github.com/zackees/soldr/issues/11), [#12](https://github.com/zackees/soldr/issues/12), and [#13](https://github.com/zackees/soldr/issues/13).
+The release-governance and hermetic-input follow-up items remain tracked in issues [#11](https://github.com/zackees/soldr/issues/11) and [#13](https://github.com/zackees/soldr/issues/13). SBOM publication and independently reproduced builds are intentionally outside the current release claim.
 
 ## Release Asset Names
 
@@ -62,7 +75,9 @@ The checksum step tells you the file you downloaded matches the checksum manifes
 
 ## Step 2: Verify The Artifact Attestation
 
-Use GitHub CLI's attestation support to verify the artifact provenance:
+Use GitHub CLI's attestation support to verify the artifact provenance.
+
+This is the primary documented verification path for `soldr`:
 
 ```bash
 gh attestation verify soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz \
@@ -90,7 +105,7 @@ This validates that GitHub has a matching attestation for the artifact and that 
 
 It does not, by itself, prove that every external input used during the build was mirrored or hermetic. For the current trust boundary inventory, see [TRUST_BOUNDARIES.md](./TRUST_BOUNDARIES.md).
 
-## Optional: Offline Verification
+## Optional: Offline Verification And Sigstore-Compatible Bundles
 
 GitHub CLI also supports downloading attestation bundles and verifying them offline.
 
@@ -101,13 +116,15 @@ gh attestation download soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz --repo zack
 gh attestation trusted-root
 ```
 
-Offline verification is not yet the primary documented path for `soldr`, but it remains available if you want to archive bundles and trusted roots alongside release artifacts.
+Offline verification is not the primary documented path for `soldr`, but it remains available if you want to archive bundles and trusted roots alongside release artifacts.
+
+This is also the nearest current equivalent to a Sigstore-style workflow for this repository. We do not require users to install separate Sigstore tooling as part of the normal `soldr` verification story.
 
 ## About `gh release verify`
 
 GitHub CLI also has `gh release verify`, which verifies release-level attestations.
 
-We do not currently document that as the primary verification path for `soldr` because immutable releases and the surrounding release-governance settings are still tracked separately. Today, the repository's strongest implemented verification path is:
+We do not currently document that as the primary verification path for `soldr` because immutable releases and the surrounding release-governance settings are still tracked separately. Today, the repository's official verification path is:
 
 1. checksum verification
 2. artifact attestation verification with `gh attestation verify`

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -2,7 +2,7 @@
 
 This document describes the current external trust boundaries for `soldr`.
 
-It is a factual inventory of what the project trusts today, not a claim that every trust edge is already ideal.
+It records both the factual inventory of what the project trusts today and the current repo policy for which of those trust edges are acceptable on the `0.5.x` line.
 
 ## Controlled Inputs
 
@@ -27,6 +27,16 @@ Even with a validated release workflow, the release path still depends on extern
   - Published crate versions are immutable, but the transport and index are still external.
 - GitHub APIs and GitHub Releases
   - The release workflow uses GitHub services to create releases, publish assets, and store attestations.
+
+## Audit: What The Published Release Artifacts Depend On
+
+Based on the committed release workflow in `.github/workflows/release.yml`:
+
+- the published `soldr` release archives are built from the repository source tree plus Rust dependencies resolved through Cargo
+- the workflow does not explicitly download and repackage third-party release binaries into the published `soldr` archives
+- the release path still depends on external services and package sources such as GitHub-hosted runners, `rustup`, crates.io, and GitHub APIs
+- the live `apt` install and pinned third-party repository checkout are part of release-gating validation, not packaged release contents
+- the managed `zccache` download path is runtime behavior in `soldr`, not an input to building the published `soldr` release artifacts
 
 ## E2E Validation External Dependencies
 
@@ -64,7 +74,7 @@ It does not yet enforce:
 - upstream artifact attestations
 - mirrored internal copies of third-party tool binaries
 
-## Current Policy Direction
+## Current Policy Decisions
 
 Current repo policy is:
 
@@ -72,11 +82,27 @@ Current repo policy is:
 - make external trust edges explicit in documentation
 - treat floating workflow refs as unacceptable
 - prefer exact commit or version selection where possible
+- `0.5.x` does not claim hermetic builds
+- the documented release-time dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt` in the bootstrap e2e path, and the pinned third-party bootstrap repository are acceptable for `0.5.x`
+- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are accepted future hardening work, but they are not blockers for the current `0.5.x` release line
+- the pinned third-party bootstrap checkout is acceptable for current validation, but it must not be described as mirrored or hermetic
+- release verification for `soldr` covers the published `soldr` artifacts and their provenance, not every external input used during CI
 
-Open follow-up decisions are tracked in:
+## Current Runtime Fetch Policy
+
+Current `0.5.x` policy for runtime-fetched binaries is:
+
+- `soldr` fetching a third-party tool is a convenience/bootstrap path, not a repository-side trust guarantee
+- a successful fetch currently means crates.io metadata and GitHub Releases produced a matching archive for the selected target and `soldr` extracted it successfully
+- `soldr` does not currently enforce maintainer allowlists, repo-managed checksums, upstream signatures, upstream attestations, or mirrored copies before executing a fetched tool
+- the managed `zccache` path is pinned to a repo-chosen version, but it still uses the same direct GitHub Release download model and is not independently checksum- or attestation-verified by `soldr` itself today
+- stronger runtime trust enforcement is accepted follow-up work, but it is not part of the current `0.5.x` trust claim
+
+Open follow-up implementation issues are tracked in:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
-- [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust hardening
+- [#41](https://github.com/zackees/soldr/issues/41) for reducing live external release inputs
+- [#42](https://github.com/zackees/soldr/issues/42) for fetched-binary trust enforcement
 
 ## Practical Reading Of This Document
 
@@ -84,6 +110,6 @@ If you are deciding whether to trust a published `soldr` release:
 
 - trust the validated GitHub workflow run and artifact attestation for the released commit
 - separately evaluate whether the remaining external build inputs are acceptable for your threat model
-- separately evaluate whether `soldr` fetching third-party tool binaries at runtime is acceptable for your threat model
+- separately evaluate whether `soldr` fetching third-party tool binaries at runtime is acceptable for your threat model, because that remains an upstream trust decision on `0.5.x`
 
 Those are related but distinct trust decisions.

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -76,7 +76,6 @@ Current repo policy is:
 Open follow-up decisions are tracked in:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
-- [#12](https://github.com/zackees/soldr/issues/12) for verification and reproducibility policy
 - [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust hardening
 
 ## Practical Reading Of This Document


### PR DESCRIPTION
## Summary

Fast-forward the `release` branch to include:
- Toolchain subcommands + clippy-driver wrapper fix (#73)
- Version bump to 0.6.0 (#74)

This prepares the `release` branch for the v0.6.0 release workflow dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)