### PR TITLE
Preinstall exact setup-soldr toolchains

### DIFF
--- a/.github/actions/setup-soldr/ensure_rust_toolchain.py
+++ b/.github/actions/setup-soldr/ensure_rust_toolchain.py
@@ -13,6 +13,14 @@ def run(command: list[str]) -> None:
     subprocess.run(command, check=True)
 
 
+def append_github_env(name: str, value: str) -> None:
+    output = os.environ.get("GITHUB_ENV")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
 def main() -> None:
     cargo_home = Path(os.environ["CARGO_HOME"])
     rustup_home = Path(os.environ["RUSTUP_HOME"])
@@ -35,12 +43,15 @@ def main() -> None:
     targets = json.loads(os.environ.get("SETUP_SOLDR_TOOLCHAIN_TARGETS", "[]"))
 
     run([rustup, "set", "profile", profile])
-    run([rustup, "toolchain", "install", channel, "--profile", profile])
-    if components:
-        run([rustup, "component", "add", "--toolchain", channel, *components])
-    if targets:
-        run([rustup, "target", "add", "--toolchain", channel, *targets])
+    install_command = [rustup, "toolchain", "install", channel, "--profile", profile]
+    for component in components:
+        install_command.extend(["--component", component])
+    for target in targets:
+        install_command.extend(["--target", target])
+    run(install_command)
     run([rustup, "default", channel])
+    os.environ["RUSTUP_TOOLCHAIN"] = channel
+    append_github_env("RUSTUP_TOOLCHAIN", channel)
 
     cargo = shutil.which("cargo")
     rustc = shutil.which("rustc")

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -32,7 +32,7 @@ When stable action tags exist, prefer a major tag such as `@v1`. Until then, pin
 The root action:
 
 - installs one `soldr` binary
-- provisions the Rust toolchain without requiring a separate toolchain action
+- preinstalls the exact Rust toolchain resolved from `rust-toolchain.toml` or `toolchain:`
 - sets `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME`
 - restores and saves that runner-local root through GitHub cache when `cache: true`
 
@@ -40,6 +40,7 @@ Important toolchain rule:
 
 - if your repository already pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact channel with `toolchain:`
 - do not preinstall a different generic toolchain such as `stable` and assume a later `soldr cargo ...` step will reconcile it
