### PR TITLE
chore: bump version to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.7.2" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.2" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.7.2" }
+soldr-core = { path = "crates/soldr-core", version = "0.7.3" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.3" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.7.3" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.7.2");
+        assert_eq!(version(), "0.7.3");
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.7.2"
+  "soldr_version": "0.7.3"
 }
 ```
 


### PR DESCRIPTION
## Summary
- bump the workspace release version to 0.7.3
- update the public API example version
- keep the soldr-core version assertion aligned

## Verification
- cargo check --workspace
