### PR TITLE
Auto-detect repo-local Rust toolchain homes

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -5,6 +5,7 @@ use soldr_fetch::VersionSpec;
 
 const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
 const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
+const TEST_RUSTUP_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTUP_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 const JSON_SCHEMA_VERSION: u32 = 1;
 const RUSTC_WRAPPER_OVERRIDE_ENV_VAR: &str = "SOLDR_RUSTC_WRAPPER";
@@ -397,9 +398,10 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
         resolve_toolchain_binary(tool_stem)?
     };
 
-    let status = std::process::Command::new(tool_path)
-        .args(&raw_args[2..])
-        .status()?;
+    let mut command = std::process::Command::new(tool_path);
+    command.args(&raw_args[2..]);
+    apply_implicit_toolchain_homes(&mut command);
+    let status = command.status()?;
 
     Ok(status.code().unwrap_or(1))
 }
@@ -407,7 +409,10 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
 /// Run a rustup-managed toolchain binary with pass-through args.
 fn run_toolchain_passthrough(tool: &str, args: &[String]) -> Result<i32, SoldrError> {
     let binary = resolve_toolchain_binary(tool)?;
-    let status = std::process::Command::new(binary).args(args).status()?;
+    let mut command = std::process::Command::new(binary);
+    command.args(args);
+    apply_implicit_toolchain_homes(&mut command);
+    let status = command.status()?;
     Ok(status.code().unwrap_or(1))
 }
 
@@ -446,6 +451,7 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
 
     let mut command = std::process::Command::new(cargo);
     command.args(args);
+    apply_implicit_toolchain_homes(&mut command);
     command.env("RUSTC", rustc);
     command.env(
         soldr_cache::CACHE_ENABLED_ENV_VAR,
@@ -578,9 +584,10 @@ fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError
         return Ok(path);
     }
 
