### PR TITLE
Enable setup-soldr build cache by default

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -47,6 +47,7 @@ jobs:
           Write-Host "soldr-version=${{ steps.setup.outputs.soldr-version }}"
           Write-Host "cache-dir=${{ steps.setup.outputs.cache-dir }}"
           Write-Host "cache-hit=${{ steps.setup.outputs.cache-hit }}"
+          Write-Host "build-cache-hit=${{ steps.setup.outputs.build-cache-hit }}"
           Write-Host "toolchain=${{ steps.setup.outputs.toolchain }}"
 
       - name: Verify setup state

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -62,6 +62,7 @@ The root action:
 - preinstalls the exact Rust toolchain resolved from `rust-toolchain.toml` or `toolchain:` via `rustup`
 - sets `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME`
 - restores and saves that runner-local root through GitHub cache when `cache: true`
+- restores and saves the zccache compilation artifact cache at `~/.zccache` by default; set `build-cache: false` to disable that layer
 
 Important toolchain rule:
 
@@ -108,6 +109,7 @@ Useful inputs when wiring the action into another repository:
 - `toolchain`: explicit Rust channel override when you do not want to rely on `rust-toolchain.toml`
 - `toolchain-file`: alternate toolchain file path when the repo does not use the default root `rust-toolchain.toml`
 - `cache`: turn the runner-local cache root on or off
+- `build-cache`: turn the `~/.zccache` compilation artifact cache on or off; defaults to `true`
 - `cache-dir`: move the shared Soldr/Cargo/rustup root to a specific path
 - `trust-mode`: set `SOLDR_TRUST_MODE` for stricter fetched-binary policy
 
@@ -119,6 +121,7 @@ Useful outputs:
 - `soldr-version`
 - `cache-dir`
 - `cache-hit`
+- `build-cache-hit`
 - `toolchain`
 
 ### What gets rehydrated today

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ That action:
 - bootstraps `rustup` into the cached runner-local root when the runner does not already have it
 - preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
+- restores and saves the zccache compilation artifact cache at `~/.zccache` by default; set `build-cache: false` to disable it
 - puts `soldr` on `PATH` for later steps
 - is the extraction source for the planned public `zackees/setup-soldr` action product
 

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
   build-cache:
     description: >
       Restore and save the zccache compilation artifact cache (~/.zccache)
-      across workflow runs. Default "true" — the action restores ~/.zccache
+      across workflow runs. Default "true"; the action restores ~/.zccache
       with a toolchain-scoped key and saves it at end-of-job, letting
       GitHub's own-branch -> PR base -> default-branch restore order seed
       feature-branch runs from the latest main-branch save without any

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -18,8 +18,8 @@ You get, for free:
 
 - branch-agnostic cache keys the action produces on its own
 - automatic restore on feature branches from the latest `main` cache on a miss
-- no separate `actions/cache` step — the action already runs one internally
-- a `cache-hit` output you can read to confirm warm vs cold runs
+- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves `~/.zccache` by default
+- `cache-hit` and `build-cache-hit` outputs you can read to confirm warm vs cold runs
 
 The rest of this document explains how and why that works.
 
@@ -42,14 +42,13 @@ Two consequences of that scoping rule matter for soldr:
 
 ## What setup-soldr Does For You Automatically
 
-The `zackees/soldr@v1` action (see [`action.yml`](../action.yml)) runs an internal `actions/cache` step keyed so that the parent-to-child restore works correctly without you configuring anything:
+The `zackees/soldr@v1` action (see [`action.yml`](../action.yml)) runs internal cache steps keyed so that the parent-to-child restore works correctly without you configuring anything:
 
-- **Branch-agnostic cache keys.** The cache key is derived from runner OS, runner architecture, the resolved Rust toolchain channel, and the requested soldr version. No branch name is in the key. Two branches with the same toolchain pin produce the same key, so a cache written by `main` is a valid candidate for a run on any feature branch.
+- **Branch-agnostic state-cache keys.** The setup-state cache key is derived from runner OS, runner architecture, the resolved Rust toolchain channel, and the requested soldr version. No branch name is in the key. Two branches with the same toolchain pin produce the same key, so a cache written by `main` is a valid candidate for a run on any feature branch.
 - **Restore-keys prefix for partial-match fallback.** The action registers a restore prefix (`setup-soldr-v1-{os}-{arch}-`) so that even if a future toolchain bump changes the exact key, GitHub can still fall back to the most recent compatible cache for the same OS and architecture.
 - **Push-only save semantics come for free.** GitHub's cache scoping already prevents feature-branch runs from overwriting `main`'s cache. You do not need to gate `save-if` yourself the way internal Rust caching wrappers usually make you do.
 - **Rehydrated state.** On a cache hit, the action restores the soldr root, `CARGO_HOME`, and `RUSTUP_HOME` under the runner-local cache/state root. The resolved Rust toolchain and the `soldr` binary are then provisioned on top of whatever was restored.
-
-Note that the action does not currently cache the `zccache` compiler artifact directory. Compiler output caching at the `RUSTC_WRAPPER` layer is still managed by zccache's own defaults today.
+- **Build-artifact cache enabled by default.** The action also restores `~/.zccache` with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs unless you opt out with `build-cache: false`.
 
 ## Minimum Config For An External Repo
 
