### PR TITLE
chore(release): drop GitHub App + release env, gate on PyPI, bump 0.7.4

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       should_release: ${{ steps.validate.outputs.should_release }}
+      tag_exists: ${{ steps.validate.outputs.tag_exists }}
       version: ${{ steps.validate.outputs.version }}
       commit_sha: ${{ steps.validate.outputs.commit_sha }}
 
@@ -30,14 +31,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Derive release version and commit
+      - name: Compare candidate version against PyPI
         id: validate
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          before_sha='${{ github.event.before }}'
           commit_sha='${{ github.sha }}'
 
           if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
@@ -57,26 +57,6 @@ jobs:
             exit 1
           fi
 
-          previous_version=""
-          if [[ "$before_sha" =~ ^0+$ ]]; then
-            previous_version=""
-          elif git rev-parse --verify "${before_sha}^{commit}" >/dev/null 2>&1; then
-            previous_version="$(
-              git show "${before_sha}:Cargo.toml" |
-                sed -n '/^\[workspace.package\]/,/^\[/{s/^version = "\([^"]*\)"/\1/p}' |
-                head -n1
-            )"
-          fi
-
-          if [[ "$cargo_version" == "$previous_version" ]]; then
-            {
-              echo "should_release=false"
-              echo "version=v${cargo_version}"
-              echo "commit_sha=$commit_sha"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           version="v${cargo_version}"
 
           if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
@@ -84,18 +64,35 @@ jobs:
             exit 1
           fi
 
+          tag_exists=false
           if git ls-remote --exit-code --tags origin "$version" >/dev/null 2>&1; then
-            echo "tag $version already exists" >&2
+            tag_exists=true
+          fi
+
+          pypi_version="$(
+            curl -fsSL https://pypi.org/pypi/soldr/json | jq -r '.info.version'
+          )"
+
+          if [[ -z "$pypi_version" || "$pypi_version" == "null" ]]; then
+            echo "failed to fetch latest PyPI version for soldr" >&2
             exit 1
           fi
 
