### PR TITLE
ci: restore phase 1 cache benchmark workflow

### DIFF
--- a/.github/workflows/_cache-benchmark-build.yml
+++ b/.github/workflows/_cache-benchmark-build.yml
@@ -31,10 +31,17 @@ on:
         required: false
         type: boolean
         default: true
+      upload_name:
+        required: false
+        type: string
+        default: ""
     outputs:
       wall_seconds:
         description: Wall-clock seconds for the cargo build step.
         value: ${{ jobs.build.outputs.wall_seconds }}
+      timing_report:
+        description: Relative path to the latest cargo timing report.
+        value: ${{ jobs.build.outputs.timing_report }}
       cache_hit:
         description: Whether the cache backend restored an exact cache hit relevant to the benchmark.
         value: ${{ jobs.build.outputs.cache_hit }}
@@ -50,6 +57,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     outputs:
       wall_seconds: ${{ steps.measure.outputs.wall_seconds }}
+      timing_report: ${{ steps.measure.outputs.timing_report }}
       cache_hit: ${{ steps.cache_hit.outputs.value }}
       cache_hit_detail: ${{ steps.cache_hit.outputs.detail }}
 
@@ -115,6 +123,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY'
+          import pathlib
           import os
           import subprocess
           import time
@@ -131,18 +140,33 @@ jobs:
                   "--locked",
                   "--target",
                   target,
+                  "--timings",
               ],
               check=True,
           )
           elapsed = time.perf_counter() - start
+          timing_reports = sorted(
+              pathlib.Path("target/cargo-timings").glob("cargo-timing*.html"),
+              key=lambda path: path.stat().st_mtime,
+          )
+          timing_report = timing_reports[-1].as_posix() if timing_reports else ""
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
               fh.write(f"wall_seconds={elapsed:.2f}\n")
+              fh.write(f"timing_report={timing_report}\n")
           PY
 
       - name: Cleanup zccache
         if: ${{ always() && inputs.cache_backend == 'zccache' }}
         uses: ./.github/actions/cache-benchmark-zccache-cleanup
+
+      - name: Upload cargo timing artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ inputs.upload_name != '' && inputs.upload_name || format('cache-benchmark-{0}-{1}-{2}-timings', inputs.cache_backend, inputs.mutation, inputs.save_cache && 'seed' || (inputs.cache_backend == 'none' && 'cold' || 'warm')) }}
+          path: target/cargo-timings
+          if-no-files-found: warn
 
       - name: Compute cache-hit summary
         id: cache_hit
@@ -192,6 +216,9 @@ jobs:
             echo "- mutation: \`${{ inputs.mutation }}\`"
             if [ -n "${{ steps.measure.outputs.wall_seconds }}" ]; then
               echo "- wall seconds: \`${{ steps.measure.outputs.wall_seconds }}\`"
+            fi
+            if [ -n "${{ steps.measure.outputs.timing_report }}" ]; then
+              echo "- timing report: \`${{ steps.measure.outputs.timing_report }}\`"
             fi
             echo "- timing scope: \`cargo build --package soldr-cli --release --locked --target ${{ inputs.target }}\` only"
             echo "- measurement source: \`time.perf_counter()\` around the cargo subprocess"

--- a/.github/workflows/_cache-benchmark-scenario.yml
+++ b/.github/workflows/_cache-benchmark-scenario.yml
@@ -59,6 +59,7 @@ jobs:
       cache_shared_key: benchmark-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.cache_backend }}-${{ inputs.mutation }}
       mutation: none
       save_cache: true
+      upload_name: cache-benchmark-${{ inputs.cache_backend }}-${{ inputs.mutation }}-seed-timings
 
   cold-control:
     name: Cold control
@@ -71,6 +72,7 @@ jobs:
       cache_shared_key: ""
       mutation: ${{ inputs.mutation }}
       save_cache: false
+      upload_name: cache-benchmark-none-${{ inputs.mutation }}-cold-timings
 
   warm-cache:
     name: Warm cache
@@ -84,6 +86,7 @@ jobs:
       cache_shared_key: benchmark-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.cache_backend }}-${{ inputs.mutation }}
       mutation: ${{ inputs.mutation }}
       save_cache: false
