### PR TITLE
chore: bump version to 0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.7.4" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.4" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.7.4" }
+soldr-core = { path = "crates/soldr-core", version = "0.7.5" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.5" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.7.5" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.7.4 to 0.7.5 so the Autonomous Release workflow can publish a new release on merge.

## What's in this release

- **#160** — opt-in \`build-cache: true\` input on the \`setup-soldr\` action that restores/saves \`~/.zccache\` across runs, plus the CLI test isolation fixes that unblocked the action smoke workflow.
- **#162** — jobserver FD inheritance fix (exec into zccache on Unix instead of spawning, so cargo's \`--jobserver-fds=N,M\` from \`CARGO_MAKEFLAGS\` actually reaches rustc) and \`cargo install\` PATH-warning suppression. Together these make downstream Linux/musl builds through \`soldr cargo build\` quiet again — the issues that motivated [TechWatchProject/datalake-core#69](https://github.com/TechWatchProject/datalake-core/pull/69) and [datalake-core#70](https://github.com/TechWatchProject/datalake-core/issues/70).

## Test plan

- [ ] Autonomous Release workflow runs on merge and publishes \`v0.7.5\` to GitHub Releases + PyPI
- [ ] After publish, datalake-core can bump its pin from \`soldr==0.7.4\` to \`soldr==0.7.5\` and re-enable \`soldr cargo build\` on the musl docker workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)