### PR TITLE
Phase 3: fetch dev-ergonomics ecosystem tools

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -857,4 +857,14 @@ mod tests {
             assert!(spec.crate_name.starts_with("cargo-"));
         }
     }
+
+    #[test]
+    fn known_subcommand_registry_recognizes_phase_three_tools() {
+        for sub in ["udeps", "semver-checks", "expand", "watch"] {
+            let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
+                .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
+            assert_eq!(spec.cargo_subcommand, sub);
+            assert!(spec.crate_name.starts_with("cargo-"));
+        }
+    }
 }

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -50,6 +50,35 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
         repo: Some(("taiki-e", "cargo-llvm-cov")),
         tag_prefix: None,
     },
+    // Phase 3 — dev ergonomics.
+    ToolSpec {
+        crate_name: "cargo-udeps",
+        cargo_subcommand: "udeps",
+        binary_name: "cargo-udeps",
+        repo: Some(("est31", "cargo-udeps")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-semver-checks",
+        cargo_subcommand: "semver-checks",
+        binary_name: "cargo-semver-checks",
+        repo: Some(("obi1kenobi", "cargo-semver-checks")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-expand",
+        cargo_subcommand: "expand",
+        binary_name: "cargo-expand",
+        repo: Some(("dtolnay", "cargo-expand")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-watch",
+        cargo_subcommand: "watch",
+        binary_name: "cargo-watch",
+        repo: Some(("watchexec", "cargo-watch")),
+        tag_prefix: None,
+    },
 ];
 
 pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {


### PR DESCRIPTION
## Summary

Phase 3 of the orchestration in #83. Builds on the `known_tools` registry introduced in Phase 2 (#84). No new infrastructure — each tool is one additional registry entry.

Registers:
- `cargo-udeps` → `cargo udeps` (est31/cargo-udeps)
- `cargo-semver-checks` → `cargo semver-checks` (obi1kenobi/cargo-semver-checks)
- `cargo-expand` → `cargo expand` (dtolnay/cargo-expand)
- `cargo-watch` → `cargo watch` (watchexec/cargo-watch)

All four use plain `vX.Y.Z` release tags, so no `tag_prefix` is required. Each carries an explicit GitHub `(owner, repo)` so fetch skips the crates.io round-trip.

> **Merge order:** This branch is based on `phase/2-fetch-test-security` (#84). Rebase/merge onto `main` after Phase 2 lands, or GitHub will show both PRs' commits until the base is updated.

## Test plan

- [x] `cargo test --workspace` — 50 tests pass including `known_subcommand_registry_recognizes_phase_three_tools`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace`
- [ ] End-to-end network validation deferred to manual: `soldr cargo udeps --help`, `soldr cargo semver-checks --help`, etc.

Closes #63, #64, #65, #66
Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)