### PR TITLE
ci: pin benchmark zccache cache actions

### DIFF
--- a/.github/actions/cache-benchmark-zccache-cleanup/action.yml
+++ b/.github/actions/cache-benchmark-zccache-cleanup/action.yml
@@ -47,6 +47,26 @@ runs:
 
     - name: Save cargo registry cache
       if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-registry == 'true'
+      id: registry-save
+      shell: bash
+      run: |
+        set -euo pipefail
+        paths=(
+          "$HOME/.cargo/registry/index"
+          "$HOME/.cargo/registry/cache"
+          "$HOME/.cargo/git/db"
+        )
+        found=false
+        for path in "${paths[@]}"; do
+          if [ -e "$path" ]; then
+            found=true
+            break
+          fi
+        done
+        echo "found=$found" >> "$GITHUB_OUTPUT"
+
+    - name: Persist cargo registry cache
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-registry == 'true' && steps.registry-save.outputs.found == 'true'
       uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: |

--- a/.github/actions/cache-benchmark-zccache-cleanup/action.yml
+++ b/.github/actions/cache-benchmark-zccache-cleanup/action.yml
@@ -1,0 +1,84 @@
+name: "cache benchmark zccache cleanup"
+description: >
+  Repo-local copy of the zccache cleanup action with actions/cache save steps
+  pinned to full SHAs so the soldr ruleset accepts it.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Print zccache stats
+      if: always()
+      shell: bash
+      run: zccache status 2>/dev/null || true
+
+    - name: Stop zccache daemon
+      if: always()
+      shell: bash
+      run: zccache stop 2>/dev/null || true
+
+    - name: Read state from setup
+      if: always()
+      id: state
+      shell: bash
+      run: |
+        STATE_DIR="$HOME/.zccache-action-state"
+        if [ -d "$STATE_DIR" ]; then
+          echo "compilation-key=$(cat "$STATE_DIR/compilation-key" 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+          echo "registry-key=$(cat "$STATE_DIR/registry-key" 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+          echo "target-key=$(cat "$STATE_DIR/target-key" 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+          echo "save-cache=$(cat "$STATE_DIR/save-cache" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
+          echo "cache-compilation=$(cat "$STATE_DIR/cache-compilation" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
+          echo "cache-registry=$(cat "$STATE_DIR/cache-registry" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
+          echo "cache-target=$(cat "$STATE_DIR/cache-target" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
+          echo "target-dir=$(cat "$STATE_DIR/target-dir" 2>/dev/null || echo 'target')" >> "$GITHUB_OUTPUT"
+        else
+          echo "save-cache=false" >> "$GITHUB_OUTPUT"
+          echo "cache-compilation=false" >> "$GITHUB_OUTPUT"
+          echo "cache-registry=false" >> "$GITHUB_OUTPUT"
+          echo "cache-target=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Save zccache compilation cache
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-compilation == 'true'
+      uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ~/.zccache
+        key: ${{ steps.state.outputs.compilation-key }}
+
+    - name: Save cargo registry cache
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-registry == 'true'
+      uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ steps.state.outputs.registry-key }}
+
+    - name: Create target metadata snapshot
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true'
+      shell: bash
+      run: |
+        TARGET="${{ steps.state.outputs.target-dir }}"
+        SNAPSHOT_DIR="$HOME/.zccache-target-meta"
+        rm -rf "$SNAPSHOT_DIR"
+        mkdir -p "$SNAPSHOT_DIR"
+        if [ -d "$TARGET" ]; then
+          tar cf "$SNAPSHOT_DIR/target-meta.tar" -C "$TARGET" \
+            --exclude='incremental' \
+            . 2>/dev/null || true
+          SIZE=$(du -sh "$SNAPSHOT_DIR/target-meta.tar" 2>/dev/null | cut -f1 || echo "?")
+          echo "Saved target metadata snapshot ($SIZE)"
+        fi
+
+    - name: Save cargo target metadata
+      if: always() && steps.state.outputs.save-cache == 'true' && steps.state.outputs.cache-target == 'true'
+      uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ~/.zccache-target-meta
+        key: ${{ steps.state.outputs.target-key }}
+
+    - name: Clean up state
+      if: always()
+      shell: bash
+      run: rm -rf ~/.zccache-action-state

