### PR TITLE
Document setup-soldr public action extraction plan

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -27,6 +27,33 @@ This repository currently ships an in-repo root GitHub Action for Soldr setup. T
 
 The stable-major public setup action product is not shipped yet. Today, pin the current in-repo action by full commit SHA or explicit release tag; do not assume a public `@v1` contract yet.
 
+### Public-action status
+
+The target public UX after extraction is:
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+
+  - uses: zackees/setup-soldr@v1
+    with:
+      version: 0.7.4
+      cache: true
+
+  - run: soldr cargo build --locked --release
+  - run: soldr cargo test --locked
+```
+
+That public repo is not shipped yet. This repository cannot publish it directly to GitHub Marketplace because Marketplace action repositories must keep one root `action.yml` and no workflow files. The extraction plan and intended `@v1` contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md).
+
+Stable-major rule for the planned public repo:
+
+- `@v1` is the moving major tag for backward-compatible updates
+- `@v2` is introduced only for breaking contract changes
+- the intended normal path is still one `setup-soldr` step plus `soldr cargo ...`; no separate toolchain action is part of the common-case contract
+
+Until that repo exists, no verified public one-line Soldr action exists yet. Use `zackees/soldr@<ref>` or `uses: ./` instead.
+
 ### Preferred setup action path
 
 The root action:
@@ -83,6 +110,8 @@ Useful inputs when wiring the action into another repository:
 - `cache`: turn the runner-local cache root on or off
 - `cache-dir`: move the shared Soldr/Cargo/rustup root to a specific path
 - `trust-mode`: set `SOLDR_TRUST_MODE` for stricter fetched-binary policy
+
+The current `repo` input is an implementation/testing override for the in-repo action. It is not part of the intended public `setup-soldr@v1` contract.
 
 Useful outputs:
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ That action:
 - preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
 - puts `soldr` on `PATH` for later steps
+- is the extraction source for the planned public `zackees/setup-soldr` action product
 
 If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later. The action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the toolchain it just installed instead of asking `rustup` to resolve a pinned file lazily.
 
 On GitHub-hosted runners, this means you usually do not need a separate toolchain setup action for the normal path. That does not mean `rustup` has been removed from the stack: this action still uses `rustup` under the hood today, and self-hosted runners must provide it.
 
-For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). The separate stable-major public action product is not shipped yet, so treat `zackees/soldr@<ref>` as the current contract and pin a full commit SHA or explicit release tag instead of assuming `@v1`. For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
+For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). GitHub Marketplace publication still requires extracting this action into a separate public action repository because GitHub requires a single root `action.yml` and no workflow files in the published repository. The repo-contained extraction plan and intended `zackees/setup-soldr@v1` contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md). Until that public repo exists, treat `zackees/soldr@<ref>` as the current contract and pin a full commit SHA or explicit release tag instead of assuming `@v1`. For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
 
 ## Why soldr exists
 

--- a/action.yml
+++ b/action.yml
@@ -1,28 +1,29 @@
 name: setup-soldr
-description: Current in-repo Soldr setup action. Installs soldr, provisions the resolved Rust toolchain via rustup, and restores a cacheable runner-local Soldr root.
+author: zackees
+description: Extraction-ready Soldr setup action. Installs one soldr binary, provisions the resolved Rust toolchain via rustup, and restores a cacheable runner-local Soldr root.
 inputs:
   version:
     description: Soldr version or tag to install. Defaults to the latest release.
     required: false
     default: ""
   repo:
-    description: GitHub repository that publishes Soldr releases.
+    description: Release source repository override for extraction or local testing. Not part of the intended public setup-soldr@v1 contract.
     required: false
     default: zackees/soldr
   cache:
-    description: Restore and save the setup cache across workflow runs.
+    description: Restore and save the action-managed cache/state root across workflow runs.
     required: false
     default: "true"
   cache-dir:
-    description: Override the runner-local cache root used for Soldr, Cargo, and rustup state rehydrated by this action.
+    description: Override the runner-local cache/state root used for Soldr, Cargo, and rustup state rehydrated by this action.
     required: false
     default: ""
   cache-key-suffix:
-    description: Optional extra suffix added to the cache key.
+    description: Optional extra suffix appended to the cache key.
     required: false
     default: ""
   toolchain:
-    description: Override the exact Rust toolchain channel string. When empty, rust-toolchain.toml is used if present.
+    description: Override the exact Rust toolchain channel string. When empty, toolchain-file is used if present, otherwise stable.
     required: false
     default: ""
   toolchain-file:
@@ -35,16 +36,16 @@ inputs:
     default: ""
 outputs:
   soldr-path:
-    description: Installed Soldr binary path.
+    description: Installed Soldr binary path added to PATH for later steps.
     value: ${{ steps.resolve.outputs.soldr_path }}
   soldr-version:
-    description: Installed Soldr version.
+    description: Installed Soldr version reported by soldr version --json.
     value: ${{ steps.verify.outputs.soldr_version }}
   cache-dir:
-    description: Runner-local cache root used by the action.
+    description: Runner-local cache/state root used by the action.
     value: ${{ steps.resolve.outputs.cache_root }}
   cache-hit:
-    description: Whether the action restored an exact setup cache hit.
+    description: Whether the action restored an exact cache hit for the selected cache/state root.
     value: ${{ steps.cache-meta.outputs.cache_hit }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -841,10 +841,10 @@ fn explicit_toolchain_home_env_vars_win_over_repo_local_homes() {
 #[test]
 fn rustup_resolution_failure_reports_raw_error_and_ci_guidance() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["rustc", "--version"])
+        .args(["--no-cache", "rustc", "--version"])
         .env("RUSTUP_TOOLCHAIN", "soldr-ci-missing-toolchain")
         .output()
-        .expect("failed to run soldr rustc --version with invalid RUSTUP_TOOLCHAIN");
+        .expect("failed to run soldr --no-cache rustc --version with invalid RUSTUP_TOOLCHAIN");
 
     assert!(
         !output.status.success(),

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -1,0 +1,170 @@
+# setup-soldr Public Action Plan
+
+This document is the repo-contained delivery for [issue #137](https://github.com/zackees/soldr/issues/137).
+
+`soldr` cannot publish its current root action to GitHub Marketplace directly. The useful work that can land here is to freeze the intended public `setup-soldr` contract, define the extraction boundary, and document the exact release process that turns the current in-repo action into a separate public action product.
+
+## Why Extraction Is Required
+
+GitHub's current action guidance says public actions are best kept in their own repository, and GitHub Marketplace requires:
+
+- a public repository
+- a single root `action.yml` or `action.yaml`
+- no workflow files in the published repository
+
+References:
+
+- https://docs.github.com/en/actions/how-tos/sharing-automations/creating-actions/publishing-actions-in-github-marketplace
+- https://docs.github.com/actions/how-tos/creating-and-publishing-actions/managing-custom-actions
+
+This repository intentionally contains normal application code and workflow files under `.github/workflows/`, so it is the source repository for the action, not the eventual Marketplace repository.
+
+## Current Source Of Truth
+
+The current setup action that should be extracted is:
+
+- [action.yml](../action.yml)
+- `.github/actions/setup-soldr/resolve_setup.py`
+- `.github/actions/setup-soldr/ensure_rust_toolchain.py`
+- `.github/actions/setup-soldr/ensure_soldr.py`
+- `.github/actions/setup-soldr/verify_soldr.py`
+
+The current smoke validation stays in this repository and is not copied into the public action repository:
+
+- `.github/workflows/setup-soldr-action.yml`
+
+That split is intentional. The Marketplace repository stays minimal, while this repository keeps the broader test and release context.
+
+## Planned Public Repository Shape
+
+Create a separate public repository, expected name:
+
+- `zackees/setup-soldr`
+
+Initial extraction should keep the helper-script layout unchanged so the copy is mechanical:
+
+```text
+setup-soldr/
+|-- action.yml
+|-- README.md
+`-- .github/
+    `-- actions/
+        `-- setup-soldr/
+            |-- resolve_setup.py
+            |-- ensure_rust_toolchain.py
+            |-- ensure_soldr.py
+            `-- verify_soldr.py
+```
+
+Do not copy any file from `.github/workflows/`.
+
+## Stable Public `v1` Contract
+
+The intended public UX is:
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+
+  - uses: zackees/setup-soldr@v1
+    with:
+      version: 0.7.4
+      cache: true
+
+  - run: soldr cargo build --locked --release
+  - run: soldr cargo test --locked
+```
+
+### Supported Inputs
+
+`v1` should treat these inputs as the public contract:
+
+| Input | Meaning |
+|---|---|
+| `version` | Soldr release tag or version to install. Empty means latest release. |
+| `cache` | Restore and save the action-managed cache/state root. |
+| `cache-dir` | Override the runner-local cache/state root. |
+| `cache-key-suffix` | Optional escape hatch appended to the cache key. |
+| `toolchain` | Explicit Rust toolchain channel override. |
+| `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
+| `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+
+The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v1` contract and should not be documented in the extracted public action README.
+
+### Supported Outputs
+
+`v1` should treat these outputs as the public contract:
+
+| Output | Meaning |
+|---|---|
+| `soldr-path` | Installed Soldr binary path added to `PATH`. |
+| `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
+| `cache-dir` | Action-managed runner-local cache/state root. |
+| `cache-hit` | Whether the action restored an exact cache hit. |
+| `toolchain` | Exact Rust toolchain channel configured for the action. |
+
+### Required Behavior
+
+`v1` should preserve these behaviors:
+
+- install exactly one released Soldr binary for the active runner OS and architecture
+- provision the normal-path Rust toolchain itself via `rustup`; users should not need a separate toolchain action for the common path
+- create and export `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME`
+- put the installed `soldr` binary on `PATH`
+- restore and save the action-managed cache/state root when `cache: true`
+- export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
+
+### Current Limits That Must Stay Explicit
+
+The extracted public action must document these current limits honestly:
+
+- the action rehydrates the Soldr root, Cargo home, and rustup home under the chosen cache/state root
+- Soldr still uses `rustup` under the hood today
+- managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path
+
+### Non-Contract Details
+
+These details can change inside `v1` without forcing `v2`, as long as the supported inputs, outputs, and behaviors above stay compatible:
+
+- the exact cache key format
+- the default runner-local filesystem path chosen when `cache-dir` is empty
+- internal helper script layout or implementation language
+- the exact release API calls used to download Soldr
+
+## Release And Tagging Plan
+
+GitHub's current release guidance recommends semantic tags and moving major tags for actions. If immutable releases are enabled, keep the immutable release tags and the moving compatibility tags separate.
+
+References:
+
+- https://docs.github.com/actions/how-tos/create-and-publish-actions/using-immutable-releases-and-tags-to-manage-your-actions-releases
+- https://docs.github.com/actions/how-tos/creating-and-publishing-actions/managing-custom-actions
+
+Use this release model for `zackees/setup-soldr`:
+
+1. Validate the action changes in this repository first with the existing smoke path.
+2. Copy the release contents into `zackees/setup-soldr` without workflow files.
+3. Publish an immutable release tag such as `v1.0.0`.
+4. Move the major compatibility tag `v1` to the same commit as the latest compatible `v1.x.y` release.
+5. Introduce `v2` only for breaking contract changes such as input removal, output removal, or behavior changes that require workflow edits.
+
+## Extraction Checklist
+
+Before the first public release:
+
+1. Create `zackees/setup-soldr` as a public repository.
+2. Accept the GitHub Marketplace Developer Agreement for the owning account or organization if it has not already been accepted.
+3. Copy [action.yml](../action.yml) and the helper scripts listed above into the public repository.
+4. Copy the user-facing setup docs from this repository's `README.md`, `INTEGRATION.md`, and this file into the public repository `README.md`, but remove any mention of the temporary in-repo `zackees/soldr@<ref>` path.
+5. Ensure the public repository contains no workflow files.
+6. Create the first release tag `v1.0.0`, then move `v1` to that commit.
+7. Publish the release to GitHub Marketplace from the public repository.
+
+## What This PR Changes
+
+This repo-contained plan is useful even before the public repository exists because it:
+
+- defines the exact public contract the extracted action should preserve
+- distinguishes public contract from current implementation-only escape hatches
+- gives a mechanical file-copy plan for extraction
+- gives a stable tagging and release model for `@v1` and later `@v2`


### PR DESCRIPTION
﻿Advances #137.

## Summary
- add a repo-contained extraction and publication plan for the future `zackees/setup-soldr@v1` action
- define the intended public `v1` contract: inputs, outputs, behavior, and current cache limits
- align `README.md`, `INTEGRATION.md`, and `action.yml` so the current root action is the clear extraction source for that future public repo

## Verification
- `git diff --check -- README.md INTEGRATION.md action.yml docs/SETUP_SOLDR_PUBLIC_ACTION.md`
- parsed `action.yml` with `PyYAML`
- verified markdown link targets exist
