### PR TITLE
Phase 9: narrow musl-tools install surface + audit log

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -57,8 +57,33 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
+          # Narrower input surface per #41:
+          # - --no-install-recommends prevents apt from pulling in optional deps,
+          #   so the exact package set is what the release path declares.
+          # - a small retry loop makes transient apt/mirror errors recoverable
+          #   without weakening the installed set.
+          # - the resolved package version is logged so it is auditable from
+          #   the workflow run.
+          attempts=0
+          max_attempts=3
+          until sudo apt-get update; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get update failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+          attempts=0
+          until sudo apt-get install -y --no-install-recommends musl-tools; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get install musl-tools failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+          dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -47,12 +47,28 @@ The bootstrap e2e jobs currently trust additional external systems:
 
 - Ubuntu package repositories
   - musl validation jobs install `musl-tools` from live `apt` repositories
+  - the install command uses `--no-install-recommends`, a retry loop, and logs the resolved `musl-tools` version for auditability; the set of installed packages is therefore the declared set, not an open-ended recommended expansion
 - third-party source repository hosting
   - the e2e workflow checks out a pinned commit of `zackees/running-process` from GitHub
 - third-party Rust toolchain installation
   - the e2e workflow reads the third-party project's `rust-toolchain.toml` and installs that toolchain through `rustup`
 
 These inputs are pinned where possible, but they are not yet mirrored or fully hermetic.
+
+## Hermetic Inputs Hardening Status
+
+Tracked by #41. Concrete narrowings already in place:
+
+- the `musl-tools` install uses `--no-install-recommends` so the Ubuntu package surface is exactly what the release path declares
+- the `musl-tools` install logs its resolved version so the exact package contents are visible in workflow logs
+- the `musl-tools` install retries on transient apt failures rather than either flapping or pulling unrelated extras
+
+Still deferred (acceptable follow-up, not blockers for the current line):
+
+- a `cargo vendor` or mirrored-registry strategy for crates.io resolution during release
+- a mirrored or prebuilt-image strategy for Rust toolchain acquisition during release
+- a mirror for the pinned third-party bootstrap repository checkout
+- replacement of the live `apt` repository with a prebuilt image or pinned-package snapshot
 
 ## Runtime Tool-Fetch Trust Boundaries
 


### PR DESCRIPTION
## Summary

Phase 9 of the orchestration in #83. First concrete slice on #41: reduce live external inputs in the release path without blocking the current line.

Changes to \`.github/workflows/_bootstrap-e2e.yml\` — the musl install step:
- \`apt-get install\` now passes \`--no-install-recommends\`, so the installed package set is exactly what the release path declares rather than an open-ended expansion.
- Both \`apt-get update\` and \`apt-get install\` are wrapped in a small retry loop with backoff, so transient mirror errors are recoverable without weakening the install.
- The resolved \`musl-tools\` Debian package version is logged via \`dpkg-query\` after install so the exact package contents are auditable from the workflow run.

\`docs/TRUST_BOUNDARIES.md\` records the narrowed E2E input surface and a new **Hermetic Inputs Hardening Status** section listing what is in place and what remains accepted follow-up:
- cargo vendor / mirrored-registry strategy
- mirrored or prebuilt-image Rust toolchain acquisition
- mirror for the pinned third-party bootstrap repository
- replacement of live \`apt\` repos with a prebuilt image or pinned-package snapshot

These deferred items are the next concrete steps on #41 but are intentionally out of scope for this PR — each is a structural change that deserves its own review.

## Test plan

- [x] YAML parses cleanly (validated via \`yaml.safe_load\`)
- [x] No Rust code changed → workspace tests/fmt/clippy not affected
- [ ] Workflow dry-run deferred to CI on this branch; the change is strictly a narrowing, retries preserve prior behavior on transient failure

Refs #41, #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)