--- a/.github/actions/cache-benchmark-zccache/action.yml
+++ b/.github/actions/cache-benchmark-zccache/action.yml
@@ -1,0 +1,262 @@
+name: "cache benchmark zccache"
+description: >
+  Repo-local copy of zackees/zccache for the benchmark workflow, with
+  actions/cache restore steps pinned to full SHAs so the soldr ruleset accepts it.
+
+inputs:
+  cache-cargo-registry:
+    description: >
+      Cache cargo registry index, downloaded crate files, and git dependencies.
+      Replaces Swatinem/rust-cache registry caching.
+    required: false
+    default: "true"
+  cache-compilation:
+    description: >
+      Cache individual compilation units (.o/.rlib) via the zccache daemon.
+      Replaces sccache.
+    required: false
+    default: "true"
+  cache-target:
+    description: >
+      Cache cargo target/ metadata (fingerprints, dep-info, build script outputs).
+      Allows cargo to skip invoking rustc entirely on warm builds.
+      Only caches lightweight metadata, not full .rlib files.
+    required: false
+    default: "true"
+  compilation-restore-fallback:
+    description: >
+      Whether restore-key fallback is allowed for the zccache compilation cache.
+      Keep "true" for faster incremental CI across commits. Set to "false" for
+      exact-key-only restores.
+    required: false
+    default: "true"
+  target-restore-fallback:
+    description: >
+      Whether restore-key fallback is allowed for cargo target metadata.
+      Default "false" because fallback metadata can be stale for changed source
+      trees, especially on pull_request merge refs.
+    required: false
+    default: "false"
+  target-dir:
+    description: >
+      Path to the cargo target directory.
+      Default: ./target
+    required: false
+    default: "target"
+  shared-key:
+    description: >
+      Additional key segment for cache isolation in matrix builds.
+      Typically the Rust target triple (e.g., x86_64-unknown-linux-gnu).
+    required: false
+    default: ""
+  zccache-version:
+    description: >
+      Version of zccache to install. Use "latest" for the newest release,
+      or a specific version like "1.2.5".
+    required: false
+    default: "latest"
+  save-cache:
+    description: >
+      Whether to save caches at the end. Set to "false" for PR builds
+      where you only want to restore.
+    required: false
+    default: "true"
+
+outputs:
+  cache-hit-compilation:
+    description: "Whether the zccache compilation cache was restored"
+    value: ${{ steps.restore-zccache.outputs.cache-hit }}
+  cache-hit-registry:
+    description: "Whether the cargo registry cache was restored"
+    value: ${{ steps.restore-registry.outputs.cache-hit }}
+  cache-hit-target:
+    description: "Whether the cargo target metadata cache was restored"
+    value: ${{ steps.restore-target.outputs.cache-hit }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute cache keys
+      id: keys
+      shell: bash
+      run: |
+        OS="${{ runner.os }}"
+        ARCH="${{ runner.arch }}"
+        SHARED="${{ inputs.shared-key }}"
+        if [ -n "$SHARED" ]; then
+          PREFIX="zccache-${OS}-${ARCH}-${SHARED}"
+          REG_PREFIX="cargo-registry-${OS}-${ARCH}-${SHARED}"
+          TGT_PREFIX="cargo-target-${OS}-${ARCH}-${SHARED}"
+        else
+          PREFIX="zccache-${OS}-${ARCH}"
+          REG_PREFIX="cargo-registry-${OS}-${ARCH}"
+          TGT_PREFIX="cargo-target-${OS}-${ARCH}"
+        fi
+
+        if [ -f Cargo.lock ]; then
+          if command -v sha256sum >/dev/null 2>&1; then
+            LOCK_HASH=$(sha256sum Cargo.lock | cut -c1-16)
+          else
+            LOCK_HASH=$(shasum -a 256 Cargo.lock | cut -c1-16)
+          fi
+        else
+          LOCK_HASH="no-lock"
+        fi
+
+        echo "compilation-key=${PREFIX}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        if [ "${{ inputs.compilation-restore-fallback }}" = "true" ]; then
+          echo "compilation-restore=${PREFIX}-" >> "$GITHUB_OUTPUT"
+        else
+          echo "compilation-restore=" >> "$GITHUB_OUTPUT"
+        fi
+        echo "registry-key=${REG_PREFIX}-${LOCK_HASH}" >> "$GITHUB_OUTPUT"
+        echo "registry-restore=${REG_PREFIX}-" >> "$GITHUB_OUTPUT"
+        echo "target-key=${TGT_PREFIX}-${LOCK_HASH}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        if [ "${{ inputs.target-restore-fallback }}" = "true" ]; then
+          echo "target-restore=${TGT_PREFIX}-${LOCK_HASH}-" >> "$GITHUB_OUTPUT"
+        else
+          echo "target-restore=" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Restore zccache compilation cache
+      id: restore-zccache
+      if: inputs.cache-compilation == 'true'
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ~/.zccache
+        key: ${{ steps.keys.outputs.compilation-key }}
+        restore-keys: ${{ steps.keys.outputs.compilation-restore }}
+
+    - name: Restore cargo registry cache
+      id: restore-registry
+      if: inputs.cache-cargo-registry == 'true'
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ steps.keys.outputs.registry-key }}
+        restore-keys: ${{ steps.keys.outputs.registry-restore }}
+
+    - name: Restore cargo target metadata
+      id: restore-target
+      if: inputs.cache-target == 'true'
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ~/.zccache-target-meta
+        key: ${{ steps.keys.outputs.target-key }}
+        restore-keys: ${{ steps.keys.outputs.target-restore }}
+
+    - name: Extract target metadata
+      if: inputs.cache-target == 'true'
+      shell: bash
+      run: |
+        TARGET="${{ inputs.target-dir }}"
+        META_TAR="$HOME/.zccache-target-meta/target-meta.tar"
+        if [ -f "$META_TAR" ]; then
+          mkdir -p "$TARGET"
+          tar xf "$META_TAR" -C "$TARGET" 2>/dev/null || true
+          echo "Restored target metadata ($(du -sh "$META_TAR" | cut -f1))"
+        fi
+
+    - name: Install zccache and start daemon
+      shell: bash
+      run: |
+        VERSION="${{ inputs.zccache-version }}"
+        INSTALLED=false
+
+        if [ "${{ runner.os }}" != "Windows" ]; then
+          INSTALL_DIR="$HOME/.local/bin"
+          mkdir -p "$INSTALL_DIR"
+          INSTALL_SCRIPT="${{ github.action_path }}/install.sh"
+          if ZCCACHE_INSTALL_VERSION="$VERSION" \
+             ZCCACHE_INSTALL_DIR="$INSTALL_DIR" \
+             ZCCACHE_NO_MODIFY_PATH=1 \
+             sh "$INSTALL_SCRIPT" 2>/dev/null; then
+            echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+            export PATH="$INSTALL_DIR:$PATH"
+            INSTALLED=true
+          fi
+        fi
+
+        if [ "$INSTALLED" = "false" ] && command -v cargo-binstall >/dev/null 2>&1; then
+          INSTALL_DIR="$HOME/.cargo/bin"
+          if [ "$VERSION" = "latest" ]; then
+            cargo-binstall zccache-cli --no-confirm --install-path "$INSTALL_DIR" 2>/dev/null && INSTALLED=true
+          else
+            cargo-binstall "zccache-cli@${VERSION}" --no-confirm --install-path "$INSTALL_DIR" 2>/dev/null && INSTALLED=true
+          fi
+          if [ "$INSTALLED" = "true" ]; then
+            echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+            export PATH="$INSTALL_DIR:$PATH"
+          fi
+        fi
+
+        if [ "$INSTALLED" = "false" ]; then
+          if [ "$VERSION" = "latest" ]; then
+            pip install zccache
+          else
+            pip install "zccache==${VERSION}"
+          fi
+          FOUND_DIR=""
+          for DIR in \
+            "$(python -c 'import sysconfig; print(sysconfig.get_path(\"scripts\"))' 2>/dev/null || true)" \
+            "$(python -c 'import sysconfig; print(sysconfig.get_path(\"scripts\", \"posix_user\"))' 2>/dev/null || true)" \
+            "$(python -c 'import sysconfig; print(sysconfig.get_path(\"scripts\", \"nt_user\"))' 2>/dev/null || true)" \
+            "$(dirname "$(python -c 'import sys; print(sys.executable)')")" \
+            "$HOME/.local/bin" \
+            "/usr/local/bin"; do
+            if [ -n "$DIR" ] && [ -f "$DIR/zccache" -o -f "$DIR/zccache.exe" ]; then
+              FOUND_DIR="$DIR"
+              break
+            fi
+          done
+
+          if [ -z "$FOUND_DIR" ]; then
+            FOUND_DIR="$(python -c 'import importlib.metadata as m, os; d = m.distribution(\"zccache\"); [print(os.path.dirname(str((d._path.parent / f).resolve()))) for f in d.files if f.name in (\"zccache\", \"zccache.exe\")]' 2>/dev/null | head -1 || true)"
+          fi
+
+          if [ -n "$FOUND_DIR" ]; then
+            export PATH="$FOUND_DIR:$PATH"
+            echo "$FOUND_DIR" >> "$GITHUB_PATH"
+            if [ "${{ runner.os }}" != "Windows" ]; then
+              chmod +x "$FOUND_DIR/zccache" "$FOUND_DIR/zccache-daemon" 2>/dev/null || true
+            fi
+          fi
+        fi
+
+        which zccache || { echo "ERROR: zccache not found on PATH"; echo "PATH=$PATH"; exit 1; }
+
+    - name: Warm target from zccache
+      if: inputs.cache-target == 'true'
+      shell: bash
+      run: |
+        TARGET="${{ inputs.target-dir }}"
+        if [ -d "$TARGET" ]; then
+          zccache warm --target-dir "$TARGET" || true
+          STAMP=$(date -d '+1 minute' +%Y%m%d%H%M.%S 2>/dev/null || date -v+1M +%Y%m%d%H%M.%S)
+          find "$TARGET" -type f -exec touch -t "$STAMP" {} + 2>/dev/null || true
+        fi
+
+    - name: Start zccache daemon
+      shell: bash
+      run: zccache start
+
+    - name: Set build environment
+      shell: bash
+      run: |
+        echo "RUSTC_WRAPPER=zccache" >> "$GITHUB_ENV"
+
+    - name: Save state for cleanup
+      shell: bash
+      run: |
+        mkdir -p ~/.zccache-action-state
+        echo "${{ steps.keys.outputs.compilation-key }}" > ~/.zccache-action-state/compilation-key
+        echo "${{ steps.keys.outputs.registry-key }}" > ~/.zccache-action-state/registry-key
+        echo "${{ steps.keys.outputs.target-key }}" > ~/.zccache-action-state/target-key
+        echo "${{ inputs.save-cache }}" > ~/.zccache-action-state/save-cache
+        echo "${{ inputs.cache-compilation }}" > ~/.zccache-action-state/cache-compilation
+        echo "${{ inputs.cache-cargo-registry }}" > ~/.zccache-action-state/cache-registry
+        echo "${{ inputs.cache-target }}" > ~/.zccache-action-state/cache-target
+        echo "${{ inputs.target-dir }}" > ~/.zccache-action-state/target-dir

