### PR TITLE
Gate macOS x64 jobs to main and release pushes

### DIFF
--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release
     paths-ignore:
       - '*.md'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     needs: lint
+    if: matrix.runner != 'macos-15-intel' || github.event_name != 'push' || github.ref_name == 'main' || github.ref_name == 'release'
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:
@@ -107,6 +108,7 @@ jobs:
 
   e2e-macos-x64:
     name: build
+    if: github.event_name != 'push' || github.ref_name == 'main' || github.ref_name == 'release'
     uses: ./.github/workflows/_bootstrap-e2e.yml
     with:
       runner: macos-15-intel


### PR DESCRIPTION
Limit the expensive macOS x64 runner usage to the branches that actually need it.

## What changed
- skip the `CI` macOS x64 test matrix leg unless the event is a PR or a push to `main` / `release`
- skip the `CI` `e2e-macos-x64` job unless the event is a PR or a push to `main` / `release`
- allow the dedicated `build-macos-x64` workflow to trigger on `release` in addition to `main`

## Why
Intel macOS runners are the current bottleneck. Feature-branch pushes should not spend queue time on that lane.

## Verification
- `git diff --check`
- YAML parse for `.github/workflows/ci.yml` and `.github/workflows/build-macos-x64.yml`
