### PR TITLE
Add root setup-soldr GitHub Action

### DIFF
--- a/.github/actions/setup-soldr/ensure_rust_toolchain.py
+++ b/.github/actions/setup-soldr/ensure_rust_toolchain.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(command: list[str]) -> None:
+    subprocess.run(command, check=True)
+
+
+def main() -> None:
+    cargo_home = Path(os.environ["CARGO_HOME"])
+    rustup_home = Path(os.environ["RUSTUP_HOME"])
+    soldr_root = Path(os.environ["SOLDR_CACHE_DIR"])
+    bin_dir = Path(cargo_home / "bin")
+
+    for path in (cargo_home, rustup_home, soldr_root, soldr_root / "cache", soldr_root / "bin", bin_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    rustup = shutil.which("rustup")
+    if rustup is None:
+        sys.exit(
+            "setup-soldr requires rustup to already be available on the runner. "
+            "GitHub-hosted runners include rustup; self-hosted runners must provide it."
+        )
+
+    channel = os.environ.get("SETUP_SOLDR_TOOLCHAIN_CHANNEL", "").strip() or "stable"
+    profile = os.environ.get("SETUP_SOLDR_TOOLCHAIN_PROFILE", "").strip() or "minimal"
+    components = json.loads(os.environ.get("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", "[]"))
+    targets = json.loads(os.environ.get("SETUP_SOLDR_TOOLCHAIN_TARGETS", "[]"))
+
+    run([rustup, "set", "profile", profile])
+    run([rustup, "toolchain", "install", channel, "--profile", profile])
+    if components:
+        run([rustup, "component", "add", "--toolchain", channel, *components])
+    if targets:
+        run([rustup, "target", "add", "--toolchain", channel, *targets])
+    run([rustup, "default", channel])
+
+    cargo = shutil.which("cargo")
+    rustc = shutil.which("rustc")
+    if cargo is None or rustc is None:
+        sys.exit(
+            "setup-soldr failed to expose cargo/rustc after rustup configured the toolchain"
+        )
+
+    run([cargo, "--version"])
+    run([rustc, "--version"])
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as fh:
+            fh.write(f"toolchain={channel}\n")

--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -47,14 +47,22 @@ def _release_url(repo: str, version: str) -> str:
     return f"https://api.github.com/repos/{repo}/releases/latest"
 
 
+def _request_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "setup-soldr-action",
+    }
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
 def _fetch_release(repo: str, version: str) -> dict[str, object]:
     request = urllib.request.Request(
         _release_url(repo, version),
-        headers={
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "setup-soldr-action",
-        },
+        headers=_request_headers(),
     )
     with urllib.request.urlopen(request) as response:
         return json.load(response)

