### PR TITLE
chore: sync release branch to v0.7.0

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -57,8 +57,33 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
+          # Narrower input surface per #41:
+          # - --no-install-recommends prevents apt from pulling in optional deps,
+          #   so the exact package set is what the release path declares.
+          # - a small retry loop makes transient apt/mirror errors recoverable
+          #   without weakening the installed set.
+          # - the resolved package version is logged so it is auditable from
+          #   the workflow run.
+          attempts=0
+          max_attempts=3
+          until sudo apt-get update; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get update failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+          attempts=0
+          until sudo apt-get install -y --no-install-recommends musl-tools; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get install musl-tools failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+          dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,41 +38,50 @@ uv run maturin build --release         # Build wheel
 Four-crate Rust workspace under `crates/`:
 
 - **soldr-core** — Shared types, config (`~/.soldr/config.toml`), target triple resolution (MSVC default on Windows at runtime), error types. No I/O beyond config files.
-- **soldr-fetch** — Binary resolution chain: local cache → binstall metadata → GitHub Releases → QuickInstall → `cargo install` (last resort). Manages `~/.soldr/bin/`.
+- **soldr-fetch** — Binary resolution. Ships two sub-modules:
+  - `known_tools` — registry of ecosystem tools with explicit GitHub `(owner, repo)`, cargo subcommand mapping, and optional monorepo tag prefix (e.g. `cargo-audit/v0.21.0`). Keeps dispatch off the crates.io round-trip and handles per-tool release quirks.
+  - `trust` — SHA-256 computation + `SOLDR_TRUST_MODE` / `SOLDR_CHECKSUMS_FILE` enforcement. Every fetch emits a `trust: verified` or `trust: unverified` line and a pin mismatch is a hard error regardless of mode.
+  - Resolution chain: local cache → registry-or-crates.io repo lookup → GitHub Releases asset download → extract.
 - **soldr-cache** — `RUSTC_WRAPPER` logic: hash inputs (blake3), check `~/.soldr/cache/`, daemon IPC (Unix socket / Windows named pipe), LRU eviction.
-- **soldr-cli** — Thin dispatch layer. `main()` with mode detection, clap for built-ins, exec for tool fetch. No business logic here.
+- **soldr-cli** — Thin dispatch layer. `main()` with mode detection, clap for built-ins, exec for tool fetch. The cargo front door (`soldr cargo ...`) inspects the first positional arg; if it matches a `known_tools` `cargo_subcommand`, the corresponding `cargo-<sub>` binary is fetched and prepended to `PATH` before cargo runs.
 
 Dependency flow: `soldr-cli → {soldr-core, soldr-fetch, soldr-cache}`, both fetch and cache depend on `soldr-core`.
 
 Python package (`src/soldr/`) wraps the CLI binary via Maturin as `soldr._native`.
 
+## Supported Tools
+
+Two categories, surfaced as first-class subcommands or via the generic fetch path:
+
+**Rustup toolchain passthroughs** (resolved via `rustup which`):
+`rustc`, `rustfmt`, `clippy-driver`, `rustdoc`, `rust-gdb`, `rust-lldb`, `rust-analyzer`.
+
+**Ecosystem fetches** (registered in `known_tools`, pulled from GitHub Releases):
+- cargo subcommands invoked via `soldr cargo <sub>`: `nextest`, `deny`, `audit`, `llvm-cov`, `udeps`, `semver-checks`, `expand`, `watch`.
+- top-level tools invoked directly via `soldr <tool>`: `cross`, `mdbook`, `cbindgen`, `wasm-pack`, `trunk`, `sccache`.
+
+Anything not registered falls through the generic External subcommand, which resolves via crates.io → GitHub Releases.
+
 ## Key Design Rules
 
-- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
+- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
 - **MSVC on Windows always**: Default to `x86_64-pc-windows-msvc` (or aarch64). Only use GNU if `rust-toolchain.toml` explicitly says so. Target resolved at runtime, not compile-time.
 - **Pre-built first**: Try every binary source before `cargo install`. Resolution order matters.
 - **RUSTC_WRAPPER defaults to zccache**: If `RUSTC_WRAPPER` is not set, soldr defaults to using `zccache` as the wrapper.
 - **Daemon auto-starts**: First `RUSTC_WRAPPER` call starts the cache daemon transparently. No manual `soldr start`.
+- **Integrity is default**: every fetch records sha256. Pins are opt-in via `SOLDR_CHECKSUMS_FILE`; `SOLDR_TRUST_MODE=strict` refuses unpinned fetches.
 - **Version independence**: Users install once and forget. CI should pin: `pip install soldr==X.Y.Z`.
 
 ## Toolchain
 
-- Rust 1.85 (rust-toolchain.toml), edition 2021, MSRV 1.75
+- Rust 1.94.1 (rust-toolchain.toml), edition 2021, MSRV 1.75
 - Python >=3.10 (for PyPI distribution via Maturin)
 - uv for Python dependency management
 - Workspace dependencies shared in root `Cargo.toml`
-
-## Implementation Status
-
-Currently in **Phase 1 (Tool Fetcher MVP)**. All crate lib.rs files are stubs; CLI skeleton exists with clap commands that print "(not yet implemented)". See DESIGN.md for the four-phase roadmap.
 
 ## Reference Docs
 
 - `DESIGN.md` — Authoritative implementation guide, architecture decisions, phase roadmap
 - `docs/API.md` — Full CLI specification, environment variables, cache layout
+- `docs/TRUST_BOUNDARIES.md` — Runtime fetch policy, what integrity is enforced, what remains follow-up
 - `README.md` — User-facing motivation and prior art comparison
