### PR TITLE
Phase 2: fetch ecosystem test+security tools

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -281,6 +281,11 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     let paths = SoldrPaths::new()?;
     paths.ensure_dirs()?;
 
+    // If the user invoked a known ecosystem subcommand (e.g. `cargo nextest`),
+    // fetch the corresponding `cargo-<sub>` binary and prepend its directory to
+    // PATH so cargo's subcommand dispatch finds it.
+    let extra_bin_dirs = ensure_known_subcommand_tool(args, &paths).await?;
+
     let mut command = std::process::Command::new(cargo);
     command.args(args);
     command.env("RUSTC", rustc);
@@ -288,10 +293,10 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
         soldr_cache::CACHE_ENABLED_ENV_VAR,
         soldr_cache::cache_enabled_env_value(cache_enabled),
     );
-    command.env(
-        "PATH",
-        prepend_path(&cargo_bin_dir, existing_path.as_deref())?,
-    );
+    let mut path_dirs: Vec<std::path::PathBuf> = Vec::with_capacity(1 + extra_bin_dirs.len());
+    path_dirs.push(cargo_bin_dir);
+    path_dirs.extend(extra_bin_dirs);
+    command.env("PATH", prepend_paths(&path_dirs, existing_path.as_deref())?);
     if let Some(target) = default_cargo_build_target(args)? {
         command.env("CARGO_BUILD_TARGET", target);
     }
@@ -347,15 +352,67 @@ fn cargo_args_use_reserved_no_cache(args: &[String]) -> bool {
     false
 }
 
