### PR TITLE
docs: refresh CLAUDE.md to reflect 0.6.x reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,41 +38,50 @@ uv run maturin build --release         # Build wheel
 Four-crate Rust workspace under `crates/`:
 
 - **soldr-core** — Shared types, config (`~/.soldr/config.toml`), target triple resolution (MSVC default on Windows at runtime), error types. No I/O beyond config files.
-- **soldr-fetch** — Binary resolution chain: local cache → binstall metadata → GitHub Releases → QuickInstall → `cargo install` (last resort). Manages `~/.soldr/bin/`.
+- **soldr-fetch** — Binary resolution. Ships two sub-modules:
+  - `known_tools` — registry of ecosystem tools with explicit GitHub `(owner, repo)`, cargo subcommand mapping, and optional monorepo tag prefix (e.g. `cargo-audit/v0.21.0`). Keeps dispatch off the crates.io round-trip and handles per-tool release quirks.
+  - `trust` — SHA-256 computation + `SOLDR_TRUST_MODE` / `SOLDR_CHECKSUMS_FILE` enforcement. Every fetch emits a `trust: verified` or `trust: unverified` line and a pin mismatch is a hard error regardless of mode.
+  - Resolution chain: local cache → registry-or-crates.io repo lookup → GitHub Releases asset download → extract.
 - **soldr-cache** — `RUSTC_WRAPPER` logic: hash inputs (blake3), check `~/.soldr/cache/`, daemon IPC (Unix socket / Windows named pipe), LRU eviction.
-- **soldr-cli** — Thin dispatch layer. `main()` with mode detection, clap for built-ins, exec for tool fetch. No business logic here.
+- **soldr-cli** — Thin dispatch layer. `main()` with mode detection, clap for built-ins, exec for tool fetch. The cargo front door (`soldr cargo ...`) inspects the first positional arg; if it matches a `known_tools` `cargo_subcommand`, the corresponding `cargo-<sub>` binary is fetched and prepended to `PATH` before cargo runs.
 
 Dependency flow: `soldr-cli → {soldr-core, soldr-fetch, soldr-cache}`, both fetch and cache depend on `soldr-core`.
 
 Python package (`src/soldr/`) wraps the CLI binary via Maturin as `soldr._native`.
 
+## Supported Tools
+
+Two categories, surfaced as first-class subcommands or via the generic fetch path:
+
+**Rustup toolchain passthroughs** (resolved via `rustup which`):
+`rustc`, `rustfmt`, `clippy-driver`, `rustdoc`, `rust-gdb`, `rust-lldb`, `rust-analyzer`.
+
+**Ecosystem fetches** (registered in `known_tools`, pulled from GitHub Releases):
+- cargo subcommands invoked via `soldr cargo <sub>`: `nextest`, `deny`, `audit`, `llvm-cov`, `udeps`, `semver-checks`, `expand`, `watch`.
+- top-level tools invoked directly via `soldr <tool>`: `cross`, `mdbook`, `cbindgen`, `wasm-pack`, `trunk`, `sccache`.
+
+Anything not registered falls through the generic External subcommand, which resolves via crates.io → GitHub Releases.
+
 ## Key Design Rules
 
-- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
+- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
 - **MSVC on Windows always**: Default to `x86_64-pc-windows-msvc` (or aarch64). Only use GNU if `rust-toolchain.toml` explicitly says so. Target resolved at runtime, not compile-time.
 - **Pre-built first**: Try every binary source before `cargo install`. Resolution order matters.
 - **RUSTC_WRAPPER defaults to zccache**: If `RUSTC_WRAPPER` is not set, soldr defaults to using `zccache` as the wrapper.
 - **Daemon auto-starts**: First `RUSTC_WRAPPER` call starts the cache daemon transparently. No manual `soldr start`.
+- **Integrity is default**: every fetch records sha256. Pins are opt-in via `SOLDR_CHECKSUMS_FILE`; `SOLDR_TRUST_MODE=strict` refuses unpinned fetches.
 - **Version independence**: Users install once and forget. CI should pin: `pip install soldr==X.Y.Z`.
 
 ## Toolchain
 
-- Rust 1.85 (rust-toolchain.toml), edition 2021, MSRV 1.75
+- Rust 1.94.1 (rust-toolchain.toml), edition 2021, MSRV 1.75
 - Python >=3.10 (for PyPI distribution via Maturin)
 - uv for Python dependency management
 - Workspace dependencies shared in root `Cargo.toml`
-
-## Implementation Status
-
-Currently in **Phase 1 (Tool Fetcher MVP)**. All crate lib.rs files are stubs; CLI skeleton exists with clap commands that print "(not yet implemented)". See DESIGN.md for the four-phase roadmap.
 
 ## Reference Docs
 
 - `DESIGN.md` — Authoritative implementation guide, architecture decisions, phase roadmap
 - `docs/API.md` — Full CLI specification, environment variables, cache layout
+- `docs/TRUST_BOUNDARIES.md` — Runtime fetch policy, what integrity is enforced, what remains follow-up
 - `README.md` — User-facing motivation and prior art comparison
-
-## Known Issues
-
-- CLI currently has `Build` and `Run` subcommands that contradict DESIGN.md (which says no `soldr build` and tool fetch should be the bare `soldr <tool>` form, not `soldr run <tool>`)
-- LICENSE file says MIT but Cargo.toml specifies BSD-3-Clause


### PR DESCRIPTION
## Summary

The previous \`CLAUDE.md\` described the repo as "Phase 1 (Tool Fetcher MVP) with lib.rs stubs" and carried a Known Issues list pointing at problems already fixed on main. That picture no longer matches the codebase after the #83 orchestration. This refresh brings the doc back in line with 0.6.x.

Changes:
- **Architecture**: \`soldr-fetch\` now documents its \`known_tools\` registry (per-tool GitHub repo overrides + cargo subcommand mapping + monorepo tag prefixes) and the \`trust\` module (SHA-256 + \`SOLDR_TRUST_MODE\` / \`SOLDR_CHECKSUMS_FILE\`).
- **soldr-cli**: describes the cargo front-door subcommand interception that prepends fetched \`cargo-<sub>\` binaries to PATH.
- **New Supported Tools section**: lists the rustup passthroughs and the 14 registered ecosystem fetches (8 cargo subcommands + 6 top-level tools).
- **Key Design Rules**: expanded to reference the new toolchain passthroughs and an \"Integrity is default\" entry.
- **Toolchain version**: 1.85 → 1.94.1, matching \`rust-toolchain.toml\`.
- **Removed Implementation Status** (Phase 1 MVP claim is wrong).
- **Removed Known Issues** (both items resolved: Build/Run subcommands no longer exist; LICENSE/Cargo.toml mismatch fixed in #90).
- **Added \`docs/TRUST_BOUNDARIES.md\`** to the Reference Docs list.

No code changes.

## Test plan

- [x] Doc-only; workspace tests/fmt/clippy unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)