--- a/.github/actions/cache-benchmark-zccache/install.sh
+++ b/.github/actions/cache-benchmark-zccache/install.sh
@@ -1,0 +1,196 @@
+#!/bin/sh
+set -eu
+
+ZCCACHE_INSTALL_MODE="${ZCCACHE_INSTALL_MODE:-user}"
+ZCCACHE_INSTALL_REPO="${ZCCACHE_INSTALL_REPO:-zackees/zccache}"
+ZCCACHE_INSTALL_BASE_URL="${ZCCACHE_INSTALL_BASE_URL:-}"
+ZCCACHE_INSTALL_VERSION="${ZCCACHE_INSTALL_VERSION:-latest}"
+ZCCACHE_NO_MODIFY_PATH="${ZCCACHE_NO_MODIFY_PATH:-0}"
+
+usage() {
+    cat <<'EOF'
+Usage: install.sh [--user|--global] [--bin-dir PATH] [--version VERSION]
+
+Environment:
+  ZCCACHE_INSTALL_MODE      user or global
+  ZCCACHE_INSTALL_DIR       explicit install directory
+  ZCCACHE_INSTALL_VERSION   latest or a specific version/tag
+  ZCCACHE_INSTALL_REPO      GitHub repo owner/name
+  ZCCACHE_INSTALL_BASE_URL  Override release base URL (for testing/mirrors)
+  ZCCACHE_NO_MODIFY_PATH    1 to skip shell profile updates
+EOF
+}
+
+log() {
+    printf '[zccache-install] %s\n' "$*"
+}
+
+die() {
+    printf '[zccache-install] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+append_path_line() {
+    profile="$1"
+    line="$2"
+    [ -f "$profile" ] || : >"$profile"
+    grep -F "$line" "$profile" >/dev/null 2>&1 || printf '\n%s\n' "$line" >>"$profile"
+}
+
+modify_path() {
+    install_dir="$1"
+    case ":${PATH:-}:" in
+        *:"$install_dir":*) return 0 ;;
+    esac
+    if [ "$ZCCACHE_NO_MODIFY_PATH" = "1" ]; then
+        return 0
+    fi
+    export_line="export PATH=\"$install_dir:\$PATH\""
+    append_path_line "$HOME/.profile" "$export_line"
+    if [ -n "${SHELL:-}" ] && [ "$(basename "$SHELL")" = "zsh" ]; then
+        append_path_line "$HOME/.zprofile" "$export_line"
+    fi
+    log "Added $install_dir to shell startup PATH configuration."
+}
+
+normalize_arch() {
+    case "$1" in
+        x86_64|amd64) printf 'x86_64' ;;
+        arm64|aarch64) printf 'aarch64' ;;
+        *) die "unsupported architecture: $1" ;;
+    esac
+}
+
+detect_target() {
+    os="$(uname -s)"
+    arch="$(normalize_arch "$(uname -m)")"
+    case "$os" in
+        Linux) printf '%s-unknown-linux-musl' "$arch" ;;
+        Darwin) printf '%s-apple-darwin' "$arch" ;;
+        *) die "unsupported operating system: $os" ;;
+    esac
+}
+
+resolve_tag() {
+    version="$1"
+    case "$version" in
+        latest) printf 'latest' ;;
+        v*) printf '%s' "$version" ;;
+        *) printf 'v%s' "$version" ;;
+    esac
+}
+
+asset_url() {
+    tag="$1"
+    asset="$2"
+    if [ -n "$ZCCACHE_INSTALL_BASE_URL" ]; then
+        base="$ZCCACHE_INSTALL_BASE_URL"
+    else
+        base="https://github.com/$ZCCACHE_INSTALL_REPO/releases"
+    fi
+    if [ "$tag" = "latest" ]; then
+        printf '%s/latest/download/%s' "$base" "$asset"
+    else
+        printf '%s/download/%s/%s' "$base" "$tag" "$asset"
+    fi
+}
+
+download() {
+    url="$1"
+    dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$dest"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$dest" "$url"
+    else
+        die "either curl or wget is required"
+    fi
+}
+
+extract_archive() {
+    archive="$1"
+    dest="$2"
+    mkdir -p "$dest"
+    tar -xzf "$archive" -C "$dest"
+}
+
+main() {
+    install_dir="${ZCCACHE_INSTALL_DIR:-}"
+    version="$ZCCACHE_INSTALL_VERSION"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --user) ZCCACHE_INSTALL_MODE="user" ;;
+            --global) ZCCACHE_INSTALL_MODE="global" ;;
+            --bin-dir)
+                shift
+                [ "$#" -gt 0 ] || die "--bin-dir requires a value"
+                install_dir="$1"
+                ;;
+            --version)
+                shift
+                [ "$#" -gt 0 ] || die "--version requires a value"
+                version="$1"
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                die "unknown argument: $1"
+                ;;
+        esac
+        shift
+    done
+
+    need_cmd tar
+    need_cmd mktemp
+
+    if [ -z "$install_dir" ]; then
+        if [ "$ZCCACHE_INSTALL_MODE" = "global" ]; then
+            install_dir="/usr/local/bin"
+        else
+            install_dir="$HOME/.local/bin"
+        fi
+    fi
+
+    target="$(detect_target)"
+    tag="$(resolve_tag "$version")"
+    asset="zccache-${tag}-${target}.tar.gz"
+    url="$(asset_url "$tag" "$asset")"
+
+    tmpdir="$(mktemp -d 2>/dev/null || mktemp -d -t zccache-install)"
+    trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+    archive="$tmpdir/$asset"
+    log "Downloading $url"
+    download "$url" "$archive"
+    extract_archive "$archive" "$tmpdir"
+
+    archive_root="$tmpdir/zccache-${tag}-${target}"
+    [ -d "$archive_root" ] || die "archive layout was not recognized"
+
+    mkdir -p "$install_dir"
+    cp "$archive_root"/zccache "$install_dir"/
+    cp "$archive_root"/zccache-daemon "$install_dir"/
+    if [ -f "$archive_root/zccache-fp" ]; then
+        cp "$archive_root"/zccache-fp "$install_dir"/
+    fi
+    chmod 755 "$install_dir"/zccache "$install_dir"/zccache-daemon 2>/dev/null || true
+    [ -f "$install_dir/zccache-fp" ] && chmod 755 "$install_dir"/zccache-fp 2>/dev/null || true
+
+    if [ "$ZCCACHE_INSTALL_MODE" = "user" ]; then
+        modify_path "$install_dir"
+    fi
+
+    log "Installed to $install_dir"
+    if ! command -v zccache >/dev/null 2>&1; then
+        log "Open a new shell or export PATH=\"$install_dir:\$PATH\" before running zccache."
+    fi
+}
+
+main "$@"

