### PR TITLE
Make main the canonical CI cache source

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -12,6 +12,10 @@ on:
       binary_name:
         required: true
         type: string
+      save_cache:
+        required: false
+        type: string
+        default: "false"
       source_ref:
         required: true
         type: string
@@ -91,7 +95,10 @@ jobs:
 
       - uses: ./soldr/.github/actions/cache-benchmark-zccache
         with:
+          # Keep branch-agnostic restore keys so feature branches can warm from
+          # canonical main caches, but only let main save new shared entries.
           shared-key: ${{ inputs.target }}
+          save-cache: ${{ inputs.save_cache }}
           target-dir: soldr/target
 
       - name: Build soldr-cli

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -96,7 +96,8 @@ jobs:
       - uses: ./soldr/.github/actions/cache-benchmark-zccache
         with:
           # Keep branch-agnostic restore keys so feature branches can warm from
-          # canonical main caches, but only let main save new shared entries.
+          # canonical main caches, while push builds on feature branches can
+          # also save their own preferred branch-local cache entries.
           shared-key: ${{ inputs.target }}
           save-cache: ${{ inputs.save_cache }}
           target-dir: soldr/target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  pull_request:
-    paths-ignore:
-      - '*.md'
   push:
     branches:
       - '**'
@@ -29,11 +26,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
-          # GitHub caches are branch-scoped. A push writes into the current
-          # branch scope, so main continuously refreshes the canonical cache and
-          # feature branches can also save their own preferred branch-local
-          # cache entries. PR runs stay restore-only because merge-ref caches are
-          # much less reusable.
+          # GitHub caches are branch-scoped. This workflow runs on push only, so
+          # each branch writes into its own scope. That lets main refresh the
+          # canonical parent cache while feature branches can also save their own
+          # preferred child cache without duplicating work in pull_request runs.
           shared-key: workspace
           save-if: ${{ github.event_name == 'push' }}
 
@@ -70,7 +66,8 @@ jobs:
         with:
           # Use the same stable key lineage as lint. Pushes save branch-local
           # caches, which GitHub restores before falling back to base/default
