### PR TITLE
Phase 5: fetch web/wasm + cache ecosystem tools

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -870,7 +870,14 @@ mod tests {
 
     #[test]
     fn top_level_tools_are_not_cargo_subcommands() {
-        for crate_name in ["cross", "mdbook", "cbindgen"] {
+        for crate_name in [
+            "cross",
+            "mdbook",
+            "cbindgen",
+            "wasm-pack",
+            "trunk",
+            "sccache",
+        ] {
             let spec = soldr_fetch::lookup_by_crate(crate_name)
                 .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
             assert_eq!(spec.cargo_subcommand, None);

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -104,6 +104,28 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
         repo: Some(("mozilla", "cbindgen")),
         tag_prefix: None,
     },
+    // Phase 5 — web/wasm + cache. Top-level tools invoked directly.
+    ToolSpec {
+        crate_name: "wasm-pack",
+        cargo_subcommand: None,
+        binary_name: "wasm-pack",
+        repo: Some(("rustwasm", "wasm-pack")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "trunk",
+        cargo_subcommand: None,
+        binary_name: "trunk",
+        repo: Some(("trunk-rs", "trunk")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "sccache",
+        cargo_subcommand: None,
+        binary_name: "sccache",
+        repo: Some(("mozilla", "sccache")),
+        tag_prefix: None,
+    },
 ];
 
 pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {
@@ -172,7 +194,14 @@ mod tests {
 
     #[test]
     fn top_level_tools_are_registered_without_cargo_subcommand() {
-        for crate_name in ["cross", "mdbook", "cbindgen"] {
+        for crate_name in [
+            "cross",
+            "mdbook",
+            "cbindgen",
+            "wasm-pack",
+            "trunk",
+            "sccache",
+        ] {
             let spec = lookup_by_crate(crate_name)
                 .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
             assert_eq!(spec.cargo_subcommand, None);


### PR DESCRIPTION
## Summary

Phase 5 of the orchestration in #83. Builds on Phases 2 (#84), 3 (#85), and 4 (#86).

Registers:
- `wasm-pack` → `soldr wasm-pack ...` (rustwasm/wasm-pack)
- `trunk` → `soldr trunk ...` (trunk-rs/trunk)
- `sccache` → `soldr sccache ...` (mozilla/sccache)

All three are top-level tools (`cargo_subcommand: None`). With explicit `repo` overrides, fetching skips the crates.io round-trip and goes straight to GitHub Releases.

> **Note on sccache:** This exposes standalone `sccache` binary fetching. The managed-zccache RUSTC_WRAPPER flow inside `soldr cargo ...` is unchanged — they are independent code paths.

> **Merge order:** Stacked on #86 (`phase/4-fetch-build-docs`). Rebase onto `main` after #84 → #85 → #86 merge, or retarget the base after each upstream merge.

## Test plan

- [x] `cargo test --workspace` — all tests pass including the expanded `top_level_tools_*` invariants
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace`
- [ ] End-to-end network validation deferred to manual: `soldr wasm-pack --version`, `soldr trunk --version`, `soldr sccache --version`

Closes #70, #71, #72
Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)