### PR TITLE
Phase 4: fetch build+docs ecosystem tools

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -853,7 +853,7 @@ mod tests {
         for sub in ["nextest", "deny", "audit", "llvm-cov"] {
             let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
                 .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
-            assert_eq!(spec.cargo_subcommand, sub);
+            assert_eq!(spec.cargo_subcommand, Some(sub));
             assert!(spec.crate_name.starts_with("cargo-"));
         }
     }
@@ -863,8 +863,17 @@ mod tests {
         for sub in ["udeps", "semver-checks", "expand", "watch"] {
             let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
                 .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
-            assert_eq!(spec.cargo_subcommand, sub);
+            assert_eq!(spec.cargo_subcommand, Some(sub));
             assert!(spec.crate_name.starts_with("cargo-"));
+        }
+    }
+
+    #[test]
+    fn top_level_tools_are_not_cargo_subcommands() {
+        for crate_name in ["cross", "mdbook", "cbindgen"] {
+            let spec = soldr_fetch::lookup_by_crate(crate_name)
+                .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
+            assert_eq!(spec.cargo_subcommand, None);
         }
     }
 }

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -1,4 +1,4 @@
-//! Registry of ecosystem tools with known GitHub Releases and cargo-subcommand mapping.
+//! Registry of ecosystem tools with known GitHub Releases and (optional) cargo-subcommand mapping.
 //!
 //! Some crates have monorepo-style release tags (e.g. `cargo-audit/v0.21.0`) or
 //! live in a repository whose name differs from the crate. Falling back to the
