### PR TITLE
fix: use uv for PyPI wheel build in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,61 +377,26 @@ jobs:
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
-      - name: Install maturin
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 -m pip install --upgrade pip
-          python3 -m pip install "maturin>=1.7,<2"
-
-      - name: Install maturin
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          py -3 -m pip install --upgrade pip
-          py -3 -m pip install "maturin>=1.7,<2"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Build hardened wheel
-        if: runner.os != 'Windows'
         shell: bash
         run: |
-          set -euo pipefail
-          python3 -m maturin build \
+          uv tool install "maturin>=1.7,<2"
+          maturin build \
             --release \
             --locked \
             --compatibility pypi \
             --target "${{ matrix.target }}" \
             --out dist
 
-      - name: Build hardened wheel
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          py -3 -m maturin build `
-            --release `
-            --locked `
-            --compatibility pypi `
-            --target "${{ matrix.target }}" `
-            --out dist
-
       - name: Smoke test wheel
-        if: runner.os != 'Windows'
         shell: bash
         run: |
-          set -euo pipefail
-          python3 -m venv .venv
-          . .venv/bin/activate
-          python -m pip install dist/*.whl
-          soldr --version
-
-      - name: Smoke test wheel
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          py -3 -m venv .venv
-          .\.venv\Scripts\python.exe -m pip install dist\*.whl
-          .\.venv\Scripts\soldr.exe --version
+          uv venv .venv
+          uv pip install --python .venv dist/*.whl
+          .venv/bin/soldr --version || .venv/Scripts/soldr.exe --version
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## Summary

Replace platform-specific pip/venv/maturin install steps with `uv` in the release workflow.

**Fixes:**
- macOS: PEP 668 `externally-managed-environment` error blocking `pip install maturin`
- Windows ARM64: PowerShell `dist\*.whl` glob not expanding

**Changes:**
- Use `astral-sh/setup-uv@v5` action
- `uv tool install maturin` instead of `pip install maturin`
- `uv venv` + `uv pip install` for smoke tests
- Unified bash steps instead of separate OS-specific blocks (-35 lines)

## Test plan

- [ ] Re-run release workflow after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)