### PR TITLE
chore: sync release branch to v0.7.0

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -15,10 +15,6 @@ on:
       source_ref:
         required: true
         type: string
-      soldr_toolchain:
-        required: false
-        type: string
-        default: "1.94.1"
       third_party_repo:
         required: false
         type: string
@@ -54,7 +50,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
-          toolchain: ${{ inputs.soldr_toolchain }}
           targets: ${{ inputs.target }}
 
       - name: Install musl tools

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -57,8 +57,33 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
+          # Narrower input surface per #41:
+          # - --no-install-recommends prevents apt from pulling in optional deps,
+          #   so the exact package set is what the release path declares.
+          # - a small retry loop makes transient apt/mirror errors recoverable
+          #   without weakening the installed set.
+          # - the resolved package version is logged so it is auditable from
+          #   the workflow run.
+          attempts=0
+          max_attempts=3
+          until sudo apt-get update; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get update failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+          attempts=0
+          until sudo apt-get install -y --no-install-recommends musl-tools; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get install musl-tools failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+          dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:

--- a/.github/workflows/build-linux-arm64-musl.yml
+++ b/.github/workflows/build-linux-arm64-musl.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-linux-x64-musl.yml
+++ b/.github/workflows/build-linux-x64-musl.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-linux-x64.yml
+++ b/.github/workflows/build-linux-x64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
   pull_request:
+    paths-ignore:
+      - README.md
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,61 +377,26 @@ jobs:
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
-      - name: Install maturin
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 -m pip install --upgrade pip
-          python3 -m pip install "maturin>=1.7,<2"
-
-      - name: Install maturin
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          py -3 -m pip install --upgrade pip
-          py -3 -m pip install "maturin>=1.7,<2"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Build hardened wheel
-        if: runner.os != 'Windows'
         shell: bash
         run: |
-          set -euo pipefail
-          python3 -m maturin build \
+          uv tool install "maturin>=1.7,<2"
+          maturin build \
             --release \
             --locked \
             --compatibility pypi \
             --target "${{ matrix.target }}" \
             --out dist
 
