### PR TITLE
feat(action): default build-cache to true (closes #164)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,12 +37,13 @@ inputs:
   build-cache:
     description: >
       Restore and save the zccache compilation artifact cache (~/.zccache)
-      across workflow runs. Opt-in. When "true", the action restores
-      ~/.zccache with a toolchain-scoped key and saves it at end-of-job,
-      letting GitHub's own-branch -> PR base -> default-branch restore order
-      seed feature-branch runs from the latest main-branch save.
+      across workflow runs. Default "true" — the action restores ~/.zccache
+      with a toolchain-scoped key and saves it at end-of-job, letting
+      GitHub's own-branch -> PR base -> default-branch restore order seed
+      feature-branch runs from the latest main-branch save without any
+      repo-side configuration. Set to "false" to opt out.
     required: false
-    default: "false"
+    default: "true"
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -59,8 +60,9 @@ outputs:
   build-cache-hit:
     description: >
       Whether the action restored the zccache compilation artifact cache
-      (~/.zccache). Empty string when `build-cache` is not enabled,
-      otherwise "true" for an exact key match, "false" otherwise.
+      (~/.zccache). "true" for an exact key match, "false" for a
+      restore-key fallback or no cache, empty string when `build-cache`
+      is explicitly disabled.
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -88,7 +88,7 @@ steps:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
-| `build-cache` | Opt-in. Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `"false"`. |
+| `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `"true"`; set to `"false"` to opt out. |
 
 The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v1` contract and should not be documented in the extracted public action README.
 
@@ -102,7 +102,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
-| `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty when `build-cache` is disabled. |
+| `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is explicitly disabled. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ### Required Behavior
@@ -115,7 +115,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - put the installed `soldr` binary on `PATH`
 - restore and save the action-managed cache/state root when `cache: true`
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
-- when `build-cache: true`, restore `~/.zccache` at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration.
+- when `build-cache: true` (the default), restore `~/.zccache` at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
 
 ### Current Limits That Must Stay Explicit
 


### PR DESCRIPTION
## Summary

Closes #164. Flips the \`setup-soldr\` action's \`build-cache\` input default from \`"false"\` to \`"true"\` so the zccache compilation artifact cache is restored and saved across runs by default.

## Why

The cache lineage from #160 (own branch → PR base → default branch) already gives parent-to-child cache seeding with no repo-side configuration. Defaulting the input to opt-in meant every consumer had to remember to flip the flag in every workflow that wanted the speedup. Defaulting to \`true\` matches the recommended usage and removes that footgun.

The opt-out path is unchanged: consumers that explicitly do not want cross-run cache reuse set \`build-cache: false\`.

## Behavior change

| | before | after |
|---|---|---|
| default | opt-in (\`false\`) | opt-in by default (\`true\`) |
| restore step runs | only with \`build-cache: true\` | always, unless \`build-cache: false\` |
| save step runs | only with \`build-cache: true\` | always, unless \`build-cache: false\` |
| \`build-cache-hit\` output | \`""\` when not opted in | \`""\` only when explicitly opted out |

The \`build-cache-hit\` output's description was tightened to make the new semantics explicit — empty now means the user opted out, not that the input wasn't passed.

## Follow-up

Per #164, downstream repos like \`TechWatchProject/datalake-core\` no longer need to remember to set \`build-cache: true\` — they get the cache automatically once they bump to the next \`setup-soldr\` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)