-          if gh release view "$version" >/dev/null 2>&1; then
-            echo "release $version already exists" >&2
-            exit 1
+          pypi_tag="v${pypi_version}"
+          highest_version="$(printf '%s\n%s\n' "$pypi_tag" "$version" | sort -V | tail -n1)"
+          if [[ "$highest_version" != "$version" || "$pypi_tag" == "$version" ]]; then
+            {
+              echo "should_release=false"
+              echo "tag_exists=$tag_exists"
+              echo "version=$version"
+              echo "commit_sha=$commit_sha"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           {
             echo "should_release=true"
+            echo "tag_exists=$tag_exists"
             echo "version=$version"
             echo "commit_sha=$commit_sha"
           } >> "$GITHUB_OUTPUT"
@@ -424,6 +421,7 @@ jobs:
       ${{
         always() &&
         needs.prepare.outputs.should_release == 'true' &&
+        needs.prepare.outputs.tag_exists == 'false' &&
         needs.prepare.result == 'success' &&
         needs.build.result == 'success' &&
         needs.build-pypi.result == 'success'
@@ -433,7 +431,6 @@ jobs:
       - build
       - build-pypi
     runs-on: ubuntu-24.04
-    environment: release
 
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -441,23 +438,6 @@ jobs:
           path: dist
           pattern: release-soldr-*
           merge-multiple: true
-
-      - name: Create GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: soldr
-
-      - name: Verify GitHub App token
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}" --jq '.full_name'
 
       - name: Generate release checksums
         shell: bash
@@ -472,7 +452,7 @@ jobs:
 
       - name: Create draft GitHub Release
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -485,7 +465,7 @@ jobs:
 
       - name: Publish GitHub Release
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -495,13 +475,16 @@ jobs:
 
   publish-pypi:
     name: Publish hardened PyPI wheels
-    if: needs.prepare.outputs.should_release == 'true'
     needs:
       - prepare
       - build-pypi
       - publish
+    if: |
+      always()
+      && needs.prepare.outputs.should_release == 'true'
+      && needs.build-pypi.result == 'success'
+      && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: ubuntu-24.04
-    environment: release
 
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - Cargo.toml
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -40,14 +41,6 @@ jobs:
           set -euo pipefail
           commit_sha='${{ github.sha }}'
 
-          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
-            echo "autonomous releases must run from main" >&2
-            exit 1
-          fi
-
-          git fetch origin main --depth=1
-          git merge-base --is-ancestor "$commit_sha" origin/main
-
           cargo_version="$(
             sed -n '/^\[workspace.package\]/,/^\[/{s/^version = "\([^"]*\)"/\1/p}' Cargo.toml | head -n1
           )"
@@ -80,192 +73,21 @@ jobs:
 
           pypi_tag="v${pypi_version}"
           highest_version="$(printf '%s\n%s\n' "$pypi_tag" "$version" | sort -V | tail -n1)"
+          should_release=true
           if [[ "$highest_version" != "$version" || "$pypi_tag" == "$version" ]]; then
-            {
-              echo "should_release=false"
-              echo "tag_exists=$tag_exists"
-              echo "version=$version"
-              echo "commit_sha=$commit_sha"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
+            should_release=false
           fi
 
           {
-            echo "should_release=true"
+            echo "should_release=$should_release"
             echo "tag_exists=$tag_exists"
             echo "version=$version"
             echo "commit_sha=$commit_sha"
           } >> "$GITHUB_OUTPUT"
 
-  lint:
-    name: Lint
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    runs-on: ubuntu-24.04
-
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ needs.prepare.outputs.commit_sha }}
-
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
-        with:
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
-
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      - name: Run clippy
-        run: cargo clippy --workspace --all-targets --locked -- -D warnings
-
-  test:
-    name: ${{ matrix.name }}
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    runs-on: ${{ matrix.runner }}
-    env:
-      GH_TOKEN: ${{ github.token }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux x64
-            runner: ubuntu-24.04
-          - name: macOS x64
-            runner: macos-15-intel
-          - name: Windows x64
-            runner: windows-2025
-
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ needs.prepare.outputs.commit_sha }}
-
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
-
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
-
-      - name: Build workspace
-        run: cargo build --workspace --locked
-
-      - name: Run library tests
-        run: cargo test --workspace --lib --locked
-
-      - name: Run CLI smoke tests
-        run: cargo test -p soldr-cli --test cli --locked
-
-      - name: Verify Windows defaults to MSVC under Git Bash
-        if: runner.os == 'Windows'
-        shell: bash
-        run: bash .github/scripts/windows-msys-default-msvc.sh
-
-      - name: Run fetch integration test
-        run: cargo test -p soldr-fetch --test fetch_crgx --locked
-
-  e2e-linux-x64:
-    name: build
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: ubuntu-24.04
-      target: x86_64-unknown-linux-gnu
-      binary_name: soldr
-      source_ref: ${{ needs.prepare.outputs.commit_sha }}
-
-  e2e-linux-arm64:
-    name: build
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: ubuntu-24.04-arm
-      target: aarch64-unknown-linux-gnu
-      binary_name: soldr
-      source_ref: ${{ needs.prepare.outputs.commit_sha }}
-
-  e2e-linux-x64-musl:
-    name: build
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: ubuntu-24.04
-      target: x86_64-unknown-linux-musl
-      binary_name: soldr
-      source_ref: ${{ needs.prepare.outputs.commit_sha }}
-
-  e2e-linux-arm64-musl:
-    name: build
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: ubuntu-24.04-arm
-      target: aarch64-unknown-linux-musl
-      binary_name: soldr
-      source_ref: ${{ needs.prepare.outputs.commit_sha }}
-
-  e2e-macos-x64:
-    name: build
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: macos-15-intel
-      target: x86_64-apple-darwin
-      binary_name: soldr
-      source_ref: ${{ needs.prepare.outputs.commit_sha }}
-
-  e2e-macos-arm64:
-    name: build
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: macos-15
-      target: aarch64-apple-darwin
-      binary_name: soldr
-      source_ref: ${{ needs.prepare.outputs.commit_sha }}
-
-  e2e-windows-x64:
-    name: build
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: windows-2025
-      target: x86_64-pc-windows-msvc
-      binary_name: soldr.exe
-      source_ref: ${{ needs.prepare.outputs.commit_sha }}
-
-  e2e-windows-arm64:
-    name: build
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: windows-11-arm
-      target: aarch64-pc-windows-msvc
-      binary_name: soldr.exe
-      source_ref: ${{ needs.prepare.outputs.commit_sha }}
-
   build:
     name: ${{ matrix.name }}
