### PR TITLE
docs: finalize 0.5 hermeticity posture and close #41

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,22 +94,14 @@ Current verification policy:
 - reproducible-build claims are not currently made for `soldr`
 - no extra signed release metadata is currently published beyond `SHA256SUMS` and GitHub provenance attestations
 
-Current hermeticity and runtime-trust policy:
+Hermeticity and runtime-trust policy (final for `0.5`):
 
 - `0.5.x` release verification covers published `soldr` artifacts, not every external input used during CI
-- `0.5.x` does not claim hermetic builds; documented dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt`, and the pinned bootstrap test repository remain acceptable for this release line
-- Cargo/toolchain/package mirroring or vendoring is deferred hardening tracked in issue [#41](https://github.com/zackees/soldr/issues/41)
-- runtime third-party binary fetches are a convenience/bootstrap path on `0.5.x`, not a repository-side trust guarantee
-- stronger trust enforcement for fetched binaries is tracked in issue [#42](https://github.com/zackees/soldr/issues/42)
-
-Planned state, tracked in issue `#7`:
-
-Remaining follow-up decisions before the attested secure `0.5` release, tracked in issues `#12` and `#13`:
-
-- whether `0.5` should publish SBOMs in addition to provenance attestations
-- whether `0.5` should claim reproducible builds and how that would be validated
-- whether release-time dependencies should be vendored or mirrored
-- what trust policy should apply to third-party binaries fetched by `soldr` at runtime
+- `0.5.x` does not claim hermetic builds; documented dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt`, and the pinned bootstrap test repository are accepted as the final input set for this line
+- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are explicitly out of scope for `0.5`; any revisit is scoped to a future `1.0.0-rc` hardening milestone
+- SBOMs are not required for `0.5`; GitHub provenance attestations plus `SHA256SUMS` are the verification story
+- reproducible-build claims are not made for `0.5`
+- runtime third-party binary trust is enforced as of `0.6.x` via SHA-256 pinning and `SOLDR_TRUST_MODE=strict` (originally tracked in [#42](https://github.com/zackees/soldr/issues/42), closed)
 
 `1.0.0-rc` remains gated on actual compilation-cache integration rather than release hardening alone.
 

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -55,20 +55,22 @@ The bootstrap e2e jobs currently trust additional external systems:
 
 These inputs are pinned where possible, but they are not yet mirrored or fully hermetic.
 
-## Hermetic Inputs Hardening Status
+## Hermetic Inputs: Final `0.5.x` Stance
 
-Tracked by #41. Concrete narrowings already in place:
+Concrete narrowings in place:
 
 - the `musl-tools` install uses `--no-install-recommends` so the Ubuntu package surface is exactly what the release path declares
 - the `musl-tools` install logs its resolved version so the exact package contents are visible in workflow logs
 - the `musl-tools` install retries on transient apt failures rather than either flapping or pulling unrelated extras
 
-Still deferred (acceptable follow-up, not blockers for the current line):
+Explicitly out of scope for `0.5.x` (not planned; any revisit is scoped to a future `1.0.0-rc` hardening milestone):
 
 - a `cargo vendor` or mirrored-registry strategy for crates.io resolution during release
 - a mirrored or prebuilt-image strategy for Rust toolchain acquisition during release
 - a mirror for the pinned third-party bootstrap repository checkout
 - replacement of the live `apt` repository with a prebuilt image or pinned-package snapshot
+
+The attested release artifact — built from an exact commit SHA on the protected `release` branch, with GitHub build-provenance attestation and a `SHA256SUMS` manifest — is the user-facing trust guarantee for `0.5.x`. Narrowing the live CI input surface below that attestation-based guarantee is not a project goal on this line.
 
 ## Runtime Tool-Fetch Trust Boundaries
 
@@ -109,7 +111,7 @@ Current repo policy is:
 - prefer exact commit or version selection where possible
 - `0.5.x` does not claim hermetic builds
 - the documented release-time dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt` in the bootstrap e2e path, and the pinned third-party bootstrap repository are acceptable for `0.5.x`
-- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are accepted future hardening work, but they are not blockers for the current `0.5.x` release line
+- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are explicitly out of scope for `0.5.x`; any revisit is scoped to a future `1.0.0-rc` hardening milestone
 - the pinned third-party bootstrap checkout is acceptable for current validation, but it must not be described as mirrored or hermetic
 - release verification for `soldr` covers the published `soldr` artifacts and their provenance, not every external input used during CI
 
@@ -141,11 +143,11 @@ What is still deferred:
 
 Those remain acceptable future hardening work and are tracked on the issues linked below.
 
-Open follow-up implementation issues are tracked in:
+Open follow-up implementation issues:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
-- [#41](https://github.com/zackees/soldr/issues/41) for reducing live external release inputs
-- [#42](https://github.com/zackees/soldr/issues/42) for fetched-binary trust enforcement (checksum enforcement landed; allowlist/signature work still open)
+
+Previously tracked, now closed: [#41](https://github.com/zackees/soldr/issues/41) (reducing live external release inputs — closed as out of scope for `0.5.x`), [#42](https://github.com/zackees/soldr/issues/42) (fetched-binary trust enforcement — checksum enforcement landed in `0.6.x`).
 
 ## Practical Reading Of This Document
 


### PR DESCRIPTION
## Summary

Formalizes the `0.5` trust posture as final rather than deferred, so `#41` can close as "decision made" instead of sitting open as permanent TODO.

## Changes

- **SECURITY.md** — replaces the "Current hermeticity and runtime-trust policy" + "Planned state / Remaining follow-up decisions" sections with a single "Final for 0.5" section. Drops the `#41` deferral pointer and the stale `#7`/`#12`/`#13` "remaining decisions" framing (all of those are closed).
- **docs/TRUST_BOUNDARIES.md** — renames "Hermetic Inputs Hardening Status" to "Hermetic Inputs: Final 0.5.x Stance"; changes the "Still deferred" bullets to "Explicitly out of scope for 0.5.x"; updates the policy-decisions bullet to match; moves `#41` and `#42` from the "open follow-up" list to "previously tracked, now closed." Adds a short paragraph stating that the attested release artifact is the user-facing trust guarantee and that narrowing live CI inputs below attestation-based trust is not a project goal on this line.

## Policy in one line

> The attested release artifact — built from an exact commit SHA on the protected `release` branch, with GitHub build-provenance attestation and a `SHA256SUMS` manifest — is the user-facing trust guarantee for `0.5.x`. Further hermeticity (cargo vendoring, toolchain/registry mirroring, OS-package mirroring, third-party bootstrap source mirroring) is explicitly out of scope for `0.5`; any revisit is scoped to a future `1.0.0-rc` hardening milestone.

## Closes

- Closes #41

## Test plan

- [ ] Render both docs and confirm no stale deferral references remain
- [ ] Confirm no dangling links to closed issues (#7, #12, #13, #42 still appear in context, but now correctly framed as historical/closed)