### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.6.0" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.6.0" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.6.0" }
+soldr-core = { path = "crates/soldr-core", version = "0.7.0" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.0" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.7.0" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.6.0");
+        assert_eq!(version(), "0.7.0");
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.6.0"
+  "soldr_version": "0.7.0"
 }
 ```
 


### PR DESCRIPTION
## Summary

Bumps the workspace to \`0.7.0\` so the release path can cut \`v0.7.0\`. Tracking issue: #93.

\`Cargo.toml\` workspace version and the three internal path dependencies move together. \`Cargo.lock\` regenerated. \`soldr-core\`'s version test and the \`docs/API.md\` JSON example updated to match.

## What's in v0.7.0 (since v0.6.0)

- Ecosystem fetch registry + cargo-subcommand dispatch (#84, #85, #86, #87) — 14 registered tools
- Trust policy (#88) — SHA-256 on every fetch, \`SOLDR_CHECKSUMS_FILE\` pinning, \`SOLDR_TRUST_MODE=strict\` enforcement
- Hermeticity first slice (#89) — narrower \`musl-tools\` install
- LICENSE aligned to BSD-3-Clause (#90)
- CLAUDE.md refreshed to 0.6.x reality (#91)
- \`--as <version>\` trampoline (#92) for per-invocation soldr pinning

## Test plan

- [x] \`cargo test --workspace\` — 80 tests pass (version test updated)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace\`
- [ ] Post-merge: sync \`main\` → \`release\` branch
- [ ] Post-merge: dispatch \`release.yml\` with \`version=v0.7.0\`, \`dry_run=true\` first

Refs #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)