--- a/.github/workflows/_cache-benchmark-build.yml
+++ b/.github/workflows/_cache-benchmark-build.yml
@@ -60,6 +60,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
+          toolchain: stable
+          profile: minimal
           targets: ${{ inputs.target }}
 
       - name: Restore Swatinem rust-cache

--- a/.github/workflows/_cache-benchmark-build.yml
+++ b/.github/workflows/_cache-benchmark-build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Restore zccache
         id: zccache
         if: ${{ inputs.cache_backend == 'zccache' }}
-        uses: zackees/zccache@096f6ebb68a65d052514cf2612aa445d2be79261
+        uses: ./.github/actions/cache-benchmark-zccache
         with:
           shared-key: ${{ inputs.cache_shared_key }}
           save-cache: ${{ inputs.save_cache }}
@@ -151,7 +151,7 @@ jobs:
 
       - name: Cleanup zccache
         if: ${{ always() && inputs.cache_backend == 'zccache' }}
-        uses: zackees/zccache/action/cleanup@096f6ebb68a65d052514cf2612aa445d2be79261
+        uses: ./.github/actions/cache-benchmark-zccache-cleanup
 
       - name: Compute cache-hit summary
         id: cache_hit

--- a/.github/workflows/_cache-benchmark-build.yml
+++ b/.github/workflows/_cache-benchmark-build.yml
@@ -31,17 +31,10 @@ on:
         required: false
         type: boolean
         default: true
-      upload_name:
-        required: false
-        type: string
-        default: cache-benchmark
     outputs:
       wall_seconds:
         description: Wall-clock seconds for the cargo build step.
         value: ${{ jobs.build.outputs.wall_seconds }}