-fn prepend_path(
-    dir: &std::path::Path,
+fn prepend_paths(
+    dirs: &[std::path::PathBuf],
     existing_path: Option<&std::ffi::OsStr>,
 ) -> Result<std::ffi::OsString, SoldrError> {
-    let mut paths = vec![dir.to_path_buf()];
+    let mut paths: Vec<std::path::PathBuf> = dirs.to_vec();
     if let Some(existing_path) = existing_path {
         paths.extend(std::env::split_paths(existing_path));
     }
     std::env::join_paths(paths).map_err(|e| SoldrError::Other(format!("invalid PATH: {e}")))
+}
+
+/// Return the first positional argument (skipping flags) of the cargo
+/// front-door args, which is conventionally the cargo subcommand.
+fn first_cargo_subcommand(args: &[String]) -> Option<&str> {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        return Some(arg.as_str());
+    }
+    None
+}
+
+async fn ensure_known_subcommand_tool(
+    args: &[String],
+    paths: &SoldrPaths,
+) -> Result<Vec<std::path::PathBuf>, SoldrError> {
+    let Some(sub) = first_cargo_subcommand(args) else {
+        return Ok(Vec::new());
+    };
+    let Some(spec) = soldr_fetch::lookup_by_cargo_subcommand(sub) else {
+        return Ok(Vec::new());
+    };
+
+    eprintln!("soldr: fetching {}...", spec.crate_name);
+    let result =
+        soldr_fetch::fetch_tool_with_paths(spec.crate_name, &VersionSpec::Latest, paths).await?;
+
+    if result.cached {
+        eprintln!(
+            "soldr: using cached {} v{}",
+            spec.crate_name, result.version
+        );
+    } else {
+        eprintln!("soldr: downloaded {} v{}", spec.crate_name, result.version);
+    }
+
+    let dir = result
+        .binary_path
+        .parent()
+        .ok_or_else(|| {
+            SoldrError::Other(format!(
+                "failed to resolve bin dir for fetched {}",
+                spec.crate_name
+            ))
+        })?
+        .to_path_buf();
+    Ok(vec![dir])
 }
 
 fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError> {
@@ -720,7 +777,10 @@ fn cached_managed_zccache(
 
 #[cfg(test)]
 mod tests {
-    use super::{cargo_args_specify_target, cargo_args_use_reserved_no_cache, parse_tool_spec};
+    use super::{
+        cargo_args_specify_target, cargo_args_use_reserved_no_cache, first_cargo_subcommand,
+        parse_tool_spec,
+    };
     use soldr_fetch::VersionSpec;
 
     #[test]
@@ -764,5 +824,37 @@ mod tests {
         let (tool, version) = parse_tool_spec("maturin");
         assert_eq!(tool, "maturin");
         assert!(matches!(version, VersionSpec::Latest));
+    }
+
+    #[test]
+    fn first_cargo_subcommand_skips_leading_flags() {
+        assert_eq!(
+            first_cargo_subcommand(&["--verbose".into(), "nextest".into(), "run".into()]),
+            Some("nextest")
+        );
+        assert_eq!(
+            first_cargo_subcommand(&["nextest".into(), "run".into()]),
+            Some("nextest")
+        );
+        assert_eq!(first_cargo_subcommand(&["--help".into()]), None);
+        assert_eq!(first_cargo_subcommand(&[]), None);
+    }
+
+    #[test]
+    fn first_cargo_subcommand_stops_at_passthrough_separator() {
+        assert_eq!(
+            first_cargo_subcommand(&["--".into(), "nextest".into()]),
+            None
+        );
+    }
+
+    #[test]
+    fn known_subcommand_registry_recognizes_phase_two_tools() {
+        for sub in ["nextest", "deny", "audit", "llvm-cov"] {
+            let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
+                .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
+            assert_eq!(spec.cargo_subcommand, sub);
+            assert!(spec.crate_name.starts_with("cargo-"));
+        }
     }
 }

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -1,0 +1,114 @@
+//! Registry of ecosystem tools with known GitHub Releases and cargo-subcommand mapping.
+//!
+//! Some crates have monorepo-style release tags (e.g. `cargo-audit/v0.21.0`) or
+//! live in a repository whose name differs from the crate. Falling back to the
+//! crates.io → GitHub repository lookup plus `/releases/latest` can pick up the
+//! wrong release in those cases. When a tool needs per-release handling, encode
+//! it here once and fetch paths can use it directly.
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolSpec {
+    /// crates.io crate name and fetch cache key.
+    pub crate_name: &'static str,
+    /// Name used as `cargo <sub>`.
+    pub cargo_subcommand: &'static str,
+    /// Binary shipped inside the release archive (no OS extension).
+    pub binary_name: &'static str,
+    /// Optional (owner, repo) override; skips the crates.io lookup when set.
+    pub repo: Option<(&'static str, &'static str)>,
+    /// Optional release-tag prefix used to filter monorepo releases, e.g.
+    /// `"cargo-audit/"` to pick only `cargo-audit/v0.21.0`-style tags.
+    pub tag_prefix: Option<&'static str>,
+}
+
+pub const KNOWN_TOOLS: &[ToolSpec] = &[
+    ToolSpec {
+        crate_name: "cargo-nextest",
+        cargo_subcommand: "nextest",
+        binary_name: "cargo-nextest",
+        repo: Some(("nextest-rs", "nextest")),
+        tag_prefix: Some("cargo-nextest-"),
+    },
+    ToolSpec {
+        crate_name: "cargo-deny",
+        cargo_subcommand: "deny",
+        binary_name: "cargo-deny",
+        repo: Some(("EmbarkStudios", "cargo-deny")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-audit",
+        cargo_subcommand: "audit",
+        binary_name: "cargo-audit",
+        repo: Some(("rustsec", "rustsec")),
+        tag_prefix: Some("cargo-audit/"),
+    },
+    ToolSpec {
+        crate_name: "cargo-llvm-cov",
+        cargo_subcommand: "llvm-cov",
+        binary_name: "cargo-llvm-cov",
+        repo: Some(("taiki-e", "cargo-llvm-cov")),
+        tag_prefix: None,
+    },
+];
+
+pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {
+    KNOWN_TOOLS.iter().find(|t| t.crate_name == crate_name)
+}
+
+pub fn lookup_by_cargo_subcommand(sub: &str) -> Option<&'static ToolSpec> {
+    KNOWN_TOOLS.iter().find(|t| t.cargo_subcommand == sub)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_by_crate_finds_registered_tools() {
+        assert_eq!(
+            lookup_by_crate("cargo-nextest").unwrap().cargo_subcommand,
+            "nextest"
+        );
+        assert_eq!(
+            lookup_by_crate("cargo-llvm-cov").unwrap().binary_name,
+            "cargo-llvm-cov"
+        );
+        assert!(lookup_by_crate("not-a-tool").is_none());
+    }
+
+    #[test]
+    fn lookup_by_cargo_subcommand_finds_registered_tools() {
+        assert_eq!(
+            lookup_by_cargo_subcommand("nextest").unwrap().crate_name,
+            "cargo-nextest"
+        );
+        assert_eq!(
+            lookup_by_cargo_subcommand("deny").unwrap().crate_name,
+            "cargo-deny"
+        );
+        assert!(lookup_by_cargo_subcommand("build").is_none());
+    }
+
+    #[test]
+    fn cargo_audit_carries_monorepo_tag_prefix() {
+        let spec = lookup_by_crate("cargo-audit").unwrap();
+        assert_eq!(spec.tag_prefix, Some("cargo-audit/"));
+    }
+
+    #[test]
+    fn known_tools_are_unique_by_crate_and_subcommand() {
+        for (i, a) in KNOWN_TOOLS.iter().enumerate() {
+            for b in KNOWN_TOOLS.iter().skip(i + 1) {
+                assert_ne!(
+                    a.crate_name, b.crate_name,
+                    "duplicate crate_name in registry"
+                );
+                assert_ne!(
+                    a.cargo_subcommand, b.cargo_subcommand,
+                    "duplicate cargo_subcommand in registry"
+                );
+            }
+        }
+    }
+}

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -2,7 +2,11 @@
 //!
 //! Resolution chain (Phase 1 MVP):
 //! 1. Local cache (`~/.soldr/bin/<tool>-<version>/`)
-//! 2. GitHub Releases (repository URL from crates.io)
+//! 2. GitHub Releases (repository URL from crates.io, or override from `known_tools`)
+
+pub mod known_tools;
+
+pub use known_tools::{lookup_by_cargo_subcommand, lookup_by_crate, ToolSpec, KNOWN_TOOLS};
 
 use soldr_core::{Arch, Env, Os, SoldrError, SoldrPaths, TargetTriple};
 use std::path::{Path, PathBuf};
@@ -52,8 +56,28 @@ pub async fn fetch_tool_with_paths(
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
+
+    if let Some(spec) = lookup_by_crate(crate_name) {
+        let repo = match spec.repo {
+            Some((owner, name)) => RepoInfo {
+                owner: owner.to_string(),
+                repo: name.to_string(),
+            },
+            None => resolve_repo(crate_name).await?,
+        };
+        return fetch_repo_binary_with_paths(
+            spec.crate_name,
+            &[spec.binary_name],
+            &repo,
+            version,
+            spec.tag_prefix,
+            paths,
+        )
+        .await;
+    }
+
     let repo = resolve_repo(crate_name).await?;
-    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, paths).await
+    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, None, paths).await
 }
 
 pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
