### PR TITLE
site: render benchmark commands more clearly

### DIFF
--- a/.github/scripts/cache_benchmark_report.py
+++ b/.github/scripts/cache_benchmark_report.py
@@ -39,6 +39,63 @@ SCENARIOS = [
     },
 ]
 
+DEFAULT_BENCHMARK_TARGET = "x86_64-unknown-linux-gnu"
+BENCHMARK_COMMAND_TEMPLATE = (
+    "soldr cargo build --package soldr-cli --release --locked --target {target}"
+)
+BASE_COMMAND_REFERENCE = [
+    {
+        "purpose": "Setup / status",
+        "command": "soldr status --json",
+        "status": "setup check",
+    },
+    {
+        "purpose": "Cache inspect",
+        "command": "soldr cache --json",
+        "status": "setup check",
+    },
+    {
+        "purpose": "Release build",
+        "command": "soldr cargo build --workspace --locked",
+        "status": "common compile path",
+    },
+    {
+        "purpose": "Targeted check",
+        "command": "soldr cargo check -p soldr-cli",
+        "status": "common compile path",
+    },
+    {
+        "purpose": "Library tests",
+        "command": "soldr cargo test --workspace --lib --locked",
+        "status": "common test path",
+    },
+    {
+        "purpose": "CLI smoke tests",
+        "command": "soldr cargo test -p soldr-cli --test cli --locked",
+        "status": "common test path",
+    },
+    {
+        "purpose": "Fetch integration test",
+        "command": "soldr cargo test -p soldr-fetch --test fetch_crgx --locked",
+        "status": "common test path",
+    },
+    {
+        "purpose": "Formatting check",
+        "command": "soldr cargo fmt --all -- --check",
+        "status": "quality check",
+    },
+    {
+        "purpose": "Clippy",
+        "command": "soldr cargo clippy --workspace --all-targets --locked -- -D warnings",
+        "status": "quality check",
+    },
+    {
+        "purpose": "Dylint",
+        "command": "soldr cargo-dylint check",
+        "status": "tooling check",
+    },
+]
+
 
 def _read_float(value: str) -> float | None:
     if not value:
@@ -82,6 +139,8 @@ def _format_percent(value: float | None) -> str:
 
 def _load_results() -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
+    benchmark_target = os.environ.get("BENCHMARK_COMMAND_TARGET", DEFAULT_BENCHMARK_TARGET)
+    benchmark_command = BENCHMARK_COMMAND_TEMPLATE.format(target=benchmark_target)
     for scenario in SCENARIOS:
         prefix = scenario["env_prefix"]
         result = os.environ[f"{prefix}_RESULT"]
@@ -101,6 +160,7 @@ def _load_results() -> list[dict[str, Any]]:
                 "backend": scenario["backend"],
                 "mutation": scenario["mutation"],
                 "label": scenario["label"],
+                "command": benchmark_command,
                 "result": result,
                 "cold_seconds": _round_metric(cold_seconds),
                 "warm_seconds": _round_metric(warm_seconds),
@@ -160,6 +220,15 @@ def _build_report(results: list[dict[str, Any]]) -> dict[str, Any]:
         "workflow": "cache-benchmark.yml",
         "requested_scenario": os.environ["SCENARIO"],
         "threshold_ratio": _round_metric(float(os.environ["THRESHOLD_RATIO"])),
