### PR TITLE
sync: align release with main for v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.7.0" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.0" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.7.0" }
+soldr-core = { path = "crates/soldr-core", version = "0.7.1" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.1" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.7.1" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 soldr cargo build --release
 soldr cargo test
 soldr --no-cache cargo test
+SOLDR_RUSTC_WRAPPER=sccache soldr cargo build
+SOLDR_RUSTC_WRAPPER=none soldr cargo build
 
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,22 +94,14 @@ Current verification policy:
 - reproducible-build claims are not currently made for `soldr`
 - no extra signed release metadata is currently published beyond `SHA256SUMS` and GitHub provenance attestations
 
-Current hermeticity and runtime-trust policy:
+Hermeticity and runtime-trust policy (final for `0.5`):
 
 - `0.5.x` release verification covers published `soldr` artifacts, not every external input used during CI
-- `0.5.x` does not claim hermetic builds; documented dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt`, and the pinned bootstrap test repository remain acceptable for this release line
-- Cargo/toolchain/package mirroring or vendoring is deferred hardening tracked in issue [#41](https://github.com/zackees/soldr/issues/41)
-- runtime third-party binary fetches are a convenience/bootstrap path on `0.5.x`, not a repository-side trust guarantee
-- stronger trust enforcement for fetched binaries is tracked in issue [#42](https://github.com/zackees/soldr/issues/42)
-
-Planned state, tracked in issue `#7`:
-
-Remaining follow-up decisions before the attested secure `0.5` release, tracked in issues `#12` and `#13`:
-
-- whether `0.5` should publish SBOMs in addition to provenance attestations
-- whether `0.5` should claim reproducible builds and how that would be validated
-- whether release-time dependencies should be vendored or mirrored
-- what trust policy should apply to third-party binaries fetched by `soldr` at runtime
+- `0.5.x` does not claim hermetic builds; documented dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt`, and the pinned bootstrap test repository are accepted as the final input set for this line
+- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are explicitly out of scope for `0.5`; any revisit is scoped to a future `1.0.0-rc` hardening milestone
+- SBOMs are not required for `0.5`; GitHub provenance attestations plus `SHA256SUMS` are the verification story
+- reproducible-build claims are not made for `0.5`
+- runtime third-party binary trust is enforced as of `0.6.x` via SHA-256 pinning and `SOLDR_TRUST_MODE=strict` (originally tracked in [#42](https://github.com/zackees/soldr/issues/42), closed)
 
 `1.0.0-rc` remains gated on actual compilation-cache integration rather than release hardening alone.
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -7,6 +7,7 @@ const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
 const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 const JSON_SCHEMA_VERSION: u32 = 1;
+const RUSTC_WRAPPER_OVERRIDE_ENV_VAR: &str = "SOLDR_RUSTC_WRAPPER";
 
 /// Pin a specific soldr version to handle this invocation. Explicit
 /// `--as <version>` flag takes precedence over this env var.
@@ -459,7 +460,7 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     }
 
     let session = if cache_enabled {
-        Some(prepare_zccache_build(&mut command, &paths).await?)
+        prepare_rustc_wrapper(&mut command, &paths).await?
     } else {
         None
     };
@@ -609,6 +610,54 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
 struct ZccacheBuildSession {
     binary_path: std::path::PathBuf,
     session_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RustcWrapperMode {
+    ManagedZccache,
+    Custom(std::ffi::OsString),
+    Disabled,
+}
+
+fn rustc_wrapper_mode_from_env_var(value: Option<&std::ffi::OsStr>) -> RustcWrapperMode {
+    match value.and_then(std::ffi::OsStr::to_str) {
+        None => value
+            .map(|value| RustcWrapperMode::Custom(value.to_os_string()))
+            .unwrap_or(RustcWrapperMode::ManagedZccache),
+        Some(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("none") {
+                RustcWrapperMode::Disabled
+            } else {
+                RustcWrapperMode::Custom(trimmed.into())
+            }
+        }
+    }
+}
+
+fn rustc_wrapper_mode() -> RustcWrapperMode {
+    rustc_wrapper_mode_from_env_var(std::env::var_os(RUSTC_WRAPPER_OVERRIDE_ENV_VAR).as_deref())
+}
+
+async fn prepare_rustc_wrapper(
+    cargo: &mut std::process::Command,
+    paths: &SoldrPaths,
+) -> Result<Option<ZccacheBuildSession>, SoldrError> {
+    match rustc_wrapper_mode() {
+        RustcWrapperMode::ManagedZccache => prepare_zccache_build(cargo, paths).await.map(Some),
+        RustcWrapperMode::Custom(wrapper) => {
+            cargo.env("RUSTC_WRAPPER", wrapper);
+            cargo.env_remove(soldr_cache::ZCCACHE_BINARY_ENV_VAR);
+            cargo.env_remove(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR);
+            Ok(None)
+        }
+        RustcWrapperMode::Disabled => {
+            cargo.env_remove("RUSTC_WRAPPER");
+            cargo.env_remove(soldr_cache::ZCCACHE_BINARY_ENV_VAR);
+            cargo.env_remove(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR);
+            Ok(None)
+        }
+    }
 }
 
 async fn prepare_zccache_build(
@@ -936,9 +985,11 @@ fn cached_managed_zccache(
 mod tests {
     use super::{
         cargo_args_specify_target, cargo_args_use_reserved_no_cache, extract_as_pin,
-        first_cargo_subcommand, normalize_version, parse_tool_spec, should_trampoline,
+        first_cargo_subcommand, normalize_version, parse_tool_spec,
+        rustc_wrapper_mode_from_env_var, should_trampoline, RustcWrapperMode,
     };
     use soldr_fetch::VersionSpec;
+    use std::ffi::OsStr;
 
     #[test]
     fn cargo_args_detect_explicit_target_flag() {
@@ -974,6 +1025,33 @@ mod tests {
             "--".into(),
             "--no-cache".into(),
         ]));
+    }
+
+    #[test]
+    fn rustc_wrapper_override_defaults_to_managed_zccache() {
+        assert_eq!(
+            rustc_wrapper_mode_from_env_var(None),
+            RustcWrapperMode::ManagedZccache
+        );
+    }
+
+    #[test]
+    fn rustc_wrapper_override_disables_wrapper_for_empty_or_none() {
+        for value in ["", " ", "none", "NONE"] {
+            assert_eq!(
+                rustc_wrapper_mode_from_env_var(Some(OsStr::new(value))),
+                RustcWrapperMode::Disabled,
+                "expected {value:?} to disable wrapper injection"
+            );
+        }
+    }
+
+    #[test]
+    fn rustc_wrapper_override_uses_custom_wrapper_name() {
+        assert_eq!(
+            rustc_wrapper_mode_from_env_var(Some(OsStr::new("sccache"))),
+            RustcWrapperMode::Custom("sccache".into())
+        );
     }
 
     #[test]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -177,6 +177,34 @@ fn fake_zccache_script(log_path: &Path) -> String {
     }
 }
 
+fn fake_custom_wrapper_script(log_path: &Path, wrapper_name: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             set \"rustc=%~1\"\n\
+             shift\n\
+             echo {1} wrapper %rustc% %*>>\"{0}\"\n\
+             call \"%rustc%\" %*\n\
+             exit /b %ERRORLEVEL%\n",
+            log_path.display(),
+            wrapper_name
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             rustc=\"$1\"\n\
+             shift\n\
+             echo \"{1} wrapper $rustc $*\" >> \"{0}\"\n\
+             \"$rustc\" \"$@\"\n",
+            log_path.display(),
+            wrapper_name
+        )
+    }
+}
+
 fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
     let dir = unique_temp_dir("fake-toolchain");
     let cargo = fake_script_path(&dir, "cargo");
@@ -186,6 +214,16 @@ fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
     write_fake_script(&rustc, &fake_rustc_script(log_path));
     write_fake_script(&zccache, &fake_zccache_script(log_path));
     (cargo, rustc, zccache)
+}
+
+fn install_fake_wrapper(log_path: &Path, wrapper_name: &str) -> PathBuf {
+    let dir = unique_temp_dir("fake-wrapper");
+    let wrapper = fake_script_path(&dir, wrapper_name);
+    write_fake_script(
+        &wrapper,
+        &fake_custom_wrapper_script(log_path, wrapper_name),
+    );
+    wrapper
 }
 
 #[test]
@@ -380,6 +418,97 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         journal.exists(),
         "expected session journal at {}",
         journal.display()
+    );
+}
+
+#[test]
+fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
+    let cache_root = unique_temp_dir("cargo-custom-wrapper");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let wrapper = install_fake_wrapper(&log_path, "sccache");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_RUSTC_WRAPPER", &wrapper)
+        .output()
+        .expect("failed to run soldr cargo build with custom rustc wrapper");
+
+    assert!(
+        output.status.success(),
+        "custom-wrapper front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains(&format!("cargo wrapper={}", wrapper.display())),
+        "cargo should receive the custom wrapper path: {log}"
+    );
+    assert!(
+        log.contains("sccache wrapper"),
+        "custom wrapper should be invoked for rustc: {log}"
+    );
+    assert!(
+        !log.contains(env!("CARGO_BIN_EXE_soldr")),
+        "soldr should not stay in the wrapper slot when overridden: {log}"
+    );
+    assert!(
+        !log.contains("zccache start")
+            && !log.contains("zccache session-start")
+            && !log.contains("zccache wrapper")
+            && !log.contains("zccache session-end"),
+        "managed zccache should be skipped when using a custom wrapper: {log}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("soldr: zccache session summary"),
+        "custom wrapper path should not emit zccache session output: {stderr}"
+    );
+}
+
+#[test]
+fn empty_rustc_wrapper_override_disables_wrapper_injection() {
+    let cache_root = unique_temp_dir("cargo-wrapper-disabled");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_RUSTC_WRAPPER", "")
+        .output()
+        .expect("failed to run soldr cargo build with wrapper disabled");
+
+    assert!(
+        output.status.success(),
+        "wrapper-disabled front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cargo wrapper= rustc="),
+        "cargo should not receive a wrapper when override is empty: {log}"
+    );
+    assert!(
+        !log.contains("zccache start")
+            && !log.contains("zccache session-start")
+            && !log.contains("zccache wrapper")
+            && !log.contains("zccache session-end"),
+        "managed zccache should be skipped when wrapper injection is disabled: {log}"
+    );
+    assert!(
+        log.contains("rustc ") && log.contains("--crate-name demo"),
+        "rustc should still run directly when wrapper injection is disabled: {log}"
     );
 }
 

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.7.0");
+        assert_eq!(version(), "0.7.1");
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.7.0"
+  "soldr_version": "0.7.1"
 }
 ```
 
@@ -231,6 +231,7 @@ Commands:
 |---|---|---|
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
 | `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
+| `SOLDR_RUSTC_WRAPPER` | Override soldr's managed zccache wrapper with another wrapper binary, or disable wrapper injection with `none` / empty | unset |
 | `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
@@ -238,6 +239,7 @@ Commands:
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
+When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.
 
 ---
 

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -55,20 +55,22 @@ The bootstrap e2e jobs currently trust additional external systems:
 
 These inputs are pinned where possible, but they are not yet mirrored or fully hermetic.
 
-## Hermetic Inputs Hardening Status
+## Hermetic Inputs: Final `0.5.x` Stance
 
-Tracked by #41. Concrete narrowings already in place:
+Concrete narrowings in place:
 
 - the `musl-tools` install uses `--no-install-recommends` so the Ubuntu package surface is exactly what the release path declares
 - the `musl-tools` install logs its resolved version so the exact package contents are visible in workflow logs
 - the `musl-tools` install retries on transient apt failures rather than either flapping or pulling unrelated extras
 
-Still deferred (acceptable follow-up, not blockers for the current line):
+Explicitly out of scope for `0.5.x` (not planned; any revisit is scoped to a future `1.0.0-rc` hardening milestone):
 
 - a `cargo vendor` or mirrored-registry strategy for crates.io resolution during release
 - a mirrored or prebuilt-image strategy for Rust toolchain acquisition during release
 - a mirror for the pinned third-party bootstrap repository checkout
 - replacement of the live `apt` repository with a prebuilt image or pinned-package snapshot
+
+The attested release artifact — built from an exact commit SHA on the protected `release` branch, with GitHub build-provenance attestation and a `SHA256SUMS` manifest — is the user-facing trust guarantee for `0.5.x`. Narrowing the live CI input surface below that attestation-based guarantee is not a project goal on this line.
 
 ## Runtime Tool-Fetch Trust Boundaries
 
@@ -109,7 +111,7 @@ Current repo policy is:
 - prefer exact commit or version selection where possible
 - `0.5.x` does not claim hermetic builds
 - the documented release-time dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt` in the bootstrap e2e path, and the pinned third-party bootstrap repository are acceptable for `0.5.x`
-- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are accepted future hardening work, but they are not blockers for the current `0.5.x` release line
+- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are explicitly out of scope for `0.5.x`; any revisit is scoped to a future `1.0.0-rc` hardening milestone
 - the pinned third-party bootstrap checkout is acceptable for current validation, but it must not be described as mirrored or hermetic
 - release verification for `soldr` covers the published `soldr` artifacts and their provenance, not every external input used during CI
 
@@ -141,11 +143,11 @@ What is still deferred:
 
 Those remain acceptable future hardening work and are tracked on the issues linked below.
 
-Open follow-up implementation issues are tracked in:
+Open follow-up implementation issues:
 
 - [#11](https://github.com/zackees/soldr/issues/11) for repository and release-governance settings
-- [#41](https://github.com/zackees/soldr/issues/41) for reducing live external release inputs
-- [#42](https://github.com/zackees/soldr/issues/42) for fetched-binary trust enforcement (checksum enforcement landed; allowlist/signature work still open)
+
+Previously tracked, now closed: [#41](https://github.com/zackees/soldr/issues/41) (reducing live external release inputs — closed as out of scope for `0.5.x`), [#42](https://github.com/zackees/soldr/issues/42) (fetched-binary trust enforcement — checksum enforcement landed in `0.6.x`).
 
 ## Practical Reading Of This Document
 


### PR DESCRIPTION
## Summary
- align the protected release branch tree with the current main snapshot for v0.7.1
- carry the merged version bump from #100 onto release
- resolve the direct main->release conflicts by promoting the exact main content

## Source
- origin/main tree at 550001abd4b41803a9f68afae7bc5dd9b95bdc95
- sync commit b577eb6e0bfc6c820e58a57d44152802f0c9fe08