+- the action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo` and `rustc` calls keep using the preinstalled toolchain instead of asking rustup to resolve it on demand
 
 Example:
 
@@ -120,6 +121,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+        with:
+          toolchain: 1.94.1
 
       - name: Install soldr 0.7.4
         shell: bash
@@ -162,6 +165,8 @@ jobs:
           path: soldr
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+        with:
+          toolchain: 1.94.1
 
       - name: Build soldr from source
         working-directory: soldr

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ The preferred CI path is the repository root action:
 That action:
 
 - installs `soldr`
-- provisions the Rust toolchain, using `rust-toolchain.toml` by default
+- preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
 - puts `soldr` on `PATH` for later steps
 
-If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later.
+If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later. The action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the toolchain it just installed instead of asking rustup to resolve a pinned file lazily.
 
 For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: setup-soldr
-description: Install soldr, provision the Rust toolchain, and restore a cacheable runner-local Soldr root.
+description: Install soldr, preinstall the resolved Rust toolchain, and restore a cacheable runner-local Soldr root.
 inputs:
   version:
     description: Soldr version or tag to install. Defaults to the latest release.
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: ""
   toolchain:
-    description: Override the Rust toolchain channel. When empty, rust-toolchain.toml is used if present.
+    description: Override the exact Rust toolchain channel string. When empty, rust-toolchain.toml is used if present.
     required: false
     default: ""
   toolchain-file:
@@ -47,7 +47,7 @@ outputs:
     description: Whether the action restored an exact setup cache hit.
     value: ${{ steps.cache-meta.outputs.cache_hit }}
   toolchain:
-    description: Rust toolchain channel configured by the action.
+    description: Exact Rust toolchain channel configured by the action.
     value: ${{ steps.resolve.outputs.toolchain }}
 runs:
   using: composite

--- a/tests/test_setup_soldr_ensure_rust_toolchain.py
+++ b/tests/test_setup_soldr_ensure_rust_toolchain.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "ensure_rust_toolchain.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("ensure_rust_toolchain", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_main_installs_requested_toolchain_and_exports_rustup_toolchain(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_module()
+    github_env = tmp_path / "github.env"
+    github_output = tmp_path / "github.output"
+
+    monkeypatch.setenv("CARGO_HOME", str(tmp_path / "cargo"))
+    monkeypatch.setenv("RUSTUP_HOME", str(tmp_path / "rustup"))
+    monkeypatch.setenv("SOLDR_CACHE_DIR", str(tmp_path / "soldr"))
+    monkeypatch.setenv("SETUP_SOLDR_TOOLCHAIN_CHANNEL", "1.94.1")
+    monkeypatch.setenv("SETUP_SOLDR_TOOLCHAIN_PROFILE", "minimal")
+    monkeypatch.setenv("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", '["rustfmt", "clippy"]')
+    monkeypatch.setenv("SETUP_SOLDR_TOOLCHAIN_TARGETS", '["x86_64-unknown-linux-musl"]')
+    monkeypatch.setenv("GITHUB_ENV", str(github_env))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    commands: list[list[str]] = []
+
+    def fake_which(name: str) -> str | None:
+        return {
+            "rustup": "C:/tools/rustup.exe",
+            "cargo": "C:/tools/cargo.exe",
+            "rustc": "C:/tools/rustc.exe",
+        }.get(name)
+
+    monkeypatch.setattr(module.shutil, "which", fake_which)
+    monkeypatch.setattr(module, "run", lambda command: commands.append(command))
+
+    module.main()
+
+    assert commands == [
+        ["C:/tools/rustup.exe", "set", "profile", "minimal"],
+        [
+            "C:/tools/rustup.exe",
+            "toolchain",
+            "install",
+            "1.94.1",
+            "--profile",
+            "minimal",
+            "--component",
+            "rustfmt",
+            "--component",
+            "clippy",
+            "--target",
+            "x86_64-unknown-linux-musl",
+        ],
+        ["C:/tools/rustup.exe", "default", "1.94.1"],
+        ["C:/tools/cargo.exe", "--version"],
+        ["C:/tools/rustc.exe", "--version"],
+    ]
+    assert github_env.read_text(encoding="utf-8") == "RUSTUP_TOOLCHAIN=1.94.1\n"
+    assert github_output.read_text(encoding="utf-8") == "toolchain=1.94.1\n"
+
+
+def test_main_exits_when_rustup_is_missing(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setenv("CARGO_HOME", str(tmp_path / "cargo"))
+    monkeypatch.setenv("RUSTUP_HOME", str(tmp_path / "rustup"))
+    monkeypatch.setenv("SOLDR_CACHE_DIR", str(tmp_path / "soldr"))
+    monkeypatch.setenv("SETUP_SOLDR_TOOLCHAIN_CHANNEL", "1.94.1")
+    monkeypatch.setenv("SETUP_SOLDR_TOOLCHAIN_PROFILE", "minimal")
+    monkeypatch.setenv("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", "[]")
+    monkeypatch.setenv("SETUP_SOLDR_TOOLCHAIN_TARGETS", "[]")
+    monkeypatch.setattr(module.shutil, "which", lambda _: None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.main()
+
+    assert "requires rustup to already be available" in str(excinfo.value)


### PR DESCRIPTION
Refs #140.

## Summary
- install the resolved Rust toolchain, components, and targets in one explicit `rustup toolchain install ... --component ... --target ...` step
- export `RUSTUP_TOOLCHAIN` so later `cargo`, `rustc`, and `soldr cargo ...` invocations stay on the preinstalled toolchain instead of asking rustup to resolve it lazily
- update action metadata and docs so GitHub Actions examples pin the exact toolchain rather than implying a generic `stable` install is sufficient
- add focused tests for the new setup-action behavior

## Verification
- `python -m pytest tests/test_setup_soldr_action.py tests/test_setup_soldr_ensure_rust_toolchain.py tests/test_setup_soldr_ensure_soldr.py`

## Notes
- I did not change #103 in this PR. The current `_bootstrap-e2e.yml` shape is not a clean drop-in target for `zackees/zccache` because it currently caches two separate target trees and the third-party build path goes through `soldr cargo`, which overwrites action-level `RUSTC_WRAPPER`.