+      upload_name: cache-benchmark-${{ inputs.cache_backend }}-${{ inputs.mutation }}-warm-timings
 
   compare:
     name: Compare warm vs cold

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -1,15 +1,18 @@
 name: Cache Benchmark
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "*.md"
   workflow_dispatch:
     inputs:
+      cache_backend:
+        description: Cache action under test.
+        required: true
+        type: choice
+        default: swatinem
+        options:
+          - swatinem
+          - zccache
       scenario:
-        description: Which mutation scenario set to run.
+        description: Which Phase 1 scenario set to run.
         required: true
         type: choice
         default: all
@@ -27,301 +30,147 @@ permissions:
   contents: read
 
 jobs:
-  benchmark:
-    name: Config-driven benchmark
+  soldr-cli:
+    if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-cli' }}
+    name: Top-crate edit
+    uses: ./.github/workflows/_cache-benchmark-scenario.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-gnu
+      source_ref: ${{ github.sha }}
+      cache_backend: ${{ inputs.cache_backend }}
+      mutation: soldr-cli
+      threshold_ratio: ${{ inputs.threshold_ratio }}
+
+  soldr-core:
+    if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-core' }}
+    name: Lower-crate edit
+    uses: ./.github/workflows/_cache-benchmark-scenario.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-gnu
+      source_ref: ${{ github.sha }}
+      cache_backend: ${{ inputs.cache_backend }}
+      mutation: soldr-core
+      threshold_ratio: ${{ inputs.threshold_ratio }}
+
+  summary:
+    if: ${{ always() }}
+    name: Phase 1 summary
+    needs:
+      - soldr-cli
+      - soldr-core
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Resolve benchmark config
-        id: config
-        shell: bash
-        env:
-          BENCHMARK_CONFIG_PATH: benchmark.toml
-          INPUT_THRESHOLD_RATIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.threshold_ratio || '' }}
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import os
-          import tomllib
-          from pathlib import Path
-
-          config = tomllib.loads(Path(os.environ["BENCHMARK_CONFIG_PATH"]).read_text(encoding="utf-8"))
-          target = config["site"].get("default_target", "x86_64-unknown-linux-gnu")
-          threshold = os.environ["INPUT_THRESHOLD_RATIO"] or str(
-              config["site"].get("default_threshold_ratio", 10.0)
-          )
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-              fh.write(f"target={target}\n")
-              fh.write(f"threshold_ratio={threshold}\n")
-          PY
-
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
-        with:
-          components: clippy
-          targets: ${{ steps.config.outputs.target }}
-
-      - name: Prepare zccache tool
-        uses: ./.github/actions/cache-benchmark-zccache
-        with:
-          cache-cargo-registry: "false"
-          cache-compilation: "false"
-          cache-target: "false"
-          save-cache: "false"
-
-      - name: Run configured benchmarks
-        shell: bash
-        env:
-          BENCHMARK_COMMAND_TARGET: ${{ steps.config.outputs.target }}
-          BENCHMARK_CONFIG_PATH: benchmark.toml
-          BENCHMARK_RESULTS_JSON: benchmark-summary/cache-benchmark-results.json
-          SCENARIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scenario || 'all' }}
-          THRESHOLD_RATIO: ${{ steps.config.outputs.threshold_ratio }}
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import os
-          import shutil
-          import subprocess
-          import time
-          import tomllib
-          from pathlib import Path
-
-          class SafeFormatDict(dict):
-              def __missing__(self, key):
-                  return "{" + key + "}"
-
-
-          repo_root = Path.cwd()
-          config = tomllib.loads(Path(os.environ["BENCHMARK_CONFIG_PATH"]).read_text(encoding="utf-8"))
-          target = os.environ["BENCHMARK_COMMAND_TARGET"]
-          threshold = float(os.environ["THRESHOLD_RATIO"])
-          scenario = os.environ["SCENARIO"]
-          output_path = Path(os.environ["BENCHMARK_RESULTS_JSON"])
-
-          selected_mutations = [
-              mutation
-              for mutation in config["mutations"]
-              if scenario == "all" or mutation["id"] == scenario
-          ]
-          competitors = [
-              {"id": competitor_id, **competitor}
-              for competitor_id, competitor in config["competitors"].items()
-              if competitor.get("show", True)
-          ]
-          profiles = list(config["profiles"])
-
-          def render_parts(parts):
-              return [part.format_map(SafeFormatDict(target=target)) for part in parts]
-
-          def clean_workspace():
-              subprocess.run(
-                  ["git", "reset", "--hard", "HEAD"],
-                  cwd=repo_root,
-                  check=True,
-                  stdout=subprocess.DEVNULL,
-                  stderr=subprocess.DEVNULL,
-              )
-              subprocess.run(
-                  ["git", "clean", "-fdx"],
-                  cwd=repo_root,
-                  check=True,
-                  stdout=subprocess.DEVNULL,
-                  stderr=subprocess.DEVNULL,
-              )
-
-          def reset_backend(backend):
-              if backend == "zccache":
-                  subprocess.run(["zccache", "stop"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                  shutil.rmtree(Path.home() / ".zccache", ignore_errors=True)
-              subprocess.run(["cargo", "clean"], cwd=repo_root, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-
-          def apply_mutation(mutation):
-              mutation_path = repo_root / mutation["path"]
-              with mutation_path.open("a", encoding="utf-8") as handle:
-                  handle.write(f"\n// cache benchmark mutation: {mutation['id']}\n")
-
-          def run_cargo(profile, backend):
-              command = ["cargo", *render_parts(profile["cargo_args"])]
-              env = os.environ.copy()
-              env["CARGO_TERM_COLOR"] = "never"
-              env.pop("RUSTC_WRAPPER", None)
-              if backend == "zccache":
-                  subprocess.run(["zccache", "start"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                  env["RUSTC_WRAPPER"] = "zccache"
-              start = time.perf_counter()
-              subprocess.run(command, cwd=repo_root, env=env, check=True)
-              return time.perf_counter() - start
-
-          results = []
-          failures = []
-          output_path.parent.mkdir(parents=True, exist_ok=True)
-
-          for mutation in selected_mutations:
-              for profile in profiles:
-                  for competitor in competitors:
-                      backend = competitor["backend"]
-                      result = {
-                          "competitor": competitor["id"],
-                          "profile": profile["id"],
-                          "mutation": mutation["id"],
-                          "result": "success",
-                          "cold_seconds": None,
-                          "warm_seconds": None,
-                          "saved_seconds": None,
-                          "speedup_ratio": None,
-                          "cache_hit": False,
-                          "cache_hit_detail": f"backend={backend};same_job_seed=true",
-                          "threshold_failed": False,
-                      }
-
-                      try:
-                          clean_workspace()
-                          reset_backend("none")
-                          apply_mutation(mutation)
-                          cold_seconds = run_cargo(profile, "none")
-
-                          clean_workspace()
-                          reset_backend(backend)
-                          run_cargo(profile, backend)
-                          apply_mutation(mutation)
-                          warm_seconds = run_cargo(profile, backend)
-                      except subprocess.CalledProcessError as exc:
-                          result["result"] = "failure"
-                          result["cache_hit_detail"] = (
-                              f"backend={backend};same_job_seed=true;returncode={exc.returncode}"
-                          )
-                          failures.append(
-                              f"{profile['id']}/{mutation['id']}/{competitor['id']} failed with exit code {exc.returncode}"
-                          )
-                      else:
-                          speedup_ratio = cold_seconds / warm_seconds if warm_seconds else float("inf")
-                          result["cold_seconds"] = round(cold_seconds, 2)
-                          result["warm_seconds"] = round(warm_seconds, 2)
-                          result["saved_seconds"] = round(cold_seconds - warm_seconds, 2)
-                          result["speedup_ratio"] = round(speedup_ratio, 2)
-                          result["cache_hit"] = warm_seconds < cold_seconds
-                          result["threshold_failed"] = speedup_ratio < threshold
-                          if result["threshold_failed"]:
-                              failures.append(
-                                  f"{profile['id']}/{mutation['id']}/{competitor['id']} observed {speedup_ratio:.2f}x, required {threshold:.2f}x"
-                              )
-
-                      results.append(result)
-
-          output_path.write_text(
-              json.dumps(
-                  {
-                      "threshold_ratio": threshold,
-                      "scenario": scenario,
-                      "results": results,
-                  },
-                  indent=2,
-              )
-              + "\n",
-              encoding="utf-8",
-          )
-
-          if failures:
-              print("Benchmark threshold or command failures detected:")
-              for failure in failures:
-                  print(f"- {failure}")
-          PY
-
       - name: Write benchmark summary
         shell: bash
         env:
-          BENCHMARK_COMMAND_TARGET: ${{ steps.config.outputs.target }}
-          BENCHMARK_CONFIG_PATH: benchmark.toml
-          BENCHMARK_INPUT_JSON: benchmark-summary/cache-benchmark-results.json
-          BENCHMARK_SUMMARY_JSON: benchmark-summary/cache-benchmark-summary.json
-          BENCHMARK_SUMMARY_WWW_DIR: benchmark-summary/site
-          SCENARIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scenario || 'all' }}
-          THRESHOLD_RATIO: ${{ steps.config.outputs.threshold_ratio }}
-        run: |
-          set -euo pipefail
-          python3 .github/scripts/cache_benchmark_report.py
-
-      - name: Enforce configured thresholds
-        shell: bash
-        env:
-          BENCHMARK_RESULTS_JSON: benchmark-summary/cache-benchmark-results.json
+          CACHE_BACKEND: ${{ inputs.cache_backend }}
+          SCENARIO: ${{ inputs.scenario }}
+          THRESHOLD_RATIO: ${{ inputs.threshold_ratio }}
+          SOLDR_CLI_RESULT: ${{ needs.soldr-cli.result }}
+          SOLDR_CLI_COLD: ${{ needs.soldr-cli.outputs.cold_seconds }}
+          SOLDR_CLI_WARM: ${{ needs.soldr-cli.outputs.warm_seconds }}
+          SOLDR_CLI_SAVED: ${{ needs.soldr-cli.outputs.saved_seconds }}
+          SOLDR_CLI_RATIO: ${{ needs.soldr-cli.outputs.speedup_ratio }}
+          SOLDR_CLI_HIT: ${{ needs.soldr-cli.outputs.cache_hit }}
+          SOLDR_CLI_HIT_DETAIL: ${{ needs.soldr-cli.outputs.cache_hit_detail }}
+          SOLDR_CORE_RESULT: ${{ needs.soldr-core.result }}
+          SOLDR_CORE_COLD: ${{ needs.soldr-core.outputs.cold_seconds }}
+          SOLDR_CORE_WARM: ${{ needs.soldr-core.outputs.warm_seconds }}
+          SOLDR_CORE_SAVED: ${{ needs.soldr-core.outputs.saved_seconds }}
+          SOLDR_CORE_RATIO: ${{ needs.soldr-core.outputs.speedup_ratio }}
+          SOLDR_CORE_HIT: ${{ needs.soldr-core.outputs.cache_hit }}
+          SOLDR_CORE_HIT_DETAIL: ${{ needs.soldr-core.outputs.cache_hit_detail }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
-          import json
           import os
-          import sys
-          from pathlib import Path
 
-          payload = json.loads(Path(os.environ["BENCHMARK_RESULTS_JSON"]).read_text(encoding="utf-8"))
-          failures = []
-          for result in payload["results"]:
-              slug = f"{result['profile']}/{result['mutation']}/{result['competitor']}"
-              if result["result"] != "success":
-                  failures.append(f"{slug} failed")
+          scenarios = [
+              (
+                  "soldr-cli",
+                  "top-crate edit (`crates/soldr-cli/src/main.rs`)",
+                  os.environ["SOLDR_CLI_RESULT"],
+                  os.environ["SOLDR_CLI_COLD"],
+                  os.environ["SOLDR_CLI_WARM"],
+                  os.environ["SOLDR_CLI_SAVED"],
+                  os.environ["SOLDR_CLI_RATIO"],
+                  os.environ["SOLDR_CLI_HIT"],
+                  os.environ["SOLDR_CLI_HIT_DETAIL"],
+              ),
+              (
+                  "soldr-core",
+                  "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
+                  os.environ["SOLDR_CORE_RESULT"],
+                  os.environ["SOLDR_CORE_COLD"],
+                  os.environ["SOLDR_CORE_WARM"],
+                  os.environ["SOLDR_CORE_SAVED"],
+                  os.environ["SOLDR_CORE_RATIO"],
+                  os.environ["SOLDR_CORE_HIT"],
+                  os.environ["SOLDR_CORE_HIT_DETAIL"],
+              ),
+          ]
+
+          workflow_summary = [
+              "### Cache Benchmark Summary",
+              "",
+              f"- cache backend: `{os.environ['CACHE_BACKEND']}`",
+              f"- requested scenario: `{os.environ['SCENARIO']}`",
+              f"- required ratio: `{float(os.environ['THRESHOLD_RATIO']):.2f}x`",
+              "- runner: `ubuntu-24.04`",
+              "- target: `x86_64-unknown-linux-gnu`",
+              "- measured command: `cargo build --package soldr-cli --release --locked --target x86_64-unknown-linux-gnu --timings`",
+              "",
+          ]
+          issue_comment = [
+              "### Phase 1 benchmark results",
+              "",
+              f"- workflow: `cache-benchmark.yml`",
+              f"- cache backend under test: `{os.environ['CACHE_BACKEND']}`",
+              f"- threshold used: `{float(os.environ['THRESHOLD_RATIO']):.2f}x`",
+              f"- runner: `ubuntu-24.04`",
+              f"- target: `x86_64-unknown-linux-gnu`",
+              "",
+          ]
+
+          for key, label, result, cold, warm, saved, ratio, cache_hit, hit_detail in scenarios:
+              if result == "skipped":
                   continue
-              if result["threshold_failed"]:
-                  failures.append(f"{slug} missed the configured speedup threshold")
 
-          if failures:
-              sys.exit("\n".join(failures))
+              workflow_summary.extend(
+                  [
+                      f"#### {label}",
+                      "",
+                      f"- job result: `{result}`",
+                      f"- cold wall seconds: `{cold}`",
+                      f"- warm wall seconds: `{warm}`",
+                      f"- seconds saved: `{saved}`",
+                      f"- speedup ratio: `{ratio}x`",
+                      f"- warm cache hit: `{cache_hit}`",
+                      f"- warm cache hit detail: `{hit_detail}`",
+                      "",
+                  ]
+              )
+              issue_comment.extend(
+                  [
+                      f"- {label}: cold `{cold}s`, warm `{warm}s`, saved `{saved}s`, speedup `{ratio}x`, cache hit `{cache_hit}`",
+                      f"  cache detail: `{hit_detail}`",
+                  ]
+              )
+
+          issue_comment.extend(
+              [
+                  "",
+                  "Timing artifacts are attached for each seed, cold, and warm child job as `cache-benchmark-<backend>-<mutation>-<stage>-timings`.",
+              ]
+          )
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+              fh.write("\n".join(workflow_summary) + "\n\n")
+              fh.write("### Issue Comment Draft\n\n")
+              fh.write("```markdown\n")
+              fh.write("\n".join(issue_comment) + "\n")
+              fh.write("```\n")
           PY
-
-      - name: Cleanup zccache
-        if: ${{ always() }}
-        uses: ./.github/actions/cache-benchmark-zccache-cleanup
-
-      - name: Upload raw benchmark artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: cache-benchmark-raw
-          path: benchmark-summary/cache-benchmark-results.json
-          if-no-files-found: error
-
-      - name: Upload benchmark summary artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: cache-benchmark-summary
-          path: benchmark-summary/cache-benchmark-summary.json
-          if-no-files-found: error
-
-      - name: Upload benchmark www artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: cache-benchmark-www
-          path: benchmark-summary/site
-          if-no-files-found: error
-
-      - name: Configure GitHub Pages
-        if: ${{ success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-
-      - name: Upload GitHub Pages artifact
-        if: ${{ success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
-        with:
-          path: benchmark-summary/site
-
-  deploy-pages:
-    if: ${{ always() && needs.benchmark.result == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-    name: Deploy benchmark site
-    needs:
-      - benchmark
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/docs/CI_CACHE_PHASE1.md
+++ b/docs/CI_CACHE_PHASE1.md
@@ -1,48 +1,24 @@
 # CI Cache Phase 1 Benchmark
 
-Issue [#136](https://github.com/zackees/soldr/issues/136) moves the benchmark report away from hardcoded scenarios and the oversized command-reference page.
+Issue [#122](https://github.com/zackees/soldr/issues/122) requires Linux x64 baseline measurements on GitHub-hosted runners before any broader CI cache work advances.
 
-The benchmark pipeline is now driven by [`benchmark.toml`](../benchmark.toml):
+Use `.github/workflows/cache-benchmark.yml` for that Phase 1 measurement. The workflow dispatch:
 
-- competitors and their internal backend mapping live in the TOML file
-- benchmark profiles live in the TOML file
-- mutation scenarios live in the TOML file
-- the rendered page labels come from the same config
-
-`Cache Benchmark` reads that config and currently benchmarks three profile families on Linux x64:
-
-- `release`: `soldr cargo build --package soldr-cli --release --locked --target <target>`
-- `quick`: `soldr cargo check -p soldr-cli --locked --target <target>`
-- `lint`: `soldr cargo clippy --workspace --all-targets --locked --target <target> -- -D warnings`
-
-For each selected mutation and visible competitor, the workflow:
-
-- runs one cold control build without the cache backend
-- runs one seed build for the configured backend
-- applies the mutation and measures the warm build
-- writes raw per-run metrics into `cache-benchmark-results.json`
-- renders `cache-benchmark-summary.json` and the website bundle from the same TOML config
-
-Presentation changes from the previous version:
-
-- the public page now compares `soldr` vs `swatinem`
-- the wide `Result` column is gone
-- the giant command-reference table is gone
-- the page instead shows one compact comparison table plus a short benchmarked-command list
-- the page links to `latest.json` for raw detail
-
-Artifacts:
-
-- `cache-benchmark-raw`: raw benchmark rows in `cache-benchmark-results.json`
-- `cache-benchmark-summary`: rendered summary JSON in `cache-benchmark-summary.json`
-- `cache-benchmark-www`: static site bundle with `index.html` and `latest.json`
+- runs on `ubuntu-24.04` with target `x86_64-unknown-linux-gnu`
+- calls the reusable scenario workflow for each selected mutation
+- lets each scenario run three reusable child builds: seed, cold, and warm
+- measures `cargo build --package soldr-cli --release --locked --target x86_64-unknown-linux-gnu --timings`
+- fails unless the warm path is at least the configured ratio faster than the cold control
+- writes an issue-comment-ready summary into the workflow summary
+- uploads each measured build's `target/cargo-timings` bundle as an artifact
 
 Workflow dispatch inputs:
 
+- `cache_backend=swatinem|zccache`
 - `scenario=all|soldr-cli|soldr-core`
 - `threshold_ratio=<float>`
 
-Scenarios from `benchmark.toml`:
+Scenarios:
 
 - `soldr-cli`: top-crate edit in `crates/soldr-cli/src/main.rs`
 - `soldr-core`: lower-crate edit in `crates/soldr-core/src/lib.rs`
@@ -50,8 +26,8 @@ Scenarios from `benchmark.toml`:
 Recommended run:
 
 1. Dispatch `Cache Benchmark`.
-2. Leave `scenario=all` unless you only need one mutation row set.
-3. Leave `threshold_ratio=10` unless you are intentionally tightening or loosening the warm-path gate.
-4. Open the workflow summary for the compact warm comparison table.
-5. Download `cache-benchmark-raw` for the full per-profile JSON rows.
-6. Download `cache-benchmark-www` if you want the rendered site bundle directly.
+2. Leave `cache_backend=swatinem` for the Phase 1 baseline.
+3. Leave `scenario=all` unless you only need one mutation case.
+4. Leave `threshold_ratio=10` unless you are intentionally tightening or loosening the gate.
+5. Open the workflow summary and copy the `Issue Comment Draft` block into issue `#122`.
+6. Download any `cache-benchmark-<backend>-<mutation>-<stage>-timings` artifact you want to inspect. Each one contains the `cargo build --timings` output from that child job.


### PR DESCRIPTION
﻿Advances #122.

## Summary
- switch `Cache Benchmark` back to a Phase 1 manual workflow that orchestrates the reusable scenario/build benchmark jobs
- make each measured child build run `cargo build --timings` and upload the `target/cargo-timings` bundle
- update the Phase 1 doc and workflow summary wording to match the current tracker flow

## Notes
- keeps #103 runtime CI behavior untouched; this only changes the benchmark workflow path
- adds explicit timing artifact names so `scenario=all` does not collide across seed, cold, and warm uploads

## Verification
- parsed workflow YAML locally with `yaml.safe_load`
- `git diff --check`
- did not run the GitHub Actions workflow end-to-end locally
