### PR TITLE
Prefer repo-local toolchain binaries before rustup

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -584,6 +584,11 @@ fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError
         return Ok(path);
     }
 
+    let start_dir = std::env::current_dir().ok();
+    if let Some(path) = soldr_core::probe_toolchain_binary(tool, start_dir.as_deref()) {
+        return Ok(path);
+    }
+
     let mut command = std::process::Command::new(rustup_binary());
     command.args(["which", tool]);
     apply_implicit_toolchain_homes(&mut command);

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -214,6 +214,29 @@ fn fake_rustup_script(log_path: &Path, tool_dir: &Path) -> String {
     }
 }
 
+fn fake_failing_rustup_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo rustup %* cargo_home=%CARGO_HOME% rustup_home=%RUSTUP_HOME%>>\"{}\"\n\
+             echo rustup should not have been invoked 1>&2\n\
+             exit /b 1\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"rustup $* cargo_home=${{CARGO_HOME:-}} rustup_home=${{RUSTUP_HOME:-}}\" >> \"{}\"\n\
+             echo \"rustup should not have been invoked\" >&2\n\
+             exit 1\n",
+            log_path.display()
+        )
+    }
+}
+
 fn fake_zccache_script(log_path: &Path) -> String {
     #[cfg(windows)]
     {
@@ -327,6 +350,16 @@ fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
     (cargo, rustc, zccache)
 }
 
+fn install_fake_version_toolchain(tool_dir: &Path, log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let cargo = fake_script_path(tool_dir, "cargo");
+    let rustc = fake_script_path(tool_dir, "rustc");
+    let rustfmt = fake_script_path(tool_dir, "rustfmt");
+    write_fake_script(&cargo, &fake_version_tool_script(log_path, "cargo"));
+    write_fake_script(&rustc, &fake_version_tool_script(log_path, "rustc"));
+    write_fake_script(&rustfmt, &fake_version_tool_script(log_path, "rustfmt"));
+    (cargo, rustc, rustfmt)
+}
+
 fn install_fake_wrapper(log_path: &Path, wrapper_name: &str) -> PathBuf {
     let dir = unique_temp_dir("fake-wrapper");
     let wrapper = fake_script_path(&dir, wrapper_name);
@@ -351,6 +384,16 @@ fn install_fake_rustup_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf,
     write_fake_script(&rustfmt, &fake_version_tool_script(log_path, "rustfmt"));
     write_fake_script(&rustup, &fake_rustup_script(log_path, &dir));
     (rustup, cargo, rustc, rustfmt)
+}
+
+fn install_failing_fake_rustup(log_path: &Path) -> PathBuf {
+    let dir = unique_temp_dir("fake-rustup-failure");
+    #[cfg(windows)]
+    let rustup = dir.join("rustup.bat");
+    #[cfg(not(windows))]
+    let rustup = fake_script_path(&dir, "rustup");
+    write_fake_script(&rustup, &fake_failing_rustup_script(log_path));
+    rustup
 }
 
 #[cfg(windows)]
@@ -781,6 +824,62 @@ fn repo_local_toolchain_homes_are_used_when_env_vars_are_unset() {
     assert!(
         log_contains_toolchain_homes(&log, "rustc", &repo_cargo_home, &repo_rustup_home),
         "rustc execution should inherit repo-local homes: {log}"
+    );
+}
+
+#[test]
+fn repo_local_cargo_bin_tools_work_without_rustup() {
+    let cache_root = unique_temp_dir("repo-local-cargo-bin");
+    let log_path = cache_root.join("tool.log");
+    let rustup = install_failing_fake_rustup(&log_path);
+    let repo_root = unique_temp_dir("repo-local-cargo-bin-root");
+    let repo_cargo_bin = repo_root.join(".cargo").join("bin");
+    let nested = repo_root.join("workspace").join("crate");
+    fs::create_dir_all(&repo_cargo_bin).expect("failed to create repo-local .cargo/bin");
+    fs::create_dir_all(&nested).expect("failed to create nested working dir");
+    install_fake_version_toolchain(&repo_cargo_bin, &log_path);
+
+    for args in [
+        vec!["--no-cache", "cargo", "--version"],
+        vec!["rustfmt", "--version"],
+        vec!["rustc", "--version"],
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+            .args(&args)
+            .current_dir(&nested)
+            .env("SOLDR_CACHE_DIR", &cache_root)
+            .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+            .env_remove("CARGO_HOME")
+            .env_remove("RUSTUP_HOME")
+            .env_remove("RUSTUP_TOOLCHAIN")
+            .output()
+            .unwrap_or_else(|_| panic!("failed to run soldr with args {args:?}"));
+
+        assert!(
+            output.status.success(),
+            "soldr invocation failed for {:?}\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.lines().any(|line| line.starts_with("cargo ")),
+        "expected repo-local cargo shim to run: {log}"
+    );
+    assert!(
+        log.lines().any(|line| line.starts_with("rustfmt ")),
+        "expected repo-local rustfmt shim to run: {log}"
+    );
+    assert!(
+        log.lines().any(|line| line.starts_with("rustc ")),
+        "expected repo-local rustc shim to run: {log}"
+    );
+    assert!(
+        !log.lines().any(|line| line.starts_with("rustup ")),
+        "repo-local .cargo/bin tools should bypass rustup entirely: {log}"
     );
 }
 

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 
 pub const CARGO_HOME_ENV_VAR: &str = "CARGO_HOME";
 pub const RUSTUP_HOME_ENV_VAR: &str = "RUSTUP_HOME";
+const RUSTUP_TOOLCHAIN_ENV_VAR: &str = "RUSTUP_TOOLCHAIN";
 
 // ---------------------------------------------------------------------------
 // Target triple detection
@@ -273,6 +274,64 @@ impl ImplicitToolchainHomes {
     }
 }
 
+fn cargo_home_bin_dir(start_dir: Option<&Path>) -> Option<PathBuf> {
+    match std::env::var_os(CARGO_HOME_ENV_VAR) {
+        Some(value) if value.is_empty() => None,
+        Some(value) => Some(PathBuf::from(value).join("bin")),
+        None => ImplicitToolchainHomes::detect(start_dir)
+            .cargo_home
+            .map(|path| path.join("bin")),
+    }
+}
+
+fn rustup_toolchain_env_is_explicit(value: Option<&OsStr>) -> bool {
+    value.is_some_and(|value| !value.is_empty())
+}
+
+fn executable_exists(path: &Path) -> bool {
+    path.is_file()
+}
+
+#[cfg(windows)]
+fn windows_pathexts() -> Vec<String> {
+    let pathext = std::env::var_os("PATHEXT")
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string());
+    pathext
+        .split(';')
+        .map(str::trim)
+        .filter(|ext| !ext.is_empty())
+        .map(|ext| ext.to_ascii_lowercase())
+        .collect()
+}
+
+fn find_executable_in_dir(dir: &Path, tool: &str) -> Option<PathBuf> {
+    let candidate = dir.join(tool);
+    if executable_exists(&candidate) {
+        return Some(candidate);
+    }
+
+    #[cfg(windows)]
+    {
+        let ext = candidate
+            .extension()
+            .and_then(OsStr::to_str)
+            .map(|ext| format!(".{}", ext.to_ascii_lowercase()));
+        if ext.is_some() {
+            return None;
+        }
+
+        for suffix in windows_pathexts() {
+            let suffixed = dir.join(format!("{tool}{suffix}"));
+            if executable_exists(&suffixed) {
+                return Some(suffixed);
+            }
+        }
+    }
+
+    None
+}
+
 fn find_dir_in_ancestors(start_dir: Option<&Path>, relative_path: &str) -> Option<PathBuf> {
     let mut current = start_dir?.to_path_buf();
     loop {
@@ -288,6 +347,14 @@ fn find_dir_in_ancestors(start_dir: Option<&Path>, relative_path: &str) -> Optio
 
 pub fn apply_implicit_toolchain_homes(command: &mut Command, start_dir: Option<&Path>) {
     ImplicitToolchainHomes::detect(start_dir).apply_to_command(command);
+}
+
+pub fn probe_toolchain_binary(tool: &str, start_dir: Option<&Path>) -> Option<PathBuf> {
+    if rustup_toolchain_env_is_explicit(std::env::var_os(RUSTUP_TOOLCHAIN_ENV_VAR).as_deref()) {
+        return None;
+    }
+
+    cargo_home_bin_dir(start_dir).and_then(|dir| find_executable_in_dir(&dir, tool))
 }
 
 fn detect_runtime_rustc_triple(start_dir: Option<&Path>) -> Option<String> {
@@ -311,6 +378,10 @@ fn detect_runtime_rustc_triple(start_dir: Option<&Path>) -> Option<String> {
 }
 
 fn resolve_runtime_rustc(start_dir: Option<&Path>) -> Option<PathBuf> {
+    if let Some(rustc) = probe_toolchain_binary("rustc", start_dir) {
+        return Some(rustc);
+    }
+
     let mut rustup = std::process::Command::new("rustup");
     apply_implicit_toolchain_homes(&mut rustup, start_dir);
     if let Some(start_dir) = start_dir {
@@ -666,5 +737,12 @@ mod tests {
             Some(OsStr::new("")),
         );
         assert_eq!(homes, ImplicitToolchainHomes::default());
+    }
+
+    #[test]
+    fn explicit_rustup_toolchain_env_disables_direct_probe() {
+        assert!(rustup_toolchain_env_is_explicit(Some(OsStr::new("stable"))));
+        assert!(!rustup_toolchain_env_is_explicit(Some(OsStr::new(""))));
+        assert!(!rustup_toolchain_env_is_explicit(None));
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -44,8 +44,8 @@ soldr --no-cache cargo build
 
 Behavior:
 
-- Resolve the real `cargo` binary through `rustup`
-- Resolve the matching real `rustc` binary through `rustup`
+- Prefer direct `cargo` and `rustc` binaries from repo-local or explicit `CARGO_HOME/bin`
+- Fall back to `rustup which <tool>` when no matching binary is present in that repo-contained toolchain location
 - Fetch a pinned managed `zccache` release when caching is enabled
 - Set `RUSTC_WRAPPER` to the current soldr binary
 - Pass the managed `zccache` binary path into wrapper mode through the environment
@@ -59,6 +59,7 @@ Current cache-control behavior:
 - `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
 - zccache integration currently targets Rust builds through the cargo front door
 - zccache's current artifact store and daemon endpoint remain on zccache's default paths; soldr currently manages the session lifecycle and logs
+- if `RUSTUP_TOOLCHAIN` is explicitly set, soldr continues to ask `rustup` for the matching toolchain binary
 
 This is the normal build entry point.
 
@@ -101,7 +102,7 @@ In this mode, soldr should act as the transparent build-assistance layer around 
 
 Current implementation status:
 
-- Wrapper mode still transparently resolves the real `rustc`
+- Wrapper mode still transparently resolves the real `rustc`, preferring direct binaries before `rustup`
 - The normal cache-enabled build path now runs through soldr wrapper mode and delegates into managed `zccache`
 - If caching is disabled, wrapper mode falls through to real `rustc` without zccache involvement
 


### PR DESCRIPTION
﻿Advances #139.

## Summary
- prefer direct tool binaries from explicit or repo-local `CARGO_HOME/bin` before falling back to `rustup`
- keep the existing `RUSTUP_TOOLCHAIN` path and rustup-based CI guidance when that env var is explicitly set
- add CLI coverage for a repo-local `.cargo/bin` toolchain that works even when `rustup` is broken
- update API docs to describe the new resolution order

## Verification
- `cargo fmt --all`
- `cargo test -p soldr-core --lib`
- `cargo test -p soldr-cli --test cli repo_local_cargo_bin_tools_work_without_rustup -- --nocapture`
- `cargo test -p soldr-cli --test cli repo_local_toolchain_homes_are_used_when_env_vars_are_unset -- --nocapture`
- `cargo test -p soldr-cli --test cli explicit_toolchain_home_env_vars_win_over_repo_local_homes -- --nocapture`
- `cargo test -p soldr-cli --test cli rustup_resolution_failure_reports_raw_error_and_ci_guidance -- --nocapture`
