### PR TITLE
chore(fetch): bump MANAGED_ZCCACHE_VERSION 1.2.8 -> 1.2.15

### DIFF
--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -618,7 +618,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.2.14");
+    assert_eq!(json["managed_zccache_version"], "1.2.15");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -701,7 +701,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.2.14");
+    assert_eq!(json["managed_zccache_version"], "1.2.15");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -618,7 +618,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["managed_zccache_version"], "1.2.14");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -701,7 +701,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.2.8");
+    assert_eq!(json["managed_zccache_version"], "1.2.14");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.8";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.14";
 
 /// Fetch a tool binary for the current platform.
 pub async fn fetch_tool(

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.14";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.2.15";
 
 /// Fetch a tool binary for the current platform.
 pub async fn fetch_tool(


### PR DESCRIPTION
## Summary
- bump the pinned managed zccache version from \1.2.8\ to \1.2.15\
- update the two CLI JSON assertions that pin the expected managed version
- supersede #104 with the same functional change rebased onto current \main\, using the actual upstream release version

## Verification
- cargo test -p soldr-fetch --lib
- cargo test -p soldr-cli --test cli
