### PR TITLE
Clarify current setup action docs and metadata

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -19,20 +19,20 @@ The same pattern applies to `cargo test`, `cargo check`, and similar Cargo invoc
 
 ## GitHub Actions
 
-This repository now ships a root GitHub Action for Soldr setup. The preferred GitHub Actions path is:
+This repository currently ships an in-repo root GitHub Action for Soldr setup. The current GitHub Actions path is:
 
 1. use `zackees/soldr@<ref>` or `uses: ./` in the same repository
-2. let the action provision the Rust toolchain and restore the Soldr/Cargo/rustup cache root
+2. let the action provision the Rust toolchain through `rustup` and restore the Soldr/Cargo/rustup cache root
 3. run `soldr cargo ...`
 
-When stable action tags exist, prefer a major tag such as `@v1`. Until then, pin a full commit SHA or an explicit release tag.
+The stable-major public setup action product is not shipped yet. Today, pin the current in-repo action by full commit SHA or explicit release tag; do not assume a public `@v1` contract yet.
 
 ### Preferred setup action path
 
 The root action:
 
 - installs one `soldr` binary
-- preinstalls the exact Rust toolchain resolved from `rust-toolchain.toml` or `toolchain:`
+- preinstalls the exact Rust toolchain resolved from `rust-toolchain.toml` or `toolchain:` via `rustup`
 - sets `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME`
 - restores and saves that runner-local root through GitHub cache when `cache: true`
 
@@ -40,7 +40,8 @@ Important toolchain rule:
 
 - if your repository already pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact channel with `toolchain:`
 - do not preinstall a different generic toolchain such as `stable` and assume a later `soldr cargo ...` step will reconcile it
-- the action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo` and `rustc` calls keep using the preinstalled toolchain instead of asking rustup to resolve it on demand
+- the action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo` and `rustc` calls keep using the preinstalled toolchain instead of asking `rustup` to resolve it on demand
+- on GitHub-hosted runners, no separate toolchain setup action is usually needed for this path, but `rustup` is still the implementation dependency today; self-hosted runners must provide it
 
 Example:
 
@@ -231,8 +232,9 @@ On Windows PowerShell:
 
 When updating a workflow for `soldr`, do this:
 
-1. Keep the existing Rust toolchain setup.
-2. Install `soldr` or build `soldr` from source.
-3. Replace each `cargo ...` build/test/check command with `soldr cargo ...`.
-4. Do not add manual `RUSTC_WRAPPER` wiring unless the workflow explicitly needs wrapper-mode testing.
-5. Use the local source-build path when you need the most reliable cross-environment fallback.
+1. If you use the current root action on GitHub-hosted runners, do not add a separate toolchain setup action just for the normal path.
+2. If you are not using the root action, keep or add explicit Rust toolchain setup yourself.
+3. Install `soldr` or build `soldr` from source.
+4. Replace each `cargo ...` build/test/check command with `soldr cargo ...`.
+5. Do not add manual `RUSTC_WRAPPER` wiring unless the workflow explicitly needs wrapper-mode testing.
+6. Use the local source-build path when you need the most reliable cross-environment fallback.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Current release line:
 
 ## GitHub Actions setup
 
-The preferred CI path is the repository root action:
+The current GitHub Actions entry point is the repository root action in this repository:
 
 ```yaml
 - uses: zackees/soldr@<ref>
@@ -59,13 +59,15 @@ The preferred CI path is the repository root action:
 That action:
 
 - installs `soldr`
-- preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default
+- preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
 - puts `soldr` on `PATH` for later steps
 
-If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later. The action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the toolchain it just installed instead of asking rustup to resolve a pinned file lazily.
+If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later. The action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the toolchain it just installed instead of asking `rustup` to resolve a pinned file lazily.
 
-For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
+On GitHub-hosted runners, this means you usually do not need a separate toolchain setup action for the normal path. That does not mean `rustup` has been removed from the stack: this action still uses `rustup` under the hood today, and self-hosted runners must provide it.
+
+For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). The separate stable-major public action product is not shipped yet, so treat `zackees/soldr@<ref>` as the current contract and pin a full commit SHA or explicit release tag instead of assuming `@v1`. For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
 
 ## Why soldr exists
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: setup-soldr
-description: Install soldr, preinstall the resolved Rust toolchain, and restore a cacheable runner-local Soldr root.
+description: Current in-repo Soldr setup action. Installs soldr, provisions the resolved Rust toolchain via rustup, and restores a cacheable runner-local Soldr root.
 inputs:
   version:
     description: Soldr version or tag to install. Defaults to the latest release.
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: "true"
   cache-dir:
-    description: Override the runner-local cache root used for Soldr, Cargo, and rustup state.
+    description: Override the runner-local cache root used for Soldr, Cargo, and rustup state rehydrated by this action.
     required: false
     default: ""
   cache-key-suffix:
@@ -47,7 +47,7 @@ outputs:
     description: Whether the action restored an exact setup cache hit.
     value: ${{ steps.cache-meta.outputs.cache_hit }}
   toolchain:
-    description: Exact Rust toolchain channel configured by the action.
+    description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
 runs:
   using: composite


### PR DESCRIPTION
﻿## Summary
- clarify that the current GitHub Actions contract is the root in-repo action in `zackees/soldr`
- stop implying that a stable-major public setup action product such as `@v1` is already shipped
- make the current `rustup` implementation dependency explicit in docs and action metadata

## Why
This keeps the published contract accurate relative to #137 and #139:
- #137 tracks the future public setup action product with stable major tags
- #139 tracks removing the remaining runtime dependency on `rustup`

## Verification
- `git diff --check`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('action.yml').read_text(encoding='utf-8'))"`
