### PR TITLE
Document the setup-soldr GitHub Action

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -3,6 +3,8 @@ name: Setup Soldr Action
 on:
   pull_request:
     paths:
+      - README.md
+      - INTEGRATION.md
       - action.yml
       - install.sh
       - rust-toolchain.toml

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -36,6 +36,11 @@ The root action:
 - sets `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME`
 - restores and saves that runner-local root through GitHub cache when `cache: true`
 
+Important toolchain rule:
+
+- if your repository already pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact channel with `toolchain:`
+- do not preinstall a different generic toolchain such as `stable` and assume a later `soldr cargo ...` step will reconcile it
+
 Example:
 
 ```yaml
@@ -68,6 +73,22 @@ For same-repository testing, use:
     version: 0.7.4
     cache: true
 ```
+
+Useful inputs when wiring the action into another repository:
+
+- `toolchain`: explicit Rust channel override when you do not want to rely on `rust-toolchain.toml`
+- `toolchain-file`: alternate toolchain file path when the repo does not use the default root `rust-toolchain.toml`
+- `cache`: turn the runner-local cache root on or off
+- `cache-dir`: move the shared Soldr/Cargo/rustup root to a specific path
+- `trust-mode`: set `SOLDR_TRUST_MODE` for stricter fetched-binary policy
+
+Useful outputs:
+
+- `soldr-path`
+- `soldr-version`
+- `cache-dir`
+- `cache-hit`
+- `toolchain`
 
 ### What gets rehydrated today
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ Current release line:
 - the supported external integration boundary remains the `soldr` executable, not the internal Rust crates; see [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md)
 - practical integration examples for local builds and GitHub Actions live in [INTEGRATION.md](./INTEGRATION.md)
 
+## GitHub Actions setup
+
+The preferred CI path is the repository root action:
+
+```yaml
+- uses: zackees/soldr@<ref>
+  with:
+    version: 0.7.4
+    cache: true
+
+- run: soldr cargo build --locked --release
+- run: soldr cargo test --locked
+```
+
+That action:
+
+- installs `soldr`
+- provisions the Rust toolchain, using `rust-toolchain.toml` by default
+- restores a cacheable runner-local root for Soldr, Cargo, and rustup state
+- puts `soldr` on `PATH` for later steps
+
+If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later.
+
+For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
+
 ## Why soldr exists
 
 On Windows, the real problem is not "how do I cache builds?" or "how do I download a tool binary?" in isolation.


### PR DESCRIPTION
## Summary
- add explicit setup-soldr GitHub Action usage to README.md
- expand INTEGRATION.md with the key toolchain rule plus action inputs/outputs
- rerun the in-repo setup-soldr smoke workflow when README.md or INTEGRATION.md changes

## Testing
- git diff --check -- README.md INTEGRATION.md .github/workflows/setup-soldr-action.yml
