### PR TITLE
ci: make phase 1 cache benchmark summary config-driven

### DIFF
--- a/.github/scripts/cache_benchmark_report.py
+++ b/.github/scripts/cache_benchmark_report.py
@@ -65,9 +65,19 @@ def _format_percent(value: float | None) -> str:
     return "n/a" if value is None else f"{value:.2f}%"
 
 
+def _format_bool(value: bool | None) -> str:
+    if value is None:
+        return "n/a"
+    return "true" if value else "false"
+
+
 def _load_config() -> tuple[dict[str, Any], Path]:
     config_path = Path(os.environ.get("BENCHMARK_CONFIG_PATH", DEFAULT_CONFIG_PATH))
     return tomllib.loads(config_path.read_text(encoding="utf-8")), config_path
+
+
+def _mutation_by_id(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {mutation["id"]: mutation for mutation in config.get("mutations", [])}
 
 
 def _format_command(template: str, target: str) -> str:
@@ -94,7 +104,7 @@ def _load_results(
     profiles = list(config["profiles"])
     profile_by_id = {profile["id"]: profile for profile in profiles}
     mutations = list(config["mutations"])
-    mutation_by_id = {mutation["id"]: mutation for mutation in mutations}
+    mutation_by_id = _mutation_by_id(config)
 
     results: list[dict[str, Any]] = []
     for raw_result in raw_results:
@@ -448,8 +458,123 @@ def _append_step_summary(report: dict[str, Any]) -> None:
         handle.write("\n".join(summary_lines) + "\n")
 
 
+def _phase1_result_label(
+    mutation_by_id: dict[str, dict[str, Any]], mutation_id: str
+) -> str:
+    mutation = mutation_by_id.get(mutation_id)
+    if mutation is None:
+        return f"`{mutation_id}`"
+    return f"{mutation['label']} (`{mutation['path']}`)"
+
+
+def _build_phase1_summary_lines(config: dict[str, Any], payload: dict[str, Any]) -> list[str]:
+    phase1 = config["phase1"]
+    mutation_by_id = _mutation_by_id(config)
+    runner = payload.get("runner") or phase1["runner"]
+    target = payload.get("target") or phase1["target"]
+    threshold = float(payload.get("threshold_ratio") or phase1["default_threshold_ratio"])
+    cache_backend = payload["cache_backend"]
+    scenario = payload["scenario"]
+    command = _format_command(phase1["command"], target)
+    workflow_summary = [
+        "### Cache Benchmark Summary",
+        "",
+        f"- cache backend: `{cache_backend}`",
+        f"- requested scenario: `{scenario}`",
+        f"- required ratio: `{threshold:.2f}x`",
+        f"- runner: `{runner}`",
+        f"- target: `{target}`",
+        f"- measured command: `{command}`",
+        "",
+    ]
+    issue_comment = [
+        "### Phase 1 benchmark results",
+        "",
+        "- workflow: `cache-benchmark.yml`",
+        f"- cache backend under test: `{cache_backend}`",
+        f"- threshold used: `{threshold:.2f}x`",
+        f"- runner: `{runner}`",
+        f"- target: `{target}`",
+        "",
+    ]
+
+    for result in payload["results"]:
+        mutation_id = result["mutation"]
+        label = _phase1_result_label(mutation_by_id, mutation_id)
+        status = result.get("result", "success")
+        cold = _read_float(result.get("cold_seconds"))
+        warm = _read_float(result.get("warm_seconds"))
+        saved = _read_float(result.get("saved_seconds"))
+        ratio = _read_float(result.get("speedup_ratio"))
+        cache_hit = _read_bool(result.get("cache_hit"))
+        hit_detail = result.get("cache_hit_detail") or "n/a"
+
+        if status == "skipped":
+            continue
+
+        workflow_summary.extend(
+            [
+                f"#### {label}",
+                "",
+                f"- job result: `{status}`",
+                f"- cold wall seconds: `{_format_seconds(cold)}`",
+                f"- warm wall seconds: `{_format_seconds(warm)}`",
+                f"- seconds saved: `{_format_seconds(saved)}`",
+                f"- speedup ratio: `{_format_ratio(ratio)}`",
+                f"- warm cache hit: `{_format_bool(cache_hit)}`",
+                f"- warm cache hit detail: `{hit_detail}`",
+                "",
+            ]
+        )
+
+        issue_summary = [
+            f"- {label}: job result `{status}`",
+            f"  cache detail: `{hit_detail}`",
+        ]
+        if status == "success":
+            issue_summary[0] = (
+                f"- {label}: cold `{_format_seconds(cold)}`, warm `{_format_seconds(warm)}`, "
+                f"saved `{_format_seconds(saved)}`, speedup `{_format_ratio(ratio)}`, "
+                f"cache hit `{_format_bool(cache_hit)}`"
+            )
+        issue_comment.extend(issue_summary)
+
+    issue_number = phase1.get("issue")
+    issue_target = f"#{issue_number}" if issue_number is not None else "the Phase 1 tracker issue"
+    issue_comment.extend(
+        [
+            "",
+            "Timing artifacts are attached for each seed, cold, and warm child job as `cache-benchmark-<backend>-<mutation>-<stage>-timings`.",
+            "",
+            f"Copy this block into issue {issue_target}.",
+        ]
+    )
+
+    return workflow_summary + [
+        "### Issue Comment Draft",
+        "",
+        "```markdown",
+        *issue_comment,
+        "```",
+    ]
+
+
+def _append_phase1_step_summary(config: dict[str, Any]) -> None:
+    input_path = Path(os.environ["BENCHMARK_PHASE1_INPUT_JSON"])
+    payload = json.loads(input_path.read_text(encoding="utf-8"))
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    summary_lines = _build_phase1_summary_lines(config, payload)
+    with Path(summary_path).open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(summary_lines) + "\n")
+
+
 def main() -> None:
     config, config_path = _load_config()
+    if os.environ.get("BENCHMARK_REPORT_MODE") == "phase1-summary":
+        _append_phase1_step_summary(config)
+        return
     results, competitors, profiles, mutations = _load_results(config)
     report = _build_report(config, config_path, results, competitors, profiles, mutations)
     _write_json_report(report)

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -30,45 +30,87 @@ permissions:
   contents: read
 
 jobs:
+  config:
+    name: Resolve Phase 1 config
+    runs-on: ubuntu-24.04
+    outputs:
+      runner: ${{ steps.config.outputs.runner }}
+      target: ${{ steps.config.outputs.target }}
+      threshold_ratio: ${{ steps.config.outputs.threshold_ratio }}
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Read benchmark config
+        id: config
+        shell: bash
+        env:
+          INPUT_THRESHOLD_RATIO: ${{ inputs.threshold_ratio }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          config = tomllib.loads(Path("benchmark.toml").read_text(encoding="utf-8"))
+          phase1 = config["phase1"]
+          threshold = os.environ["INPUT_THRESHOLD_RATIO"] or str(
+              phase1["default_threshold_ratio"]
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"runner={phase1['runner']}\n")
+              fh.write(f"target={phase1['target']}\n")
+              fh.write(f"threshold_ratio={threshold}\n")
+          PY
+
   soldr-cli:
+    needs: config
     if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-cli' }}
     name: Top-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
-      runner: ubuntu-24.04
-      target: x86_64-unknown-linux-gnu
+      runner: ${{ needs.config.outputs.runner }}
+      target: ${{ needs.config.outputs.target }}
       source_ref: ${{ github.sha }}
       cache_backend: ${{ inputs.cache_backend }}
       mutation: soldr-cli
-      threshold_ratio: ${{ inputs.threshold_ratio }}
+      threshold_ratio: ${{ needs.config.outputs.threshold_ratio }}
 
   soldr-core:
+    needs: config
     if: ${{ inputs.scenario == 'all' || inputs.scenario == 'soldr-core' }}
     name: Lower-crate edit
     uses: ./.github/workflows/_cache-benchmark-scenario.yml
     with:
-      runner: ubuntu-24.04
-      target: x86_64-unknown-linux-gnu
+      runner: ${{ needs.config.outputs.runner }}
+      target: ${{ needs.config.outputs.target }}
       source_ref: ${{ github.sha }}
       cache_backend: ${{ inputs.cache_backend }}
       mutation: soldr-core
-      threshold_ratio: ${{ inputs.threshold_ratio }}
+      threshold_ratio: ${{ needs.config.outputs.threshold_ratio }}
 
   summary:
     if: ${{ always() }}
     name: Phase 1 summary
     needs:
+      - config
       - soldr-cli
       - soldr-core
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Write benchmark summary
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Write phase 1 summary input
         shell: bash
         env:
           CACHE_BACKEND: ${{ inputs.cache_backend }}
           SCENARIO: ${{ inputs.scenario }}
-          THRESHOLD_RATIO: ${{ inputs.threshold_ratio }}
+          BENCH_RUNNER: ${{ needs.config.outputs.runner }}
+          BENCH_TARGET: ${{ needs.config.outputs.target }}
+          THRESHOLD_RATIO: ${{ needs.config.outputs.threshold_ratio }}
           SOLDR_CLI_RESULT: ${{ needs.soldr-cli.result }}
           SOLDR_CLI_COLD: ${{ needs.soldr-cli.outputs.cold_seconds }}
           SOLDR_CLI_WARM: ${{ needs.soldr-cli.outputs.warm_seconds }}
@@ -86,91 +128,48 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY'
+          import json
           import os
+          from pathlib import Path
 
-          scenarios = [
-              (
-                  "soldr-cli",
-                  "top-crate edit (`crates/soldr-cli/src/main.rs`)",
-                  os.environ["SOLDR_CLI_RESULT"],
-                  os.environ["SOLDR_CLI_COLD"],
-                  os.environ["SOLDR_CLI_WARM"],
-                  os.environ["SOLDR_CLI_SAVED"],
-                  os.environ["SOLDR_CLI_RATIO"],
-                  os.environ["SOLDR_CLI_HIT"],
-                  os.environ["SOLDR_CLI_HIT_DETAIL"],
-              ),
-              (
-                  "soldr-core",
-                  "lower-crate edit (`crates/soldr-core/src/lib.rs`)",
-                  os.environ["SOLDR_CORE_RESULT"],
-                  os.environ["SOLDR_CORE_COLD"],
-                  os.environ["SOLDR_CORE_WARM"],
-                  os.environ["SOLDR_CORE_SAVED"],
-                  os.environ["SOLDR_CORE_RATIO"],
-                  os.environ["SOLDR_CORE_HIT"],
-                  os.environ["SOLDR_CORE_HIT_DETAIL"],
-              ),
-          ]
+          payload = {
+              "cache_backend": os.environ["CACHE_BACKEND"],
+              "scenario": os.environ["SCENARIO"],
+              "runner": os.environ["BENCH_RUNNER"],
+              "target": os.environ["BENCH_TARGET"],
+              "threshold_ratio": os.environ["THRESHOLD_RATIO"],
+              "results": [
+                  {
+                      "mutation": "soldr-cli",
+                      "result": os.environ["SOLDR_CLI_RESULT"],
+                      "cold_seconds": os.environ["SOLDR_CLI_COLD"],
+                      "warm_seconds": os.environ["SOLDR_CLI_WARM"],
+                      "saved_seconds": os.environ["SOLDR_CLI_SAVED"],
+                      "speedup_ratio": os.environ["SOLDR_CLI_RATIO"],
+                      "cache_hit": os.environ["SOLDR_CLI_HIT"],
+                      "cache_hit_detail": os.environ["SOLDR_CLI_HIT_DETAIL"],
+                  },
+                  {
+                      "mutation": "soldr-core",
+                      "result": os.environ["SOLDR_CORE_RESULT"],
+                      "cold_seconds": os.environ["SOLDR_CORE_COLD"],
+                      "warm_seconds": os.environ["SOLDR_CORE_WARM"],
+                      "saved_seconds": os.environ["SOLDR_CORE_SAVED"],
+                      "speedup_ratio": os.environ["SOLDR_CORE_RATIO"],
+                      "cache_hit": os.environ["SOLDR_CORE_HIT"],
+                      "cache_hit_detail": os.environ["SOLDR_CORE_HIT_DETAIL"],
+                  },
+              ],
+          }
 
-          workflow_summary = [
-              "### Cache Benchmark Summary",
-              "",
-              f"- cache backend: `{os.environ['CACHE_BACKEND']}`",
-              f"- requested scenario: `{os.environ['SCENARIO']}`",
-              f"- required ratio: `{float(os.environ['THRESHOLD_RATIO']):.2f}x`",
-              "- runner: `ubuntu-24.04`",
-              "- target: `x86_64-unknown-linux-gnu`",
-              "- measured command: `cargo build --package soldr-cli --release --locked --target x86_64-unknown-linux-gnu --timings`",
-              "",
-          ]
-          issue_comment = [
-              "### Phase 1 benchmark results",
-              "",
-              f"- workflow: `cache-benchmark.yml`",
-              f"- cache backend under test: `{os.environ['CACHE_BACKEND']}`",
-              f"- threshold used: `{float(os.environ['THRESHOLD_RATIO']):.2f}x`",
-              f"- runner: `ubuntu-24.04`",
-              f"- target: `x86_64-unknown-linux-gnu`",
-              "",
-          ]
-
-          for key, label, result, cold, warm, saved, ratio, cache_hit, hit_detail in scenarios:
-              if result == "skipped":
-                  continue
-
-              workflow_summary.extend(
-                  [
-                      f"#### {label}",
-                      "",
-                      f"- job result: `{result}`",
-                      f"- cold wall seconds: `{cold}`",
-                      f"- warm wall seconds: `{warm}`",
-                      f"- seconds saved: `{saved}`",
-                      f"- speedup ratio: `{ratio}x`",
-                      f"- warm cache hit: `{cache_hit}`",
-                      f"- warm cache hit detail: `{hit_detail}`",
-                      "",
-                  ]
-              )
-              issue_comment.extend(
-                  [
-                      f"- {label}: cold `{cold}s`, warm `{warm}s`, saved `{saved}s`, speedup `{ratio}x`, cache hit `{cache_hit}`",
-                      f"  cache detail: `{hit_detail}`",
-                  ]
-              )
-
-          issue_comment.extend(
-              [
-                  "",
-                  "Timing artifacts are attached for each seed, cold, and warm child job as `cache-benchmark-<backend>-<mutation>-<stage>-timings`.",
-              ]
-          )
-
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
-              fh.write("\n".join(workflow_summary) + "\n\n")
-              fh.write("### Issue Comment Draft\n\n")
-              fh.write("```markdown\n")
-              fh.write("\n".join(issue_comment) + "\n")
-              fh.write("```\n")
+          output_path = Path("benchmark-summary/phase1-summary-input.json")
+          output_path.parent.mkdir(parents=True, exist_ok=True)
+          output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
           PY
+
+      - name: Write benchmark summary
+        env:
+          BENCHMARK_REPORT_MODE: phase1-summary
+          BENCHMARK_CONFIG_PATH: benchmark.toml
+          BENCHMARK_PHASE1_INPUT_JSON: benchmark-summary/phase1-summary-input.json
+        run: python3 .github/scripts/cache_benchmark_report.py

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -5,6 +5,13 @@ default_target = "x86_64-unknown-linux-gnu"
 base_competitor = "swatinem"
 soldr_note = "soldr uses managed zccache internally."
 
+[phase1]
+issue = 122
+runner = "ubuntu-24.04"
+target = "x86_64-unknown-linux-gnu"
+command = "cargo build --package soldr-cli --release --locked --target {target} --timings"
+default_threshold_ratio = 10.0
+
 [competitors.soldr]
 label = "soldr"
 backend = "zccache"

--- a/docs/CI_CACHE_PHASE1.md
+++ b/docs/CI_CACHE_PHASE1.md
@@ -4,12 +4,12 @@ Issue [#122](https://github.com/zackees/soldr/issues/122) requires Linux x64 bas
 
 Use `.github/workflows/cache-benchmark.yml` for that Phase 1 measurement. The workflow dispatch:
 
-- runs on `ubuntu-24.04` with target `x86_64-unknown-linux-gnu`
+- resolves the Phase 1 runner, target, measured command, and mutation labels from [`benchmark.toml`](../benchmark.toml)
 - calls the reusable scenario workflow for each selected mutation
 - lets each scenario run three reusable child builds: seed, cold, and warm
 - measures `cargo build --package soldr-cli --release --locked --target x86_64-unknown-linux-gnu --timings`
 - fails unless the warm path is at least the configured ratio faster than the cold control
-- writes an issue-comment-ready summary into the workflow summary
+- writes an issue-comment-ready summary into the workflow summary via `.github/scripts/cache_benchmark_report.py`
 - uploads each measured build's `target/cargo-timings` bundle as an artifact
 
 Workflow dispatch inputs:
@@ -31,3 +31,5 @@ Recommended run:
 4. Leave `threshold_ratio=10` unless you are intentionally tightening or loosening the gate.
 5. Open the workflow summary and copy the `Issue Comment Draft` block into issue `#122`.
 6. Download any `cache-benchmark-<backend>-<mutation>-<stage>-timings` artifact you want to inspect. Each one contains the `cargo build --timings` output from that child job.
+
+The workflow's Phase 1 defaults currently live in `benchmark.toml` under `[phase1]`. Update that block if the benchmark runner, target, or measured command changes so the workflow, summary text, and docs stay aligned.


### PR DESCRIPTION
﻿Advances #122.

## Summary
- move Phase 1 benchmark defaults into `benchmark.toml`
- replace the inline Phase 1 summary script in `cache-benchmark.yml` with a config-driven call to `.github/scripts/cache_benchmark_report.py`
- update the Phase 1 doc so the workflow, summary text, and docs point at the same config source

## Notes
- keeps #103 untouched; this does not change runtime CI cache behavior or the reusable bootstrap path
- preserves the existing benchmark report generator path and its current test coverage

## Verification
- `pytest tests/test_cache_benchmark_report.py`
- parsed `.github/workflows/cache-benchmark.yml` with `yaml.safe_load`
- locally simulated the new Phase 1 summary mode
- `git diff --check`