@@ -79,7 +78,7 @@ jobs:
       - run: soldr cargo test --locked
 ```
 
-That is enough. No separate `actions/cache` step, no `Swatinem/rust-cache`, no manual `save-if` gating. The action handles the cache internally with the key shape described above.
+That is enough. No separate `actions/cache` step, no `Swatinem/rust-cache`, no manual `save-if` gating. The action handles the cache internally with the key shapes described above.
 
 A slightly fuller example that also demonstrates reading the action's outputs lives in [`examples/ci-minimal.yml`](../examples/ci-minimal.yml).
 
@@ -105,34 +104,39 @@ Add `pull_request` only if you explicitly need CI on the PR merge commit (for ex
 
 After two pushes to the same branch, you should be able to confirm the cache lineage is healthy.
 
-1. **Check the `cache-hit` output of the setup step.** Reference it from a later step like this:
+1. **Check the `cache-hit` and `build-cache-hit` outputs of the setup step.** Reference them from a later step like this:
 
-    ```yaml
-    - id: soldr
-      uses: zackees/soldr@v1
-      with:
-        cache: true
-    - run: echo "cache-hit=${{ steps.soldr.outputs.cache-hit }}"
-    ```
+   ```yaml
+   - id: soldr
+     uses: zackees/soldr@v1
+     with:
+       cache: true
+   - run: echo "cache-hit=${{ steps.soldr.outputs.cache-hit }}"
+   - run: echo "build-cache-hit=${{ steps.soldr.outputs.build-cache-hit }}"
+   ```
 
-    `true` means the key matched exactly. `false` means either a fresh key (cold) or a restore-keys fallback match (partial). Both `false` cases show the same literal `false` — distinguish them using the raw log.
+   `true` means the key matched exactly. `false` means either a fresh key (cold) or a restore-keys fallback match (partial). Both `false` cases show the same literal `false`; distinguish them using the raw log.
 
-2. **Open the raw log of the setup step.** Expand the internal `actions/cache` step inside the composite action. You want to see either:
-    - `Cache restored from key: setup-soldr-v1-...` — exact match, own-branch or default-branch key hit, or
-    - `Cache restored successfully` followed by a key that matches the restore prefix `setup-soldr-v1-{os}-{arch}-` — partial match via restore-keys.
+2. **Open the raw log of the setup step.** Expand the internal cache steps inside the composite action. You want to see either:
+   - `Cache restored from key: setup-soldr-v1-...` for an exact setup-state cache hit, or
+   - `Cache restored successfully` followed by a key that matches the restore prefix `setup-soldr-v1-{os}-{arch}-` for a partial setup-state restore.
+
    A line that says no cache was found at all, with no restore match, indicates a cold miss.
 
-3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. If you see `rustup` installing or soldr downloading from GitHub Releases on every run, the restore is not happening and something below is wrong.
+   For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
+
+3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 
 ## Debugging Cold Misses
 
 If feature branches keep rebuilding from scratch, check these in order:
 
 - **Has `main` run successfully recently?** The restore fallback only works if the default branch has written a cache. If the main-branch pipeline is red or was never run on this workflow file, there is no parent to restore from. Fix `main` first.
-- **Is `Cargo.lock` churning on every push?** Lockfile changes do not change the setup-soldr cache key, but they do invalidate downstream compilation caches managed by zccache. Check whether your workflow keeps regenerating `Cargo.lock` (for example, because `Cargo.lock` is gitignored in an application repo where it should be committed).
-- **Did `rust-toolchain.toml` change?** The resolved toolchain channel is part of the cache key hash. Bumping the toolchain channel or the components/targets list invalidates every existing entry. That is expected behavior; the next push to `main` will write a fresh canonical entry.
-- **Did you pass a `cache-key-suffix` input?** That value is appended to the cache key (see `action.yml`). A different suffix on a feature branch produces a different key than `main` writes, and the restore will only succeed through the prefix fallback. Make sure the same suffix is used (or omitted) on every branch you want to share a lineage.
+- **Is `Cargo.lock` churning on every push?** Lockfile changes do not change the setup-soldr state-cache key, but they do invalidate downstream compilation caches managed by zccache. Check whether your workflow keeps regenerating `Cargo.lock` (for example, because `Cargo.lock` is gitignored in an application repo where it should be committed).
+- **Did `rust-toolchain.toml` change?** The resolved toolchain channel is part of both cache key families. Bumping the toolchain channel or the components/targets list invalidates every existing entry. That is expected behavior; the next push to `main` will write a fresh canonical entry.
+- **Did you pass a `cache-key-suffix` input?** That value is appended to both cache key families (see `action.yml`). A different suffix on a feature branch produces a different key than `main` writes, and the restore will only succeed through the prefix fallback. Make sure the same suffix is used (or omitted) on every branch you want to share a lineage.
 - **Mixed runner OS/arch.** Cache keys are scoped by runner OS and architecture. A cache written on `ubuntu-24.04` will not restore on `macos-15` and vice versa. Each combination needs its own warm lineage from `main`.
+- **Did someone opt out of build caching?** If `build-cache: false` is set in the workflow, `build-cache-hit` will be empty and `~/.zccache` will not be restored or saved.
 
 ---
 

--- a/examples/ci-minimal.yml
+++ b/examples/ci-minimal.yml
@@ -38,5 +38,6 @@ jobs:
           cache: true
 
       - run: echo "soldr cache-hit=${{ steps.soldr.outputs.cache-hit }}"
+      - run: echo "soldr build-cache-hit=${{ steps.soldr.outputs.build-cache-hit }}"
       - run: soldr cargo build --locked
       - run: soldr cargo test --locked


### PR DESCRIPTION
## Summary
- default `build-cache` to `true` in the setup action
- update README, integration, public-action, CI cache, and example docs for the opt-out behavior
- surface `build-cache-hit` in the setup action smoke workflow and minimal CI example

## Validation
- `git diff --check -- action.yml README.md INTEGRATION.md docs\CI_CACHE.md docs\SETUP_SOLDR_PUBLIC_ACTION.md examples\ci-minimal.yml .github\workflows\setup-soldr-action.yml`