### PR TITLE
Regenerate benchmark pages on main changes

### DIFF
--- a/.github/workflows/build-linux-arm64-musl.yml
+++ b/.github/workflows/build-linux-arm64-musl.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - README.md
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - README.md
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/build-linux-x64-musl.yml
+++ b/.github/workflows/build-linux-x64-musl.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - README.md
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/build-linux-x64.yml
+++ b/.github/workflows/build-linux-x64.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - README.md
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - README.md
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - README.md
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - README.md
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - README.md
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -1,6 +1,11 @@
 name: Cache Benchmark
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
     inputs:
       scenario:
@@ -18,12 +23,16 @@ on:
         default: "10"
         type: string
 
+env:
+  BENCHMARK_SCENARIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scenario || 'all' }}
+  BENCHMARK_THRESHOLD_RATIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
+
 permissions:
   contents: read
 
 jobs:
   swatinem-soldr-cli:
-    if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-cli' }}
+    if: ${{ env.BENCHMARK_SCENARIO == 'all' || env.BENCHMARK_SCENARIO == 'soldr-cli' }}
     name: Swatinem / Top-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
@@ -32,10 +41,10 @@ jobs:
       source_ref: ${{ github.sha }}
       cache_backend: swatinem
       mutation: soldr-cli
-      threshold_ratio: ${{ inputs.threshold_ratio }}
+      threshold_ratio: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
 
   swatinem-soldr-core:
-    if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-core' }}
+    if: ${{ env.BENCHMARK_SCENARIO == 'all' || env.BENCHMARK_SCENARIO == 'soldr-core' }}
     name: Swatinem / Lower-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
@@ -44,10 +53,10 @@ jobs:
       source_ref: ${{ github.sha }}
       cache_backend: swatinem
       mutation: soldr-core
-      threshold_ratio: ${{ inputs.threshold_ratio }}
+      threshold_ratio: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
 
   zccache-soldr-cli:
-    if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-cli' }}
+    if: ${{ env.BENCHMARK_SCENARIO == 'all' || env.BENCHMARK_SCENARIO == 'soldr-cli' }}
     name: zccache / Top-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
@@ -56,10 +65,10 @@ jobs:
       source_ref: ${{ github.sha }}
       cache_backend: zccache
       mutation: soldr-cli
-      threshold_ratio: ${{ inputs.threshold_ratio }}
+      threshold_ratio: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
 
   zccache-soldr-core:
-    if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-core' }}
+    if: ${{ env.BENCHMARK_SCENARIO == 'all' || env.BENCHMARK_SCENARIO == 'soldr-core' }}
     name: zccache / Lower-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
@@ -68,7 +77,7 @@ jobs:
       source_ref: ${{ github.sha }}
       cache_backend: zccache
       mutation: soldr-core
-      threshold_ratio: ${{ inputs.threshold_ratio }}
+      threshold_ratio: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
 
   summary:
     if: ${{ always() }}
@@ -89,8 +98,8 @@ jobs:
           BENCHMARK_COMMAND_TARGET: x86_64-unknown-linux-gnu
           BENCHMARK_SUMMARY_JSON: benchmark-summary/cache-benchmark-summary.json
           BENCHMARK_SUMMARY_WWW_DIR: benchmark-summary/site
-          SCENARIO: ${{ inputs.scenario }}
-          THRESHOLD_RATIO: ${{ inputs.threshold_ratio }}
+          SCENARIO: ${{ env.BENCHMARK_SCENARIO }}
+          THRESHOLD_RATIO: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
           SWATINEM_CLI_RESULT: ${{ needs.swatinem-soldr-cli.result }}
           SWATINEM_CLI_COLD: ${{ needs.swatinem-soldr-cli.outputs.cold_seconds }}
           SWATINEM_CLI_WARM: ${{ needs.swatinem-soldr-cli.outputs.warm_seconds }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     paths-ignore:
-      - README.md
+      - '*.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- run the cache benchmark workflow automatically on pushes to main so the benchmark page is regenerated on each change
- keep workflow_dispatch support by defaulting the benchmark scenario and threshold outside manual runs
- ignore root-level Markdown-only changes for CI and builder workflows so docs edits at the repo root do not fan out into rebuilds

## Notes
- direct push to main was blocked by branch protection, so this change is opened as a PR instead