+        "benchmarked_command": results[0]["command"] if results else None,
+        "command_reference": [
+            {
+                "purpose": "Benchmarked release build",
+                "command": results[0]["command"] if results else "n/a",
+                "status": "benchmarked now",
+            },
+            *BASE_COMMAND_REFERENCE,
+        ],
         "metric_definition": {
             "percent_less_wall_time_than_bare": (
                 "(cold_seconds - warm_seconds) / cold_seconds * 100"
@@ -187,7 +256,8 @@ def _build_table_rows(report: dict[str, Any]) -> str:
             winner = "yes" if result["backend"] == leader_backend else ""
             rows.append(
                 "<tr>"
-                f"<td>{escape(result['mutation'])}</td>"
+                f"<td><code>{escape(result['command'])}</code></td>"
+                f"<td>{escape(result['label'])}</td>"
                 f"<td>{escape(result['backend'])}</td>"
                 f"<td>{escape(result['result'])}</td>"
                 f"<td>{_format_seconds(result['cold_seconds'])}</td>"
@@ -198,6 +268,22 @@ def _build_table_rows(report: dict[str, Any]) -> str:
                 f"<td>{winner}</td>"
                 "</tr>"
             )
+    return "\n".join(rows)
+
+
+def _build_command_reference_rows(report: dict[str, Any]) -> str:
+    rows: list[str] = []
+    benchmarked = report.get("benchmarked_command")
+    for item in report["command_reference"]:
+        benchmarked_flag = "yes" if item["command"] == benchmarked else "not yet"
+        rows.append(
+            "<tr>"
+            f"<td>{escape(item['purpose'])}</td>"
+            f"<td><code>{escape(item['command'])}</code></td>"
+            f"<td>{escape(item['status'])}</td>"
+            f"<td>{benchmarked_flag}</td>"
+            "</tr>"
+        )
     return "\n".join(rows)
 
 
@@ -284,11 +370,15 @@ def _build_html_page(report: dict[str, Any]) -> str:
         Scenario: {escape(report["requested_scenario"])} |
         Threshold: {report["threshold_ratio"]:.2f}x
       </p>
+      <p class="meta">
+        Benchmarked command: <code>{escape(report["benchmarked_command"] or "n/a")}</code>
+      </p>
       <div class="table-wrap">
         <table>
           <thead>
             <tr>
-              <th>Mutation</th>
+              <th>Command</th>
+              <th>Change</th>
               <th>Backend</th>
               <th>Result</th>
               <th>Cold</th>
@@ -301,6 +391,22 @@ def _build_html_page(report: dict[str, Any]) -> str:
           </thead>
           <tbody>
             {_build_table_rows(report)}
+          </tbody>
+        </table>
+      </div>
+      <h2>Common soldr commands</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Purpose</th>
+              <th>Command</th>
+              <th>Type</th>
+              <th>Benchmarked</th>
+            </tr>
+          </thead>
+          <tbody>
+            {_build_command_reference_rows(report)}
           </tbody>
         </table>
       </div>

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Write benchmark summary
         shell: bash
         env:
+          BENCHMARK_COMMAND_TARGET: x86_64-unknown-linux-gnu
           BENCHMARK_SUMMARY_JSON: benchmark-summary/cache-benchmark-summary.json
           BENCHMARK_SUMMARY_WWW_DIR: benchmark-summary/site
           SCENARIO: ${{ inputs.scenario }}

--- a/docs/CI_CACHE_PHASE1.md
+++ b/docs/CI_CACHE_PHASE1.md
@@ -12,6 +12,7 @@ Use `.github/workflows/cache-benchmark.yml` for that Phase 1 measurement. The wo
 - uploads one top-level `cache-benchmark-summary` artifact containing `cache-benchmark-summary.json`
 - uploads one website-ready `cache-benchmark-www` artifact containing `index.html` and `latest.json`
 - deploys that same generated site bundle to GitHub Pages when the benchmark workflow runs on the default branch
+- renders the benchmark page with the actual `soldr ...` command under test as the first column, plus a reference table of common soldr commands such as `build`, `check`, `test`, `fmt`, and `clippy`
 - keeps the final workflow summary focused on percent less wall time than bare and the leader's advantage over the next-best cache backend
 - fails a compare job unless the warm path is at least the configured ratio faster than the cold control
 

--- a/tests/test_cache_benchmark_report.py
+++ b/tests/test_cache_benchmark_report.py
@@ -20,6 +20,7 @@ def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
         {
             "SCENARIO": "all",
             "THRESHOLD_RATIO": "10",
+            "BENCHMARK_COMMAND_TARGET": "x86_64-unknown-linux-gnu",
             "BENCHMARK_SUMMARY_JSON": str(json_path),
             "BENCHMARK_SUMMARY_WWW_DIR": str(www_dir),
             "GITHUB_STEP_SUMMARY": str(summary_path),
@@ -63,6 +64,20 @@ def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
     report = json.loads(json_path.read_text(encoding="utf-8"))
     assert report["workflow"] == "cache-benchmark.yml"
     assert report["threshold_ratio"] == 10.0
+    assert (
+        report["benchmarked_command"]
+        == "soldr cargo build --package soldr-cli --release --locked --target x86_64-unknown-linux-gnu"
+    )
+    assert any(
+        item["command"] == "soldr cargo fmt --all -- --check"
+        for item in report["command_reference"]
+    )
+    assert any(item["command"] == "soldr status --json" for item in report["command_reference"])
+    assert any(
+        item["command"]
+        == "soldr cargo clippy --workspace --all-targets --locked -- -D warnings"
+        for item in report["command_reference"]
+    )
 
     cli_mutation = next(
         mutation for mutation in report["mutations"] if mutation["mutation"] == "soldr-cli"
@@ -79,6 +94,9 @@ def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
     assert www_json["workflow"] == "cache-benchmark.yml"
     www_html = (www_dir / "index.html").read_text(encoding="utf-8")
     assert "<title>soldr rendered benchmarks</title>" in www_html
-    assert "<th>Mutation</th>" in www_html
-    assert "<td>soldr-cli</td>" in www_html
+    assert "<th>Command</th>" in www_html
+    assert "soldr cargo build --package soldr-cli --release --locked --target x86_64-unknown-linux-gnu" in www_html
+    assert "soldr status --json" in www_html
+    assert "soldr cargo fmt --all -- --check" in www_html
+    assert "soldr cargo clippy --workspace --all-targets --locked -- -D warnings" in www_html
     assert (www_dir / ".nojekyll").exists()


### PR DESCRIPTION
## Summary
- make the rendered benchmark table command-first so the left column shows the actual soldr ... command under test
- add a simple common-command table covering setup, build, check, test, fmt, clippy, and related soldr workflows
- keep the benchmark page generated from the benchmark JSON and document the clearer rendering

## Verification
- uv run pytest tests/test_cache_benchmark_report.py -q
- python -m py_compile .github/scripts/cache_benchmark_report.py

## Related
- Follow-up to #122