@@ -10,8 +10,9 @@
 pub struct ToolSpec {
     /// crates.io crate name and fetch cache key.
     pub crate_name: &'static str,
-    /// Name used as `cargo <sub>`.
-    pub cargo_subcommand: &'static str,
+    /// Name used as `cargo <sub>`. `None` for tools that are not cargo
+    /// subcommands (e.g. `cross`, `mdbook`, `sccache`).
+    pub cargo_subcommand: Option<&'static str>,
     /// Binary shipped inside the release archive (no OS extension).
     pub binary_name: &'static str,
     /// Optional (owner, repo) override; skips the crates.io lookup when set.
@@ -22,30 +23,31 @@ pub struct ToolSpec {
 }
 
 pub const KNOWN_TOOLS: &[ToolSpec] = &[
+    // Phase 2 — test + security.
     ToolSpec {
         crate_name: "cargo-nextest",
-        cargo_subcommand: "nextest",
+        cargo_subcommand: Some("nextest"),
         binary_name: "cargo-nextest",
         repo: Some(("nextest-rs", "nextest")),
         tag_prefix: Some("cargo-nextest-"),
     },
     ToolSpec {
         crate_name: "cargo-deny",
-        cargo_subcommand: "deny",
+        cargo_subcommand: Some("deny"),
         binary_name: "cargo-deny",
         repo: Some(("EmbarkStudios", "cargo-deny")),
         tag_prefix: None,
     },
     ToolSpec {
         crate_name: "cargo-audit",
-        cargo_subcommand: "audit",
+        cargo_subcommand: Some("audit"),
         binary_name: "cargo-audit",
         repo: Some(("rustsec", "rustsec")),
         tag_prefix: Some("cargo-audit/"),
     },
     ToolSpec {
         crate_name: "cargo-llvm-cov",
-        cargo_subcommand: "llvm-cov",
+        cargo_subcommand: Some("llvm-cov"),
         binary_name: "cargo-llvm-cov",
         repo: Some(("taiki-e", "cargo-llvm-cov")),
         tag_prefix: None,
@@ -53,30 +55,53 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
     // Phase 3 — dev ergonomics.
     ToolSpec {
         crate_name: "cargo-udeps",
-        cargo_subcommand: "udeps",
+        cargo_subcommand: Some("udeps"),
         binary_name: "cargo-udeps",
         repo: Some(("est31", "cargo-udeps")),
         tag_prefix: None,
     },
     ToolSpec {
         crate_name: "cargo-semver-checks",
-        cargo_subcommand: "semver-checks",
+        cargo_subcommand: Some("semver-checks"),
         binary_name: "cargo-semver-checks",
         repo: Some(("obi1kenobi", "cargo-semver-checks")),
         tag_prefix: None,
     },
     ToolSpec {
         crate_name: "cargo-expand",
-        cargo_subcommand: "expand",
+        cargo_subcommand: Some("expand"),
         binary_name: "cargo-expand",
         repo: Some(("dtolnay", "cargo-expand")),
         tag_prefix: None,
     },
     ToolSpec {
         crate_name: "cargo-watch",
-        cargo_subcommand: "watch",
+        cargo_subcommand: Some("watch"),
         binary_name: "cargo-watch",
         repo: Some(("watchexec", "cargo-watch")),
+        tag_prefix: None,
+    },
+    // Phase 4 — build + docs. None of these are cargo subcommands — they are
+    // top-level tools invoked as `soldr cross ...`, `soldr mdbook ...`, etc.
+    ToolSpec {
+        crate_name: "cross",
+        cargo_subcommand: None,
+        binary_name: "cross",
+        repo: Some(("cross-rs", "cross")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "mdbook",
+        cargo_subcommand: None,
+        binary_name: "mdbook",
+        repo: Some(("rust-lang", "mdBook")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cbindgen",
+        cargo_subcommand: None,
+        binary_name: "cbindgen",
+        repo: Some(("mozilla", "cbindgen")),
         tag_prefix: None,
     },
 ];
@@ -86,7 +111,7 @@ pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {
 }
 
 pub fn lookup_by_cargo_subcommand(sub: &str) -> Option<&'static ToolSpec> {
-    KNOWN_TOOLS.iter().find(|t| t.cargo_subcommand == sub)
+    KNOWN_TOOLS.iter().find(|t| t.cargo_subcommand == Some(sub))
 }
 
 #[cfg(test)]
@@ -97,12 +122,13 @@ mod tests {
     fn lookup_by_crate_finds_registered_tools() {
         assert_eq!(
             lookup_by_crate("cargo-nextest").unwrap().cargo_subcommand,
-            "nextest"
+            Some("nextest")
         );
         assert_eq!(
             lookup_by_crate("cargo-llvm-cov").unwrap().binary_name,
             "cargo-llvm-cov"
         );
+        assert_eq!(lookup_by_crate("mdbook").unwrap().cargo_subcommand, None);
         assert!(lookup_by_crate("not-a-tool").is_none());
     }
 
@@ -117,6 +143,10 @@ mod tests {
             "cargo-deny"
         );
         assert!(lookup_by_cargo_subcommand("build").is_none());
+        // Tools with cargo_subcommand: None should never be returned here.
+        assert!(lookup_by_cargo_subcommand("mdbook").is_none());
+        assert!(lookup_by_cargo_subcommand("cross").is_none());
+        assert!(lookup_by_cargo_subcommand("cbindgen").is_none());
     }
 
     #[test]
@@ -133,11 +163,20 @@ mod tests {
                     a.crate_name, b.crate_name,
                     "duplicate crate_name in registry"
                 );
-                assert_ne!(
-                    a.cargo_subcommand, b.cargo_subcommand,
-                    "duplicate cargo_subcommand in registry"
-                );
+                if let (Some(asub), Some(bsub)) = (a.cargo_subcommand, b.cargo_subcommand) {
+                    assert_ne!(asub, bsub, "duplicate cargo_subcommand in registry");
+                }
             }
+        }
+    }
+
+    #[test]
+    fn top_level_tools_are_registered_without_cargo_subcommand() {
+        for crate_name in ["cross", "mdbook", "cbindgen"] {
+            let spec = lookup_by_crate(crate_name)
+                .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
+            assert_eq!(spec.cargo_subcommand, None);
+            assert!(spec.repo.is_some());
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 4 of the orchestration in #83. Builds on Phases 2 (#84) and 3 (#85).

Registers:
- `cross` → `soldr cross ...` (cross-rs/cross)
- `mdbook` → `soldr mdbook ...` (rust-lang/mdBook)
- `cbindgen` → `soldr cbindgen ...` (mozilla/cbindgen)

None of these are cargo subcommands — they are top-level tools invoked via the generic External dispatch path. To represent that cleanly, `ToolSpec::cargo_subcommand` becomes `Option<&'static str>`. `lookup_by_cargo_subcommand` skips `None` entries; the uniqueness invariant still holds for crate names across the whole registry and for subcommand names among entries that have one.

With explicit `repo: Some((owner, name))` set, fetching skips the crates.io round-trip and targets the correct repository (notably `rust-lang/mdBook` — uppercase B).

> **Merge order:** Stacked on #85 (`phase/3-fetch-dev-tools`). Rebase onto `main` after #84 → #85 merge, or retarget the base after each upstream merge.

## Test plan

- [x] `cargo test --workspace` — all tests pass including new `top_level_tools_are_registered_without_cargo_subcommand` and `top_level_tools_are_not_cargo_subcommands`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (only the pre-existing `needless_return` in `tests/cli.rs:31`)
- [ ] End-to-end network validation deferred to manual: `soldr cross --version`, `soldr mdbook --help`, `soldr cbindgen --version`

Closes #67, #68, #69
Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)