### PR TITLE
docs: clarify rustup fallback and rustup-init bootstrap

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -59,7 +59,7 @@ Current cache-control behavior:
 - `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
 - zccache integration currently targets Rust builds through the cargo front door
 - zccache's current artifact store and daemon endpoint remain on zccache's default paths; soldr currently manages the session lifecycle and logs
-- if `RUSTUP_TOOLCHAIN` is explicitly set, soldr continues to ask `rustup` for the matching toolchain binary
+- toolchain binaries (`rustc`, `rustfmt`, `clippy-driver`, etc.) are resolved directly from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` before any `rustup` call; `rustup which` is only used as a fallback when the direct probe fails. The sole exception is when `RUSTUP_TOOLCHAIN` is explicitly set to a non-empty value — in that case soldr skips the direct probe and asks `rustup` for the matching toolchain binary so the pinned channel always wins
 
 This is the normal build entry point.
 

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -108,7 +108,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 `v1` should preserve these behaviors:
 
 - install exactly one released Soldr binary for the active runner OS and architecture
-- provision the normal-path Rust toolchain itself via `rustup`; users should not need a separate toolchain action for the common path
+- provision the normal-path Rust toolchain itself, bootstrapping `rustup` via `rustup-init` when it is not already on the runner; users should not need to preinstall `rustup` or run a separate toolchain-setup action for the common path
 - create and export `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME`
 - put the installed `soldr` binary on `PATH`
 - restore and save the action-managed cache/state root when `cache: true`
@@ -119,7 +119,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 The extracted public action must document these current limits honestly:
 
 - the action rehydrates the Soldr root, Cargo home, and rustup home under the chosen cache/state root
-- Soldr still uses `rustup` under the hood today
+- the action bootstraps `rustup` on demand via `rustup-init` when it is absent, then uses it to install the requested toolchain; at runtime Soldr prefers direct toolchain binaries from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` and only falls back to `rustup which` when the direct probe fails (or when `RUSTUP_TOOLCHAIN` is explicitly set)
 - managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path
 
 ### Non-Contract Details


### PR DESCRIPTION
## Summary

- `docs/API.md`: rewrite the `RUSTUP_TOOLCHAIN` bullet so it states the current runtime contract — soldr resolves toolchain binaries directly from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` first and only falls back to `rustup which` when that probe fails, with explicit `RUSTUP_TOOLCHAIN` being the sole case where the direct probe is skipped (matches `soldr_core::probe_toolchain_binary` / `resolve_runtime_rustc`).
- `docs/SETUP_SOLDR_PUBLIC_ACTION.md`: update the "Required Behavior" and "Current Limits" bullets so they describe the real setup-soldr flow — `rustup` is bootstrapped on demand via `rustup-init` when missing (see `.github/actions/setup-soldr/ensure_rust_toolchain.py::ensure_rustup_available`) and users do not need to preinstall `rustup` or run a separate toolchain-setup action.

Refs #139.

## Test plan

- [ ] CI runs unit + integration tests on this PR.

Generated with [Claude Code](https://claude.com/claude-code)