-      - name: Build hardened wheel
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          py -3 -m maturin build `
-            --release `
-            --locked `
-            --compatibility pypi `
-            --target "${{ matrix.target }}" `
-            --out dist
-
       - name: Smoke test wheel
-        if: runner.os != 'Windows'
         shell: bash
         run: |
-          set -euo pipefail
-          python3 -m venv .venv
-          . .venv/bin/activate
-          python -m pip install dist/*.whl
-          soldr --version
-
-      - name: Smoke test wheel
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          py -3 -m venv .venv
-          .\.venv\Scripts\python.exe -m pip install dist\*.whl
-          .\.venv\Scripts\soldr.exe --version
+          uv venv .venv
+          uv pip install --python .venv dist/*.whl
+          .venv/bin/soldr --version || .venv/Scripts/soldr.exe --version
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,7 +378,7 @@ jobs:
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
 
       - name: Build hardened wheel
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
         description: Exact commit SHA to validate and release
         required: true
         type: string
+      dry_run:
+        description: Validate the full release flow without creating a release tag or publishing assets
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -45,8 +50,8 @@ jobs:
           version='${{ inputs.version }}'
           commit_sha='${{ inputs.commit_sha }}'
 
-          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
-            echo "validated releases must be dispatched from main" >&2
+          if [[ "${GITHUB_REF_NAME}" != "release" ]]; then
+            echo "validated releases must be dispatched from release" >&2
             exit 1
           fi
 
@@ -60,9 +65,9 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main --depth=1
+          git fetch origin release --depth=1
           git rev-parse --verify "${commit_sha}^{commit}" >/dev/null
-          git merge-base --is-ancestor "$commit_sha" origin/main
+          git merge-base --is-ancestor "$commit_sha" origin/release
 
           if git ls-remote --exit-code --tags origin "$version" >/dev/null 2>&1; then
             echo "tag $version already exists" >&2
@@ -322,6 +327,23 @@ jobs:
           pattern: soldr-*
           merge-multiple: true
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: soldr
+
+      - name: Verify GitHub App token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}" --jq '.full_name'
+
       - name: Generate release checksums
         shell: bash
         run: |
@@ -333,9 +355,17 @@ jobs:
         with:
           subject-checksums: dist/soldr-${{ needs.prepare.outputs.version }}-SHA256SUMS.txt
 
+      - name: Stop after dry run validation
+        if: inputs.dry_run
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "dry run complete: release gating, artifact build, attestation, and GitHub App authentication all succeeded"
+
       - name: Create draft GitHub Release
+        if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -346,8 +376,9 @@ jobs:
             --title "${{ needs.prepare.outputs.version }}"
 
       - name: Publish GitHub Release
+        if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: soldr-${{ matrix.target }}
+          name: release-soldr-${{ matrix.target }}
           path: dist/soldr-*
 
   publish:
@@ -324,7 +324,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
-          pattern: soldr-*
+          pattern: release-soldr-*
           merge-multiple: true
 
       - name: Create GitHub App token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ on:
         required: false
         default: true
         type: boolean
+      publish_pypi:
+        description: Build hardened wheel artifacts and publish them to PyPI via Trusted Publishing
+        required: false
+        default: false
+        type: boolean
+      pypi_repository_url:
+        description: Optional alternate upload endpoint such as https://test.pypi.org/legacy/
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -49,6 +59,8 @@ jobs:
           set -euo pipefail
           version='${{ inputs.version }}'
           commit_sha='${{ inputs.commit_sha }}'
+          publish_pypi='${{ inputs.publish_pypi }}'
+          pypi_repository_url='${{ inputs.pypi_repository_url }}'
 
           if [[ "${GITHUB_REF_NAME}" != "release" ]]; then
             echo "validated releases must be dispatched from release" >&2
@@ -62,6 +74,11 @@ jobs:
 
           if [[ ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "commit_sha must be a full 40-character commit SHA" >&2
+            exit 1
+          fi
+
+          if [[ "$publish_pypi" != "true" && -n "$pypi_repository_url" ]]; then
+            echo "pypi_repository_url requires publish_pypi=true" >&2
             exit 1
           fi
 
@@ -312,6 +329,115 @@ jobs:
           name: release-soldr-${{ matrix.target }}
           path: dist/soldr-*
 
+  build-pypi:
+    name: PyPI ${{ matrix.name }}
+    if: ${{ inputs.publish_pypi }}
+    needs:
+      - prepare
+      - lint
+      - test
+      - e2e-linux-x64
+      - e2e-linux-arm64
+      - e2e-linux-x64-musl
+      - e2e-linux-arm64-musl
+      - e2e-macos-x64
+      - e2e-macos-arm64
+      - e2e-windows-x64
+      - e2e-windows-arm64
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - name: Linux ARM64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS x64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - name: macOS ARM64
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - name: Windows x64
+            runner: windows-2025
+            target: x86_64-pc-windows-msvc
+          - name: Windows ARM64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Install maturin
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "maturin>=1.7,<2"
+
+      - name: Install maturin
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m pip install --upgrade pip
+          py -3 -m pip install "maturin>=1.7,<2"
+
+      - name: Build hardened wheel
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m maturin build \
+            --release \
+            --locked \
+            --compatibility pypi \
+            --target "${{ matrix.target }}" \
+            --out dist
+
+      - name: Build hardened wheel
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m maturin build `
+            --release `
+            --locked `
+            --compatibility pypi `
+            --target "${{ matrix.target }}" `
+            --out dist
+
+      - name: Smoke test wheel
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m venv .venv
+          . .venv/bin/activate
+          python -m pip install dist/*.whl
+          soldr --version
+
+      - name: Smoke test wheel
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          py -3 -m venv .venv
+          .\.venv\Scripts\python.exe -m pip install dist\*.whl
+          .\.venv\Scripts\soldr.exe --version
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pypi-soldr-${{ matrix.target }}
+          path: dist/*.whl
+
   publish:
     name: Attest and publish release assets
     needs:
@@ -370,6 +496,7 @@ jobs:
         run: |
           set -euo pipefail
           gh release create "${{ needs.prepare.outputs.version }}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
             --draft \
             --generate-notes \
             --target "${{ needs.prepare.outputs.commit_sha }}" \
@@ -382,4 +509,42 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh release edit "${{ needs.prepare.outputs.version }}" --draft=false
+          gh release edit "${{ needs.prepare.outputs.version }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --draft=false
+
+  publish-pypi:
+    name: Publish hardened PyPI wheels
+    if: ${{ inputs.publish_pypi && !inputs.dry_run }}
+    needs:
+      - prepare
+      - build-pypi
+      - publish
+    runs-on: ubuntu-24.04
+    environment: release
+
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          pattern: pypi-soldr-*
+          merge-multiple: true
+
+      - name: Show Python distributions
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -1 dist
+
+      - name: Publish wheel set to PyPI
+        if: ${{ inputs.pypi_repository_url == '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
+
+      - name: Publish wheel set to alternate index
+        if: ${{ inputs.pypi_repository_url != '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          repository-url: ${{ inputs.pypi_repository_url }}
+          packages-dir: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -440,9 +440,17 @@ jobs:
 
   publish:
     name: Attest and publish release assets
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.result == 'success' &&
+        needs.build.result == 'success' &&
+        (needs.build-pypi.result == 'success' || needs.build-pypi.result == 'skipped')
+      }}
     needs:
       - prepare
       - build
+      - build-pypi
     runs-on: ubuntu-24.04
     environment: release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,41 +38,50 @@ uv run maturin build --release         # Build wheel
 Four-crate Rust workspace under `crates/`:
 
 - **soldr-core** — Shared types, config (`~/.soldr/config.toml`), target triple resolution (MSVC default on Windows at runtime), error types. No I/O beyond config files.
-- **soldr-fetch** — Binary resolution chain: local cache → binstall metadata → GitHub Releases → QuickInstall → `cargo install` (last resort). Manages `~/.soldr/bin/`.
+- **soldr-fetch** — Binary resolution. Ships two sub-modules:
+  - `known_tools` — registry of ecosystem tools with explicit GitHub `(owner, repo)`, cargo subcommand mapping, and optional monorepo tag prefix (e.g. `cargo-audit/v0.21.0`). Keeps dispatch off the crates.io round-trip and handles per-tool release quirks.
+  - `trust` — SHA-256 computation + `SOLDR_TRUST_MODE` / `SOLDR_CHECKSUMS_FILE` enforcement. Every fetch emits a `trust: verified` or `trust: unverified` line and a pin mismatch is a hard error regardless of mode.
+  - Resolution chain: local cache → registry-or-crates.io repo lookup → GitHub Releases asset download → extract.
 - **soldr-cache** — `RUSTC_WRAPPER` logic: hash inputs (blake3), check `~/.soldr/cache/`, daemon IPC (Unix socket / Windows named pipe), LRU eviction.
-- **soldr-cli** — Thin dispatch layer. `main()` with mode detection, clap for built-ins, exec for tool fetch. No business logic here.
+- **soldr-cli** — Thin dispatch layer. `main()` with mode detection, clap for built-ins, exec for tool fetch. The cargo front door (`soldr cargo ...`) inspects the first positional arg; if it matches a `known_tools` `cargo_subcommand`, the corresponding `cargo-<sub>` binary is fetched and prepended to `PATH` before cargo runs.
 
 Dependency flow: `soldr-cli → {soldr-core, soldr-fetch, soldr-cache}`, both fetch and cache depend on `soldr-core`.
 
 Python package (`src/soldr/`) wraps the CLI binary via Maturin as `soldr._native`.
 
+## Supported Tools
+
+Two categories, surfaced as first-class subcommands or via the generic fetch path:
+
+**Rustup toolchain passthroughs** (resolved via `rustup which`):
+`rustc`, `rustfmt`, `clippy-driver`, `rustdoc`, `rust-gdb`, `rust-lldb`, `rust-analyzer`.
+
+**Ecosystem fetches** (registered in `known_tools`, pulled from GitHub Releases):
+- cargo subcommands invoked via `soldr cargo <sub>`: `nextest`, `deny`, `audit`, `llvm-cov`, `udeps`, `semver-checks`, `expand`, `watch`.
+- top-level tools invoked directly via `soldr <tool>`: `cross`, `mdbook`, `cbindgen`, `wasm-pack`, `trunk`, `sccache`.
+
+Anything not registered falls through the generic External subcommand, which resolves via crates.io → GitHub Releases.
+
 ## Key Design Rules
 
-- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
+- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
 - **MSVC on Windows always**: Default to `x86_64-pc-windows-msvc` (or aarch64). Only use GNU if `rust-toolchain.toml` explicitly says so. Target resolved at runtime, not compile-time.
 - **Pre-built first**: Try every binary source before `cargo install`. Resolution order matters.
 - **RUSTC_WRAPPER defaults to zccache**: If `RUSTC_WRAPPER` is not set, soldr defaults to using `zccache` as the wrapper.
 - **Daemon auto-starts**: First `RUSTC_WRAPPER` call starts the cache daemon transparently. No manual `soldr start`.
+- **Integrity is default**: every fetch records sha256. Pins are opt-in via `SOLDR_CHECKSUMS_FILE`; `SOLDR_TRUST_MODE=strict` refuses unpinned fetches.
 - **Version independence**: Users install once and forget. CI should pin: `pip install soldr==X.Y.Z`.
 
 ## Toolchain
 
-- Rust 1.85 (rust-toolchain.toml), edition 2021, MSRV 1.75
+- Rust 1.94.1 (rust-toolchain.toml), edition 2021, MSRV 1.75
 - Python >=3.10 (for PyPI distribution via Maturin)
 - uv for Python dependency management
 - Workspace dependencies shared in root `Cargo.toml`
-
-## Implementation Status
-
-Currently in **Phase 1 (Tool Fetcher MVP)**. All crate lib.rs files are stubs; CLI skeleton exists with clap commands that print "(not yet implemented)". See DESIGN.md for the four-phase roadmap.
 
 ## Reference Docs
 
 - `DESIGN.md` — Authoritative implementation guide, architecture decisions, phase roadmap
 - `docs/API.md` — Full CLI specification, environment variables, cache layout
+- `docs/TRUST_BOUNDARIES.md` — Runtime fetch policy, what integrity is enforced, what remains follow-up
 - `README.md` — User-facing motivation and prior art comparison
-
-## Known Issues
-
-- CLI currently has `Build` and `Run` subcommands that contradict DESIGN.md (which says no `soldr build` and tool fetch should be the bare `soldr <tool>` form, not `soldr run <tool>`)
-- LICENSE file says MIT but Cargo.toml specifies BSD-3-Clause

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "serde",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "clap",
  "serde",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.2.0-beta"
+version = "0.6.0"
 dependencies = [
  "flate2",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,8 @@ name = "soldr-cli"
 version = "0.2.0-beta"
 dependencies = [
  "clap",
+ "serde",
+ "serde_json",
  "soldr-cache",
  "soldr-core",
  "soldr-fetch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1400,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,14 +1505,17 @@ name = "soldr-fetch"
 version = "0.6.0"
 dependencies = [
  "flate2",
+ "hex",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "soldr-core",
  "tar",
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.6.0" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.6.0" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.6.0" }
+soldr-core = { path = "crates/soldr-core", version = "0.7.0" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.0" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.7.0" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 blake3 = "1"
+sha2 = "0.10"
+hex = "0.4"
 reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 tempfile = "3"
 zip = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0-beta"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.2.0-beta" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.2.0-beta" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.2.0-beta" }
+soldr-core = { path = "crates/soldr-core", version = "0.6.0" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.6.0" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.6.0" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -90,15 +90,16 @@ For `soldr cargo ...`:
 
 1. Resolve real `cargo` via `rustup`
 2. Resolve matching real `rustc` via `rustup`
-3. Set `RUSTC_WRAPPER=soldr`
-4. Delegate to Cargo with unchanged user flags
+3. Set `RUSTC_WRAPPER` to the current soldr binary
+4. Start managed zccache and pass its binary/session state through the environment
+5. Delegate to Cargo with unchanged user flags
 
 For wrapper mode:
 
 1. Detect `rustc` invocation shape
 2. Resolve the real `rustc`
-3. Perform cache logic when implemented
-4. Fall through to the real compiler
+3. Delegate cache-enabled builds into the managed zccache binary
+4. Fall through to the real compiler when caching is disabled or unavailable
 
 ---
 
@@ -174,9 +175,10 @@ all resolve quickly from cache or pre-built binaries.
 
 Done when:
 
-- wrapper mode hashes compiler inputs
-- cache hits avoid recompilation
-- daemon behavior is stable across platforms
+- `soldr cargo ...` enables managed zccache by default
+- `soldr --no-cache cargo ...` cleanly bypasses the cache path
+- wrapper mode routes cache-enabled builds into managed zccache instead of pure pass-through
+- cache commands report and manage real zccache state
 
 ### Phase 4: Bootstrap Validation
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,29 @@
-MIT License
+BSD 3-Clause License
 
-Copyright (c) 2019 zackees
+Copyright (c) 2019, zackees
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Current release line:
 
 - `0.5.x` is the secure front-door, tool-fetch, and built-in zccache-backed cache release line
 - `1.0.0-rc` remains reserved for broader release hardening and bootstrap validation
+- the supported external integration boundary remains the `soldr` executable, not the internal Rust crates; see [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md)
 
 ## Why soldr exists
 
@@ -96,7 +97,7 @@ soldr/
 |   |-- soldr-core/      # Shared types, config, cache directory layout
 |   |-- soldr-fetch/     # Binary resolution + download (the crgx half)
 |   |-- soldr-cache/     # Compilation caching (the zccache half)
-|   `-- soldr-cli/       # CLI entry point + daemon
+|   `-- soldr-cli/       # CLI entry point + wrapper mode
 |-- src/soldr/           # Python package (maturin bin bindings)
 `-- tests/
 ```
@@ -107,6 +108,8 @@ soldr/
 | `soldr-fetch` | Resolve crate binaries from crates.io metadata and GitHub Releases. Download and cache. |
 | `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
 | `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
+
+These workspace crates are implementation details. They are not a supported public Rust library API.
 
 ## Prior art
 
@@ -119,6 +122,7 @@ Built on lessons from:
 ## Security And Verification
 
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
+- [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md) defines the supported machine-facing integration boundary.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Built on lessons from:
 
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
 - [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md) defines the supported machine-facing integration boundary.
+- [docs/PYPI_TRUSTED_PUBLISHING.md](./docs/PYPI_TRUSTED_PUBLISHING.md) describes the optional Trusted Publishing path for hardened PyPI wheels.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ When you run `soldr`, the tool should do the obvious thing:
 
 If soldr solves that one problem well, it becomes a super tool: the command you reach for first, because it makes the rest of the stack behave.
 
-- **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse.
+- **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse. On `0.5.x`, this is still an upstream trust decision rather than a repo-side trust guarantee; see [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md).
 
 - **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring; zccache's artifact store still uses its current default cache root.
 
@@ -104,7 +104,7 @@ soldr/
 | Crate | Role |
 |---|---|
 | `soldr-core` | Cache paths, config, version types |
-| `soldr-fetch` | Resolve crate binaries from binstall metadata, GitHub Releases, QuickInstall. Download, verify, cache. |
+| `soldr-fetch` | Resolve crate binaries from crates.io metadata and GitHub Releases. Download and cache. |
 | `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
 | `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
 
@@ -121,7 +121,7 @@ Built on lessons from:
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
-- [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts.
+- [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ That is the same reason [uv](https://github.com/astral-sh/uv) is compelling. uv 
 
 soldr aims for the same outcome in the Rust toolchain world.
 
+Current release line:
+
+- `0.5.x` is the secure front-door, tool-fetch, and built-in zccache-backed cache release line
+- `1.0.0-rc` remains reserved for broader release hardening and bootstrap validation
+
 ## Why soldr exists
 
 On Windows, the real problem is not "how do I cache builds?" or "how do I download a tool binary?" in isolation.
@@ -36,18 +41,19 @@ When you run `soldr`, the tool should do the obvious thing:
 - pick MSVC on Windows by default
 - fetch the tool you asked for
 - cache it locally
-- carry `zccache` along for transparent `rustc` caching without manual wrapper setup
+- fetch and manage zccache so Rust builds get transparent caching without manual wrapper setup
 
 If soldr solves that one problem well, it becomes a super tool: the command you reach for first, because it makes the rest of the stack behave.
 
 - **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse.
 
-- **Compilation caching** (the zccache half): When your build invokes `rustc` hundreds of times, soldr caches every compilation unit. Second builds finish in milliseconds, not minutes.
+- **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring; zccache's artifact store still uses its current default cache root.
 
 ```bash
 # Build through soldr's front door:
 soldr cargo build --release
 soldr cargo test
+soldr --no-cache cargo test
 
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release
@@ -60,7 +66,9 @@ soldr rustfmt src/main.rs
 ```text
 soldr cargo build --release
   +-- resolve the real cargo binary
-  +-- wire soldr's wrapper path internally
+  +-- fetch/start managed zccache when cache is enabled
+  +-- set soldr as the compiler wrapper for this build
+  +-- have soldr wrapper mode delegate to managed zccache
   +-- delegate to cargo with your existing flags
 
 soldr maturin build --release
@@ -70,10 +78,11 @@ soldr maturin build --release
 
 ## Design goals
 
-- **One obvious command**: Fetch tools, pick the right Windows target, and enable build caching through the same entry point.
+- **One obvious command**: Fetch tools, pick the right Windows target, and run through managed zccache through the same entry point.
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
-- **Invisible caching**: soldr wires its build-assistance internals for you. No manual `RUSTC_WRAPPER` setup in the common case.
-- **One cache**: Tools and compilation artifacts in a single `~/.soldr/` directory.
+- **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
+- **Real cache controls**: `soldr status`, `soldr cache`, and `soldr clean` report and manage the soldr-managed zccache state instead of placeholder behavior.
+- **One cache boundary, eventually**: soldr keeps its own tools and zccache session state in `~/.soldr/`. Current zccache artifacts still live in zccache's default cache root until upstream exposes a supported cache-dir override.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
 - **Cross-platform**: Linux, macOS, Windows (x86_64 + aarch64).
@@ -88,7 +97,7 @@ soldr/
 |   |-- soldr-fetch/     # Binary resolution + download (the crgx half)
 |   |-- soldr-cache/     # Compilation caching (the zccache half)
 |   `-- soldr-cli/       # CLI entry point + daemon
-|-- src/soldr/           # Python package (PyO3 bindings)
+|-- src/soldr/           # Python package (maturin bin bindings)
 `-- tests/
 ```
 
@@ -96,8 +105,8 @@ soldr/
 |---|---|
 | `soldr-core` | Cache paths, config, version types |
 | `soldr-fetch` | Resolve crate binaries from binstall metadata, GitHub Releases, QuickInstall. Download, verify, cache. |
-| `soldr-cache` | Wrap rustc, hash inputs, store/retrieve compiled artifacts. The compilation cache daemon. |
-| `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`), tool fetch dispatch. |
+| `soldr-cache` | zccache integration helpers, cache policy, session plumbing. |
+| `soldr-cli` | Mode detection, cargo front door, built-in commands (`status`, `clean`, `config`, `cache`), tool fetch dispatch. |
 
 ## Prior art
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,12 +22,24 @@ The release model should satisfy all of these properties:
 These controls are already in place:
 
 - `main` is protected with required CI and e2e checks
+- `release` is protected with the same required validation gates
 - the `release` environment exists and requires approval from `@zackees`
 - immutable GitHub Releases are enabled
 - GitHub Actions requires full-SHA pinning for third-party actions
 - the validated release workflow exists in `.github/workflows/release.yml`
+- a dedicated GitHub App is used for release publication
+- release tags matching `refs/tags/v*.*.*` are protected by a repository ruleset whose only bypass actor is the release GitHub App
 
-The remaining gap is protected workflow-only release tags.
+The remaining work before the attested secure `0.5` release is operational rather than architectural:
+
+- exercise the full release path with a rehearsal and first release candidate
+- verify that humans cannot mint, move, or delete release tags in practice
+- finish policy decisions around SBOMs, reproducibility, and hermeticity
+- register the existing `soldr` PyPI project for Trusted Publishing if hardened wheel upload is in scope for `0.5.0`
+
+`1.0.0-rc` remains intentionally reserved for broader release hardening and bootstrap validation beyond the `0.5.x` built-in zccache release line.
+
+crates.io publication is not part of the current release direction. `soldr` is being released as a hardened binary tool, not as a promised Rust library API surface.
 
 ## Recommended Final Model
 
@@ -127,9 +139,9 @@ The owner should remain the required reviewer for the `release` environment.
 
 That means the human decides when a release is authorized, while the machine identity performs tag issuance and publication.
 
-## Future Workflow Changes
+## Current Workflow Behavior
 
-Once the GitHub App exists, the release workflow should be updated to do this:
+The release workflow now does this:
 
 1. Accept a version and exact commit SHA.
 2. Verify the commit SHA is on `release`.
@@ -139,6 +151,7 @@ Once the GitHub App exists, the release workflow should be updated to do this:
 6. Use that App token to create the tag.
 7. Use that same App token to create the GitHub Release.
 8. Attach checksums and build provenance attestations.
+9. Optionally build hardened platform wheels and publish them to PyPI through OIDC Trusted Publishing.
 
 The release workflow must not use:
 
@@ -147,16 +160,17 @@ The release workflow must not use:
 
 ## Future Agent Instructions
 
-If a future agent is asked to finish the maximum-security release flow, the agent should:
+If a future agent is asked to audit or extend the release flow, the agent should:
 
 1. Read this file.
-2. Check issue `#18` for the release-tag governance problem.
-3. Confirm whether the GitHub App has been created and installed.
-4. Confirm whether the `release` branch exists and is protected.
-5. Confirm whether a tag ruleset protects `v*.*.*` and only the App may bypass it.
-6. Only then modify `.github/workflows/release.yml` to use the App token for tag and release creation.
+2. Audit the live GitHub-side controls before trusting the checked-in docs.
+3. Confirm whether the GitHub App remains installed and scoped only to this repository.
+4. Confirm whether `release` still exists and is protected.
+5. Confirm whether a tag ruleset still protects `v*.*.*` and only the App may bypass it.
+6. Check issues `#12` and `#13` for the remaining `0.5` policy decisions.
+7. Only then modify `.github/workflows/release.yml` or the verification docs.
 
-If the GitHub App or ruleset is missing, the agent should stop and report the missing GitHub-side prerequisites instead of faking the policy in code.
+If the live GitHub-side controls drift from the documented trust model, the agent should stop and report the drift instead of assuming the release posture is still intact.
 
 ## Verification Checklist
 
@@ -173,7 +187,7 @@ After the final setup is complete, verify all of these:
 
 - [README.md](./README.md)
 - [SECURITY.md](./SECURITY.md)
+- [docs/RELEASE_0_5_CHECKLIST.md](./docs/RELEASE_0_5_CHECKLIST.md)
 - [docs/RELEASE_GOVERNANCE_CHECKLIST.md](./docs/RELEASE_GOVERNANCE_CHECKLIST.md)
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md)
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md)
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,15 @@ Current state:
 - immutable releases and protected tag settings still depend on repository configuration outside the git tree
 - current user-facing verification guidance is checksum verification plus `gh attestation verify`
 
+Current verification policy:
+
+- checksum verification plus `gh attestation verify` is the official user-facing verification story
+- GitHub CLI is the primary documented attestation-verification tool
+- offline attestation bundles may be archived, but separate Sigstore tooling is not required for the normal verification path
+- SBOM publication is not currently required for the release line
+- reproducible-build claims are not currently made for `soldr`
+- no extra signed release metadata is currently published beyond `SHA256SUMS` and GitHub provenance attestations
+
 Planned state, tracked in issue `#7`:
 
 - release tags created only after full validation passes for the exact release commit

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@
 - workflow and dependency immutability
 - user verification of published artifacts
 
-This document describes the current hardening posture and the policy direction for future work tracked in issue [#7](https://github.com/zackees/soldr/issues/7).
+This document describes the current hardening posture for the `0.5.x` line and the remaining policy work before the first attested secure release.
 
 Related documentation:
 
@@ -25,11 +25,13 @@ The repository currently enforces several baseline controls:
 - CI and release builds use `cargo ... --locked`.
 - CI now enforces `cargo fmt --check` and `cargo clippy -D warnings`.
 - No Cargo `git` dependencies are currently used; dependencies resolve from crates.io.
-- Published crates.io versions are immutable and cannot be overwritten, only yanked.
 - Third-party GitHub Actions in the repository workflows are pinned to full commit SHAs.
 - The e2e third-party source input is pinned to an exact Git commit in the workflow inputs.
 - Releases are promoted by `workflow_dispatch` for an exact commit SHA instead of publishing immediately on tag push.
 - Release assets are attested in GitHub Actions before publication.
+- Release publication uses a dedicated GitHub App instead of `GITHUB_TOKEN` or a PAT.
+- Release tags matching `v*.*.*` are protected by a repository ruleset.
+- Immutable GitHub Releases are enabled.
 
 These controls reduce drift, but they do not make the full release pipeline hermetic.
 
@@ -53,7 +55,7 @@ Even with the current pinning, some inputs still come from external systems at b
 - rustup toolchain downloads during CI/release
 - crates.io index and crate downloads unless dependencies are vendored or mirrored
 - OS package repositories such as `apt` in musl jobs
-- GitHub Releases as the publication surface unless immutable releases are enabled
+- GitHub Releases as the publication surface, even though immutable releases are enabled
 - third-party binary artifacts fetched by soldr at runtime
 
 These boundaries are intentional or transitional. They must be documented so users understand what is and is not covered by our own release assurances.
@@ -75,8 +77,11 @@ Current state:
 
 - releases are validated in GitHub Actions from an exact commit SHA
 - the release workflow re-runs lint, build, test, integration, and e2e checks before publishing
+- the release commit must be reachable from the protected `release` branch
+- release tags are created through a GitHub App-backed workflow path
 - release assets are published to GitHub Releases with a generated checksum manifest
 - release assets are attested in GitHub Actions prior to publication
+- the release workflow can also build hardened PyPI wheels, but enabling PyPI upload still requires Trusted Publisher registration on the existing `soldr` PyPI project
 - immutable releases and protected tag settings still depend on repository configuration outside the git tree
 - current user-facing verification guidance is checksum verification plus `gh attestation verify`
 
@@ -99,10 +104,14 @@ Current hermeticity and runtime-trust policy:
 
 Planned state, tracked in issue `#7`:
 
-- release tags created only after full validation passes for the exact release commit
-- release assets attested and verifiable
-- protected tag and release controls
-- clearer documentation of external trust boundaries
+Remaining follow-up decisions before the attested secure `0.5` release, tracked in issues `#12` and `#13`:
+
+- whether `0.5` should publish SBOMs in addition to provenance attestations
+- whether `0.5` should claim reproducible builds and how that would be validated
+- whether release-time dependencies should be vendored or mirrored
+- what trust policy should apply to third-party binaries fetched by `soldr` at runtime
+
+`1.0.0-rc` remains gated on actual compilation-cache integration rather than release hardening alone.
 
 ## Reporting a security issue
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ The repository currently enforces several baseline controls:
 
 These controls reduce drift, but they do not make the full release pipeline hermetic.
 
+The current `0.5.x` line does not claim hermetic builds, and it does not claim that third-party binaries fetched later by `soldr` are repository-verified just because `soldr` downloaded them.
+
 ## What is pinned
 
 The repo aims to pin security-relevant inputs wherever practical:
@@ -86,6 +88,14 @@ Current verification policy:
 - SBOM publication is not currently required for the release line
 - reproducible-build claims are not currently made for `soldr`
 - no extra signed release metadata is currently published beyond `SHA256SUMS` and GitHub provenance attestations
+
+Current hermeticity and runtime-trust policy:
+
+- `0.5.x` release verification covers published `soldr` artifacts, not every external input used during CI
+- `0.5.x` does not claim hermetic builds; documented dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt`, and the pinned bootstrap test repository remain acceptable for this release line
+- Cargo/toolchain/package mirroring or vendoring is deferred hardening tracked in issue [#41](https://github.com/zackees/soldr/issues/41)
+- runtime third-party binary fetches are a convenience/bootstrap path on `0.5.x`, not a repository-side trust guarantee
+- stronger trust enforcement for fetched binaries is tracked in issue [#42](https://github.com/zackees/soldr/issues/42)
 
 Planned state, tracked in issue `#7`:
 

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -1,4 +1,177 @@
-//! Compilation caching.
+//! zccache integration surface for soldr.
 //!
-//! Wraps rustc invocations, hashes inputs, and stores/retrieves
-//! compiled artifacts (.o, .rlib, .rmeta) for cache hits.
+//! soldr owns the build UX and cache policy, while zccache provides the actual
+//! compiler-cache engine and daemon.
+
+use serde::Deserialize;
+use soldr_core::SoldrPaths;
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+/// Environment variable used to carry cache enable/disable state from the
+/// front-door cargo command into child processes.
+pub const CACHE_ENABLED_ENV_VAR: &str = "SOLDR_CACHE_ENABLED";
+
+/// Encoded environment value for an enabled cache invocation.
+pub const CACHE_ENABLED_VALUE: &str = "1";
+
+/// Encoded environment value for a disabled cache invocation.
+pub const CACHE_DISABLED_VALUE: &str = "0";
+
+/// Per-build session identifier recognized by zccache.
+pub const ZCCACHE_SESSION_ID_ENV_VAR: &str = "ZCCACHE_SESSION_ID";
+
+/// Managed zccache binary path propagated from the soldr front door into
+/// wrapper-mode children.
+pub const ZCCACHE_BINARY_ENV_VAR: &str = "SOLDR_ZCCACHE_BIN";
+
+pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
+    if enabled {
+        CACHE_ENABLED_VALUE
+    } else {
+        CACHE_DISABLED_VALUE
+    }
+}
+
+pub fn cache_enabled_from_env_var(value: Option<&OsStr>) -> bool {
+    match value.and_then(OsStr::to_str) {
+        None => true,
+        Some(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+    }
+}
+
+pub fn cache_enabled_in_current_process() -> bool {
+    cache_enabled_from_env_var(std::env::var_os(CACHE_ENABLED_ENV_VAR).as_deref())
+}
+
+pub fn zccache_dir(paths: &SoldrPaths) -> PathBuf {
+    paths.cache.join("zccache")
+}
+
+pub fn parse_zccache_session_id(stdout: &str) -> Option<String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(response) = serde_json::from_str::<SessionStartResponse>(trimmed) {
+        if !response.session_id.trim().is_empty() {
+            return Some(response.session_id);
+        }
+    }
+
+    for line in trimmed.lines() {
+        let line = line.trim();
+        for prefix in [
+            "ZCCACHE_SESSION_ID=",
+            "export ZCCACHE_SESSION_ID=",
+            "$env:ZCCACHE_SESSION_ID=",
+        ] {
+            if let Some(value) = line.strip_prefix(prefix) {
+                let value = value.trim().trim_matches('"').trim_matches('\'');
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+pub fn session_journal_path(zccache_dir: &Path) -> PathBuf {
+    zccache_dir.join("logs").join("last-session.jsonl")
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionStartResponse {
+    session_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id,
+        session_journal_path, zccache_dir, CACHE_DISABLED_VALUE, CACHE_ENABLED_VALUE,
+    };
+    use soldr_core::SoldrPaths;
+    use std::{ffi::OsStr, path::Path};
+
+    #[test]
+    fn cache_defaults_to_enabled_when_env_is_missing() {
+        assert!(cache_enabled_from_env_var(None));
+    }
+
+    #[test]
+    fn cache_control_parses_common_false_values() {
+        for value in ["0", "false", "FALSE", "no", "off", ""] {
+            assert!(
+                !cache_enabled_from_env_var(Some(OsStr::new(value))),
+                "expected {value:?} to disable cache"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_control_treats_other_values_as_enabled() {
+        for value in ["1", "true", "yes", "unexpected"] {
+            assert!(
+                cache_enabled_from_env_var(Some(OsStr::new(value))),
+                "expected {value:?} to enable cache"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_control_serializes_boolean_state() {
+        assert_eq!(cache_enabled_env_value(true), CACHE_ENABLED_VALUE);
+        assert_eq!(cache_enabled_env_value(false), CACHE_DISABLED_VALUE);
+    }
+
+    #[test]
+    fn zccache_dir_lives_under_soldr_cache_root() {
+        let paths = SoldrPaths::with_root(Path::new("C:\\soldr-root").to_path_buf());
+        assert_eq!(
+            zccache_dir(&paths),
+            paths.root.join("cache").join("zccache")
+        );
+    }
+
+    #[test]
+    fn parses_json_session_start_output() {
+        let session_id = parse_zccache_session_id(
+            r#"{"session_id":"08f063c0-5f01-4c92-aec1-3f304d9224d0","started_at":1776141813}"#,
+        );
+        assert_eq!(
+            session_id.as_deref(),
+            Some("08f063c0-5f01-4c92-aec1-3f304d9224d0")
+        );
+    }
+
+    #[test]
+    fn parses_shell_style_session_start_output() {
+        let session_id = parse_zccache_session_id(
+            "export ZCCACHE_SESSION_ID=08f063c0-5f01-4c92-aec1-3f304d9224d0",
+        );
+        assert_eq!(
+            session_id.as_deref(),
+            Some("08f063c0-5f01-4c92-aec1-3f304d9224d0")
+        );
+    }
+
+    #[test]
+    fn session_journal_path_uses_logs_directory() {
+        let path = session_journal_path(Path::new("C:\\soldr-root\\cache\\zccache"));
+        assert_eq!(
+            path,
+            Path::new("C:\\soldr-root\\cache\\zccache")
+                .join("logs")
+                .join("last-session.jsonl")
+        );
+    }
+}

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -12,9 +12,14 @@ soldr-core = { workspace = true }
 soldr-fetch = { workspace = true }
 soldr-cache = { workspace = true }
 clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [[bin]]
 name = "soldr"

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,10 +1,17 @@
 use clap::{Parser, Subcommand};
-use soldr_core::SoldrError;
+use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
+
+const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
+const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
+const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
 struct Cli {
+    /// Disable soldr's compilation cache for this invocation
+    #[arg(long)]
+    no_cache: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -48,25 +55,35 @@ async fn main() {
 
 async fn run() -> Result<(), SoldrError> {
     let cli = Cli::parse();
+    let cache_enabled = !cli.no_cache;
 
     match cli.command {
         Commands::Cargo { args } => {
-            std::process::exit(run_cargo_front_door(&args)?);
+            std::process::exit(run_cargo_front_door(&args, cache_enabled).await?);
         }
         Commands::Status => {
             println!("soldr {}", soldr_core::version());
             let target = soldr_core::TargetTriple::detect()?;
+            let paths = soldr_core::SoldrPaths::new()?;
             println!("target: {target}");
-            println!("(status not yet implemented)");
+            println!("root dir: {}", paths.root.display());
+            println!("cache dir: {}", paths.cache.display());
+            println!("cache default: enabled");
+            println!(
+                "cache mode: {}",
+                if cache_enabled { "enabled" } else { "disabled" }
+            );
+            println!("zccache version: {}", soldr_fetch::MANAGED_ZCCACHE_VERSION);
+            print_zccache_status(&paths)?;
         }
         Commands::Clean => {
-            println!("(clean not yet implemented)");
+            clear_zccache_cache()?;
         }
         Commands::Config => {
             println!("(config not yet implemented)");
         }
         Commands::Cache => {
-            println!("(cache not yet implemented)");
+            print_zccache_status(&SoldrPaths::new()?)?;
         }
         Commands::Version => {
             println!("soldr {}", soldr_core::version());
@@ -106,13 +123,23 @@ fn report_and_exit(error: SoldrError) -> i32 {
 }
 
 fn is_rustc_path(arg: &str) -> bool {
-    arg == "rustc"
-        || arg.ends_with("/rustc")
-        || arg.ends_with("\\rustc")
-        || arg.ends_with("rustc.exe")
+    if arg == "rustc" {
+        return true;
+    }
+
+    std::path::Path::new(arg)
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        == Some("rustc")
 }
 
 fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
+    if soldr_cache::cache_enabled_in_current_process() {
+        if let Some(zccache) = zccache_binary_override() {
+            return run_wrapper_through_zccache(raw_args, &zccache);
+        }
+    }
+
     let rustc = raw_args
         .get(1)
         .ok_or_else(|| SoldrError::Other("missing rustc path in wrapper mode".into()))?;
@@ -129,20 +156,41 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     Ok(status.code().unwrap_or(1))
 }
 
-fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
+fn run_wrapper_through_zccache(
+    raw_args: &[String],
+    zccache: &std::path::Path,
+) -> Result<i32, SoldrError> {
+    let status = std::process::Command::new(zccache)
+        .args(&raw_args[1..])
+        .status()?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {
+    if cargo_args_use_reserved_no_cache(args) {
+        return Err(SoldrError::Other(
+            "`--no-cache` must appear before `cargo`, as in `soldr --no-cache cargo build`".into(),
+        ));
+    }
+
     let cargo = resolve_toolchain_binary("cargo")?;
     let rustc = resolve_toolchain_binary("rustc")?;
-    let current_exe = std::env::current_exe()?;
     let cargo_bin_dir = cargo
         .parent()
         .ok_or_else(|| SoldrError::Other("failed to resolve cargo bin directory".into()))?
         .to_path_buf();
     let existing_path = std::env::var_os("PATH");
+    let paths = SoldrPaths::new()?;
+    paths.ensure_dirs()?;
 
     let mut command = std::process::Command::new(cargo);
     command.args(args);
-    command.env("RUSTC_WRAPPER", current_exe);
     command.env("RUSTC", rustc);
+    command.env(
+        soldr_cache::CACHE_ENABLED_ENV_VAR,
+        soldr_cache::cache_enabled_env_value(cache_enabled),
+    );
     command.env(
         "PATH",
         prepend_path(&cargo_bin_dir, existing_path.as_deref())?,
@@ -151,7 +199,16 @@ fn run_cargo_front_door(args: &[String]) -> Result<i32, SoldrError> {
         command.env("CARGO_BUILD_TARGET", target);
     }
 
+    let session = if cache_enabled {
+        Some(prepare_zccache_build(&mut command, &paths).await?)
+    } else {
+        None
+    };
+
     let status = command.status()?;
+    if let Some(session) = session {
+        finish_zccache_build(&session)?;
+    }
     Ok(status.code().unwrap_or(1))
 }
 
@@ -181,6 +238,18 @@ fn cargo_args_specify_target(args: &[String]) -> bool {
     false
 }
 
+fn cargo_args_use_reserved_no_cache(args: &[String]) -> bool {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--no-cache" {
+            return true;
+        }
+    }
+    false
+}
+
 fn prepend_path(
     dir: &std::path::Path,
     existing_path: Option<&std::ffi::OsStr>,
@@ -193,6 +262,10 @@ fn prepend_path(
 }
 
 fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError> {
+    if let Some(path) = toolchain_binary_override(tool) {
+        return Ok(path);
+    }
+
     let output = std::process::Command::new("rustup")
         .args(["which", tool])
         .output()?;
@@ -222,9 +295,206 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
     }
 }
 
+struct ZccacheBuildSession {
+    binary_path: std::path::PathBuf,
+    session_id: String,
+}
+
+async fn prepare_zccache_build(
+    cargo: &mut std::process::Command,
+    paths: &SoldrPaths,
+) -> Result<ZccacheBuildSession, SoldrError> {
+    let fetch = fetch_managed_zccache(paths).await?;
+    let zccache_dir = soldr_cache::zccache_dir(paths);
+    std::fs::create_dir_all(&zccache_dir)?;
+    std::fs::create_dir_all(zccache_dir.join("logs"))?;
+    if fetch.cached {
+        eprintln!(
+            "soldr: using managed zccache {}",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    } else {
+        eprintln!(
+            "soldr: fetched managed zccache {}",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    }
+
+    run_zccache_command(&fetch.binary_path, &["start"])?;
+
+    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    let journal_path = journal_path.display().to_string();
+    let session_json = run_zccache_command(
+        &fetch.binary_path,
+        &["session-start", "--stats", "--journal", &journal_path],
+    )?;
+    let session_id =
+        soldr_cache::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
+            SoldrError::Other(format!(
+                "failed to parse zccache session id from output: {}",
+                session_json.stdout.trim()
+            ))
+        })?;
+
+    cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
+    cargo.env(soldr_cache::ZCCACHE_BINARY_ENV_VAR, &fetch.binary_path);
+    cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
+
+    Ok(ZccacheBuildSession {
+        binary_path: fetch.binary_path,
+        session_id,
+    })
+}
+
+fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
+    let output = run_zccache_command(&session.binary_path, &["session-end", &session.session_id])?;
+    let stdout = output.stdout.trim();
+    if !stdout.is_empty() {
+        eprintln!("soldr: zccache session summary");
+        eprintln!("{stdout}");
+    }
+    Ok(())
+}
+
+fn clear_zccache_cache() -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let zccache_dir = soldr_cache::zccache_dir(&paths);
+    let mut cleared_anything = false;
+
+    if let Some(fetch) = cached_managed_zccache(&paths)? {
+        let _ = run_zccache_command(&fetch.binary_path, &["clear"])?;
+        println!("cleared zccache artifact cache");
+        cleared_anything = true;
+    }
+    if zccache_dir.exists() {
+        std::fs::remove_dir_all(&zccache_dir)?;
+        println!("removed soldr zccache state dir: {}", zccache_dir.display());
+        cleared_anything = true;
+    }
+    if !cleared_anything {
+        println!(
+            "managed zccache {} not fetched yet",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    }
+    Ok(())
+}
+
+fn print_zccache_status(paths: &SoldrPaths) -> Result<(), SoldrError> {
+    let zccache_dir = soldr_cache::zccache_dir(paths);
+    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    println!("soldr zccache state dir: {}", zccache_dir.display());
+    println!(
+        "last session journal: {} ({})",
+        journal_path.display(),
+        if journal_path.exists() {
+            "present"
+        } else {
+            "missing"
+        }
+    );
+
+    match cached_managed_zccache(paths)? {
+        Some(fetch) => {
+            println!("zccache binary: {}", fetch.binary_path.display());
+            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
+            let stdout = output.stdout.trim();
+            if stdout.is_empty() {
+                println!("zccache status: no output");
+            } else {
+                for line in stdout.lines() {
+                    println!("zccache: {line}");
+                }
+            }
+        }
+        None => {
+            println!(
+                "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
+                soldr_fetch::MANAGED_ZCCACHE_VERSION
+            );
+        }
+    }
+    Ok(())
+}
+
+struct CommandOutput {
+    stdout: String,
+}
+
+fn run_zccache_command(
+    binary: &std::path::Path,
+    args: &[&str],
+) -> Result<CommandOutput, SoldrError> {
+    let output = std::process::Command::new(binary).args(args).output()?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(format!(
+            "zccache {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    Ok(CommandOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+    })
+}
+
+fn toolchain_binary_override(tool: &str) -> Option<std::path::PathBuf> {
+    let env_var = match tool {
+        "cargo" => TEST_CARGO_BIN_ENV_VAR,
+        "rustc" => TEST_RUSTC_BIN_ENV_VAR,
+        _ => return None,
+    };
+    non_empty_env_path(env_var)
+}
+
+fn zccache_binary_override() -> Option<std::path::PathBuf> {
+    non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR)
+        .or_else(|| non_empty_env_path(soldr_cache::ZCCACHE_BINARY_ENV_VAR))
+}
+
+fn non_empty_env_path(env_var: &str) -> Option<std::path::PathBuf> {
+    let value = std::env::var_os(env_var)?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.into())
+}
+
+fn current_soldr_binary() -> Result<std::path::PathBuf, SoldrError> {
+    std::env::current_exe().map_err(SoldrError::from)
+}
+
+async fn fetch_managed_zccache(paths: &SoldrPaths) -> Result<soldr_fetch::FetchResult, SoldrError> {
+    if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
+        return Ok(soldr_fetch::FetchResult {
+            binary_path,
+            version: soldr_fetch::MANAGED_ZCCACHE_VERSION.to_string(),
+            cached: true,
+        });
+    }
+
+    soldr_fetch::fetch_zccache_with_paths(paths).await
+}
+
+fn cached_managed_zccache(
+    paths: &SoldrPaths,
+) -> Result<Option<soldr_fetch::FetchResult>, SoldrError> {
+    if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
+        return Ok(Some(soldr_fetch::FetchResult {
+            binary_path,
+            version: soldr_fetch::MANAGED_ZCCACHE_VERSION.to_string(),
+            cached: true,
+        }));
+    }
+
+    soldr_fetch::cached_zccache_binary(paths)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::cargo_args_specify_target;
+    use super::{cargo_args_specify_target, cargo_args_use_reserved_no_cache, parse_tool_spec};
+    use soldr_fetch::VersionSpec;
 
     #[test]
     fn cargo_args_detect_explicit_target_flag() {
@@ -247,5 +517,25 @@ mod tests {
             "--target".into(),
             "ignored".into(),
         ]));
+    }
+
+    #[test]
+    fn cargo_args_reject_reserved_no_cache_before_passthrough_separator() {
+        assert!(cargo_args_use_reserved_no_cache(&[
+            "build".into(),
+            "--no-cache".into(),
+        ]));
+        assert!(!cargo_args_use_reserved_no_cache(&[
+            "test".into(),
+            "--".into(),
+            "--no-cache".into(),
+        ]));
+    }
+
+    #[test]
+    fn parse_tool_spec_defaults_to_latest_version() {
+        let (tool, version) = parse_tool_spec("maturin");
+        assert_eq!(tool, "maturin");
+        assert!(matches!(version, VersionSpec::Latest));
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,10 +1,12 @@
 use clap::{Parser, Subcommand};
+use serde::Serialize;
 use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 
 const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
 const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
+const JSON_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
@@ -24,15 +26,27 @@ enum Commands {
         args: Vec<String>,
     },
     /// Show cache status and tool info
-    Status,
+    Status {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
+    },
     /// Clear caches
     Clean,
     /// Show or set configuration
     Config,
     /// Inspect the compilation cache
-    Cache,
+    Cache {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
+    },
     /// Show version
-    Version,
+    Version {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
+    },
     /// Anything else is a tool to fetch and run
     #[command(external_subcommand)]
     External(Vec<String>),
@@ -61,20 +75,13 @@ async fn run() -> Result<(), SoldrError> {
         Commands::Cargo { args } => {
             std::process::exit(run_cargo_front_door(&args, cache_enabled).await?);
         }
-        Commands::Status => {
-            println!("soldr {}", soldr_core::version());
-            let target = soldr_core::TargetTriple::detect()?;
-            let paths = soldr_core::SoldrPaths::new()?;
-            println!("target: {target}");
-            println!("root dir: {}", paths.root.display());
-            println!("cache dir: {}", paths.cache.display());
-            println!("cache default: enabled");
-            println!(
-                "cache mode: {}",
-                if cache_enabled { "enabled" } else { "disabled" }
-            );
-            println!("zccache version: {}", soldr_fetch::MANAGED_ZCCACHE_VERSION);
-            print_zccache_status(&paths)?;
+        Commands::Status { json } => {
+            let output = collect_status_output(cache_enabled)?;
+            if json {
+                print_json(&output)?;
+            } else {
+                print_status_output(&output);
+            }
         }
         Commands::Clean => {
             clear_zccache_cache()?;
@@ -82,11 +89,21 @@ async fn run() -> Result<(), SoldrError> {
         Commands::Config => {
             println!("(config not yet implemented)");
         }
-        Commands::Cache => {
-            print_zccache_status(&SoldrPaths::new()?)?;
+        Commands::Cache { json } => {
+            let output = collect_cache_output()?;
+            if json {
+                print_json(&output)?;
+            } else {
+                print_cache_output(&output);
+            }
         }
-        Commands::Version => {
-            println!("soldr {}", soldr_core::version());
+        Commands::Version { json } => {
+            let output = version_output();
+            if json {
+                print_json(&output)?;
+            } else {
+                println!("soldr {}", output.soldr_version);
+            }
         }
         Commands::External(args) => {
             if args.is_empty() {
@@ -380,40 +397,170 @@ fn clear_zccache_cache() -> Result<(), SoldrError> {
     Ok(())
 }
 
-fn print_zccache_status(paths: &SoldrPaths) -> Result<(), SoldrError> {
+#[derive(Serialize)]
+struct VersionOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+}
+
+#[derive(Serialize)]
+struct StatusOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+    target: String,
+    root_dir: String,
+    cache_dir: String,
+    cache_default_enabled: bool,
+    cache_enabled_for_invocation: bool,
+    managed_zccache_version: &'static str,
+    zccache: ZccacheStatusSnapshot,
+}
+
+#[derive(Serialize)]
+struct CacheOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+    managed_zccache_version: &'static str,
+    zccache: ZccacheStatusSnapshot,
+}
+
+#[derive(Serialize)]
+struct ZccacheStatusSnapshot {
+    state_dir: String,
+    journal_path: String,
+    journal_present: bool,
+    binary_path: Option<String>,
+    binary_fetched: bool,
+    status_lines: Vec<String>,
+    status_empty: bool,
+}
+
+fn version_output() -> VersionOutput {
+    VersionOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "version",
+        soldr_version: soldr_core::version().to_string(),
+    }
+}
+
+fn collect_status_output(cache_enabled: bool) -> Result<StatusOutput, SoldrError> {
+    let target = soldr_core::TargetTriple::detect()?;
+    let paths = SoldrPaths::new()?;
+    Ok(StatusOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "status",
+        soldr_version: soldr_core::version().to_string(),
+        target: target.to_string(),
+        root_dir: paths.root.display().to_string(),
+        cache_dir: paths.cache.display().to_string(),
+        cache_default_enabled: true,
+        cache_enabled_for_invocation: cache_enabled,
+        managed_zccache_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+        zccache: collect_zccache_status(&paths)?,
+    })
+}
+
+fn collect_cache_output() -> Result<CacheOutput, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    Ok(CacheOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "cache",
+        soldr_version: soldr_core::version().to_string(),
+        managed_zccache_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+        zccache: collect_zccache_status(&paths)?,
+    })
+}
+
+fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, SoldrError> {
     let zccache_dir = soldr_cache::zccache_dir(paths);
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
-    println!("soldr zccache state dir: {}", zccache_dir.display());
+    let journal_present = journal_path.exists();
+
+    match cached_managed_zccache(paths)? {
+        Some(fetch) => {
+            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
+            let stdout = output.stdout.trim();
+            let status_lines = stdout.lines().map(str::to_owned).collect();
+            Ok(ZccacheStatusSnapshot {
+                state_dir: zccache_dir.display().to_string(),
+                journal_path: journal_path.display().to_string(),
+                journal_present,
+                binary_path: Some(fetch.binary_path.display().to_string()),
+                binary_fetched: true,
+                status_lines,
+                status_empty: stdout.is_empty(),
+            })
+        }
+        None => Ok(ZccacheStatusSnapshot {
+            state_dir: zccache_dir.display().to_string(),
+            journal_path: journal_path.display().to_string(),
+            journal_present,
+            binary_path: None,
+            binary_fetched: false,
+            status_lines: Vec::new(),
+            status_empty: false,
+        }),
+    }
+}
+
+fn print_status_output(output: &StatusOutput) {
+    println!("soldr {}", output.soldr_version);
+    println!("target: {}", output.target);
+    println!("root dir: {}", output.root_dir);
+    println!("cache dir: {}", output.cache_dir);
+    println!("cache default: enabled");
+    println!(
+        "cache mode: {}",
+        if output.cache_enabled_for_invocation {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+    println!("zccache version: {}", output.managed_zccache_version);
+    print_zccache_status_snapshot(&output.zccache);
+}
+
+fn print_cache_output(output: &CacheOutput) {
+    print_zccache_status_snapshot(&output.zccache);
+}
+
+fn print_zccache_status_snapshot(snapshot: &ZccacheStatusSnapshot) {
+    println!("soldr zccache state dir: {}", snapshot.state_dir);
     println!(
         "last session journal: {} ({})",
-        journal_path.display(),
-        if journal_path.exists() {
+        snapshot.journal_path,
+        if snapshot.journal_present {
             "present"
         } else {
             "missing"
         }
     );
 
-    match cached_managed_zccache(paths)? {
-        Some(fetch) => {
-            println!("zccache binary: {}", fetch.binary_path.display());
-            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
-            let stdout = output.stdout.trim();
-            if stdout.is_empty() {
-                println!("zccache status: no output");
-            } else {
-                for line in stdout.lines() {
-                    println!("zccache: {line}");
-                }
+    if let Some(binary_path) = &snapshot.binary_path {
+        println!("zccache binary: {binary_path}");
+        if snapshot.status_empty {
+            println!("zccache status: no output");
+        } else {
+            for line in &snapshot.status_lines {
+                println!("zccache: {line}");
             }
         }
-        None => {
-            println!(
-                "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
-                soldr_fetch::MANAGED_ZCCACHE_VERSION
-            );
-        }
+    } else {
+        println!(
+            "zccache binary: not fetched yet (will fetch managed zccache {} on the first cache-enabled build)",
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
     }
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<(), SoldrError> {
+    serde_json::to_writer_pretty(std::io::stdout(), value)
+        .map_err(|e| SoldrError::Other(format!("failed to serialize JSON output: {e}")))?;
+    println!();
     Ok(())
 }
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -8,6 +8,13 @@ const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 const JSON_SCHEMA_VERSION: u32 = 1;
 
+/// Pin a specific soldr version to handle this invocation. Explicit
+/// `--as <version>` flag takes precedence over this env var.
+const SOLDR_AS_ENV_VAR: &str = "SOLDR_AS";
+/// Sentinel that the currently-running soldr was itself invoked by another
+/// soldr through `--as`. Prevents infinite hand-offs.
+const SOLDR_TRAMPOLINING_ENV_VAR: &str = "SOLDR_TRAMPOLINING";
+
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
 struct Cli {
@@ -100,14 +107,57 @@ async fn main() {
         std::process::exit(run_rustc_wrapper(&raw_args).unwrap_or_else(report_and_exit));
     }
 
-    if let Err(e) = run().await {
-        eprintln!("soldr: {e}");
-        std::process::exit(1);
+    // `--as <version>` trampoline. Peeled off before clap so the fetched
+    // older soldr parses its own argv on its own terms.
+    let (pinned_version, trampoline_args) = match extract_as_pin(&raw_args[1..]) {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("soldr: {e}");
+            std::process::exit(1);
+        }
+    };
+    let pinned_version = pinned_version.or_else(|| {
+        std::env::var(SOLDR_AS_ENV_VAR)
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    });
+
+    if let Some(version) = pinned_version {
+        if should_trampoline(&version) {
+            std::process::exit(
+                run_trampoline(&version, &trampoline_args)
+                    .await
+                    .unwrap_or_else(report_and_exit),
+            );
+        }
+        // Short-circuit: requested version == current. Continue with args
+        // that have `--as <ver>` stripped.
+        std::process::exit(
+            run_with_args(&raw_args[0], &trampoline_args)
+                .await
+                .unwrap_or_else(report_and_exit),
+        );
     }
+
+    let rc = run_with_args(&raw_args[0], &raw_args[1..])
+        .await
+        .unwrap_or_else(report_and_exit);
+    std::process::exit(rc);
 }
 
-async fn run() -> Result<(), SoldrError> {
-    let cli = Cli::parse();
+async fn run_with_args(prog: &str, args: &[String]) -> Result<i32, SoldrError> {
+    let mut argv: Vec<String> = Vec::with_capacity(args.len() + 1);
+    argv.push(prog.to_string());
+    argv.extend(args.iter().cloned());
+    // Use parse_from (not try_parse_from) so clap handles --help / --version /
+    // usage errors with its built-in exit(0) / exit(2), matching the original
+    // invocation path's UX exactly.
+    let cli = Cli::parse_from(argv);
+    run_cli(cli).await.map(|_| 0)
+}
+
+async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
     let cache_enabled = !cli.no_cache;
 
     match cli.command {
@@ -197,6 +247,113 @@ async fn run() -> Result<(), SoldrError> {
 fn report_and_exit(error: SoldrError) -> i32 {
     eprintln!("soldr: {error}");
     1
+}
+
+/// Extract `--as <version>` or `--as=<version>` from the leading flag
+/// region of the user's argv. Stops scanning at the first non-flag
+/// positional (conventionally the subcommand), so a `--as` appearing
+/// after `cargo` belongs to cargo and is left alone.
+fn extract_as_pin(args: &[String]) -> Result<(Option<String>, Vec<String>), SoldrError> {
+    let mut out: Vec<String> = Vec::with_capacity(args.len());
+    let mut version: Option<String> = None;
+    let mut before_subcommand = true;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if !before_subcommand {
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--as" {
+            let value = iter.next().ok_or_else(|| {
+                SoldrError::Other("--as requires a version argument, e.g. --as 0.5.2".into())
+            })?;
+            if version.is_some() {
+                return Err(SoldrError::Other("--as specified more than once".into()));
+            }
+            if value.is_empty() {
+                return Err(SoldrError::Other(
+                    "--as version argument must not be empty".into(),
+                ));
+            }
+            version = Some(value.clone());
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--as=") {
+            if version.is_some() {
+                return Err(SoldrError::Other("--as specified more than once".into()));
+            }
+            if value.is_empty() {
+                return Err(SoldrError::Other(
+                    "--as= requires a version, e.g. --as=0.5.2".into(),
+                ));
+            }
+            version = Some(value.to_string());
+            continue;
+        }
+        if arg == "--" {
+            before_subcommand = false;
+            out.push(arg.clone());
+            continue;
+        }
+        if arg.starts_with('-') {
+            out.push(arg.clone());
+            continue;
+        }
+        before_subcommand = false;
+        out.push(arg.clone());
+    }
+    Ok((version, out))
+}
+
+/// True when the requested version is different from this binary's. A match
+/// short-circuits the trampoline so the current in-process soldr handles it.
+fn should_trampoline(requested: &str) -> bool {
+    let current = env!("CARGO_PKG_VERSION");
+    normalize_version(requested) != normalize_version(current)
+}
+
+fn normalize_version(v: &str) -> String {
+    v.trim().trim_start_matches('v').to_string()
+}
+
+async fn run_trampoline(version: &str, args: &[String]) -> Result<i32, SoldrError> {
+    if let Ok(prior) = std::env::var(SOLDR_TRAMPOLINING_ENV_VAR) {
+        return Err(SoldrError::Other(format!(
+            "refusing to trampoline again: this process was already reached via `--as` from soldr {prior}. Drop the inner --as flag."
+        )));
+    }
+
+    eprintln!("soldr: trampolining to soldr@{version}...");
+    let result =
+        soldr_fetch::fetch_tool("soldr", &VersionSpec::Exact(normalize_version(version))).await?;
+
+    if result.cached {
+        eprintln!(
+            "soldr: using cached soldr v{} at {}",
+            result.version,
+            result.binary_path.display()
+        );
+    } else {
+        eprintln!(
+            "soldr: downloaded soldr v{} to {}",
+            result.version,
+            result.binary_path.display()
+        );
+    }
+
+    let status = std::process::Command::new(&result.binary_path)
+        .args(args)
+        .env(SOLDR_TRAMPOLINING_ENV_VAR, env!("CARGO_PKG_VERSION"))
+        .status()
+        .map_err(|e| {
+            SoldrError::Other(format!(
+                "failed to exec soldr v{} at {}: {e}",
+                result.version,
+                result.binary_path.display()
+            ))
+        })?;
+
+    Ok(status.code().unwrap_or(1))
 }
 
 /// Known toolchain binaries that cargo may invoke through RUSTC_WRAPPER
@@ -778,8 +935,8 @@ fn cached_managed_zccache(
 #[cfg(test)]
 mod tests {
     use super::{
-        cargo_args_specify_target, cargo_args_use_reserved_no_cache, first_cargo_subcommand,
-        parse_tool_spec,
+        cargo_args_specify_target, cargo_args_use_reserved_no_cache, extract_as_pin,
+        first_cargo_subcommand, normalize_version, parse_tool_spec, should_trampoline,
     };
     use soldr_fetch::VersionSpec;
 
@@ -882,5 +1039,102 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
             assert_eq!(spec.cargo_subcommand, None);
         }
+    }
+
+    #[test]
+    fn soldr_itself_is_registered_for_self_trampoline() {
+        let spec = soldr_fetch::lookup_by_crate("soldr")
+            .expect("soldr should be registered in known_tools for --as trampoline");
+        assert_eq!(spec.binary_name, "soldr");
+        assert_eq!(spec.repo, Some(("zackees", "soldr")));
+        assert_eq!(spec.cargo_subcommand, None);
+    }
+
+    #[test]
+    fn extract_as_pin_extracts_space_separated_flag_before_subcommand() {
+        let (version, rest) = extract_as_pin(&[
+            "--as".into(),
+            "0.5.2".into(),
+            "cargo".into(),
+            "build".into(),
+        ])
+        .unwrap();
+        assert_eq!(version, Some("0.5.2".into()));
+        assert_eq!(rest, vec!["cargo".to_string(), "build".into()]);
+    }
+
+    #[test]
+    fn extract_as_pin_extracts_equals_form() {
+        let (version, rest) =
+            extract_as_pin(&["--as=0.5.2".into(), "cargo".into(), "build".into()]).unwrap();
+        assert_eq!(version, Some("0.5.2".into()));
+        assert_eq!(rest, vec!["cargo".to_string(), "build".into()]);
+    }
+
+    #[test]
+    fn extract_as_pin_preserves_other_leading_flags() {
+        let (version, rest) = extract_as_pin(&[
+            "--no-cache".into(),
+            "--as".into(),
+            "0.5.2".into(),
+            "cargo".into(),
+        ])
+        .unwrap();
+        assert_eq!(version, Some("0.5.2".into()));
+        assert_eq!(rest, vec!["--no-cache".to_string(), "cargo".into()]);
+    }
+
+    #[test]
+    fn extract_as_pin_ignores_flag_after_subcommand() {
+        let args = vec!["cargo".into(), "--as".into(), "0.5.2".into()];
+        let (version, rest) = extract_as_pin(&args).unwrap();
+        assert_eq!(version, None);
+        assert_eq!(rest, args);
+    }
+
+    #[test]
+    fn extract_as_pin_ignores_flag_after_passthrough_separator() {
+        let args = vec!["cargo".into(), "--".into(), "--as".into(), "0.5.2".into()];
+        let (version, rest) = extract_as_pin(&args).unwrap();
+        assert_eq!(version, None);
+        assert_eq!(rest, args);
+    }
+
+    #[test]
+    fn extract_as_pin_rejects_missing_value() {
+        let err = extract_as_pin(&["--as".into()]).unwrap_err();
+        assert!(err.to_string().contains("requires a version"));
+    }
+
+    #[test]
+    fn extract_as_pin_rejects_empty_value() {
+        let err = extract_as_pin(&["--as".into(), "".into()]).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+        let err2 = extract_as_pin(&["--as=".into()]).unwrap_err();
+        assert!(err2.to_string().contains("requires a version"));
+    }
+
+    #[test]
+    fn extract_as_pin_rejects_duplicate_flag() {
+        let err =
+            extract_as_pin(&["--as".into(), "0.5.2".into(), "--as=0.4.0".into()]).unwrap_err();
+        assert!(err.to_string().contains("more than once"));
+    }
+
+    #[test]
+    fn normalize_version_strips_leading_v() {
+        assert_eq!(normalize_version("0.5.2"), "0.5.2");
+        assert_eq!(normalize_version("v0.5.2"), "0.5.2");
+        assert_eq!(normalize_version("  v0.5.2 "), "0.5.2");
+    }
+
+    #[test]
+    fn should_trampoline_matches_current_version_as_no_op() {
+        assert!(!should_trampoline(env!("CARGO_PKG_VERSION")));
+        assert!(!should_trampoline(&format!(
+            "v{}",
+            env!("CARGO_PKG_VERSION")
+        )));
+        assert!(should_trampoline("0.0.0-not-this-version"));
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -853,7 +853,7 @@ mod tests {
         for sub in ["nextest", "deny", "audit", "llvm-cov"] {
             let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
                 .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
-            assert_eq!(spec.cargo_subcommand, sub);
+            assert_eq!(spec.cargo_subcommand, Some(sub));
             assert!(spec.crate_name.starts_with("cargo-"));
         }
     }
@@ -863,8 +863,17 @@ mod tests {
         for sub in ["udeps", "semver-checks", "expand", "watch"] {
             let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
                 .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
-            assert_eq!(spec.cargo_subcommand, sub);
+            assert_eq!(spec.cargo_subcommand, Some(sub));
             assert!(spec.crate_name.starts_with("cargo-"));
+        }
+    }
+
+    #[test]
+    fn top_level_tools_are_not_cargo_subcommands() {
+        for crate_name in ["cross", "mdbook", "cbindgen"] {
+            let spec = soldr_fetch::lookup_by_crate(crate_name)
+                .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
+            assert_eq!(spec.cargo_subcommand, None);
         }
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -857,4 +857,14 @@ mod tests {
             assert!(spec.crate_name.starts_with("cargo-"));
         }
     }
+
+    #[test]
+    fn known_subcommand_registry_recognizes_phase_three_tools() {
+        for sub in ["udeps", "semver-checks", "expand", "watch"] {
+            let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
+                .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
+            assert_eq!(spec.cargo_subcommand, sub);
+            assert!(spec.crate_name.starts_with("cargo-"));
+        }
+    }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -870,7 +870,14 @@ mod tests {
 
     #[test]
     fn top_level_tools_are_not_cargo_subcommands() {
-        for crate_name in ["cross", "mdbook", "cbindgen"] {
+        for crate_name in [
+            "cross",
+            "mdbook",
+            "cbindgen",
+            "wasm-pack",
+            "trunk",
+            "sccache",
+        ] {
             let spec = soldr_fetch::lookup_by_crate(crate_name)
                 .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
             assert_eq!(spec.cargo_subcommand, None);

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -25,6 +25,45 @@ enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Run rustc from the active toolchain
+    Rustc {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rustfmt from the active toolchain
+    Rustfmt {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run clippy-driver from the active toolchain
+    #[command(name = "clippy-driver")]
+    ClippyDriver {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rustdoc from the active toolchain
+    Rustdoc {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rust-gdb from the active toolchain
+    #[command(name = "rust-gdb")]
+    RustGdb {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rust-lldb from the active toolchain
+    #[command(name = "rust-lldb")]
+    RustLldb {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run rust-analyzer from the active toolchain
+    #[command(name = "rust-analyzer")]
+    RustAnalyzer {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Show cache status and tool info
     Status {
         /// Emit the stable machine-facing JSON form for this command
@@ -57,7 +96,7 @@ async fn main() {
     // RUSTC_WRAPPER mode: cargo passes `soldr /path/to/rustc <args...>`
     // Must be checked before clap parsing.
     let raw_args: Vec<String> = std::env::args().collect();
-    if raw_args.len() > 1 && is_rustc_path(&raw_args[1]) {
+    if raw_args.len() > 1 && is_wrapper_invocation(&raw_args[1]) {
         std::process::exit(run_rustc_wrapper(&raw_args).unwrap_or_else(report_and_exit));
     }
 
@@ -74,6 +113,27 @@ async fn run() -> Result<(), SoldrError> {
     match cli.command {
         Commands::Cargo { args } => {
             std::process::exit(run_cargo_front_door(&args, cache_enabled).await?);
+        }
+        Commands::Rustc { args } => {
+            std::process::exit(run_toolchain_passthrough("rustc", &args)?);
+        }
+        Commands::Rustfmt { args } => {
+            std::process::exit(run_toolchain_passthrough("rustfmt", &args)?);
+        }
+        Commands::ClippyDriver { args } => {
+            std::process::exit(run_toolchain_passthrough("clippy-driver", &args)?);
+        }
+        Commands::Rustdoc { args } => {
+            std::process::exit(run_toolchain_passthrough("rustdoc", &args)?);
+        }
+        Commands::RustGdb { args } => {
+            std::process::exit(run_toolchain_passthrough("rust-gdb", &args)?);
+        }
+        Commands::RustLldb { args } => {
+            std::process::exit(run_toolchain_passthrough("rust-lldb", &args)?);
+        }
+        Commands::RustAnalyzer { args } => {
+            std::process::exit(run_toolchain_passthrough("rust-analyzer", &args)?);
         }
         Commands::Status { json } => {
             let output = collect_status_output(cache_enabled)?;
@@ -139,37 +199,57 @@ fn report_and_exit(error: SoldrError) -> i32 {
     1
 }
 
-fn is_rustc_path(arg: &str) -> bool {
-    if arg == "rustc" {
-        return true;
-    }
+/// Known toolchain binaries that cargo may invoke through RUSTC_WRAPPER
+/// or RUSTC_WORKSPACE_WRAPPER. When soldr is set as a wrapper, cargo
+/// passes: `soldr <toolchain-binary> <rustc-args...>`
+const WRAPPER_PASSTHROUGH_TOOLS: &[&str] = &["rustc", "clippy-driver"];
 
-    std::path::Path::new(arg)
+fn is_wrapper_invocation(arg: &str) -> bool {
+    let stem = std::path::Path::new(arg)
         .file_stem()
         .and_then(std::ffi::OsStr::to_str)
-        == Some("rustc")
+        .unwrap_or(arg);
+
+    WRAPPER_PASSTHROUGH_TOOLS.contains(&stem)
 }
 
 fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
-    if soldr_cache::cache_enabled_in_current_process() {
+    let tool_arg = raw_args
+        .get(1)
+        .ok_or_else(|| SoldrError::Other("missing tool path in wrapper mode".into()))?;
+
+    let tool_stem = std::path::Path::new(tool_arg.as_str())
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or(tool_arg);
+
+    // Only route through zccache for actual rustc invocations, not
+    // clippy-driver or other workspace wrappers.
+    if tool_stem == "rustc" && soldr_cache::cache_enabled_in_current_process() {
         if let Some(zccache) = zccache_binary_override() {
             return run_wrapper_through_zccache(raw_args, &zccache);
         }
     }
 
-    let rustc = raw_args
-        .get(1)
-        .ok_or_else(|| SoldrError::Other("missing rustc path in wrapper mode".into()))?;
-    let rustc = if rustc == "rustc" {
-        resolve_toolchain_binary("rustc")?
+    // Resolve the tool binary. If it's already a full path, use it
+    // directly. Otherwise resolve via rustup.
+    let tool_path: std::path::PathBuf = if std::path::Path::new(tool_arg.as_str()).is_absolute() {
+        tool_arg.into()
     } else {
-        rustc.into()
+        resolve_toolchain_binary(tool_stem)?
     };
 
-    let status = std::process::Command::new(rustc)
+    let status = std::process::Command::new(tool_path)
         .args(&raw_args[2..])
         .status()?;
 
+    Ok(status.code().unwrap_or(1))
+}
+
+/// Run a rustup-managed toolchain binary with pass-through args.
+fn run_toolchain_passthrough(tool: &str, args: &[String]) -> Result<i32, SoldrError> {
+    let binary = resolve_toolchain_binary(tool)?;
+    let status = std::process::Command::new(binary).args(args).status()?;
     Ok(status.code().unwrap_or(1))
 }
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -281,6 +281,11 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     let paths = SoldrPaths::new()?;
     paths.ensure_dirs()?;
 
+    // If the user invoked a known ecosystem subcommand (e.g. `cargo nextest`),
+    // fetch the corresponding `cargo-<sub>` binary and prepend its directory to
+    // PATH so cargo's subcommand dispatch finds it.
+    let extra_bin_dirs = ensure_known_subcommand_tool(args, &paths).await?;
+
     let mut command = std::process::Command::new(cargo);
     command.args(args);
     command.env("RUSTC", rustc);
@@ -288,10 +293,10 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
         soldr_cache::CACHE_ENABLED_ENV_VAR,
         soldr_cache::cache_enabled_env_value(cache_enabled),
     );
-    command.env(
-        "PATH",
-        prepend_path(&cargo_bin_dir, existing_path.as_deref())?,
-    );
+    let mut path_dirs: Vec<std::path::PathBuf> = Vec::with_capacity(1 + extra_bin_dirs.len());
+    path_dirs.push(cargo_bin_dir);
+    path_dirs.extend(extra_bin_dirs);
+    command.env("PATH", prepend_paths(&path_dirs, existing_path.as_deref())?);
     if let Some(target) = default_cargo_build_target(args)? {
         command.env("CARGO_BUILD_TARGET", target);
     }
@@ -347,15 +352,67 @@ fn cargo_args_use_reserved_no_cache(args: &[String]) -> bool {
     false
 }
 
-fn prepend_path(
-    dir: &std::path::Path,
+fn prepend_paths(
+    dirs: &[std::path::PathBuf],
     existing_path: Option<&std::ffi::OsStr>,
 ) -> Result<std::ffi::OsString, SoldrError> {
-    let mut paths = vec![dir.to_path_buf()];
+    let mut paths: Vec<std::path::PathBuf> = dirs.to_vec();
     if let Some(existing_path) = existing_path {
         paths.extend(std::env::split_paths(existing_path));
     }
     std::env::join_paths(paths).map_err(|e| SoldrError::Other(format!("invalid PATH: {e}")))
+}
+
+/// Return the first positional argument (skipping flags) of the cargo
+/// front-door args, which is conventionally the cargo subcommand.
+fn first_cargo_subcommand(args: &[String]) -> Option<&str> {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        return Some(arg.as_str());
+    }
+    None
+}
+
+async fn ensure_known_subcommand_tool(
+    args: &[String],
+    paths: &SoldrPaths,
+) -> Result<Vec<std::path::PathBuf>, SoldrError> {
+    let Some(sub) = first_cargo_subcommand(args) else {
+        return Ok(Vec::new());
+    };
+    let Some(spec) = soldr_fetch::lookup_by_cargo_subcommand(sub) else {
+        return Ok(Vec::new());
+    };
+
+    eprintln!("soldr: fetching {}...", spec.crate_name);
+    let result =
+        soldr_fetch::fetch_tool_with_paths(spec.crate_name, &VersionSpec::Latest, paths).await?;
+
+    if result.cached {
+        eprintln!(
+            "soldr: using cached {} v{}",
+            spec.crate_name, result.version
+        );
+    } else {
+        eprintln!("soldr: downloaded {} v{}", spec.crate_name, result.version);
+    }
+
+    let dir = result
+        .binary_path
+        .parent()
+        .ok_or_else(|| {
+            SoldrError::Other(format!(
+                "failed to resolve bin dir for fetched {}",
+                spec.crate_name
+            ))
+        })?
+        .to_path_buf();
+    Ok(vec![dir])
 }
 
 fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError> {
@@ -720,7 +777,10 @@ fn cached_managed_zccache(
 
 #[cfg(test)]
 mod tests {
-    use super::{cargo_args_specify_target, cargo_args_use_reserved_no_cache, parse_tool_spec};
+    use super::{
+        cargo_args_specify_target, cargo_args_use_reserved_no_cache, first_cargo_subcommand,
+        parse_tool_spec,
+    };
     use soldr_fetch::VersionSpec;
 
     #[test]
@@ -764,5 +824,37 @@ mod tests {
         let (tool, version) = parse_tool_spec("maturin");
         assert_eq!(tool, "maturin");
         assert!(matches!(version, VersionSpec::Latest));
+    }
+
+    #[test]
+    fn first_cargo_subcommand_skips_leading_flags() {
+        assert_eq!(
+            first_cargo_subcommand(&["--verbose".into(), "nextest".into(), "run".into()]),
+            Some("nextest")
+        );
+        assert_eq!(
+            first_cargo_subcommand(&["nextest".into(), "run".into()]),
+            Some("nextest")
+        );
+        assert_eq!(first_cargo_subcommand(&["--help".into()]), None);
+        assert_eq!(first_cargo_subcommand(&[]), None);
+    }
+
+    #[test]
+    fn first_cargo_subcommand_stops_at_passthrough_separator() {
+        assert_eq!(
+            first_cargo_subcommand(&["--".into(), "nextest".into()]),
+            None
+        );
+    }
+
+    #[test]
+    fn known_subcommand_registry_recognizes_phase_two_tools() {
+        for sub in ["nextest", "deny", "audit", "llvm-cov"] {
+            let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
+                .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
+            assert_eq!(spec.cargo_subcommand, sub);
+            assert!(spec.crate_name.starts_with("cargo-"));
+        }
     }
 }

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-#[cfg(windows)]
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -13,6 +12,179 @@ fn rustup_which(tool: &str) -> String {
         .expect("failed to resolve tool with rustup");
     assert!(output.status.success(), "rustup which failed for {tool}");
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
+    fs::create_dir_all(&dir).expect("failed to create temp dir");
+    dir
+}
+
+fn fake_script_path(dir: &Path, name: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        return dir.join(format!("{name}.cmd"));
+    }
+    #[cfg(not(windows))]
+    {
+        dir.join(name)
+    }
+}
+
+fn write_fake_script(path: &Path, body: &str) {
+    #[cfg(windows)]
+    {
+        fs::write(path, body.replace('\n', "\r\n")).expect("failed to write fake script");
+    }
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::write(path, body).expect("failed to write fake script");
+        let mut perms = fs::metadata(path)
+            .expect("failed to stat fake script")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("failed to chmod fake script");
+    }
+}
+
+fn fake_cargo_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID%>>\"{}\"\n\
+             if defined RUSTC_WRAPPER (\n\
+             call \"%RUSTC_WRAPPER%\" \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
+             ) else (\n\
+             call \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
+             )\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}}\" >> \"{}\"\n\
+             if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\
+               \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
+             else\n\
+               \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
+             fi\n",
+            log_path.display()
+        )
+    }
+}
+
+fn fake_rustc_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo rustc %*>>\"{}\"\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"rustc $*\" >> \"{}\"\n",
+            log_path.display()
+        )
+    }
+}
+
+fn fake_zccache_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             if \"%~1\"==\"start\" (\n\
+               echo zccache start>>\"{0}\"\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"session-start\" (\n\
+               echo zccache session-start>>\"{0}\"\n\
+               if not \"%~4\"==\"\" type nul > \"%~4\"\n\
+               echo {{\"session_id\":\"test-session\"}}\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"session-end\" (\n\
+               echo zccache session-end %~2>>\"{0}\"\n\
+               echo hits: 1\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"status\" (\n\
+               echo hits=7\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"clear\" (\n\
+               echo zccache clear>>\"{0}\"\n\
+               exit /b 0\n\
+             )\n\
+             set \"rustc=%~1\"\n\
+             shift\n\
+             echo zccache wrapper %rustc% %*>>\"{0}\"\n\
+             call \"%rustc%\" %*\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             case \"$1\" in\n\
+               start)\n\
+                 echo \"zccache start\" >> \"{0}\"\n\
+                 exit 0\n\
+                 ;;\n\
+               session-start)\n\
+                 echo \"zccache session-start\" >> \"{0}\"\n\
+                 : > \"$4\"\n\
+                 echo '{{\"session_id\":\"test-session\"}}'\n\
+                 exit 0\n\
+                 ;;\n\
+               session-end)\n\
+                 echo \"zccache session-end $2\" >> \"{0}\"\n\
+                 echo 'hits: 1'\n\
+                 exit 0\n\
+                 ;;\n\
+               status)\n\
+                 echo 'hits=7'\n\
+                 exit 0\n\
+                 ;;\n\
+               clear)\n\
+                 echo \"zccache clear\" >> \"{0}\"\n\
+                 exit 0\n\
+                 ;;\n\
+             esac\n\
+             rustc=\"$1\"\n\
+             shift\n\
+             echo \"zccache wrapper $rustc $*\" >> \"{0}\"\n\
+             \"$rustc\" \"$@\"\n",
+            log_path.display()
+        )
+    }
+}
+
+fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let dir = unique_temp_dir("fake-toolchain");
+    let cargo = fake_script_path(&dir, "cargo");
+    let rustc = fake_script_path(&dir, "rustc");
+    let zccache = fake_script_path(&dir, "zccache");
+    write_fake_script(&cargo, &fake_cargo_script(log_path));
+    write_fake_script(&rustc, &fake_rustc_script(log_path));
+    write_fake_script(&zccache, &fake_zccache_script(log_path));
+    (cargo, rustc, zccache)
 }
 
 #[test]
@@ -51,8 +223,10 @@ fn help_lists_phase_one_command_surface() {
 
 #[test]
 fn cargo_front_door_runs_real_cargo() {
+    let cache_root = unique_temp_dir("cargo-version");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "--version"])
+        .args(["--no-cache", "cargo", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
         .expect("failed to run soldr cargo --version");
 
@@ -67,6 +241,168 @@ fn cargo_front_door_runs_real_cargo() {
     assert!(
         !stderr.contains("soldr: fetching cargo"),
         "cargo front door should not fetch cargo: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_front_door_consumes_no_cache_flag() {
+    let cache_root = unique_temp_dir("cargo-no-cache");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["--no-cache", "cargo", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr --no-cache cargo --version");
+
+    assert!(
+        output.status.success(),
+        "cargo front door with top-level --no-cache failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("cargo"),
+        "unexpected cargo output with --no-cache: {stdout}"
+    );
+    assert!(
+        !stderr.contains("unexpected argument '--no-cache'"),
+        "--no-cache should be consumed by soldr, not forwarded to cargo: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_subcommand_rejects_no_cache_flag() {
+    let cache_root = unique_temp_dir("cargo-subcommand-no-cache");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "--no-cache", "--version"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr cargo --no-cache --version");
+
+    assert!(
+        !output.status.success(),
+        "cargo subcommand form should no longer accept --no-cache"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--no-cache"),
+        "expected cargo-subcommand form to fail mentioning --no-cache: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
+    let cache_root = unique_temp_dir("cargo-default-cache");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cargo build with fake zccache");
+
+    assert!(
+        output.status.success(),
+        "cache-enabled front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cargo wrapper="),
+        "fake cargo did not record wrapper env: {log}"
+    );
+    assert!(
+        log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "soldr should own the wrapper slot in cache-enabled mode: {log}"
+    );
+    assert!(
+        log.contains("cache=1"),
+        "cache-enabled front door should propagate cache flag: {log}"
+    );
+    assert!(
+        log.contains("zccache start"),
+        "managed zccache should be started for cache-enabled builds: {log}"
+    );
+    assert!(
+        log.contains("zccache session-start"),
+        "managed zccache session should start before cargo runs: {log}"
+    );
+    assert!(
+        log.contains("zccache wrapper"),
+        "wrapper mode should dispatch into zccache on cache-enabled builds: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "real rustc invocation should still happen through the wrapper path: {log}"
+    );
+    assert!(
+        log.contains("zccache session-end test-session"),
+        "managed zccache session should end after cargo finishes: {log}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("soldr: zccache session summary"),
+        "expected zccache session summary in stderr: {stderr}"
+    );
+
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    assert!(
+        journal.exists(),
+        "expected session journal at {}",
+        journal.display()
+    );
+}
+
+#[test]
+fn no_cache_bypasses_wrapper_and_zccache() {
+    let cache_root = unique_temp_dir("cargo-no-cache-fake");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["--no-cache", "cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr --no-cache cargo build with fake tools");
+
+    assert!(
+        output.status.success(),
+        "no-cache front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cache=0"),
+        "no-cache front door should propagate cache disable flag: {log}"
+    );
+    assert!(
+        !log.contains("zccache start"),
+        "no-cache front door should not start zccache: {log}"
+    );
+    assert!(
+        !log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "no-cache front door should not set soldr as wrapper: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "no-cache front door should call rustc directly: {log}"
     );
 }
 
@@ -88,15 +424,118 @@ fn rustc_wrapper_mode_passes_through_to_rustc() {
     );
 }
 
-#[cfg(windows)]
-fn unique_temp_dir(label: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("time went backwards")
-        .as_nanos();
-    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
-    fs::create_dir_all(&dir).expect("failed to create temp dir");
-    dir
+#[test]
+fn status_reports_cache_control_defaults() {
+    let cache_root = unique_temp_dir("status");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("status")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr status");
+
+    assert!(output.status.success(), "status command failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cache dir:"),
+        "status missing cache dir: {stdout}"
+    );
+    assert!(
+        stdout.contains("cache default: enabled"),
+        "status missing cache default: {stdout}"
+    );
+    assert!(
+        stdout.contains("zccache version:"),
+        "status missing zccache version: {stdout}"
+    );
+    assert!(
+        stdout.contains("not fetched yet"),
+        "status should explain unfetched managed zccache state: {stdout}"
+    );
+}
+
+#[test]
+fn cache_command_reports_managed_zccache_status() {
+    let cache_root = unique_temp_dir("cache-command");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("cache")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache");
+
+    assert!(output.status.success(), "cache command failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("soldr zccache state dir:"),
+        "cache command missing state dir: {stdout}"
+    );
+    assert!(
+        stdout.contains("last session journal:"),
+        "cache command missing journal path: {stdout}"
+    );
+    assert!(
+        stdout.contains("(present)"),
+        "cache command should report present journal: {stdout}"
+    );
+    assert!(
+        stdout.contains("zccache: hits=7"),
+        "cache command should surface managed zccache status output: {stdout}"
+    );
+}
+
+#[test]
+fn clean_clears_managed_zccache_and_state_dir() {
+    let cache_root = unique_temp_dir("clean-command");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let state_dir = cache_root.join("cache").join("zccache");
+    let journal = state_dir.join("logs").join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("clean")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr clean");
+
+    assert!(output.status.success(), "clean command failed");
+    assert!(
+        !state_dir.exists(),
+        "clean should remove soldr zccache state dir at {}",
+        state_dir.display()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cleared zccache artifact cache"),
+        "clean should report artifact cache cleanup: {stdout}"
+    );
+    assert!(
+        stdout.contains("removed soldr zccache state dir:"),
+        "clean should report state dir cleanup: {stdout}"
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("zccache clear"),
+        "clean should call managed zccache clear: {log}"
+    );
 }
 
 #[cfg(windows)]
@@ -128,10 +567,11 @@ fn cargo_front_door_forces_msvc_target_even_with_polluted_path() {
         .join("fixtures")
         .join("windows-msvc-default");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cargo", "build"])
+        .args(["--no-cache", "cargo", "build"])
         .current_dir(&fixture)
         .env("PATH", prepend_to_path(&fake_tools))
         .env("CARGO_TARGET_DIR", &target_dir)
+        .env("SOLDR_CACHE_DIR", unique_temp_dir("msvc-cache-root"))
         .output()
         .expect("failed to run soldr cargo build");
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,3 +1,4 @@
+use serde_json::Value;
 use std::process::Command;
 use std::{
     fs,
@@ -201,6 +202,22 @@ fn version_command_prints_workspace_version() {
         stdout.trim(),
         format!("soldr {}", env!("CARGO_PKG_VERSION"))
     );
+}
+
+#[test]
+fn version_command_emits_versioned_json() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["version", "--json"])
+        .output()
+        .expect("failed to run soldr version --json");
+
+    assert!(output.status.success(), "version --json command failed");
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("version --json did not return JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "version");
+    assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
 }
 
 #[test]
@@ -455,6 +472,38 @@ fn status_reports_cache_control_defaults() {
 }
 
 #[test]
+fn status_json_reports_stable_machine_fields() {
+    let cache_root = unique_temp_dir("status-json");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["status", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr status --json");
+
+    assert!(output.status.success(), "status --json command failed");
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("status --json did not return JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "status");
+    assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(json["cache_default_enabled"], true);
+    assert_eq!(json["cache_enabled_for_invocation"], true);
+    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["root_dir"], cache_root.display().to_string());
+    assert_eq!(
+        json["cache_dir"],
+        cache_root.join("cache").display().to_string()
+    );
+    assert_eq!(json["zccache"]["binary_fetched"], false);
+    assert_eq!(json["zccache"]["journal_present"], false);
+    assert!(
+        json["target"].as_str().is_some(),
+        "status JSON missing target"
+    );
+}
+
+#[test]
 fn cache_command_reports_managed_zccache_status() {
     let cache_root = unique_temp_dir("cache-command");
     let log_path = cache_root.join("tool.log");
@@ -497,6 +546,46 @@ fn cache_command_reports_managed_zccache_status() {
 }
 
 #[test]
+fn cache_json_reports_managed_zccache_status() {
+    let cache_root = unique_temp_dir("cache-command-json");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let journal = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.jsonl");
+    fs::create_dir_all(journal.parent().expect("journal parent missing"))
+        .expect("failed to create journal dir");
+    fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache --json");
+
+    assert!(output.status.success(), "cache --json command failed");
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "cache");
+    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["zccache"]["journal_present"], true);
+    assert_eq!(json["zccache"]["binary_fetched"], true);
+    assert_eq!(
+        json["zccache"]["journal_path"],
+        journal.display().to_string()
+    );
+    assert_eq!(
+        json["zccache"]["status_lines"][0],
+        Value::String("hits=7".to_string())
+    );
+}
+
+#[test]
 fn clean_clears_managed_zccache_and_state_dir() {
     let cache_root = unique_temp_dir("clean-command");
     let log_path = cache_root.join("tool.log");
@@ -535,6 +624,25 @@ fn clean_clears_managed_zccache_and_state_dir() {
     assert!(
         log.contains("zccache clear"),
         "clean should call managed zccache clear: {log}"
+    );
+}
+
+#[test]
+fn clean_rejects_json_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["clean", "--json"])
+        .output()
+        .expect("failed to run soldr clean --json");
+
+    assert!(
+        !output.status.success(),
+        "clean --json should be rejected because JSON is not supported there"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--json"),
+        "expected clap to reject clean --json: {stderr}"
     );
 }
 

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -1,5 +1,8 @@
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 use thiserror::Error;
 
 // ---------------------------------------------------------------------------
@@ -304,6 +307,8 @@ fn compile_time_fallback_triple() -> Result<String, SoldrError> {
 // Paths - ~/.soldr/ layout
 // ---------------------------------------------------------------------------
 
+pub const SOLDR_CACHE_DIR_ENV_VAR: &str = "SOLDR_CACHE_DIR";
+
 pub struct SoldrPaths {
     pub root: PathBuf,
     pub bin: PathBuf,
@@ -313,7 +318,8 @@ pub struct SoldrPaths {
 
 impl SoldrPaths {
     pub fn new() -> Result<Self, SoldrError> {
-        let root = home_dir()?.join(".soldr");
+        let root = soldr_root_from_env_var(std::env::var_os(SOLDR_CACHE_DIR_ENV_VAR).as_deref())
+            .unwrap_or_else(|| home_dir().map(|home| home.join(".soldr")))?;
         Ok(Self::with_root(root))
     }
 
@@ -331,6 +337,14 @@ impl SoldrPaths {
         std::fs::create_dir_all(&self.cache)?;
         Ok(())
     }
+}
+
+fn soldr_root_from_env_var(value: Option<&OsStr>) -> Option<Result<PathBuf, SoldrError>> {
+    let value = value?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(Ok(PathBuf::from(value)))
 }
 
 fn home_dir() -> Result<PathBuf, SoldrError> {
@@ -437,6 +451,19 @@ mod tests {
         assert!(paths.root.ends_with(".soldr"));
         assert!(paths.bin.ends_with("bin"));
         assert!(paths.cache.ends_with("cache"));
+    }
+
+    #[test]
+    fn soldr_root_override_uses_env_path() {
+        let root = soldr_root_from_env_var(Some(OsStr::new("C:\\temp\\soldr-cache-root")))
+            .unwrap()
+            .unwrap();
+        assert_eq!(root, PathBuf::from("C:\\temp\\soldr-cache-root"));
+    }
+
+    #[test]
+    fn soldr_root_override_ignores_empty_env() {
+        assert!(soldr_root_from_env_var(Some(OsStr::new(""))).is_none());
     }
 
     #[test]

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.2.0-beta");
+        assert_eq!(version(), "0.6.0");
     }
 
     #[test]

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.6.0");
+        assert_eq!(version(), "0.7.0");
     }
 
     #[test]

--- a/crates/soldr-fetch/Cargo.toml
+++ b/crates/soldr-fetch/Cargo.toml
@@ -17,6 +17,9 @@ tempfile = { workspace = true }
 zip = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
+toml = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -126,6 +126,15 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
         repo: Some(("mozilla", "sccache")),
         tag_prefix: None,
     },
+    // Self-trampoline: `soldr --as <version>` fetches this entry so an older
+    // soldr binary can handle the rest of the invocation.
+    ToolSpec {
+        crate_name: "soldr",
+        cargo_subcommand: None,
+        binary_name: "soldr",
+        repo: Some(("zackees", "soldr")),
+        tag_prefix: None,
+    },
 ];
 
 pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -1,0 +1,114 @@
+//! Registry of ecosystem tools with known GitHub Releases and cargo-subcommand mapping.
+//!
+//! Some crates have monorepo-style release tags (e.g. `cargo-audit/v0.21.0`) or
+//! live in a repository whose name differs from the crate. Falling back to the
+//! crates.io → GitHub repository lookup plus `/releases/latest` can pick up the
+//! wrong release in those cases. When a tool needs per-release handling, encode
+//! it here once and fetch paths can use it directly.
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolSpec {
+    /// crates.io crate name and fetch cache key.
+    pub crate_name: &'static str,
+    /// Name used as `cargo <sub>`.
+    pub cargo_subcommand: &'static str,
+    /// Binary shipped inside the release archive (no OS extension).
+    pub binary_name: &'static str,
+    /// Optional (owner, repo) override; skips the crates.io lookup when set.
+    pub repo: Option<(&'static str, &'static str)>,
+    /// Optional release-tag prefix used to filter monorepo releases, e.g.
+    /// `"cargo-audit/"` to pick only `cargo-audit/v0.21.0`-style tags.
+    pub tag_prefix: Option<&'static str>,
+}
+
+pub const KNOWN_TOOLS: &[ToolSpec] = &[
+    ToolSpec {
+        crate_name: "cargo-nextest",
+        cargo_subcommand: "nextest",
+        binary_name: "cargo-nextest",
+        repo: Some(("nextest-rs", "nextest")),
+        tag_prefix: Some("cargo-nextest-"),
+    },
+    ToolSpec {
+        crate_name: "cargo-deny",
+        cargo_subcommand: "deny",
+        binary_name: "cargo-deny",
+        repo: Some(("EmbarkStudios", "cargo-deny")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-audit",
+        cargo_subcommand: "audit",
+        binary_name: "cargo-audit",
+        repo: Some(("rustsec", "rustsec")),
+        tag_prefix: Some("cargo-audit/"),
+    },
+    ToolSpec {
+        crate_name: "cargo-llvm-cov",
+        cargo_subcommand: "llvm-cov",
+        binary_name: "cargo-llvm-cov",
+        repo: Some(("taiki-e", "cargo-llvm-cov")),
+        tag_prefix: None,
+    },
+];
+
+pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {
+    KNOWN_TOOLS.iter().find(|t| t.crate_name == crate_name)
+}
+
+pub fn lookup_by_cargo_subcommand(sub: &str) -> Option<&'static ToolSpec> {
+    KNOWN_TOOLS.iter().find(|t| t.cargo_subcommand == sub)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_by_crate_finds_registered_tools() {
+        assert_eq!(
+            lookup_by_crate("cargo-nextest").unwrap().cargo_subcommand,
+            "nextest"
+        );
+        assert_eq!(
+            lookup_by_crate("cargo-llvm-cov").unwrap().binary_name,
+            "cargo-llvm-cov"
+        );
+        assert!(lookup_by_crate("not-a-tool").is_none());
+    }
+
+    #[test]
+    fn lookup_by_cargo_subcommand_finds_registered_tools() {
+        assert_eq!(
+            lookup_by_cargo_subcommand("nextest").unwrap().crate_name,
+            "cargo-nextest"
+        );
+        assert_eq!(
+            lookup_by_cargo_subcommand("deny").unwrap().crate_name,
+            "cargo-deny"
+        );
+        assert!(lookup_by_cargo_subcommand("build").is_none());
+    }
+
+    #[test]
+    fn cargo_audit_carries_monorepo_tag_prefix() {
+        let spec = lookup_by_crate("cargo-audit").unwrap();
+        assert_eq!(spec.tag_prefix, Some("cargo-audit/"));
+    }
+
+    #[test]
+    fn known_tools_are_unique_by_crate_and_subcommand() {
+        for (i, a) in KNOWN_TOOLS.iter().enumerate() {
+            for b in KNOWN_TOOLS.iter().skip(i + 1) {
+                assert_ne!(
+                    a.crate_name, b.crate_name,
+                    "duplicate crate_name in registry"
+                );
+                assert_ne!(
+                    a.cargo_subcommand, b.cargo_subcommand,
+                    "duplicate cargo_subcommand in registry"
+                );
+            }
+        }
+    }
+}

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -1,4 +1,4 @@
-//! Registry of ecosystem tools with known GitHub Releases and cargo-subcommand mapping.
+//! Registry of ecosystem tools with known GitHub Releases and (optional) cargo-subcommand mapping.
 //!
 //! Some crates have monorepo-style release tags (e.g. `cargo-audit/v0.21.0`) or
 //! live in a repository whose name differs from the crate. Falling back to the
@@ -10,8 +10,9 @@
 pub struct ToolSpec {
     /// crates.io crate name and fetch cache key.
     pub crate_name: &'static str,
-    /// Name used as `cargo <sub>`.
-    pub cargo_subcommand: &'static str,
+    /// Name used as `cargo <sub>`. `None` for tools that are not cargo
+    /// subcommands (e.g. `cross`, `mdbook`, `sccache`).
+    pub cargo_subcommand: Option<&'static str>,
     /// Binary shipped inside the release archive (no OS extension).
     pub binary_name: &'static str,
     /// Optional (owner, repo) override; skips the crates.io lookup when set.
@@ -22,30 +23,31 @@ pub struct ToolSpec {
 }
 
 pub const KNOWN_TOOLS: &[ToolSpec] = &[
+    // Phase 2 — test + security.
     ToolSpec {
         crate_name: "cargo-nextest",
-        cargo_subcommand: "nextest",
+        cargo_subcommand: Some("nextest"),
         binary_name: "cargo-nextest",
         repo: Some(("nextest-rs", "nextest")),
         tag_prefix: Some("cargo-nextest-"),
     },
     ToolSpec {
         crate_name: "cargo-deny",
-        cargo_subcommand: "deny",
+        cargo_subcommand: Some("deny"),
         binary_name: "cargo-deny",
         repo: Some(("EmbarkStudios", "cargo-deny")),
         tag_prefix: None,
     },
     ToolSpec {
         crate_name: "cargo-audit",
-        cargo_subcommand: "audit",
+        cargo_subcommand: Some("audit"),
         binary_name: "cargo-audit",
         repo: Some(("rustsec", "rustsec")),
         tag_prefix: Some("cargo-audit/"),
     },
     ToolSpec {
         crate_name: "cargo-llvm-cov",
-        cargo_subcommand: "llvm-cov",
+        cargo_subcommand: Some("llvm-cov"),
         binary_name: "cargo-llvm-cov",
         repo: Some(("taiki-e", "cargo-llvm-cov")),
         tag_prefix: None,
@@ -53,30 +55,53 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
     // Phase 3 — dev ergonomics.
     ToolSpec {
         crate_name: "cargo-udeps",
-        cargo_subcommand: "udeps",
+        cargo_subcommand: Some("udeps"),
         binary_name: "cargo-udeps",
         repo: Some(("est31", "cargo-udeps")),
         tag_prefix: None,
     },
     ToolSpec {
         crate_name: "cargo-semver-checks",
-        cargo_subcommand: "semver-checks",
+        cargo_subcommand: Some("semver-checks"),
         binary_name: "cargo-semver-checks",
         repo: Some(("obi1kenobi", "cargo-semver-checks")),
         tag_prefix: None,
     },
     ToolSpec {
         crate_name: "cargo-expand",
-        cargo_subcommand: "expand",
+        cargo_subcommand: Some("expand"),
         binary_name: "cargo-expand",
         repo: Some(("dtolnay", "cargo-expand")),
         tag_prefix: None,
     },
     ToolSpec {
         crate_name: "cargo-watch",
-        cargo_subcommand: "watch",
+        cargo_subcommand: Some("watch"),
         binary_name: "cargo-watch",
         repo: Some(("watchexec", "cargo-watch")),
+        tag_prefix: None,
+    },
+    // Phase 4 — build + docs. None of these are cargo subcommands — they are
+    // top-level tools invoked as `soldr cross ...`, `soldr mdbook ...`, etc.
+    ToolSpec {
+        crate_name: "cross",
+        cargo_subcommand: None,
+        binary_name: "cross",
+        repo: Some(("cross-rs", "cross")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "mdbook",
+        cargo_subcommand: None,
+        binary_name: "mdbook",
+        repo: Some(("rust-lang", "mdBook")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cbindgen",
+        cargo_subcommand: None,
+        binary_name: "cbindgen",
+        repo: Some(("mozilla", "cbindgen")),
         tag_prefix: None,
     },
 ];
@@ -86,7 +111,7 @@ pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {
 }
 
 pub fn lookup_by_cargo_subcommand(sub: &str) -> Option<&'static ToolSpec> {
-    KNOWN_TOOLS.iter().find(|t| t.cargo_subcommand == sub)
+    KNOWN_TOOLS.iter().find(|t| t.cargo_subcommand == Some(sub))
 }
 
 #[cfg(test)]
@@ -97,12 +122,13 @@ mod tests {
     fn lookup_by_crate_finds_registered_tools() {
         assert_eq!(
             lookup_by_crate("cargo-nextest").unwrap().cargo_subcommand,
-            "nextest"
+            Some("nextest")
         );
         assert_eq!(
             lookup_by_crate("cargo-llvm-cov").unwrap().binary_name,
             "cargo-llvm-cov"
         );
+        assert_eq!(lookup_by_crate("mdbook").unwrap().cargo_subcommand, None);
         assert!(lookup_by_crate("not-a-tool").is_none());
     }
 
@@ -117,6 +143,10 @@ mod tests {
             "cargo-deny"
         );
         assert!(lookup_by_cargo_subcommand("build").is_none());
+        // Tools with cargo_subcommand: None should never be returned here.
+        assert!(lookup_by_cargo_subcommand("mdbook").is_none());
+        assert!(lookup_by_cargo_subcommand("cross").is_none());
+        assert!(lookup_by_cargo_subcommand("cbindgen").is_none());
     }
 
     #[test]
@@ -133,11 +163,20 @@ mod tests {
                     a.crate_name, b.crate_name,
                     "duplicate crate_name in registry"
                 );
-                assert_ne!(
-                    a.cargo_subcommand, b.cargo_subcommand,
-                    "duplicate cargo_subcommand in registry"
-                );
+                if let (Some(asub), Some(bsub)) = (a.cargo_subcommand, b.cargo_subcommand) {
+                    assert_ne!(asub, bsub, "duplicate cargo_subcommand in registry");
+                }
             }
+        }
+    }
+
+    #[test]
+    fn top_level_tools_are_registered_without_cargo_subcommand() {
+        for crate_name in ["cross", "mdbook", "cbindgen"] {
+            let spec = lookup_by_crate(crate_name)
+                .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
+            assert_eq!(spec.cargo_subcommand, None);
+            assert!(spec.repo.is_some());
         }
     }
 }

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -104,6 +104,28 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
         repo: Some(("mozilla", "cbindgen")),
         tag_prefix: None,
     },
+    // Phase 5 — web/wasm + cache. Top-level tools invoked directly.
+    ToolSpec {
+        crate_name: "wasm-pack",
+        cargo_subcommand: None,
+        binary_name: "wasm-pack",
+        repo: Some(("rustwasm", "wasm-pack")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "trunk",
+        cargo_subcommand: None,
+        binary_name: "trunk",
+        repo: Some(("trunk-rs", "trunk")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "sccache",
+        cargo_subcommand: None,
+        binary_name: "sccache",
+        repo: Some(("mozilla", "sccache")),
+        tag_prefix: None,
+    },
 ];
 
 pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {
@@ -172,7 +194,14 @@ mod tests {
 
     #[test]
     fn top_level_tools_are_registered_without_cargo_subcommand() {
-        for crate_name in ["cross", "mdbook", "cbindgen"] {
+        for crate_name in [
+            "cross",
+            "mdbook",
+            "cbindgen",
+            "wasm-pack",
+            "trunk",
+            "sccache",
+        ] {
             let spec = lookup_by_crate(crate_name)
                 .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
             assert_eq!(spec.cargo_subcommand, None);

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -50,6 +50,35 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
         repo: Some(("taiki-e", "cargo-llvm-cov")),
         tag_prefix: None,
     },
+    // Phase 3 — dev ergonomics.
+    ToolSpec {
+        crate_name: "cargo-udeps",
+        cargo_subcommand: "udeps",
+        binary_name: "cargo-udeps",
+        repo: Some(("est31", "cargo-udeps")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-semver-checks",
+        cargo_subcommand: "semver-checks",
+        binary_name: "cargo-semver-checks",
+        repo: Some(("obi1kenobi", "cargo-semver-checks")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-expand",
+        cargo_subcommand: "expand",
+        binary_name: "cargo-expand",
+        repo: Some(("dtolnay", "cargo-expand")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-watch",
+        cargo_subcommand: "watch",
+        binary_name: "cargo-watch",
+        repo: Some(("watchexec", "cargo-watch")),
+        tag_prefix: None,
+    },
 ];
 
 pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -2,7 +2,11 @@
 //!
 //! Resolution chain (Phase 1 MVP):
 //! 1. Local cache (`~/.soldr/bin/<tool>-<version>/`)
-//! 2. GitHub Releases (repository URL from crates.io)
+//! 2. GitHub Releases (repository URL from crates.io, or override from `known_tools`)
+
+pub mod known_tools;
+
+pub use known_tools::{lookup_by_cargo_subcommand, lookup_by_crate, ToolSpec, KNOWN_TOOLS};
 
 use soldr_core::{Arch, Env, Os, SoldrError, SoldrPaths, TargetTriple};
 use std::path::{Path, PathBuf};
@@ -52,8 +56,28 @@ pub async fn fetch_tool_with_paths(
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
+
+    if let Some(spec) = lookup_by_crate(crate_name) {
+        let repo = match spec.repo {
+            Some((owner, name)) => RepoInfo {
+                owner: owner.to_string(),
+                repo: name.to_string(),
+            },
+            None => resolve_repo(crate_name).await?,
+        };
+        return fetch_repo_binary_with_paths(
+            spec.crate_name,
+            &[spec.binary_name],
+            &repo,
+            version,
+            spec.tag_prefix,
+            paths,
+        )
+        .await;
+    }
+
     let repo = resolve_repo(crate_name).await?;
-    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, paths).await
+    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, None, paths).await
 }
 
 pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
@@ -110,6 +134,7 @@ async fn fetch_repo_binary_with_paths(
     binary_names: &[&str],
     repo: &RepoInfo,
     version: &VersionSpec,
+    tag_prefix: Option<&str>,
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
@@ -126,7 +151,7 @@ async fn fetch_repo_binary_with_paths(
         }
     }
 
-    let release = fetch_release(repo, version).await?;
+    let release = fetch_release(repo, version, tag_prefix).await?;
 
     if let Some(r) = check_cache(paths, cache_name, &release.version, binary_names, &target)? {
         return Ok(r);
@@ -266,19 +291,28 @@ fn parse_github_url(url: &str) -> Result<RepoInfo, SoldrError> {
 }
 
 /// Fetch release metadata (asset list) from GitHub.
-async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<ReleaseInfo, SoldrError> {
+async fn fetch_release(
+    repo: &RepoInfo,
+    version: &VersionSpec,
+    tag_prefix: Option<&str>,
+) -> Result<ReleaseInfo, SoldrError> {
     let client = http_client()?;
 
     let release = match version {
-        VersionSpec::Latest => {
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/releases/latest",
-                repo.owner, repo.repo
-            );
-            fetch_release_value(&client, repo, &url).await?
-        }
+        VersionSpec::Latest => match tag_prefix {
+            // Monorepo releases: `/releases/latest` may pick a sibling tool;
+            // instead list releases and take the newest whose tag matches.
+            Some(prefix) => fetch_latest_by_prefix(&client, repo, prefix).await?,
+            None => {
+                let url = format!(
+                    "https://api.github.com/repos/{}/{}/releases/latest",
+                    repo.owner, repo.repo
+                );
+                fetch_release_value(&client, repo, &url).await?
+            }
+        },
         VersionSpec::Exact(v) => {
-            let candidate_tags = release_tag_candidates(v);
+            let candidate_tags = release_tag_candidates(v, tag_prefix);
             let mut found = None;
             for tag in &candidate_tags {
                 let url = format!(
@@ -301,7 +335,59 @@ async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<Release
         }
     };
 
-    parse_release_info(release)
+    parse_release_info(release, tag_prefix)
+}
+
+async fn fetch_latest_by_prefix(
+    client: &reqwest::Client,
+    repo: &RepoInfo,
+    prefix: &str,
+) -> Result<serde_json::Value, SoldrError> {
+    let url = format!(
+        "https://api.github.com/repos/{}/{}/releases?per_page=60",
+        repo.owner, repo.repo
+    );
+    let resp = github_request(client, &url)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    if !resp.status().is_success() {
+        return Err(SoldrError::ToolNotFound(format!(
+            "no release found for {}/{}",
+            repo.owner, repo.repo
+        )));
+    }
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    let releases: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| SoldrError::Other(e.to_string()))?;
+
+    let matched = releases
+        .as_array()
+        .and_then(|items| {
+            items.iter().find(|release| {
+                let is_prerelease = release["prerelease"].as_bool().unwrap_or(false);
+                if is_prerelease {
+                    return false;
+                }
+                release["tag_name"]
+                    .as_str()
+                    .map(|tag| tag.starts_with(prefix))
+                    .unwrap_or(false)
+            })
+        })
+        .cloned();
+
+    matched.ok_or_else(|| {
+        SoldrError::ToolNotFound(format!(
+            "no release with tag prefix {prefix:?} found for {}/{}",
+            repo.owner, repo.repo
+        ))
+    })
 }
 
 async fn fetch_release_value(
@@ -372,12 +458,15 @@ async fn fetch_release_by_listing(
     })
 }
 
-fn release_tag_candidates(version: &str) -> Vec<String> {
-    let mut tags = Vec::with_capacity(2);
+fn release_tag_candidates(version: &str, tag_prefix: Option<&str>) -> Vec<String> {
+    let mut tags = Vec::with_capacity(4);
     let raw = version.trim();
     if raw.is_empty() {
         return tags;
     }
+    let bare = raw.trim_start_matches('v').to_string();
+
+    // Core bare + v-prefixed variants.
     tags.push(raw.to_string());
     if let Some(stripped) = raw.strip_prefix('v') {
         if !stripped.is_empty() {
@@ -386,6 +475,13 @@ fn release_tag_candidates(version: &str) -> Vec<String> {
     } else {
         tags.push(format!("v{raw}"));
     }
+
+    // Monorepo-style tags: e.g. `cargo-audit/v0.21.0`.
+    if let Some(prefix) = tag_prefix {
+        tags.push(format!("{prefix}{bare}"));
+        tags.push(format!("{prefix}v{bare}"));
+    }
+
     tags.sort();
     tags.dedup();
     tags
@@ -398,11 +494,18 @@ fn managed_zccache_download_url(version: &str, target: &TargetTriple) -> String 
     )
 }
 
-fn parse_release_info(body: serde_json::Value) -> Result<ReleaseInfo, SoldrError> {
+fn parse_release_info(
+    body: serde_json::Value,
+    tag_prefix: Option<&str>,
+) -> Result<ReleaseInfo, SoldrError> {
     let tag = body["tag_name"]
         .as_str()
         .ok_or_else(|| SoldrError::Other("no tag_name in release".into()))?;
-    let version = tag.trim_start_matches('v').to_string();
+    let stripped = match tag_prefix {
+        Some(prefix) => tag.strip_prefix(prefix).unwrap_or(tag),
+        None => tag,
+    };
+    let version = stripped.trim_start_matches('v').to_string();
 
     let assets = body["assets"]
         .as_array()
@@ -733,13 +836,42 @@ mod tests {
     #[test]
     fn release_tag_candidates_support_plain_and_v_prefixed_tags() {
         assert_eq!(
-            release_tag_candidates("1.2.8"),
+            release_tag_candidates("1.2.8", None),
             vec!["1.2.8".to_string(), "v1.2.8".to_string()]
         );
         assert_eq!(
-            release_tag_candidates("v1.2.8"),
+            release_tag_candidates("v1.2.8", None),
             vec!["1.2.8".to_string(), "v1.2.8".to_string()]
         );
+    }
+
+    #[test]
+    fn release_tag_candidates_include_monorepo_prefix_variants() {
+        let candidates = release_tag_candidates("0.21.0", Some("cargo-audit/"));
+        assert!(candidates.contains(&"0.21.0".to_string()));
+        assert!(candidates.contains(&"v0.21.0".to_string()));
+        assert!(candidates.contains(&"cargo-audit/0.21.0".to_string()));
+        assert!(candidates.contains(&"cargo-audit/v0.21.0".to_string()));
+    }
+
+    #[test]
+    fn parse_release_info_strips_monorepo_tag_prefix() {
+        let body = serde_json::json!({
+            "tag_name": "cargo-audit/v0.21.0",
+            "assets": [],
+        });
+        let info = parse_release_info(body, Some("cargo-audit/")).unwrap();
+        assert_eq!(info.version, "0.21.0");
+    }
+
+    #[test]
+    fn parse_release_info_strips_nextest_prefix() {
+        let body = serde_json::json!({
+            "tag_name": "cargo-nextest-0.9.100",
+            "assets": [],
+        });
+        let info = parse_release_info(body, Some("cargo-nextest-")).unwrap();
+        assert_eq!(info.version, "0.9.100");
     }
 
     #[test]

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -8,6 +8,13 @@ pub mod known_tools;
 
 pub use known_tools::{lookup_by_cargo_subcommand, lookup_by_crate, ToolSpec, KNOWN_TOOLS};
 
+pub mod trust;
+
+pub use trust::{
+    sha256_of, verify_download, PinnedChecksumStore, TrustMode, VerifyOutcome,
+    CHECKSUMS_FILE_ENV_VAR, TRUST_MODE_ENV_VAR,
+};
+
 use soldr_core::{Arch, Env, Os, SoldrError, SoldrPaths, TargetTriple};
 use std::path::{Path, PathBuf};
 
@@ -643,6 +650,31 @@ async fn download_and_extract(
         .bytes()
         .await
         .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    // Integrity + trust enforcement (issue #42). Compute sha256 and consult
+    // the pinned-checksum store before writing anything to disk.
+    let asset_name = url
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(url);
+    let digest = trust::sha256_of(&bytes);
+    let store = trust::PinnedChecksumStore::from_env()?;
+    let mode = trust::TrustMode::from_env();
+    match trust::verify_download(cache_name, version, asset_name, &digest, &store, mode)? {
+        trust::VerifyOutcome::Verified { sha256 } => {
+            eprintln!(
+                "soldr: trust: verified {cache_name} v{version} {asset_name} sha256={sha256}"
+            );
+        }
+        trust::VerifyOutcome::Unverified { sha256 } => {
+            eprintln!(
+                "soldr: trust: unverified {cache_name} v{version} {asset_name} sha256={sha256} (set {} to pin; run with {}=strict to require pins)",
+                trust::CHECKSUMS_FILE_ENV_VAR,
+                trust::TRUST_MODE_ENV_VAR
+            );
+        }
+    }
 
     let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
     let desired_binaries = desired_binary_names(binary_names, target);

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -34,6 +34,8 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.8";
+
 /// Fetch a tool binary for the current platform.
 pub async fn fetch_tool(
     crate_name: &str,
@@ -50,36 +52,95 @@ pub async fn fetch_tool_with_paths(
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
-    let target = TargetTriple::detect()?;
+    let repo = resolve_repo(crate_name).await?;
+    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, paths).await
+}
 
-    // 1. Check local cache (exact version only)
+pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    fetch_zccache_with_paths(&paths).await
+}
+
+pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
+    paths.ensure_dirs()?;
+    let target = TargetTriple::detect()?;
+    let binary_names = ["zccache", "zccache-daemon", "zccache-fp"];
+
+    if let Some(result) = check_cache(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &binary_names,
+        &target,
+    )? {
+        return Ok(result);
+    }
+
+    let download_url = managed_zccache_download_url(MANAGED_ZCCACHE_VERSION, &target);
+    let binary_path = download_and_extract(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &download_url,
+        &target,
+        &binary_names,
+    )
+    .await?;
+
+    Ok(FetchResult {
+        binary_path,
+        version: MANAGED_ZCCACHE_VERSION.to_string(),
+        cached: false,
+    })
+}
+
+pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, SoldrError> {
+    let target = TargetTriple::detect()?;
+    check_cache(
+        paths,
+        "zccache",
+        MANAGED_ZCCACHE_VERSION,
+        &["zccache", "zccache-daemon", "zccache-fp"],
+        &target,
+    )
+}
+
+async fn fetch_repo_binary_with_paths(
+    cache_name: &str,
+    binary_names: &[&str],
+    repo: &RepoInfo,
+    version: &VersionSpec,
+    paths: &SoldrPaths,
+) -> Result<FetchResult, SoldrError> {
+    paths.ensure_dirs()?;
+    let target = TargetTriple::detect()?;
+    if binary_names.is_empty() {
+        return Err(SoldrError::Other(format!(
+            "no binary names configured for {cache_name}"
+        )));
+    }
+
     if let VersionSpec::Exact(ref v) = version {
-        if let Some(r) = check_cache(paths, crate_name, v, &target)? {
+        if let Some(r) = check_cache(paths, cache_name, v, binary_names, &target)? {
             return Ok(r);
         }
     }
 
-    // 2. Resolve repository from crates.io
-    let repo = resolve_repo(crate_name).await?;
+    let release = fetch_release(repo, version).await?;
 
-    // 3. Get release metadata from GitHub
-    let release = fetch_release(&repo, version).await?;
-
-    // 4. Check cache for the resolved version (handles Latest -> concrete version)
-    if let Some(r) = check_cache(paths, crate_name, &release.version, &target)? {
+    if let Some(r) = check_cache(paths, cache_name, &release.version, binary_names, &target)? {
         return Ok(r);
     }
 
-    // 5. Find matching asset for our target
     let asset = match_asset(&release.assets, &target)?;
 
-    // 6. Download and extract
     let binary_path = download_and_extract(
         paths,
-        crate_name,
+        cache_name,
         &release.version,
         &asset.download_url,
         &target,
+        binary_names,
     )
     .await?;
 
@@ -96,15 +157,28 @@ pub async fn fetch_tool_with_paths(
 
 fn check_cache(
     paths: &SoldrPaths,
-    crate_name: &str,
+    cache_name: &str,
     version: &str,
+    binary_names: &[&str],
     target: &TargetTriple,
 ) -> Result<Option<FetchResult>, SoldrError> {
-    let bin_name = format!("{crate_name}{}", target.binary_ext());
-    let tool_dir = paths.bin.join(format!("{crate_name}-{version}"));
+    let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
+    let bin_name = format!(
+        "{}{}",
+        binary_names
+            .first()
+            .ok_or_else(|| SoldrError::Other(format!(
+                "no binary names configured for {cache_name}"
+            )))?,
+        target.binary_ext()
+    );
     let binary_path = tool_dir.join(&bin_name);
 
-    if binary_path.exists() {
+    if binary_names.iter().all(|binary_name| {
+        tool_dir
+            .join(format!("{binary_name}{}", target.binary_ext()))
+            .exists()
+    }) {
         Ok(Some(FetchResult {
             binary_path,
             version: version.to_string(),
@@ -204,21 +278,25 @@ async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<Release
             fetch_release_value(&client, repo, &url).await?
         }
         VersionSpec::Exact(v) => {
-            let tag = if v.starts_with('v') {
-                v.clone()
-            } else {
-                format!("v{v}")
-            };
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/releases/tags/{tag}",
-                repo.owner, repo.repo
-            );
-            match fetch_release_value(&client, repo, &url).await {
-                Ok(release) => release,
-                Err(SoldrError::ToolNotFound(_)) => {
-                    fetch_release_by_listing(&client, repo, &tag).await?
+            let candidate_tags = release_tag_candidates(v);
+            let mut found = None;
+            for tag in &candidate_tags {
+                let url = format!(
+                    "https://api.github.com/repos/{}/{}/releases/tags/{tag}",
+                    repo.owner, repo.repo
+                );
+                match fetch_release_value(&client, repo, &url).await {
+                    Ok(release) => {
+                        found = Some(release);
+                        break;
+                    }
+                    Err(SoldrError::ToolNotFound(_)) => continue,
+                    Err(err) => return Err(err),
                 }
-                Err(err) => return Err(err),
+            }
+            match found {
+                Some(release) => release,
+                None => fetch_release_by_listing(&client, repo, &candidate_tags).await?,
             }
         }
     };
@@ -253,7 +331,7 @@ async fn fetch_release_value(
 async fn fetch_release_by_listing(
     client: &reqwest::Client,
     repo: &RepoInfo,
-    tag: &str,
+    tags: &[String],
 ) -> Result<serde_json::Value, SoldrError> {
     let url = format!(
         "https://api.github.com/repos/{}/{}/releases?per_page=30",
@@ -283,7 +361,7 @@ async fn fetch_release_by_listing(
             items.iter().find(|release| {
                 release["tag_name"]
                     .as_str()
-                    .map(|release_tag| release_tag == tag)
+                    .map(|release_tag| tags.iter().any(|tag| release_tag == tag))
                     .unwrap_or(false)
             })
         })
@@ -292,6 +370,32 @@ async fn fetch_release_by_listing(
     matched.ok_or_else(|| {
         SoldrError::ToolNotFound(format!("no release found for {}/{}", repo.owner, repo.repo))
     })
+}
+
+fn release_tag_candidates(version: &str) -> Vec<String> {
+    let mut tags = Vec::with_capacity(2);
+    let raw = version.trim();
+    if raw.is_empty() {
+        return tags;
+    }
+    tags.push(raw.to_string());
+    if let Some(stripped) = raw.strip_prefix('v') {
+        if !stripped.is_empty() {
+            tags.push(stripped.to_string());
+        }
+    } else {
+        tags.push(format!("v{raw}"));
+    }
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
+fn managed_zccache_download_url(version: &str, target: &TargetTriple) -> String {
+    format!(
+        "https://github.com/zackees/zccache/releases/download/{version}/zccache-{version}-{}.tar.gz",
+        target.triple()
+    )
 }
 
 fn parse_release_info(body: serde_json::Value) -> Result<ReleaseInfo, SoldrError> {
@@ -411,10 +515,11 @@ fn match_asset<'a>(
 
 async fn download_and_extract(
     paths: &SoldrPaths,
-    crate_name: &str,
+    cache_name: &str,
     version: &str,
     url: &str,
     target: &TargetTriple,
+    binary_names: &[&str],
 ) -> Result<PathBuf, SoldrError> {
     let client = http_client()?;
 
@@ -436,18 +541,27 @@ async fn download_and_extract(
         .await
         .map_err(|e| SoldrError::Network(e.to_string()))?;
 
-    let tool_dir = paths.bin.join(format!("{crate_name}-{version}"));
+    let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
+    let desired_binaries = desired_binary_names(binary_names, target);
     std::fs::create_dir_all(&tool_dir)?;
 
-    let bin_name = format!("{crate_name}{}", target.binary_ext());
-    let binary_path = tool_dir.join(&bin_name);
+    let main_binary_name = desired_binaries
+        .first()
+        .cloned()
+        .ok_or_else(|| SoldrError::Other(format!("no binary names configured for {cache_name}")))?;
+    let binary_path = tool_dir.join(&main_binary_name);
 
     if url.ends_with(".zip") {
-        extract_zip(&bytes, &binary_path, &bin_name)?;
+        extract_zip(&bytes, &tool_dir, &desired_binaries)?;
     } else if url.ends_with(".tar.gz") || url.ends_with(".tgz") {
-        extract_tar_gz(&bytes, &binary_path, &bin_name)?;
+        extract_tar_gz(&bytes, &tool_dir, &desired_binaries)?;
     } else {
         // Assume raw binary.
+        if desired_binaries.len() != 1 {
+            return Err(SoldrError::Archive(format!(
+                "cannot extract multiple binaries from raw asset for {cache_name}"
+            )));
+        }
         std::fs::write(&binary_path, &bytes)?;
     }
 
@@ -455,18 +569,29 @@ async fn download_and_extract(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&binary_path)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&binary_path, perms)?;
+        for binary_name in &desired_binaries {
+            let binary_path = tool_dir.join(binary_name);
+            let mut perms = std::fs::metadata(&binary_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&binary_path, perms)?;
+        }
     }
 
     Ok(binary_path)
 }
 
-fn extract_zip(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrError> {
+fn desired_binary_names(binary_names: &[&str], target: &TargetTriple) -> Vec<String> {
+    binary_names
+        .iter()
+        .map(|binary_name| format!("{binary_name}{}", target.binary_ext()))
+        .collect()
+}
+
+fn extract_zip(data: &[u8], dest_dir: &Path, binary_names: &[String]) -> Result<(), SoldrError> {
     let reader = std::io::Cursor::new(data);
     let mut archive =
         zip::ZipArchive::new(reader).map_err(|e| SoldrError::Archive(e.to_string()))?;
+    let mut found = std::collections::BTreeSet::new();
 
     for i in 0..archive.len() {
         let mut file = archive
@@ -482,23 +607,25 @@ fn extract_zip(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrErro
             .and_then(|f| f.to_str())
             .unwrap_or("");
 
-        if file_name == bin_name || file_name == bin_name.trim_end_matches(".exe") {
-            let mut out = std::fs::File::create(dest)?;
+        let wanted = binary_names.iter().find(|binary_name| {
+            file_name == *binary_name || file_name == binary_name.trim_end_matches(".exe")
+        });
+
+        if let Some(binary_name) = wanted {
+            let mut out = std::fs::File::create(dest_dir.join(binary_name))?;
             std::io::copy(&mut file, &mut out)?;
-            return Ok(());
+            found.insert(binary_name.clone());
         }
     }
 
-    Err(SoldrError::Archive(format!(
-        "{bin_name} not found in zip archive"
-    )))
+    ensure_all_binaries_found(binary_names, &found)
 }
 
-fn extract_tar_gz(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrError> {
+fn extract_tar_gz(data: &[u8], dest_dir: &Path, binary_names: &[String]) -> Result<(), SoldrError> {
     let reader = std::io::Cursor::new(data);
     let gz = flate2::read::GzDecoder::new(reader);
     let mut archive = tar::Archive::new(gz);
-    let base_name = bin_name.trim_end_matches(".exe");
+    let mut found = std::collections::BTreeSet::new();
 
     for entry in archive
         .entries()
@@ -511,16 +638,37 @@ fn extract_tar_gz(data: &[u8], dest: &Path, bin_name: &str) -> Result<(), SoldrE
 
         let file_name = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
 
-        if file_name == bin_name || file_name == base_name {
-            let mut out = std::fs::File::create(dest)?;
+        let wanted = binary_names.iter().find(|binary_name| {
+            file_name == *binary_name || file_name == binary_name.trim_end_matches(".exe")
+        });
+
+        if let Some(binary_name) = wanted {
+            let mut out = std::fs::File::create(dest_dir.join(binary_name))?;
             std::io::copy(&mut entry, &mut out)?;
-            return Ok(());
+            found.insert(binary_name.clone());
         }
     }
 
-    Err(SoldrError::Archive(format!(
-        "{bin_name} not found in tar.gz archive"
-    )))
+    ensure_all_binaries_found(binary_names, &found)
+}
+
+fn ensure_all_binaries_found(
+    binary_names: &[String],
+    found: &std::collections::BTreeSet<String>,
+) -> Result<(), SoldrError> {
+    let missing = binary_names
+        .iter()
+        .filter(|binary_name| !found.contains(*binary_name))
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(SoldrError::Archive(format!(
+            "missing binaries in archive: {}",
+            missing.join(", ")
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -580,5 +728,30 @@ mod tests {
 
         let selected = match_asset(&assets, &target).unwrap();
         assert_eq!(selected.name, "tool-x86_64-unknown-linux-musl.tar.gz");
+    }
+
+    #[test]
+    fn release_tag_candidates_support_plain_and_v_prefixed_tags() {
+        assert_eq!(
+            release_tag_candidates("1.2.8"),
+            vec!["1.2.8".to_string(), "v1.2.8".to_string()]
+        );
+        assert_eq!(
+            release_tag_candidates("v1.2.8"),
+            vec!["1.2.8".to_string(), "v1.2.8".to_string()]
+        );
+    }
+
+    #[test]
+    fn managed_zccache_download_url_uses_target_triple() {
+        let target = TargetTriple {
+            arch: Arch::Aarch64,
+            os: Os::MacOs,
+            env: Env::None,
+        };
+        assert_eq!(
+            managed_zccache_download_url("1.2.8", &target),
+            "https://github.com/zackees/zccache/releases/download/1.2.8/zccache-1.2.8-aarch64-apple-darwin.tar.gz"
+        );
     }
 }

--- a/crates/soldr-fetch/src/trust.rs
+++ b/crates/soldr-fetch/src/trust.rs
@@ -1,0 +1,352 @@
+//! Integrity and trust policy for fetched binaries.
+//!
+//! `soldr` has historically treated every successful GitHub-Releases download
+//! as authentic. Issue #42 requires that claim to be backed by actual integrity
+//! enforcement. This module adds the primitives:
+//!
+//! - `sha256_of(bytes)` — compute the canonical integrity hash of an archive.
+//! - `TrustMode` — `permissive` (default) or `strict`, read from
+//!   `SOLDR_TRUST_MODE`.
+//! - `PinnedChecksumStore` — loaded from a TOML file referenced by
+//!   `SOLDR_CHECKSUMS_FILE`, or returned empty if the env var is unset.
+//! - `verify_download(asset, tool, version, sha256, store, mode)` — returns a
+//!   `VerifyOutcome` that the caller logs and obeys.
+//!
+//! The fetch path then:
+//! 1. Always prints the computed sha256 to stderr so humans can audit it.
+//! 2. If a pin exists for the asset and mismatches, returns an error in any
+//!    mode. This is the "no longer implicitly trusted" guarantee.
+//! 3. If no pin exists and mode is `strict`, refuses to install. In
+//!    `permissive` mode it installs and prints a `trust: unverified` warning.
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use soldr_core::SoldrError;
+use std::collections::HashMap;
+use std::path::Path;
+
+pub const TRUST_MODE_ENV_VAR: &str = "SOLDR_TRUST_MODE";
+pub const CHECKSUMS_FILE_ENV_VAR: &str = "SOLDR_CHECKSUMS_FILE";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustMode {
+    /// Default. Unverified fetches install but emit a warning.
+    Permissive,
+    /// Every fetch must match a pinned checksum; unverified fetches fail.
+    Strict,
+}
+
+impl TrustMode {
+    pub fn from_env() -> Self {
+        match std::env::var(TRUST_MODE_ENV_VAR)
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("strict") => Self::Strict,
+            Some("permissive") | Some("") | None => Self::Permissive,
+            Some(other) => {
+                eprintln!(
+                    "soldr: ignoring unknown {TRUST_MODE_ENV_VAR}={other:?}; expected \"permissive\" or \"strict\""
+                );
+                Self::Permissive
+            }
+        }
+    }
+}
+
+/// A single pinned checksum entry. Keyed by (tool, version, asset name) so
+/// asset matching stays platform-scoped — a Windows MSVC zip and a Linux musl
+/// tar.gz for the same tool+version carry different checksums.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+struct RawPinnedChecksum {
+    tool: String,
+    version: String,
+    asset: String,
+    sha256: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct RawPinnedFile {
+    #[serde(default, rename = "tool")]
+    tools: Vec<RawPinnedChecksum>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PinnedChecksumStore {
+    // (tool, version, asset) → sha256 (lowercase hex)
+    entries: HashMap<(String, String, String), String>,
+}
+
+impl PinnedChecksumStore {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_env() -> Result<Self, SoldrError> {
+        match std::env::var(CHECKSUMS_FILE_ENV_VAR) {
+            Ok(path) if !path.trim().is_empty() => Self::from_file(Path::new(path.trim())),
+            _ => Ok(Self::empty()),
+        }
+    }
+
+    pub fn from_file(path: &Path) -> Result<Self, SoldrError> {
+        let text = std::fs::read_to_string(path).map_err(|e| {
+            SoldrError::Other(format!(
+                "failed to read {CHECKSUMS_FILE_ENV_VAR} at {}: {e}",
+                path.display()
+            ))
+        })?;
+        Self::from_toml(&text)
+    }
+
+    pub fn from_toml(text: &str) -> Result<Self, SoldrError> {
+        let raw: RawPinnedFile = toml::from_str(text).map_err(|e| {
+            SoldrError::Other(format!("failed to parse pinned checksums TOML: {e}"))
+        })?;
+        let mut entries = HashMap::new();
+        for entry in raw.tools {
+            let sha = entry.sha256.trim().to_ascii_lowercase();
+            if !is_hex64(&sha) {
+                return Err(SoldrError::Other(format!(
+                    "pinned sha256 for {}@{} asset {} is not a 64-char hex string",
+                    entry.tool, entry.version, entry.asset
+                )));
+            }
+            entries.insert((entry.tool, entry.version, entry.asset), sha);
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn lookup(&self, tool: &str, version: &str, asset: &str) -> Option<&str> {
+        self.entries
+            .get(&(tool.to_string(), version.to_string(), asset.to_string()))
+            .map(|s| s.as_str())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+fn is_hex64(s: &str) -> bool {
+    s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Compute the canonical SHA-256 hex digest of a downloaded archive.
+pub fn sha256_of(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifyOutcome {
+    /// A pinned checksum existed and matched.
+    Verified { sha256: String },
+    /// No pinned checksum exists for this (tool, version, asset); permissive
+    /// mode installed it anyway.
+    Unverified { sha256: String },
+}
+
+/// Verify a downloaded archive against a pinned checksum store and the active
+/// trust mode.
+///
+/// Returns `Err` in two cases:
+/// 1. A pin exists for this (tool, version, asset) and does not match. Always
+///    an error regardless of mode.
+/// 2. No pin exists and mode is `Strict`.
+pub fn verify_download(
+    tool: &str,
+    version: &str,
+    asset_name: &str,
+    sha256: &str,
+    store: &PinnedChecksumStore,
+    mode: TrustMode,
+) -> Result<VerifyOutcome, SoldrError> {
+    let actual = sha256.to_ascii_lowercase();
+    match store.lookup(tool, version, asset_name) {
+        Some(expected) => {
+            if expected == actual {
+                Ok(VerifyOutcome::Verified { sha256: actual })
+            } else {
+                Err(SoldrError::Other(format!(
+                    "trust: pinned sha256 mismatch for {tool} v{version} asset {asset_name}\n  expected: {expected}\n  actual:   {actual}"
+                )))
+            }
+        }
+        None => match mode {
+            TrustMode::Strict => Err(SoldrError::Other(format!(
+                "trust: no pinned checksum for {tool} v{version} asset {asset_name}; refusing fetch under {TRUST_MODE_ENV_VAR}=strict"
+            ))),
+            TrustMode::Permissive => Ok(VerifyOutcome::Unverified { sha256: actual }),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_of_matches_expected_digest() {
+        // sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        assert_eq!(
+            sha256_of(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        // sha256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        assert_eq!(
+            sha256_of(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn trust_mode_defaults_to_permissive() {
+        // Not touching the process env to avoid races; validate the parser.
+        let parse = |v: Option<&str>| match v.map(str::to_ascii_lowercase).as_deref() {
+            Some("strict") => TrustMode::Strict,
+            _ => TrustMode::Permissive,
+        };
+        assert_eq!(parse(None), TrustMode::Permissive);
+        assert_eq!(parse(Some("strict")), TrustMode::Strict);
+        assert_eq!(parse(Some("permissive")), TrustMode::Permissive);
+    }
+
+    #[test]
+    fn pinned_store_parses_toml_entries() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "cargo-nextest"
+            version = "0.9.100"
+            asset = "cargo-nextest-0.9.100-x86_64-pc-windows-msvc.zip"
+            sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+        "#;
+        let store = PinnedChecksumStore::from_toml(toml_text).unwrap();
+        assert_eq!(
+            store.lookup(
+                "cargo-nextest",
+                "0.9.100",
+                "cargo-nextest-0.9.100-x86_64-pc-windows-msvc.zip"
+            ),
+            Some("0000000000000000000000000000000000000000000000000000000000000000")
+        );
+        assert!(store
+            .lookup("cargo-nextest", "0.9.100", "other.zip")
+            .is_none());
+    }
+
+    #[test]
+    fn pinned_store_rejects_malformed_sha256() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "x"
+            version = "1"
+            asset = "x.zip"
+            sha256 = "not-a-hex-string"
+        "#;
+        let err = PinnedChecksumStore::from_toml(toml_text).unwrap_err();
+        assert!(err.to_string().contains("64-char hex"));
+    }
+
+    #[test]
+    fn verify_download_accepts_matching_pin() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "cargo-nextest"
+            version = "0.9.100"
+            asset = "cargo-nextest.zip"
+            sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        "#;
+        let store = PinnedChecksumStore::from_toml(toml_text).unwrap();
+        let outcome = verify_download(
+            "cargo-nextest",
+            "0.9.100",
+            "cargo-nextest.zip",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            &store,
+            TrustMode::Strict,
+        )
+        .unwrap();
+        assert!(matches!(outcome, VerifyOutcome::Verified { .. }));
+    }
+
+    #[test]
+    fn verify_download_rejects_pin_mismatch_in_either_mode() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "t"
+            version = "1"
+            asset = "a.zip"
+            sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        "#;
+        let store = PinnedChecksumStore::from_toml(toml_text).unwrap();
+        for mode in [TrustMode::Permissive, TrustMode::Strict] {
+            let err = verify_download(
+                "t",
+                "1",
+                "a.zip",
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                &store,
+                mode,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("pinned sha256 mismatch"));
+        }
+    }
+
+    #[test]
+    fn verify_download_strict_mode_rejects_missing_pin() {
+        let store = PinnedChecksumStore::empty();
+        let err = verify_download(
+            "cargo-nextest",
+            "0.9.100",
+            "cargo-nextest.zip",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            &store,
+            TrustMode::Strict,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("no pinned checksum"));
+    }
+
+    #[test]
+    fn verify_download_permissive_mode_allows_missing_pin() {
+        let store = PinnedChecksumStore::empty();
+        let outcome = verify_download(
+            "cargo-nextest",
+            "0.9.100",
+            "cargo-nextest.zip",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            &store,
+            TrustMode::Permissive,
+        )
+        .unwrap();
+        assert!(matches!(outcome, VerifyOutcome::Unverified { .. }));
+    }
+
+    #[test]
+    fn verify_download_is_case_insensitive_on_the_digest() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "t"
+            version = "1"
+            asset = "a.zip"
+            sha256 = "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
+        "#;
+        let store = PinnedChecksumStore::from_toml(toml_text).unwrap();
+        let outcome = verify_download(
+            "t",
+            "1",
+            "a.zip",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            &store,
+            TrustMode::Strict,
+        )
+        .unwrap();
+        assert!(matches!(outcome, VerifyOutcome::Verified { .. }));
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,8 @@ Current support policy:
 - the supported external integration surface is invoking the `soldr` executable through documented commands and flags
 - the internal Rust crates are not a supported public API
 - wrapper mode and internal environment variables are operational mechanics, not a general-purpose API contract
-- human-oriented command output is not yet the stable machine-facing protocol; explicit structured output is future work tracked in [#44](https://github.com/zackees/soldr/issues/44)
+- human-oriented command output is not the stable machine-facing protocol
+- the first stable machine-facing protocol is the JSON mode on selected commands documented below
 
 ---
 
@@ -134,6 +135,12 @@ soldr --no-cache cargo test
 
 Show cache and target information.
 
+Stable machine-facing mode:
+
+```bash
+soldr status --json
+```
+
 ### `soldr clean`
 
 Clear the managed local zccache artifact cache and remove soldr's zccache session state directory.
@@ -146,9 +153,57 @@ Show or set configuration.
 
 Inspect managed zccache status.
 
+Stable machine-facing mode:
+
+```bash
+soldr cache --json
+```
+
 ### `soldr version`
 
 Print soldr version.
+
+Stable machine-facing mode:
+
+```bash
+soldr version --json
+```
+
+---
+
+## Structured JSON Output
+
+The supported JSON protocol currently exists on:
+
+- `soldr status --json`
+- `soldr cache --json`
+- `soldr version --json`
+
+The JSON response always includes:
+
+- `schema_version`
+- `command`
+
+Current schema version:
+
+- `schema_version: 1`
+
+Compatibility rules for schema version `1`:
+
+- existing fields keep their current meaning
+- fields may be added in later releases without changing `schema_version`
+- removing a field, renaming a field, or changing the meaning/type of an existing field requires a new schema version
+- human-readable stdout for commands without `--json` is not covered by this compatibility promise
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "command": "version",
+  "soldr_version": "0.2.0-beta"
+}
+```
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.2.0-beta"
+  "soldr_version": "0.6.0"
 }
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.6.0"
+  "soldr_version": "0.7.0"
 }
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,9 @@
 # soldr API Reference
 
+This file is the CLI reference for `soldr`.
+
+For the product-level support contract about what counts as a supported external API, see [API_BOUNDARY.md](./API_BOUNDARY.md).
+
 ## Overview
 
 soldr is a single front door for Rust tool execution and Rust builds.
@@ -14,6 +18,15 @@ It has three invocation modes:
    Low-level passthrough wrapper mode for explicit `RUSTC_WRAPPER=soldr` usage.
 
 The primary user experience is `soldr cargo ...`.
+
+## Machine-Facing Support Level
+
+Current support policy:
+
+- the supported external integration surface is invoking the `soldr` executable through documented commands and flags
+- the internal Rust crates are not a supported public API
+- wrapper mode and internal environment variables are operational mechanics, not a general-purpose API contract
+- human-oriented command output is not yet the stable machine-facing protocol; explicit structured output is future work tracked in [#44](https://github.com/zackees/soldr/issues/44)
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,11 +7,11 @@ soldr is a single front door for Rust tool execution and Rust builds.
 It has three invocation modes:
 
 1. `soldr cargo ...`
-   Delegates to the real Cargo binary while wiring soldr into the build path.
+   Delegates to the real Cargo binary while wiring soldr-managed zccache into the build path.
 2. `soldr <tool> [args...]`
    Fetches and runs a Rust CLI tool binary.
 3. `soldr rustc ...`
-   Internal wrapper mode used during builds after `soldr cargo ...` sets `RUSTC_WRAPPER=soldr`.
+   Low-level passthrough wrapper mode for explicit `RUSTC_WRAPPER=soldr` usage.
 
 The primary user experience is `soldr cargo ...`.
 
@@ -25,14 +25,26 @@ The primary user experience is `soldr cargo ...`.
 soldr cargo build --release
 soldr cargo test
 soldr cargo run -- --help
+soldr --no-cache cargo build
 ```
 
 Behavior:
 
 - Resolve the real `cargo` binary through `rustup`
 - Resolve the matching real `rustc` binary through `rustup`
-- Set `RUSTC_WRAPPER` to the current `soldr` executable
+- Fetch a pinned managed `zccache` release when caching is enabled
+- Set `RUSTC_WRAPPER` to the current soldr binary
+- Pass the managed `zccache` binary path into wrapper mode through the environment
+- Start a per-build zccache session on zccache's current default daemon endpoint
 - Delegate to Cargo with the exact flags the user passed
+
+Current cache-control behavior:
+
+- caching is enabled by default for `soldr cargo ...`
+- `soldr --no-cache cargo ...` disables soldr's compilation-cache path for that invocation
+- `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
+- zccache integration currently targets Rust builds through the cargo front door
+- zccache's current artifact store and daemon endpoint remain on zccache's default paths; soldr currently manages the session lifecycle and logs
 
 This is the normal build entry point.
 
@@ -75,8 +87,9 @@ In this mode, soldr should act as the transparent build-assistance layer around 
 
 Current implementation status:
 
-- Wrapper-mode passthrough to real `rustc` exists
-- Cache and daemon behavior are still being implemented
+- Wrapper mode still transparently resolves the real `rustc`
+- The normal cache-enabled build path now runs through soldr wrapper mode and delegates into managed `zccache`
+- If caching is disabled, wrapper mode falls through to real `rustc` without zccache involvement
 
 ---
 
@@ -101,6 +114,7 @@ Run Cargo through soldr's front door.
 soldr cargo build --release
 soldr cargo test --workspace
 soldr cargo check -p soldr-cli
+soldr --no-cache cargo test
 ```
 
 ### `soldr status`
@@ -109,7 +123,7 @@ Show cache and target information.
 
 ### `soldr clean`
 
-Clear caches.
+Clear the managed local zccache artifact cache and remove soldr's zccache session state directory.
 
 ### `soldr config`
 
@@ -117,7 +131,7 @@ Show or set configuration.
 
 ### `soldr cache`
 
-Inspect build-cache state.
+Inspect managed zccache status.
 
 ### `soldr version`
 
@@ -148,11 +162,14 @@ Commands:
 | Variable | Purpose | Default |
 |---|---|---|
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
+| `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
+| `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
+| `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 
-`RUSTC_WRAPPER=soldr cargo build` remains a valid low-level integration path, but it is no longer the preferred user-facing workflow.
+`RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 
 ---
 
@@ -190,5 +207,6 @@ For bootstrap verification of another Rust project:
 The key design rule is simple:
 
 - users build through `soldr cargo ...`
-- soldr uses wrapper mode internally
+- soldr owns the wrapper slot on the common path
+- soldr delegates cache-enabled wrapper invocations into managed zccache
 - users do not need to manually wire `RUSTC_WRAPPER` for the common path

--- a/docs/API_BOUNDARY.md
+++ b/docs/API_BOUNDARY.md
@@ -10,7 +10,7 @@ Current repo policy is:
 - the supported external surface is the `soldr` executable, not the internal Rust workspace crates
 - there is no supported public Rust crate API, C ABI, or FFI surface
 - there is no supported long-running daemon or local service protocol today
-- the first future machine-facing API should be explicit CLI commands with structured JSON output, tracked in [#44](https://github.com/zackees/soldr/issues/44)
+- the first supported machine-facing API is explicit CLI commands with structured JSON output on selected commands
 
 ## What Is Supported Today
 
@@ -19,9 +19,12 @@ Supported use today means invoking the `soldr` binary as a subprocess through do
 - `soldr cargo ...`
 - `soldr <tool>[@version] ...`
 - `soldr status`
+- `soldr status --json`
 - `soldr cache`
+- `soldr cache --json`
 - `soldr clean`
 - `soldr version`
+- `soldr version --json`
 
 The current CLI reference lives in [API.md](./API.md).
 
@@ -34,13 +37,14 @@ The following are implementation details and may change without a semver promise
 - undocumented environment variables or wrapper-mode conventions
 - the exact on-disk cache/session layout beyond what is explicitly documented for users
 - human-oriented stdout/stderr wording unless a command is explicitly documented as structured and stable
+- commands that do not explicitly document `--json` as a supported protocol surface
 
 ## Future Direction
 
 The intended progression is:
 
 1. Keep `soldr` binary-first.
-2. Add explicit JSON output for selected commands that need automation support.
+2. Expand explicit JSON output only for selected commands that need automation support.
 3. Version that structured output as an external protocol.
 4. Only consider a daemon or other long-running local protocol if a real use case appears that the CLI cannot serve cleanly.
 

--- a/docs/API_BOUNDARY.md
+++ b/docs/API_BOUNDARY.md
@@ -1,0 +1,56 @@
+# Machine-Facing API Boundary
+
+This document defines the supported external integration boundary for `soldr`.
+
+## Decision Summary
+
+Current repo policy is:
+
+- `soldr` is a binary-first product
+- the supported external surface is the `soldr` executable, not the internal Rust workspace crates
+- there is no supported public Rust crate API, C ABI, or FFI surface
+- there is no supported long-running daemon or local service protocol today
+- the first future machine-facing API should be explicit CLI commands with structured JSON output, tracked in [#44](https://github.com/zackees/soldr/issues/44)
+
+## What Is Supported Today
+
+Supported use today means invoking the `soldr` binary as a subprocess through documented commands and flags such as:
+
+- `soldr cargo ...`
+- `soldr <tool>[@version] ...`
+- `soldr status`
+- `soldr cache`
+- `soldr clean`
+- `soldr version`
+
+The current CLI reference lives in [API.md](./API.md).
+
+## What Is Not A Supported Public API
+
+The following are implementation details and may change without a semver promise to automation consumers:
+
+- the internal Rust crates in `crates/`
+- direct use of `soldr-core`, `soldr-fetch`, `soldr-cache`, or `soldr-cli` as library dependencies
+- undocumented environment variables or wrapper-mode conventions
+- the exact on-disk cache/session layout beyond what is explicitly documented for users
+- human-oriented stdout/stderr wording unless a command is explicitly documented as structured and stable
+
+## Future Direction
+
+The intended progression is:
+
+1. Keep `soldr` binary-first.
+2. Add explicit JSON output for selected commands that need automation support.
+3. Version that structured output as an external protocol.
+4. Only consider a daemon or other long-running local protocol if a real use case appears that the CLI cannot serve cleanly.
+
+If a daemon or other protocol is ever added, it should be documented and versioned as a separate external interface. It should not expose the internal Rust crate graph and call that the supported API.
+
+## Non-Goals
+
+This repo is not currently pursuing:
+
+- a stable public Rust library API
+- a stable embeddable C ABI
+- undocumented machine parsing of human help/status text
+- a background service that third parties are expected to integrate with by default

--- a/docs/PYPI_TRUSTED_PUBLISHING.md
+++ b/docs/PYPI_TRUSTED_PUBLISHING.md
@@ -1,0 +1,88 @@
+# PyPI Trusted Publishing
+
+This document describes the repo-side and owner-side steps needed to publish `soldr` wheels to PyPI using GitHub Actions OIDC Trusted Publishing.
+
+It is intentionally PyPI-only. crates.io publication is not part of the current `0.5.x` release direction.
+
+## Current State
+
+As of April 14, 2026:
+
+- the release workflow can build hardened `soldr` wheels when `publish_pypi=true`
+- the workflow can publish those wheels through `pypa/gh-action-pypi-publish` in a dedicated OIDC job
+- the existing PyPI project `soldr` already exists
+- the current public PyPI `0.1.0` file details say `Uploaded using Trusted Publishing? No`
+
+The next secure PyPI release should replace that stale packaging path with the real wheel set built from the validated release workflow.
+
+## Why This Uses Trusted Publishing
+
+PyPI Trusted Publishing avoids long-lived API tokens.
+
+The workflow receives a short-lived upload credential from PyPI using the GitHub Actions OIDC identity for a specific repository, workflow file, and optional environment.
+
+For `soldr`, the intended trusted identity is:
+
+- owner: `zackees`
+- repository: `soldr`
+- workflow: `.github/workflows/release.yml`
+- environment: `release`
+
+Using the existing `release` environment keeps the PyPI publish step behind the same manual approval gate as the immutable GitHub release path.
+
+## Owner Setup On PyPI
+
+These steps must be performed in the PyPI web UI by a maintainer of the `soldr` project.
+
+1. Open the `soldr` project on PyPI.
+2. Click `Manage`.
+3. Open the `Publishing` page in the project sidebar.
+4. Add a new GitHub Actions publisher with:
+   - repository owner: `zackees`
+   - repository name: `soldr`
+   - workflow filename: `.github/workflows/release.yml`
+   - environment name: `release`
+
+The environment field is optional in PyPI, but it should be filled in here because the repo already uses `release` as the human approval boundary.
+
+## Repo-Side Workflow Inputs
+
+The release workflow supports these PyPI-related inputs:
+
+- `publish_pypi=true`
+- `pypi_repository_url=...` for alternate endpoints such as TestPyPI
+
+If `publish_pypi=false`, the workflow keeps its GitHub-release-only behavior.
+
+If `publish_pypi=true`, the workflow:
+
+1. Builds hardened wheels on the supported platform runners.
+2. Smoke-tests the built wheel on each runner by installing it and running `soldr --version`.
+3. Publishes the GitHub Release.
+4. Publishes the wheel set to PyPI from a dedicated Linux job with `id-token: write`.
+
+No source distribution is published in this path. The current design is wheel-only because the project is prioritizing hardened binary distribution rather than source release through package registries.
+
+## Recommended Rehearsal
+
+Before enabling real PyPI publishing, rehearse against TestPyPI.
+
+Recommended command:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=false \
+  -f publish_pypi=true \
+  -f pypi_repository_url=https://test.pypi.org/legacy/
+```
+
+This uses a real publish path instead of `dry_run=true`, because the OIDC publisher exchange only happens in the real publish job.
+
+## Expected Manual Stop
+
+The repo-side work can be completed without additional secrets.
+
+If the PyPI trusted publisher has not been registered yet, that PyPI-side publisher registration is the remaining manual stop. Until that is done, the PyPI publish job will not be able to mint a trusted upload token.

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -1,0 +1,179 @@
+# Release 0.5 Checklist
+
+This document is the concrete execution list for the first attested secure `soldr 0.5` release.
+
+It assumes the current repository state on April 13, 2026:
+
+- the validated release workflow exists in `.github/workflows/release.yml`
+- the workflow requires an exact commit SHA on `release`
+- publication uses a dedicated GitHub App
+- `v*.*.*` tags are protected by repository rulesets
+- immutable GitHub Releases are enabled
+- `main` and `release` are protected
+
+## 1. Freeze The `0.5` Product Surface
+
+Decide what `0.5` means for the user-facing CLI.
+
+Required decision:
+
+- the `0.5` release line is the front-door build and tool-fetch line
+- built-in zccache-backed compilation caching is part of the front-door `0.5.x` line
+- `status`, `clean`, `config`, and `cache` must not be presented as complete features unless implemented
+
+Do not ship `0.5` with placeholder commands presented as finished behavior.
+
+## 2. Freeze The `0.5` Security Claim
+
+Resolve the open policy questions in:
+
+- issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
+- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
+
+Minimum decisions needed before `0.5`:
+
+- whether checksum plus `gh attestation verify` is the official verification story
+- whether SBOM generation is required for `0.5`
+- whether reproducible-build claims are in scope for `0.5`
+- whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
+- what trust statement applies to third-party binaries fetched by `soldr` at runtime
+
+## 3. Rehearse The Release Path
+
+Before the first public `0.5` tag, run a dry-run rehearsal from `release`.
+
+Inputs to choose:
+
+- candidate version such as `v0.5.0-rc1`
+- exact commit SHA on `release`
+
+Required checks:
+
+- the workflow rejects SHAs not reachable from `release`
+- the workflow completes lint, test, packaging, and e2e gates for the exact SHA
+- the `release` environment approval gate triggers as expected
+- the GitHub App token step succeeds
+- checksums and provenance attestation steps succeed
+
+Recommended command path:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=true
+```
+
+## 4. Verify The Governance Controls Manually
+
+Before the first real release, verify the controls that live outside the git tree.
+
+```bash
+gh api repos/zackees/soldr/rulesets
+gh api repos/zackees/soldr/environments
+gh api repos/zackees/soldr/branches/main/protection
+gh api repos/zackees/soldr/branches/release/protection
+gh api repos/zackees/soldr/immutable-releases
+```
+
+Success criteria:
+
+- the `v*.*.*` tag ruleset is active
+- only the release GitHub App can bypass that ruleset
+- `release` still requires approval from `@zackees`
+- `main` and `release` still require the expected checks
+- immutable releases remain enabled
+
+## 5. Cut A Real Release Candidate
+
+After the dry run passes, create the first real release candidate through the workflow.
+
+Recommended first tag:
+
+- `v0.5.0-rc1`
+
+Required checks after publication:
+
+- the GitHub Release contains all expected platform archives
+- the `SHA256SUMS` manifest is present
+- `gh attestation verify` succeeds for at least one downloaded archive
+- a human cannot create, move, or delete the release tag manually
+- the release cannot be mutated after publication because immutable releases are enabled
+
+## 6. Enable Trusted PyPI Publishing If `0.5.0` Will Ship Wheels
+
+If PyPI is part of `0.5.0`, configure the existing `soldr` project for Trusted Publishing before the final release.
+
+Required setup:
+
+- add the GitHub Actions trusted publisher on PyPI for:
+  - owner: `zackees`
+  - repository: `soldr`
+  - workflow: `.github/workflows/release.yml`
+  - environment: `release`
+- confirm the existing `soldr` PyPI project is the correct project and that stale pre-Trusted-Publishing metadata will be superseded by the next upload
+
+Recommended rehearsal:
+
+- use TestPyPI first with the same workflow and `publish_pypi=true`
+- pass `pypi_repository_url=https://test.pypi.org/legacy/`
+- treat this as a real publish rehearsal, not a `dry_run`, because OIDC publish cannot be fully exercised in the workflow's dry-run path
+
+Recommended command path:
+
+```bash
+gh workflow run release.yml \
+  --ref release \
+  -f version=v0.5.0-rc1 \
+  -f commit_sha=<40-char-sha> \
+  -f dry_run=false \
+  -f publish_pypi=true \
+  -f pypi_repository_url=https://test.pypi.org/legacy/
+```
+
+Recommended GitHub-release verification commands:
+
+```bash
+gh release view v0.5.0-rc1 --repo zackees/soldr
+gh attestation verify soldr-v0.5.0-rc1-x86_64-unknown-linux-gnu.tar.gz \
+  --repo zackees/soldr \
+  --signer-workflow zackees/soldr/.github/workflows/release.yml
+```
+
+## 7. Audit The First Published Release
+
+After `v0.5.0-rc1`, confirm that reality matches the docs:
+
+- [RELEASE.md](../RELEASE.md)
+- [RELEASE_VERIFICATION.md](./RELEASE_VERIFICATION.md)
+- [RELEASE_GOVERNANCE_CHECKLIST.md](./RELEASE_GOVERNANCE_CHECKLIST.md)
+- [PYPI_TRUSTED_PUBLISHING.md](./PYPI_TRUSTED_PUBLISHING.md)
+- [TRUST_BOUNDARIES.md](./TRUST_BOUNDARIES.md)
+
+Anything discovered during the RC must become either:
+
+- a code fix
+- a GitHub settings fix
+- an explicit documented limitation
+
+## 8. Decide Go Or No-Go For `v0.5.0`
+
+Ship `v0.5.0` only when all of these are true:
+
+- the intended `0.5` CLI surface is clearly scoped and honestly documented
+- the release workflow has passed in dry-run and real-release modes
+- the first RC was verified with checksums and attestations
+- the protected-tag and immutable-release controls behaved as expected
+- if PyPI is in scope, Trusted Publishing was exercised successfully against TestPyPI or PyPI with the hardened wheel set
+- the remaining policy questions are closed or explicitly deferred in writing
+
+## 9. Gate `1.0.0-rc`
+
+Do not cut `1.0.0-rc` until:
+
+- `soldr cargo ...` enables managed zccache by default with `--no-cache` as the explicit opt-out
+- the cache-enabled wrapper path delegates through managed zccache instead of acting as pure rustc pass-through
+- the public cache commands describe and manage real behavior instead of placeholders
+
+If those are not true, stay on the `0.5.x` line.

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -28,15 +28,15 @@ Do not ship `0.5` with placeholder commands presented as finished behavior.
 Confirm the documented policy decisions in:
 
 - issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
-- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
+- issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy, with implementation follow-up in [#41](https://github.com/zackees/soldr/issues/41) and [#42](https://github.com/zackees/soldr/issues/42)
 
 Current decisions for `0.5`:
 
 - checksum plus `gh attestation verify` is the official user-facing verification story
 - SBOM generation is not required for `0.5`
 - reproducible-build claims are out of scope for `0.5`
-- whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
-- what trust statement applies to third-party binaries fetched by `soldr` at runtime
+- `0.5.x` does not claim hermetic builds; vendoring or mirroring Cargo, toolchain, OS-package, and pinned bootstrap-test inputs is deferred hardening tracked in [#41](https://github.com/zackees/soldr/issues/41)
+- third-party binaries fetched by `soldr` at runtime remain an upstream trust decision on `0.5.x`, not a repository-side trust guarantee; stronger enforcement is tracked in [#42](https://github.com/zackees/soldr/issues/42)
 
 ## 3. Rehearse The Release Path
 

--- a/docs/RELEASE_0_5_CHECKLIST.md
+++ b/docs/RELEASE_0_5_CHECKLIST.md
@@ -25,16 +25,16 @@ Do not ship `0.5` with placeholder commands presented as finished behavior.
 
 ## 2. Freeze The `0.5` Security Claim
 
-Resolve the open policy questions in:
+Confirm the documented policy decisions in:
 
 - issue [#12](https://github.com/zackees/soldr/issues/12) for verification, SBOM, and reproducibility policy
 - issue [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust policy
 
-Minimum decisions needed before `0.5`:
+Current decisions for `0.5`:
 
-- whether checksum plus `gh attestation verify` is the official verification story
-- whether SBOM generation is required for `0.5`
-- whether reproducible-build claims are in scope for `0.5`
+- checksum plus `gh attestation verify` is the official user-facing verification story
+- SBOM generation is not required for `0.5`
+- reproducible-build claims are out of scope for `0.5`
 - whether vendoring or mirroring Cargo, toolchain, or OS-package inputs is required now or deferred
 - what trust statement applies to third-party binaries fetched by `soldr` at runtime
 

--- a/docs/RELEASE_GOVERNANCE_CHECKLIST.md
+++ b/docs/RELEASE_GOVERNANCE_CHECKLIST.md
@@ -26,9 +26,12 @@ The intended release-governance state is:
 
 Observed on April 13, 2026 via GitHub API:
 
-- no repository rulesets for release tags
+- an active repository tag ruleset protects `refs/tags/v*.*.*`
+- the release-tag ruleset blocks tag creation, update, and deletion
+- the release GitHub App is the only bypass actor for that ruleset
 - the `release` environment exists and requires approval from `@zackees`
 - `main` branch protection requires pull requests, conversation resolution, linear history, and the current CI plus per-target e2e checks
+- `release` branch protection requires the same validation gate before promotion
 - immutable GitHub Releases are enabled
 - GitHub Actions requires full-SHA pinning for third-party actions
 - no published GitHub Releases yet
@@ -37,14 +40,16 @@ Those observations were produced with:
 
 ```bash
 gh api repos/zackees/soldr/rulesets
+gh api repos/zackees/soldr/rulesets/15033379
 gh api repos/zackees/soldr/environments
 gh api repos/zackees/soldr/branches/main/protection
+gh api repos/zackees/soldr/branches/release/protection
 gh api repos/zackees/soldr/actions/permissions
 gh api repos/zackees/soldr/immutable-releases
 gh api repos/zackees/soldr/releases?per_page=5
 ```
 
-The tag-ruleset query still returns an empty list. That is intentional for now: GitHub rejected a repository-ruleset bypass entry for the built-in `github-actions` integration on this personal repository, which means a true workflow-only tag rule needs either a different repository ownership model or a dedicated installed GitHub App.
+The ruleset now exists and is active. The critical detail is not just that a tag ruleset exists, but that the only bypass actor is the dedicated release GitHub App rather than a human maintainer or a PAT-backed workaround.
 
 ## Audit Steps
 
@@ -59,14 +64,17 @@ gh api repos/zackees/soldr/rulesets
 What to look for:
 
 - a ruleset that applies to release tag patterns such as `v*`
+- the ruleset is active
+- tag creation, update, and deletion are all blocked by default
+- the only bypass actor is the dedicated release GitHub App
 - protection against moving or deleting release tags
 - restrictions that make the validated workflow the normal release path
 
-Current limitation:
+Current constraint:
 
-- On this personal repository, GitHub rejected a bypass actor for the built-in `github-actions` integration when attempting to create a workflow-only release-tag ruleset.
-- Do not replace this with a maintainer-user bypass or PAT-backed workaround and call it equivalent. That would weaken the workflow-only release intent.
-- If strict workflow-only tags are required, solve this with repository-ownership changes or a dedicated installed GitHub App whose token is used by the release workflow.
+- On this personal repository, the built-in `github-actions` integration was not suitable as the bypass actor for a workflow-only tag rule.
+- The current secure model uses a dedicated installed GitHub App instead.
+- Do not replace the App bypass with a maintainer-user bypass or PAT-backed workaround and call it equivalent.
 
 ### 2. Check The Release Environment
 
@@ -86,15 +94,17 @@ The validated release workflow already targets `environment: release`, so this e
 
 ### 3. Check Branch Protection Or Equivalent Rulesets
 
-Confirm that the default branch is protected either by branch protection or a ruleset-based equivalent:
+Confirm that both `main` and `release` are protected either by branch protection or a ruleset-based equivalent:
 
 ```bash
 gh api repos/zackees/soldr/branches/main/protection
+gh api repos/zackees/soldr/branches/release/protection
 ```
 
 What to look for:
 
 - pull requests are required for `main`
+- `release` is also protected and requires the same validation gate
 - the required-check list includes:
   - `Lint`
   - `Linux x64`

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -22,9 +22,11 @@ Those positions are deliberate. They may be revisited later, but they are the cu
 For a normal `soldr` release:
 
 - the release workflow is started manually with an explicit version and exact commit SHA
-- that exact commit must be reachable from `main`
+- that exact commit must be reachable from the protected `release` branch
 - the workflow re-runs lint, workspace build, tests, integration, and all supported e2e bootstrap jobs for that exact commit
 - release archives are built from that exact commit
+- the version tag is protected by repository rulesets and created through the release workflow path
+- the published GitHub Release is immutable once published
 - a SHA-256 checksum manifest is published with the release assets
 - GitHub build provenance attestations are generated for the published assets
 
@@ -32,8 +34,6 @@ For a normal `soldr` release:
 
 The current release flow does not yet claim all of the following:
 
-- immutable GitHub Releases
-- protected release-tag rulesets enforced outside the git tree
 - SBOM publication
 - independently reproduced builds by a second builder
 - fully hermetic inputs for rustup, crates.io, OS packages, or third-party test inputs

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -38,7 +38,7 @@ The current release flow does not yet claim all of the following:
 - independently reproduced builds by a second builder
 - fully hermetic inputs for rustup, crates.io, OS packages, or third-party test inputs
 
-The release-governance and hermetic-input follow-up items remain tracked in issues [#11](https://github.com/zackees/soldr/issues/11) and [#13](https://github.com/zackees/soldr/issues/13). SBOM publication and independently reproduced builds are intentionally outside the current release claim.
+The release-governance and hermetic-input follow-up items remain tracked in issues [#11](https://github.com/zackees/soldr/issues/11), [#41](https://github.com/zackees/soldr/issues/41), and [#42](https://github.com/zackees/soldr/issues/42). SBOM publication and independently reproduced builds are intentionally outside the current release claim.
 
 ## Release Asset Names
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -4,6 +4,19 @@ This document describes how to verify a published `soldr` release today.
 
 It is intentionally limited to what the repository currently implements.
 
+## Verification Policy
+
+The current `soldr` verification policy is:
+
+- the official user-facing verification path is checksum verification plus `gh attestation verify`
+- GitHub CLI is the primary documented tool for attestation verification
+- Sigstore-compatible offline verification remains possible through downloaded attestation bundles, but it is not the primary documented path
+- `soldr` does not currently require or publish SBOMs for the release line
+- `soldr` does not currently claim independently reproducible builds
+- `soldr` does not currently publish extra signed metadata beyond the checksum manifest and GitHub provenance attestations
+
+Those positions are deliberate. They may be revisited later, but they are the current release policy rather than open questions.
+
 ## What The Current Release Flow Guarantees
 
 For a normal `soldr` release:
@@ -25,7 +38,7 @@ The current release flow does not yet claim all of the following:
 - independently reproduced builds by a second builder
 - fully hermetic inputs for rustup, crates.io, OS packages, or third-party test inputs
 
-Those follow-up items are tracked in issues [#11](https://github.com/zackees/soldr/issues/11), [#12](https://github.com/zackees/soldr/issues/12), and [#13](https://github.com/zackees/soldr/issues/13).
+The release-governance and hermetic-input follow-up items remain tracked in issues [#11](https://github.com/zackees/soldr/issues/11) and [#13](https://github.com/zackees/soldr/issues/13). SBOM publication and independently reproduced builds are intentionally outside the current release claim.
 
 ## Release Asset Names
 
@@ -62,7 +75,9 @@ The checksum step tells you the file you downloaded matches the checksum manifes
 
 ## Step 2: Verify The Artifact Attestation
 
-Use GitHub CLI's attestation support to verify the artifact provenance:
+Use GitHub CLI's attestation support to verify the artifact provenance.
+
+This is the primary documented verification path for `soldr`:
 
 ```bash
 gh attestation verify soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz \
@@ -90,7 +105,7 @@ This validates that GitHub has a matching attestation for the artifact and that 
 
 It does not, by itself, prove that every external input used during the build was mirrored or hermetic. For the current trust boundary inventory, see [TRUST_BOUNDARIES.md](./TRUST_BOUNDARIES.md).
 
-## Optional: Offline Verification
+## Optional: Offline Verification And Sigstore-Compatible Bundles
 
 GitHub CLI also supports downloading attestation bundles and verifying them offline.
 
@@ -101,13 +116,15 @@ gh attestation download soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz --repo zack
 gh attestation trusted-root
 ```
 
-Offline verification is not yet the primary documented path for `soldr`, but it remains available if you want to archive bundles and trusted roots alongside release artifacts.
+Offline verification is not the primary documented path for `soldr`, but it remains available if you want to archive bundles and trusted roots alongside release artifacts.
+
+This is also the nearest current equivalent to a Sigstore-style workflow for this repository. We do not require users to install separate Sigstore tooling as part of the normal `soldr` verification story.
 
 ## About `gh release verify`
 
 GitHub CLI also has `gh release verify`, which verifies release-level attestations.
 
-We do not currently document that as the primary verification path for `soldr` because immutable releases and the surrounding release-governance settings are still tracked separately. Today, the repository's strongest implemented verification path is:
+We do not currently document that as the primary verification path for `soldr` because immutable releases and the surrounding release-governance settings are still tracked separately. Today, the repository's official verification path is:
 
 1. checksum verification
 2. artifact attestation verification with `gh attestation verify`

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -2,7 +2,7 @@
 
 This document describes the current external trust boundaries for `soldr`.
 
-It is a factual inventory of what the project trusts today, not a claim that every trust edge is already ideal.
+It records both the factual inventory of what the project trusts today and the current repo policy for which of those trust edges are acceptable on the `0.5.x` line.
 
 ## Controlled Inputs
 
@@ -27,6 +27,16 @@ Even with a validated release workflow, the release path still depends on extern
   - Published crate versions are immutable, but the transport and index are still external.
 - GitHub APIs and GitHub Releases
   - The release workflow uses GitHub services to create releases, publish assets, and store attestations.
+
+## Audit: What The Published Release Artifacts Depend On
+
+Based on the committed release workflow in `.github/workflows/release.yml`:
+
+- the published `soldr` release archives are built from the repository source tree plus Rust dependencies resolved through Cargo
+- the workflow does not explicitly download and repackage third-party release binaries into the published `soldr` archives
+- the release path still depends on external services and package sources such as GitHub-hosted runners, `rustup`, crates.io, and GitHub APIs
+- the live `apt` install and pinned third-party repository checkout are part of release-gating validation, not packaged release contents
+- the managed `zccache` download path is runtime behavior in `soldr`, not an input to building the published `soldr` release artifacts
 
 ## E2E Validation External Dependencies
 
@@ -64,7 +74,7 @@ It does not yet enforce:
 - upstream artifact attestations
 - mirrored internal copies of third-party tool binaries
 
-## Current Policy Direction
+## Current Policy Decisions
 
 Current repo policy is:
 
@@ -72,11 +82,27 @@ Current repo policy is:
 - make external trust edges explicit in documentation
 - treat floating workflow refs as unacceptable
 - prefer exact commit or version selection where possible
+- `0.5.x` does not claim hermetic builds
+- the documented release-time dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt` in the bootstrap e2e path, and the pinned third-party bootstrap repository are acceptable for `0.5.x`
+- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are accepted future hardening work, but they are not blockers for the current `0.5.x` release line
+- the pinned third-party bootstrap checkout is acceptable for current validation, but it must not be described as mirrored or hermetic
+- release verification for `soldr` covers the published `soldr` artifacts and their provenance, not every external input used during CI
 
-Open follow-up decisions are tracked in:
+## Current Runtime Fetch Policy
+
+Current `0.5.x` policy for runtime-fetched binaries is:
+
+- `soldr` fetching a third-party tool is a convenience/bootstrap path, not a repository-side trust guarantee
+- a successful fetch currently means crates.io metadata and GitHub Releases produced a matching archive for the selected target and `soldr` extracted it successfully
+- `soldr` does not currently enforce maintainer allowlists, repo-managed checksums, upstream signatures, upstream attestations, or mirrored copies before executing a fetched tool
+- the managed `zccache` path is pinned to a repo-chosen version, but it still uses the same direct GitHub Release download model and is not independently checksum- or attestation-verified by `soldr` itself today
+- stronger runtime trust enforcement is accepted follow-up work, but it is not part of the current `0.5.x` trust claim
+
+Open follow-up implementation issues are tracked in:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
-- [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust hardening
+- [#41](https://github.com/zackees/soldr/issues/41) for reducing live external release inputs
+- [#42](https://github.com/zackees/soldr/issues/42) for fetched-binary trust enforcement
 
 ## Practical Reading Of This Document
 
@@ -84,6 +110,6 @@ If you are deciding whether to trust a published `soldr` release:
 
 - trust the validated GitHub workflow run and artifact attestation for the released commit
 - separately evaluate whether the remaining external build inputs are acceptable for your threat model
-- separately evaluate whether `soldr` fetching third-party tool binaries at runtime is acceptable for your threat model
+- separately evaluate whether `soldr` fetching third-party tool binaries at runtime is acceptable for your threat model, because that remains an upstream trust decision on `0.5.x`
 
 Those are related but distinct trust decisions.

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -47,12 +47,28 @@ The bootstrap e2e jobs currently trust additional external systems:
 
 - Ubuntu package repositories
   - musl validation jobs install `musl-tools` from live `apt` repositories
+  - the install command uses `--no-install-recommends`, a retry loop, and logs the resolved `musl-tools` version for auditability; the set of installed packages is therefore the declared set, not an open-ended recommended expansion
 - third-party source repository hosting
   - the e2e workflow checks out a pinned commit of `zackees/running-process` from GitHub
 - third-party Rust toolchain installation
   - the e2e workflow reads the third-party project's `rust-toolchain.toml` and installs that toolchain through `rustup`
 
 These inputs are pinned where possible, but they are not yet mirrored or fully hermetic.
+
+## Hermetic Inputs Hardening Status
+
+Tracked by #41. Concrete narrowings already in place:
+
+- the `musl-tools` install uses `--no-install-recommends` so the Ubuntu package surface is exactly what the release path declares
+- the `musl-tools` install logs its resolved version so the exact package contents are visible in workflow logs
+- the `musl-tools` install retries on transient apt failures rather than either flapping or pulling unrelated extras
+
+Still deferred (acceptable follow-up, not blockers for the current line):
+
+- a `cargo vendor` or mirrored-registry strategy for crates.io resolution during release
+- a mirrored or prebuilt-image strategy for Rust toolchain acquisition during release
+- a mirror for the pinned third-party bootstrap repository checkout
+- replacement of the live `apt` repository with a prebuilt image or pinned-package snapshot
 
 ## Runtime Tool-Fetch Trust Boundaries
 

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -27,6 +27,9 @@ Even with a validated release workflow, the release path still depends on extern
   - Published crate versions are immutable, but the transport and index are still external.
 - GitHub APIs and GitHub Releases
   - The release workflow uses GitHub services to create releases, publish assets, and store attestations.
+- PyPI
+  - Optional hardened wheel publication relies on PyPI's Trusted Publishing and package hosting.
+  - The project already has an existing `soldr` PyPI record whose ownership and publisher settings live outside this repository.
 
 ## Audit: What The Published Release Artifacts Depend On
 

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -69,10 +69,16 @@ That means the runtime tool-fetch path currently trusts:
 - GitHub repository ownership and release contents for the target tool
 - HTTPS transport to those services
 
+Integrity enforcement that is in place today:
+
+- SHA-256 is always computed on the downloaded archive and printed to stderr
+- user-supplied per-asset SHA-256 pins from `SOLDR_CHECKSUMS_FILE` are enforced as hard errors on mismatch
+- `SOLDR_TRUST_MODE=strict` refuses any fetch without a matching pin
+
 It does not yet enforce:
 
 - maintainer allowlists
-- per-tool checksums committed in this repo
+- repo-committed default checksums for tools shipped in the `known_tools` registry
 - upstream signatures
 - upstream artifact attestations
 - mirrored internal copies of third-party tool binaries
@@ -93,19 +99,37 @@ Current repo policy is:
 
 ## Current Runtime Fetch Policy
 
-Current `0.5.x` policy for runtime-fetched binaries is:
+As of the `0.6.x` line, `soldr` enforces integrity on every third-party fetch:
 
-- `soldr` fetching a third-party tool is a convenience/bootstrap path, not a repository-side trust guarantee
-- a successful fetch currently means crates.io metadata and GitHub Releases produced a matching archive for the selected target and `soldr` extracted it successfully
-- `soldr` does not currently enforce maintainer allowlists, repo-managed checksums, upstream signatures, upstream attestations, or mirrored copies before executing a fetched tool
-- the managed `zccache` path is pinned to a repo-chosen version, but it still uses the same direct GitHub Release download model and is not independently checksum- or attestation-verified by `soldr` itself today
-- stronger runtime trust enforcement is accepted follow-up work, but it is not part of the current `0.5.x` trust claim
+- every downloaded archive has its SHA-256 computed before extraction; the digest is printed to stderr so a human or CI log grep can audit what actually installed
+- users can pin per-asset SHA-256 values in a TOML file at the path named by `SOLDR_CHECKSUMS_FILE`; any pin mismatch is a hard error regardless of mode
+- `SOLDR_TRUST_MODE=strict` refuses to install any tool that does not have a matching pin
+- `SOLDR_TRUST_MODE=permissive` (the default) installs and emits a `trust: unverified` warning when no pin is available; this preserves the convenience/bootstrap path while making the trust state legible
+- the managed `zccache` download goes through the same verification path as any other fetch
+
+Example pin file layout:
+
+```toml
+[[tool]]
+tool = "cargo-nextest"
+version = "0.9.100"
+asset = "cargo-nextest-0.9.100-x86_64-pc-windows-msvc.zip"
+sha256 = "0123...cdef"   # 64-char lowercase hex
+```
+
+What is still deferred:
+
+- maintainer allowlists (limiting which crate/repo pairs `soldr` will even attempt to fetch)
+- upstream signature or attestation verification
+- mirrored internal copies of third-party tool binaries
+
+Those remain acceptable future hardening work and are tracked on the issues linked below.
 
 Open follow-up implementation issues are tracked in:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
 - [#41](https://github.com/zackees/soldr/issues/41) for reducing live external release inputs
-- [#42](https://github.com/zackees/soldr/issues/42) for fetched-binary trust enforcement
+- [#42](https://github.com/zackees/soldr/issues/42) for fetched-binary trust enforcement (checksum enforcement landed; allowlist/signature work still open)
 
 ## Practical Reading Of This Document
 

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -76,7 +76,6 @@ Current repo policy is:
 Open follow-up decisions are tracked in:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
-- [#12](https://github.com/zackees/soldr/issues/12) for verification and reproducibility policy
 - [#13](https://github.com/zackees/soldr/issues/13) for hermeticity and runtime trust hardening
 
 ## Practical Reading Of This Document


### PR DESCRIPTION
## Summary

Syncs \`release\` branch to \`main\` so \`release.yml\` can cut \`v0.7.0\` from the release branch HEAD. Tracking: #93.

This bundles everything that landed on main since the \`v0.6.0\` cut:
- Ecosystem fetch registry + cargo-subcommand dispatch (#84, #85, #86, #87)
- Trust policy (#88)
- Musl install hardening (#89)
- LICENSE alignment (#90)
- CLAUDE.md refresh (#91)
- \`--as <version>\` trampoline (#92)
- Version bump to 0.7.0 (#94)

Following the existing sync pattern from #78, this will be squash-merged to \`release\` so the branch gets one sync commit per release cut.

## Post-merge

- [ ] Dispatch \`release.yml\` with \`version=v0.7.0\`, \`dry_run=true\`, \`commit_sha=<release HEAD>\`
- [ ] Review dry-run; if clean, dispatch again with \`dry_run=false\`, \`publish_pypi=true\` (requires environment approval)

Refs #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)