### PR TITLE
ci: deploy benchmark pages after partial failures

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -149,7 +149,7 @@ jobs:
           path: benchmark-summary/site
 
   deploy-pages:
-    if: ${{ needs.summary.result == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    if: ${{ always() && needs.summary.result == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     name: Deploy benchmark site
     needs:
       - summary


### PR DESCRIPTION
## Summary
- let the GitHub Pages deploy job run whenever the benchmark summary job succeeds
- avoid skipping site publication when one benchmark compare job fails threshold

## Verification
- uv run pytest tests/test_cache_benchmark_report.py -q

## Related
- Follow-up to #122