-      timing_report:
-        description: Relative path to the latest cargo timing report.
-        value: ${{ jobs.build.outputs.timing_report }}
       cache_hit:
         description: Whether the cache backend restored an exact cache hit relevant to the benchmark.
         value: ${{ jobs.build.outputs.cache_hit }}
@@ -57,7 +50,6 @@ jobs:
     runs-on: ${{ inputs.runner }}
     outputs:
       wall_seconds: ${{ steps.measure.outputs.wall_seconds }}
-      timing_report: ${{ steps.measure.outputs.timing_report }}
       cache_hit: ${{ steps.cache_hit.outputs.value }}
       cache_hit_detail: ${{ steps.cache_hit.outputs.detail }}
 
@@ -116,12 +108,11 @@ jobs:
           set -euo pipefail
           python3 - <<'PY'
           import os
-          import pathlib
           import subprocess
           import time
 
           target = os.environ["BENCH_TARGET"]
-          start = time.time()
+          start = time.perf_counter()
           subprocess.run(
               [
                   "cargo",
@@ -132,21 +123,13 @@ jobs:
                   "--locked",
                   "--target",
                   target,
-                  "--timings",
               ],
               check=True,
           )
-          elapsed = time.time() - start
-
-          timing_reports = sorted(
-              pathlib.Path("target/cargo-timings").glob("cargo-timing*.html"),
-              key=lambda path: path.stat().st_mtime,
-          )
-          timing_report = timing_reports[-1].as_posix() if timing_reports else ""
+          elapsed = time.perf_counter() - start
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
               fh.write(f"wall_seconds={elapsed:.2f}\n")
-              fh.write(f"timing_report={timing_report}\n")
           PY
 
       - name: Cleanup zccache
@@ -190,15 +173,6 @@ jobs:
             echo "detail=$detail"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Upload timing artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: ${{ inputs.upload_name }}
