### PR TITLE
Append CI guidance to rustup tool resolution failures

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -590,10 +590,7 @@ fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError
     let output = command.output()?;
 
     if !output.status.success() {
-        return Err(SoldrError::Other(format!(
-            "failed to resolve {tool} via rustup: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
+        return Err(rustup_resolution_failure(tool, &output.stderr));
     }
 
     let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -609,6 +606,15 @@ fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError
 fn apply_implicit_toolchain_homes(command: &mut std::process::Command) {
     let start_dir = std::env::current_dir().ok();
     soldr_core::apply_implicit_toolchain_homes(command, start_dir.as_deref());
+}
+
+fn rustup_resolution_failure(tool: &str, stderr: &[u8]) -> SoldrError {
+    let raw_failure = String::from_utf8_lossy(stderr).trim().to_string();
+    SoldrError::Other(format!(
+        "failed to resolve {tool} via rustup: {raw_failure}\n\
+CI hint: if this repository pins Rust in rust-toolchain.toml, preinstall that exact channel instead of a generic stable toolchain.\n\
+CI hint: export RUSTUP_TOOLCHAIN to that exact channel for later cargo, rustc, and soldr cargo steps, or use the documented setup-soldr action path (uses: zackees/soldr@<ref> or uses: ./)."
+    ))
 }
 
 fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
@@ -1002,7 +1008,8 @@ mod tests {
     use super::{
         cargo_args_specify_target, cargo_args_use_reserved_no_cache, extract_as_pin,
         first_cargo_subcommand, normalize_version, parse_tool_spec,
-        rustc_wrapper_mode_from_env_var, should_trampoline, RustcWrapperMode,
+        rustc_wrapper_mode_from_env_var, rustup_resolution_failure, should_trampoline,
+        RustcWrapperMode,
     };
     use soldr_fetch::VersionSpec;
     use std::ffi::OsStr;
@@ -1230,5 +1237,20 @@ mod tests {
             env!("CARGO_PKG_VERSION")
         )));
         assert!(should_trampoline("0.0.0-not-this-version"));
+    }
+
+    #[test]
+    fn rustup_resolution_failure_appends_ci_guidance() {
+        let error = rustup_resolution_failure(
+            "rustc",
+            b"error: toolchain '1.94.1-x86_64-pc-windows-msvc' is not installed",
+        );
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("failed to resolve rustc via rustup: error: toolchain '1.94.1-x86_64-pc-windows-msvc' is not installed"));
+        assert!(rendered.contains("pins Rust in rust-toolchain.toml"));
+        assert!(rendered.contains("generic stable toolchain"));
+        assert!(rendered.contains("RUSTUP_TOOLCHAIN"));
+        assert!(rendered.contains("setup-soldr action path"));
     }
 }

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -839,6 +839,48 @@ fn explicit_toolchain_home_env_vars_win_over_repo_local_homes() {
 }
 
 #[test]
+fn rustup_resolution_failure_reports_raw_error_and_ci_guidance() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["rustc", "--version"])
+        .env("RUSTUP_TOOLCHAIN", "soldr-ci-missing-toolchain")
+        .output()
+        .expect("failed to run soldr rustc --version with invalid RUSTUP_TOOLCHAIN");
+
+    assert!(
+        !output.status.success(),
+        "expected soldr rustc --version to fail when rustup resolution fails"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to resolve rustc via rustup: error: override toolchain 'soldr-ci-missing-toolchain' is not installed"),
+        "expected raw rustup stderr to be preserved: {stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "the RUSTUP_TOOLCHAIN environment variable specifies an uninstalled toolchain"
+        ),
+        "expected raw rustup explanation in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("pins Rust in rust-toolchain.toml"),
+        "expected rust-toolchain.toml guidance in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("generic stable toolchain"),
+        "expected exact-channel guidance in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("RUSTUP_TOOLCHAIN"),
+        "expected RUSTUP_TOOLCHAIN guidance in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("setup-soldr action path"),
+        "expected setup-soldr guidance in stderr: {stderr}"
+    );
+}
+
+#[test]
 fn status_reports_cache_control_defaults() {
     let cache_root = unique_temp_dir("status");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))


### PR DESCRIPTION
﻿Closes #140.

## Summary
- preserve the raw `rustup which` failure text when toolchain passthrough resolution fails
- append actionable CI guidance for repositories pinned via `rust-toolchain.toml`
- point users to the exact-channel preinstall path, `RUSTUP_TOOLCHAIN`, and the documented `setup-soldr` action flow

## Verification
- `cargo test -p soldr-cli rustup_resolution_failure`
