### PR TITLE
Add SOLDR_RUSTC_WRAPPER override for cargo builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 soldr cargo build --release
 soldr cargo test
 soldr --no-cache cargo test
+SOLDR_RUSTC_WRAPPER=sccache soldr cargo build
+SOLDR_RUSTC_WRAPPER=none soldr cargo build
 
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -7,6 +7,7 @@ const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
 const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 const JSON_SCHEMA_VERSION: u32 = 1;
+const RUSTC_WRAPPER_OVERRIDE_ENV_VAR: &str = "SOLDR_RUSTC_WRAPPER";
 
 /// Pin a specific soldr version to handle this invocation. Explicit
 /// `--as <version>` flag takes precedence over this env var.
@@ -459,7 +460,7 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     }
 
     let session = if cache_enabled {
-        Some(prepare_zccache_build(&mut command, &paths).await?)
+        prepare_rustc_wrapper(&mut command, &paths).await?
     } else {
         None
     };
@@ -609,6 +610,54 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
 struct ZccacheBuildSession {
     binary_path: std::path::PathBuf,
     session_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RustcWrapperMode {
+    ManagedZccache,
+    Custom(std::ffi::OsString),
+    Disabled,
+}
+
+fn rustc_wrapper_mode_from_env_var(value: Option<&std::ffi::OsStr>) -> RustcWrapperMode {
+    match value.and_then(std::ffi::OsStr::to_str) {
+        None => value
+            .map(|value| RustcWrapperMode::Custom(value.to_os_string()))
+            .unwrap_or(RustcWrapperMode::ManagedZccache),
+        Some(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("none") {
+                RustcWrapperMode::Disabled
+            } else {
+                RustcWrapperMode::Custom(trimmed.into())
+            }
+        }
+    }
+}
+
+fn rustc_wrapper_mode() -> RustcWrapperMode {
+    rustc_wrapper_mode_from_env_var(std::env::var_os(RUSTC_WRAPPER_OVERRIDE_ENV_VAR).as_deref())
+}
+
+async fn prepare_rustc_wrapper(
+    cargo: &mut std::process::Command,
+    paths: &SoldrPaths,
+) -> Result<Option<ZccacheBuildSession>, SoldrError> {
+    match rustc_wrapper_mode() {
+        RustcWrapperMode::ManagedZccache => prepare_zccache_build(cargo, paths).await.map(Some),
+        RustcWrapperMode::Custom(wrapper) => {
+            cargo.env("RUSTC_WRAPPER", wrapper);
+            cargo.env_remove(soldr_cache::ZCCACHE_BINARY_ENV_VAR);
+            cargo.env_remove(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR);
+            Ok(None)
+        }
+        RustcWrapperMode::Disabled => {
+            cargo.env_remove("RUSTC_WRAPPER");
+            cargo.env_remove(soldr_cache::ZCCACHE_BINARY_ENV_VAR);
+            cargo.env_remove(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR);
+            Ok(None)
+        }
+    }
 }
 
 async fn prepare_zccache_build(
@@ -936,9 +985,11 @@ fn cached_managed_zccache(
 mod tests {
     use super::{
         cargo_args_specify_target, cargo_args_use_reserved_no_cache, extract_as_pin,
-        first_cargo_subcommand, normalize_version, parse_tool_spec, should_trampoline,
+        first_cargo_subcommand, normalize_version, parse_tool_spec,
+        rustc_wrapper_mode_from_env_var, should_trampoline, RustcWrapperMode,
     };
     use soldr_fetch::VersionSpec;
+    use std::ffi::OsStr;
 
     #[test]
     fn cargo_args_detect_explicit_target_flag() {
@@ -974,6 +1025,33 @@ mod tests {
             "--".into(),
             "--no-cache".into(),
         ]));
+    }
+
+    #[test]
+    fn rustc_wrapper_override_defaults_to_managed_zccache() {
+        assert_eq!(
+            rustc_wrapper_mode_from_env_var(None),
+            RustcWrapperMode::ManagedZccache
+        );
+    }
+
+    #[test]
+    fn rustc_wrapper_override_disables_wrapper_for_empty_or_none() {
+        for value in ["", " ", "none", "NONE"] {
+            assert_eq!(
+                rustc_wrapper_mode_from_env_var(Some(OsStr::new(value))),
+                RustcWrapperMode::Disabled,
+                "expected {value:?} to disable wrapper injection"
+            );
+        }
+    }
+
+    #[test]
+    fn rustc_wrapper_override_uses_custom_wrapper_name() {
+        assert_eq!(
+            rustc_wrapper_mode_from_env_var(Some(OsStr::new("sccache"))),
+            RustcWrapperMode::Custom("sccache".into())
+        );
     }
 
     #[test]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -177,6 +177,34 @@ fn fake_zccache_script(log_path: &Path) -> String {
     }
 }
 
