### PR TITLE
fix: unbreak musl & other Unix builds through soldr cargo build

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -420,11 +420,31 @@ fn run_wrapper_through_zccache(
     raw_args: &[String],
     zccache: &std::path::Path,
 ) -> Result<i32, SoldrError> {
-    let status = std::process::Command::new(zccache)
-        .args(&raw_args[1..])
-        .status()?;
+    let mut command = std::process::Command::new(zccache);
+    command.args(&raw_args[1..]);
 
-    Ok(status.code().unwrap_or(1))
+    // Cargo's jobserver lives on numbered file descriptors that it inherits
+    // into the RUSTC_WRAPPER, advertised via CARGO_MAKEFLAGS. On Unix,
+    // exec'ing into zccache replaces the wrapper process in-place so those
+    // FDs flow straight through to the inner rustc — rustc otherwise emits
+    // "failed to connect to jobserver from environment variable
+    // CARGO_MAKEFLAGS=...: cannot open file descriptor N" because spawning
+    // a Rust child closes any FDs not explicitly inherited.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = command.exec();
+        return Err(SoldrError::Other(format!(
+            "failed to exec zccache at {}: {err}",
+            zccache.display()
+        )));
+    }
+
+    #[cfg(not(unix))]
+    {
+        let status = command.status()?;
+        Ok(status.code().unwrap_or(1))
+    }
 }
 
 async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -141,6 +141,23 @@ fn install_zccache_from_crates_io(
     std::fs::create_dir_all(&tool_dir)?;
 
     let install_root = tempfile::tempdir_in(&paths.bin)?;
+    // Cargo emits a "be sure to add `<root>/bin` to your PATH" warning whenever
+    // it installs into a `--root` that isn't already on PATH. The temp root
+    // here is just a staging area before we copy the binaries into the
+    // managed soldr cache, so the warning is misleading noise. Prepend the
+    // staging bin dir to PATH for the cargo subprocess so the check passes.
+    let install_bin = install_root.path().join("bin");
+    let install_path_env = match std::env::var_os("PATH") {
+        Some(existing) => {
+            let mut dirs: Vec<PathBuf> = vec![install_bin.clone()];
+            dirs.extend(std::env::split_paths(&existing));
+            std::env::join_paths(dirs).map_err(|e| {
+                SoldrError::Other(format!("failed to extend PATH for cargo install: {e}"))
+            })?
+        }
+        None => install_bin.clone().into_os_string(),
+    };
+
     for (package_name, binary_name) in MANAGED_ZCCACHE_PACKAGES {
         let install_status = std::process::Command::new("cargo")
             .args([
@@ -153,6 +170,7 @@ fn install_zccache_from_crates_io(
             ])
             .arg(install_root.path())
             .args(["--bin", binary_name, "--force"])
+            .env("PATH", &install_path_env)
             .status()
             .map_err(|e| {
                 SoldrError::Other(format!(


### PR DESCRIPTION
## Summary

Two regressions surface when downstream repos try to build through `soldr cargo build` on Linux — concrete reproducer is the [TechWatchProject/datalake-core docker-build job](https://github.com/TechWatchProject/datalake-core/actions/runs/24695030079/job/72225731111?pr=68) building \`x86_64-unknown-linux-musl\`. The PR there ([#69](https://github.com/TechWatchProject/datalake-core/pull/69)) was to drop \`soldr\` from that workflow as a workaround. This PR fixes the underlying issues so soldr stays usable for musl (and any other Linux build).

## Bug 1 — Jobserver FDs are dropped across the wrapper

### Symptom
Inside the user's \`soldr cargo build\`, rustc emits:
\`\`\`
warning: failed to connect to jobserver from environment variable
\`CARGO_MAKEFLAGS=\"-j --jobserver-fds=8,9 --jobserver-auth=8,9\"\`:
cannot open file descriptor 8 from the jobserver environment variable value: Bad file descriptor (os error 9)
\`\`\`

### Cause
- Cargo creates a jobserver, advertises FDs (e.g. 8,9) via \`CARGO_MAKEFLAGS\`, then spawns \`RUSTC_WRAPPER\` (== soldr) for each compilation expecting those FDs to flow through.
- soldr was using \`Command::new(zccache).status()\`. \`std::process::Command\` only inherits stdin/stdout/stderr by default; numbered FDs like the jobserver pair get dropped across the spawn.
- zccache then spawns rustc with \`CARGO_MAKEFLAGS\` still in env, but FDs 8,9 are gone, so rustc fails the \`fcntl(F_GETFD)\` check.

### Fix
On Unix, \`exec\` into zccache instead of spawn. The wrapper process is replaced in place, so the jobserver FDs (and everything else) flow straight through to the inner rustc with no spawn boundary to lose them across. Windows keeps \`status()\` — \`exec\` isn't available and the jobserver model differs.

## Bug 2 — \`cargo install\` PATH warning leaks to user output

### Symptom
During \`soldr\`'s first-run zccache fetch, three of these:
\`\`\`
warning: be sure to add \`/home/runner/.soldr/bin/.tmpYy9CLo/bin\` to your PATH to be able to run the installed binaries
\`\`\`

### Cause
\`install_zccache_from_crates_io\` shells out to \`cargo install --root <tempdir>\` three times (one per managed package). Cargo's \"add this to PATH\" check fires every time because the temp staging root is by definition not on PATH. soldr copies the binaries straight out of that dir into the managed cache and discards the temp dir, so the warning is misleading noise.

### Fix
Prepend the staging \`bin\` dir to \`PATH\` for the cargo subprocess so the check passes. No suppression of unrelated warnings.

## Test plan

- [x] \`cargo test --workspace\` passes locally with \`RUSTUP_TOOLCHAIN\` set
- [ ] CI green on this branch
- [ ] After merge + new release, re-enable \`soldr cargo build\` in TechWatchProject/datalake-core's docker-build workflow and confirm both warnings are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)