### PR TITLE
Add setup-soldr action exporter

### DIFF
--- a/docs/SETUP_SOLDR_EXPORTER.md
+++ b/docs/SETUP_SOLDR_EXPORTER.md
@@ -1,0 +1,45 @@
+# setup-soldr Exporter
+
+This repository cannot publish its root `action.yml` directly to GitHub Marketplace, but it now contains an exporter that materializes the releaseable `setup-soldr` action bundle for a future public `zackees/setup-soldr` repository.
+
+## Command
+
+From the `soldr` repository root:
+
+```powershell
+python tools/export_setup_soldr_action.py ..\setup-soldr
+```
+
+You can also target another checkout explicitly:
+
+```powershell
+python tools/export_setup_soldr_action.py C:\tmp\setup-soldr --source-root C:\src\soldr
+```
+
+## Exported Files
+
+The exporter writes the standalone repository shape defined in `docs/SETUP_SOLDR_PUBLIC_ACTION.md`:
+
+- `action.yml`
+- `README.md`
+- `LICENSE`
+- `.github/actions/setup-soldr/resolve_setup.py`
+- `.github/actions/setup-soldr/ensure_rust_toolchain.py`
+- `.github/actions/setup-soldr/ensure_soldr.py`
+- `.github/actions/setup-soldr/verify_soldr.py`
+
+## Behavior
+
+- rewrites the root `action.yml` into the public action form by removing the internal-only `repo` input and its `INPUT_REPO` wiring
+- keeps the helper-script layout unchanged so extraction stays mechanical
+- generates a public-facing `README.md` with Linux, macOS, and Windows workflow examples plus the supported action inputs and outputs
+- refuses to export into the `soldr` source repository root
+
+## Intended Release Flow
+
+1. Validate action changes in `zackees/soldr`.
+2. Run the exporter into a clean `zackees/setup-soldr` checkout.
+3. Review the generated bundle diff there.
+4. Tag and release the public action from that dedicated repository.
+
+The contract and release-versioning rules still live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./SETUP_SOLDR_PUBLIC_ACTION.md).

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+HELPER_SCRIPT_PATHS = (
+    Path('.github/actions/setup-soldr/resolve_setup.py'),
+    Path('.github/actions/setup-soldr/ensure_rust_toolchain.py'),
+    Path('.github/actions/setup-soldr/ensure_soldr.py'),
+    Path('.github/actions/setup-soldr/verify_soldr.py'),
+)
+
+PUBLIC_ACTION_REPO = 'zackees/setup-soldr'
+PUBLIC_README = """# setup-soldr
+
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring a cacheable runner-local root for Soldr, Cargo, and rustup state.
+
+This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
+
+## Usage
+
+### Linux
+
+```yaml
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v1
+        with:
+          version: 0.7.4
+          cache: true
+      - run: soldr cargo build --locked --release
+      - run: soldr cargo test --locked
+```
+
+### macOS
+
+```yaml
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v1
+        with:
+          version: 0.7.4
+          cache: true
+      - run: soldr cargo build --locked --release
+      - run: soldr cargo test --locked
+```
+
+### Windows
+
+```yaml
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v1
+        with:
+          version: 0.7.4
+          cache: true
+      - run: soldr cargo build --locked --release
+      - run: soldr cargo test --locked
+```
+
+## Inputs
+
+| Input | Meaning |
+|---|---|
+| `version` | Soldr release tag or version to install. Empty means latest release. |
+| `cache` | Restore and save the action-managed cache/state root. |
+| `cache-dir` | Override the runner-local cache/state root. |
+| `cache-key-suffix` | Optional escape hatch appended to the cache key. |
+| `toolchain` | Explicit Rust toolchain channel override. |
+| `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
+| `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+
+## Outputs
+
+| Output | Meaning |
+|---|---|
+| `soldr-path` | Installed Soldr binary path added to `PATH`. |
+| `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
+| `cache-dir` | Action-managed runner-local cache/state root. |
+| `cache-hit` | Whether the action restored an exact cache hit. |
+| `toolchain` | Exact Rust toolchain channel configured for the action. |
+
+## Notes
+
+- The action installs exactly one released `soldr` binary for the active runner target.
+- The normal path provisions Rust with `rustup`; on self-hosted runners, `rustup` must already be available.
+- The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
+- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
+
+## Development
+
+Regenerate this repository bundle from the source repository with the exporter in `zackees/soldr`.
+"""
+
+
+def _module_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding='utf-8')
+
+
+def _copy_file(source_root: Path, destination_root: Path, relative_path: Path) -> None:
+    source_path = source_root / relative_path
+    if not source_path.is_file():
+        raise FileNotFoundError(f'Missing source file for export: {source_path}')
+    destination_path = destination_root / relative_path
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, destination_path)
+
+
+def _strip_repo_input(action_text: str) -> str:
+    output_lines: list[str] = []
+    skipping_repo_input = False
+
+    for line in action_text.splitlines():
+        if skipping_repo_input:
+            if line.startswith('  ') and not line.startswith('    '):
+                skipping_repo_input = False
+            else:
+                continue
+
+        if line == '  repo:':
+            skipping_repo_input = True
+            continue
+
+        if 'INPUT_REPO:' in line:
+            continue
+
+        output_lines.append(line)
+
+    return '\n'.join(output_lines) + '\n'
+
+
+def render_public_action_yaml(source_root: Path) -> str:
+    return _strip_repo_input((source_root / 'action.yml').read_text(encoding='utf-8'))
+
+
+def render_public_readme() -> str:
+    return PUBLIC_README
+
+
+def export_setup_soldr_bundle(source_root: Path, destination_root: Path) -> Path:
+    source_root = source_root.resolve()
+    destination_root = destination_root.expanduser().resolve()
+
+    if destination_root == source_root:
+        raise ValueError('Destination must not be the source repository root')
+
+    destination_root.mkdir(parents=True, exist_ok=True)
+    _write_text(destination_root / 'action.yml', render_public_action_yaml(source_root))
+    _write_text(destination_root / 'README.md', render_public_readme())
+    _copy_file(source_root, destination_root, Path('LICENSE'))
+
+    for relative_path in HELPER_SCRIPT_PATHS:
+        _copy_file(source_root, destination_root, relative_path)
+
+    return destination_root
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Export the standalone public setup-soldr action bundle.'
+    )
+    parser.add_argument('destination', help='Directory to materialize as the future public action repository.')
+    parser.add_argument(
+        '--source-root',
+        default=str(_module_repo_root()),
+        help='Source soldr repository root. Defaults to the current checkout.',
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    destination = export_setup_soldr_bundle(Path(args.source_root), Path(args.destination))
+    print(f'Exported setup-soldr bundle to {destination}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -1,0 +1,106 @@
+# setup-soldr
+
+Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring a cacheable runner-local root for Soldr, Cargo, and rustup state.
+
+This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
+
+## Usage
+
+### Linux
+
+```yaml
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v1
+        with:
+          version: 0.7.4
+          cache: true
+      - run: soldr cargo build --locked --release
+      - run: soldr cargo test --locked
+```
+
+### macOS
+
+```yaml
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v1
+        with:
+          version: 0.7.4
+          cache: true
+      - run: soldr cargo build --locked --release
+      - run: soldr cargo test --locked
+```
+
+### Windows
+
+```yaml
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v1
+        with:
+          version: 0.7.4
+          cache: true
+      - run: soldr cargo build --locked --release
+      - run: soldr cargo test --locked
+```
+
+## Inputs
+
+| Input | Meaning |
+|---|---|
+| `version` | Soldr release tag or version to install. Empty means latest release. |
+| `cache` | Restore and save the action-managed cache/state root. |
+| `cache-dir` | Override the runner-local cache/state root. |
+| `cache-key-suffix` | Optional escape hatch appended to the cache key. |
+| `toolchain` | Explicit Rust toolchain channel override. |
+| `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
+| `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+
+## Outputs
+
+| Output | Meaning |
+|---|---|
+| `soldr-path` | Installed Soldr binary path added to `PATH`. |
+| `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
+| `cache-dir` | Action-managed runner-local cache/state root. |
+| `cache-hit` | Whether the action restored an exact cache hit. |
+| `toolchain` | Exact Rust toolchain channel configured for the action. |
+
+## Notes
+
+- The action installs exactly one released `soldr` binary for the active runner target.
+- The normal path provisions Rust with `rustup`; on self-hosted runners, `rustup` must already be available.
+- The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
+- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
+
+## Development
+
+Regenerate this repository bundle from the source repository with the exporter in `zackees/soldr`.

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -1,0 +1,103 @@
+name: setup-soldr
+author: zackees
+description: Extraction-ready Soldr setup action. Installs one soldr binary, provisions the resolved Rust toolchain via rustup, and restores a cacheable runner-local Soldr root.
+inputs:
+  version:
+    description: Soldr version or tag to install. Defaults to the latest release.
+    required: false
+    default: ""
+  cache:
+    description: Restore and save the action-managed cache/state root across workflow runs.
+    required: false
+    default: "true"
+  cache-dir:
+    description: Override the runner-local cache/state root used for Soldr, Cargo, and rustup state rehydrated by this action.
+    required: false
+    default: ""
+  cache-key-suffix:
+    description: Optional extra suffix appended to the cache key.
+    required: false
+    default: ""
+  toolchain:
+    description: Override the exact Rust toolchain channel string. When empty, toolchain-file is used if present, otherwise stable.
+    required: false
+    default: ""
+  toolchain-file:
+    description: Toolchain file to read when toolchain is not explicitly set.
+    required: false
+    default: rust-toolchain.toml
+  trust-mode:
+    description: Optional value for SOLDR_TRUST_MODE.
+    required: false
+    default: ""
+outputs:
+  soldr-path:
+    description: Installed Soldr binary path added to PATH for later steps.
+    value: ${{ steps.resolve.outputs.soldr_path }}
+  soldr-version:
+    description: Installed Soldr version reported by soldr version --json.
+    value: ${{ steps.verify.outputs.soldr_version }}
+  cache-dir:
+    description: Runner-local cache/state root used by the action.
+    value: ${{ steps.resolve.outputs.cache_root }}
+  cache-hit:
+    description: Whether the action restored an exact cache hit for the selected cache/state root.
+    value: ${{ steps.cache-meta.outputs.cache_hit }}
+  toolchain:
+    description: Exact Rust toolchain channel configured by rustup for the action.
+    value: ${{ steps.resolve.outputs.toolchain }}
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: pwsh
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_CACHE_DIR: ${{ inputs.cache-dir }}
+        INPUT_CACHE_KEY_SUFFIX: ${{ inputs.cache-key-suffix }}
+        INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
+        INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
+        INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
+        ACTION_WORKSPACE: ${{ github.workspace }}
+        ACTION_OS: ${{ runner.os }}
+        ACTION_ARCH: ${{ runner.arch }}
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/resolve_setup.py"
+
+    - id: cache
+      if: ${{ inputs.cache == 'true' }}
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.cache_root }}
+        key: ${{ steps.resolve.outputs.cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.cache_restore_prefix }}
+
+    - id: toolchain
+      shell: pwsh
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_rust_toolchain.py"
+
+    - id: install
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        SOLDR_REPO: ${{ steps.resolve.outputs.soldr_repo }}
+        SOLDR_INSTALL_DIR: ${{ steps.resolve.outputs.bin_dir }}
+        SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_requested }}
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_soldr.py"
+
+    - id: verify
+      shell: pwsh
+      env:
+        SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
+
+    - id: cache-meta
+      shell: pwsh
+      env:
+        RAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+      run: |
+        $value = $env:RAW_CACHE_HIT
+        if ([string]::IsNullOrWhiteSpace($value)) {
+          $value = "false"
+        }
+        "cache_hit=$value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/tests/test_setup_soldr_exporter.py
+++ b/tests/test_setup_soldr_exporter.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "src" / "soldr" / "setup_soldr_exporter.py"
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "setup_soldr_exporter"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("setup_soldr_exporter", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_export_bundle_creates_expected_public_repo_layout(tmp_path: Path) -> None:
+    module = _load_module()
+    destination = tmp_path / "setup-soldr"
+
+    module.export_setup_soldr_bundle(REPO_ROOT, destination)
+
+    assert sorted(
+        path.relative_to(destination).as_posix()
+        for path in destination.rglob("*")
+        if path.is_file()
+    ) == [
+        ".github/actions/setup-soldr/ensure_rust_toolchain.py",
+        ".github/actions/setup-soldr/ensure_soldr.py",
+        ".github/actions/setup-soldr/resolve_setup.py",
+        ".github/actions/setup-soldr/verify_soldr.py",
+        "LICENSE",
+        "README.md",
+        "action.yml",
+    ]
+
+    assert destination.joinpath("action.yml").read_text(encoding="utf-8") == FIXTURE_DIR.joinpath(
+        "expected_action.yml"
+    ).read_text(encoding="utf-8")
+    assert destination.joinpath("README.md").read_text(encoding="utf-8") == FIXTURE_DIR.joinpath(
+        "expected_README.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_export_bundle_excludes_internal_repo_override_input(tmp_path: Path) -> None:
+    module = _load_module()
+    destination = tmp_path / "setup-soldr"
+
+    module.export_setup_soldr_bundle(REPO_ROOT, destination)
+
+    action_yaml = destination.joinpath("action.yml").read_text(encoding="utf-8")
+    assert "repo:" not in action_yaml
+    assert "INPUT_REPO" not in action_yaml
+    assert "Not part of the intended public setup-soldr@v1 contract" not in action_yaml
+
+
+def test_export_bundle_refuses_repo_root_as_destination() -> None:
+    module = _load_module()
+
+    with pytest.raises(ValueError, match="Destination must not be the source repository root"):
+        module.export_setup_soldr_bundle(REPO_ROOT, REPO_ROOT)

--- a/tools/export_setup_soldr_action.py
+++ b/tools/export_setup_soldr_action.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / 'src'))
+
+from soldr.setup_soldr_exporter import main
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a standalone `setup-soldr` exporter module and wrapper script that materialize the future public action repository bundle
- generate a public-only `action.yml` and `README.md` while copying the helper scripts and `LICENSE`
- cover the exported bundle contract with fixture-backed tests and document the exporter workflow

## Testing
- `python -m pytest tests\test_setup_soldr_exporter.py`
- `python -m pytest tests\test_setup_soldr_action.py tests\test_setup_soldr_ensure_rust_toolchain.py tests\test_setup_soldr_ensure_soldr.py tests\test_setup_soldr_exporter.py`
- `python tools\export_setup_soldr_action.py $env:TEMP\setup-soldr-export-smoke`

Closes #137