-    let output = std::process::Command::new("rustup")
-        .args(["which", tool])
-        .output()?;
+    let mut command = std::process::Command::new(rustup_binary());
+    command.args(["which", tool]);
+    apply_implicit_toolchain_homes(&mut command);
+    let output = command.output()?;
 
     if !output.status.success() {
         return Err(SoldrError::Other(format!(
@@ -597,6 +604,11 @@ fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError
     }
 
     Ok(path.into())
+}
+
+fn apply_implicit_toolchain_homes(command: &mut std::process::Command) {
+    let start_dir = std::env::current_dir().ok();
+    soldr_core::apply_implicit_toolchain_homes(command, start_dir.as_deref());
 }
 
 fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
@@ -936,6 +948,10 @@ fn toolchain_binary_override(tool: &str) -> Option<std::path::PathBuf> {
         _ => return None,
     };
     non_empty_env_path(env_var)
+}
+
+fn rustup_binary() -> std::path::PathBuf {
+    non_empty_env_path(TEST_RUSTUP_BIN_ENV_VAR).unwrap_or_else(|| "rustup".into())
 }
 
 fn zccache_binary_override() -> Option<std::path::PathBuf> {

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -324,6 +324,7 @@ fn install_fake_rustup_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf,
     (rustup, cargo, rustc, rustfmt)
 }
 
+#[cfg(windows)]
 fn prepend_to_path(dir: &Path) -> std::ffi::OsString {
     let existing = std::env::var_os("PATH").unwrap_or_default();
     let mut paths = vec![dir.to_path_buf()];

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -103,6 +103,88 @@ fn fake_rustc_script(log_path: &Path) -> String {
     }
 }
 
+fn fake_version_tool_script(log_path: &Path, tool_name: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo {0} cargo_home=%CARGO_HOME% rustup_home=%RUSTUP_HOME% args=%*>>\"{1}\"\n\
+             echo {0} 1.0.0 (fake)\n",
+            tool_name,
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"{0} cargo_home=${{CARGO_HOME:-}} rustup_home=${{RUSTUP_HOME:-}} args=$*\" >> \"{1}\"\n\
+             echo \"{0} 1.0.0 (fake)\"\n",
+            tool_name,
+            log_path.display()
+        )
+    }
+}
+
+fn fake_rustup_script(log_path: &Path, tool_dir: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo rustup %* cargo_home=%CARGO_HOME% rustup_home=%RUSTUP_HOME%>>\"{0}\"\n\
+             if \"%~1\"==\"which\" (\n\
+               if \"%~2\"==\"cargo\" (\n\
+                 echo {1}\n\
+                 exit /b 0\n\
+               )\n\
+               if \"%~2\"==\"rustc\" (\n\
+                 echo {2}\n\
+                 exit /b 0\n\
+               )\n\
+               if \"%~2\"==\"rustfmt\" (\n\
+                 echo {3}\n\
+                 exit /b 0\n\
+               )\n\
+             )\n\
+             echo unsupported rustup invocation %* 1>&2\n\
+             exit /b 1\n",
+            log_path.display(),
+            tool_dir.join("cargo.cmd").display(),
+            tool_dir.join("rustc.cmd").display(),
+            tool_dir.join("rustfmt.cmd").display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"rustup $* cargo_home=${{CARGO_HOME:-}} rustup_home=${{RUSTUP_HOME:-}}\" >> \"{0}\"\n\
+             if [ \"$1\" = \"which\" ]; then\n\
+               case \"$2\" in\n\
+                 cargo)\n\
+                   echo \"{1}\"\n\
+                   exit 0\n\
+                   ;;\n\
+                 rustc)\n\
+                   echo \"{2}\"\n\
+                   exit 0\n\
+                   ;;\n\
+                 rustfmt)\n\
+                   echo \"{3}\"\n\
+                   exit 0\n\
+                   ;;\n\
+               esac\n\
+             fi\n\
+             echo \"unsupported rustup invocation: $*\" >&2\n\
+             exit 1\n",
+            log_path.display(),
+            tool_dir.join("cargo").display(),
+            tool_dir.join("rustc").display(),
+            tool_dir.join("rustfmt").display()
+        )
+    }
+}
+
 fn fake_zccache_script(log_path: &Path) -> String {
     #[cfg(windows)]
     {
@@ -224,6 +306,29 @@ fn install_fake_wrapper(log_path: &Path, wrapper_name: &str) -> PathBuf {
         &fake_custom_wrapper_script(log_path, wrapper_name),
     );
     wrapper
+}
+
+fn install_fake_rustup_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let dir = unique_temp_dir("fake-rustup-toolchain");
+    let cargo = fake_script_path(&dir, "cargo");
+    let rustc = fake_script_path(&dir, "rustc");
+    let rustfmt = fake_script_path(&dir, "rustfmt");
+    #[cfg(windows)]
+    let rustup = dir.join("rustup.bat");
+    #[cfg(not(windows))]
+    let rustup = fake_script_path(&dir, "rustup");
+    write_fake_script(&cargo, &fake_version_tool_script(log_path, "cargo"));
+    write_fake_script(&rustc, &fake_version_tool_script(log_path, "rustc"));
+    write_fake_script(&rustfmt, &fake_version_tool_script(log_path, "rustfmt"));
+    write_fake_script(&rustup, &fake_rustup_script(log_path, &dir));
+    (rustup, cargo, rustc, rustfmt)
+}
+
+fn prepend_to_path(dir: &Path) -> std::ffi::OsString {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&existing));
+    std::env::join_paths(paths).expect("failed to join PATH")
 }
 
 #[test]
@@ -571,6 +676,138 @@ fn rustc_wrapper_mode_passes_through_to_rustc() {
 }
 
 #[test]