--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+
+def _normalize_version(value: str) -> str:
+    return value[1:] if value.startswith("v") else value
+
+
+def _detect_target() -> tuple[str, str, str]:
+    machine = platform.machine().lower()
+    if machine in {"x86_64", "amd64"}:
+        arch = "x86_64"
+    elif machine in {"arm64", "aarch64"}:
+        arch = "aarch64"
+    else:
+        raise RuntimeError(f"unsupported architecture: {machine}")
+
+    system = platform.system()
+    if system == "Linux":
+        return f"{arch}-unknown-linux-gnu", "tar.gz", "soldr"
+    if system == "Darwin":
+        return f"{arch}-apple-darwin", "tar.gz", "soldr"
+    if system == "Windows":
+        return f"{arch}-pc-windows-msvc", "zip", "soldr.exe"
+
+    raise RuntimeError(f"unsupported operating system: {system}")
+
+
+def _release_url(repo: str, version: str) -> str:
+    if version:
+        tag = version if version.startswith("v") else f"v{version}"
+        return f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
+    return f"https://api.github.com/repos/{repo}/releases/latest"
+
+
+def _fetch_release(repo: str, version: str) -> dict[str, object]:
+    request = urllib.request.Request(
+        _release_url(repo, version),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "setup-soldr-action",
+        },
+    )
+    with urllib.request.urlopen(request) as response:
+        return json.load(response)
+
+
+def _installed_version(binary_path: Path) -> str | None:
+    if not binary_path.exists():
+        return None
+
+    output = subprocess.check_output([str(binary_path), "version", "--json"], text=True)
+    payload = json.loads(output)
+    return str(payload["soldr_version"])
+
+
+def _select_asset(release: dict[str, object], target: str, archive_ext: str) -> tuple[str, str]:
+    assets = release.get("assets") or []
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        name = str(asset.get("name", ""))
+        if target in name and name.endswith(archive_ext):
+            return name, str(asset["browser_download_url"])
+    raise RuntimeError(f"no release asset found for target {target}")
+
+
+def _extract_binary(archive_path: Path, archive_ext: str, binary_name: str, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if archive_ext == "zip":
+        with zipfile.ZipFile(archive_path) as archive:
+            archive.extractall(out_dir)
+    else:
+        with tarfile.open(archive_path, "r:gz") as archive:
+            archive.extractall(out_dir)
+
+    for candidate in out_dir.rglob(binary_name):
+        if candidate.is_file():
+            return candidate
+    raise RuntimeError(f"downloaded archive did not contain {binary_name}")
+
+
+def main() -> None:
+    install_dir = Path(os.environ["SOLDR_INSTALL_DIR"])
+    install_dir.mkdir(parents=True, exist_ok=True)
+    binary_name = "soldr.exe" if os.name == "nt" else "soldr"
+    binary_path = install_dir / binary_name
+    requested_version = os.environ.get("SETUP_SOLDR_VERSION", "").strip()
+
+    current = _installed_version(binary_path)
+    if current is not None:
+        if not requested_version or _normalize_version(current) == _normalize_version(requested_version):
+            output = os.environ.get("GITHUB_OUTPUT")
+            if output:
+                with open(output, "a", encoding="utf-8") as fh:
+                    fh.write(f"installed_version={current}\n")
+            return
+
+    repo = os.environ.get("SOLDR_REPO", "zackees/soldr").strip() or "zackees/soldr"
+    target, archive_ext, binary_name = _detect_target()
+    release = _fetch_release(repo, requested_version)
+    asset_name, download_url = _select_asset(release, target, archive_ext)
+    tag_name = str(release["tag_name"])
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        archive_path = tmp_dir / asset_name
+        extract_dir = tmp_dir / "extract"
+        urllib.request.urlretrieve(download_url, archive_path)
+        source = _extract_binary(archive_path, archive_ext, binary_name, extract_dir)
+        shutil.copy2(source, binary_path)
+        if os.name != "nt":
+            binary_path.chmod(binary_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as fh:
+            fh.write(f"installed_version={tag_name}\n")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (RuntimeError, urllib.error.URLError, subprocess.CalledProcessError) as exc:
+        sys.exit(str(exc))

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -108,6 +108,18 @@ def main() -> None:
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
 
+    for path in (
+        cache_root,
+        soldr_root,
+        soldr_root / "cache",
+        soldr_root / "bin",
+        cargo_home,
+        cargo_home / "bin",
+        rustup_home,
+        bin_dir,
+    ):
+        path.mkdir(parents=True, exist_ok=True)
+
     toolchain = load_toolchain_spec(
         workspace=workspace,
         toolchain_file=os.environ.get("INPUT_TOOLCHAIN_FILE", "rust-toolchain.toml"),
@@ -166,6 +178,7 @@ def main() -> None:
             "toolchain_channel": toolchain["channel"],
             "toolchain_profile": toolchain["profile"],
             "toolchain_source": toolchain["source"],
+            "toolchain": toolchain["channel"],
         }
     )
 

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    tomllib = None
+
+
+def _normalize_list(value: Any) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def load_toolchain_spec(
+    workspace: Path,
+    toolchain_file: str,
+    toolchain_override: str,
+) -> dict[str, Any]:
+    channel = "stable"
+    profile = "minimal"
+    components: list[str] = []
+    targets: list[str] = []
+    source = "default"
+    file_hash = "none"
+
+    if toolchain_file:
+        path = workspace / toolchain_file
+        if path.exists():
+            source = str(path.relative_to(workspace))
+            file_bytes = path.read_bytes()
+            file_hash = hashlib.sha256(file_bytes).hexdigest()[:16]
+            if tomllib is None:
+                raise RuntimeError("python tomllib support is required for setup-soldr")
+            data = tomllib.loads(file_bytes.decode("utf-8"))
+            toolchain = data.get("toolchain", {})
+            if isinstance(toolchain, dict):
+                channel = str(toolchain.get("channel", channel))
+                profile = str(toolchain.get("profile", profile))
+                components = _normalize_list(toolchain.get("components"))
+                targets = _normalize_list(toolchain.get("targets"))
+
+    if toolchain_override:
+        channel = toolchain_override.strip()
+        source = "input"
+
+    return {
+        "channel": channel,
+        "profile": profile,
+        "components": components,
+        "targets": targets,
+        "source": source,
+        "file_hash": file_hash,
+    }
+
+
+def _sanitize_fragment(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-") or "default"
+
+
+def _write_env(name: str, value: str) -> None:
+    output = os.environ.get("GITHUB_ENV")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def _write_path(value: str) -> None:
+    output = os.environ.get("GITHUB_PATH")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as fh:
+        fh.write(f"{value}\n")
+
+
+def _write_outputs(values: dict[str, str]) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as fh:
+        for key, value in values.items():
+            fh.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    workspace = Path(os.environ["ACTION_WORKSPACE"]).resolve()
+    runner_temp = Path(os.environ.get("RUNNER_TEMP", workspace / ".tmp")).resolve()
+
+    requested_cache_dir = os.environ.get("INPUT_CACHE_DIR", "").strip()
+    cache_root = Path(requested_cache_dir).expanduser().resolve() if requested_cache_dir else (
+        runner_temp / "setup-soldr"
+    )
+    soldr_root = cache_root / "soldr"
+    cargo_home = cache_root / "cargo"
+    rustup_home = cache_root / "rustup"
+    bin_dir = cache_root / "bin"
+    soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
+    soldr_path = bin_dir / soldr_binary
+
+    toolchain = load_toolchain_spec(
+        workspace=workspace,
+        toolchain_file=os.environ.get("INPUT_TOOLCHAIN_FILE", "rust-toolchain.toml"),
+        toolchain_override=os.environ.get("INPUT_TOOLCHAIN", ""),
+    )
+
+    soldr_repo = os.environ.get("INPUT_REPO", "zackees/soldr").strip() or "zackees/soldr"
+    soldr_version = os.environ.get("INPUT_VERSION", "").strip()
+    toolchain_signature = {
+        "channel": toolchain["channel"],
+        "profile": toolchain["profile"],
+        "components": toolchain["components"],
+        "targets": toolchain["targets"],
+        "source": toolchain["source"],
+        "file_hash": toolchain["file_hash"],
+        "soldr_repo": soldr_repo,
+        "soldr_version": soldr_version or "latest",
+    }
+    digest = hashlib.sha256(
+        json.dumps(toolchain_signature, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:16]
+    runner_os = _sanitize_fragment(os.environ.get("ACTION_OS", os.name).lower())
+    runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
+    cache_prefix = f"setup-soldr-v1-{runner_os}-{runner_arch}"
+    cache_key = f"{cache_prefix}-{digest}"
+
+    suffix = os.environ.get("INPUT_CACHE_KEY_SUFFIX", "").strip()
+    if suffix:
+        cache_key = f"{cache_key}-{_sanitize_fragment(suffix)}"
+
+    _write_env("SOLDR_CACHE_DIR", str(soldr_root))
+    _write_env("CARGO_HOME", str(cargo_home))
+    _write_env("RUSTUP_HOME", str(rustup_home))
+    _write_env("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain["channel"])
+    _write_env("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain["profile"])
+    _write_env("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", json.dumps(toolchain["components"]))
+    _write_env("SETUP_SOLDR_TOOLCHAIN_TARGETS", json.dumps(toolchain["targets"]))
+    if os.environ.get("INPUT_TRUST_MODE", "").strip():
+        _write_env("SOLDR_TRUST_MODE", os.environ["INPUT_TRUST_MODE"].strip())
+
+    _write_path(str(bin_dir))
+    _write_path(str(cargo_home / "bin"))
+
+    _write_outputs(
+        {
+            "cache_root": str(cache_root),
+            "cache_key": cache_key,
+            "cache_restore_prefix": f"{cache_prefix}-",
+            "soldr_root": str(soldr_root),
+            "cargo_home": str(cargo_home),
+            "rustup_home": str(rustup_home),
+            "bin_dir": str(bin_dir),
+            "soldr_path": str(soldr_path),
+            "soldr_repo": soldr_repo,
+            "soldr_version_requested": soldr_version,
+            "toolchain_channel": toolchain["channel"],
+            "toolchain_profile": toolchain["profile"],
+            "toolchain_source": toolchain["source"],
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/setup-soldr/verify_soldr.py
+++ b/.github/actions/setup-soldr/verify_soldr.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    binary = os.environ["SETUP_SOLDR_PATH"]
+    output_path = os.environ["GITHUB_OUTPUT"]
+
+    version_json = subprocess.check_output([binary, "version", "--json"], text=True)
+    payload = json.loads(version_json)
+
+    with open(output_path, "a", encoding="utf-8") as fh:
+        fh.write(f"soldr_version={payload['soldr_version']}\n")
+
+    subprocess.run(["cargo", "--version"], check=True)
+    subprocess.run(["rustc", "--version"], check=True)
+    subprocess.run(["soldr", "status", "--json"], check=True, stdout=subprocess.DEVNULL)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as exc:
+        sys.exit(exc.returncode)

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -23,16 +23,12 @@ on:
         default: "10"
         type: string
 
-env:
-  BENCHMARK_SCENARIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scenario || 'all' }}
-  BENCHMARK_THRESHOLD_RATIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
-
 permissions:
   contents: read
 
 jobs:
   swatinem-soldr-cli:
-    if: ${{ env.BENCHMARK_SCENARIO == 'all' || env.BENCHMARK_SCENARIO == 'soldr-cli' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'soldr-cli' }}
     name: Swatinem / Top-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
@@ -41,10 +37,10 @@ jobs:
       source_ref: ${{ github.sha }}
       cache_backend: swatinem
       mutation: soldr-cli
-      threshold_ratio: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
+      threshold_ratio: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
 
   swatinem-soldr-core:
-    if: ${{ env.BENCHMARK_SCENARIO == 'all' || env.BENCHMARK_SCENARIO == 'soldr-core' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'soldr-core' }}
     name: Swatinem / Lower-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
@@ -53,10 +49,10 @@ jobs:
       source_ref: ${{ github.sha }}
       cache_backend: swatinem
       mutation: soldr-core
-      threshold_ratio: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
+      threshold_ratio: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
 
   zccache-soldr-cli:
-    if: ${{ env.BENCHMARK_SCENARIO == 'all' || env.BENCHMARK_SCENARIO == 'soldr-cli' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'soldr-cli' }}
     name: zccache / Top-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
@@ -65,10 +61,10 @@ jobs:
       source_ref: ${{ github.sha }}
       cache_backend: zccache
       mutation: soldr-cli
-      threshold_ratio: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
+      threshold_ratio: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
 
   zccache-soldr-core:
-    if: ${{ env.BENCHMARK_SCENARIO == 'all' || env.BENCHMARK_SCENARIO == 'soldr-core' }}
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'soldr-core' }}
     name: zccache / Lower-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
@@ -77,7 +73,7 @@ jobs:
       source_ref: ${{ github.sha }}
       cache_backend: zccache
       mutation: soldr-core
-      threshold_ratio: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
+      threshold_ratio: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
 
   summary:
     if: ${{ always() }}
@@ -98,8 +94,8 @@ jobs:
           BENCHMARK_COMMAND_TARGET: x86_64-unknown-linux-gnu
           BENCHMARK_SUMMARY_JSON: benchmark-summary/cache-benchmark-summary.json
           BENCHMARK_SUMMARY_WWW_DIR: benchmark-summary/site
-          SCENARIO: ${{ env.BENCHMARK_SCENARIO }}
-          THRESHOLD_RATIO: ${{ env.BENCHMARK_THRESHOLD_RATIO }}
+          SCENARIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scenario || 'all' }}
+          THRESHOLD_RATIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
           SWATINEM_CLI_RESULT: ${{ needs.swatinem-soldr-cli.result }}
           SWATINEM_CLI_COLD: ${{ needs.swatinem-soldr-cli.outputs.cold_seconds }}
           SWATINEM_CLI_WARM: ${{ needs.swatinem-soldr-cli.outputs.warm_seconds }}

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -1,0 +1,66 @@
+name: Setup Soldr Action
+
+on:
+  pull_request:
+    paths:
+      - action.yml
+      - install.sh
+      - rust-toolchain.toml
+      - Cargo.toml
+      - Cargo.lock
+      - .github/actions/setup-soldr/**
+      - .github/workflows/setup-soldr-action.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            runner: ubuntu-24.04
+          - name: macOS
+            runner: macos-15
+          - name: Windows
+            runner: windows-2025
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - id: setup
+        uses: ./
+        with:
+          cache: true
+
+      - name: Show action outputs
+        shell: pwsh
+        run: |
+          Write-Host "soldr-path=${{ steps.setup.outputs.soldr-path }}"
+          Write-Host "soldr-version=${{ steps.setup.outputs.soldr-version }}"
+          Write-Host "cache-dir=${{ steps.setup.outputs.cache-dir }}"
+          Write-Host "cache-hit=${{ steps.setup.outputs.cache-hit }}"
+          Write-Host "toolchain=${{ steps.setup.outputs.toolchain }}"
+
+      - name: Verify setup state
+        shell: pwsh
+        run: |
+          if (-not (Test-Path $env:SOLDR_CACHE_DIR)) { throw "missing SOLDR_CACHE_DIR" }
+          if (-not (Test-Path $env:CARGO_HOME)) { throw "missing CARGO_HOME" }
+          if (-not (Test-Path $env:RUSTUP_HOME)) { throw "missing RUSTUP_HOME" }
+          soldr version --json
+          cargo --version
+          rustc --version
+
+      - name: Build through soldr
+        shell: pwsh
+        run: soldr cargo build --package soldr-cli --release --locked
+
+      - name: Test through soldr
+        shell: pwsh
+        run: soldr cargo test -p soldr-cli --test cli --locked

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -19,10 +19,67 @@ The same pattern applies to `cargo test`, `cargo check`, and similar Cargo invoc
 
 ## GitHub Actions
 
-No public one-line `uses: owner/repo@ref` Soldr action is verified in this repository today. The supported path is:
+This repository now ships a root GitHub Action for Soldr setup. The preferred GitHub Actions path is:
 
-1. install `soldr`
-2. replace `cargo ...` with `soldr cargo ...`
+1. use `zackees/soldr@<ref>` or `uses: ./` in the same repository
+2. let the action provision the Rust toolchain and restore the Soldr/Cargo/rustup cache root
+3. run `soldr cargo ...`
+
+When stable action tags exist, prefer a major tag such as `@v1`. Until then, pin a full commit SHA or an explicit release tag.
+
+### Preferred setup action path
+
+The root action:
+
+- installs one `soldr` binary
+- provisions the Rust toolchain without requiring a separate toolchain action
+- sets `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME`
+- restores and saves that runner-local root through GitHub cache when `cache: true`
+
+Example:
+
+```yaml
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: zackees/soldr@<ref>
+        with:
+          version: 0.7.4
+          cache: true
+
+      - run: soldr cargo build --locked --release
+      - run: soldr cargo test --locked
+```
+
+For same-repository testing, use:
+
+```yaml
+- uses: ./
+  with:
+    version: 0.7.4
+    cache: true
+```
+
+### What gets rehydrated today
+
+The action-managed cache root includes:
+
+- `SOLDR_CACHE_DIR`
+- `CARGO_HOME`
+- `RUSTUP_HOME`
+
+That means the Soldr binary, the Rust toolchain, cargo registry state, and Soldr-managed state are reusable on later runs.
+
+Current limitation: soldr still documents managed `zccache` artifact storage as following zccache's current supported/default behavior rather than a fully action-controlled custom artifact path, so the action should not claim more than that.
 
 ### Shortest CI path: install a released soldr
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,123 @@
+name: setup-soldr
+description: Install soldr, provision the Rust toolchain, and restore a cacheable runner-local Soldr root.
+inputs:
+  version:
+    description: Soldr version or tag to install. Defaults to the latest release.
+    required: false
+    default: ""
+  repo:
+    description: GitHub repository that publishes Soldr releases.
+    required: false
+    default: zackees/soldr
+  cache:
+    description: Restore and save the setup cache across workflow runs.
+    required: false
+    default: "true"
+  cache-dir:
+    description: Override the runner-local cache root used for Soldr, Cargo, and rustup state.
+    required: false
+    default: ""
+  cache-key-suffix:
+    description: Optional extra suffix added to the cache key.
+    required: false
+    default: ""
+  toolchain:
+    description: Override the Rust toolchain channel. When empty, rust-toolchain.toml is used if present.
+    required: false
+    default: ""
+  toolchain-file:
+    description: Toolchain file to read when toolchain is not explicitly set.
+    required: false
+    default: rust-toolchain.toml
+  trust-mode:
+    description: Optional value for SOLDR_TRUST_MODE.
+    required: false
+    default: ""
+outputs:
+  soldr-path:
+    description: Installed Soldr binary path.
+    value: ${{ steps.resolve.outputs.soldr_path }}
+  soldr-version:
+    description: Installed Soldr version.
+    value: ${{ steps.verify.outputs.soldr_version }}
+  cache-dir:
+    description: Runner-local cache root used by the action.
+    value: ${{ steps.resolve.outputs.cache_root }}
+  cache-hit:
+    description: Whether the action restored an exact setup cache hit.
+    value: ${{ steps.cache-meta.outputs.cache_hit }}
+  toolchain:
+    description: Rust toolchain channel configured by the action.
+    value: ${{ steps.toolchain.outputs.toolchain }}
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: pwsh
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_CACHE_DIR: ${{ inputs.cache-dir }}
+        INPUT_CACHE_KEY_SUFFIX: ${{ inputs.cache-key-suffix }}
+        INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
+        INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
+        INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
+        ACTION_WORKSPACE: ${{ github.workspace }}
+        ACTION_OS: ${{ runner.os }}
+        ACTION_ARCH: ${{ runner.arch }}
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/resolve_setup.py"
+
+    - id: cache
+      if: ${{ inputs.cache == 'true' }}
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.cache_root }}
+        key: ${{ steps.resolve.outputs.cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.cache_restore_prefix }}
+
+    - id: toolchain
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_rust_toolchain.py"
+
+    - id: install
+      shell: pwsh
+      env:
+        SOLDR_REPO: ${{ steps.resolve.outputs.soldr_repo }}
+        SOLDR_INSTALL_DIR: ${{ steps.resolve.outputs.bin_dir }}
+        SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_requested }}
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_soldr.py"
+
+    - id: verify
+      shell: pwsh
+      env:
+        SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
+      run: |
+        @'
+import json
+import subprocess
+import sys
+
+binary = sys.argv[1]
+output_path = sys.argv[2]
+version_json = subprocess.check_output([binary, "version", "--json"], text=True)
+payload = json.loads(version_json)
+
+with open(output_path, "a", encoding="utf-8") as fh:
+    fh.write(f"soldr_version={payload['soldr_version']}\n")
+'@ | python - "$env:SETUP_SOLDR_PATH" "$env:GITHUB_OUTPUT"
+
+        cargo --version
+        rustc --version
+        soldr status --json | Out-Null
+
+    - id: cache-meta
+      shell: pwsh
+      env:
+        RAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+      run: |
+        $value = $env:RAW_CACHE_HIT
+        if ([string]::IsNullOrWhiteSpace($value)) {
+          $value = "false"
+        }
+        "cache_hit=$value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/action.yml
+++ b/action.yml
@@ -92,24 +92,7 @@ runs:
       shell: pwsh
       env:
         SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
-      run: |
-        @'
-import json
-import subprocess
-import sys
-
-binary = sys.argv[1]
-output_path = sys.argv[2]
-version_json = subprocess.check_output([binary, "version", "--json"], text=True)
-payload = json.loads(version_json)
-
-with open(output_path, "a", encoding="utf-8") as fh:
-    fh.write(f"soldr_version={payload['soldr_version']}\n")
-'@ | python - "$env:SETUP_SOLDR_PATH" "$env:GITHUB_OUTPUT"
-
-        cargo --version
-        rustc --version
-        soldr status --json | Out-Null
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
 
     - id: cache-meta
       shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ outputs:
     value: ${{ steps.cache-meta.outputs.cache_hit }}
   toolchain:
     description: Rust toolchain channel configured by the action.
-    value: ${{ steps.toolchain.outputs.toolchain }}
+    value: ${{ steps.resolve.outputs.toolchain }}
 runs:
   using: composite
   steps:

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,7 @@ runs:
     - id: install
       shell: pwsh
       env:
+        GITHUB_TOKEN: ${{ github.token }}
         SOLDR_REPO: ${{ steps.resolve.outputs.soldr_repo }}
         SOLDR_INSTALL_DIR: ${{ steps.resolve.outputs.bin_dir }}
         SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_requested }}

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -81,3 +81,46 @@ def test_toolchain_signature_payload_is_json_serializable() -> None:
     }
 
     assert json.loads(json.dumps(payload))["channel"] == "1.94.1"
+
+
+def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    workspace = tmp_path / "workspace"
+    runner_temp = tmp_path / "runner-temp"
+    workspace.mkdir()
+    runner_temp.mkdir()
+
+    github_env = tmp_path / "github.env"
+    github_output = tmp_path / "github.output"
+    github_path = tmp_path / "github.path"
+
+    monkeypatch.setenv("ACTION_WORKSPACE", str(workspace))
+    monkeypatch.setenv("RUNNER_TEMP", str(runner_temp))
+    monkeypatch.setenv("ACTION_OS", "Linux")
+    monkeypatch.setenv("ACTION_ARCH", "X64")
+    monkeypatch.setenv("INPUT_REPO", "zackees/soldr")
+    monkeypatch.setenv("INPUT_VERSION", "")
+    monkeypatch.setenv("INPUT_CACHE_DIR", "")
+    monkeypatch.setenv("INPUT_CACHE_KEY_SUFFIX", "")
+    monkeypatch.setenv("INPUT_TOOLCHAIN", "")
+    monkeypatch.setenv("INPUT_TOOLCHAIN_FILE", "missing.toml")
+    monkeypatch.setenv("INPUT_TRUST_MODE", "")
+    monkeypatch.setenv("GITHUB_ENV", str(github_env))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setenv("GITHUB_PATH", str(github_path))
+
+    module.main()
+
+    cache_root = runner_temp / "setup-soldr"
+    assert cache_root.is_dir()
+    assert (cache_root / "soldr").is_dir()
+    assert (cache_root / "soldr" / "cache").is_dir()
+    assert (cache_root / "soldr" / "bin").is_dir()
+    assert (cache_root / "cargo").is_dir()
+    assert (cache_root / "cargo" / "bin").is_dir()
+    assert (cache_root / "rustup").is_dir()
+    assert (cache_root / "bin").is_dir()
+
+    outputs = github_output.read_text(encoding="utf-8")
+    assert f"cache_root={cache_root}" in outputs
+    assert "toolchain=stable" in outputs

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "resolve_setup.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("resolve_setup", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_toolchain_spec_reads_rust_toolchain_toml() -> None:
+    module = _load_module()
+
+    spec = module.load_toolchain_spec(REPO_ROOT, "rust-toolchain.toml", "")
+
+    assert spec["channel"] == "1.94.1"
+    assert spec["profile"] == "minimal"
+    assert "rustfmt" in spec["components"]
+    assert "clippy" in spec["components"]
+    assert spec["source"] == "rust-toolchain.toml"
+    assert spec["file_hash"] != "none"
+
+
+def test_load_toolchain_spec_defaults_when_file_missing(tmp_path: Path) -> None:
+    module = _load_module()
+
+    spec = module.load_toolchain_spec(tmp_path, "missing.toml", "")
+
+    assert spec == {
+        "channel": "stable",
+        "profile": "minimal",
+        "components": [],
+        "targets": [],
+        "source": "default",
+        "file_hash": "none",
+    }
+
+
+def test_load_toolchain_spec_prefers_explicit_override() -> None:
+    module = _load_module()
+
+    spec = module.load_toolchain_spec(REPO_ROOT, "rust-toolchain.toml", "stable")
+
+    assert spec["channel"] == "stable"
+    assert spec["profile"] == "minimal"
+    assert spec["source"] == "input"
+
+
+def test_normalize_list_accepts_csv_strings() -> None:
+    module = _load_module()
+
+    value = module._normalize_list("rustfmt, clippy, ")
+
+    assert value == ["rustfmt", "clippy"]
+
+
+def test_toolchain_signature_payload_is_json_serializable() -> None:
+    module = _load_module()
+
+    spec = module.load_toolchain_spec(REPO_ROOT, "rust-toolchain.toml", "")
+
+    payload = {
+        "channel": spec["channel"],
+        "profile": spec["profile"],
+        "components": spec["components"],
+        "targets": spec["targets"],
+        "source": spec["source"],
+        "file_hash": spec["file_hash"],
+        "soldr_repo": "zackees/soldr",
+        "soldr_version": "0.7.4",
+    }
+
+    assert json.loads(json.dumps(payload))["channel"] == "1.94.1"

--- a/tests/test_setup_soldr_ensure_soldr.py
+++ b/tests/test_setup_soldr_ensure_soldr.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "ensure_soldr.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("ensure_soldr", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_request_headers_include_github_token_when_present(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+
+    headers = module._request_headers()
+
+    assert headers["Authorization"] == "Bearer test-token"
+    assert headers["User-Agent"] == "setup-soldr-action"
+
+
+def test_request_headers_omit_authorization_when_token_missing(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    headers = module._request_headers()
+
+    assert "Authorization" not in headers


### PR DESCRIPTION
## Summary
- add a root setup-soldr GitHub Action in this repo so workflows can use zackees/soldr@<ref> or uses: ./
- make the action own toolchain provisioning and cache wiring by restoring a runner-local root that contains SOLDR_CACHE_DIR, CARGO_HOME, and RUSTUP_HOME
- add helper scripts for deterministic cache-key resolution, Rust toolchain setup, and single-binary Soldr installation from releases
- add a repo-local workflow that exercises the action on Linux, macOS, and Windows
- update INTEGRATION.md to document the new action path and current cache rehydration boundary

## Verification
- pytest tests/test_setup_soldr_action.py
- local smoke run of .github/actions/setup-soldr/ensure_soldr.py against the real 