-          if-no-files-found: warn
-          path: |
-            target/cargo-timings/*.html
-
       - name: Write job summary
         if: ${{ always() }}
         shell: bash
@@ -211,9 +185,8 @@ jobs:
             if [ -n "${{ steps.measure.outputs.wall_seconds }}" ]; then
               echo "- wall seconds: \`${{ steps.measure.outputs.wall_seconds }}\`"
             fi
-            if [ -n "${{ steps.measure.outputs.timing_report }}" ]; then
-              echo "- timing report: \`${{ steps.measure.outputs.timing_report }}\`"
-            fi
+            echo "- timing scope: \`cargo build --package soldr-cli --release --locked --target ${{ inputs.target }}\` only"
+            echo "- measurement source: \`time.perf_counter()\` around the cargo subprocess"
             echo "- cache hit summary: \`${{ steps.cache_hit.outputs.detail }}\`"
             if [ "${{ inputs.cache_backend }}" = "swatinem" ]; then
               echo "- rust-cache exact hit: \`${{ steps.rust_cache.outputs.cache-hit }}\`"

--- a/.github/workflows/_cache-benchmark-build.yml
+++ b/.github/workflows/_cache-benchmark-build.yml
@@ -60,9 +60,14 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
-          toolchain: stable
-          profile: minimal
           targets: ${{ inputs.target }}
+
+      - name: Resolve compiler path
+        id: rustc
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "path=$(rustup which rustc)" >> "$GITHUB_OUTPUT"
 
       - name: Restore Swatinem rust-cache
         id: rust_cache
@@ -106,6 +111,7 @@ jobs:
         shell: bash
         env:
           BENCH_TARGET: ${{ inputs.target }}
+          RUSTC: ${{ steps.rustc.outputs.path }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -189,6 +195,7 @@ jobs:
             fi
             echo "- timing scope: \`cargo build --package soldr-cli --release --locked --target ${{ inputs.target }}\` only"
             echo "- measurement source: \`time.perf_counter()\` around the cargo subprocess"
+            echo "- compiler path: \`${{ steps.rustc.outputs.path }}\`"
             echo "- cache hit summary: \`${{ steps.cache_hit.outputs.detail }}\`"
             if [ "${{ inputs.cache_backend }}" = "swatinem" ]; then
               echo "- rust-cache exact hit: \`${{ steps.rust_cache.outputs.cache-hit }}\`"

--- a/.github/workflows/_cache-benchmark-scenario.yml
+++ b/.github/workflows/_cache-benchmark-scenario.yml
@@ -31,6 +31,9 @@ on:
       warm_seconds:
         description: Warm cached wall-clock duration.
         value: ${{ jobs.compare.outputs.warm_seconds }}
+      saved_seconds:
+        description: Cold minus warm wall-clock duration.
+        value: ${{ jobs.compare.outputs.saved_seconds }}
       speedup_ratio:
         description: Cold divided by warm wall-clock time.
         value: ${{ jobs.compare.outputs.speedup_ratio }}
@@ -56,7 +59,6 @@ jobs:
       cache_shared_key: benchmark-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.cache_backend }}-${{ inputs.mutation }}
       mutation: none
       save_cache: true
-      upload_name: benchmark-seed-${{ inputs.cache_backend }}-${{ inputs.mutation }}
 
   cold-control:
     name: Cold control
@@ -69,7 +71,6 @@ jobs:
       cache_shared_key: ""
       mutation: ${{ inputs.mutation }}
       save_cache: false
-      upload_name: benchmark-cold-${{ inputs.mutation }}
 
   warm-cache:
     name: Warm cache
@@ -83,7 +84,6 @@ jobs:
       cache_shared_key: benchmark-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.cache_backend }}-${{ inputs.mutation }}
       mutation: ${{ inputs.mutation }}
       save_cache: false
-      upload_name: benchmark-warm-${{ inputs.cache_backend }}-${{ inputs.mutation }}
 
   compare:
     name: Compare warm vs cold
@@ -94,6 +94,7 @@ jobs:
     outputs:
       cold_seconds: ${{ steps.analyze.outputs.cold_seconds }}
       warm_seconds: ${{ steps.analyze.outputs.warm_seconds }}
+      saved_seconds: ${{ steps.analyze.outputs.saved_seconds }}
       speedup_ratio: ${{ steps.analyze.outputs.speedup_ratio }}
       cache_hit: ${{ steps.analyze.outputs.cache_hit }}
       cache_hit_detail: ${{ steps.analyze.outputs.cache_hit_detail }}
@@ -123,6 +124,7 @@ jobs:
           warm = float(os.environ["WARM_SECONDS"])
           threshold = float(os.environ["THRESHOLD_RATIO"])
           ratio = cold / warm if warm else float("inf")
+          saved = cold - warm
 
           summary = [
               "### Cache Benchmark Comparison",
@@ -131,15 +133,19 @@ jobs:
               f"- mutation: `{mutation}`",
               f"- cold wall seconds: `{cold:.2f}`",
               f"- warm wall seconds: `{warm:.2f}`",
+              f"- seconds saved: `{saved:.2f}`",
               f"- warm cache hit: `{cache_hit}`",
               f"- warm cache hit detail: `{cache_hit_detail}`",
               f"- speedup ratio: `{ratio:.2f}x`",
               f"- required ratio: `{threshold:.2f}x`",
+              "- timing scope: `cargo build --package soldr-cli --release --locked --target <target>` only",
+              "- measurement source: `time.perf_counter()` around the cargo subprocess",
           ]
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
               fh.write(f"cold_seconds={cold:.2f}\n")
               fh.write(f"warm_seconds={warm:.2f}\n")
+              fh.write(f"saved_seconds={saved:.2f}\n")
               fh.write(f"speedup_ratio={ratio:.2f}\n")
               fh.write(f"cache_hit={cache_hit}\n")
               fh.write(f"cache_hit_detail={cache_hit_detail}\n")

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -3,14 +3,6 @@ name: Cache Benchmark
 on:
   workflow_dispatch:
     inputs:
-      cache_backend:
-        description: Cache action under test.
-        required: true
-        type: choice
-        default: swatinem
-        options:
-          - swatinem
-          - zccache
       scenario:
         description: Which Phase 1 scenario set to run.
         required: true
@@ -30,27 +22,51 @@ permissions:
   contents: read
 
 jobs:
-  soldr-cli:
+  swatinem-soldr-cli:
     if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-cli' }}
-    name: Top-crate edit
+    name: Swatinem / Top-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-gnu
       source_ref: ${{ github.sha }}
-      cache_backend: ${{ inputs.cache_backend }}
+      cache_backend: swatinem
       mutation: soldr-cli
       threshold_ratio: ${{ inputs.threshold_ratio }}
 
-  soldr-core:
+  swatinem-soldr-core:
     if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-core' }}
-    name: Lower-crate edit
+    name: Swatinem / Lower-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-gnu
       source_ref: ${{ github.sha }}
-      cache_backend: ${{ inputs.cache_backend }}
+      cache_backend: swatinem
+      mutation: soldr-core
+      threshold_ratio: ${{ inputs.threshold_ratio }}
+
+  zccache-soldr-cli:
+    if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-cli' }}
+    name: zccache / Top-crate edit
+    uses: ./.github/workflows/_cache-benchmark-scenario.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-gnu
+      source_ref: ${{ github.sha }}
+      cache_backend: zccache
+      mutation: soldr-cli
+      threshold_ratio: ${{ inputs.threshold_ratio }}
+
+  zccache-soldr-core:
+    if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-core' }}
+    name: zccache / Lower-crate edit
+    uses: ./.github/workflows/_cache-benchmark-scenario.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-gnu
+      source_ref: ${{ github.sha }}
+      cache_backend: zccache
       mutation: soldr-core
       threshold_ratio: ${{ inputs.threshold_ratio }}
 
@@ -58,29 +74,46 @@ jobs:
     if: ${{ always() }}
     name: Phase 1 summary
     needs:
-      - soldr-cli
-      - soldr-core
+      - swatinem-soldr-cli
+      - swatinem-soldr-core
+      - zccache-soldr-cli
+      - zccache-soldr-core
     runs-on: ubuntu-24.04
 
     steps:
       - name: Write benchmark summary
         shell: bash
         env:
-          CACHE_BACKEND: ${{ inputs.cache_backend }}
           SCENARIO: ${{ inputs.scenario }}
           THRESHOLD_RATIO: ${{ inputs.threshold_ratio }}
-          SOLDR_CLI_RESULT: ${{ needs.soldr-cli.result }}
-          SOLDR_CLI_COLD: ${{ needs.soldr-cli.outputs.cold_seconds }}
-          SOLDR_CLI_WARM: ${{ needs.soldr-cli.outputs.warm_seconds }}
-          SOLDR_CLI_RATIO: ${{ needs.soldr-cli.outputs.speedup_ratio }}
-          SOLDR_CLI_HIT: ${{ needs.soldr-cli.outputs.cache_hit }}
-          SOLDR_CLI_HIT_DETAIL: ${{ needs.soldr-cli.outputs.cache_hit_detail }}
-          SOLDR_CORE_RESULT: ${{ needs.soldr-core.result }}
-          SOLDR_CORE_COLD: ${{ needs.soldr-core.outputs.cold_seconds }}
-          SOLDR_CORE_WARM: ${{ needs.soldr-core.outputs.warm_seconds }}
-          SOLDR_CORE_RATIO: ${{ needs.soldr-core.outputs.speedup_ratio }}
-          SOLDR_CORE_HIT: ${{ needs.soldr-core.outputs.cache_hit }}
-          SOLDR_CORE_HIT_DETAIL: ${{ needs.soldr-core.outputs.cache_hit_detail }}
+          SWATINEM_CLI_RESULT: ${{ needs.swatinem-soldr-cli.result }}
+          SWATINEM_CLI_COLD: ${{ needs.swatinem-soldr-cli.outputs.cold_seconds }}
+          SWATINEM_CLI_WARM: ${{ needs.swatinem-soldr-cli.outputs.warm_seconds }}
+          SWATINEM_CLI_SAVED: ${{ needs.swatinem-soldr-cli.outputs.saved_seconds }}
+          SWATINEM_CLI_RATIO: ${{ needs.swatinem-soldr-cli.outputs.speedup_ratio }}
+          SWATINEM_CLI_HIT: ${{ needs.swatinem-soldr-cli.outputs.cache_hit }}
+          SWATINEM_CLI_HIT_DETAIL: ${{ needs.swatinem-soldr-cli.outputs.cache_hit_detail }}
+          SWATINEM_CORE_RESULT: ${{ needs.swatinem-soldr-core.result }}
+          SWATINEM_CORE_COLD: ${{ needs.swatinem-soldr-core.outputs.cold_seconds }}
+          SWATINEM_CORE_WARM: ${{ needs.swatinem-soldr-core.outputs.warm_seconds }}
+          SWATINEM_CORE_SAVED: ${{ needs.swatinem-soldr-core.outputs.saved_seconds }}
+          SWATINEM_CORE_RATIO: ${{ needs.swatinem-soldr-core.outputs.speedup_ratio }}
+          SWATINEM_CORE_HIT: ${{ needs.swatinem-soldr-core.outputs.cache_hit }}
+          SWATINEM_CORE_HIT_DETAIL: ${{ needs.swatinem-soldr-core.outputs.cache_hit_detail }}
+          ZCCACHE_CLI_RESULT: ${{ needs.zccache-soldr-cli.result }}
+          ZCCACHE_CLI_COLD: ${{ needs.zccache-soldr-cli.outputs.cold_seconds }}
+          ZCCACHE_CLI_WARM: ${{ needs.zccache-soldr-cli.outputs.warm_seconds }}
+          ZCCACHE_CLI_SAVED: ${{ needs.zccache-soldr-cli.outputs.saved_seconds }}
+          ZCCACHE_CLI_RATIO: ${{ needs.zccache-soldr-cli.outputs.speedup_ratio }}
+          ZCCACHE_CLI_HIT: ${{ needs.zccache-soldr-cli.outputs.cache_hit }}
+          ZCCACHE_CLI_HIT_DETAIL: ${{ needs.zccache-soldr-cli.outputs.cache_hit_detail }}
+          ZCCACHE_CORE_RESULT: ${{ needs.zccache-soldr-core.result }}
+          ZCCACHE_CORE_COLD: ${{ needs.zccache-soldr-core.outputs.cold_seconds }}
+          ZCCACHE_CORE_WARM: ${{ needs.zccache-soldr-core.outputs.warm_seconds }}
+          ZCCACHE_CORE_SAVED: ${{ needs.zccache-soldr-core.outputs.saved_seconds }}
+          ZCCACHE_CORE_RATIO: ${{ needs.zccache-soldr-core.outputs.speedup_ratio }}
+          ZCCACHE_CORE_HIT: ${{ needs.zccache-soldr-core.outputs.cache_hit }}
+          ZCCACHE_CORE_HIT_DETAIL: ${{ needs.zccache-soldr-core.outputs.cache_hit_detail }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -88,74 +121,92 @@ jobs:
 
           scenarios = [
               (
-                  "soldr-cli",
+                  "swatinem",
                   "top-crate edit (`crates/soldr-cli/src/main.rs`)",
-                  os.environ["SOLDR_CLI_RESULT"],
-                  os.environ["SOLDR_CLI_COLD"],
-                  os.environ["SOLDR_CLI_WARM"],
-                  os.environ["SOLDR_CLI_RATIO"],
-                  os.environ["SOLDR_CLI_HIT"],
-                  os.environ["SOLDR_CLI_HIT_DETAIL"],
+                  os.environ["SWATINEM_CLI_RESULT"],
+                  os.environ["SWATINEM_CLI_COLD"],
+                  os.environ["SWATINEM_CLI_WARM"],
+                  os.environ["SWATINEM_CLI_SAVED"],
+                  os.environ["SWATINEM_CLI_RATIO"],
+                  os.environ["SWATINEM_CLI_HIT"],
+                  os.environ["SWATINEM_CLI_HIT_DETAIL"],
               ),
               (
-                  "soldr-core",
+                  "swatinem",
                   "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
-                  os.environ["SOLDR_CORE_RESULT"],
-                  os.environ["SOLDR_CORE_COLD"],
-                  os.environ["SOLDR_CORE_WARM"],
-                  os.environ["SOLDR_CORE_RATIO"],
-                  os.environ["SOLDR_CORE_HIT"],
-                  os.environ["SOLDR_CORE_HIT_DETAIL"],
+                  os.environ["SWATINEM_CORE_RESULT"],
+                  os.environ["SWATINEM_CORE_COLD"],
+                  os.environ["SWATINEM_CORE_WARM"],
+                  os.environ["SWATINEM_CORE_SAVED"],
+                  os.environ["SWATINEM_CORE_RATIO"],
+                  os.environ["SWATINEM_CORE_HIT"],
+                  os.environ["SWATINEM_CORE_HIT_DETAIL"],
+              ),
+              (
+                  "zccache",
+                  "top-crate edit (`crates/soldr-cli/src/main.rs`)",
+                  os.environ["ZCCACHE_CLI_RESULT"],
+                  os.environ["ZCCACHE_CLI_COLD"],
+                  os.environ["ZCCACHE_CLI_WARM"],
+                  os.environ["ZCCACHE_CLI_SAVED"],
+                  os.environ["ZCCACHE_CLI_RATIO"],
+                  os.environ["ZCCACHE_CLI_HIT"],
+                  os.environ["ZCCACHE_CLI_HIT_DETAIL"],
+              ),
+              (
+                  "zccache",
+                  "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
+                  os.environ["ZCCACHE_CORE_RESULT"],
+                  os.environ["ZCCACHE_CORE_COLD"],
+                  os.environ["ZCCACHE_CORE_WARM"],
+                  os.environ["ZCCACHE_CORE_SAVED"],
+                  os.environ["ZCCACHE_CORE_RATIO"],
+                  os.environ["ZCCACHE_CORE_HIT"],
+                  os.environ["ZCCACHE_CORE_HIT_DETAIL"],
               ),
           ]
 
           workflow_summary = [
               "### Cache Benchmark Summary",
               "",
-              f"- cache backend: `{os.environ['CACHE_BACKEND']}`",
               f"- requested scenario: `{os.environ['SCENARIO']}`",
               f"- required ratio: `{float(os.environ['THRESHOLD_RATIO']):.2f}x`",
+              "- timing scope: `cargo build --package soldr-cli --release --locked --target <target>` only",
+              "- measurement source: `time.perf_counter()` around the cargo subprocess",
               "",
+              "| backend | mutation | result | cold (s) | warm (s) | saved (s) | speedup | cache hit |",
+              "| --- | --- | --- | ---: | ---: | ---: | ---: | --- |",
           ]
           issue_comment = [
               "### Phase 1 benchmark results",
               "",
-              f"- workflow: `cache-benchmark.yml`",
-              f"- cache backend under test: `{os.environ['CACHE_BACKEND']}`",
+              "- workflow: `cache-benchmark.yml`",
+              "- cache backends under test: `swatinem`, `zccache`",
               f"- threshold used: `{float(os.environ['THRESHOLD_RATIO']):.2f}x`",
               "",
+              "| backend | mutation | cold (s) | warm (s) | saved (s) | speedup | cache hit |",
+              "| --- | --- | ---: | ---: | ---: | ---: | --- |",
           ]
 
-          for key, label, result, cold, warm, ratio, cache_hit, hit_detail in scenarios:
+          cache_details = []
+
+          for backend, label, result, cold, warm, saved, ratio, cache_hit, hit_detail in scenarios:
               if result == "skipped":
                   continue
 
-              workflow_summary.extend(
-                  [
-                      f"#### {label}",
-                      "",
-                      f"- job result: `{result}`",
-                      f"- cold wall seconds: `{cold}`",
-                      f"- warm wall seconds: `{warm}`",
-                      f"- speedup ratio: `{ratio}x`",
-                      f"- warm cache hit: `{cache_hit}`",
-                      f"- warm cache hit detail: `{hit_detail}`",
-                      "",
-                  ]
+              workflow_summary.append(
+                  f"| `{backend}` | {label} | `{result}` | `{cold}` | `{warm}` | `{saved}` | `{ratio}x` | `{cache_hit}` |"
               )
-              issue_comment.extend(
-                  [
-                      f"- {label}: cold `{cold}s`, warm `{warm}s`, speedup `{ratio}x`, cache hit `{cache_hit}`",
-                      f"  cache detail: `{hit_detail}`",
-                  ]
+              issue_comment.append(
+                  f"| `{backend}` | {label} | `{cold}` | `{warm}` | `{saved}` | `{ratio}x` | `{cache_hit}` |"
               )
+              cache_details.append(f"- `{backend}` / {label}: `{hit_detail}`")
 
-          issue_comment.extend(
-              [
-                  "",
-                  "Timing HTML artifacts are attached to the workflow run for each seed/cold/warm child job.",
-              ]
-          )
+          workflow_summary.extend(["", "### Cache Details", ""])
+          workflow_summary.extend(cache_details)
+
+          issue_comment.extend(["", "Cache details:"])
+          issue_comment.extend(cache_details)
 
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
               fh.write("\n".join(workflow_summary) + "\n\n")

--- a/docs/CI_CACHE_PHASE1.md
+++ b/docs/CI_CACHE_PHASE1.md
@@ -5,11 +5,12 @@ Issue [#122](https://github.com/zackees/soldr/issues/122) requires Linux x64 bas
 Use `.github/workflows/cache-benchmark.yml` for that Phase 1 measurement. The workflow dispatch:
 
 - runs on `ubuntu-24.04` with target `x86_64-unknown-linux-gnu`
-- seeds the cache backend under test in one child job
-- measures a cold control build in a second child job
-- measures a warm cached build in a third child job after applying a one-line source edit
-- fails unless the warm path is at least the configured ratio faster than the cold control
-- uploads each child job's `cargo build --timings` HTML output as an artifact
+- runs both cache backends in parallel: `Swatinem/rust-cache` and `zccache`
+- seeds each backend cache in one child job, then measures cold and warm builds for each selected scenario
+- measures only the `cargo build --package soldr-cli --release --locked --target <target>` wall time
+- uses Python `time.perf_counter()` around the cargo subprocess for the benchmark timing
+- writes the human-readable report into the compare jobs and the final workflow summary
+- fails a compare job unless the warm path is at least the configured ratio faster than the cold control
 
 Scenarios:
 
@@ -20,7 +21,7 @@ Scenarios:
 Recommended Phase 1 run:
 
 1. Dispatch `Cache Benchmark`.
-2. Leave `cache_backend=swatinem`.
-3. Leave `scenario=all`.
-4. Leave `threshold_ratio=10`.
+2. Leave `scenario=all`.
+3. Leave `threshold_ratio=10`.
+4. Read the side-by-side backend report from the compare jobs and the `Phase 1 summary` job.
 5. Copy the generated `Issue Comment Draft` block from the workflow summary into issue `#122`.


### PR DESCRIPTION
## Summary

Fixes the merged Phase 1 cache benchmark workflow so it passes the repository action-pinning rules and can be executed.

Refs #122.

## What changed

- replace the remote zackees/zccache benchmark usage with repo-local vendored benchmark-only setup/cleanup composite actions
- pin ctions/cache/restore and ctions/cache/save to the full 4.2.4 commit SHA inside those local actions
- keep the benchmark workflow interface unchanged while removing the validation failure from nested floating action references

## Validation

- failing run on main: https://github.com/zackees/soldr/actions/runs/24647642526
- successful rerun on this branch: https://github.com/zackees/soldr/actions/runs/24647728828
- local YAML parse check for the updated workflow and local composite action files

## Notes

The successful rerun was executed with cache_backend=swatinem, scenario=all, and 	hreshold_ratio=10.