### PR TITLE
ci: migrate bootstrap e2e cache to zccache

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -89,7 +89,7 @@ jobs:
           done
           dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
-      - uses: ./.github/actions/cache-benchmark-zccache
+      - uses: ./soldr/.github/actions/cache-benchmark-zccache
         with:
           shared-key: ${{ inputs.target }}
           target-dir: soldr/target
@@ -150,4 +150,4 @@ jobs:
           path: ${{ steps.soldr_binary.outputs.path }}
 
       - if: ${{ always() }}
-        uses: ./.github/actions/cache-benchmark-zccache-cleanup
+        uses: ./soldr/.github/actions/cache-benchmark-zccache-cleanup

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -89,11 +89,10 @@ jobs:
           done
           dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: ./.github/actions/cache-benchmark-zccache
         with:
-          workspaces: |
-            soldr -> target
-            ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }} -> target
+          shared-key: ${{ inputs.target }}
+          target-dir: soldr/target
 
       - name: Build soldr-cli
         shell: pwsh
@@ -149,3 +148,6 @@ jobs:
         with:
           name: soldr-${{ inputs.target }}
           path: ${{ steps.soldr_binary.outputs.path }}
+
+      - if: ${{ always() }}
+        uses: ./.github/actions/cache-benchmark-zccache-cleanup


### PR DESCRIPTION
﻿Closes #103.

## Summary
- replace `_bootstrap-e2e.yml`'s `Swatinem/rust-cache` step with pinned `zackees/zccache`
- wire the required `shared-key: ${{ inputs.target }}`
- add the required zccache cleanup step with `if: always()`
- set `target-dir: soldr/target` so the metadata cache matches the soldr checkout path

## Validation
- `git diff --check`
- parsed `.github/workflows/_bootstrap-e2e.yml` with `PyYAML`

## Notes
- follows issue #103's required shared-key wiring
- zccache target metadata is configured for the soldr checkout; the third-party build still benefits from zccache's compilation and registry caches
