### PR TITLE
fix(action): save zccache after user build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ runs:
 
     - id: build-cache-restore
       if: ${{ inputs.build-cache == 'true' }}
-      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ~/.zccache
         key: ${{ steps.resolve.outputs.build_cache_key }}
@@ -145,10 +145,3 @@ runs:
           $buildValue = ""
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
-    - id: build-cache-save
-      if: ${{ always() && inputs.build-cache == 'true' }}
-      uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: ~/.zccache
-        key: ${{ steps.resolve.outputs.build_cache_key }}


### PR DESCRIPTION
## Summary

- replace the setup action's immediate `actions/cache/save` build-cache step with `actions/cache@v4`
- keep the existing build-cache key/output contract while letting GitHub save `~/.zccache` in the post-job phase after user build steps populate it

## Validation

- `python -m pytest tests/test_setup_soldr_action.py tests/test_setup_soldr_ensure_rust_toolchain.py tests/test_setup_soldr_ensure_soldr.py tests/test_setup_soldr_verify_soldr.py`
- Probe branch showed the previous implementation saved too early and logged `Path Validation Error: Path(s) specified in the action for caching do(es) not exist`
- Probe run after this change saved the build cache in post-job: `Cache saved with key: setup-soldr-buildcache-v1-linux-x64-...-2cc904a...`
- Rerunning the same commit restored that exact build cache and surfaced `build-cache-hit=true`

## Follow-up from #168

This fixes the missing `~/.zccache` save. The probe still did not achieve the fast path: even with exact `build-cache-hit=true`, zccache reported `0 cached, 181 cold` and the build remained ~37s. That means #168 should continue tracking the next layer: why restored zccache artifacts do not hit, or whether the public action needs a target-metadata cache layer like the repo-local benchmark action.