### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.7.0" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.0" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.7.0" }
+soldr-core = { path = "crates/soldr-core", version = "0.7.1" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.1" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.7.1" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.7.0");
+        assert_eq!(version(), "0.7.1");
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.7.0"
+  "soldr_version": "0.7.1"
 }
 ```
 


### PR DESCRIPTION
## Summary
- bump the workspace version from 0.7.0 to 0.7.1
- refresh the lockfile for the new workspace crate versions
- update the version assertion and API example

## Testing
- cargo check -p soldr-cli
- cargo test -p soldr-core
- cargo test -p soldr-cli --test cli
- cargo fmt --all --check