-          # branch caches on later runs.
+          # branch caches on later branch pushes and on PR checks attached to
+          # the branch head.
           shared-key: workspace
           save-if: ${{ github.event_name == 'push' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     paths-ignore:
       - '*.md'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '*.md'
 
 permissions:
   contents: read
@@ -21,6 +26,11 @@ jobs:
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          # GitHub caches are branch-scoped. Save the canonical dependency cache
+          # only on the default branch, then let PRs restore from that lineage.
+          shared-key: workspace
+          save-if: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -52,6 +62,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          # Use the same stable cache lineage as lint so Linux/macOS/Windows PR
+          # jobs can restore from canonical main-branch caches on misses.
+          shared-key: workspace
+          save-if: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Build workspace
         run: cargo build --workspace --locked
@@ -77,6 +92,7 @@ jobs:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-gnu
       binary_name: soldr
+      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       source_ref: ${{ github.sha }}
 
   e2e-linux-arm64:
@@ -86,6 +102,7 @@ jobs:
       runner: ubuntu-24.04-arm
       target: aarch64-unknown-linux-gnu
       binary_name: soldr
+      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       source_ref: ${{ github.sha }}
 
   e2e-linux-x64-musl:
@@ -95,6 +112,7 @@ jobs:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-musl
       binary_name: soldr
+      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       source_ref: ${{ github.sha }}
 
   e2e-linux-arm64-musl:
@@ -104,6 +122,7 @@ jobs:
       runner: ubuntu-24.04-arm
       target: aarch64-unknown-linux-musl
       binary_name: soldr
+      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       source_ref: ${{ github.sha }}
 
   e2e-macos-x64:
@@ -114,6 +133,7 @@ jobs:
       runner: macos-15-intel
       target: x86_64-apple-darwin
       binary_name: soldr
+      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       source_ref: ${{ github.sha }}
 
   e2e-macos-arm64:
@@ -123,6 +143,7 @@ jobs:
       runner: macos-15
       target: aarch64-apple-darwin
       binary_name: soldr
+      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       source_ref: ${{ github.sha }}
 
   e2e-windows-x64:
@@ -132,6 +153,7 @@ jobs:
       runner: windows-2025
       target: x86_64-pc-windows-msvc
       binary_name: soldr.exe
+      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       source_ref: ${{ github.sha }}
 
   e2e-windows-arm64:
@@ -141,4 +163,5 @@ jobs:
       runner: windows-11-arm
       target: aarch64-pc-windows-msvc
       binary_name: soldr.exe
+      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       source_ref: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ on:
       - '*.md'
   push:
     branches:
-      - main
+      - '**'
+    tags-ignore:
+      - '*'
     paths-ignore:
       - '*.md'
 
@@ -27,10 +29,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
-          # GitHub caches are branch-scoped. Save the canonical dependency cache
-          # only on the default branch, then let PRs restore from that lineage.
+          # GitHub caches are branch-scoped. A push writes into the current
+          # branch scope, so main continuously refreshes the canonical cache and
+          # feature branches can also save their own preferred branch-local
+          # cache entries. PR runs stay restore-only because merge-ref caches are
+          # much less reusable.
           shared-key: workspace
-          save-if: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+          save-if: ${{ github.event_name == 'push' }}
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -63,10 +68,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
-          # Use the same stable cache lineage as lint so Linux/macOS/Windows PR
-          # jobs can restore from canonical main-branch caches on misses.
+          # Use the same stable key lineage as lint. Pushes save branch-local
+          # caches, which GitHub restores before falling back to base/default
+          # branch caches on later runs.
           shared-key: workspace
-          save-if: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+          save-if: ${{ github.event_name == 'push' }}
 
       - name: Build workspace
         run: cargo build --workspace --locked
@@ -92,7 +98,7 @@ jobs:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-gnu
       binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
   e2e-linux-arm64:
@@ -102,7 +108,7 @@ jobs:
       runner: ubuntu-24.04-arm
       target: aarch64-unknown-linux-gnu
       binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
   e2e-linux-x64-musl:
@@ -112,7 +118,7 @@ jobs:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-musl
       binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
   e2e-linux-arm64-musl:
@@ -122,7 +128,7 @@ jobs:
       runner: ubuntu-24.04-arm
       target: aarch64-unknown-linux-musl
       binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
   e2e-macos-x64:
@@ -133,7 +139,7 @@ jobs:
       runner: macos-15-intel
       target: x86_64-apple-darwin
       binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
   e2e-macos-arm64:
@@ -143,7 +149,7 @@ jobs:
       runner: macos-15
       target: aarch64-apple-darwin
       binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
   e2e-windows-x64:
@@ -153,7 +159,7 @@ jobs:
       runner: windows-2025
       target: x86_64-pc-windows-msvc
       binary_name: soldr.exe
-      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
   e2e-windows-arm64:
@@ -163,5 +169,5 @@ jobs:
       runner: windows-11-arm
       target: aarch64-pc-windows-msvc
       binary_name: soldr.exe
-      save_cache: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -78,12 +78,13 @@ GitHub Actions caches are not shared across arbitrary sibling feature branches. 
 
 That means Soldr treats `main` as the canonical warm-cache source:
 
-- CI runs on pushes to `main` so `main` continuously refreshes the shared dependency cache lineage.
-- Pull request runs restore from their exact cache when available, then fall back to the `main` cache lineage through branch-agnostic keys and restore prefixes.
-- Pull request merge-ref caches are treated as opportunistic rerun caches, not as the primary warm-cache strategy.
-- Cargo target metadata remains more conservative than registry / compilation caches because broad fallback there is easier to get wrong for changed source trees.
+- CI runs on pushes to `main` and feature branches.
+- A feature-branch push can save a branch-local cache entry in its own branch scope.
+- Later pushes and PRs for that same branch restore that branch-local cache first.
+- If the feature branch has no exact cache yet, GitHub falls back to the `main` cache lineage through the same stable keys.
+- Pull request runs are restore-only; they do not depend on PR merge-ref caches as the main strategy.
 
-In practice this is the idiomatic GitHub Actions pattern for fast feature-branch builds: keep the canonical cache keys stable enough for `main` to feed later PRs, and only use branch-specific cache state when correctness requires it.
+In practice this gives the exact parent/child model we want: `main` acts as the shared parent cache, feature branches read from that parent on miss, and each feature branch may also save its own preferred child cache when the workflow runs on `push`. This repository is the first reference implementation of that pattern. For the full wiring and rollout notes, see [docs/CI_CACHE.md](./docs/CI_CACHE.md).
 
 ## Why soldr exists
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ That means Soldr treats `main` as the canonical warm-cache source:
 - A feature-branch push can save a branch-local cache entry in its own branch scope.
 - Later pushes and PRs for that same branch restore that branch-local cache first.
 - If the feature branch has no exact cache yet, GitHub falls back to the `main` cache lineage through the same stable keys.
-- Pull request runs are restore-only; they do not depend on PR merge-ref caches as the main strategy.
+- The heavy cache-producing CI runs on branch pushes, not `pull_request`, so each feature branch gets one useful cache lineage instead of a duplicate PR merge-ref lineage.
 
-In practice this gives the exact parent/child model we want: `main` acts as the shared parent cache, feature branches read from that parent on miss, and each feature branch may also save its own preferred child cache when the workflow runs on `push`. This repository is the first reference implementation of that pattern. For the full wiring and rollout notes, see [docs/CI_CACHE.md](./docs/CI_CACHE.md).
+In practice this gives the exact parent/child model we want: `main` acts as the shared parent cache, feature branches read from that parent on miss, and each feature branch may also save its own preferred child cache when the workflow runs on `push`. Pull requests then reflect the branch-push CI state instead of creating a second heavy cache path. This repository is the first reference implementation of that pattern. For the full wiring and rollout notes, see [docs/CI_CACHE.md](./docs/CI_CACHE.md).
 
 ## Why soldr exists
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ On runners without `rustup`, the action downloads and installs it into the cache
 
 For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). GitHub Marketplace publication still requires extracting this action into a separate public action repository because GitHub requires a single root `action.yml` and no workflow files in the published repository. The repo-contained extraction plan and intended `zackees/setup-soldr@v1` contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md). Until that public repo exists, treat `zackees/soldr@<ref>` as the current contract and pin a full commit SHA or explicit release tag instead of assuming `@v1`. For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
 
