### PR TITLE
ci: restore standalone build badges

### DIFF
--- a/.github/workflows/build-linux-arm64-musl.yml
+++ b/.github/workflows/build-linux-arm64-musl.yml
@@ -1,0 +1,20 @@
+name: Build Linux ARM64 musl
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-musl
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -1,0 +1,20 @@
+name: Build Linux ARM64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-gnu
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-linux-x64-musl.yml
+++ b/.github/workflows/build-linux-x64-musl.yml
@@ -1,0 +1,20 @@
+name: Build Linux x64 musl
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-musl
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-linux-x64.yml
+++ b/.github/workflows/build-linux-x64.yml
@@ -1,0 +1,20 @@
+name: Build Linux x64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-gnu
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -1,0 +1,20 @@
+name: Build macOS ARM64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15
+      target: aarch64-apple-darwin
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -1,0 +1,20 @@
+name: Build macOS x64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15-intel
+      target: x86_64-apple-darwin
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -1,0 +1,20 @@
+name: Build Windows ARM64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-11-arm
+      target: aarch64-pc-windows-msvc
+      binary_name: soldr.exe
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -1,0 +1,20 @@
+name: Build Windows x64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-2025
+      target: x86_64-pc-windows-msvc
+      binary_name: soldr.exe
+      source_ref: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # soldr
 
+[![Linux x64](https://github.com/zackees/soldr/actions/workflows/build-linux-x64.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-linux-x64.yml)
+[![Linux ARM64](https://github.com/zackees/soldr/actions/workflows/build-linux-arm64.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-linux-arm64.yml)
+[![Linux x64 musl](https://github.com/zackees/soldr/actions/workflows/build-linux-x64-musl.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-linux-x64-musl.yml)
+[![Linux ARM64 musl](https://github.com/zackees/soldr/actions/workflows/build-linux-arm64-musl.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-linux-arm64-musl.yml)
+[![macOS x64](https://github.com/zackees/soldr/actions/workflows/build-macos-x64.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-macos-x64.yml)
+[![macOS ARM64](https://github.com/zackees/soldr/actions/workflows/build-macos-arm64.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-macos-arm64.yml)
+[![Windows x64](https://github.com/zackees/soldr/actions/workflows/build-windows-x64.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-windows-x64.yml)
+[![Windows ARM64](https://github.com/zackees/soldr/actions/workflows/build-windows-arm64.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-windows-arm64.yml)
+
 **Instant tools. Instant builds. One command.**
 
 soldr = [crgx](https://crgx.dev/) + [zccache](https://github.com/zackees/zccache) in a single tool.


### PR DESCRIPTION
## Summary
- restore the eight standalone per-platform build workflows on `main`
- keep PR validation centralized in `ci.yml` by not re-enabling these on `pull_request`
- add README badges for the per-platform build workflows so status is visible at a glance again

## Why
The previous workflow cleanup removed the standalone workflow files entirely, which also removed the separate main-branch status badges/surfaces. That broke the at-a-glance platform visibility you wanted.

## Validation
- parsed every workflow YAML file with PyYAML
- `git diff --check`