### PR TITLE
ci: shrink bootstrap fixture target

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -18,15 +18,19 @@ on:
       third_party_repo:
         required: false
         type: string
-        default: "zackees/running-process"
+        default: "zackees/soldr"
       third_party_ref:
         required: false
         type: string
-        default: "b4e005318ce320bcbd652df3aa8381f4ab95fea7"
+        default: "0c8daefe4a4ac526b491fade590b32636340dce1"
       third_party_path:
         required: false
         type: string
-        default: "third_party/running-process"
+        default: "third_party/bootstrap-fixture"
+      third_party_build_dir:
+        required: false
+        type: string
+        default: "crates/soldr-cli/tests/fixtures/windows-msvc-default"
 
 permissions:
   contents: read
@@ -89,7 +93,7 @@ jobs:
         with:
           workspaces: |
             soldr -> target
-            ${{ inputs.third_party_path }} -> target
+            ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }} -> target
 
       - name: Build soldr-cli
         shell: pwsh
@@ -101,11 +105,23 @@ jobs:
         id: third_party_toolchain
         shell: pwsh
         run: |
-          $toolchainFile = Join-Path $env:GITHUB_WORKSPACE "${{ inputs.third_party_path }}/rust-toolchain.toml"
+          $checkoutRoot = Join-Path $env:GITHUB_WORKSPACE "${{ inputs.third_party_path }}"
+          $candidateFiles = @(
+            (Join-Path $checkoutRoot "${{ inputs.third_party_build_dir }}/rust-toolchain.toml"),
+            (Join-Path $checkoutRoot "rust-toolchain.toml")
+          )
+
+          $toolchainFile = $candidateFiles | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $toolchainFile) {
+            "channel=repo-default" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            exit 0
+          }
+
           $channelLine = Select-String -Path $toolchainFile -Pattern '^channel = "(.*)"$' | Select-Object -First 1
           if (-not $channelLine) {
             throw "failed to resolve third-party Rust toolchain from $toolchainFile"
           }
+
           $channel = $channelLine.Matches[0].Groups[1].Value
           rustup toolchain install $channel --profile minimal
           rustup target add --toolchain $channel "${{ inputs.target }}"
@@ -125,7 +141,7 @@ jobs:
 
       - name: Build third-party app through soldr
         shell: pwsh
-        working-directory: ${{ inputs.third_party_path }}
+        working-directory: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}
         run: |
           & "${{ steps.soldr_binary.outputs.path }}" cargo build --locked --target "${{ inputs.target }}"
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ The repository currently enforces several baseline controls:
 - CI now enforces `cargo fmt --check` and `cargo clippy -D warnings`.
 - No Cargo `git` dependencies are currently used; dependencies resolve from crates.io.
 - Third-party GitHub Actions in the repository workflows are pinned to full commit SHAs.
-- The e2e third-party source input is pinned to an exact Git commit in the workflow inputs.
+- The e2e bootstrap fixture input is pinned to an exact Git commit in the workflow inputs.
 - Releases are promoted from reviewed version bumps on `main` through `.github/workflows/release-auto.yml`.
 - Release assets are attested in GitHub Actions before publication.
 - Release publication uses a dedicated GitHub App instead of `GITHUB_TOKEN` or a PAT.
@@ -66,7 +66,7 @@ Security-relevant versioning and pinning should follow these rules:
 
 - Cargo dependency changes must update `Cargo.lock`.
 - Workflow action upgrades should be explicit pull requests that update SHAs, not floating major tags.
-- Third-party test inputs should remain pinned to exact commits.
+- Bootstrap fixture inputs should remain pinned to exact commits.
 - Release toolchain changes should be explicit and reviewed.
 
 When a pinned dependency, action, or external input is updated, the change should be visible in git history and reviewed like code.
