### PR TITLE
ci: add autonomous main release workflow

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -1,0 +1,516 @@
+name: Autonomous Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Validate the autonomous release flow without publishing the GitHub Release or PyPI wheels
+        required: false
+        default: false
+        type: boolean
+      publish_pypi:
+        description: Publish hardened wheel artifacts to PyPI or TestPyPI after the GitHub Release
+        required: false
+        default: true
+        type: boolean
+      pypi_repository_url:
+        description: Optional alternate upload endpoint such as https://test.pypi.org/legacy/
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: write
+  attestations: write
+  id-token: write
+
+concurrency:
+  group: release-auto-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Validate main branch head
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      commit_sha: ${{ steps.validate.outputs.commit_sha }}
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive release version and commit
+        id: validate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_pypi='${{ inputs.publish_pypi }}'
+          pypi_repository_url='${{ inputs.pypi_repository_url }}'
+
+          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
+            echo "autonomous releases must be dispatched from main" >&2
+            exit 1
+          fi
+
+          if [[ "$publish_pypi" != "true" && -n "$pypi_repository_url" ]]; then
+            echo "pypi_repository_url requires publish_pypi=true" >&2
+            exit 1
+          fi
+
+          git fetch origin main --depth=1
+          commit_sha="$(git rev-parse HEAD)"
+          git merge-base --is-ancestor "$commit_sha" origin/main
+
+          cargo_version="$(
+            sed -n '/^\[workspace.package\]/,/^\[/{s/^version = "\([^"]*\)"/\1/p}' Cargo.toml | head -n1
+          )"
+
+          if [[ -z "$cargo_version" ]]; then
+            echo "failed to derive workspace version from Cargo.toml" >&2
+            exit 1
+          fi
+
+          version="v${cargo_version}"
+
+          if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "derived version must look like vX.Y.Z" >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "$version" >/dev/null 2>&1; then
+            echo "tag $version already exists" >&2
+            exit 1
+          fi
+
+          if gh release view "$version" >/dev/null 2>&1; then
+            echo "release $version already exists" >&2
+            exit 1
+          fi
+
+          {
+            echo "version=$version"
+            echo "commit_sha=$commit_sha"
+          } >> "$GITHUB_OUTPUT"
+
+  lint:
+    name: Lint
+    needs: prepare
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+  test:
+    name: ${{ matrix.name }}
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            runner: ubuntu-24.04
+          - name: macOS x64
+            runner: macos-15-intel
+          - name: Windows x64
+            runner: windows-2025
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Build workspace
+        run: cargo build --workspace --locked
+
+      - name: Run library tests
+        run: cargo test --workspace --lib --locked
+
+      - name: Run CLI smoke tests
+        run: cargo test -p soldr-cli --test cli --locked
+
+      - name: Run fetch integration test
+        run: cargo test -p soldr-fetch --test fetch_crgx --locked
+
+  e2e-linux-x64:
+    name: E2E Linux x64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-gnu
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-linux-arm64:
+    name: E2E Linux ARM64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-gnu
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-linux-x64-musl:
+    name: E2E Linux x64 musl
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-musl
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-linux-arm64-musl:
+    name: E2E Linux ARM64 musl
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-musl
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-macos-x64:
+    name: E2E macOS x64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15-intel
+      target: x86_64-apple-darwin
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-macos-arm64:
+    name: E2E macOS ARM64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15
+      target: aarch64-apple-darwin
+      binary_name: soldr
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-windows-x64:
+    name: E2E Windows x64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-2025
+      target: x86_64-pc-windows-msvc
+      binary_name: soldr.exe
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  e2e-windows-arm64:
+    name: E2E Windows ARM64
+    needs: prepare
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-11-arm
+      target: aarch64-pc-windows-msvc
+      binary_name: soldr.exe
+      source_ref: ${{ needs.prepare.outputs.commit_sha }}
+
+  build:
+    name: ${{ matrix.name }}
+    needs:
+      - prepare
+      - lint
+      - test
+      - e2e-linux-x64
+      - e2e-linux-arm64
+      - e2e-linux-x64-musl
+      - e2e-linux-arm64-musl
+      - e2e-macos-x64
+      - e2e-macos-arm64
+      - e2e-windows-x64
+      - e2e-windows-arm64
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+            binary: soldr
+          - name: Linux ARM64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            archive: tar.gz
+            binary: soldr
+          - name: macOS x64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+            archive: tar.gz
+            binary: soldr
+          - name: macOS ARM64
+            runner: macos-15
+            target: aarch64-apple-darwin
+            archive: tar.gz
+            binary: soldr
+          - name: Windows x64
+            runner: windows-2025
+            target: x86_64-pc-windows-msvc
+            archive: zip
+            binary: soldr.exe
+          - name: Windows ARM64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            archive: zip
+            binary: soldr.exe
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Build release binary
+        run: cargo build --package soldr-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Package tarball
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.prepare.outputs.version }}"
+          name="soldr-${version}-${{ matrix.target }}"
+          mkdir -p dist/package
+          cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "dist/package/${{ matrix.binary }}"
+          tar -C dist/package -czf "dist/${name}.tar.gz" "${{ matrix.binary }}"
+
+      - name: Package zip
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          $version = "${{ needs.prepare.outputs.version }}"
+          $name = "soldr-$version-${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path dist\package | Out-Null
+          Copy-Item "target\${{ matrix.target }}\release\${{ matrix.binary }}" "dist\package\${{ matrix.binary }}"
+          Compress-Archive -Path "dist\package\${{ matrix.binary }}" -DestinationPath "dist\$name.zip" -Force
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-soldr-${{ matrix.target }}
+          path: dist/soldr-*
+
+  build-pypi:
+    name: PyPI ${{ matrix.name }}
+    if: ${{ inputs.publish_pypi }}
+    needs:
+      - prepare
+      - lint
+      - test
+      - e2e-linux-x64
+      - e2e-linux-arm64
+      - e2e-linux-x64-musl
+      - e2e-linux-arm64-musl
+      - e2e-macos-x64
+      - e2e-macos-arm64
+      - e2e-windows-x64
+      - e2e-windows-arm64
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - name: Linux ARM64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS x64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - name: macOS ARM64
+            runner: macos-15
+            target: aarch64-apple-darwin
+          - name: Windows x64
+            runner: windows-2025
+            target: x86_64-pc-windows-msvc
+          - name: Windows ARM64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+
+      - name: Build hardened wheel
+        shell: bash
+        run: |
+          uv tool install "maturin>=1.7,<2"
+          maturin build \
+            --release \
+            --locked \
+            --compatibility pypi \
+            --target "${{ matrix.target }}" \
+            --out dist
+
+      - name: Smoke test wheel
+        shell: bash
+        run: |
+          uv venv .venv
+          uv pip install --python .venv dist/*.whl
+          .venv/bin/soldr --version || .venv/Scripts/soldr.exe --version
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pypi-soldr-${{ matrix.target }}
+          path: dist/*.whl
+
+  publish:
+    name: Attest and publish release assets
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.result == 'success' &&
+        needs.build.result == 'success' &&
+        (needs.build-pypi.result == 'success' || needs.build-pypi.result == 'skipped')
+      }}
+    needs:
+      - prepare
+      - build
+      - build-pypi
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          pattern: release-soldr-*
+          merge-multiple: true
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: soldr
+
+      - name: Verify GitHub App token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}" --jq '.full_name'
+
+      - name: Generate release checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum soldr-* > "soldr-${{ needs.prepare.outputs.version }}-SHA256SUMS.txt"
+
+      - uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-checksums: dist/soldr-${{ needs.prepare.outputs.version }}-SHA256SUMS.txt
+
+      - name: Stop after dry run validation
+        if: inputs.dry_run
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "dry run complete: autonomous release build, attestation, and GitHub App authentication all succeeded"
+
+      - name: Create draft GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "${{ needs.prepare.outputs.version }}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --draft \
+            --generate-notes \
+            --target "${{ needs.prepare.outputs.commit_sha }}" \
+            --title "${{ needs.prepare.outputs.version }}"
+
+      - name: Publish GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release edit "${{ needs.prepare.outputs.version }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --draft=false
+
+  publish-pypi:
+    name: Publish hardened PyPI wheels
+    if: ${{ inputs.publish_pypi && !inputs.dry_run }}
+    needs:
+      - prepare
+      - build-pypi
+      - publish
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          pattern: pypi-soldr-*
+          merge-multiple: true
+
+      - name: Show Python distributions
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -1 dist
+
+      - name: Publish wheel set to PyPI
+        if: ${{ inputs.pypi_repository_url == '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
+
+      - name: Publish wheel set to alternate index
+        if: ${{ inputs.pypi_repository_url != '' }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          repository-url: ${{ inputs.pypi_repository_url }}
+          packages-dir: dist

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Built on lessons from:
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
 - [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md) defines the supported machine-facing integration boundary.
 - [docs/PYPI_TRUSTED_PUBLISHING.md](./docs/PYPI_TRUSTED_PUBLISHING.md) describes the optional Trusted Publishing path for hardened PyPI wheels.
+- [`.github/workflows/release-auto.yml`](./.github/workflows/release-auto.yml) is the unattended release path for agents: it derives the version from `Cargo.toml` at the `main` branch head and publishes without the manual `release` environment stop.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,6 +56,21 @@ The strongest GitHub-native model for this repository is:
 
 The GitHub App is the machine identity that performs the irreversible tag-creation step.
 
+## Autonomous Publish Model
+
+If the repository decides that a future agent should be able to cut a release without waiting for the owner, use `.github/workflows/release-auto.yml`.
+
+That workflow intentionally changes the authorization model:
+
+1. An agent dispatches the workflow from the protected `main` branch.
+2. The workflow derives `vX.Y.Z` directly from `Cargo.toml`.
+3. The workflow validates the `main` branch head instead of asking the caller for a commit SHA.
+4. The workflow reruns the same lint, test, packaging, and e2e gate.
+5. The workflow uses the release GitHub App to mint the protected tag and GitHub Release.
+6. The workflow optionally publishes the hardened wheel set to PyPI without a manual environment stop.
+
+This is weaker than the maximum-security owner-approved model because it removes the `release` environment approval boundary. It exists specifically for unattended publication, not because it is equivalent to the stronger trust model above.
+
 ## Why A GitHub App Is Needed
 
 On this personal repository, GitHub would not let the built-in `github-actions` integration be used as the bypass actor for a release-tag ruleset.
@@ -168,7 +183,8 @@ If a future agent is asked to audit or extend the release flow, the agent should
 4. Confirm whether `release` still exists and is protected.
 5. Confirm whether a tag ruleset still protects `v*.*.*` and only the App may bypass it.
 6. Check issues `#12` and `#13` for the remaining `0.5` policy decisions.
-7. Only then modify `.github/workflows/release.yml` or the verification docs.
+7. Decide whether the task wants the owner-approved path in `.github/workflows/release.yml` or the unattended path in `.github/workflows/release-auto.yml`.
+8. Only then modify the relevant workflow or the verification docs.
 
 If the live GitHub-side controls drift from the documented trust model, the agent should stop and report the drift instead of assuming the release posture is still intact.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,7 @@ The repository currently enforces several baseline controls:
 - Third-party GitHub Actions in the repository workflows are pinned to full commit SHAs.
 - The e2e third-party source input is pinned to an exact Git commit in the workflow inputs.
 - Releases are promoted by `workflow_dispatch` for an exact commit SHA instead of publishing immediately on tag push.
+- An unattended `workflow_dispatch` path now exists in `.github/workflows/release-auto.yml` for agents that should release the `main` branch head without manual input selection.
 - Release assets are attested in GitHub Actions before publication.
 - Release publication uses a dedicated GitHub App instead of `GITHUB_TOKEN` or a PAT.
 - Release tags matching `v*.*.*` are protected by a repository ruleset.
@@ -76,6 +77,7 @@ When a pinned dependency, action, or external input is updated, the change shoul
 Current state:
 
 - releases are validated in GitHub Actions from an exact commit SHA
+- unattended releases can also be promoted from the protected `main` branch head by `.github/workflows/release-auto.yml`, which derives the version from `Cargo.toml`
 - the release workflow re-runs lint, build, test, integration, and e2e checks before publishing
 - the release commit must be reachable from the protected `release` branch
 - release tags are created through a GitHub App-backed workflow path
@@ -84,6 +86,12 @@ Current state:
 - the release workflow can also build hardened PyPI wheels, but enabling PyPI upload still requires Trusted Publisher registration on the existing `soldr` PyPI project
 - immutable releases and protected tag settings still depend on repository configuration outside the git tree
 - current user-facing verification guidance is checksum verification plus `gh attestation verify`
+
+Autonomous-release tradeoff:
+
+- `.github/workflows/release-auto.yml` keeps the GitHub App tag-creation path, pinned actions, full validation gate, checksums, and attestations
+- `.github/workflows/release-auto.yml` intentionally omits the `release` environment approval gate so an agent can publish without waiting for a human
+- `.github/workflows/release.yml` remains the stronger owner-approved path when that manual authorization boundary matters more than autonomy
 
 Current verification policy:
 

--- a/docs/PYPI_TRUSTED_PUBLISHING.md
+++ b/docs/PYPI_TRUSTED_PUBLISHING.md
@@ -30,6 +30,15 @@ For `soldr`, the intended trusted identity is:
 
 Using the existing `release` environment keeps the PyPI publish step behind the same manual approval gate as the immutable GitHub release path.
 
+The unattended path in `.github/workflows/release-auto.yml` is a second trusted identity:
+
+- owner: `zackees`
+- repository: `soldr`
+- workflow: `.github/workflows/release-auto.yml`
+- environment: leave blank
+
+That second publisher is required if autonomous releases should also publish to PyPI, because PyPI binds Trusted Publishers to a specific workflow filename.
+
 ## Owner Setup On PyPI
 
 These steps must be performed in the PyPI web UI by a maintainer of the `soldr` project.
@@ -44,6 +53,13 @@ These steps must be performed in the PyPI web UI by a maintainer of the `soldr` 
    - environment name: `release`
 
 The environment field is optional in PyPI, but it should be filled in here because the repo already uses `release` as the human approval boundary.
+
+If autonomous releases are enabled, add a second publisher with:
+
+- repository owner: `zackees`
+- repository name: `soldr`
+- workflow filename: `.github/workflows/release-auto.yml`
+- environment name: leave empty
 
 ## Repo-Side Workflow Inputs
 
@@ -62,6 +78,20 @@ If `publish_pypi=true`, the workflow:
 4. Publishes the wheel set to PyPI from a dedicated Linux job with `id-token: write`.
 
 No source distribution is published in this path. The current design is wheel-only because the project is prioritizing hardened binary distribution rather than source release through package registries.
+
+The unattended workflow supports the same release surfaces but derives the version from `Cargo.toml` and the target commit from the `main` branch head:
+
+```bash
+gh workflow run release-auto.yml --ref main
+```
+
+Dry-run rehearsal remains available:
+
+```bash
+gh workflow run release-auto.yml \
+  --ref main \
+  -f dry_run=true
+```
 
 ## Recommended Rehearsal
 


### PR DESCRIPTION
## Summary
- add an unattended release workflow that derives the version from the main branch head
- keep the owner-approved release.yml path intact for the stricter manual flow
- document the PyPI trusted publisher and security tradeoffs for the autonomous path

## Verification
- git diff --check
- python YAML parse for .github/workflows/release-auto.yml
