### PR TITLE
fix(action): restore target cache for no-op builds

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -68,6 +68,12 @@ def _sanitize_fragment(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-") or "default"
 
 
+def _short_file_hash(path: Path, missing: str) -> str:
+    if not path.exists():
+        return missing
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
 def _write_env(name: str, value: str) -> None:
     output = os.environ.get("GITHUB_ENV")
     if not output:
@@ -150,6 +156,7 @@ def main() -> None:
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
     cache_prefix = f"setup-soldr-v1-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
+    cargo_lock_hash = _short_file_hash(workspace / "Cargo.lock", "no-lock")
 
     suffix = os.environ.get("INPUT_CACHE_KEY_SUFFIX", "").strip()
     if suffix:
@@ -165,9 +172,19 @@ def main() -> None:
     build_cache_toolchain_prefix = f"{build_cache_prefix}-{digest}-"
     build_cache_key = f"{build_cache_toolchain_prefix}{github_sha}"
 
+    target_dir_input = os.environ.get("INPUT_TARGET_DIR", "target").strip() or "target"
+    target_cache_path = Path(target_dir_input).expanduser()
+    if not target_cache_path.is_absolute():
+        target_cache_path = workspace / target_cache_path
+    target_cache_path = target_cache_path.resolve()
+    target_cache_prefix = f"setup-soldr-targetcache-v1-{runner_os}-{runner_arch}"
+    target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+    target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
+
     if suffix:
         sanitized_suffix = _sanitize_fragment(suffix)
         build_cache_key = f"{build_cache_key}-{sanitized_suffix}"
+        target_cache_key = f"{target_cache_key}-{sanitized_suffix}"
 
     _write_env("SOLDR_CACHE_DIR", str(soldr_root))
     _write_env("CARGO_HOME", str(cargo_home))
@@ -190,6 +207,9 @@ def main() -> None:
             "build_cache_key": build_cache_key,
             "build_cache_restore_key_toolchain": build_cache_toolchain_prefix,
             "build_cache_restore_key_os_arch": f"{build_cache_prefix}-",
+            "target_cache_path": str(target_cache_path),
+            "target_cache_key": target_cache_key,
+            "target_cache_restore_key_lock": target_cache_lock_prefix,
             "soldr_root": str(soldr_root),
             "cargo_home": str(cargo_home),
             "rustup_home": str(rustup_home),

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -48,6 +48,7 @@ jobs:
           Write-Host "cache-dir=${{ steps.setup.outputs.cache-dir }}"
           Write-Host "cache-hit=${{ steps.setup.outputs.cache-hit }}"
           Write-Host "build-cache-hit=${{ steps.setup.outputs.build-cache-hit }}"
+          Write-Host "target-cache-hit=${{ steps.setup.outputs.target-cache-hit }}"
           Write-Host "toolchain=${{ steps.setup.outputs.toolchain }}"
 
       - name: Verify setup state

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ That action:
 - preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
 - restores and saves the zccache compilation artifact cache at `~/.zccache` by default; set `build-cache: false` to disable it
+- restores and saves the Cargo target directory by default for no-op CI fast paths; set `target-cache: false` to disable it or `target-dir:` to choose another target directory
 - puts `soldr` on `PATH` for later steps
 - is the extraction source for the planned public `zackees/setup-soldr` action product
 

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,18 @@ inputs:
       repo-side configuration. Set to "false" to opt out.
     required: false
     default: "true"
+  target-cache:
+    description: >
+      Restore and save the Cargo target directory across workflow runs.
+      Default "true"; this gives no-op child-branch builds a fast path when
+      Cargo can reuse restored fingerprints and outputs. Set to "false" to
+      cache only zccache compilation artifacts.
+    required: false
+    default: "true"
+  target-dir:
+    description: Cargo target directory restored by target-cache.
+    required: false
+    default: target
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -64,6 +76,12 @@ outputs:
       restore-key fallback or no cache, empty string when `build-cache`
       is explicitly disabled.
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
+  target-cache-hit:
+    description: >
+      Whether the action restored the Cargo target directory cache. "true"
+      for an exact key match, "false" for a restore-key fallback or no cache,
+      empty string when `target-cache` or `build-cache` is disabled.
+    value: ${{ steps.cache-meta.outputs.target_cache_hit }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
@@ -80,6 +98,7 @@ runs:
         INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
         INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
+        INPUT_TARGET_DIR: ${{ inputs.target-dir }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
@@ -104,6 +123,15 @@ runs:
           ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
+    - id: target-cache
+      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.target_cache_path }}
+        key: ${{ steps.resolve.outputs.target_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+
     - id: toolchain
       shell: pwsh
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_rust_toolchain.py"
@@ -123,12 +151,57 @@ runs:
         SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
 
+    - id: zccache-warm-target
+      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      shell: pwsh
+      env:
+        TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
+      run: |
+        $target = $env:TARGET_CACHE_PATH
+        if ([string]::IsNullOrWhiteSpace($target) -or -not (Test-Path -LiteralPath $target)) {
+          Write-Host "No restored target directory to warm."
+          exit 0
+        }
+
+        $exeName = if ($IsWindows) { "zccache.exe" } else { "zccache" }
+        $zccache = $null
+        if (-not [string]::IsNullOrWhiteSpace($env:SOLDR_CACHE_DIR)) {
+          $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
+          if (Test-Path -LiteralPath $soldrBin) {
+            $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
+              Select-Object -First 1 -ExpandProperty FullName
+          }
+        }
+        if ([string]::IsNullOrWhiteSpace($zccache)) {
+          $command = Get-Command zccache -ErrorAction SilentlyContinue
+          if ($command) {
+            $zccache = $command.Source
+          }
+        }
+        if ([string]::IsNullOrWhiteSpace($zccache)) {
+          Write-Host "zccache binary is not available yet; refreshing target mtimes only."
+        } else {
+          Write-Host "Warming target directory from zccache: $target"
+          & $zccache warm --target-dir $target
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "zccache warm did not complete successfully; continuing."
+          }
+        }
+
+        $stamp = (Get-Date).AddMinutes(1)
+        Get-ChildItem -LiteralPath $target -Recurse -File -Force -ErrorAction SilentlyContinue |
+          ForEach-Object { $_.LastWriteTime = $stamp }
+        Write-Host "Refreshed target file mtimes."
+        exit 0
+
     - id: cache-meta
       shell: pwsh
       env:
         RAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
         RAW_BUILD_CACHE_HIT: ${{ steps.build-cache-restore.outputs.cache-hit }}
+        RAW_TARGET_CACHE_HIT: ${{ steps.target-cache.outputs.cache-hit }}
         BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
+        TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
       run: |
         $value = $env:RAW_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($value)) {
@@ -145,3 +218,13 @@ runs:
           $buildValue = ""
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") {
+          $targetValue = $env:RAW_TARGET_CACHE_HIT
+          if ([string]::IsNullOrWhiteSpace($targetValue)) {
+            $targetValue = "false"
+          }
+        } else {
+          $targetValue = ""
+        }
+        "target_cache_hit=$targetValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -89,6 +89,8 @@ steps:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `"true"`; set to `"false"` to opt out. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
+| `target-dir` | Cargo target directory restored by `target-cache`. Default `"target"`. |
 
 The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v1` contract and should not be documented in the extracted public action README.
 
@@ -103,6 +105,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is explicitly disabled. |
+| `target-cache-hit` | Whether the Cargo target directory cache was restored. Empty only when `build-cache` or `target-cache` is explicitly disabled. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ### Required Behavior
@@ -116,6 +119,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - restore and save the action-managed cache/state root when `cache: true`
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
 - when `build-cache: true` (the default), restore `~/.zccache` at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
+- when `build-cache: true` and `target-cache: true` (the defaults), restore the configured Cargo target directory at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and outputs. Keys include the runner OS, architecture, resolved toolchain digest, `Cargo.lock` hash, and commit SHA, with fallback limited to the same toolchain and lockfile lineage.
 
 ### Current Limits That Must Stay Explicit
 

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -99,6 +99,9 @@ jobs:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+| `build-cache` | Restore and save the zccache compilation artifact cache. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
+| `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
 
@@ -108,6 +111,8 @@ jobs:
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
+| `build-cache-hit` | Whether the zccache compilation cache was restored. |
+| `target-cache-hit` | Whether the Cargo target directory cache was restored. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
@@ -115,6 +120,7 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`; on self-hosted runners, `rustup` must already be available.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
+- The action restores `~/.zccache` and the Cargo target directory by default so child branches can reuse parent-branch build state.
 - Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
 
 ## Development

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -83,6 +83,9 @@ jobs:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+| `build-cache` | Restore and save the zccache compilation artifact cache. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
+| `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
 
@@ -92,6 +95,8 @@ jobs:
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
+| `build-cache-hit` | Whether the zccache compilation cache was restored. |
+| `target-cache-hit` | Whether the Cargo target directory cache was restored. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
@@ -99,6 +104,7 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`; on self-hosted runners, `rustup` must already be available.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
+- The action restores `~/.zccache` and the Cargo target directory by default so child branches can reuse parent-branch build state.
 - Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
 
 ## Development

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -1,6 +1,6 @@
 name: setup-soldr
 author: zackees
-description: Extraction-ready Soldr setup action. Installs one soldr binary, provisions the resolved Rust toolchain via rustup, and restores a cacheable runner-local Soldr root.
+description: Extraction-ready Soldr setup action. Installs one soldr binary, bootstraps rustup when needed, provisions the resolved Rust toolchain, and restores a cacheable runner-local Soldr root.
 inputs:
   version:
     description: Soldr version or tag to install. Defaults to the latest release.
@@ -30,6 +30,28 @@ inputs:
     description: Optional value for SOLDR_TRUST_MODE.
     required: false
     default: ""
+  build-cache:
+    description: >
+      Restore and save the zccache compilation artifact cache (~/.zccache)
+      across workflow runs. Default "true"; the action restores ~/.zccache
+      with a toolchain-scoped key and saves it at end-of-job, letting
+      GitHub's own-branch -> PR base -> default-branch restore order seed
+      feature-branch runs from the latest main-branch save without any
+      repo-side configuration. Set to "false" to opt out.
+    required: false
+    default: "true"
+  target-cache:
+    description: >
+      Restore and save the Cargo target directory across workflow runs.
+      Default "true"; this gives no-op child-branch builds a fast path when
+      Cargo can reuse restored fingerprints and outputs. Set to "false" to
+      cache only zccache compilation artifacts.
+    required: false
+    default: "true"
+  target-dir:
+    description: Cargo target directory restored by target-cache.
+    required: false
+    default: target
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -43,6 +65,19 @@ outputs:
   cache-hit:
     description: Whether the action restored an exact cache hit for the selected cache/state root.
     value: ${{ steps.cache-meta.outputs.cache_hit }}
+  build-cache-hit:
+    description: >
+      Whether the action restored the zccache compilation artifact cache
+      (~/.zccache). "true" for an exact key match, "false" for a
+      restore-key fallback or no cache, empty string when `build-cache`
+      is explicitly disabled.
+    value: ${{ steps.cache-meta.outputs.build_cache_hit }}
+  target-cache-hit:
+    description: >
+      Whether the action restored the Cargo target directory cache. "true"
+      for an exact key match, "false" for a restore-key fallback or no cache,
+      empty string when `target-cache` or `build-cache` is disabled.
+    value: ${{ steps.cache-meta.outputs.target_cache_hit }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
@@ -58,6 +93,7 @@ runs:
         INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
         INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
+        INPUT_TARGET_DIR: ${{ inputs.target-dir }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
@@ -71,6 +107,25 @@ runs:
         key: ${{ steps.resolve.outputs.cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
+
+    - id: build-cache-restore
+      if: ${{ inputs.build-cache == 'true' }}
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ~/.zccache
+        key: ${{ steps.resolve.outputs.build_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
+
+    - id: target-cache
+      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.target_cache_path }}
+        key: ${{ steps.resolve.outputs.target_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
 
     - id: toolchain
       shell: pwsh
@@ -91,13 +146,80 @@ runs:
         SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
 
+    - id: zccache-warm-target
+      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      shell: pwsh
+      env:
+        TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
+      run: |
+        $target = $env:TARGET_CACHE_PATH
+        if ([string]::IsNullOrWhiteSpace($target) -or -not (Test-Path -LiteralPath $target)) {
+          Write-Host "No restored target directory to warm."
+          exit 0
+        }
+
+        $exeName = if ($IsWindows) { "zccache.exe" } else { "zccache" }
+        $zccache = $null
+        if (-not [string]::IsNullOrWhiteSpace($env:SOLDR_CACHE_DIR)) {
+          $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
+          if (Test-Path -LiteralPath $soldrBin) {
+            $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
+              Select-Object -First 1 -ExpandProperty FullName
+          }
+        }
+        if ([string]::IsNullOrWhiteSpace($zccache)) {
+          $command = Get-Command zccache -ErrorAction SilentlyContinue
+          if ($command) {
+            $zccache = $command.Source
+          }
+        }
+        if ([string]::IsNullOrWhiteSpace($zccache)) {
+          Write-Host "zccache binary is not available yet; refreshing target mtimes only."
+        } else {
+          Write-Host "Warming target directory from zccache: $target"
+          & $zccache warm --target-dir $target
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "zccache warm did not complete successfully; continuing."
+          }
+        }
+
+        $stamp = (Get-Date).AddMinutes(1)
+        Get-ChildItem -LiteralPath $target -Recurse -File -Force -ErrorAction SilentlyContinue |
+          ForEach-Object { $_.LastWriteTime = $stamp }
+        Write-Host "Refreshed target file mtimes."
+        exit 0
+
     - id: cache-meta
       shell: pwsh
       env:
         RAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        RAW_BUILD_CACHE_HIT: ${{ steps.build-cache-restore.outputs.cache-hit }}
+        RAW_TARGET_CACHE_HIT: ${{ steps.target-cache.outputs.cache-hit }}
+        BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
+        TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
       run: |
         $value = $env:RAW_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($value)) {
           $value = "false"
         }
         "cache_hit=$value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+        if ($env:BUILD_CACHE_ENABLED -eq "true") {
+          $buildValue = $env:RAW_BUILD_CACHE_HIT
+          if ([string]::IsNullOrWhiteSpace($buildValue)) {
+            $buildValue = "false"
+          }
+        } else {
+          $buildValue = ""
+        }
+        "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") {
+          $targetValue = $env:RAW_TARGET_CACHE_HIT
+          if ([string]::IsNullOrWhiteSpace($targetValue)) {
+            $targetValue = "false"
+          }
+        } else {
+          $targetValue = ""
+        }
+        "target_cache_hit=$targetValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -105,6 +105,8 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     monkeypatch.setenv("INPUT_TOOLCHAIN", "")
     monkeypatch.setenv("INPUT_TOOLCHAIN_FILE", "missing.toml")
     monkeypatch.setenv("INPUT_TRUST_MODE", "")
+    monkeypatch.setenv("INPUT_TARGET_DIR", "custom-target")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
     monkeypatch.setenv("GITHUB_ENV", str(github_env))
     monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
     monkeypatch.setenv("GITHUB_PATH", str(github_path))
@@ -123,4 +125,7 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
 
     outputs = github_output.read_text(encoding="utf-8")
     assert f"cache_root={cache_root}" in outputs
+    assert f"target_cache_path={workspace / 'custom-target'}" in outputs
+    assert "target_cache_key=setup-soldr-targetcache-v1-linux-x64-" in outputs
+    assert outputs.count("-no-lock-abc123") == 1
     assert "toolchain=stable" in outputs


### PR DESCRIPTION
## Summary

- adds a default-on `target-cache` fast path to `setup-soldr`
- restores/saves the configured Cargo target directory with a toolchain + `Cargo.lock` scoped key
- exposes `target-cache-hit` and reports it in the setup action smoke workflow
- opportunistically runs `zccache warm --target-dir` when a restored setup cache already contains the managed zccache binary

## Why

Issue #170 showed that exact `~/.zccache` restore works after #169, but zccache still reports `0 cached` and no warm-build speedup. The benchmark action gets its no-op speed by restoring target state in addition to zccache artifacts. Composite actions cannot create the benchmark's metadata tar in a custom post step, so this PR uses `actions/cache` post-job behavior on the configured target directory itself.

## Validation

```text
python -m pytest tests/test_setup_soldr_action.py tests/test_setup_soldr_exporter.py tests/test_setup_soldr_ensure_rust_toolchain.py tests/test_setup_soldr_ensure_soldr.py tests/test_setup_soldr_verify_soldr.py
15 passed

git diff --check
passed
```

Follow-up for #170.