@@ -105,7 +105,7 @@ Hermeticity and runtime-trust policy (final for `0.5`):
 
 - `0.5.x` release verification covers published `soldr` artifacts, not every external input used during CI
 - `0.5.x` does not claim hermetic builds; documented dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt`, and the pinned bootstrap test repository are accepted as the final input set for this line
-- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are explicitly out of scope for `0.5`; any revisit is scoped to a future `1.0.0-rc` hardening milestone
+- Cargo vendoring, toolchain mirroring, OS-package mirroring, and bootstrap fixture source mirroring are explicitly out of scope for `0.5`; any revisit is scoped to a future `1.0.0-rc` hardening milestone
 - SBOMs are not required for `0.5`; GitHub provenance attestations plus `SHA256SUMS` are the verification story
 - reproducible-build claims are not made for `0.5`
 - runtime third-party binary trust is enforced as of `0.6.x` via SHA-256 pinning and `SOLDR_TRUST_MODE=strict` (originally tracked in [#42](https://github.com/zackees/soldr/issues/42), closed)

--- a/docs/TRUST_BOUNDARIES.md
+++ b/docs/TRUST_BOUNDARIES.md
@@ -12,7 +12,7 @@ The repository directly controls:
 - the Cargo dependency graph recorded in `Cargo.lock`
 - the workflow definitions committed in `.github/workflows/`
 - the action revisions pinned by full commit SHA in those workflows
-- the exact third-party Git commit used by the current bootstrap e2e workflow
+- the exact pinned fixture commit used by the current bootstrap e2e workflow
 
 ## Release-Time External Dependencies
 
@@ -38,7 +38,7 @@ Based on the committed release workflow in `.github/workflows/release-auto.yml`:
 - the published `soldr` release archives are built from the repository source tree plus Rust dependencies resolved through Cargo
 - the workflow does not explicitly download and repackage third-party release binaries into the published `soldr` archives
 - the release path still depends on external services and package sources such as GitHub-hosted runners, `rustup`, crates.io, and GitHub APIs
-- the live `apt` install and pinned third-party repository checkout are part of release-gating validation, not packaged release contents
+- the live `apt` install and pinned bootstrap fixture checkout are part of release-gating validation, not packaged release contents
 - the managed `zccache` download path is runtime behavior in `soldr`, not an input to building the published `soldr` release artifacts
 
 ## E2E Validation External Dependencies
@@ -48,8 +48,8 @@ The bootstrap e2e jobs currently trust additional external systems:
 - Ubuntu package repositories
   - musl validation jobs install `musl-tools` from live `apt` repositories
   - the install command uses `--no-install-recommends`, a retry loop, and logs the resolved `musl-tools` version for auditability; the set of installed packages is therefore the declared set, not an open-ended recommended expansion
-- third-party source repository hosting
-  - the e2e workflow checks out a pinned commit of `zackees/running-process` from GitHub
+- GitHub repository hosting for the bootstrap fixture
+  - the e2e workflow checks out a pinned commit of `zackees/soldr` and builds `crates/soldr-cli/tests/fixtures/windows-msvc-default`
 - third-party Rust toolchain installation
   - the e2e workflow reads the third-party project's `rust-toolchain.toml` and installs that toolchain through `rustup`
 
@@ -67,7 +67,7 @@ Explicitly out of scope for `0.5.x` (not planned; any revisit is scoped to a fut
 
 - a `cargo vendor` or mirrored-registry strategy for crates.io resolution during release
 - a mirrored or prebuilt-image strategy for Rust toolchain acquisition during release
-- a mirror for the pinned third-party bootstrap repository checkout
+- a mirror for the pinned bootstrap fixture checkout
 - replacement of the live `apt` repository with a prebuilt image or pinned-package snapshot
 
 The attested release artifact - built from the reviewed `main` commit that bumped the workspace version, published through the `release` environment, with GitHub build-provenance attestation and a `SHA256SUMS` manifest - is the user-facing trust guarantee for `0.5.x`. Narrowing the live CI input surface below that attestation-based guarantee is not a project goal on this line.
@@ -110,9 +110,9 @@ Current repo policy is:
 - treat floating workflow refs as unacceptable
 - prefer exact commit or version selection where possible
 - `0.5.x` does not claim hermetic builds
-- the documented release-time dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt` in the bootstrap e2e path, and the pinned third-party bootstrap repository are acceptable for `0.5.x`
-- Cargo vendoring, toolchain mirroring, OS-package mirroring, and third-party bootstrap source mirroring are explicitly out of scope for `0.5.x`; any revisit is scoped to a future `1.0.0-rc` hardening milestone
-- the pinned third-party bootstrap checkout is acceptable for current validation, but it must not be described as mirrored or hermetic
+- the documented release-time dependencies on GitHub-hosted runners, `rustup`, crates.io, GitHub APIs/Releases, live `apt` in the bootstrap e2e path, and the pinned bootstrap fixture checkout are acceptable for `0.5.x`
+- Cargo vendoring, toolchain mirroring, OS-package mirroring, and bootstrap fixture source mirroring are explicitly out of scope for `0.5.x`; any revisit is scoped to a future `1.0.0-rc` hardening milestone
+- the pinned bootstrap fixture checkout is acceptable for current validation, but it must not be described as mirrored or hermetic
 - release verification for `soldr` covers the published `soldr` artifacts and their provenance, not every external input used during CI
 
 ## Current Runtime Fetch Policy


### PR DESCRIPTION
## Summary
- replace the heavy `running-process` bootstrap target with the tiny in-repo fixture at `crates/soldr-cli/tests/fixtures/windows-msvc-default`
- pin the bootstrap fixture checkout to a specific `zackees/soldr` commit instead of a large external workspace
- make `_bootstrap-e2e.yml` fall back cleanly when the bootstrap target does not ship `rust-toolchain.toml`
- update security/trust docs to match the new bootstrap source

## Why
The previous bootstrap target was a large multi-crate workspace with a very large dependency graph. It slowed every PR and release gate without adding proportional signal. The new fixture is a tiny cargo project with just enough behavior to exercise the soldr front door and the Windows MSVC assertion.

## Validation
- parsed every workflow YAML file with PyYAML
- `cargo run -p soldr-cli -- --no-cache cargo build --manifest-path crates/soldr-cli/tests/fixtures/windows-msvc-default/Cargo.toml --locked`