### PR TITLE
ci: simplify cache benchmark summary

### DIFF
--- a/.github/scripts/cache_benchmark_report.py
+++ b/.github/scripts/cache_benchmark_report.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Generate the top-level cache benchmark report and JSON artifact."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCENARIOS = [
+    {
+        "backend": "swatinem",
+        "mutation": "soldr-cli",
+        "label": "top-crate edit (`crates/soldr-cli/src/main.rs`)",
+        "env_prefix": "SWATINEM_CLI",
+    },
+    {
+        "backend": "swatinem",
+        "mutation": "soldr-core",
+        "label": "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
+        "env_prefix": "SWATINEM_CORE",
+    },
+    {
+        "backend": "zccache",
+        "mutation": "soldr-cli",
+        "label": "top-crate edit (`crates/soldr-cli/src/main.rs`)",
+        "env_prefix": "ZCCACHE_CLI",
+    },
+    {
+        "backend": "zccache",
+        "mutation": "soldr-core",
+        "label": "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
+        "env_prefix": "ZCCACHE_CORE",
+    },
+]
+
+
+def _read_float(value: str) -> float | None:
+    if not value:
+        return None
+    return float(value)
+
+
+def _read_bool(value: str) -> bool | None:
+    if not value:
+        return None
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ValueError(f"unsupported boolean value: {value!r}")
+
+
+def _percent_less_time(baseline: float, candidate: float) -> float:
+    if baseline <= 0:
+        return 0.0
+    return ((baseline - candidate) / baseline) * 100.0
+
+
+def _round_metric(value: float | None) -> float | None:
+    if value is None or not math.isfinite(value):
+        return None
+    return round(value, 2)
+
+
+def _load_results() -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for scenario in SCENARIOS:
+        prefix = scenario["env_prefix"]
+        result = os.environ[f"{prefix}_RESULT"]
+        cold_seconds = _read_float(os.environ.get(f"{prefix}_COLD", ""))
+        warm_seconds = _read_float(os.environ.get(f"{prefix}_WARM", ""))
+        saved_seconds = _read_float(os.environ.get(f"{prefix}_SAVED", ""))
+        speedup_ratio = _read_float(os.environ.get(f"{prefix}_RATIO", ""))
+        cache_hit = _read_bool(os.environ.get(f"{prefix}_HIT", ""))
+        cache_hit_detail = os.environ.get(f"{prefix}_HIT_DETAIL", "")
+
+        percent_less_wall_time_than_bare = None
+        if cold_seconds is not None and warm_seconds is not None:
+            percent_less_wall_time_than_bare = _percent_less_time(cold_seconds, warm_seconds)
+
+        results.append(
+            {
+                "backend": scenario["backend"],
+                "mutation": scenario["mutation"],
+                "label": scenario["label"],
+                "result": result,
+                "cold_seconds": _round_metric(cold_seconds),
+                "warm_seconds": _round_metric(warm_seconds),
+                "saved_seconds": _round_metric(saved_seconds),
+                "speedup_ratio": _round_metric(speedup_ratio),
+                "cache_hit": cache_hit,
+                "cache_hit_detail": cache_hit_detail or None,
+                "percent_less_wall_time_than_bare": _round_metric(
+                    percent_less_wall_time_than_bare
+                ),
+            }
+        )
+    return results
+
+
+def _build_report(results: list[dict[str, Any]]) -> dict[str, Any]:
+    by_mutation: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for result in results:
+        by_mutation[result["mutation"]].append(result)
+
+    mutation_summaries: list[dict[str, Any]] = []
+    for mutation, mutation_results in by_mutation.items():
+        successful = [
+            result
+            for result in mutation_results
+            if result["result"] == "success" and result["warm_seconds"] is not None
+        ]
+        successful.sort(key=lambda result: result["warm_seconds"])
+
+        leader = successful[0] if successful else None
+        runner_up = successful[1] if len(successful) > 1 else None
+        leader_advantage = None
+        if leader and runner_up:
+            leader_advantage = _percent_less_time(
+                runner_up["warm_seconds"], leader["warm_seconds"]
+            )
+
+        mutation_summaries.append(
+            {
+                "mutation": mutation,
+                "label": mutation_results[0]["label"],
+                "leader_backend": leader["backend"] if leader else None,
+                "leader_percent_less_wall_time_than_bare": (
+                    leader["percent_less_wall_time_than_bare"] if leader else None
+                ),
+                "runner_up_backend": runner_up["backend"] if runner_up else None,
+                "leader_percent_less_wall_time_than_runner_up": _round_metric(
+                    leader_advantage
+                ),
+                "results": mutation_results,
+            }
+        )
+
+    mutation_summaries.sort(key=lambda item: item["mutation"])
+
+    return {
+        "workflow": "cache-benchmark.yml",
+        "requested_scenario": os.environ["SCENARIO"],
+        "threshold_ratio": _round_metric(float(os.environ["THRESHOLD_RATIO"])),
+        "metric_definition": {
+            "percent_less_wall_time_than_bare": (
+                "(cold_seconds - warm_seconds) / cold_seconds * 100"
+            ),
+            "leader_percent_less_wall_time_than_runner_up": (
+                "(runner_up_warm_seconds - leader_warm_seconds) / "
+                "runner_up_warm_seconds * 100"
+            ),
+        },
+        "mutations": mutation_summaries,
+    }
+
+
+def _write_json_report(report: dict[str, Any]) -> None:
+    output_path = Path(os.environ["BENCHMARK_SUMMARY_JSON"])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+
+def _build_summary_lines(report: dict[str, Any]) -> list[str]:
+    lines = [
+        "### Cache Benchmark Summary",
+        "",
+        f"- requested scenario: `{report['requested_scenario']}`",
+        f"- threshold ratio: `{report['threshold_ratio']:.2f}x`",
+        "- primary metric: percent less wall time than bare build",
+        "- secondary metric: leader advantage over the next-best cache backend",
+        "- artifact: `cache-benchmark-summary.json`",
+        "",
+        "### Leaders",
+        "",
+    ]
+
+    for mutation in report["mutations"]:
+        leader_backend = mutation["leader_backend"]
+        if leader_backend is None:
+            lines.append(f"- `{mutation['mutation']}`: no successful benchmark results")
+            continue
+
+        leader_vs_bare = mutation["leader_percent_less_wall_time_than_bare"]
+        runner_up_backend = mutation["runner_up_backend"]
+        leader_vs_runner_up = mutation["leader_percent_less_wall_time_than_runner_up"]
+        line = (
+            f"- `{mutation['mutation']}`: `{leader_backend}` is best, "
+            f"`{leader_vs_bare:.2f}%` less wall time than bare"
+        )
+        if runner_up_backend and leader_vs_runner_up is not None:
+            line += (
+                f", `{leader_vs_runner_up:.2f}%` less wall time than `{runner_up_backend}`"
+            )
+        lines.append(line)
+
+    lines.extend(
+        [
+            "",
+            "### Percent Less Wall Time Than Bare",
+            "",
+            "| mutation | backend | result | % less wall time than bare |",
+            "| --- | --- | --- | ---: |",
+        ]
+    )
+
+    for mutation in report["mutations"]:
+        for result in mutation["results"]:
+            percent = result["percent_less_wall_time_than_bare"]
+            percent_display = f"{percent:.2f}%" if percent is not None else "n/a"
+            lines.append(
+                f"| `{result['mutation']}` | `{result['backend']}` | "
+                f"`{result['result']}` | `{percent_display}` |"
+            )
+
+    return lines
+
+
+def _append_step_summary(report: dict[str, Any]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    summary_lines = _build_summary_lines(report)
+    with Path(summary_path).open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(summary_lines) + "\n")
+
+
+def main() -> None:
+    report = _build_report(_load_results())
+    _write_json_report(report)
+    _append_step_summary(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/_cache-benchmark-build.yml
+++ b/.github/workflows/_cache-benchmark-build.yml
@@ -60,6 +60,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
+          toolchain: stable
+          profile: minimal
           targets: ${{ inputs.target }}
 
       - name: Resolve compiler path

--- a/.github/workflows/_cache-benchmark-build.yml
+++ b/.github/workflows/_cache-benchmark-build.yml
@@ -60,8 +60,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
-          toolchain: stable
-          profile: minimal
           targets: ${{ inputs.target }}
 
       - name: Resolve compiler path

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -81,9 +81,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Write benchmark summary
         shell: bash
         env:
+          BENCHMARK_SUMMARY_JSON: benchmark-summary/cache-benchmark-summary.json
           SCENARIO: ${{ inputs.scenario }}
           THRESHOLD_RATIO: ${{ inputs.threshold_ratio }}
           SWATINEM_CLI_RESULT: ${{ needs.swatinem-soldr-cli.result }}
@@ -116,102 +119,12 @@ jobs:
           ZCCACHE_CORE_HIT_DETAIL: ${{ needs.zccache-soldr-core.outputs.cache_hit_detail }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import os
+          python3 .github/scripts/cache_benchmark_report.py
 
-          scenarios = [
-              (
-                  "swatinem",
-                  "top-crate edit (`crates/soldr-cli/src/main.rs`)",
-                  os.environ["SWATINEM_CLI_RESULT"],
-                  os.environ["SWATINEM_CLI_COLD"],
-                  os.environ["SWATINEM_CLI_WARM"],
-                  os.environ["SWATINEM_CLI_SAVED"],
-                  os.environ["SWATINEM_CLI_RATIO"],
-                  os.environ["SWATINEM_CLI_HIT"],
-                  os.environ["SWATINEM_CLI_HIT_DETAIL"],
-              ),
-              (
-                  "swatinem",
-                  "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
-                  os.environ["SWATINEM_CORE_RESULT"],
-                  os.environ["SWATINEM_CORE_COLD"],
-                  os.environ["SWATINEM_CORE_WARM"],
-                  os.environ["SWATINEM_CORE_SAVED"],
-                  os.environ["SWATINEM_CORE_RATIO"],
-                  os.environ["SWATINEM_CORE_HIT"],
-                  os.environ["SWATINEM_CORE_HIT_DETAIL"],
-              ),
-              (
-                  "zccache",
-                  "top-crate edit (`crates/soldr-cli/src/main.rs`)",
-                  os.environ["ZCCACHE_CLI_RESULT"],
-                  os.environ["ZCCACHE_CLI_COLD"],
-                  os.environ["ZCCACHE_CLI_WARM"],
-                  os.environ["ZCCACHE_CLI_SAVED"],
-                  os.environ["ZCCACHE_CLI_RATIO"],
-                  os.environ["ZCCACHE_CLI_HIT"],
-                  os.environ["ZCCACHE_CLI_HIT_DETAIL"],
-              ),
-              (
-                  "zccache",
-                  "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
-                  os.environ["ZCCACHE_CORE_RESULT"],
-                  os.environ["ZCCACHE_CORE_COLD"],
-                  os.environ["ZCCACHE_CORE_WARM"],
-                  os.environ["ZCCACHE_CORE_SAVED"],
-                  os.environ["ZCCACHE_CORE_RATIO"],
-                  os.environ["ZCCACHE_CORE_HIT"],
-                  os.environ["ZCCACHE_CORE_HIT_DETAIL"],
-              ),
-          ]
-
-          workflow_summary = [
-              "### Cache Benchmark Summary",
-              "",
-              f"- requested scenario: `{os.environ['SCENARIO']}`",
-              f"- required ratio: `{float(os.environ['THRESHOLD_RATIO']):.2f}x`",
-              "- timing scope: `cargo build --package soldr-cli --release --locked --target <target>` only",
-              "- measurement source: `time.perf_counter()` around the cargo subprocess",
-              "",
-              "| backend | mutation | result | cold (s) | warm (s) | saved (s) | speedup | cache hit |",
-              "| --- | --- | --- | ---: | ---: | ---: | ---: | --- |",
-          ]
-          issue_comment = [
-              "### Phase 1 benchmark results",
-              "",
-              "- workflow: `cache-benchmark.yml`",
-              "- cache backends under test: `swatinem`, `zccache`",
-              f"- threshold used: `{float(os.environ['THRESHOLD_RATIO']):.2f}x`",
-              "",
-              "| backend | mutation | cold (s) | warm (s) | saved (s) | speedup | cache hit |",
-              "| --- | --- | ---: | ---: | ---: | ---: | --- |",
-          ]
-
-          cache_details = []
-
-          for backend, label, result, cold, warm, saved, ratio, cache_hit, hit_detail in scenarios:
-              if result == "skipped":
-                  continue
-
-              workflow_summary.append(
-                  f"| `{backend}` | {label} | `{result}` | `{cold}` | `{warm}` | `{saved}` | `{ratio}x` | `{cache_hit}` |"
-              )
-              issue_comment.append(
-                  f"| `{backend}` | {label} | `{cold}` | `{warm}` | `{saved}` | `{ratio}x` | `{cache_hit}` |"
-              )
-              cache_details.append(f"- `{backend}` / {label}: `{hit_detail}`")
-
-          workflow_summary.extend(["", "### Cache Details", ""])
-          workflow_summary.extend(cache_details)
-
-          issue_comment.extend(["", "Cache details:"])
-          issue_comment.extend(cache_details)
-
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
-              fh.write("\n".join(workflow_summary) + "\n\n")
-              fh.write("### Issue Comment Draft\n\n")
-              fh.write("```markdown\n")
-              fh.write("\n".join(issue_comment) + "\n")
-              fh.write("```\n")
-          PY
+      - name: Upload benchmark summary artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cache-benchmark-summary
+          path: benchmark-summary/cache-benchmark-summary.json
+          if-no-files-found: error

--- a/docs/CI_CACHE_PHASE1.md
+++ b/docs/CI_CACHE_PHASE1.md
@@ -9,19 +9,20 @@ Use `.github/workflows/cache-benchmark.yml` for that Phase 1 measurement. The wo
 - seeds each backend cache in one child job, then measures cold and warm builds for each selected scenario
 - measures only the `cargo build --package soldr-cli --release --locked --target <target>` wall time
 - uses Python `time.perf_counter()` around the cargo subprocess for the benchmark timing
-- writes the human-readable report into the compare jobs and the final workflow summary
+- uploads one top-level `cache-benchmark-summary` artifact containing `cache-benchmark-summary.json`
+- keeps the final workflow summary focused on percent less wall time than bare and the leader's advantage over the next-best cache backend
 - fails a compare job unless the warm path is at least the configured ratio faster than the cold control
 
 Scenarios:
 
 - `soldr-cli`: top-crate edit in `crates/soldr-cli/src/main.rs`
 - `soldr-core`: lower-crate edit in `crates/soldr-core/src/lib.rs`
-- `all`: runs both scenarios and emits an issue-comment-ready summary in the workflow summary
+- `all`: runs both scenarios and writes both mutation summaries into the same top-level JSON artifact
 
 Recommended Phase 1 run:
 
 1. Dispatch `Cache Benchmark`.
 2. Leave `scenario=all`.
 3. Leave `threshold_ratio=10`.
-4. Read the side-by-side backend report from the compare jobs and the `Phase 1 summary` job.
-5. Copy the generated `Issue Comment Draft` block from the workflow summary into issue `#122`.
+4. Open the `Phase 1 summary` job for the high-level percent deltas.
+5. Download the `cache-benchmark-summary` artifact if you need the raw wall times and cache-hit details.

--- a/tests/test_cache_benchmark_report.py
+++ b/tests/test_cache_benchmark_report.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "cache_benchmark_report.py"
+
+
+def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
+    json_path = tmp_path / "cache-benchmark-summary.json"
+    summary_path = tmp_path / "step-summary.md"
+    env = os.environ.copy()
+    env.update(
+        {
+            "SCENARIO": "all",
+            "THRESHOLD_RATIO": "10",
+            "BENCHMARK_SUMMARY_JSON": str(json_path),
+            "GITHUB_STEP_SUMMARY": str(summary_path),
+            "SWATINEM_CLI_RESULT": "success",
+            "SWATINEM_CLI_COLD": "78.70",
+            "SWATINEM_CLI_WARM": "6.11",
+            "SWATINEM_CLI_SAVED": "72.59",
+            "SWATINEM_CLI_RATIO": "12.88",
+            "SWATINEM_CLI_HIT": "true",
+            "SWATINEM_CLI_HIT_DETAIL": "backend=swatinem;exact_hit=true",
+            "SWATINEM_CORE_RESULT": "success",
+            "SWATINEM_CORE_COLD": "74.88",
+            "SWATINEM_CORE_WARM": "6.10",
+            "SWATINEM_CORE_SAVED": "68.78",
+            "SWATINEM_CORE_RATIO": "12.28",
+            "SWATINEM_CORE_HIT": "true",
+            "SWATINEM_CORE_HIT_DETAIL": "backend=swatinem;exact_hit=true",
+            "ZCCACHE_CLI_RESULT": "success",
+            "ZCCACHE_CLI_COLD": "74.55",
+            "ZCCACHE_CLI_WARM": "1.72",
+            "ZCCACHE_CLI_SAVED": "72.83",
+            "ZCCACHE_CLI_RATIO": "43.34",
+            "ZCCACHE_CLI_HIT": "true",
+            "ZCCACHE_CLI_HIT_DETAIL": (
+                "backend=zccache;compilation=true;target=true;registry=true"
+            ),
+            "ZCCACHE_CORE_RESULT": "success",
+            "ZCCACHE_CORE_COLD": "75.38",
+            "ZCCACHE_CORE_WARM": "1.46",
+            "ZCCACHE_CORE_SAVED": "73.92",
+            "ZCCACHE_CORE_RATIO": "51.63",
+            "ZCCACHE_CORE_HIT": "true",
+            "ZCCACHE_CORE_HIT_DETAIL": (
+                "backend=zccache;compilation=true;target=true;registry=true"
+            ),
+        }
+    )
+
+    subprocess.run([sys.executable, str(SCRIPT_PATH)], check=True, env=env, cwd=REPO_ROOT)
+
+    report = json.loads(json_path.read_text(encoding="utf-8"))
+    assert report["workflow"] == "cache-benchmark.yml"
+    assert report["threshold_ratio"] == 10.0
+
+    cli_mutation = next(
+        mutation for mutation in report["mutations"] if mutation["mutation"] == "soldr-cli"
+    )
+    assert cli_mutation["leader_backend"] == "zccache"
+    assert cli_mutation["leader_percent_less_wall_time_than_bare"] == 97.69
+    assert cli_mutation["leader_percent_less_wall_time_than_runner_up"] == 71.85
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "cache-benchmark-summary.json" in summary
+    assert "`soldr-cli`: `zccache` is best, `97.69%` less wall time than bare" in summary


### PR DESCRIPTION
## Summary
- move cache benchmark summary generation into a dedicated Python script
- upload a single top-level \cache-benchmark-summary.json\ artifact from the summary job
- reduce the workflow summary to leader-focused percent wall-time reductions and document the new flow

## Verification
- \uv run pytest tests/test_cache_benchmark_report.py -q\
- \python -m py_compile .github/scripts/cache_benchmark_report.py\

Refs #122