### PR TITLE
Emit cache benchmark issue comment artifact

### DIFF
--- a/.github/scripts/cache_benchmark_report.py
+++ b/.github/scripts/cache_benchmark_report.py
@@ -467,27 +467,21 @@ def _phase1_result_label(
     return f"{mutation['label']} (`{mutation['path']}`)"
 
 
-def _build_phase1_summary_lines(config: dict[str, Any], payload: dict[str, Any]) -> list[str]:
+def _phase1_issue_target(config: dict[str, Any]) -> str:
+    issue_number = config["phase1"].get("issue")
+    return f"#{issue_number}" if issue_number is not None else "the Phase 1 tracker issue"
+
+
+def _build_phase1_issue_comment_lines(
+    config: dict[str, Any], payload: dict[str, Any]
+) -> list[str]:
     phase1 = config["phase1"]
     mutation_by_id = _mutation_by_id(config)
     runner = payload.get("runner") or phase1["runner"]
     target = payload.get("target") or phase1["target"]
     threshold = float(payload.get("threshold_ratio") or phase1["default_threshold_ratio"])
     cache_backend = payload["cache_backend"]
-    scenario = payload["scenario"]
-    command = _format_command(phase1["command"], target)
-    workflow_summary = [
-        "### Cache Benchmark Summary",
-        "",
-        f"- cache backend: `{cache_backend}`",
-        f"- requested scenario: `{scenario}`",
-        f"- required ratio: `{threshold:.2f}x`",
-        f"- runner: `{runner}`",
-        f"- target: `{target}`",
-        f"- measured command: `{command}`",
-        "",
-    ]
-    issue_comment = [
+    issue_comment_lines = [
         "### Phase 1 benchmark results",
         "",
         "- workflow: `cache-benchmark.yml`",
@@ -512,7 +506,48 @@ def _build_phase1_summary_lines(config: dict[str, Any], payload: dict[str, Any])
         if status == "skipped":
             continue
 
-        workflow_summary.extend(
+        issue_summary = [
+            f"- {label}: job result `{status}`",
+            f"  cache detail: `{hit_detail}`",
+        ]
+        if status == "success":
+            issue_summary[0] = (
+                f"- {label}: cold `{_format_seconds(cold)}`, warm `{_format_seconds(warm)}`, "
+                f"saved `{_format_seconds(saved)}`, speedup `{_format_ratio(ratio)}`, "
+                f"cache hit `{_format_bool(cache_hit)}`"
+            )
+        issue_comment_lines.extend(issue_summary)
+
+    issue_comment_lines.extend(
+        [
+            "",
+            "Timing artifacts are attached for each seed, cold, and warm child job as `cache-benchmark-<backend>-<mutation>-<stage>-timings`.",
+        ]
+    )
+
+    return issue_comment_lines
+
+
+def _build_phase1_workflow_detail_lines(
+    config: dict[str, Any], payload: dict[str, Any]
+) -> list[str]:
+    mutation_by_id = _mutation_by_id(config)
+    detail_lines: list[str] = []
+
+    for result in payload["results"]:
+        mutation_id = result["mutation"]
+        label = _phase1_result_label(mutation_by_id, mutation_id)
+        status = result.get("result", "success")
+        if status == "skipped":
+            continue
+
+        cold = _read_float(result.get("cold_seconds"))
+        warm = _read_float(result.get("warm_seconds"))
+        saved = _read_float(result.get("saved_seconds"))
+        ratio = _read_float(result.get("speedup_ratio"))
+        cache_hit = _read_bool(result.get("cache_hit"))
+        hit_detail = result.get("cache_hit_detail") or "n/a"
+        detail_lines.extend(
             [
                 f"#### {label}",
                 "",
@@ -527,35 +562,60 @@ def _build_phase1_summary_lines(config: dict[str, Any], payload: dict[str, Any])
             ]
         )
 
-        issue_summary = [
-            f"- {label}: job result `{status}`",
-            f"  cache detail: `{hit_detail}`",
-        ]
-        if status == "success":
-            issue_summary[0] = (
-                f"- {label}: cold `{_format_seconds(cold)}`, warm `{_format_seconds(warm)}`, "
-                f"saved `{_format_seconds(saved)}`, speedup `{_format_ratio(ratio)}`, "
-                f"cache hit `{_format_bool(cache_hit)}`"
-            )
-        issue_comment.extend(issue_summary)
+    return detail_lines
 
-    issue_number = phase1.get("issue")
-    issue_target = f"#{issue_number}" if issue_number is not None else "the Phase 1 tracker issue"
-    issue_comment.extend(
-        [
-            "",
-            "Timing artifacts are attached for each seed, cold, and warm child job as `cache-benchmark-<backend>-<mutation>-<stage>-timings`.",
-            "",
-            f"Copy this block into issue {issue_target}.",
-        ]
-    )
+
+def _write_phase1_issue_comment(lines: list[str]) -> str | None:
+    issue_comment_path = os.environ.get("BENCHMARK_PHASE1_ISSUE_COMMENT_PATH")
+    if not issue_comment_path:
+        return None
+    output_path = Path(issue_comment_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return issue_comment_path
+
+
+def _build_phase1_summary_lines(config: dict[str, Any], payload: dict[str, Any]) -> list[str]:
+    phase1 = config["phase1"]
+    runner = payload.get("runner") or phase1["runner"]
+    target = payload.get("target") or phase1["target"]
+    threshold = float(payload.get("threshold_ratio") or phase1["default_threshold_ratio"])
+    cache_backend = payload["cache_backend"]
+    scenario = payload["scenario"]
+    command = _format_command(phase1["command"], target)
+    issue_comment_lines = _build_phase1_issue_comment_lines(config, payload)
+    issue_target = _phase1_issue_target(config)
+    issue_comment_path = _write_phase1_issue_comment(issue_comment_lines)
+    workflow_summary = [
+        "### Cache Benchmark Summary",
+        "",
+        f"- cache backend: `{cache_backend}`",
+        f"- requested scenario: `{scenario}`",
+        f"- required ratio: `{threshold:.2f}x`",
+        f"- runner: `{runner}`",
+        f"- target: `{target}`",
+        f"- measured command: `{command}`",
+        "",
+    ]
+    workflow_summary.extend(_build_phase1_workflow_detail_lines(config, payload))
+    if issue_comment_path:
+        workflow_summary.extend(
+            [
+                "### Issue Comment Artifact",
+                "",
+                f"- markdown artifact: `{issue_comment_path}`",
+                "",
+            ]
+        )
 
     return workflow_summary + [
         "### Issue Comment Draft",
         "",
         "```markdown",
-        *issue_comment,
+        *issue_comment_lines,
         "```",
+        "",
+        f"Copy this block into issue {issue_target}.",
     ]
 
 

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -172,4 +172,12 @@ jobs:
           BENCHMARK_REPORT_MODE: phase1-summary
           BENCHMARK_CONFIG_PATH: benchmark.toml
           BENCHMARK_PHASE1_INPUT_JSON: benchmark-summary/phase1-summary-input.json
+          BENCHMARK_PHASE1_ISSUE_COMMENT_PATH: benchmark-summary/phase1-issue-comment.md
         run: python3 .github/scripts/cache_benchmark_report.py
+
+      - name: Upload phase 1 issue comment artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cache-benchmark-phase1-issue-comment
+          path: benchmark-summary/phase1-issue-comment.md
+          if-no-files-found: error

--- a/tests/test_cache_benchmark_report.py
+++ b/tests/test_cache_benchmark_report.py
@@ -161,6 +161,38 @@ def _sample_results() -> list[dict[str, object]]:
     ]
 
 
+def _phase1_payload() -> dict[str, object]:
+    return {
+        "cache_backend": "zccache",
+        "scenario": "all",
+        "runner": "ubuntu-24.04",
+        "target": "x86_64-unknown-linux-gnu",
+        "threshold_ratio": "10",
+        "results": [
+            {
+                "mutation": "soldr-cli",
+                "result": "success",
+                "cold_seconds": 76.2,
+                "warm_seconds": 1.4,
+                "saved_seconds": 74.8,
+                "speedup_ratio": 54.43,
+                "cache_hit": True,
+                "cache_hit_detail": "backend=zccache;same_job_seed=true",
+            },
+            {
+                "mutation": "soldr-core",
+                "result": "skipped",
+                "cold_seconds": "",
+                "warm_seconds": "",
+                "saved_seconds": "",
+                "speedup_ratio": "",
+                "cache_hit": "",
+                "cache_hit_detail": "",
+            },
+        ],
+    }
+
+
 def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
     input_path = tmp_path / "cache-benchmark-results.json"
     json_path = tmp_path / "cache-benchmark-summary.json"
@@ -229,3 +261,63 @@ def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
     assert "soldr uses managed zccache internally." in www_html
     assert "latest.json" in www_html
     assert (www_dir / ".nojekyll").exists()
+
+
+def test_phase1_summary_writes_issue_comment_markdown_artifact(tmp_path: Path) -> None:
+    input_path = tmp_path / "phase1-summary-input.json"
+    summary_path = tmp_path / "step-summary.md"
+    issue_comment_path = tmp_path / "benchmark-summary" / "phase1-issue-comment.md"
+    input_path.write_text(json.dumps(_phase1_payload(), indent=2) + "\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "BENCHMARK_REPORT_MODE": "phase1-summary",
+            "BENCHMARK_CONFIG_PATH": str(CONFIG_PATH),
+            "BENCHMARK_PHASE1_INPUT_JSON": str(input_path),
+            "BENCHMARK_PHASE1_ISSUE_COMMENT_PATH": "benchmark-summary/phase1-issue-comment.md",
+            "GITHUB_STEP_SUMMARY": str(summary_path),
+        }
+    )
+
+    subprocess.run([sys.executable, str(SCRIPT_PATH)], check=True, env=env, cwd=tmp_path)
+
+    issue_comment = issue_comment_path.read_text(encoding="utf-8")
+    assert issue_comment.startswith("### Phase 1 benchmark results\n")
+    assert "- workflow: `cache-benchmark.yml`" in issue_comment
+    assert "- cache backend under test: `zccache`" in issue_comment
+    assert "- threshold used: `10.00x`" in issue_comment
+    assert "- Top-crate edit (`crates/soldr-cli/src/main.rs`): cold `76.20s`, warm `1.40s`, saved `74.80s`, speedup `54.43x`, cache hit `true`" in issue_comment
+    assert "Lower-crate edit" not in issue_comment
+    assert "Copy this block into issue #122." not in issue_comment
+    assert "```" not in issue_comment
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "### Issue Comment Draft" in summary
+    assert "### Issue Comment Artifact" in summary
+    assert "`benchmark-summary/phase1-issue-comment.md`" in summary
+    assert "Copy this block into issue #122." in summary
+
+
+def test_phase1_summary_without_issue_comment_path_keeps_summary_only(tmp_path: Path) -> None:
+    input_path = tmp_path / "phase1-summary-input.json"
+    summary_path = tmp_path / "step-summary.md"
+    issue_comment_path = tmp_path / "benchmark-summary" / "phase1-issue-comment.md"
+    input_path.write_text(json.dumps(_phase1_payload(), indent=2) + "\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "BENCHMARK_REPORT_MODE": "phase1-summary",
+            "BENCHMARK_CONFIG_PATH": str(CONFIG_PATH),
+            "BENCHMARK_PHASE1_INPUT_JSON": str(input_path),
+            "GITHUB_STEP_SUMMARY": str(summary_path),
+        }
+    )
+
+    subprocess.run([sys.executable, str(SCRIPT_PATH)], check=True, env=env, cwd=tmp_path)
+
+    assert not issue_comment_path.exists()
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "### Issue Comment Draft" in summary
+    assert "### Issue Comment Artifact" not in summary


### PR DESCRIPTION
Refs #122.

## Summary
- emit a standalone Phase 1 issue-comment markdown file from `.github/scripts/cache_benchmark_report.py` when the workflow requests it
- keep the detailed step summary preview while separating the copy-ready markdown artifact from operator-only instructions
- upload the generated markdown from `cache-benchmark.yml` as a dedicated artifact and add tests around the new behavior

## Verification
- `pytest tests/test_cache_benchmark_report.py`
- `git diff --check`
- `python - <<'PY'
import pathlib
import yaml
path = pathlib.Path('.github/workflows/cache-benchmark.yml')
yaml.safe_load(path.read_text(encoding='utf-8'))
print('yaml-ok')
PY`