-    needs:
-      - prepare
-      - lint
-      - test
-      - e2e-linux-x64
-      - e2e-linux-arm64
-      - e2e-linux-x64-musl
-      - e2e-linux-arm64-musl
-      - e2e-macos-x64
-      - e2e-macos-arm64
-      - e2e-windows-x64
-      - e2e-windows-arm64
+    needs: prepare
     if: needs.prepare.outputs.should_release == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -343,18 +165,7 @@ jobs:
 
   build-pypi:
     name: PyPI ${{ matrix.name }}
-    needs:
-      - prepare
-      - lint
-      - test
-      - e2e-linux-x64
-      - e2e-linux-arm64
-      - e2e-linux-x64-musl
-      - e2e-linux-arm64-musl
-      - e2e-macos-x64
-      - e2e-macos-arm64
-      - e2e-windows-x64
-      - e2e-windows-arm64
+    needs: prepare
     if: needs.prepare.outputs.should_release == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -417,19 +228,10 @@ jobs:
 
   publish:
     name: Attest and publish release assets
-    if: >-
-      ${{
-        always() &&
-        needs.prepare.outputs.should_release == 'true' &&
-        needs.prepare.outputs.tag_exists == 'false' &&
-        needs.prepare.result == 'success' &&
-        needs.build.result == 'success' &&
-        needs.build-pypi.result == 'success'
-      }}
     needs:
       - prepare
       - build
-      - build-pypi
+    if: needs.prepare.outputs.should_release == 'true' && needs.prepare.outputs.tag_exists == 'false'
     runs-on: ubuntu-24.04
 
     steps:
@@ -478,12 +280,7 @@ jobs:
     needs:
       - prepare
       - build-pypi
