### PR TITLE
fix: pin setup-uv to full commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,7 +378,7 @@ jobs:
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
 
       - name: Build hardened wheel
         shell: bash


### PR DESCRIPTION
Pin astral-sh/setup-uv to commit SHA per repo policy. Fixes PyPI wheel build in release workflow.