### PR TITLE
Drive benchmark reporting from TOML config

### DIFF
--- a/.github/scripts/cache_benchmark_report.py
+++ b/.github/scripts/cache_benchmark_report.py
@@ -1,111 +1,39 @@
 #!/usr/bin/env python3
-"""Generate the top-level cache benchmark report and JSON artifact."""
+"""Generate the cache benchmark report and rendered site bundle."""
 
 from __future__ import annotations
 
 import json
 import math
 import os
+import tomllib
 from collections import defaultdict
 from html import escape
 from pathlib import Path
 from typing import Any
 
 
-SCENARIOS = [
-    {
-        "backend": "swatinem",
-        "mutation": "soldr-cli",
-        "label": "top-crate edit (`crates/soldr-cli/src/main.rs`)",
-        "env_prefix": "SWATINEM_CLI",
-    },
-    {
-        "backend": "swatinem",
-        "mutation": "soldr-core",
-        "label": "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
-        "env_prefix": "SWATINEM_CORE",
-    },
-    {
-        "backend": "zccache",
-        "mutation": "soldr-cli",
-        "label": "top-crate edit (`crates/soldr-cli/src/main.rs`)",
-        "env_prefix": "ZCCACHE_CLI",
-    },
-    {
-        "backend": "zccache",
-        "mutation": "soldr-core",
-        "label": "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
-        "env_prefix": "ZCCACHE_CORE",
-    },
-]
-
-DEFAULT_BENCHMARK_TARGET = "x86_64-unknown-linux-gnu"
-BENCHMARK_COMMAND_TEMPLATE = (
-    "soldr cargo build --package soldr-cli --release --locked --target {target}"
-)
-BASE_COMMAND_REFERENCE = [
-    {
-        "purpose": "Setup / status",
-        "command": "soldr status --json",
-        "status": "setup check",
-    },
-    {
-        "purpose": "Cache inspect",
-        "command": "soldr cache --json",
-        "status": "setup check",
-    },
-    {
-        "purpose": "Release build",
-        "command": "soldr cargo build --workspace --locked",
-        "status": "common compile path",
-    },
-    {
-        "purpose": "Targeted check",
-        "command": "soldr cargo check -p soldr-cli",
-        "status": "common compile path",
-    },
-    {
-        "purpose": "Library tests",
-        "command": "soldr cargo test --workspace --lib --locked",
-        "status": "common test path",
-    },
-    {
-        "purpose": "CLI smoke tests",
-        "command": "soldr cargo test -p soldr-cli --test cli --locked",
-        "status": "common test path",
-    },
-    {
-        "purpose": "Fetch integration test",
-        "command": "soldr cargo test -p soldr-fetch --test fetch_crgx --locked",
-        "status": "common test path",
-    },
-    {
-        "purpose": "Formatting check",
-        "command": "soldr cargo fmt --all -- --check",
-        "status": "quality check",
-    },
-    {
-        "purpose": "Clippy",
-        "command": "soldr cargo clippy --workspace --all-targets --locked -- -D warnings",
-        "status": "quality check",
-    },
-    {
-        "purpose": "Dylint",
-        "command": "soldr cargo-dylint check",
-        "status": "tooling check",
-    },
-]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG_PATH = REPO_ROOT / "benchmark.toml"
+DEFAULT_TARGET = "x86_64-unknown-linux-gnu"
 
 
-def _read_float(value: str) -> float | None:
-    if not value:
+class _SafeFormatDict(dict[str, str]):
+    def __missing__(self, key: str) -> str:
+        return "{" + key + "}"
+
+
+def _read_float(value: Any) -> float | None:
+    if value in ("", None):
         return None
     return float(value)
 
 
-def _read_bool(value: str) -> bool | None:
-    if not value:
+def _read_bool(value: Any) -> bool | None:
+    if value in ("", None):
         return None
+    if isinstance(value, bool):
+        return value
     if value == "true":
         return True
     if value == "false":
@@ -137,108 +65,169 @@ def _format_percent(value: float | None) -> str:
     return "n/a" if value is None else f"{value:.2f}%"
 
 
