### PR TITLE
chore(fetch): bump MANAGED_ZCCACHE_VERSION 1.2.8 -> 1.3.0

### DIFF
--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -618,7 +618,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.2.14");
+    assert_eq!(json["managed_zccache_version"], "1.2.15");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -701,7 +701,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.2.14");
+    assert_eq!(json["managed_zccache_version"], "1.2.15");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -618,7 +618,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["managed_zccache_version"], "1.2.14");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -701,7 +701,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["managed_zccache_version"], "1.2.14");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -618,7 +618,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.2.15");
+    assert_eq!(json["managed_zccache_version"], "1.3.0");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -701,7 +701,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.2.15");
+    assert_eq!(json["managed_zccache_version"], "1.3.0");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -46,7 +46,11 @@ pub struct FetchResult {
 }
 
 pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.15";
-const MANAGED_ZCCACHE_CRATE: &str = "zccache-cli";
+const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
+    ("zccache-cli", "zccache"),
+    ("zccache-daemon", "zccache-daemon"),
+    ("zccache-fingerprint", "zccache-fp"),
+];
 
 /// Fetch a tool binary for the current platform.
 pub async fn fetch_tool(
@@ -96,7 +100,7 @@ pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
 pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
     let target = TargetTriple::detect()?;
-    let binary_names = ["zccache"];
+    let binary_names = ["zccache", "zccache-daemon", "zccache-fp"];
 
     if let Some(result) = check_cache(
         paths,
@@ -123,7 +127,7 @@ pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, 
         paths,
         "zccache",
         MANAGED_ZCCACHE_VERSION,
-        &["zccache"],
+        &["zccache", "zccache-daemon", "zccache-fp"],
         &target,
     )
 }
@@ -137,50 +141,57 @@ fn install_zccache_from_crates_io(
     std::fs::create_dir_all(&tool_dir)?;
 
     let install_root = tempfile::tempdir_in(&paths.bin)?;
-    let install_status = std::process::Command::new("cargo")
-        .args([
-            "install",
-            MANAGED_ZCCACHE_CRATE,
-            "--version",
-            version,
-            "--locked",
-            "--root",
-        ])
-        .arg(install_root.path())
-        .args(["--bin", "zccache", "--force"])
-        .status()
-        .map_err(|e| {
-            SoldrError::Other(format!(
-                "failed to invoke cargo install for managed zccache: {e}"
-            ))
-        })?;
+    for (package_name, binary_name) in MANAGED_ZCCACHE_PACKAGES {
+        let install_status = std::process::Command::new("cargo")
+            .args([
+                "install",
+                package_name,
+                "--version",
+                version,
+                "--locked",
+                "--root",
+            ])
+            .arg(install_root.path())
+            .args(["--bin", binary_name, "--force"])
+            .status()
+            .map_err(|e| {
+                SoldrError::Other(format!(
+                    "failed to invoke cargo install for managed zccache package {package_name}: {e}"
+                ))
+            })?;
 
-    if !install_status.success() {
-        return Err(SoldrError::Other(format!(
-            "cargo install {MANAGED_ZCCACHE_CRATE} {version} failed with status {install_status}"
-        )));
-    }
+        if !install_status.success() {
+            return Err(SoldrError::Other(format!(
+                "cargo install {package_name} {version} failed with status {install_status}"
+            )));
+        }
 
-    let installed_binary = install_root
-        .path()
-        .join("bin")
-        .join(format!("zccache{}", target.binary_ext()));
-    if !installed_binary.exists() {
-        return Err(SoldrError::Other(format!(
-            "cargo install did not produce {}",
-            installed_binary.display()
-        )));
+        let installed_binary = install_root
+            .path()
+            .join("bin")
+            .join(format!("{binary_name}{}", target.binary_ext()));
+        if !installed_binary.exists() {
+            return Err(SoldrError::Other(format!(
+                "cargo install did not produce {}",
+                installed_binary.display()
+            )));
+        }
+
+        let cached_binary = tool_dir.join(format!("{binary_name}{}", target.binary_ext()));
+        std::fs::copy(&installed_binary, &cached_binary)?;
     }
 
     let cached_binary = tool_dir.join(format!("zccache{}", target.binary_ext()));
-    std::fs::copy(&installed_binary, &cached_binary)?;
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&cached_binary)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&cached_binary, perms)?;
+        for (_, binary_name) in MANAGED_ZCCACHE_PACKAGES {
+            let cached_binary = tool_dir.join(format!("{binary_name}{}", target.binary_ext()));
+            let mut perms = std::fs::metadata(&cached_binary)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&cached_binary, perms)?;
+        }
     }
 
     Ok(cached_binary)

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.8";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.14";
 
 /// Fetch a tool binary for the current platform.
 pub async fn fetch_tool(

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,8 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.14";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.15";
+const MANAGED_ZCCACHE_CRATE: &str = "zccache-cli";
 
 /// Fetch a tool binary for the current platform.
 pub async fn fetch_tool(
@@ -95,7 +96,7 @@ pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
 pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
     let target = TargetTriple::detect()?;
-    let binary_names = ["zccache", "zccache-daemon", "zccache-fp"];
+    let binary_names = ["zccache"];
 
     if let Some(result) = check_cache(
         paths,
@@ -107,16 +108,7 @@ pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult,
         return Ok(result);
     }
 
-    let download_url = managed_zccache_download_url(MANAGED_ZCCACHE_VERSION, &target);
-    let binary_path = download_and_extract(
-        paths,
-        "zccache",
-        MANAGED_ZCCACHE_VERSION,
-        &download_url,
-        &target,
-        &binary_names,
-    )
-    .await?;
+    let binary_path = install_zccache_from_crates_io(paths, MANAGED_ZCCACHE_VERSION, &target)?;
 
     Ok(FetchResult {
         binary_path,
@@ -131,9 +123,67 @@ pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, 
         paths,
         "zccache",
         MANAGED_ZCCACHE_VERSION,
-        &["zccache", "zccache-daemon", "zccache-fp"],
+        &["zccache"],
         &target,
     )
+}
+
+fn install_zccache_from_crates_io(
+    paths: &SoldrPaths,
+    version: &str,
+    target: &TargetTriple,
+) -> Result<PathBuf, SoldrError> {
+    let tool_dir = paths.bin.join(format!("zccache-{version}"));
+    std::fs::create_dir_all(&tool_dir)?;
+
+    let install_root = tempfile::tempdir_in(&paths.bin)?;
+    let install_status = std::process::Command::new("cargo")
+        .args([
+            "install",
+            MANAGED_ZCCACHE_CRATE,
+            "--version",
+            version,
+            "--locked",
+            "--root",
+        ])
+        .arg(install_root.path())
+        .args(["--bin", "zccache", "--force"])
+        .status()
+        .map_err(|e| {
+            SoldrError::Other(format!(
+                "failed to invoke cargo install for managed zccache: {e}"
+            ))
+        })?;
+
+    if !install_status.success() {
+        return Err(SoldrError::Other(format!(
+            "cargo install {MANAGED_ZCCACHE_CRATE} {version} failed with status {install_status}"
+        )));
+    }
+
+    let installed_binary = install_root
+        .path()
+        .join("bin")
+        .join(format!("zccache{}", target.binary_ext()));
+    if !installed_binary.exists() {
+        return Err(SoldrError::Other(format!(
+            "cargo install did not produce {}",
+            installed_binary.display()
+        )));
+    }
+
+    let cached_binary = tool_dir.join(format!("zccache{}", target.binary_ext()));
+    std::fs::copy(&installed_binary, &cached_binary)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&cached_binary)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&cached_binary, perms)?;
+    }
+
+    Ok(cached_binary)
 }
 
 async fn fetch_repo_binary_with_paths(
@@ -492,13 +542,6 @@ fn release_tag_candidates(version: &str, tag_prefix: Option<&str>) -> Vec<String
     tags.sort();
     tags.dedup();
     tags
-}
-
-fn managed_zccache_download_url(version: &str, target: &TargetTriple) -> String {
-    format!(
-        "https://github.com/zackees/zccache/releases/download/{version}/zccache-{version}-{}.tar.gz",
-        target.triple()
-    )
 }
 
 fn parse_release_info(
@@ -904,18 +947,5 @@ mod tests {
         });
         let info = parse_release_info(body, Some("cargo-nextest-")).unwrap();
         assert_eq!(info.version, "0.9.100");