+### CI cache lineage
+
+GitHub Actions caches are not shared across arbitrary sibling feature branches. A workflow run can restore caches from its own branch, the default branch, and for pull requests the PR base branch. It cannot directly restore caches created on another feature branch.
+
+That means Soldr treats `main` as the canonical warm-cache source:
+
+- CI runs on pushes to `main` so `main` continuously refreshes the shared dependency cache lineage.
+- Pull request runs restore from their exact cache when available, then fall back to the `main` cache lineage through branch-agnostic keys and restore prefixes.
+- Pull request merge-ref caches are treated as opportunistic rerun caches, not as the primary warm-cache strategy.
+- Cargo target metadata remains more conservative than registry / compilation caches because broad fallback there is easier to get wrong for changed source trees.
+
+In practice this is the idiomatic GitHub Actions pattern for fast feature-branch builds: keep the canonical cache keys stable enough for `main` to feed later PRs, and only use branch-specific cache state when correctness requires it.
+
 ## Why soldr exists
 
 On Windows, the real problem is not "how do I cache builds?" or "how do I download a tool binary?" in isolation.

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -5,7 +5,7 @@ This repository uses GitHub Actions cache scope the way GitHub actually implemen
 - `main` is the canonical warm-cache source.
 - Feature branches can restore from their own branch cache first.
 - On a miss, feature branches fall back to the cache lineage from `main`.
-- Pull request runs are restore-only. They do not write merge-ref caches as the primary strategy.
+- The heavy CI workflow runs on `push`, not `pull_request`.
 - Feature branch pushes can save branch-local caches, which later pushes and PRs for that same branch will prefer automatically.
 
 ## Why
@@ -28,7 +28,7 @@ That means the right model is not "share caches between feature branches". The r
 In [.github/workflows/ci.yml](../.github/workflows/ci.yml):
 
 - `push` runs on `main` and feature branches.
-- `pull_request` runs stay enabled for review-time verification.
+- the heavy cache-producing CI workflow does not run on `pull_request`
 - `Swatinem/rust-cache` uses a stable `shared-key: workspace`.
 - `save-if` is enabled only for `push` events.
 
@@ -36,14 +36,14 @@ That produces the intended behavior:
 
 - a push to `main` refreshes the canonical dependency cache
 - a push to `feature/x` saves a branch-local cache in the `feature/x` scope
-- a PR from `feature/x` restores from the `feature/x` cache if present
-- if `feature/x` has no cache yet, the PR falls back to `main`
+- a PR from `feature/x` sees the checks produced by the latest push on `feature/x`
+- if another workflow or rerun needs a restore on that branch, GitHub still prefers the branch cache and falls back to `main`
 
 In [.github/workflows/_bootstrap-e2e.yml](../.github/workflows/_bootstrap-e2e.yml):
 
 - the repo-local `cache-benchmark-zccache` action uses stable target-based keys
 - `save_cache` is enabled only for `push`
-- PR runs restore only
+- no duplicate `pull_request` cache-writing path exists in this workflow
 
 So the e2e matrix follows the same policy as the main Rust workspace jobs.
 