+fn repo_local_toolchain_homes_are_used_when_env_vars_are_unset() {
+    let cache_root = unique_temp_dir("repo-local-toolchain-homes");
+    let log_path = cache_root.join("tool.log");
+    let (rustup, _, _, _) = install_fake_rustup_toolchain(&log_path);
+    let repo_root = unique_temp_dir("repo-local-toolchain-root");
+    let repo_cargo_home = repo_root.join(".cargo");
+    let repo_rustup_home = repo_root.join(".rustup");
+    let nested = repo_root.join("workspace").join("crate");
+    fs::create_dir_all(&repo_cargo_home).expect("failed to create repo-local .cargo");
+    fs::create_dir_all(&repo_rustup_home).expect("failed to create repo-local .rustup");
+    fs::create_dir_all(&nested).expect("failed to create nested working dir");
+
+    for args in [
+        vec!["--no-cache", "cargo", "--version"],
+        vec!["rustfmt", "--version"],
+        vec!["rustc", "--version"],
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+            .args(&args)
+            .current_dir(&nested)
+            .env("SOLDR_CACHE_DIR", &cache_root)
+            .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+            .env_remove("CARGO_HOME")
+            .env_remove("RUSTUP_HOME")
+            .output()
+            .unwrap_or_else(|_| panic!("failed to run soldr with args {args:?}"));
+
+        assert!(
+            output.status.success(),
+            "soldr invocation failed for {:?}\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake rustup log");
+    let cargo_home = repo_cargo_home.display().to_string();
+    let rustup_home = repo_rustup_home.display().to_string();
+    assert!(
+        log.contains(&format!(
+            "rustup which cargo cargo_home={cargo_home} rustup_home={rustup_home}"
+        )),
+        "cargo resolution should use repo-local homes: {log}"
+    );
+    assert!(
+        log.contains(&format!(
+            "cargo cargo_home={cargo_home} rustup_home={rustup_home}"
+        )),
+        "cargo execution should inherit repo-local homes: {log}"
+    );
+    assert!(
+        log.contains(&format!(
+            "rustup which rustfmt cargo_home={cargo_home} rustup_home={rustup_home}"
+        )),
+        "rustfmt resolution should use repo-local homes: {log}"
+    );
+    assert!(
+        log.contains(&format!(
+            "rustfmt cargo_home={cargo_home} rustup_home={rustup_home}"
+        )),
+        "rustfmt execution should inherit repo-local homes: {log}"
+    );
+    assert!(
+        log.contains(&format!(
+            "rustup which rustc cargo_home={cargo_home} rustup_home={rustup_home}"
+        )),
+        "rustc resolution should use repo-local homes: {log}"
+    );
+    assert!(
+        log.contains(&format!(
+            "rustc cargo_home={cargo_home} rustup_home={rustup_home}"
+        )),
+        "rustc execution should inherit repo-local homes: {log}"
+    );
+}
+
+#[test]
+fn explicit_toolchain_home_env_vars_win_over_repo_local_homes() {
+    let cache_root = unique_temp_dir("explicit-toolchain-homes");
+    let log_path = cache_root.join("tool.log");
+    let (rustup, _, _, _) = install_fake_rustup_toolchain(&log_path);
+    let repo_root = unique_temp_dir("explicit-toolchain-repo");
+    let repo_cargo_home = repo_root.join(".cargo");
+    let repo_rustup_home = repo_root.join(".rustup");
+    let nested = repo_root.join("workspace").join("crate");
+    let explicit_cargo_home = unique_temp_dir("explicit-cargo-home");
+    let explicit_rustup_home = unique_temp_dir("explicit-rustup-home");
+    fs::create_dir_all(&repo_cargo_home).expect("failed to create repo-local .cargo");
+    fs::create_dir_all(&repo_rustup_home).expect("failed to create repo-local .rustup");
+    fs::create_dir_all(&nested).expect("failed to create nested working dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["--no-cache", "cargo", "--version"])
+        .current_dir(&nested)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("CARGO_HOME", &explicit_cargo_home)
+        .env("RUSTUP_HOME", &explicit_rustup_home)
+        .output()
+        .expect("failed to run soldr cargo --version with explicit homes");
+
+    assert!(
+        output.status.success(),
+        "soldr cargo --version failed with explicit homes\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake rustup log");
+    let explicit_cargo_home = explicit_cargo_home.display().to_string();
+    let explicit_rustup_home = explicit_rustup_home.display().to_string();
+    assert!(
+        log.contains(&format!(
+            "rustup which cargo cargo_home={explicit_cargo_home} rustup_home={explicit_rustup_home}"
+        )),
+        "cargo resolution should prefer explicit homes: {log}"
+    );
+    assert!(
+        log.contains(&format!(
+            "cargo cargo_home={explicit_cargo_home} rustup_home={explicit_rustup_home}"
+        )),
+        "cargo execution should inherit explicit homes: {log}"
+    );
+    assert!(
+        !log.contains(&repo_cargo_home.display().to_string())
+            && !log.contains(&repo_rustup_home.display().to_string()),
+        "repo-local homes should not leak into explicit-home runs: {log}"
+    );
+}
+
+#[test]
 fn status_reports_cache_control_defaults() {
     let cache_root = unique_temp_dir("status");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -773,14 +1010,6 @@ fn clean_rejects_json_flag() {
         stderr.contains("--json"),
         "expected clap to reject clean --json: {stderr}"
     );
-}
-
-#[cfg(windows)]
-fn prepend_to_path(dir: &Path) -> std::ffi::OsString {
-    let existing = std::env::var_os("PATH").unwrap_or_default();
-    let mut paths = vec![dir.to_path_buf()];
-    paths.extend(std::env::split_paths(&existing));
-    std::env::join_paths(paths).expect("failed to join PATH")
 }
 
 #[cfg(windows)]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -25,6 +25,35 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     dir
 }
 
+fn path_display_variants(path: &Path) -> Vec<String> {
+    let mut variants = vec![path.display().to_string()];
+    if let Ok(canonical) = fs::canonicalize(path) {
+        let canonical = canonical.display().to_string();
+        if !variants.contains(&canonical) {
+            variants.push(canonical);
+        }
+    }
+    variants
+}
+
+fn log_contains_toolchain_homes(
+    log: &str,
+    prefix: &str,
+    cargo_home: &Path,
+    rustup_home: &Path,
+) -> bool {
+    for cargo_home in path_display_variants(cargo_home) {
+        for rustup_home in path_display_variants(rustup_home) {
+            if log.contains(&format!(
+                "{prefix} cargo_home={cargo_home} rustup_home={rustup_home}"
+            )) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 fn fake_script_path(dir: &Path, name: &str) -> PathBuf {
     #[cfg(windows)]
     {
@@ -714,42 +743,43 @@ fn repo_local_toolchain_homes_are_used_when_env_vars_are_unset() {
     }
 
     let log = fs::read_to_string(&log_path).expect("failed to read fake rustup log");
-    let cargo_home = repo_cargo_home.display().to_string();
-    let rustup_home = repo_rustup_home.display().to_string();
     assert!(
-        log.contains(&format!(
-            "rustup which cargo cargo_home={cargo_home} rustup_home={rustup_home}"
-        )),
+        log_contains_toolchain_homes(
+            &log,
+            "rustup which cargo",
+            &repo_cargo_home,
+            &repo_rustup_home
+        ),
         "cargo resolution should use repo-local homes: {log}"
     );
     assert!(
-        log.contains(&format!(
-            "cargo cargo_home={cargo_home} rustup_home={rustup_home}"
-        )),
+        log_contains_toolchain_homes(&log, "cargo", &repo_cargo_home, &repo_rustup_home),
         "cargo execution should inherit repo-local homes: {log}"
     );
     assert!(
-        log.contains(&format!(
-            "rustup which rustfmt cargo_home={cargo_home} rustup_home={rustup_home}"
-        )),
+        log_contains_toolchain_homes(
+            &log,
+            "rustup which rustfmt",
+            &repo_cargo_home,
+            &repo_rustup_home
+        ),
         "rustfmt resolution should use repo-local homes: {log}"
     );
     assert!(
-        log.contains(&format!(
-            "rustfmt cargo_home={cargo_home} rustup_home={rustup_home}"
-        )),
+        log_contains_toolchain_homes(&log, "rustfmt", &repo_cargo_home, &repo_rustup_home),
         "rustfmt execution should inherit repo-local homes: {log}"
     );
     assert!(
-        log.contains(&format!(
-            "rustup which rustc cargo_home={cargo_home} rustup_home={rustup_home}"
-        )),
+        log_contains_toolchain_homes(
+            &log,
+            "rustup which rustc",
+            &repo_cargo_home,
+            &repo_rustup_home
+        ),
         "rustc resolution should use repo-local homes: {log}"
     );
     assert!(
-        log.contains(&format!(
-            "rustc cargo_home={cargo_home} rustup_home={rustup_home}"
-        )),
+        log_contains_toolchain_homes(&log, "rustc", &repo_cargo_home, &repo_rustup_home),
         "rustc execution should inherit repo-local homes: {log}"
     );
 }

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -2,8 +2,12 @@ use serde::Deserialize;
 use std::{
     ffi::OsStr,
     path::{Path, PathBuf},
+    process::Command,
 };
 use thiserror::Error;
+
+pub const CARGO_HOME_ENV_VAR: &str = "CARGO_HOME";
+pub const RUSTUP_HOME_ENV_VAR: &str = "RUSTUP_HOME";
 
 // ---------------------------------------------------------------------------
 // Target triple detection
@@ -225,9 +229,71 @@ fn find_in_ancestors(start_dir: Option<&Path>, relative_path: &str) -> Option<Pa
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ImplicitToolchainHomes {
+    cargo_home: Option<PathBuf>,
+    rustup_home: Option<PathBuf>,
+}
+
+impl ImplicitToolchainHomes {
+    fn from_env(
+        start_dir: Option<&Path>,
+        cargo_home_env: Option<&OsStr>,
+        rustup_home_env: Option<&OsStr>,
+    ) -> Self {
+        Self {
+            cargo_home: if cargo_home_env.is_none() {
+                find_dir_in_ancestors(start_dir, ".cargo")
+            } else {
+                None
+            },
+            rustup_home: if rustup_home_env.is_none() {
+                find_dir_in_ancestors(start_dir, ".rustup")
+            } else {
+                None
+            },
+        }
+    }
+
+    fn detect(start_dir: Option<&Path>) -> Self {
+        Self::from_env(
+            start_dir,
+            std::env::var_os(CARGO_HOME_ENV_VAR).as_deref(),
+            std::env::var_os(RUSTUP_HOME_ENV_VAR).as_deref(),
+        )
+    }
+
+    fn apply_to_command(&self, command: &mut Command) {
+        if let Some(cargo_home) = &self.cargo_home {
+            command.env(CARGO_HOME_ENV_VAR, cargo_home);
+        }
+        if let Some(rustup_home) = &self.rustup_home {
+            command.env(RUSTUP_HOME_ENV_VAR, rustup_home);
+        }
+    }
+}
+
+fn find_dir_in_ancestors(start_dir: Option<&Path>, relative_path: &str) -> Option<PathBuf> {
+    let mut current = start_dir?.to_path_buf();
+    loop {
+        let candidate = current.join(relative_path);
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+pub fn apply_implicit_toolchain_homes(command: &mut Command, start_dir: Option<&Path>) {
+    ImplicitToolchainHomes::detect(start_dir).apply_to_command(command);
+}
+
 fn detect_runtime_rustc_triple(start_dir: Option<&Path>) -> Option<String> {
     let rustc = resolve_runtime_rustc(start_dir)?;
     let mut command = std::process::Command::new(rustc);
+    apply_implicit_toolchain_homes(&mut command, start_dir);
     if let Some(start_dir) = start_dir {
         command.current_dir(start_dir);
     }
@@ -246,6 +312,7 @@ fn detect_runtime_rustc_triple(start_dir: Option<&Path>) -> Option<String> {
 
 fn resolve_runtime_rustc(start_dir: Option<&Path>) -> Option<PathBuf> {
     let mut rustup = std::process::Command::new("rustup");
+    apply_implicit_toolchain_homes(&mut rustup, start_dir);
     if let Some(start_dir) = start_dir {
         rustup.current_dir(start_dir);
     }
@@ -555,5 +622,49 @@ mod tests {
         let _target = TargetTriple::detect_in_dir(dir.path()).unwrap();
         #[cfg(target_os = "windows")]
         assert_eq!(_target.triple(), "x86_64-pc-windows-msvc");
+    }
+
+    #[test]
+    fn implicit_toolchain_homes_detect_repo_local_directories_from_ancestors() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".cargo")).unwrap();
+        std::fs::create_dir_all(dir.path().join(".rustup")).unwrap();
+        let nested = dir.path().join("workspace").join("crate");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let homes = ImplicitToolchainHomes::from_env(Some(nested.as_path()), None, None);
+        assert_eq!(homes.cargo_home, Some(dir.path().join(".cargo")));
+        assert_eq!(homes.rustup_home, Some(dir.path().join(".rustup")));
+    }
+
+    #[test]
+    fn implicit_toolchain_homes_only_fill_missing_env_vars() {
+        let dir = tempdir().unwrap();
+        let repo_cargo_home = dir.path().join(".cargo");
+        let repo_rustup_home = dir.path().join(".rustup");
+        std::fs::create_dir_all(&repo_cargo_home).unwrap();
+        std::fs::create_dir_all(&repo_rustup_home).unwrap();
+
+        let homes = ImplicitToolchainHomes::from_env(
+            Some(dir.path()),
+            Some(OsStr::new("C:/explicit-cargo-home")),
+            None,
+        );
+        assert_eq!(homes.cargo_home, None);
+        assert_eq!(homes.rustup_home, Some(repo_rustup_home));
+    }
+
+    #[test]
+    fn implicit_toolchain_homes_treat_empty_env_as_explicit() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".cargo")).unwrap();
+        std::fs::create_dir_all(dir.path().join(".rustup")).unwrap();
+
+        let homes = ImplicitToolchainHomes::from_env(
+            Some(dir.path()),
+            Some(OsStr::new("")),
+            Some(OsStr::new("")),
+        );
+        assert_eq!(homes, ImplicitToolchainHomes::default());
     }
 }


### PR DESCRIPTION
Closes #110.

## Summary
- detect repo-local `.cargo` and `.rustup` directories when `CARGO_HOME` / `RUSTUP_HOME` are unset
- apply the inferred homes consistently across `soldr cargo`, `soldr rustfmt`, wrapper-mode `soldr rustc`, and rustup-backed tool resolution
- add deterministic CLI coverage with a test-only rustup override plus new unit tests for mixed explicit/implicit env handling

## Verification
- `cargo test -p soldr-core`
- `cargo fmt --check`
- `cargo test -p soldr-cli --test cli repo_local_toolchain_homes_are_used_when_env_vars_are_unset -- --exact`
- `cargo test -p soldr-cli --test cli explicit_toolchain_home_env_vars_win_over_repo_local_homes -- --exact`

## Notes
- Full `cargo test -p soldr-cli --test cli` was not rerun in this environment because the isolated worktree target directory hit a disk-space limit; the new focused CLI cases passed against a shared target dir.