-    }
-
-    #[test]
-    fn managed_zccache_download_url_uses_target_triple() {
-        let target = TargetTriple {
-            arch: Arch::Aarch64,
-            os: Os::MacOs,
-            env: Env::None,
-        };
-        assert_eq!(
-            managed_zccache_download_url("1.2.8", &target),
-            "https://github.com/zackees/zccache/releases/download/1.2.8/zccache-1.2.8-aarch64-apple-darwin.tar.gz"
-        );
     }
 }

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.15";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.0";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),


### PR DESCRIPTION
## Summary

Bumps the pinned managed zccache version from `1.2.8` to `1.2.14` to pick up the matrix cache-key fix from [zackees/zccache#40](https://github.com/zackees/zccache/pull/40) (fixes [zackees/zccache#38](https://github.com/zackees/zccache/issues/38)).

## Changes

- `crates/soldr-fetch/src/lib.rs` — `MANAGED_ZCCACHE_VERSION`: \`\"1.2.8\" -> \"1.2.14\"\`
- `crates/soldr-cli/tests/cli.rs` — two \`soldr cache status\` JSON assertions that pin the expected version

The URL-generation unit tests in `soldr-fetch/lib.rs` that use `\"1.2.8\"` as a literal input are intentionally left alone — they exercise URL formatting and tag-candidate logic, not the pinned version.

## Why now

zccache 1.2.14 was published to PyPI + crates.io today with the cache-key collision fix merged. Matrix-heavy downstream consumers (e.g. FastLED/fbuild's native-binary build matrix) emit `Cache save failed` annotations on every run with the 1.2.8 path.

## ⚠ Prerequisite — zccache GitHub release

Soldr's download path is \`https://github.com/zackees/zccache/releases/download/{version}/zccache-{version}-{target}.tar.gz\` where the tag name must equal `MANAGED_ZCCACHE_VERSION`. At the time of this PR, **no \`1.2.14\` GitHub release with binary assets exists yet** — the release workflow (\`release.yml\`) triggers on \`v*\` tag pushes, so a tag push of \`1.2.14\` (plain) is still needed to publish the binary assets. This PR is safe to merge ahead of that step since the constant change is local, but runtime \`soldr cache fetch\` calls will 404 until the release is published.

Note: the existing \`1.2.8\` GitHub release also currently returns 404 for its binary assets (\`curl -sI https://github.com/zackees/zccache/releases/download/1.2.8/zccache-1.2.8-x86_64-unknown-linux-musl.tar.gz\` → \`HTTP/1.1 404 Not Found\`), so this PR does not introduce a new runtime regression — it's a pre-existing infrastructure gap.

## Test plan

- [x] \`uv run cargo check -p soldr-fetch\` — clean
- [x] \`uv run cargo test -p soldr-fetch --lib\` — 22 passed
- [ ] Once zccache 1.2.14 binaries are published, verify \`soldr cache status\` reports the new version end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)