@@ -56,7 +56,7 @@ Recommended validation flow:
 1. Push a change to `main` and let CI complete. This warms the canonical cache.
 2. Create a feature branch and push a small follow-up change. The first feature-branch push should restore from `main` and then save a branch-local cache.
 3. Push a second small commit to the same feature branch. That run should prefer the branch-local cache.
-4. Open or update a PR from the same branch. The PR run should restore from the branch cache first, then fall back to `main` if needed.
+4. Open or update a PR from the same branch. The PR should surface the branch-push CI results without creating a second heavy CI cache lineage.
 
 ## Usage Pattern For Other Repos
 
@@ -64,6 +64,6 @@ Use this same shape when applying Soldr CI caching elsewhere:
 
 - keep cache keys branch-agnostic for correctness-relevant inputs only
 - let `push` runs save caches in the current branch scope
-- let PR runs restore only
+- prefer `push`-only heavy CI if PR-triggered merge-ref caches would just duplicate the work
 - rely on GitHub's built-in restore order so current-branch caches win over `main`
 - treat `main` as the canonical shared parent cache, not sibling branches

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -1,0 +1,69 @@
+# CI Cache Strategy
+
+This repository uses GitHub Actions cache scope the way GitHub actually implements it:
+
+- `main` is the canonical warm-cache source.
+- Feature branches can restore from their own branch cache first.
+- On a miss, feature branches fall back to the cache lineage from `main`.
+- Pull request runs are restore-only. They do not write merge-ref caches as the primary strategy.
+- Feature branch pushes can save branch-local caches, which later pushes and PRs for that same branch will prefer automatically.
+
+## Why
+
+GitHub Actions caches are not shared across arbitrary sibling branches. A run can restore from:
+
+- its own branch
+- the default branch
+- for pull requests, the PR base branch
+
+That means the right model is not "share caches between feature branches". The right model is:
+
+1. `main` stays warm and acts as the shared parent lineage.
+2. A feature branch restores from its own cache if it already has one.
+3. Otherwise the feature branch restores from `main`.
+4. A feature branch push may then save a better branch-local cache for later runs of that same branch.
+
+## How This Repo Is Wired
+
+In [.github/workflows/ci.yml](../.github/workflows/ci.yml):
+
+- `push` runs on `main` and feature branches.
+- `pull_request` runs stay enabled for review-time verification.
+- `Swatinem/rust-cache` uses a stable `shared-key: workspace`.
+- `save-if` is enabled only for `push` events.
+
+That produces the intended behavior:
+
+- a push to `main` refreshes the canonical dependency cache
+- a push to `feature/x` saves a branch-local cache in the `feature/x` scope
+- a PR from `feature/x` restores from the `feature/x` cache if present
+- if `feature/x` has no cache yet, the PR falls back to `main`
+
+In [.github/workflows/_bootstrap-e2e.yml](../.github/workflows/_bootstrap-e2e.yml):
+
+- the repo-local `cache-benchmark-zccache` action uses stable target-based keys
+- `save_cache` is enabled only for `push`
+- PR runs restore only
+
+So the e2e matrix follows the same policy as the main Rust workspace jobs.
+
+## First Test Case
+
+This repository is the first test case for the cache-sharing model.
+
+Recommended validation flow:
+
+1. Push a change to `main` and let CI complete. This warms the canonical cache.
+2. Create a feature branch and push a small follow-up change. The first feature-branch push should restore from `main` and then save a branch-local cache.
+3. Push a second small commit to the same feature branch. That run should prefer the branch-local cache.
+4. Open or update a PR from the same branch. The PR run should restore from the branch cache first, then fall back to `main` if needed.
+
+## Usage Pattern For Other Repos
+
+Use this same shape when applying Soldr CI caching elsewhere:
+
+- keep cache keys branch-agnostic for correctness-relevant inputs only
+- let `push` runs save caches in the current branch scope
+- let PR runs restore only
+- rely on GitHub's built-in restore order so current-branch caches win over `main`
+- treat `main` as the canonical shared parent cache, not sibling branches


### PR DESCRIPTION
Closes #153.

## Summary
- document the GitHub Actions cache visibility model in the README before the implementation details
- run CI on pushes to `main` so the default branch continuously refreshes the canonical dependency cache lineage
- save canonical caches only on the default branch while letting PRs restore from that branch-agnostic lineage in both `ci.yml` and `_bootstrap-e2e.yml`

## Verification
- `python -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in [r'C:\Users\niteris\dev\soldr-153\.github\workflows\ci.yml', r'C:\Users\niteris\dev\soldr-153\.github\workflows\_bootstrap-e2e.yml']]; print('yaml-ok')"`
- `git diff --check`