-
-## Known Issues
-
-- CLI currently has `Build` and `Run` subcommands that contradict DESIGN.md (which says no `soldr build` and tool fetch should be the bare `soldr <tool>` form, not `soldr run <tool>`)
-- LICENSE file says MIT but Cargo.toml specifies BSD-3-Clause

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1400,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "serde",
@@ -1460,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "serde",
@@ -1475,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "tempfile",
@@ -1485,17 +1502,20 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "flate2",
+ "hex",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "soldr-core",
  "tar",
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.6.0" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.6.0" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.6.0" }
+soldr-core = { path = "crates/soldr-core", version = "0.7.0" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.0" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.7.0" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
@@ -27,6 +27,8 @@ thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 blake3 = "1"
+sha2 = "0.10"
+hex = "0.4"
 reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 tempfile = "3"
 zip = "2"

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,29 @@
-MIT License
+BSD 3-Clause License
 
-Copyright (c) 2019 zackees
+Copyright (c) 2019, zackees
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -8,6 +8,13 @@ const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 const JSON_SCHEMA_VERSION: u32 = 1;
 
+/// Pin a specific soldr version to handle this invocation. Explicit
+/// `--as <version>` flag takes precedence over this env var.
+const SOLDR_AS_ENV_VAR: &str = "SOLDR_AS";
+/// Sentinel that the currently-running soldr was itself invoked by another
+/// soldr through `--as`. Prevents infinite hand-offs.
+const SOLDR_TRAMPOLINING_ENV_VAR: &str = "SOLDR_TRAMPOLINING";
+
 #[derive(Parser)]
 #[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
 struct Cli {
@@ -100,14 +107,57 @@ async fn main() {
         std::process::exit(run_rustc_wrapper(&raw_args).unwrap_or_else(report_and_exit));
     }
 
-    if let Err(e) = run().await {
-        eprintln!("soldr: {e}");
-        std::process::exit(1);
+    // `--as <version>` trampoline. Peeled off before clap so the fetched
+    // older soldr parses its own argv on its own terms.
+    let (pinned_version, trampoline_args) = match extract_as_pin(&raw_args[1..]) {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("soldr: {e}");
+            std::process::exit(1);
+        }
+    };
+    let pinned_version = pinned_version.or_else(|| {
+        std::env::var(SOLDR_AS_ENV_VAR)
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    });
+
+    if let Some(version) = pinned_version {
+        if should_trampoline(&version) {
+            std::process::exit(
+                run_trampoline(&version, &trampoline_args)
+                    .await
+                    .unwrap_or_else(report_and_exit),
+            );
+        }
+        // Short-circuit: requested version == current. Continue with args
+        // that have `--as <ver>` stripped.
+        std::process::exit(
+            run_with_args(&raw_args[0], &trampoline_args)
+                .await
+                .unwrap_or_else(report_and_exit),
+        );
     }
+
+    let rc = run_with_args(&raw_args[0], &raw_args[1..])
+        .await
+        .unwrap_or_else(report_and_exit);
+    std::process::exit(rc);
 }
 
-async fn run() -> Result<(), SoldrError> {
-    let cli = Cli::parse();
+async fn run_with_args(prog: &str, args: &[String]) -> Result<i32, SoldrError> {
+    let mut argv: Vec<String> = Vec::with_capacity(args.len() + 1);
+    argv.push(prog.to_string());
+    argv.extend(args.iter().cloned());
+    // Use parse_from (not try_parse_from) so clap handles --help / --version /
+    // usage errors with its built-in exit(0) / exit(2), matching the original
+    // invocation path's UX exactly.
+    let cli = Cli::parse_from(argv);
+    run_cli(cli).await.map(|_| 0)
+}
+
+async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
     let cache_enabled = !cli.no_cache;
 
     match cli.command {
@@ -199,6 +249,113 @@ fn report_and_exit(error: SoldrError) -> i32 {
     1
 }
 
+/// Extract `--as <version>` or `--as=<version>` from the leading flag
+/// region of the user's argv. Stops scanning at the first non-flag
+/// positional (conventionally the subcommand), so a `--as` appearing
+/// after `cargo` belongs to cargo and is left alone.
+fn extract_as_pin(args: &[String]) -> Result<(Option<String>, Vec<String>), SoldrError> {
+    let mut out: Vec<String> = Vec::with_capacity(args.len());
+    let mut version: Option<String> = None;
+    let mut before_subcommand = true;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if !before_subcommand {
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--as" {
+            let value = iter.next().ok_or_else(|| {
+                SoldrError::Other("--as requires a version argument, e.g. --as 0.5.2".into())
+            })?;
+            if version.is_some() {
+                return Err(SoldrError::Other("--as specified more than once".into()));
+            }
+            if value.is_empty() {
+                return Err(SoldrError::Other(
+                    "--as version argument must not be empty".into(),
+                ));
+            }
+            version = Some(value.clone());
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--as=") {
+            if version.is_some() {
+                return Err(SoldrError::Other("--as specified more than once".into()));
+            }
+            if value.is_empty() {
+                return Err(SoldrError::Other(
+                    "--as= requires a version, e.g. --as=0.5.2".into(),
+                ));
+            }
+            version = Some(value.to_string());
+            continue;
+        }
+        if arg == "--" {
+            before_subcommand = false;
+            out.push(arg.clone());
+            continue;
+        }
+        if arg.starts_with('-') {
+            out.push(arg.clone());
+            continue;
+        }
+        before_subcommand = false;
+        out.push(arg.clone());
+    }
+    Ok((version, out))
+}
+
+/// True when the requested version is different from this binary's. A match
+/// short-circuits the trampoline so the current in-process soldr handles it.
+fn should_trampoline(requested: &str) -> bool {
+    let current = env!("CARGO_PKG_VERSION");
+    normalize_version(requested) != normalize_version(current)
+}
+
+fn normalize_version(v: &str) -> String {
+    v.trim().trim_start_matches('v').to_string()
+}
+
+async fn run_trampoline(version: &str, args: &[String]) -> Result<i32, SoldrError> {
+    if let Ok(prior) = std::env::var(SOLDR_TRAMPOLINING_ENV_VAR) {
+        return Err(SoldrError::Other(format!(
+            "refusing to trampoline again: this process was already reached via `--as` from soldr {prior}. Drop the inner --as flag."
+        )));
+    }
+
+    eprintln!("soldr: trampolining to soldr@{version}...");
+    let result =
+        soldr_fetch::fetch_tool("soldr", &VersionSpec::Exact(normalize_version(version))).await?;
+
+    if result.cached {
+        eprintln!(
+            "soldr: using cached soldr v{} at {}",
+            result.version,
+            result.binary_path.display()
+        );
+    } else {
+        eprintln!(
+            "soldr: downloaded soldr v{} to {}",
+            result.version,
+            result.binary_path.display()
+        );
+    }
+
+    let status = std::process::Command::new(&result.binary_path)
+        .args(args)
+        .env(SOLDR_TRAMPOLINING_ENV_VAR, env!("CARGO_PKG_VERSION"))
+        .status()
+        .map_err(|e| {
+            SoldrError::Other(format!(
+                "failed to exec soldr v{} at {}: {e}",
+                result.version,
+                result.binary_path.display()
+            ))
+        })?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
 /// Known toolchain binaries that cargo may invoke through RUSTC_WRAPPER
 /// or RUSTC_WORKSPACE_WRAPPER. When soldr is set as a wrapper, cargo
 /// passes: `soldr <toolchain-binary> <rustc-args...>`
@@ -281,6 +438,11 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     let paths = SoldrPaths::new()?;
     paths.ensure_dirs()?;
 
+    // If the user invoked a known ecosystem subcommand (e.g. `cargo nextest`),
+    // fetch the corresponding `cargo-<sub>` binary and prepend its directory to
+    // PATH so cargo's subcommand dispatch finds it.
+    let extra_bin_dirs = ensure_known_subcommand_tool(args, &paths).await?;
+
     let mut command = std::process::Command::new(cargo);
     command.args(args);
     command.env("RUSTC", rustc);
@@ -288,10 +450,10 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
         soldr_cache::CACHE_ENABLED_ENV_VAR,
         soldr_cache::cache_enabled_env_value(cache_enabled),
     );
-    command.env(
-        "PATH",
-        prepend_path(&cargo_bin_dir, existing_path.as_deref())?,
-    );
+    let mut path_dirs: Vec<std::path::PathBuf> = Vec::with_capacity(1 + extra_bin_dirs.len());
+    path_dirs.push(cargo_bin_dir);
+    path_dirs.extend(extra_bin_dirs);
+    command.env("PATH", prepend_paths(&path_dirs, existing_path.as_deref())?);
     if let Some(target) = default_cargo_build_target(args)? {
         command.env("CARGO_BUILD_TARGET", target);
     }
@@ -347,15 +509,67 @@ fn cargo_args_use_reserved_no_cache(args: &[String]) -> bool {
     false
 }
 
-fn prepend_path(
-    dir: &std::path::Path,
+fn prepend_paths(
+    dirs: &[std::path::PathBuf],
     existing_path: Option<&std::ffi::OsStr>,
 ) -> Result<std::ffi::OsString, SoldrError> {
-    let mut paths = vec![dir.to_path_buf()];
+    let mut paths: Vec<std::path::PathBuf> = dirs.to_vec();
     if let Some(existing_path) = existing_path {
         paths.extend(std::env::split_paths(existing_path));
     }
     std::env::join_paths(paths).map_err(|e| SoldrError::Other(format!("invalid PATH: {e}")))
+}
+
+/// Return the first positional argument (skipping flags) of the cargo
+/// front-door args, which is conventionally the cargo subcommand.
+fn first_cargo_subcommand(args: &[String]) -> Option<&str> {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        return Some(arg.as_str());
+    }
+    None
+}
+
+async fn ensure_known_subcommand_tool(
+    args: &[String],
+    paths: &SoldrPaths,
+) -> Result<Vec<std::path::PathBuf>, SoldrError> {
+    let Some(sub) = first_cargo_subcommand(args) else {
+        return Ok(Vec::new());
+    };
+    let Some(spec) = soldr_fetch::lookup_by_cargo_subcommand(sub) else {
+        return Ok(Vec::new());
+    };
+
+    eprintln!("soldr: fetching {}...", spec.crate_name);
+    let result =
+        soldr_fetch::fetch_tool_with_paths(spec.crate_name, &VersionSpec::Latest, paths).await?;
+
+    if result.cached {
+        eprintln!(
+            "soldr: using cached {} v{}",
+            spec.crate_name, result.version
+        );
+    } else {
+        eprintln!("soldr: downloaded {} v{}", spec.crate_name, result.version);
+    }
+
+    let dir = result
+        .binary_path
+        .parent()
+        .ok_or_else(|| {
+            SoldrError::Other(format!(
+                "failed to resolve bin dir for fetched {}",
+                spec.crate_name
+            ))
+        })?
+        .to_path_buf();
+    Ok(vec![dir])
 }
 
 fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError> {
@@ -720,7 +934,10 @@ fn cached_managed_zccache(
 
 #[cfg(test)]
 mod tests {
-    use super::{cargo_args_specify_target, cargo_args_use_reserved_no_cache, parse_tool_spec};
+    use super::{
+        cargo_args_specify_target, cargo_args_use_reserved_no_cache, extract_as_pin,
+        first_cargo_subcommand, normalize_version, parse_tool_spec, should_trampoline,
+    };
     use soldr_fetch::VersionSpec;
 
     #[test]
@@ -764,5 +981,160 @@ mod tests {
         let (tool, version) = parse_tool_spec("maturin");
         assert_eq!(tool, "maturin");
         assert!(matches!(version, VersionSpec::Latest));
+    }
+
+    #[test]
+    fn first_cargo_subcommand_skips_leading_flags() {
+        assert_eq!(
+            first_cargo_subcommand(&["--verbose".into(), "nextest".into(), "run".into()]),
+            Some("nextest")
+        );
+        assert_eq!(
+            first_cargo_subcommand(&["nextest".into(), "run".into()]),
+            Some("nextest")
+        );
+        assert_eq!(first_cargo_subcommand(&["--help".into()]), None);
+        assert_eq!(first_cargo_subcommand(&[]), None);
+    }
+
+    #[test]
+    fn first_cargo_subcommand_stops_at_passthrough_separator() {
+        assert_eq!(
+            first_cargo_subcommand(&["--".into(), "nextest".into()]),
+            None
+        );
+    }
+
+    #[test]
+    fn known_subcommand_registry_recognizes_phase_two_tools() {
+        for sub in ["nextest", "deny", "audit", "llvm-cov"] {
+            let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
+                .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
+            assert_eq!(spec.cargo_subcommand, Some(sub));
+            assert!(spec.crate_name.starts_with("cargo-"));
+        }
+    }
+
+    #[test]
+    fn known_subcommand_registry_recognizes_phase_three_tools() {
+        for sub in ["udeps", "semver-checks", "expand", "watch"] {
+            let spec = soldr_fetch::lookup_by_cargo_subcommand(sub)
+                .unwrap_or_else(|| panic!("missing registry entry for cargo {sub}"));
+            assert_eq!(spec.cargo_subcommand, Some(sub));
+            assert!(spec.crate_name.starts_with("cargo-"));
+        }
+    }
+
+    #[test]
+    fn top_level_tools_are_not_cargo_subcommands() {
+        for crate_name in [
+            "cross",
+            "mdbook",
+            "cbindgen",
+            "wasm-pack",
+            "trunk",
+            "sccache",
+        ] {
+            let spec = soldr_fetch::lookup_by_crate(crate_name)
+                .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
+            assert_eq!(spec.cargo_subcommand, None);
+        }
+    }
+
+    #[test]
+    fn soldr_itself_is_registered_for_self_trampoline() {
+        let spec = soldr_fetch::lookup_by_crate("soldr")
+            .expect("soldr should be registered in known_tools for --as trampoline");
+        assert_eq!(spec.binary_name, "soldr");
+        assert_eq!(spec.repo, Some(("zackees", "soldr")));
+        assert_eq!(spec.cargo_subcommand, None);
+    }
+
+    #[test]
+    fn extract_as_pin_extracts_space_separated_flag_before_subcommand() {
+        let (version, rest) = extract_as_pin(&[
+            "--as".into(),
+            "0.5.2".into(),
+            "cargo".into(),
+            "build".into(),
+        ])
+        .unwrap();
+        assert_eq!(version, Some("0.5.2".into()));
+        assert_eq!(rest, vec!["cargo".to_string(), "build".into()]);
+    }
+
+    #[test]
+    fn extract_as_pin_extracts_equals_form() {
+        let (version, rest) =
+            extract_as_pin(&["--as=0.5.2".into(), "cargo".into(), "build".into()]).unwrap();
+        assert_eq!(version, Some("0.5.2".into()));
+        assert_eq!(rest, vec!["cargo".to_string(), "build".into()]);
+    }
+
+    #[test]
+    fn extract_as_pin_preserves_other_leading_flags() {
+        let (version, rest) = extract_as_pin(&[
+            "--no-cache".into(),
+            "--as".into(),
+            "0.5.2".into(),
+            "cargo".into(),
+        ])
+        .unwrap();
+        assert_eq!(version, Some("0.5.2".into()));
+        assert_eq!(rest, vec!["--no-cache".to_string(), "cargo".into()]);
+    }
+
+    #[test]
+    fn extract_as_pin_ignores_flag_after_subcommand() {
+        let args = vec!["cargo".into(), "--as".into(), "0.5.2".into()];
+        let (version, rest) = extract_as_pin(&args).unwrap();
+        assert_eq!(version, None);
+        assert_eq!(rest, args);
+    }
+
+    #[test]
+    fn extract_as_pin_ignores_flag_after_passthrough_separator() {
+        let args = vec!["cargo".into(), "--".into(), "--as".into(), "0.5.2".into()];
+        let (version, rest) = extract_as_pin(&args).unwrap();
+        assert_eq!(version, None);
+        assert_eq!(rest, args);
+    }
+
+    #[test]
+    fn extract_as_pin_rejects_missing_value() {
+        let err = extract_as_pin(&["--as".into()]).unwrap_err();
+        assert!(err.to_string().contains("requires a version"));
+    }
+
+    #[test]
+    fn extract_as_pin_rejects_empty_value() {
+        let err = extract_as_pin(&["--as".into(), "".into()]).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+        let err2 = extract_as_pin(&["--as=".into()]).unwrap_err();
+        assert!(err2.to_string().contains("requires a version"));
+    }
+
+    #[test]
+    fn extract_as_pin_rejects_duplicate_flag() {
+        let err =
+            extract_as_pin(&["--as".into(), "0.5.2".into(), "--as=0.4.0".into()]).unwrap_err();
+        assert!(err.to_string().contains("more than once"));
+    }
+
+    #[test]
+    fn normalize_version_strips_leading_v() {
+        assert_eq!(normalize_version("0.5.2"), "0.5.2");
+        assert_eq!(normalize_version("v0.5.2"), "0.5.2");
+        assert_eq!(normalize_version("  v0.5.2 "), "0.5.2");
+    }
+
+    #[test]
+    fn should_trampoline_matches_current_version_as_no_op() {
+        assert!(!should_trampoline(env!("CARGO_PKG_VERSION")));
+        assert!(!should_trampoline(&format!(
+            "v{}",
+            env!("CARGO_PKG_VERSION")
+        )));
+        assert!(should_trampoline("0.0.0-not-this-version"));
     }
 }

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.6.0");
+        assert_eq!(version(), "0.7.0");
     }
 
     #[test]

--- a/crates/soldr-fetch/Cargo.toml
+++ b/crates/soldr-fetch/Cargo.toml
@@ -17,6 +17,9 @@ tempfile = { workspace = true }
 zip = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
+toml = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/soldr-fetch/src/known_tools.rs
+++ b/crates/soldr-fetch/src/known_tools.rs
@@ -1,0 +1,220 @@
+//! Registry of ecosystem tools with known GitHub Releases and (optional) cargo-subcommand mapping.
+//!
+//! Some crates have monorepo-style release tags (e.g. `cargo-audit/v0.21.0`) or
+//! live in a repository whose name differs from the crate. Falling back to the
+//! crates.io → GitHub repository lookup plus `/releases/latest` can pick up the
+//! wrong release in those cases. When a tool needs per-release handling, encode
+//! it here once and fetch paths can use it directly.
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolSpec {
+    /// crates.io crate name and fetch cache key.
+    pub crate_name: &'static str,
+    /// Name used as `cargo <sub>`. `None` for tools that are not cargo
+    /// subcommands (e.g. `cross`, `mdbook`, `sccache`).
+    pub cargo_subcommand: Option<&'static str>,
+    /// Binary shipped inside the release archive (no OS extension).
+    pub binary_name: &'static str,
+    /// Optional (owner, repo) override; skips the crates.io lookup when set.
+    pub repo: Option<(&'static str, &'static str)>,
+    /// Optional release-tag prefix used to filter monorepo releases, e.g.
+    /// `"cargo-audit/"` to pick only `cargo-audit/v0.21.0`-style tags.
+    pub tag_prefix: Option<&'static str>,
+}
+
+pub const KNOWN_TOOLS: &[ToolSpec] = &[
+    // Phase 2 — test + security.
+    ToolSpec {
+        crate_name: "cargo-nextest",
+        cargo_subcommand: Some("nextest"),
+        binary_name: "cargo-nextest",
+        repo: Some(("nextest-rs", "nextest")),
+        tag_prefix: Some("cargo-nextest-"),
+    },
+    ToolSpec {
+        crate_name: "cargo-deny",
+        cargo_subcommand: Some("deny"),
+        binary_name: "cargo-deny",
+        repo: Some(("EmbarkStudios", "cargo-deny")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-audit",
+        cargo_subcommand: Some("audit"),
+        binary_name: "cargo-audit",
+        repo: Some(("rustsec", "rustsec")),
+        tag_prefix: Some("cargo-audit/"),
+    },
+    ToolSpec {
+        crate_name: "cargo-llvm-cov",
+        cargo_subcommand: Some("llvm-cov"),
+        binary_name: "cargo-llvm-cov",
+        repo: Some(("taiki-e", "cargo-llvm-cov")),
+        tag_prefix: None,
+    },
+    // Phase 3 — dev ergonomics.
+    ToolSpec {
+        crate_name: "cargo-udeps",
+        cargo_subcommand: Some("udeps"),
+        binary_name: "cargo-udeps",
+        repo: Some(("est31", "cargo-udeps")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-semver-checks",
+        cargo_subcommand: Some("semver-checks"),
+        binary_name: "cargo-semver-checks",
+        repo: Some(("obi1kenobi", "cargo-semver-checks")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-expand",
+        cargo_subcommand: Some("expand"),
+        binary_name: "cargo-expand",
+        repo: Some(("dtolnay", "cargo-expand")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-watch",
+        cargo_subcommand: Some("watch"),
+        binary_name: "cargo-watch",
+        repo: Some(("watchexec", "cargo-watch")),
+        tag_prefix: None,
+    },
+    // Phase 4 — build + docs. None of these are cargo subcommands — they are
+    // top-level tools invoked as `soldr cross ...`, `soldr mdbook ...`, etc.
+    ToolSpec {
+        crate_name: "cross",
+        cargo_subcommand: None,
+        binary_name: "cross",
+        repo: Some(("cross-rs", "cross")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "mdbook",
+        cargo_subcommand: None,
+        binary_name: "mdbook",
+        repo: Some(("rust-lang", "mdBook")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "cbindgen",
+        cargo_subcommand: None,
+        binary_name: "cbindgen",
+        repo: Some(("mozilla", "cbindgen")),
+        tag_prefix: None,
+    },
+    // Phase 5 — web/wasm + cache. Top-level tools invoked directly.
+    ToolSpec {
+        crate_name: "wasm-pack",
+        cargo_subcommand: None,
+        binary_name: "wasm-pack",
+        repo: Some(("rustwasm", "wasm-pack")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "trunk",
+        cargo_subcommand: None,
+        binary_name: "trunk",
+        repo: Some(("trunk-rs", "trunk")),
+        tag_prefix: None,
+    },
+    ToolSpec {
+        crate_name: "sccache",
+        cargo_subcommand: None,
+        binary_name: "sccache",
+        repo: Some(("mozilla", "sccache")),
+        tag_prefix: None,
+    },
+    // Self-trampoline: `soldr --as <version>` fetches this entry so an older
+    // soldr binary can handle the rest of the invocation.
+    ToolSpec {
+        crate_name: "soldr",
+        cargo_subcommand: None,
+        binary_name: "soldr",
+        repo: Some(("zackees", "soldr")),
+        tag_prefix: None,
+    },
+];
+
+pub fn lookup_by_crate(crate_name: &str) -> Option<&'static ToolSpec> {
+    KNOWN_TOOLS.iter().find(|t| t.crate_name == crate_name)
+}
+
+pub fn lookup_by_cargo_subcommand(sub: &str) -> Option<&'static ToolSpec> {
+    KNOWN_TOOLS.iter().find(|t| t.cargo_subcommand == Some(sub))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_by_crate_finds_registered_tools() {
+        assert_eq!(
+            lookup_by_crate("cargo-nextest").unwrap().cargo_subcommand,
+            Some("nextest")
+        );
+        assert_eq!(
+            lookup_by_crate("cargo-llvm-cov").unwrap().binary_name,
+            "cargo-llvm-cov"
+        );
+        assert_eq!(lookup_by_crate("mdbook").unwrap().cargo_subcommand, None);
+        assert!(lookup_by_crate("not-a-tool").is_none());
+    }
+
+    #[test]
+    fn lookup_by_cargo_subcommand_finds_registered_tools() {
+        assert_eq!(
+            lookup_by_cargo_subcommand("nextest").unwrap().crate_name,
+            "cargo-nextest"
+        );
+        assert_eq!(
+            lookup_by_cargo_subcommand("deny").unwrap().crate_name,
+            "cargo-deny"
+        );
+        assert!(lookup_by_cargo_subcommand("build").is_none());
+        // Tools with cargo_subcommand: None should never be returned here.
+        assert!(lookup_by_cargo_subcommand("mdbook").is_none());
+        assert!(lookup_by_cargo_subcommand("cross").is_none());
+        assert!(lookup_by_cargo_subcommand("cbindgen").is_none());
+    }
+
+    #[test]
+    fn cargo_audit_carries_monorepo_tag_prefix() {
+        let spec = lookup_by_crate("cargo-audit").unwrap();
+        assert_eq!(spec.tag_prefix, Some("cargo-audit/"));
+    }
+
+    #[test]
+    fn known_tools_are_unique_by_crate_and_subcommand() {
+        for (i, a) in KNOWN_TOOLS.iter().enumerate() {
+            for b in KNOWN_TOOLS.iter().skip(i + 1) {
+                assert_ne!(
+                    a.crate_name, b.crate_name,
+                    "duplicate crate_name in registry"
+                );
+                if let (Some(asub), Some(bsub)) = (a.cargo_subcommand, b.cargo_subcommand) {
+                    assert_ne!(asub, bsub, "duplicate cargo_subcommand in registry");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn top_level_tools_are_registered_without_cargo_subcommand() {
+        for crate_name in [
+            "cross",
+            "mdbook",
+            "cbindgen",
+            "wasm-pack",
+            "trunk",
+            "sccache",
+        ] {
+            let spec = lookup_by_crate(crate_name)
+                .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
+            assert_eq!(spec.cargo_subcommand, None);
+            assert!(spec.repo.is_some());
+        }
+    }
+}

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -2,7 +2,18 @@
 //!
 //! Resolution chain (Phase 1 MVP):
 //! 1. Local cache (`~/.soldr/bin/<tool>-<version>/`)
-//! 2. GitHub Releases (repository URL from crates.io)
+//! 2. GitHub Releases (repository URL from crates.io, or override from `known_tools`)
+
+pub mod known_tools;
+
+pub use known_tools::{lookup_by_cargo_subcommand, lookup_by_crate, ToolSpec, KNOWN_TOOLS};
+
+pub mod trust;
+
+pub use trust::{
+    sha256_of, verify_download, PinnedChecksumStore, TrustMode, VerifyOutcome,
+    CHECKSUMS_FILE_ENV_VAR, TRUST_MODE_ENV_VAR,
+};
 
 use soldr_core::{Arch, Env, Os, SoldrError, SoldrPaths, TargetTriple};
 use std::path::{Path, PathBuf};
@@ -52,8 +63,28 @@ pub async fn fetch_tool_with_paths(
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
+
+    if let Some(spec) = lookup_by_crate(crate_name) {
+        let repo = match spec.repo {
+            Some((owner, name)) => RepoInfo {
+                owner: owner.to_string(),
+                repo: name.to_string(),
+            },
+            None => resolve_repo(crate_name).await?,
+        };
+        return fetch_repo_binary_with_paths(
+            spec.crate_name,
+            &[spec.binary_name],
+            &repo,
+            version,
+            spec.tag_prefix,
+            paths,
+        )
+        .await;
+    }
+
     let repo = resolve_repo(crate_name).await?;
-    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, paths).await
+    fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, None, paths).await
 }
 
 pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
@@ -110,6 +141,7 @@ async fn fetch_repo_binary_with_paths(
     binary_names: &[&str],
     repo: &RepoInfo,
     version: &VersionSpec,
+    tag_prefix: Option<&str>,
     paths: &SoldrPaths,
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
@@ -126,7 +158,7 @@ async fn fetch_repo_binary_with_paths(
         }
     }
 
-    let release = fetch_release(repo, version).await?;
+    let release = fetch_release(repo, version, tag_prefix).await?;
 
     if let Some(r) = check_cache(paths, cache_name, &release.version, binary_names, &target)? {
         return Ok(r);
@@ -266,19 +298,28 @@ fn parse_github_url(url: &str) -> Result<RepoInfo, SoldrError> {
 }
 
 /// Fetch release metadata (asset list) from GitHub.
-async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<ReleaseInfo, SoldrError> {
+async fn fetch_release(
+    repo: &RepoInfo,
+    version: &VersionSpec,
+    tag_prefix: Option<&str>,
+) -> Result<ReleaseInfo, SoldrError> {
     let client = http_client()?;
 
     let release = match version {
-        VersionSpec::Latest => {
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/releases/latest",
-                repo.owner, repo.repo
-            );
-            fetch_release_value(&client, repo, &url).await?
-        }
+        VersionSpec::Latest => match tag_prefix {
+            // Monorepo releases: `/releases/latest` may pick a sibling tool;
+            // instead list releases and take the newest whose tag matches.
+            Some(prefix) => fetch_latest_by_prefix(&client, repo, prefix).await?,
+            None => {
+                let url = format!(
+                    "https://api.github.com/repos/{}/{}/releases/latest",
+                    repo.owner, repo.repo
+                );
+                fetch_release_value(&client, repo, &url).await?
+            }
+        },
         VersionSpec::Exact(v) => {
-            let candidate_tags = release_tag_candidates(v);
+            let candidate_tags = release_tag_candidates(v, tag_prefix);
             let mut found = None;
             for tag in &candidate_tags {
                 let url = format!(
@@ -301,7 +342,59 @@ async fn fetch_release(repo: &RepoInfo, version: &VersionSpec) -> Result<Release
         }
     };
 
-    parse_release_info(release)
+    parse_release_info(release, tag_prefix)
+}
+
+async fn fetch_latest_by_prefix(
+    client: &reqwest::Client,
+    repo: &RepoInfo,
+    prefix: &str,
+) -> Result<serde_json::Value, SoldrError> {
+    let url = format!(
+        "https://api.github.com/repos/{}/{}/releases?per_page=60",
+        repo.owner, repo.repo
+    );
+    let resp = github_request(client, &url)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    if !resp.status().is_success() {
+        return Err(SoldrError::ToolNotFound(format!(
+            "no release found for {}/{}",
+            repo.owner, repo.repo
+        )));
+    }
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    let releases: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| SoldrError::Other(e.to_string()))?;
+
+    let matched = releases
+        .as_array()
+        .and_then(|items| {
+            items.iter().find(|release| {
+                let is_prerelease = release["prerelease"].as_bool().unwrap_or(false);
+                if is_prerelease {
+                    return false;
+                }
+                release["tag_name"]
+                    .as_str()
+                    .map(|tag| tag.starts_with(prefix))
+                    .unwrap_or(false)
+            })
+        })
+        .cloned();
+
+    matched.ok_or_else(|| {
+        SoldrError::ToolNotFound(format!(
+            "no release with tag prefix {prefix:?} found for {}/{}",
+            repo.owner, repo.repo
+        ))
+    })
 }
 
 async fn fetch_release_value(
@@ -372,12 +465,15 @@ async fn fetch_release_by_listing(
     })
 }
 
-fn release_tag_candidates(version: &str) -> Vec<String> {
-    let mut tags = Vec::with_capacity(2);
+fn release_tag_candidates(version: &str, tag_prefix: Option<&str>) -> Vec<String> {
+    let mut tags = Vec::with_capacity(4);
     let raw = version.trim();
     if raw.is_empty() {
         return tags;
     }
+    let bare = raw.trim_start_matches('v').to_string();
+
+    // Core bare + v-prefixed variants.
     tags.push(raw.to_string());
     if let Some(stripped) = raw.strip_prefix('v') {
         if !stripped.is_empty() {
@@ -386,6 +482,13 @@ fn release_tag_candidates(version: &str) -> Vec<String> {
     } else {
         tags.push(format!("v{raw}"));
     }
+
+    // Monorepo-style tags: e.g. `cargo-audit/v0.21.0`.
+    if let Some(prefix) = tag_prefix {
+        tags.push(format!("{prefix}{bare}"));
+        tags.push(format!("{prefix}v{bare}"));
+    }
+
     tags.sort();
     tags.dedup();
     tags
@@ -398,11 +501,18 @@ fn managed_zccache_download_url(version: &str, target: &TargetTriple) -> String 
     )
 }
 
-fn parse_release_info(body: serde_json::Value) -> Result<ReleaseInfo, SoldrError> {
+fn parse_release_info(
+    body: serde_json::Value,
+    tag_prefix: Option<&str>,
+) -> Result<ReleaseInfo, SoldrError> {
     let tag = body["tag_name"]
         .as_str()
         .ok_or_else(|| SoldrError::Other("no tag_name in release".into()))?;
-    let version = tag.trim_start_matches('v').to_string();
+    let stripped = match tag_prefix {
+        Some(prefix) => tag.strip_prefix(prefix).unwrap_or(tag),
+        None => tag,
+    };
+    let version = stripped.trim_start_matches('v').to_string();
 
     let assets = body["assets"]
         .as_array()
@@ -540,6 +650,31 @@ async fn download_and_extract(
         .bytes()
         .await
         .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    // Integrity + trust enforcement (issue #42). Compute sha256 and consult
+    // the pinned-checksum store before writing anything to disk.
+    let asset_name = url
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(url);
+    let digest = trust::sha256_of(&bytes);
+    let store = trust::PinnedChecksumStore::from_env()?;
+    let mode = trust::TrustMode::from_env();
+    match trust::verify_download(cache_name, version, asset_name, &digest, &store, mode)? {
+        trust::VerifyOutcome::Verified { sha256 } => {
+            eprintln!(
+                "soldr: trust: verified {cache_name} v{version} {asset_name} sha256={sha256}"
+            );
+        }
+        trust::VerifyOutcome::Unverified { sha256 } => {
+            eprintln!(
+                "soldr: trust: unverified {cache_name} v{version} {asset_name} sha256={sha256} (set {} to pin; run with {}=strict to require pins)",
+                trust::CHECKSUMS_FILE_ENV_VAR,
+                trust::TRUST_MODE_ENV_VAR
+            );
+        }
+    }
 
     let tool_dir = paths.bin.join(format!("{cache_name}-{version}"));
     let desired_binaries = desired_binary_names(binary_names, target);
@@ -733,13 +868,42 @@ mod tests {
     #[test]
     fn release_tag_candidates_support_plain_and_v_prefixed_tags() {
         assert_eq!(
-            release_tag_candidates("1.2.8"),
+            release_tag_candidates("1.2.8", None),
             vec!["1.2.8".to_string(), "v1.2.8".to_string()]
         );
         assert_eq!(
-            release_tag_candidates("v1.2.8"),
+            release_tag_candidates("v1.2.8", None),
             vec!["1.2.8".to_string(), "v1.2.8".to_string()]
         );
+    }
+
+    #[test]
+    fn release_tag_candidates_include_monorepo_prefix_variants() {
+        let candidates = release_tag_candidates("0.21.0", Some("cargo-audit/"));
+        assert!(candidates.contains(&"0.21.0".to_string()));
+        assert!(candidates.contains(&"v0.21.0".to_string()));
+        assert!(candidates.contains(&"cargo-audit/0.21.0".to_string()));
+        assert!(candidates.contains(&"cargo-audit/v0.21.0".to_string()));
+    }
+
+    #[test]
+    fn parse_release_info_strips_monorepo_tag_prefix() {
+        let body = serde_json::json!({
+            "tag_name": "cargo-audit/v0.21.0",
+            "assets": [],
+        });
+        let info = parse_release_info(body, Some("cargo-audit/")).unwrap();
+        assert_eq!(info.version, "0.21.0");
+    }
+
+    #[test]
+    fn parse_release_info_strips_nextest_prefix() {
+        let body = serde_json::json!({
+            "tag_name": "cargo-nextest-0.9.100",
+            "assets": [],
+        });
+        let info = parse_release_info(body, Some("cargo-nextest-")).unwrap();
+        assert_eq!(info.version, "0.9.100");
     }
 
     #[test]

--- a/crates/soldr-fetch/src/trust.rs
+++ b/crates/soldr-fetch/src/trust.rs
@@ -1,0 +1,352 @@
+//! Integrity and trust policy for fetched binaries.
+//!
+//! `soldr` has historically treated every successful GitHub-Releases download
+//! as authentic. Issue #42 requires that claim to be backed by actual integrity
+//! enforcement. This module adds the primitives:
+//!
+//! - `sha256_of(bytes)` — compute the canonical integrity hash of an archive.
+//! - `TrustMode` — `permissive` (default) or `strict`, read from
+//!   `SOLDR_TRUST_MODE`.
+//! - `PinnedChecksumStore` — loaded from a TOML file referenced by
+//!   `SOLDR_CHECKSUMS_FILE`, or returned empty if the env var is unset.
+//! - `verify_download(asset, tool, version, sha256, store, mode)` — returns a
+//!   `VerifyOutcome` that the caller logs and obeys.
+//!
+//! The fetch path then:
+//! 1. Always prints the computed sha256 to stderr so humans can audit it.
+//! 2. If a pin exists for the asset and mismatches, returns an error in any
+//!    mode. This is the "no longer implicitly trusted" guarantee.
+//! 3. If no pin exists and mode is `strict`, refuses to install. In
+//!    `permissive` mode it installs and prints a `trust: unverified` warning.
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use soldr_core::SoldrError;
+use std::collections::HashMap;
+use std::path::Path;
+
+pub const TRUST_MODE_ENV_VAR: &str = "SOLDR_TRUST_MODE";
+pub const CHECKSUMS_FILE_ENV_VAR: &str = "SOLDR_CHECKSUMS_FILE";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustMode {
+    /// Default. Unverified fetches install but emit a warning.
+    Permissive,
+    /// Every fetch must match a pinned checksum; unverified fetches fail.
+    Strict,
+}
+
+impl TrustMode {
+    pub fn from_env() -> Self {
+        match std::env::var(TRUST_MODE_ENV_VAR)
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("strict") => Self::Strict,
+            Some("permissive") | Some("") | None => Self::Permissive,
+            Some(other) => {
+                eprintln!(
+                    "soldr: ignoring unknown {TRUST_MODE_ENV_VAR}={other:?}; expected \"permissive\" or \"strict\""
+                );
+                Self::Permissive
+            }
+        }
+    }
+}
+
+/// A single pinned checksum entry. Keyed by (tool, version, asset name) so
+/// asset matching stays platform-scoped — a Windows MSVC zip and a Linux musl
+/// tar.gz for the same tool+version carry different checksums.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+struct RawPinnedChecksum {
+    tool: String,
+    version: String,
+    asset: String,
+    sha256: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct RawPinnedFile {
+    #[serde(default, rename = "tool")]
+    tools: Vec<RawPinnedChecksum>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PinnedChecksumStore {
+    // (tool, version, asset) → sha256 (lowercase hex)
+    entries: HashMap<(String, String, String), String>,
+}
+
+impl PinnedChecksumStore {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_env() -> Result<Self, SoldrError> {
+        match std::env::var(CHECKSUMS_FILE_ENV_VAR) {
+            Ok(path) if !path.trim().is_empty() => Self::from_file(Path::new(path.trim())),
+            _ => Ok(Self::empty()),
+        }
+    }
+
+    pub fn from_file(path: &Path) -> Result<Self, SoldrError> {
+        let text = std::fs::read_to_string(path).map_err(|e| {
+            SoldrError::Other(format!(
+                "failed to read {CHECKSUMS_FILE_ENV_VAR} at {}: {e}",
+                path.display()
+            ))
+        })?;
+        Self::from_toml(&text)
+    }
+
+    pub fn from_toml(text: &str) -> Result<Self, SoldrError> {
+        let raw: RawPinnedFile = toml::from_str(text).map_err(|e| {
+            SoldrError::Other(format!("failed to parse pinned checksums TOML: {e}"))
+        })?;
+        let mut entries = HashMap::new();
+        for entry in raw.tools {
+            let sha = entry.sha256.trim().to_ascii_lowercase();
+            if !is_hex64(&sha) {
+                return Err(SoldrError::Other(format!(
+                    "pinned sha256 for {}@{} asset {} is not a 64-char hex string",
+                    entry.tool, entry.version, entry.asset
+                )));
+            }
+            entries.insert((entry.tool, entry.version, entry.asset), sha);
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn lookup(&self, tool: &str, version: &str, asset: &str) -> Option<&str> {
+        self.entries
+            .get(&(tool.to_string(), version.to_string(), asset.to_string()))
+            .map(|s| s.as_str())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+fn is_hex64(s: &str) -> bool {
+    s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Compute the canonical SHA-256 hex digest of a downloaded archive.
+pub fn sha256_of(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifyOutcome {
+    /// A pinned checksum existed and matched.
+    Verified { sha256: String },
+    /// No pinned checksum exists for this (tool, version, asset); permissive
+    /// mode installed it anyway.
+    Unverified { sha256: String },
+}
+
+/// Verify a downloaded archive against a pinned checksum store and the active
+/// trust mode.
+///
+/// Returns `Err` in two cases:
+/// 1. A pin exists for this (tool, version, asset) and does not match. Always
+///    an error regardless of mode.
+/// 2. No pin exists and mode is `Strict`.
+pub fn verify_download(
+    tool: &str,
+    version: &str,
+    asset_name: &str,
+    sha256: &str,
+    store: &PinnedChecksumStore,
+    mode: TrustMode,
+) -> Result<VerifyOutcome, SoldrError> {
+    let actual = sha256.to_ascii_lowercase();
+    match store.lookup(tool, version, asset_name) {
+        Some(expected) => {
+            if expected == actual {
+                Ok(VerifyOutcome::Verified { sha256: actual })
+            } else {
+                Err(SoldrError::Other(format!(
+                    "trust: pinned sha256 mismatch for {tool} v{version} asset {asset_name}\n  expected: {expected}\n  actual:   {actual}"
+                )))
+            }
+        }
+        None => match mode {
+            TrustMode::Strict => Err(SoldrError::Other(format!(
+                "trust: no pinned checksum for {tool} v{version} asset {asset_name}; refusing fetch under {TRUST_MODE_ENV_VAR}=strict"
+            ))),
+            TrustMode::Permissive => Ok(VerifyOutcome::Unverified { sha256: actual }),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_of_matches_expected_digest() {
+        // sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        assert_eq!(
+            sha256_of(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        // sha256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        assert_eq!(
+            sha256_of(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn trust_mode_defaults_to_permissive() {
+        // Not touching the process env to avoid races; validate the parser.
+        let parse = |v: Option<&str>| match v.map(str::to_ascii_lowercase).as_deref() {
+            Some("strict") => TrustMode::Strict,
+            _ => TrustMode::Permissive,
+        };
+        assert_eq!(parse(None), TrustMode::Permissive);
+        assert_eq!(parse(Some("strict")), TrustMode::Strict);
+        assert_eq!(parse(Some("permissive")), TrustMode::Permissive);
+    }
+
+    #[test]
+    fn pinned_store_parses_toml_entries() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "cargo-nextest"
+            version = "0.9.100"
+            asset = "cargo-nextest-0.9.100-x86_64-pc-windows-msvc.zip"
+            sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+        "#;
+        let store = PinnedChecksumStore::from_toml(toml_text).unwrap();
+        assert_eq!(
+            store.lookup(
+                "cargo-nextest",
+                "0.9.100",
+                "cargo-nextest-0.9.100-x86_64-pc-windows-msvc.zip"
+            ),
+            Some("0000000000000000000000000000000000000000000000000000000000000000")
+        );
+        assert!(store
+            .lookup("cargo-nextest", "0.9.100", "other.zip")
+            .is_none());
+    }
+
+    #[test]
+    fn pinned_store_rejects_malformed_sha256() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "x"
+            version = "1"
+            asset = "x.zip"
+            sha256 = "not-a-hex-string"
+        "#;
+        let err = PinnedChecksumStore::from_toml(toml_text).unwrap_err();
+        assert!(err.to_string().contains("64-char hex"));
+    }
+
+    #[test]
+    fn verify_download_accepts_matching_pin() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "cargo-nextest"
+            version = "0.9.100"
+            asset = "cargo-nextest.zip"
+            sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        "#;
+        let store = PinnedChecksumStore::from_toml(toml_text).unwrap();
+        let outcome = verify_download(
+            "cargo-nextest",
+            "0.9.100",
+            "cargo-nextest.zip",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            &store,
+            TrustMode::Strict,
+        )
+        .unwrap();
+        assert!(matches!(outcome, VerifyOutcome::Verified { .. }));
+    }
+
+    #[test]
+    fn verify_download_rejects_pin_mismatch_in_either_mode() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "t"
+            version = "1"
+            asset = "a.zip"
+            sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        "#;
+        let store = PinnedChecksumStore::from_toml(toml_text).unwrap();
+        for mode in [TrustMode::Permissive, TrustMode::Strict] {
+            let err = verify_download(
+                "t",
+                "1",
+                "a.zip",
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                &store,
+                mode,
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("pinned sha256 mismatch"));
+        }
+    }
+
+    #[test]
+    fn verify_download_strict_mode_rejects_missing_pin() {
+        let store = PinnedChecksumStore::empty();
+        let err = verify_download(
+            "cargo-nextest",
+            "0.9.100",
+            "cargo-nextest.zip",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            &store,
+            TrustMode::Strict,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("no pinned checksum"));
+    }
+
+    #[test]
+    fn verify_download_permissive_mode_allows_missing_pin() {
+        let store = PinnedChecksumStore::empty();
+        let outcome = verify_download(
+            "cargo-nextest",
+            "0.9.100",
+            "cargo-nextest.zip",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            &store,
+            TrustMode::Permissive,
+        )
+        .unwrap();
+        assert!(matches!(outcome, VerifyOutcome::Unverified { .. }));
+    }
+
+    #[test]
+    fn verify_download_is_case_insensitive_on_the_digest() {
+        let toml_text = r#"
+            [[tool]]
+            tool = "t"
+            version = "1"
+            asset = "a.zip"
+            sha256 = "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
+        "#;
+        let store = PinnedChecksumStore::from_toml(toml_text).unwrap();
+        let outcome = verify_download(
+            "t",
+            "1",
+            "a.zip",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            &store,
+            TrustMode::Strict,
+        )
+        .unwrap();
+        assert!(matches!(outcome, VerifyOutcome::Verified { .. }));
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.6.0"
+  "soldr_version": "0.7.0"
 }
 ```
 

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -47,12 +47,28 @@ The bootstrap e2e jobs currently trust additional external systems:
 
 - Ubuntu package repositories
   - musl validation jobs install `musl-tools` from live `apt` repositories
+  - the install command uses `--no-install-recommends`, a retry loop, and logs the resolved `musl-tools` version for auditability; the set of installed packages is therefore the declared set, not an open-ended recommended expansion
 - third-party source repository hosting
   - the e2e workflow checks out a pinned commit of `zackees/running-process` from GitHub
 - third-party Rust toolchain installation
   - the e2e workflow reads the third-party project's `rust-toolchain.toml` and installs that toolchain through `rustup`
 
 These inputs are pinned where possible, but they are not yet mirrored or fully hermetic.
+
+## Hermetic Inputs Hardening Status
+
+Tracked by #41. Concrete narrowings already in place:
+
+- the `musl-tools` install uses `--no-install-recommends` so the Ubuntu package surface is exactly what the release path declares
+- the `musl-tools` install logs its resolved version so the exact package contents are visible in workflow logs
+- the `musl-tools` install retries on transient apt failures rather than either flapping or pulling unrelated extras
+
+Still deferred (acceptable follow-up, not blockers for the current line):
+
+- a `cargo vendor` or mirrored-registry strategy for crates.io resolution during release
+- a mirrored or prebuilt-image strategy for Rust toolchain acquisition during release
+- a mirror for the pinned third-party bootstrap repository checkout
+- replacement of the live `apt` repository with a prebuilt image or pinned-package snapshot
 
 ## Runtime Tool-Fetch Trust Boundaries
 
@@ -69,10 +85,16 @@ That means the runtime tool-fetch path currently trusts:
 - GitHub repository ownership and release contents for the target tool
 - HTTPS transport to those services
 
+Integrity enforcement that is in place today:
+
+- SHA-256 is always computed on the downloaded archive and printed to stderr
+- user-supplied per-asset SHA-256 pins from `SOLDR_CHECKSUMS_FILE` are enforced as hard errors on mismatch
+- `SOLDR_TRUST_MODE=strict` refuses any fetch without a matching pin
+
 It does not yet enforce:
 
 - maintainer allowlists
-- per-tool checksums committed in this repo
+- repo-committed default checksums for tools shipped in the `known_tools` registry
 - upstream signatures
 - upstream artifact attestations
 - mirrored internal copies of third-party tool binaries
@@ -93,19 +115,37 @@ Current repo policy is:
 
 ## Current Runtime Fetch Policy
 
-Current `0.5.x` policy for runtime-fetched binaries is:
+As of the `0.6.x` line, `soldr` enforces integrity on every third-party fetch:
 
-- `soldr` fetching a third-party tool is a convenience/bootstrap path, not a repository-side trust guarantee
-- a successful fetch currently means crates.io metadata and GitHub Releases produced a matching archive for the selected target and `soldr` extracted it successfully
-- `soldr` does not currently enforce maintainer allowlists, repo-managed checksums, upstream signatures, upstream attestations, or mirrored copies before executing a fetched tool
-- the managed `zccache` path is pinned to a repo-chosen version, but it still uses the same direct GitHub Release download model and is not independently checksum- or attestation-verified by `soldr` itself today
-- stronger runtime trust enforcement is accepted follow-up work, but it is not part of the current `0.5.x` trust claim
+- every downloaded archive has its SHA-256 computed before extraction; the digest is printed to stderr so a human or CI log grep can audit what actually installed
+- users can pin per-asset SHA-256 values in a TOML file at the path named by `SOLDR_CHECKSUMS_FILE`; any pin mismatch is a hard error regardless of mode
+- `SOLDR_TRUST_MODE=strict` refuses to install any tool that does not have a matching pin
+- `SOLDR_TRUST_MODE=permissive` (the default) installs and emits a `trust: unverified` warning when no pin is available; this preserves the convenience/bootstrap path while making the trust state legible
+- the managed `zccache` download goes through the same verification path as any other fetch
+
+Example pin file layout:
+
+```toml
+[[tool]]
+tool = "cargo-nextest"
+version = "0.9.100"
+asset = "cargo-nextest-0.9.100-x86_64-pc-windows-msvc.zip"
+sha256 = "0123...cdef"   # 64-char lowercase hex
+```
+
+What is still deferred:
+
+- maintainer allowlists (limiting which crate/repo pairs `soldr` will even attempt to fetch)
+- upstream signature or attestation verification
+- mirrored internal copies of third-party tool binaries
+
+Those remain acceptable future hardening work and are tracked on the issues linked below.
 
 Open follow-up implementation issues are tracked in:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
 - [#41](https://github.com/zackees/soldr/issues/41) for reducing live external release inputs
-- [#42](https://github.com/zackees/soldr/issues/42) for fetched-binary trust enforcement
+- [#42](https://github.com/zackees/soldr/issues/42) for fetched-binary trust enforcement (checksum enforcement landed; allowlist/signature work still open)
 
 ## Practical Reading Of This Document
 


### PR DESCRIPTION
## Summary

Brings \`release\` to the tree state of \`main\` (commit \`bcde023\`) so \`release.yml\` can cut \`v0.7.0\` from this branch.

Bundles everything merged to main since the \`v0.6.0\` cut:
- Ecosystem fetch registry + cargo-subcommand dispatch (#84, #85, #86, #87)
- Trust policy — SHA-256 + \`SOLDR_CHECKSUMS_FILE\` + \`SOLDR_TRUST_MODE\` (#88)
- Musl install hardening (#89)
- LICENSE aligned to BSD-3-Clause (#90)
- CLAUDE.md refreshed to 0.6.x reality (#91)
- \`--as <version>\` trampoline (#92)
- Version bump to 0.7.0 (#94)

Implementation: single commit applying the \`main\` tree on top of the current \`release\` HEAD, matching the linear-history requirement on \`release\`. This is the same shape as #78 for v0.6.0.

## Post-merge steps (tracked in #93)

- [ ] Dispatch \`release.yml\` with \`version=v0.7.0\`, \`commit_sha=<release HEAD>\`, \`dry_run=true\`
- [ ] Review dry-run; confirm release-gating jobs, attestation, and PyPI publishing stages all pass
- [ ] Dispatch again with \`dry_run=false\`, \`publish_pypi=true\` (environment-gated)

Refs #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)