@@ -110,6 +134,7 @@ async fn fetch_repo_binary_with_paths(
     binary_names: &[&str],
     repo: &RepoInfo,
     version: &VersionSpec,
+    tag_prefix: Option<&str>,
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
@@ -126,7 +151,7 @@ async fn fetch_repo_binary_with_paths(
         }
     }
 
-    let release = fetch_release(repo, version).await?;
+    let release = fetch_release(repo, version, tag_prefix).await?;
 
     if let Some(r) = check_cache(paths, cache_name, &release.version, binary_names, &target)? {
         return Ok(r);
@@ -266,19 +291,28 @@ fn parse_github_url(url: &str) -> Result<RepoInfo, SoldrError> {
 }
 
 /// Fetch release metadata (asset list) from GitHub.
-async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<ReleaseInfo, SoldrError> {
+async fn fetch_release(
+    repo: &RepoInfo,
+    version: &VersionSpec,
+    tag_prefix: Option<&str>,
+) -> Result<ReleaseInfo, SoldrError> {
     let client = http_client()?;
 
     let release = match version {
-        VersionSpec::Latest => {
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/releases/latest",
-                repo.owner, repo.repo
-            );
-            fetch_release_value(&client, repo, &url).await?
-        }
+        VersionSpec::Latest => match tag_prefix {
+            // Monorepo releases: `/releases/latest` may pick a sibling tool;
+            // instead list releases and take the newest whose tag matches.
+            Some(prefix) => fetch_latest_by_prefix(&client, repo, prefix).await?,
+            None => {
+                let url = format!(
+                    "https://api.github.com/repos/{}/{}/releases/latest",
+                    repo.owner, repo.repo
+                );
+                fetch_release_value(&client, repo, &url).await?
+            }
+        },
         VersionSpec::Exact(v) => {
-            let candidate_tags = release_tag_candidates(v);
+            let candidate_tags = release_tag_candidates(v, tag_prefix);
             let mut found = None;
             for tag in &candidate_tags {
                 let url = format!(
@@ -301,7 +335,59 @@ async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<Release
         }
     };
 
-    parse_release_info(release)
+    parse_release_info(release, tag_prefix)
+}
+
+async fn fetch_latest_by_prefix(
+    client: &reqwest::Client,
+    repo: &RepoInfo,
+    prefix: &str,
+) -> Result<serde_json::Value, SoldrError> {
+    let url = format!(
+        "https://api.github.com/repos/{}/{}/releases?per_page=60",
+        repo.owner, repo.repo
+    );
+    let resp = github_request(client, &url)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    if !resp.status().is_success() {
+        return Err(SoldrError::ToolNotFound(format!(
+            "no release found for {}/{}",
+            repo.owner, repo.repo
+        )));
+    }
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    let releases: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| SoldrError::Other(e.to_string()))?;
+
+    let matched = releases
+        .as_array()
+        .and_then(|items| {
+            items.iter().find(|release| {
+                let is_prerelease = release["prerelease"].as_bool().unwrap_or(false);
+                if is_prerelease {
+                    return false;
+                }
+                release["tag_name"]
+                    .as_str()
+                    .map(|tag| tag.starts_with(prefix))
+                    .unwrap_or(false)
+            })
+        })
+        .cloned();
+
+    matched.ok_or_else(|| {
+        SoldrError::ToolNotFound(format!(
+            "no release with tag prefix {prefix:?} found for {}/{}",
+            repo.owner, repo.repo
+        ))
+    })
 }
 
 async fn fetch_release_value(
@@ -372,12 +458,15 @@ async fn fetch_release_by_listing(
     })
 }
 
-fn release_tag_candidates(version: &str) -> Vec<String> {
-    let mut tags = Vec::with_capacity(2);
+fn release_tag_candidates(version: &str, tag_prefix: Option<&str>) -> Vec<String> {
+    let mut tags = Vec::with_capacity(4);
     let raw = version.trim();
     if raw.is_empty() {
         return tags;
     }
+    let bare = raw.trim_start_matches('v').to_string();
+
+    // Core bare + v-prefixed variants.
     tags.push(raw.to_string());
     if let Some(stripped) = raw.strip_prefix('v') {
         if !stripped.is_empty() {
@@ -386,6 +475,13 @@ fn release_tag_candidates(version: &str) -> Vec<String> {
     } else {
         tags.push(format!("v{raw}"));
     }
+
+    // Monorepo-style tags: e.g. `cargo-audit/v0.21.0`.
+    if let Some(prefix) = tag_prefix {
+        tags.push(format!("{prefix}{bare}"));
+        tags.push(format!("{prefix}v{bare}"));
+    }
+
     tags.sort();
     tags.dedup();
     tags
@@ -398,11 +494,18 @@ fn managed_zccache_download_url(version: &str, target: &TargetTriple) -> String 
     )
 }
 
-fn parse_release_info(body: serde_json::Value) -> Result<ReleaseInfo, SoldrError> {
+fn parse_release_info(
+    body: serde_json::Value,
+    tag_prefix: Option<&str>,
+) -> Result<ReleaseInfo, SoldrError> {
     let tag = body["tag_name"]
         .as_str()
         .ok_or_else(|| SoldrError::Other("no tag_name in release".into()))?;
-    let version = tag.trim_start_matches('v').to_string();
+    let stripped = match tag_prefix {
+        Some(prefix) => tag.strip_prefix(prefix).unwrap_or(tag),
+        None => tag,
+    };
+    let version = stripped.trim_start_matches('v').to_string();
 
     let assets = body["assets"]
         .as_array()
@@ -733,13 +836,42 @@ mod tests {
     #[test]
     fn release_tag_candidates_support_plain_and_v_prefixed_tags() {
         assert_eq!(
-            release_tag_candidates("1.2.8"),
+            release_tag_candidates("1.2.8", None),
             vec!["1.2.8".to_string(), "v1.2.8".to_string()]
         );
         assert_eq!(
-            release_tag_candidates("v1.2.8"),
+            release_tag_candidates("v1.2.8", None),
             vec!["1.2.8".to_string(), "v1.2.8".to_string()]
         );
+    }
+
+    #[test]
+    fn release_tag_candidates_include_monorepo_prefix_variants() {
+        let candidates = release_tag_candidates("0.21.0", Some("cargo-audit/"));
+        assert!(candidates.contains(&"0.21.0".to_string()));
+        assert!(candidates.contains(&"v0.21.0".to_string()));
+        assert!(candidates.contains(&"cargo-audit/0.21.0".to_string()));
+        assert!(candidates.contains(&"cargo-audit/v0.21.0".to_string()));
+    }
+
+    #[test]
+    fn parse_release_info_strips_monorepo_tag_prefix() {
+        let body = serde_json::json!({
+            "tag_name": "cargo-audit/v0.21.0",
+            "assets": [],
+        });
+        let info = parse_release_info(body, Some("cargo-audit/")).unwrap();
+        assert_eq!(info.version, "0.21.0");
+    }
+
+    #[test]
+    fn parse_release_info_strips_nextest_prefix() {
+        let body = serde_json::json!({
+            "tag_name": "cargo-nextest-0.9.100",
+            "assets": [],
+        });
+        let info = parse_release_info(body, Some("cargo-nextest-")).unwrap();
+        assert_eq!(info.version, "0.9.100");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 2 of the orchestration in #83. Adds a `known_tools` registry and plumbs it into both the direct fetch path (`soldr cargo-nextest`) and the cargo front door (`soldr cargo nextest ...`).

- New `crates/soldr-fetch/src/known_tools.rs` registry with entries for `cargo-nextest`, `cargo-deny`, `cargo-audit`, `cargo-llvm-cov` — each carries a crates.io name, cargo subcommand, binary name, optional GitHub `(owner, repo)` override, and optional release-tag prefix for monorepo releases.
- `fetch_tool_with_paths` consults the registry first and skips the crates.io lookup when a repo override is set.
- `fetch_release` gets a `tag_prefix` parameter. For `Latest` with a prefix, a new `fetch_latest_by_prefix` lists releases and picks the newest non-prerelease matching the prefix — required because `/releases/latest` on monorepos (e.g. rustsec) can return a sibling tool's release. For `Exact(v)` with a prefix, `release_tag_candidates` additionally emits `{prefix}{v}` and `{prefix}v{v}` candidates.
- `parse_release_info` strips the tag prefix before the existing `v` strip so the resolved version is clean.
- `run_cargo_front_door` detects the first positional arg of the cargo args. If it matches a registered `cargo_subcommand`, the binary is fetched and its parent dir is prepended to `PATH`, so cargo's own subcommand dispatch finds it.

## Motivation

Child issues #59–62 each ask for `soldr cargo <sub>` + `soldr cargo-<sub>` support for four ecosystem tools. Rather than four ad-hoc code paths, one registry + one branch in the cargo front door covers the shared shape and leaves room for Phases 3–5 to extend the registry with more tools.

## Test plan

- [x] `cargo test --workspace` — 50 tests pass including new unit tests:
  - registry lookups by crate name and cargo subcommand
  - registry uniqueness invariant
  - `release_tag_candidates` with monorepo prefix
  - `parse_release_info` strips `cargo-audit/` and `cargo-nextest-` prefixes
  - `first_cargo_subcommand` skips flags and respects `--`
  - CLI-level registry recognizes all four Phase 2 subcommands
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (pre-existing warning in `tests/cli.rs:31` unchanged)
- [ ] End-to-end network validation deferred to manual: `soldr cargo nextest --help`, `soldr cargo deny --help`, etc.

Closes #59, #60, #61, #62
Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)