### PR TITLE
fix(ci): repair PyPI release publishing path

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -412,6 +412,7 @@ jobs:
       - build
       - build-pypi
     runs-on: ubuntu-24.04
+    environment: release
 
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -488,6 +489,7 @@ jobs:
       - build-pypi
       - publish
     runs-on: ubuntu-24.04
+    environment: release
 
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
       publish_pypi:
         description: Build hardened wheel artifacts and publish them to PyPI via Trusted Publishing
         required: false
-        default: false
+        default: true
         type: boolean
       pypi_repository_url:
         description: Optional alternate upload endpoint such as https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Built on lessons from:
 - [SECURITY.md](./SECURITY.md) describes the current hardening posture and release policy.
 - [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md) defines the supported machine-facing integration boundary.
 - [docs/PYPI_TRUSTED_PUBLISHING.md](./docs/PYPI_TRUSTED_PUBLISHING.md) describes the optional Trusted Publishing path for hardened PyPI wheels.
-- [`.github/workflows/release-auto.yml`](./.github/workflows/release-auto.yml) is the unattended release path for agents: it derives the version from `Cargo.toml` at the `main` branch head and publishes without the manual `release` environment stop.
+- [`.github/workflows/release-auto.yml`](./.github/workflows/release-auto.yml) is the main-driven release path for agents: it derives the version from `Cargo.toml` at the `main` branch head, then performs final publication through the `release` environment where the release credentials live.
 - [RELEASE.md](./RELEASE.md) documents the intended maximum-security release setup and owner workflow.
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md) explains how to verify published release artifacts.
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md) inventories the external systems and artifacts `soldr` currently trusts, including the current `0.5.x` limits of runtime fetched-binary trust.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,7 +58,7 @@ The GitHub App is the machine identity that performs the irreversible tag-creati
 
 ## Autonomous Publish Model
 
-If the repository decides that a future agent should be able to cut a release without waiting for the owner, use `.github/workflows/release-auto.yml`.
+If the repository decides that a future agent should be able to cut a release from `main`, use `.github/workflows/release-auto.yml`.
 
 That workflow intentionally changes the authorization model:
 
@@ -67,9 +67,9 @@ That workflow intentionally changes the authorization model:
 3. The workflow validates the `main` branch head instead of asking the caller for a commit SHA.
 4. The workflow reruns the same lint, test, packaging, and e2e gate.
 5. The workflow uses the release GitHub App to mint the protected tag and GitHub Release.
-6. The workflow optionally publishes the hardened wheel set to PyPI without a manual environment stop.
+6. The workflow performs final publication through the `release` environment, because the release GitHub App credentials are scoped there.
 
-This is weaker than the maximum-security owner-approved model because it removes the `release` environment approval boundary. It exists specifically for unattended publication, not because it is equivalent to the stronger trust model above.
+This is weaker than the maximum-security owner-approved model because it derives the version and target commit directly from `main` instead of requiring an explicit release SHA. It is not equivalent to the stronger trust model above.
 
 ## Why A GitHub App Is Needed
 
@@ -183,7 +183,7 @@ If a future agent is asked to audit or extend the release flow, the agent should
 4. Confirm whether `release` still exists and is protected.
 5. Confirm whether a tag ruleset still protects `v*.*.*` and only the App may bypass it.
 6. Check issues `#12` and `#13` for the remaining `0.5` policy decisions.
-7. Decide whether the task wants the owner-approved path in `.github/workflows/release.yml` or the unattended path in `.github/workflows/release-auto.yml`.
+7. Decide whether the task wants the owner-approved path in `.github/workflows/release.yml` or the main-driven path in `.github/workflows/release-auto.yml`.
 8. Only then modify the relevant workflow or the verification docs.
 
 If the live GitHub-side controls drift from the documented trust model, the agent should stop and report the drift instead of assuming the release posture is still intact.

--- a/docs/PYPI_TRUSTED_PUBLISHING.md
+++ b/docs/PYPI_TRUSTED_PUBLISHING.md
@@ -30,14 +30,14 @@ For `soldr`, the intended trusted identity is:
 
 Using the existing `release` environment keeps the PyPI publish step behind the same manual approval gate as the immutable GitHub release path.
 
-The unattended path in `.github/workflows/release-auto.yml` is a second trusted identity:
+The main-driven path in `.github/workflows/release-auto.yml` is a second trusted identity:
 
 - owner: `zackees`
 - repository: `soldr`
 - workflow: `.github/workflows/release-auto.yml`
-- environment: leave blank
+- environment: `release`
 
-That second publisher is required if autonomous releases should also publish to PyPI, because PyPI binds Trusted Publishers to a specific workflow filename.
+That second publisher is required if `release-auto.yml` should also publish to PyPI, because PyPI binds Trusted Publishers to a specific workflow filename.
 
 ## Owner Setup On PyPI
 
@@ -59,7 +59,7 @@ If autonomous releases are enabled, add a second publisher with:
 - repository owner: `zackees`
 - repository name: `soldr`
 - workflow filename: `.github/workflows/release-auto.yml`
-- environment name: leave empty
+- environment name: `release`
 
 ## Repo-Side Workflow Inputs
 
@@ -68,7 +68,7 @@ The release workflow supports these PyPI-related inputs:
 - `publish_pypi=true`
 - `pypi_repository_url=...` for alternate endpoints such as TestPyPI
 
-If `publish_pypi=false`, the workflow keeps its GitHub-release-only behavior.
+The validated `release.yml` workflow now defaults `publish_pypi` to `true`. Set `publish_pypi=false` only when a GitHub-release-only run is intentional.
 
 If `publish_pypi=true`, the workflow:
 
@@ -79,7 +79,7 @@ If `publish_pypi=true`, the workflow:
 
 No source distribution is published in this path. The current design is wheel-only because the project is prioritizing hardened binary distribution rather than source release through package registries.
 
-The unattended workflow supports the same release surfaces but derives the version from `Cargo.toml` and the target commit from the `main` branch head:
+The `release-auto.yml` workflow supports the same release surfaces but derives the version from `Cargo.toml` and the target commit from the `main` branch head, then enters the `release` environment for final publication:
 
 ```bash
 gh workflow run release-auto.yml --ref main


### PR DESCRIPTION
## Summary
- default validated releases to publishing PyPI wheels unless explicitly disabled
- make release-auto publish stages enter the elease environment so they can access release credentials and Trusted Publishing context
- update release docs to match the actual workflow behavior

## Validation
- parsed .github/workflows/release.yml with PyYAML
- parsed .github/workflows/release-auto.yml with PyYAML

## Notes
- I could not run a real end-to-end publish rehearsal on 0.7.3 because that tag already exists.
- The next meaningful verification is a fresh version release or a deliberate TestPyPI prerelease run.