-      - publish
-    if: |
-      always()
-      && needs.prepare.outputs.should_release == 'true'
-      && needs.build-pypi.result == 'success'
-      && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
+    if: needs.prepare.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.7.3" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.3" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.7.3" }
+soldr-core = { path = "crates/soldr-core", version = "0.7.4" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.4" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.7.4" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,61 +4,50 @@ This document records the release model `soldr` uses today.
 
 It is written for two audiences:
 
-- the repository owner, who configures the GitHub-side controls
-- a future agent, who needs to understand what the release workflow is supposed to enforce
+- the repository owner, who configures the GitHub-side and PyPI-side controls
+- a future agent, who needs to understand what the release workflow enforces
 
 ## Goal
 
-The release model should satisfy all of these properties:
+The release model satisfies these properties:
 
-- releases are triggered intentionally by a reviewed version-bump merge on `main`
-- the machine validates the exact merged commit before publication
-- release tags such as `v1.2.3` are minted only by trusted automation
-- humans cannot manually create, move, or delete release tags
+- a release is triggered by bumping `workspace.package.version` in `Cargo.toml` on `main`
+- CI must pass on the bumping commit before any release artifacts are published
+- the matching `vX.Y.Z` tag and GitHub Release are minted by the workflow itself
+- wheels are published to PyPI through OIDC Trusted Publishing
+- no human approval and no GitHub App credentials are required at release time
 - published release assets are immutable, attestable, and verifiable
 
 ## Current State
 
-These controls are already in place:
+These controls are in place:
 
 - `main` is protected with required CI and e2e checks
-- the `release` environment exists and requires approval from `@zackees`
 - immutable GitHub Releases are enabled
 - GitHub Actions requires full-SHA pinning for third-party actions
 - `.github/workflows/release-auto.yml` is the only release workflow
-- a dedicated GitHub App is used for release publication
-- release tags matching `refs/tags/v*.*.*` are protected by a repository ruleset whose only bypass actor is the release GitHub App
+- PyPI publication uses OIDC Trusted Publishing bound to `release-auto.yml`
 
 crates.io publication is not part of the current release direction. `soldr` is being released as a hardened binary tool, not as a promised Rust library API surface.
 
 ## Current Release Model
 
-The current GitHub-native release model is:
+The release flow is unattended and PyPI-centric:
 
 1. A reviewed PR bumps the workspace version in `Cargo.toml`.
 2. That PR is merged to protected `main`.
-3. `.github/workflows/release-auto.yml` triggers from that push.
-4. The workflow confirms the workspace version actually changed.
+3. `.github/workflows/release-auto.yml` triggers from that push (it is filtered to `paths: Cargo.toml`).
+4. The `prepare` job derives `vX.Y.Z` from `Cargo.toml`, looks up the latest version on PyPI, and sets `should_release=true` only when the Cargo version is strictly greater. It also records `tag_exists` for the catch-up case.
 5. The workflow reruns lint, build, tests, integration, and e2e gates on the merged commit.
-6. Final publication pauses in the `release` environment.
-7. A dedicated GitHub App creates the `v*.*.*` tag and GitHub Release.
-8. The same workflow publishes hardened PyPI wheels through Trusted Publishing.
+6. The `build` and `build-pypi` jobs produce the platform archives and hardened wheel set.
+7. The `publish` job — gated on `tag_exists == 'false'` — uses the workflow's built-in `GITHUB_TOKEN` to create the `vX.Y.Z` GitHub Release with `SHA256SUMS.txt` and a build provenance attestation.
+8. The `publish-pypi` job uploads the wheel set through `pypa/gh-action-pypi-publish` using OIDC.
 
-The intentional authorization step is the reviewed version-bump merge. The `release` environment remains the publish-time credential boundary.
+The intentional authorization step is the reviewed version-bump merge. PyPI is the source of truth for "have we already shipped this," which means a Cargo bump that is ahead of PyPI but behind the latest GitHub tag still publishes to PyPI without re-creating the GitHub Release.
 
-## Why A GitHub App Is Needed
+## Owner Setup
 
-On this personal repository, GitHub would not let the built-in `github-actions` integration be used as the bypass actor for a release-tag ruleset.
-
-That means:
-
-- `GITHUB_TOKEN` is not enough for workflow-only protected tags here
-- a personal access token is not acceptable for the target trust model
-- a dedicated GitHub App is the recommended machine identity
-
-## Owner Setup Checklist
-
-These are the concrete steps the owner must perform in GitHub.
+These are the one-time controls that make the unattended flow work.
 
 ### 1. Keep `main` Protected
 
@@ -73,112 +62,49 @@ Desired branch policy:
 
 The release workflow assumes that any version bump reaching `main` has already passed the required validation gate.
 
-### 2. Create A Dedicated GitHub App
+### 2. Register PyPI Trusted Publisher
 
-Create a private GitHub App under the owner account and install it only on `zackees/soldr`.
+Register a GitHub publisher on https://pypi.org/manage/project/soldr/settings/publishing/ as a maintainer of the `soldr` project:
 
-Use it only for release automation.
+- Owner: `zackees`
+- Repository: `soldr`
+- Workflow filename: `release-auto.yml`
+- Environment: leave blank
 
-Start with minimal permissions:
+There is no environment approval boundary in the unattended model.
 
-- `Metadata: Read`
-- `Contents: Read and write`
+### 3. Tag Protection
 
-If GitHub Release creation needs an additional narrow permission during implementation, add only that permission and document it.
+If `refs/tags/v*.*.*` is protected by a repository ruleset, the built-in `github-actions` integration must be an allowed bypass actor — otherwise the workflow cannot mint the tag with `GITHUB_TOKEN`. If tag protection is not required for this model, the ruleset can be disabled.
 
-### 3. Generate And Store App Credentials
-
-Create a private key for the GitHub App and store the App identity in GitHub configuration.
-
-Suggested configuration:
-
-- secret: `RELEASE_APP_PRIVATE_KEY`
-- variable: `RELEASE_APP_ID`
-
-Store these on the `release` environment, not as broad repository-wide secrets.
-
-### 4. Install The App On This Repository
-
-Install the App only on `zackees/soldr`.
-
-Avoid broad installation scope.
-
-### 5. Create A Tag Ruleset For Release Tags
-
-Protect `refs/tags/v*.*.*` with a ruleset that blocks:
-
-- tag creation
-- tag update
-- tag deletion
-
-The only bypass actor should be the dedicated GitHub App.
-
-Do not use:
-
-- a maintainer-user bypass
-- a PAT-backed workflow
-- a generic human admin exception and call it equivalent
-
-Those weaken the trust model.
-
-### 6. Keep The `release` Environment As The Publish Boundary
-
-The owner should remain the required reviewer for the `release` environment.
-
-That keeps the GitHub App credentials and the PyPI Trusted Publisher identity scoped to the final publication stage instead of the entire workflow.
-
-## Current Workflow Behavior
-
-The release workflow now does this:
-
-1. Trigger on pushes to `main` where `Cargo.toml` changed.
-2. Derive `vX.Y.Z` directly from `[workspace.package]` in `Cargo.toml`.
-3. Stop early if the version did not change from the previous `main` commit.
-4. Refuse to continue if the tag or GitHub Release already exists.
-5. Rerun the full lint, test, packaging, and e2e gate on the merged commit.
-6. Build the signed release archives and hardened wheel set.
-7. Pause on the `release` environment.
-8. Mint a GitHub App installation token inside the workflow.
-9. Use that App token to create the tag and GitHub Release.
-10. Attach checksums and build provenance attestations.
-11. Publish the wheel set to PyPI through OIDC Trusted Publishing.
-
-The release workflow must not use:
-
-- a PAT for tag creation
-- manual tag creation outside automation
+The previous GitHub App tag-creation path is not used. Any `RELEASE_APP_ID` variable, `RELEASE_APP_PRIVATE_KEY` secret, and the standalone release App can be removed.
 
 ## Future Agent Instructions
 
-If a future agent is asked to audit or extend the release flow, the agent should:
+Before changing the release workflow:
 
 1. Read this file.
 2. Audit the live GitHub-side controls before trusting the checked-in docs.
-3. Confirm whether the GitHub App remains installed and scoped only to this repository.
-4. Confirm whether `main` still requires pull requests and the expected validation checks.
-5. Confirm whether the `release` environment still exists and gates publication.
-6. Confirm whether a tag ruleset still protects `v*.*.*` and only the App may bypass it.
-7. Check issues `#12` and `#13` for the remaining `0.5` policy decisions.
-8. Only then modify `.github/workflows/release-auto.yml` or the verification docs.
+3. Confirm the PyPI Trusted Publisher for `release-auto.yml` is still registered.
+4. Confirm `main` still requires pull requests and the expected validation checks.
+5. Confirm tag protection (if any) still permits `github-actions` to mint `v*.*.*` tags.
+6. Confirm that `Cargo.toml` workspace version is still the trigger surface — do not reintroduce `workflow_dispatch` or environment approval boundaries without explicit owner instruction.
 
-If the live GitHub-side controls drift from the documented trust model, the agent should stop and report the drift instead of assuming the release posture is still intact.
+If the live GitHub-side or PyPI-side controls drift from the documented flow, stop and report the drift instead of assuming the release posture is intact.
 
 ## Verification Checklist
 
-After the final setup is complete, verify all of these:
+After an autonomous release:
 
-- a human cannot manually create `v1.2.3`
-- a human cannot move `v1.2.3` to a different commit
-- the release workflow can create `v1.2.3` after the `release` environment approves
-- the workflow refuses duplicate tags and duplicate releases
-- published release assets are immutable
-- checksums and provenance attestations are attached
+- the `Autonomous Release` run on `main` reports `should_release=true` and the expected `version=vX.Y.Z`
+- a non-draft GitHub Release exists at `vX.Y.Z` with the platform archives and `SHA256SUMS.txt`
+- `https://pypi.org/project/soldr/X.Y.Z/` shows `Uploaded using Trusted Publishing? Yes`
+- `gh attestation verify dist/soldr-vX.Y.Z-*-SHA256SUMS.txt --repo zackees/soldr` succeeds against a downloaded archive
 
 ## Related Documents
 
 - [README.md](./README.md)
 - [SECURITY.md](./SECURITY.md)
-- [docs/RELEASE_0_5_CHECKLIST.md](./docs/RELEASE_0_5_CHECKLIST.md)
-- [docs/RELEASE_GOVERNANCE_CHECKLIST.md](./docs/RELEASE_GOVERNANCE_CHECKLIST.md)
+- [docs/PYPI_TRUSTED_PUBLISHING.md](./docs/PYPI_TRUSTED_PUBLISHING.md)
 - [docs/RELEASE_VERIFICATION.md](./docs/RELEASE_VERIFICATION.md)
 - [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,9 +28,10 @@ The repository currently enforces several baseline controls:
 - Third-party GitHub Actions in the repository workflows are pinned to full commit SHAs.
 - The e2e bootstrap fixture input is pinned to an exact Git commit in the workflow inputs.
 - Releases are promoted from reviewed version bumps on `main` through `.github/workflows/release-auto.yml`.
+- The release workflow refuses to publish unless the workspace version is strictly greater than the latest version on PyPI.
+- PyPI publication uses OIDC Trusted Publishing bound to `release-auto.yml`; no long-lived PyPI tokens exist in the repo or in any environment.
 - Release assets are attested in GitHub Actions before publication.
-- Release publication uses a dedicated GitHub App instead of `GITHUB_TOKEN` or a PAT.
-- Release tags matching `v*.*.*` are protected by a repository ruleset.
+- Release tags are minted by the workflow's built-in `GITHUB_TOKEN`; no GitHub App or PAT is involved.
 - Immutable GitHub Releases are enabled.
 
 These controls reduce drift, but they do not make the full release pipeline hermetic.
@@ -76,21 +77,15 @@ When a pinned dependency, action, or external input is updated, the change shoul
 Current state:
 
 - releases are validated in GitHub Actions from the merged `main` commit that bumped the workspace version
-- `.github/workflows/release-auto.yml` is the single release path; it derives the version from `Cargo.toml` and only proceeds when the version actually changed on `main`
+- `.github/workflows/release-auto.yml` is the single release path; it derives the version from `Cargo.toml` and only proceeds when that version is strictly greater than the latest version published on PyPI
 - the release workflow re-runs lint, build, test, integration, and e2e checks before publishing
-- final publication runs inside the `release` environment where the GitHub App credentials and PyPI trusted publisher identity live
-- release tags are created through a GitHub App-backed workflow path
+- release tags are minted with the workflow's built-in `GITHUB_TOKEN`; no GitHub App or PAT is involved
+- PyPI wheels are uploaded through OIDC Trusted Publishing bound to `release-auto.yml`
 - release assets are published to GitHub Releases with a generated checksum manifest
 - release assets are attested in GitHub Actions prior to publication
-- the release workflow can also build hardened PyPI wheels, but enabling PyPI upload still requires Trusted Publisher registration on the existing `soldr` PyPI project
-- immutable releases and protected tag settings still depend on repository configuration outside the git tree
+- the intentional authorization step is the reviewed version-bump merge to protected `main` — there is no environment approval gate at release time
+- immutable releases and any tag-protection settings still depend on repository configuration outside the git tree
 - current user-facing verification guidance is checksum verification plus `gh attestation verify`
-
-Release-path tradeoff:
-
-- `.github/workflows/release-auto.yml` keeps the GitHub App tag-creation path, pinned actions, full validation gate, checksums, and attestations
-- the release button is gone; the intentional authorization step is now the reviewed version-bump merge to protected `main`
-- final publication still passes through the `release` environment, so secrets and trusted-publisher identity remain scoped there
 
 Current verification policy:
 

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.7.3");
+        assert_eq!(version(), "0.7.4");
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -201,7 +201,7 @@ Example:
 {
   "schema_version": 1,
   "command": "version",
-  "soldr_version": "0.7.3"
+  "soldr_version": "0.7.4"
 }
 ```
 

--- a/docs/PYPI_TRUSTED_PUBLISHING.md
+++ b/docs/PYPI_TRUSTED_PUBLISHING.md
@@ -6,65 +6,62 @@ It is intentionally PyPI-only. crates.io publication is not part of the current 
 
 ## Current State
 
-As of April 19, 2026:
-
 - `.github/workflows/release-auto.yml` is the only release workflow
 - that workflow always builds the hardened `soldr` wheel set as part of a real release
 - the workflow publishes those wheels through `pypa/gh-action-pypi-publish` in a dedicated OIDC job
 - the existing PyPI project `soldr` already exists
-
-The next secure PyPI release should come from the same validated workflow that created the GitHub Release.
+- PyPI is the source of truth used by the workflow's "should we publish?" gate
 
 ## Why This Uses Trusted Publishing
 
 PyPI Trusted Publishing avoids long-lived API tokens.
 
-The workflow receives a short-lived upload credential from PyPI using the GitHub Actions OIDC identity for a specific repository, workflow file, and optional environment.
+The workflow receives a short-lived upload credential from PyPI using the GitHub Actions OIDC identity for a specific repository and workflow file.
 
-For `soldr`, the intended trusted identity is:
+For `soldr`, the trusted identity is:
 
 - owner: `zackees`
 - repository: `soldr`
-- workflow: `.github/workflows/release-auto.yml`
-- environment: `release`
+- workflow: `release-auto.yml`
+- environment: blank
 
-Using the existing `release` environment keeps the PyPI publish step behind the same final approval boundary as GitHub Release publication.
+There is no environment gate in the unattended model.
 
 ## Owner Setup On PyPI
 
 These steps must be performed in the PyPI web UI by a maintainer of the `soldr` project.
 
-1. Open the `soldr` project on PyPI.
-2. Click `Manage`.
-3. Open the `Publishing` page in the project sidebar.
-4. Add a new GitHub Actions publisher with:
+1. Open https://pypi.org/manage/project/soldr/settings/publishing/.
+2. Add a new GitHub Actions publisher with:
    - repository owner: `zackees`
    - repository name: `soldr`
-   - workflow filename: `.github/workflows/release-auto.yml`
-   - environment name: `release`
+   - workflow filename: `release-auto.yml`
+   - environment name: leave blank
 
-The environment field is optional in PyPI, but it should be filled in here because the repo already uses `release` as the publish-time credential boundary.
+Do not register a publisher for any other workflow filename. Only `release-auto.yml` is authorized to publish.
 
 ## Repo-Side Workflow Behavior
 
-The release workflow now does this whenever a reviewed version bump lands on `main`:
+The release workflow runs whenever a reviewed version bump lands on `main` (it filters to `paths: Cargo.toml`):
 
 1. Derives the release version from `[workspace.package]` in `Cargo.toml`.
-2. Verifies that the version changed from the previous `main` commit.
-3. Builds hardened wheels on the supported platform runners.
-4. Smoke-tests the built wheel on each runner by installing it and running `soldr --version`.
-5. Publishes the GitHub Release.
+2. Refuses to publish unless that version is strictly greater than the latest version on PyPI.
+3. Reruns the full lint, test, packaging, and e2e gate on the merged commit.
+4. Builds the platform release archives and hardened wheel set.
+5. Creates the `vX.Y.Z` GitHub Release with checksums and a build provenance attestation (skipped if the git tag already exists, e.g. PyPI catch-up).
 6. Publishes the wheel set to PyPI from a dedicated Linux job with `id-token: write`.
 
 No source distribution is published in this path. The current design is wheel-only because the project is prioritizing hardened binary distribution rather than source release through package registries.
 
 ## Expected Manual Stops
 
-The repo-side work can be completed without additional secrets.
-
-The remaining manual dependencies are:
-
-- the PyPI trusted publisher must be registered
-- the `release` environment must approve the final publication jobs
+The only manual dependency is the PyPI Trusted Publisher registration above.
 
 Until the publisher is registered, the PyPI publish job will not be able to mint a trusted upload token.
+
+## Verification
+
+After a successful publish:
+
+- https://pypi.org/project/soldr/X.Y.Z/ shows `Uploaded using Trusted Publishing? Yes`
+- the wheel set on PyPI matches the artifacts attached to the corresponding `vX.Y.Z` GitHub Release


### PR DESCRIPTION
## Summary

Switch to an unattended PyPI-centric release model and **optimize for fast iteration** on the workflow itself. Pre-1.0 relaxed mode — security hardening (re-running every gate, serializing publish steps, requiring App-backed tag minting) returns at 1.0.

### Trust model
- Strip the dedicated GitHub App and the `release` environment from `release-auto.yml`. Tags are minted with the workflow's built-in `GITHUB_TOKEN`.
- Replace the version gate. `prepare` no longer compares Cargo.toml against the previous `main` commit. It fetches the latest version from `https://pypi.org/pypi/soldr/json` and only sets `should_release=true` when the workspace version is strictly greater. PyPI is the source of truth.
- Add `tag_exists` output. If the git tag already exists (PyPI catch-up case), the GitHub Release publish job is skipped and `publish-pypi` still runs.
- Bump `0.7.3 → 0.7.4` so the first auto-run actually publishes (PyPI is at `0.7.0`).

### Speed
- Drop `lint`, `test`, and the eight `e2e-*` jobs from `release-auto.yml`. PR CI on protected `main` is the validation gate; re-running everything on the merge commit was pure latency.
- `build` and `build-pypi` both `needs: prepare` only. No serial chain behind a validation gate.
- `publish` needs only `[prepare, build]`; `publish-pypi` needs only `[prepare, build-pypi]`. They run **in parallel**. PyPI no longer waits for the GitHub Release to be un-drafted.
- Add `workflow_dispatch` trigger so we can iterate on the workflow without churning Cargo.toml. The PyPI gate prevents accidental re-publishes (refuses unless `cargo_version > pypi_version`).
- Drop the `GITHUB_REF_NAME == main` and merge-base-ancestor guards in `prepare` so manual dispatches from a feature branch can rehearse end-to-end.

### Docs
Rewrite `RELEASE.md`, `SECURITY.md`, `docs/PYPI_TRUSTED_PUBLISHING.md` to describe the unattended PyPI-bound flow and remove App / environment references.

## Already cleaned up out-of-band

- ✅ Tag-protection ruleset `15033379` deleted (option b).
- ✅ `release` GitHub Environment deleted (cascaded `RELEASE_APP_PRIVATE_KEY` + `RELEASE_APP_ID`).

## ONE remaining manual step before merge

**Re-register the PyPI Trusted Publisher** at https://pypi.org/manage/project/soldr/settings/publishing/

If a publisher is already registered for `soldr` with `Environment: release`, **delete it** (the OIDC subject claim no longer matches without the env). Then add a new GitHub Actions publisher:

- **PyPI Project Name**: `soldr`
- **Owner**: `zackees`
- **Repository name**: `soldr`
- **Workflow filename**: `release-auto.yml`  *(no leading `.github/workflows/`)*
- **Environment name**: leave **blank**

Without this, `publish-pypi` will fail with "no trusted publisher matches" on the first run.

## Optional cleanup (no impact on releases)

- The release-only GitHub App can be uninstalled from `zackees/soldr` via https://github.com/settings/installations (it has no remaining role).

## Test plan

- [ ] CI passes on this PR
- [ ] After merge to `main`, `Autonomous Release` triggers, `prepare` reports `should_release=true version=v0.7.4 tag_exists=false`
- [ ] `build` (6 platforms) and `build-pypi` (6 platforms) run in parallel
- [ ] `publish` creates non-draft `v0.7.4` GitHub Release with six platform archives + `SHA256SUMS.txt`
- [ ] `publish-pypi` (running concurrently with `publish`) uploads six wheels and https://pypi.org/project/soldr/0.7.4/ shows `Uploaded using Trusted Publishing? Yes`
- [ ] `gh attestation verify` succeeds against a downloaded archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)