+fn fake_custom_wrapper_script(log_path: &Path, wrapper_name: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             set \"rustc=%~1\"\n\
+             shift\n\
+             echo {1} wrapper %rustc% %*>>\"{0}\"\n\
+             call \"%rustc%\" %*\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display(),
+            wrapper_name
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             rustc=\"$1\"\n\
+             shift\n\
+             echo \"{1} wrapper $rustc $*\" >> \"{0}\"\n\
+             \"$rustc\" \"$@\"\n",
+            log_path.display(),
+            wrapper_name
+        )
+    }
+}
+
 fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
     let dir = unique_temp_dir("fake-toolchain");
     let cargo = fake_script_path(&dir, "cargo");
@@ -186,6 +214,16 @@ fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
     write_fake_script(&rustc, &fake_rustc_script(log_path));
     write_fake_script(&zccache, &fake_zccache_script(log_path));
     (cargo, rustc, zccache)
+}
+
+fn install_fake_wrapper(log_path: &Path, wrapper_name: &str) -> PathBuf {
+    let dir = unique_temp_dir("fake-wrapper");
+    let wrapper = fake_script_path(&dir, wrapper_name);
+    write_fake_script(
+        &wrapper,
+        &fake_custom_wrapper_script(log_path, wrapper_name),
+    );
+    wrapper
 }
 
 #[test]
@@ -380,6 +418,97 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         journal.exists(),
         "expected session journal at {}",
         journal.display()
+    );
+}
+
+#[test]
+fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
+    let cache_root = unique_temp_dir("cargo-custom-wrapper");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let wrapper = install_fake_wrapper(&log_path, "sccache");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_RUSTC_WRAPPER", &wrapper)
+        .output()
+        .expect("failed to run soldr cargo build with custom rustc wrapper");
+
+    assert!(
+        output.status.success(),
+        "custom-wrapper front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains(&format!("cargo wrapper={}", wrapper.display())),
+        "cargo should receive the custom wrapper path: {log}"
+    );
+    assert!(
+        log.contains("sccache wrapper"),
+        "custom wrapper should be invoked for rustc: {log}"
+    );
+    assert!(
+        !log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "soldr should not stay in the wrapper slot when overridden: {log}"
+    );
+    assert!(
+        !log.contains("zccache start")
+            && !log.contains("zccache session-start")
+            && !log.contains("zccache wrapper")
+            && !log.contains("zccache session-end"),
+        "managed zccache should be skipped when using a custom wrapper: {log}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("soldr: zccache session summary"),
+        "custom wrapper path should not emit zccache session output: {stderr}"
+    );
+}
+
+#[test]
+fn empty_rustc_wrapper_override_disables_wrapper_injection() {
+    let cache_root = unique_temp_dir("cargo-wrapper-disabled");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_RUSTC_WRAPPER", "")
+        .output()
+        .expect("failed to run soldr cargo build with wrapper disabled");
+
+    assert!(
+        output.status.success(),
+        "wrapper-disabled front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cargo wrapper= rustc="),
+        "cargo should not receive a wrapper when override is empty: {log}"
+    );
+    assert!(
+        !log.contains("zccache start")
+            && !log.contains("zccache session-start")
+            && !log.contains("zccache wrapper")
+            && !log.contains("zccache session-end"),
+        "managed zccache should be skipped when wrapper injection is disabled: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "rustc should still run directly when wrapper injection is disabled: {log}"
     );
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -231,6 +231,7 @@ Commands:
 |---|---|---|
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
 | `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
+| `SOLDR_RUSTC_WRAPPER` | Override soldr's managed zccache wrapper with another wrapper binary, or disable wrapper injection with `none` / empty | unset |
 | `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
@@ -238,6 +239,7 @@ Commands:
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
+When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.
 
 ---
 


### PR DESCRIPTION
Closes #98.

## Summary
- add SOLDR_RUSTC_WRAPPER support to override soldr's managed zccache wrapper
- treat empty string or none as disabling wrapper injection for that build
- keep existing managed zccache behavior when the env var is unset
- document the new env var in the README and API docs

## Testing
- cargo test -p soldr-cli
- cargo fmt --all --check