-def _load_results() -> list[dict[str, Any]]:
+def _load_config() -> tuple[dict[str, Any], Path]:
+    config_path = Path(os.environ.get("BENCHMARK_CONFIG_PATH", DEFAULT_CONFIG_PATH))
+    return tomllib.loads(config_path.read_text(encoding="utf-8")), config_path
+
+
+def _format_command(template: str, target: str) -> str:
+    return template.format_map(_SafeFormatDict(target=target))
+
+
+def _load_results(
+    config: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    input_path = Path(os.environ["BENCHMARK_INPUT_JSON"])
+    payload = json.loads(input_path.read_text(encoding="utf-8"))
+    raw_results = payload["results"] if isinstance(payload, dict) else payload
+
+    site = config["site"]
+    target = os.environ.get("BENCHMARK_COMMAND_TARGET") or site.get(
+        "default_target", DEFAULT_TARGET
+    )
+    competitors = [
+        {"id": competitor_id, **competitor}
+        for competitor_id, competitor in config["competitors"].items()
+        if competitor.get("show", True)
+    ]
+    competitor_by_id = {competitor["id"]: competitor for competitor in competitors}
+    profiles = list(config["profiles"])
+    profile_by_id = {profile["id"]: profile for profile in profiles}
+    mutations = list(config["mutations"])
+    mutation_by_id = {mutation["id"]: mutation for mutation in mutations}
+
     results: list[dict[str, Any]] = []
-    benchmark_target = os.environ.get("BENCHMARK_COMMAND_TARGET", DEFAULT_BENCHMARK_TARGET)
-    benchmark_command = BENCHMARK_COMMAND_TEMPLATE.format(target=benchmark_target)
-    for scenario in SCENARIOS:
-        prefix = scenario["env_prefix"]
-        result = os.environ[f"{prefix}_RESULT"]
-        cold_seconds = _read_float(os.environ.get(f"{prefix}_COLD", ""))
-        warm_seconds = _read_float(os.environ.get(f"{prefix}_WARM", ""))
-        saved_seconds = _read_float(os.environ.get(f"{prefix}_SAVED", ""))
-        speedup_ratio = _read_float(os.environ.get(f"{prefix}_RATIO", ""))
-        cache_hit = _read_bool(os.environ.get(f"{prefix}_HIT", ""))
-        cache_hit_detail = os.environ.get(f"{prefix}_HIT_DETAIL", "")
-
-        percent_less_wall_time_than_bare = None
-        if cold_seconds is not None and warm_seconds is not None:
-            percent_less_wall_time_than_bare = _percent_less_time(cold_seconds, warm_seconds)
-
+    for raw_result in raw_results:
+        competitor = competitor_by_id[raw_result["competitor"]]
+        profile = profile_by_id[raw_result["profile"]]
+        mutation = mutation_by_id[raw_result["mutation"]]
         results.append(
             {
-                "backend": scenario["backend"],
-                "mutation": scenario["mutation"],
-                "label": scenario["label"],
-                "command": benchmark_command,
-                "result": result,
-                "cold_seconds": _round_metric(cold_seconds),
-                "warm_seconds": _round_metric(warm_seconds),
-                "saved_seconds": _round_metric(saved_seconds),
-                "speedup_ratio": _round_metric(speedup_ratio),
-                "cache_hit": cache_hit,
-                "cache_hit_detail": cache_hit_detail or None,
-                "percent_less_wall_time_than_bare": _round_metric(
-                    percent_less_wall_time_than_bare
-                ),
+                "competitor": competitor["id"],
+                "competitor_label": competitor["label"],
+                "backend": competitor["backend"],
+                "profile": profile["id"],
+                "profile_label": profile["label"],
+                "mutation": mutation["id"],
+                "mutation_label": mutation["label"],
+                "mutation_path": mutation["path"],
+                "command": _format_command(profile["command"], target),
+                "result": raw_result.get("result", "success"),
+                "cold_seconds": _round_metric(_read_float(raw_result.get("cold_seconds"))),
+                "warm_seconds": _round_metric(_read_float(raw_result.get("warm_seconds"))),
+                "saved_seconds": _round_metric(_read_float(raw_result.get("saved_seconds"))),
+                "speedup_ratio": _round_metric(_read_float(raw_result.get("speedup_ratio"))),
+                "cache_hit": _read_bool(raw_result.get("cache_hit")),
+                "cache_hit_detail": raw_result.get("cache_hit_detail") or None,
+                "threshold_failed": bool(raw_result.get("threshold_failed", False)),
             }
         )
-    return results
+
+    return results, competitors, profiles, mutations
 
 
-def _build_report(results: list[dict[str, Any]]) -> dict[str, Any]:
-    by_mutation: dict[str, list[dict[str, Any]]] = defaultdict(list)
+def _build_report(
+    config: dict[str, Any],
+    config_path: Path,
+    results: list[dict[str, Any]],
+    competitors: list[dict[str, Any]],
+    profiles: list[dict[str, Any]],
+    mutations: list[dict[str, Any]],
+) -> dict[str, Any]:
+    site = config["site"]
+    base_competitor_id = site["base_competitor"]
+    measured_mutation_ids = {result["mutation"] for result in results}
+    visible_mutations = [
+        mutation for mutation in mutations if mutation["id"] in measured_mutation_ids
+    ]
+    results_by_key: dict[tuple[str, str], dict[str, dict[str, Any]]] = defaultdict(dict)
     for result in results:
-        by_mutation[result["mutation"]].append(result)
+        results_by_key[(result["profile"], result["mutation"])][result["competitor"]] = result
 
-    mutation_summaries: list[dict[str, Any]] = []
-    for mutation, mutation_results in by_mutation.items():
-        successful = [
-            result
-            for result in mutation_results
-            if result["result"] == "success" and result["warm_seconds"] is not None
-        ]
-        successful.sort(key=lambda result: result["warm_seconds"])
+    comparison_rows: list[dict[str, Any]] = []
+    for profile in profiles:
+        for mutation in visible_mutations:
+            key = (profile["id"], mutation["id"])
+            competitor_results = results_by_key.get(key, {})
+            visible_results = {
+                competitor["id"]: competitor_results.get(competitor["id"]) for competitor in competitors
+            }
 
-        leader = successful[0] if successful else None
-        runner_up = successful[1] if len(successful) > 1 else None
-        leader_advantage = None
-        if leader and runner_up:
-            leader_advantage = _percent_less_time(
-                runner_up["warm_seconds"], leader["warm_seconds"]
+            soldr_result = visible_results.get("soldr")
+            base_result = visible_results.get(base_competitor_id)
+            soldr_vs_base = None
+            if (
+                soldr_result
+                and base_result
+                and soldr_result["result"] == "success"
+                and base_result["result"] == "success"
+                and soldr_result["warm_seconds"] is not None
+                and base_result["warm_seconds"] is not None
+            ):
+                soldr_vs_base = _round_metric(
+                    _percent_less_time(base_result["warm_seconds"], soldr_result["warm_seconds"])
+                )
+
+            comparison_rows.append(
+                {
+                    "profile": profile["id"],
+                    "profile_label": profile["label"],
+                    "mutation": mutation["id"],
+                    "mutation_label": mutation["label"],
+                    "competitors": visible_results,
+                    "soldr_vs_base_warm_percent": soldr_vs_base,
+                }
             )
 
-        mutation_summaries.append(
-            {
-                "mutation": mutation,
-                "label": mutation_results[0]["label"],
-                "leader_backend": leader["backend"] if leader else None,
-                "leader_percent_less_wall_time_than_bare": (
-                    leader["percent_less_wall_time_than_bare"] if leader else None
-                ),
-                "runner_up_backend": runner_up["backend"] if runner_up else None,
-                "leader_percent_less_wall_time_than_runner_up": _round_metric(
-                    leader_advantage
-                ),
-                "results": mutation_results,
-            }
+    comparison_values = [
+        row["soldr_vs_base_warm_percent"]
+        for row in comparison_rows
+        if row["soldr_vs_base_warm_percent"] is not None
+    ]
+    soldr_wins = sum(1 for value in comparison_values if value > 0)
+    headline = "No successful soldr vs swatinem comparisons yet."
+    if comparison_values:
+        average = sum(comparison_values) / len(comparison_values)
+        trend = "faster" if average >= 0 else "slower"
+        headline = (
+            f"Across {len(comparison_values)} configured comparisons, soldr is "
+            f"{abs(average):.2f}% {trend} on warm time than swatinem and leads "
+            f"{soldr_wins} rows."
         )
 
-    mutation_summaries.sort(key=lambda item: item["mutation"])
+    profile_commands = [
+        {
+            "id": profile["id"],
+            "label": profile["label"],
+            "command": _format_command(
+                profile["command"],
+                os.environ.get("BENCHMARK_COMMAND_TARGET")
+                or site.get("default_target", DEFAULT_TARGET),
+            ),
+        }
+        for profile in profiles
+    ]
 
     return {
         "workflow": "cache-benchmark.yml",
+        "config_path": str(config_path.relative_to(REPO_ROOT)),
         "requested_scenario": os.environ["SCENARIO"],
         "threshold_ratio": _round_metric(float(os.environ["THRESHOLD_RATIO"])),
-        "benchmarked_command": results[0]["command"] if results else None,
-        "command_reference": [
-            {
-                "purpose": "Benchmarked release build",
-                "command": results[0]["command"] if results else "n/a",
-                "status": "benchmarked now",
-            },
-            *BASE_COMMAND_REFERENCE,
-        ],
-        "metric_definition": {
-            "percent_less_wall_time_than_bare": (
-                "(cold_seconds - warm_seconds) / cold_seconds * 100"
-            ),
-            "leader_percent_less_wall_time_than_runner_up": (
-                "(runner_up_warm_seconds - leader_warm_seconds) / "
-                "runner_up_warm_seconds * 100"
-            ),
+        "headline": headline,
+        "site": {
+            "title": site["title"],
+            "soldr_note": site.get("soldr_note"),
+            "base_competitor": base_competitor_id,
         },
-        "mutations": mutation_summaries,
+        "competitors": competitors,
+        "profiles": profile_commands,
+        "mutations": visible_mutations,
+        "comparisons": comparison_rows,
+        "results": results,
+        "metric_definition": {
+            "speedup_ratio": "cold_seconds / warm_seconds",
+            "soldr_vs_base_warm_percent": "(base_warm_seconds - soldr_warm_seconds) / base_warm_seconds * 100",
+        },
     }
 
 
@@ -248,63 +237,51 @@ def _write_json_report(report: dict[str, Any]) -> None:
     output_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
 
 
+def _comparison_result(row: dict[str, Any], competitor_id: str) -> dict[str, Any] | None:
+    return row["competitors"].get(competitor_id)
+
+
 def _build_table_rows(report: dict[str, Any]) -> str:
     rows: list[str] = []
-    for mutation in report["mutations"]:
-        leader_backend = mutation["leader_backend"]
-        for result in mutation["results"]:
-            winner = "yes" if result["backend"] == leader_backend else ""
-            rows.append(
-                "<tr>"
-                f"<td><code>{escape(result['command'])}</code></td>"
-                f"<td>{escape(result['label'])}</td>"
-                f"<td>{escape(result['backend'])}</td>"
-                f"<td>{escape(result['result'])}</td>"
-                f"<td>{_format_seconds(result['cold_seconds'])}</td>"
-                f"<td>{_format_seconds(result['warm_seconds'])}</td>"
-                f"<td>{_format_seconds(result['saved_seconds'])}</td>"
-                f"<td>{_format_ratio(result['speedup_ratio'])}</td>"
-                f"<td>{_format_percent(result['percent_less_wall_time_than_bare'])}</td>"
-                f"<td>{winner}</td>"
-                "</tr>"
-            )
-    return "\n".join(rows)
-
-
-def _build_command_reference_rows(report: dict[str, Any]) -> str:
-    rows: list[str] = []
-    benchmarked = report.get("benchmarked_command")
-    for item in report["command_reference"]:
-        benchmarked_flag = "yes" if item["command"] == benchmarked else "not yet"
+    for row in report["comparisons"]:
+        soldr = _comparison_result(row, "soldr") or {}
+        swatinem = _comparison_result(row, report["site"]["base_competitor"]) or {}
         rows.append(
             "<tr>"
-            f"<td>{escape(item['purpose'])}</td>"
-            f"<td><code>{escape(item['command'])}</code></td>"
-            f"<td>{escape(item['status'])}</td>"
-            f"<td>{benchmarked_flag}</td>"
+            f"<td>{escape(row['profile_label'])}</td>"
+            f"<td>{escape(row['mutation_label'])}</td>"
+            f"<td>{_format_seconds(soldr.get('cold_seconds'))}</td>"
+            f"<td>{_format_seconds(soldr.get('warm_seconds'))}</td>"
+            f"<td>{_format_ratio(soldr.get('speedup_ratio'))}</td>"
+            f"<td>{_format_seconds(swatinem.get('cold_seconds'))}</td>"
+            f"<td>{_format_seconds(swatinem.get('warm_seconds'))}</td>"
+            f"<td>{_format_ratio(swatinem.get('speedup_ratio'))}</td>"
+            f"<td>{_format_percent(row['soldr_vs_base_warm_percent'])}</td>"
             "</tr>"
         )
     return "\n".join(rows)
 
 
-def _build_html_page(report: dict[str, Any]) -> str:
-    headline = []
-    for mutation in report["mutations"]:
-        if mutation["leader_backend"] is None:
-            continue
-        headline.append(
-            f"{mutation['mutation']}: {mutation['leader_backend']} "
-            f"({_format_percent(mutation['leader_percent_less_wall_time_than_bare'])} less wall time than bare)"
+def _build_profile_command_items(report: dict[str, Any]) -> str:
+    items: list[str] = []
+    for profile in report["profiles"]:
+        items.append(
+            "<li>"
+            f"<strong>{escape(profile['label'])}</strong>: "
+            f"<code>{escape(profile['command'])}</code>"
+            "</li>"
         )
+    return "\n".join(items)
 
-    headline_text = " | ".join(headline) if headline else "No successful benchmark results."
 
+def _build_html_page(report: dict[str, Any]) -> str:
+    soldr_note = report["site"].get("soldr_note") or ""
     return f"""<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>soldr rendered benchmarks</title>
+    <title>{escape(report["site"]["title"])}</title>
     <style>
       body {{
         margin: 0;
@@ -314,19 +291,35 @@ def _build_html_page(report: dict[str, Any]) -> str:
         background: #f8f8f6;
       }}
       main {{
-        max-width: 1100px;
+        max-width: 1080px;
         margin: 0 auto;
       }}
       h1 {{
         margin: 0 0 12px;
         font-size: 32px;
       }}
+      h2 {{
+        margin: 28px 0 10px;
+        font-size: 22px;
+      }}
+      p, li {{
+        line-height: 1.5;
+      }}
       p {{
         margin: 0 0 12px;
-        line-height: 1.5;
       }}
       .meta {{
         color: #4e5a5f;
+      }}
+      .note {{
+        color: #2f3d42;
+        background: #eef2f3;
+        border: 1px solid #d7dcdf;
+        padding: 12px 14px;
+      }}
+      ul {{
+        margin: 0;
+        padding-left: 20px;
       }}
       table {{
         width: 100%;
@@ -347,7 +340,7 @@ def _build_html_page(report: dict[str, Any]) -> str:
         background: #fafcfc;
       }}
       .footer {{
-        margin-top: 16px;
+        margin-top: 18px;
         color: #4e5a5f;
         font-size: 13px;
       }}
@@ -356,37 +349,37 @@ def _build_html_page(report: dict[str, Any]) -> str:
           overflow-x: auto;
         }}
         table {{
-          min-width: 860px;
+          min-width: 880px;
         }}
       }}
     </style>
   </head>
   <body>
     <main>
-      <h1>soldr rendered benchmarks</h1>
-      <p>{escape(headline_text)}</p>
+      <h1>{escape(report["site"]["title"])}</h1>
+      <p>{escape(report["headline"])}</p>
       <p class="meta">
         Workflow: {escape(report["workflow"])} |
         Scenario: {escape(report["requested_scenario"])} |
         Threshold: {report["threshold_ratio"]:.2f}x
       </p>
-      <p class="meta">
-        Benchmarked command: <code>{escape(report["benchmarked_command"] or "n/a")}</code>
+      <p class="note">
+        {escape(soldr_note)} Raw detail is published beside this page as
+        <a href="latest.json">latest.json</a>.
       </p>
       <div class="table-wrap">
         <table>
           <thead>
             <tr>
-              <th>Command</th>
+              <th>Profile</th>
               <th>Change</th>
-              <th>Backend</th>
-              <th>Result</th>
-              <th>Cold</th>
-              <th>Warm</th>
-              <th>Saved</th>
-              <th>Speedup</th>
-              <th>% less than bare</th>
-              <th>Winner</th>
+              <th>soldr cold</th>
+              <th>soldr warm</th>
+              <th>soldr speedup</th>
+              <th>swatinem cold</th>
+              <th>swatinem warm</th>
+              <th>swatinem speedup</th>
+              <th>soldr vs swatinem</th>
             </tr>
           </thead>
           <tbody>
@@ -394,23 +387,11 @@ def _build_html_page(report: dict[str, Any]) -> str:
           </tbody>
         </table>
       </div>
-      <h2>Common soldr commands</h2>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Purpose</th>
-              <th>Command</th>
-              <th>Type</th>
-              <th>Benchmarked</th>
-            </tr>
-          </thead>
-          <tbody>
-            {_build_command_reference_rows(report)}
-          </tbody>
-        </table>
-      </div>
-      <p class="footer">Source data is published beside this page as latest.json.</p>
+      <h2>Benchmarked Commands</h2>
+      <ul>
+        {_build_profile_command_items(report)}
+      </ul>
+      <p class="footer">Config: <code>{escape(report["config_path"])}</code>.</p>
     </main>
   </body>
 </html>
@@ -435,51 +416,25 @@ def _build_summary_lines(report: dict[str, Any]) -> list[str]:
         "",
         f"- requested scenario: `{report['requested_scenario']}`",
         f"- threshold ratio: `{report['threshold_ratio']:.2f}x`",
-        "- primary metric: percent less wall time than bare build",
-        "- secondary metric: leader advantage over the next-best cache backend",
+        f"- config: `{report['config_path']}`",
         "- artifact: `cache-benchmark-summary.json`",
+        "- raw detail artifact: `cache-benchmark-results.json`",
         "",
-        "### Leaders",
+        "### Warm Comparison",
         "",
+        "| profile | change | soldr warm | swatinem warm | soldr vs swatinem |",
+        "| --- | --- | ---: | ---: | ---: |",
     ]
 
-    for mutation in report["mutations"]:
-        leader_backend = mutation["leader_backend"]
-        if leader_backend is None:
-            lines.append(f"- `{mutation['mutation']}`: no successful benchmark results")
-            continue
-
-        leader_vs_bare = mutation["leader_percent_less_wall_time_than_bare"]
-        runner_up_backend = mutation["runner_up_backend"]
-        leader_vs_runner_up = mutation["leader_percent_less_wall_time_than_runner_up"]
-        line = (
-            f"- `{mutation['mutation']}`: `{leader_backend}` is best, "
-            f"`{leader_vs_bare:.2f}%` less wall time than bare"
+    for row in report["comparisons"]:
+        soldr = _comparison_result(row, "soldr") or {}
+        swatinem = _comparison_result(row, report["site"]["base_competitor"]) or {}
+        lines.append(
+            f"| `{row['profile_label']}` | `{row['mutation_label']}` | "
+            f"`{_format_seconds(soldr.get('warm_seconds'))}` | "
+            f"`{_format_seconds(swatinem.get('warm_seconds'))}` | "
+            f"`{_format_percent(row['soldr_vs_base_warm_percent'])}` |"
         )
-        if runner_up_backend and leader_vs_runner_up is not None:
-            line += (
-                f", `{leader_vs_runner_up:.2f}%` less wall time than `{runner_up_backend}`"
-            )
-        lines.append(line)
-
-    lines.extend(
-        [
-            "",
-            "### Percent Less Wall Time Than Bare",
-            "",
-            "| mutation | backend | result | % less wall time than bare |",
-            "| --- | --- | --- | ---: |",
-        ]
-    )
-
-    for mutation in report["mutations"]:
-        for result in mutation["results"]:
-            percent = result["percent_less_wall_time_than_bare"]
-            percent_display = f"{percent:.2f}%" if percent is not None else "n/a"
-            lines.append(
-                f"| `{result['mutation']}` | `{result['backend']}` | "
-                f"`{result['result']}` | `{percent_display}` |"
-            )
 
     return lines
 
@@ -494,7 +449,9 @@ def _append_step_summary(report: dict[str, Any]) -> None:
 
 
 def main() -> None:
-    report = _build_report(_load_results())
+    config, config_path = _load_config()
+    results, competitors, profiles, mutations = _load_results(config)
+    report = _build_report(config, config_path, results, competitors, profiles, mutations)
     _write_json_report(report)
     _write_www_bundle(report)
     _append_step_summary(report)

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
     paths-ignore:
-      - '*.md'
+      - "*.md"
   workflow_dispatch:
     inputs:
       scenario:
-        description: Which Phase 1 scenario set to run.
+        description: Which mutation scenario set to run.
         required: true
         type: choice
         default: all
@@ -27,106 +27,261 @@ permissions:
   contents: read
 
 jobs:
-  swatinem-soldr-cli:
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'soldr-cli' }}
-    name: Swatinem / Top-crate edit
-    uses: ./.github/workflows/_cache-benchmark-scenario.yml
-    with:
-      runner: ubuntu-24.04
-      target: x86_64-unknown-linux-gnu
-      source_ref: ${{ github.sha }}
-      cache_backend: swatinem
-      mutation: soldr-cli
-      threshold_ratio: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
-
-  swatinem-soldr-core:
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'soldr-core' }}
-    name: Swatinem / Lower-crate edit
-    uses: ./.github/workflows/_cache-benchmark-scenario.yml
-    with:
-      runner: ubuntu-24.04
-      target: x86_64-unknown-linux-gnu
-      source_ref: ${{ github.sha }}
-      cache_backend: swatinem
-      mutation: soldr-core
-      threshold_ratio: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
-
-  zccache-soldr-cli:
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'soldr-cli' }}
-    name: zccache / Top-crate edit
-    uses: ./.github/workflows/_cache-benchmark-scenario.yml
-    with:
-      runner: ubuntu-24.04
-      target: x86_64-unknown-linux-gnu
-      source_ref: ${{ github.sha }}
-      cache_backend: zccache
-      mutation: soldr-cli
-      threshold_ratio: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
-
-  zccache-soldr-core:
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.scenario == 'all' || github.event.inputs.scenario == 'soldr-core' }}
-    name: zccache / Lower-crate edit
-    uses: ./.github/workflows/_cache-benchmark-scenario.yml
-    with:
-      runner: ubuntu-24.04
-      target: x86_64-unknown-linux-gnu
-      source_ref: ${{ github.sha }}
-      cache_backend: zccache
-      mutation: soldr-core
-      threshold_ratio: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
-
-  summary:
-    if: ${{ always() }}
-    name: Phase 1 summary
-    needs:
-      - swatinem-soldr-cli
-      - swatinem-soldr-core
-      - zccache-soldr-cli
-      - zccache-soldr-core
+  benchmark:
+    name: Config-driven benchmark
     runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Resolve benchmark config
+        id: config
+        shell: bash
+        env:
+          BENCHMARK_CONFIG_PATH: benchmark.toml
+          INPUT_THRESHOLD_RATIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '' }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          config = tomllib.loads(Path(os.environ["BENCHMARK_CONFIG_PATH"]).read_text(encoding="utf-8"))
+          target = config["site"].get("default_target", "x86_64-unknown-linux-gnu")
+          threshold = os.environ["INPUT_THRESHOLD_RATIO"] or str(
+              config["site"].get("default_threshold_ratio", 10.0)
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"target={target}\n")
+              fh.write(f"threshold_ratio={threshold}\n")
+          PY
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+        with:
+          components: clippy
+          targets: ${{ steps.config.outputs.target }}
+
+      - name: Prepare zccache tool
+        uses: ./.github/actions/cache-benchmark-zccache
+        with:
+          cache-cargo-registry: "false"
+          cache-compilation: "false"
+          cache-target: "false"
+          save-cache: "false"
+
+      - name: Run configured benchmarks
+        shell: bash
+        env:
+          BENCHMARK_COMMAND_TARGET: ${{ steps.config.outputs.target }}
+          BENCHMARK_CONFIG_PATH: benchmark.toml
+          BENCHMARK_RESULTS_JSON: benchmark-summary/cache-benchmark-results.json
+          SCENARIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scenario || 'all' }}
+          THRESHOLD_RATIO: ${{ steps.config.outputs.threshold_ratio }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import shutil
+          import subprocess
+          import time
+          import tomllib
+          from pathlib import Path
+
+          class SafeFormatDict(dict):
+              def __missing__(self, key):
+                  return "{" + key + "}"
+
+
+          repo_root = Path.cwd()
+          config = tomllib.loads(Path(os.environ["BENCHMARK_CONFIG_PATH"]).read_text(encoding="utf-8"))
+          target = os.environ["BENCHMARK_COMMAND_TARGET"]
+          threshold = float(os.environ["THRESHOLD_RATIO"])
+          scenario = os.environ["SCENARIO"]
+          output_path = Path(os.environ["BENCHMARK_RESULTS_JSON"])
+
+          selected_mutations = [
+              mutation
+              for mutation in config["mutations"]
+              if scenario == "all" or mutation["id"] == scenario
+          ]
+          competitors = [
+              {"id": competitor_id, **competitor}
+              for competitor_id, competitor in config["competitors"].items()
+              if competitor.get("show", True)
+          ]
+          profiles = list(config["profiles"])
+
+          def render_parts(parts):
+              return [part.format_map(SafeFormatDict(target=target)) for part in parts]
+
+          def clean_workspace():
+              subprocess.run(
+                  ["git", "reset", "--hard", "HEAD"],
+                  cwd=repo_root,
+                  check=True,
+                  stdout=subprocess.DEVNULL,
+                  stderr=subprocess.DEVNULL,
+              )
+              subprocess.run(
+                  ["git", "clean", "-fdx"],
+                  cwd=repo_root,
+                  check=True,
+                  stdout=subprocess.DEVNULL,
+                  stderr=subprocess.DEVNULL,
+              )
+
+          def reset_backend(backend):
+              if backend == "zccache":
+                  subprocess.run(["zccache", "stop"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                  shutil.rmtree(Path.home() / ".zccache", ignore_errors=True)
+              subprocess.run(["cargo", "clean"], cwd=repo_root, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+          def apply_mutation(mutation):
+              mutation_path = repo_root / mutation["path"]
+              with mutation_path.open("a", encoding="utf-8") as handle:
+                  handle.write(f"\n// cache benchmark mutation: {mutation['id']}\n")
+
+          def run_cargo(profile, backend):
+              command = ["cargo", *render_parts(profile["cargo_args"])]
+              env = os.environ.copy()
+              env["CARGO_TERM_COLOR"] = "never"
+              env.pop("RUSTC_WRAPPER", None)
+              if backend == "zccache":
+                  subprocess.run(["zccache", "start"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                  env["RUSTC_WRAPPER"] = "zccache"
+              start = time.perf_counter()
+              subprocess.run(command, cwd=repo_root, env=env, check=True)
+              return time.perf_counter() - start
+
+          results = []
+          failures = []
+          output_path.parent.mkdir(parents=True, exist_ok=True)
+
+          for mutation in selected_mutations:
+              for profile in profiles:
+                  for competitor in competitors:
+                      backend = competitor["backend"]
+                      result = {
+                          "competitor": competitor["id"],
+                          "profile": profile["id"],
+                          "mutation": mutation["id"],
+                          "result": "success",
+                          "cold_seconds": None,
+                          "warm_seconds": None,
+                          "saved_seconds": None,
+                          "speedup_ratio": None,
+                          "cache_hit": False,
+                          "cache_hit_detail": f"backend={backend};same_job_seed=true",
+                          "threshold_failed": False,
+                      }
+
+                      try:
+                          clean_workspace()
+                          reset_backend("none")
+                          apply_mutation(mutation)
+                          cold_seconds = run_cargo(profile, "none")
+
+                          clean_workspace()
+                          reset_backend(backend)
+                          run_cargo(profile, backend)
+                          apply_mutation(mutation)
+                          warm_seconds = run_cargo(profile, backend)
+                      except subprocess.CalledProcessError as exc:
+                          result["result"] = "failure"
+                          result["cache_hit_detail"] = (
+                              f"backend={backend};same_job_seed=true;returncode={exc.returncode}"
+                          )
+                          failures.append(
+                              f"{profile['id']}/{mutation['id']}/{competitor['id']} failed with exit code {exc.returncode}"
+                          )
+                      else:
+                          speedup_ratio = cold_seconds / warm_seconds if warm_seconds else float("inf")
+                          result["cold_seconds"] = round(cold_seconds, 2)
+                          result["warm_seconds"] = round(warm_seconds, 2)
+                          result["saved_seconds"] = round(cold_seconds - warm_seconds, 2)
+                          result["speedup_ratio"] = round(speedup_ratio, 2)
+                          result["cache_hit"] = warm_seconds < cold_seconds
+                          result["threshold_failed"] = speedup_ratio < threshold
+                          if result["threshold_failed"]:
+                              failures.append(
+                                  f"{profile['id']}/{mutation['id']}/{competitor['id']} observed {speedup_ratio:.2f}x, required {threshold:.2f}x"
+                              )
+
+                      results.append(result)
+
+          output_path.write_text(
+              json.dumps(
+                  {
+                      "threshold_ratio": threshold,
+                      "scenario": scenario,
+                      "results": results,
+                  },
+                  indent=2,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+
+          if failures:
+              print("Benchmark threshold or command failures detected:")
+              for failure in failures:
+                  print(f"- {failure}")
+          PY
+
       - name: Write benchmark summary
         shell: bash
         env:
-          BENCHMARK_COMMAND_TARGET: x86_64-unknown-linux-gnu
+          BENCHMARK_COMMAND_TARGET: ${{ steps.config.outputs.target }}
+          BENCHMARK_CONFIG_PATH: benchmark.toml
+          BENCHMARK_INPUT_JSON: benchmark-summary/cache-benchmark-results.json
           BENCHMARK_SUMMARY_JSON: benchmark-summary/cache-benchmark-summary.json
           BENCHMARK_SUMMARY_WWW_DIR: benchmark-summary/site
           SCENARIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scenario || 'all' }}
-          THRESHOLD_RATIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '10' }}
-          SWATINEM_CLI_RESULT: ${{ needs.swatinem-soldr-cli.result }}
-          SWATINEM_CLI_COLD: ${{ needs.swatinem-soldr-cli.outputs.cold_seconds }}
-          SWATINEM_CLI_WARM: ${{ needs.swatinem-soldr-cli.outputs.warm_seconds }}
-          SWATINEM_CLI_SAVED: ${{ needs.swatinem-soldr-cli.outputs.saved_seconds }}
-          SWATINEM_CLI_RATIO: ${{ needs.swatinem-soldr-cli.outputs.speedup_ratio }}
-          SWATINEM_CLI_HIT: ${{ needs.swatinem-soldr-cli.outputs.cache_hit }}
-          SWATINEM_CLI_HIT_DETAIL: ${{ needs.swatinem-soldr-cli.outputs.cache_hit_detail }}
-          SWATINEM_CORE_RESULT: ${{ needs.swatinem-soldr-core.result }}
-          SWATINEM_CORE_COLD: ${{ needs.swatinem-soldr-core.outputs.cold_seconds }}
-          SWATINEM_CORE_WARM: ${{ needs.swatinem-soldr-core.outputs.warm_seconds }}
-          SWATINEM_CORE_SAVED: ${{ needs.swatinem-soldr-core.outputs.saved_seconds }}
-          SWATINEM_CORE_RATIO: ${{ needs.swatinem-soldr-core.outputs.speedup_ratio }}
-          SWATINEM_CORE_HIT: ${{ needs.swatinem-soldr-core.outputs.cache_hit }}
-          SWATINEM_CORE_HIT_DETAIL: ${{ needs.swatinem-soldr-core.outputs.cache_hit_detail }}
-          ZCCACHE_CLI_RESULT: ${{ needs.zccache-soldr-cli.result }}
-          ZCCACHE_CLI_COLD: ${{ needs.zccache-soldr-cli.outputs.cold_seconds }}
-          ZCCACHE_CLI_WARM: ${{ needs.zccache-soldr-cli.outputs.warm_seconds }}
-          ZCCACHE_CLI_SAVED: ${{ needs.zccache-soldr-cli.outputs.saved_seconds }}
-          ZCCACHE_CLI_RATIO: ${{ needs.zccache-soldr-cli.outputs.speedup_ratio }}
-          ZCCACHE_CLI_HIT: ${{ needs.zccache-soldr-cli.outputs.cache_hit }}
-          ZCCACHE_CLI_HIT_DETAIL: ${{ needs.zccache-soldr-cli.outputs.cache_hit_detail }}
-          ZCCACHE_CORE_RESULT: ${{ needs.zccache-soldr-core.result }}
-          ZCCACHE_CORE_COLD: ${{ needs.zccache-soldr-core.outputs.cold_seconds }}
-          ZCCACHE_CORE_WARM: ${{ needs.zccache-soldr-core.outputs.warm_seconds }}
-          ZCCACHE_CORE_SAVED: ${{ needs.zccache-soldr-core.outputs.saved_seconds }}
-          ZCCACHE_CORE_RATIO: ${{ needs.zccache-soldr-core.outputs.speedup_ratio }}
-          ZCCACHE_CORE_HIT: ${{ needs.zccache-soldr-core.outputs.cache_hit }}
-          ZCCACHE_CORE_HIT_DETAIL: ${{ needs.zccache-soldr-core.outputs.cache_hit_detail }}
+          THRESHOLD_RATIO: ${{ steps.config.outputs.threshold_ratio }}
         run: |
           set -euo pipefail
           python3 .github/scripts/cache_benchmark_report.py
+
+      - name: Enforce configured thresholds
+        shell: bash
+        env:
+          BENCHMARK_RESULTS_JSON: benchmark-summary/cache-benchmark-results.json
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["BENCHMARK_RESULTS_JSON"]).read_text(encoding="utf-8"))
+          failures = []
+          for result in payload["results"]:
+              slug = f"{result['profile']}/{result['mutation']}/{result['competitor']}"
+              if result["result"] != "success":
+                  failures.append(f"{slug} failed")
+                  continue
+              if result["threshold_failed"]:
+                  failures.append(f"{slug} missed the configured speedup threshold")
+
+          if failures:
+              sys.exit("\n".join(failures))
+          PY
+
+      - name: Cleanup zccache
+        if: ${{ always() }}
+        uses: ./.github/actions/cache-benchmark-zccache-cleanup
+
+      - name: Upload raw benchmark artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cache-benchmark-raw
+          path: benchmark-summary/cache-benchmark-results.json
+          if-no-files-found: error
 
       - name: Upload benchmark summary artifact
         if: ${{ always() }}
@@ -155,10 +310,10 @@ jobs:
           path: benchmark-summary/site
 
   deploy-pages:
-    if: ${{ always() && needs.summary.result == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    if: ${{ always() && needs.benchmark.result == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     name: Deploy benchmark site
     needs:
-      - summary
+      - benchmark
     permissions:
       pages: write
       id-token: write

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -1,0 +1,47 @@
+[site]
+title = "soldr rendered benchmarks"
+default_threshold_ratio = 10.0
+default_target = "x86_64-unknown-linux-gnu"
+base_competitor = "swatinem"
+soldr_note = "soldr uses managed zccache internally."
+
+[competitors.soldr]
+label = "soldr"
+backend = "zccache"
+show = true
+
+[competitors.swatinem]
+label = "swatinem"
+backend = "swatinem"
+show = true
+
+[[profiles]]
+id = "release"
+label = "Release build"
+command = "soldr cargo build --package soldr-cli --release --locked --target {target}"
+cargo_args = ["build", "--package", "soldr-cli", "--release", "--locked", "--target", "{target}"]
+kind = "build"
+
+[[profiles]]
+id = "quick"
+label = "Quick check"
+command = "soldr cargo check -p soldr-cli --locked --target {target}"
+cargo_args = ["check", "-p", "soldr-cli", "--locked", "--target", "{target}"]
+kind = "build"
+
+[[profiles]]
+id = "lint"
+label = "Lint"
+command = "soldr cargo clippy --workspace --all-targets --locked --target {target} -- -D warnings"
+cargo_args = ["clippy", "--workspace", "--all-targets", "--locked", "--target", "{target}", "--", "-D", "warnings"]
+kind = "lint"
+
+[[mutations]]
+id = "soldr-cli"
+label = "Top-crate edit"
+path = "crates/soldr-cli/src/main.rs"
+
+[[mutations]]
+id = "soldr-core"
+label = "Lower-crate edit"
+path = "crates/soldr-core/src/lib.rs"

--- a/docs/CI_CACHE_PHASE1.md
+++ b/docs/CI_CACHE_PHASE1.md
@@ -1,32 +1,57 @@
 # CI Cache Phase 1 Benchmark
 
-Issue [#122](https://github.com/zackees/soldr/issues/122) requires Linux x64 baseline measurements on GitHub-hosted runners before any broader CI cache work advances.
+Issue [#136](https://github.com/zackees/soldr/issues/136) moves the benchmark report away from hardcoded scenarios and the oversized command-reference page.
 
-Use `.github/workflows/cache-benchmark.yml` for that Phase 1 measurement. The workflow dispatch:
+The benchmark pipeline is now driven by [`benchmark.toml`](../benchmark.toml):
 
-- runs on `ubuntu-24.04` with target `x86_64-unknown-linux-gnu`
-- runs both cache backends in parallel: `Swatinem/rust-cache` and `zccache`
-- seeds each backend cache in one child job, then measures cold and warm builds for each selected scenario
-- measures only the `cargo build --package soldr-cli --release --locked --target <target>` wall time
-- uses Python `time.perf_counter()` around the cargo subprocess for the benchmark timing
-- uploads one top-level `cache-benchmark-summary` artifact containing `cache-benchmark-summary.json`
-- uploads one website-ready `cache-benchmark-www` artifact containing `index.html` and `latest.json`
-- deploys that same generated site bundle to GitHub Pages when the benchmark workflow runs on the default branch
-- renders the benchmark page with the actual `soldr ...` command under test as the first column, plus a reference table of common soldr commands such as `build`, `check`, `test`, `fmt`, and `clippy`
-- keeps the final workflow summary focused on percent less wall time than bare and the leader's advantage over the next-best cache backend
-- fails a compare job unless the warm path is at least the configured ratio faster than the cold control
+- competitors and their internal backend mapping live in the TOML file
+- benchmark profiles live in the TOML file
+- mutation scenarios live in the TOML file
+- the rendered page labels come from the same config
 
-Scenarios:
+`Cache Benchmark` reads that config and currently benchmarks three profile families on Linux x64:
+
+- `release`: `soldr cargo build --package soldr-cli --release --locked --target <target>`
+- `quick`: `soldr cargo check -p soldr-cli --locked --target <target>`
+- `lint`: `soldr cargo clippy --workspace --all-targets --locked --target <target> -- -D warnings`
+
+For each selected mutation and visible competitor, the workflow:
+
+- runs one cold control build without the cache backend
+- runs one seed build for the configured backend
+- applies the mutation and measures the warm build
+- writes raw per-run metrics into `cache-benchmark-results.json`
+- renders `cache-benchmark-summary.json` and the website bundle from the same TOML config
+
+Presentation changes from the previous version:
+
+- the public page now compares `soldr` vs `swatinem`
+- the wide `Result` column is gone
+- the giant command-reference table is gone
+- the page instead shows one compact comparison table plus a short benchmarked-command list
+- the page links to `latest.json` for raw detail
+
+Artifacts:
+
+- `cache-benchmark-raw`: raw benchmark rows in `cache-benchmark-results.json`
+- `cache-benchmark-summary`: rendered summary JSON in `cache-benchmark-summary.json`
+- `cache-benchmark-www`: static site bundle with `index.html` and `latest.json`
+
+Workflow dispatch inputs:
+
+- `scenario=all|soldr-cli|soldr-core`
+- `threshold_ratio=<float>`
+
+Scenarios from `benchmark.toml`:
 
 - `soldr-cli`: top-crate edit in `crates/soldr-cli/src/main.rs`
 - `soldr-core`: lower-crate edit in `crates/soldr-core/src/lib.rs`
-- `all`: runs both scenarios and writes both mutation summaries into the same top-level JSON artifact
 
-Recommended Phase 1 run:
+Recommended run:
 
 1. Dispatch `Cache Benchmark`.
-2. Leave `scenario=all`.
-3. Leave `threshold_ratio=10`.
-4. Open the `Phase 1 summary` job for the high-level percent deltas.
-5. Download the `cache-benchmark-summary` artifact if you need the raw wall times and cache-hit details.
-6. Download `cache-benchmark-www` if you want the static benchmark page bundle directly.
+2. Leave `scenario=all` unless you only need one mutation row set.
+3. Leave `threshold_ratio=10` unless you are intentionally tightening or loosening the warm-path gate.
+4. Open the workflow summary for the compact warm comparison table.
+5. Download `cache-benchmark-raw` for the full per-profile JSON rows.
+6. Download `cache-benchmark-www` if you want the rendered site bundle directly.

--- a/tests/test_cache_benchmark_report.py
+++ b/tests/test_cache_benchmark_report.py
@@ -9,53 +9,179 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "cache_benchmark_report.py"
+CONFIG_PATH = REPO_ROOT / "benchmark.toml"
+
+
+def _sample_results() -> list[dict[str, object]]:
+    return [
+        {
+            "competitor": "soldr",
+            "profile": "release",
+            "mutation": "soldr-cli",
+            "result": "success",
+            "cold_seconds": 76.2,
+            "warm_seconds": 1.4,
+            "saved_seconds": 74.8,
+            "speedup_ratio": 54.43,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=zccache;same_job_seed=true",
+        },
+        {
+            "competitor": "swatinem",
+            "profile": "release",
+            "mutation": "soldr-cli",
+            "result": "success",
+            "cold_seconds": 74.5,
+            "warm_seconds": 6.6,
+            "saved_seconds": 67.9,
+            "speedup_ratio": 11.29,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=swatinem;same_job_seed=true",
+        },
+        {
+            "competitor": "soldr",
+            "profile": "release",
+            "mutation": "soldr-core",
+            "result": "success",
+            "cold_seconds": 76.4,
+            "warm_seconds": 1.0,
+            "saved_seconds": 75.4,
+            "speedup_ratio": 76.4,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=zccache;same_job_seed=true",
+        },
+        {
+            "competitor": "swatinem",
+            "profile": "release",
+            "mutation": "soldr-core",
+            "result": "success",
+            "cold_seconds": 74.5,
+            "warm_seconds": 6.4,
+            "saved_seconds": 68.1,
+            "speedup_ratio": 11.64,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=swatinem;same_job_seed=true",
+        },
+        {
+            "competitor": "soldr",
+            "profile": "quick",
+            "mutation": "soldr-cli",
+            "result": "success",
+            "cold_seconds": 21.8,
+            "warm_seconds": 0.9,
+            "saved_seconds": 20.9,
+            "speedup_ratio": 24.22,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=zccache;same_job_seed=true",
+        },
+        {
+            "competitor": "swatinem",
+            "profile": "quick",
+            "mutation": "soldr-cli",
+            "result": "success",
+            "cold_seconds": 20.9,
+            "warm_seconds": 3.4,
+            "saved_seconds": 17.5,
+            "speedup_ratio": 6.15,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=swatinem;same_job_seed=true",
+        },
+        {
+            "competitor": "soldr",
+            "profile": "quick",
+            "mutation": "soldr-core",
+            "result": "success",
+            "cold_seconds": 22.1,
+            "warm_seconds": 0.8,
+            "saved_seconds": 21.3,
+            "speedup_ratio": 27.63,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=zccache;same_job_seed=true",
+        },
+        {
+            "competitor": "swatinem",
+            "profile": "quick",
+            "mutation": "soldr-core",
+            "result": "success",
+            "cold_seconds": 21.3,
+            "warm_seconds": 3.0,
+            "saved_seconds": 18.3,
+            "speedup_ratio": 7.1,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=swatinem;same_job_seed=true",
+        },
+        {
+            "competitor": "soldr",
+            "profile": "lint",
+            "mutation": "soldr-cli",
+            "result": "success",
+            "cold_seconds": 44.6,
+            "warm_seconds": 2.1,
+            "saved_seconds": 42.5,
+            "speedup_ratio": 21.24,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=zccache;same_job_seed=true",
+        },
+        {
+            "competitor": "swatinem",
+            "profile": "lint",
+            "mutation": "soldr-cli",
+            "result": "success",
+            "cold_seconds": 43.8,
+            "warm_seconds": 8.9,
+            "saved_seconds": 34.9,
+            "speedup_ratio": 4.92,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=swatinem;same_job_seed=true",
+        },
+        {
+            "competitor": "soldr",
+            "profile": "lint",
+            "mutation": "soldr-core",
+            "result": "success",
+            "cold_seconds": 45.0,
+            "warm_seconds": 1.9,
+            "saved_seconds": 43.1,
+            "speedup_ratio": 23.68,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=zccache;same_job_seed=true",
+        },
+        {
+            "competitor": "swatinem",
+            "profile": "lint",
+            "mutation": "soldr-core",
+            "result": "success",
+            "cold_seconds": 44.1,
+            "warm_seconds": 8.1,
+            "saved_seconds": 36.0,
+            "speedup_ratio": 5.44,
+            "cache_hit": True,
+            "cache_hit_detail": "backend=swatinem;same_job_seed=true",
+        },
+    ]
 
 
 def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
+    input_path = tmp_path / "cache-benchmark-results.json"
     json_path = tmp_path / "cache-benchmark-summary.json"
     summary_path = tmp_path / "step-summary.md"
     www_dir = tmp_path / "site"
+    input_path.write_text(
+        json.dumps({"results": _sample_results()}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
     env = os.environ.copy()
     env.update(
         {
             "SCENARIO": "all",
             "THRESHOLD_RATIO": "10",
+            "BENCHMARK_CONFIG_PATH": str(CONFIG_PATH),
             "BENCHMARK_COMMAND_TARGET": "x86_64-unknown-linux-gnu",
+            "BENCHMARK_INPUT_JSON": str(input_path),
             "BENCHMARK_SUMMARY_JSON": str(json_path),
             "BENCHMARK_SUMMARY_WWW_DIR": str(www_dir),
             "GITHUB_STEP_SUMMARY": str(summary_path),
-            "SWATINEM_CLI_RESULT": "success",
-            "SWATINEM_CLI_COLD": "78.70",
-            "SWATINEM_CLI_WARM": "6.11",
-            "SWATINEM_CLI_SAVED": "72.59",
-            "SWATINEM_CLI_RATIO": "12.88",
-            "SWATINEM_CLI_HIT": "true",
-            "SWATINEM_CLI_HIT_DETAIL": "backend=swatinem;exact_hit=true",
-            "SWATINEM_CORE_RESULT": "success",
-            "SWATINEM_CORE_COLD": "74.88",
-            "SWATINEM_CORE_WARM": "6.10",
-            "SWATINEM_CORE_SAVED": "68.78",
-            "SWATINEM_CORE_RATIO": "12.28",
-            "SWATINEM_CORE_HIT": "true",
-            "SWATINEM_CORE_HIT_DETAIL": "backend=swatinem;exact_hit=true",
-            "ZCCACHE_CLI_RESULT": "success",
-            "ZCCACHE_CLI_COLD": "74.55",
-            "ZCCACHE_CLI_WARM": "1.72",
-            "ZCCACHE_CLI_SAVED": "72.83",
-            "ZCCACHE_CLI_RATIO": "43.34",
-            "ZCCACHE_CLI_HIT": "true",
-            "ZCCACHE_CLI_HIT_DETAIL": (
-                "backend=zccache;compilation=true;target=true;registry=true"
-            ),
-            "ZCCACHE_CORE_RESULT": "success",
-            "ZCCACHE_CORE_COLD": "75.38",
-            "ZCCACHE_CORE_WARM": "1.46",
-            "ZCCACHE_CORE_SAVED": "73.92",
-            "ZCCACHE_CORE_RATIO": "51.63",
-            "ZCCACHE_CORE_HIT": "true",
-            "ZCCACHE_CORE_HIT_DETAIL": (
-                "backend=zccache;compilation=true;target=true;registry=true"
-            ),
         }
     )
 
@@ -63,40 +189,43 @@ def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
 
     report = json.loads(json_path.read_text(encoding="utf-8"))
     assert report["workflow"] == "cache-benchmark.yml"
+    assert report["config_path"] == "benchmark.toml"
     assert report["threshold_ratio"] == 10.0
-    assert (
-        report["benchmarked_command"]
-        == "soldr cargo build --package soldr-cli --release --locked --target x86_64-unknown-linux-gnu"
-    )
+    assert report["site"]["base_competitor"] == "swatinem"
+    assert len(report["profiles"]) == 3
+    assert len(report["comparisons"]) == 6
+    assert len(report["results"]) == 12
     assert any(
-        item["command"] == "soldr cargo fmt --all -- --check"
-        for item in report["command_reference"]
-    )
-    assert any(item["command"] == "soldr status --json" for item in report["command_reference"])
-    assert any(
-        item["command"]
-        == "soldr cargo clippy --workspace --all-targets --locked -- -D warnings"
-        for item in report["command_reference"]
+        profile["command"]
+        == "soldr cargo clippy --workspace --all-targets --locked --target x86_64-unknown-linux-gnu -- -D warnings"
+        for profile in report["profiles"]
     )
 
-    cli_mutation = next(
-        mutation for mutation in report["mutations"] if mutation["mutation"] == "soldr-cli"
+    quick_cli = next(
+        row
+        for row in report["comparisons"]
+        if row["profile"] == "quick" and row["mutation"] == "soldr-cli"
     )
-    assert cli_mutation["leader_backend"] == "zccache"
-    assert cli_mutation["leader_percent_less_wall_time_than_bare"] == 97.69
-    assert cli_mutation["leader_percent_less_wall_time_than_runner_up"] == 71.85
+    assert quick_cli["soldr_vs_base_warm_percent"] == 73.53
+    assert quick_cli["competitors"]["soldr"]["backend"] == "zccache"
+    assert quick_cli["competitors"]["soldr"]["competitor_label"] == "soldr"
+    assert quick_cli["competitors"]["swatinem"]["backend"] == "swatinem"
 
     summary = summary_path.read_text(encoding="utf-8")
-    assert "cache-benchmark-summary.json" in summary
-    assert "`soldr-cli`: `zccache` is best, `97.69%` less wall time than bare" in summary
+    assert "cache-benchmark-results.json" in summary
+    assert "| `Release build` | `Top-crate edit` | `1.40s` | `6.60s` | `78.79%` |" in summary
+    assert "| `Lint` | `Lower-crate edit` | `1.90s` | `8.10s` | `76.54%` |" in summary
 
     www_json = json.loads((www_dir / "latest.json").read_text(encoding="utf-8"))
-    assert www_json["workflow"] == "cache-benchmark.yml"
+    assert www_json["headline"].startswith("Across 6 configured comparisons")
     www_html = (www_dir / "index.html").read_text(encoding="utf-8")
     assert "<title>soldr rendered benchmarks</title>" in www_html
-    assert "<th>Command</th>" in www_html
-    assert "soldr cargo build --package soldr-cli --release --locked --target x86_64-unknown-linux-gnu" in www_html
-    assert "soldr status --json" in www_html
-    assert "soldr cargo fmt --all -- --check" in www_html
-    assert "soldr cargo clippy --workspace --all-targets --locked -- -D warnings" in www_html
+    assert "<th>Profile</th>" in www_html
+    assert "<th>soldr cold</th>" in www_html
+    assert "<th>swatinem warm</th>" in www_html
+    assert "<th>Result</th>" not in www_html
+    assert "soldr cargo check -p soldr-cli --locked --target x86_64-unknown-linux-gnu" in www_html
+    assert "soldr cargo clippy --workspace --all-targets --locked --target x86_64-unknown-linux-gnu -- -D warnings" in www_html
+    assert "soldr uses managed zccache internally." in www_html
+    assert "latest.json" in www_html
     assert (www_dir / ".nojekyll").exists()


### PR DESCRIPTION
Closes #136.

## Summary
- move benchmark presentation and command configuration into `benchmark.toml`
- rewrite the report generator to consume raw benchmark JSON and render compact `soldr` vs `swatinem` tables for release, quick, and lint profiles
- remove the public `Result` column and giant command-reference table while preserving detailed raw JSON artifacts
- update the benchmark workflow and docs to use the config-driven pipeline

## Verification
- `python -m pytest tests/test_cache_benchmark_report.py`
- `python -m compileall .github/scripts/cache_benchmark_report.py`
- parsed `.github/workflows/cache-benchmark.yml` with `yaml.safe_load(...)`

## Notes
- The GitHub Actions workflow itself was not executed locally.