### PR TITLE
fix(action): use Soldr-owned wrapper cache roots

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -116,6 +116,16 @@ def main() -> None:
     cargo_home = cache_root / "cargo"
     rustup_home = cache_root / "rustup"
     bin_dir = cache_root / "bin"
+    build_cache_path = soldr_root / "cache" / "zccache"
+    setup_cache_paths = "\n".join(
+        str(path)
+        for path in (
+            bin_dir,
+            cargo_home,
+            rustup_home,
+            soldr_root / "bin",
+        )
+    )
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
 
@@ -123,6 +133,7 @@ def main() -> None:
         cache_root,
         soldr_root,
         soldr_root / "cache",
+        build_cache_path,
         soldr_root / "bin",
         cargo_home,
         cargo_home / "bin",
@@ -162,7 +173,7 @@ def main() -> None:
     if suffix:
         cache_key = f"{cache_key}-{_sanitize_fragment(suffix)}"
 
-    # Build-artifact cache (zccache compilation cache at ~/.zccache).
+    # Build-artifact cache (zccache compilation cache under SOLDR_CACHE_DIR).
     # Key shape: setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{sha}.
     # Restore falls back through the same toolchain lineage and then any
     # OS+arch cache, letting GitHub's own-branch -> PR base -> default branch
@@ -187,6 +198,7 @@ def main() -> None:
         target_cache_key = f"{target_cache_key}-{sanitized_suffix}"
 
     _write_env("SOLDR_CACHE_DIR", str(soldr_root))
+    _write_env("ZCCACHE_CACHE_DIR", str(build_cache_path))
     _write_env("CARGO_HOME", str(cargo_home))
     _write_env("RUSTUP_HOME", str(rustup_home))
     _write_env("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain["channel"])
@@ -202,11 +214,13 @@ def main() -> None:
     _write_outputs(
         {
             "cache_root": str(cache_root),
+            "setup_cache_paths": setup_cache_paths,
             "cache_key": cache_key,
             "cache_restore_prefix": f"{cache_prefix}-",
             "build_cache_key": build_cache_key,
             "build_cache_restore_key_toolchain": build_cache_toolchain_prefix,
             "build_cache_restore_key_os_arch": f"{build_cache_prefix}-",
+            "build_cache_path": str(build_cache_path),
             "target_cache_path": str(target_cache_path),
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,

--- a/.github/scripts/setup_soldr_parent_child_probe_report.py
+++ b/.github/scripts/setup_soldr_parent_child_probe_report.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Render and optionally post the setup-soldr parent-to-child cache probe report."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def _read_float(value: Any) -> float | None:
+    if value in ("", None):
+        return None
+    return float(value)
+
+
+def _format_seconds(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}"
+
+
+def _format_ratio(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}x"
+
+
+def _hit_value(value: Any) -> str:
+    if value in ("", None):
+        return "n/a"
+    return str(value).lower()
+
+
+def _speedup(cold: float | None, warm: float | None) -> float | None:
+    if cold is None or warm is None or warm <= 0:
+        return None
+    return cold / warm
+
+
+def _saved_seconds(cold: float | None, warm: float | None) -> float | None:
+    if cold is None or warm is None:
+        return None
+    return cold - warm
+
+
+def _dominant_remaining_cost(payload: dict[str, Any], warm: float | None) -> str:
+    if warm is not None and warm <= 1.0:
+        return "none observed; sub-second target met"
+    if _hit_value(payload.get("target_cache_hit")) != "true":
+        return "target cache was not an exact hit; inspect restore-key fallback logs"
+    if _hit_value(payload.get("build_cache_hit")) != "true":
+        return "zccache build-cache was not an exact hit; inspect build-cache restore logs"
+
+    status_lines = "\n".join(payload.get("zccache_status_lines") or [])
+    if "0 cached" in status_lines or "Hit rate: 0.0%" in status_lines:
+        return "zccache misses despite restored caches"
+    return "Cargo metadata/checking, cache restore overhead, or non-cacheable work"
+
+
+def build_report(payload: dict[str, Any]) -> str:
+    cold = _read_float(payload.get("cold_seconds"))
+    warm = _read_float(payload.get("warm_seconds"))
+    saved = _saved_seconds(cold, warm)
+    ratio = _speedup(cold, warm)
+    subsecond = warm is not None and warm <= 1.0
+    status_lines = payload.get("zccache_status_lines") or []
+    status_block = "\n".join(status_lines).strip() or "n/a"
+
+    lines = [
+        "### Parent-to-child zccache cache report",
+        "",
+        f"- workflow run: {payload.get('run_url', 'n/a')}",
+        f"- branch/ref: `{payload.get('ref_name', 'n/a')}`",
+        f"- commit: `{payload.get('sha', 'n/a')}`",
+        f"- cold control result: `{payload.get('cold_result', 'n/a')}`",
+        f"- warm setup-soldr result: `{payload.get('warm_result', 'n/a')}`",
+        f"- cold build seconds: `{_format_seconds(cold)}`",
+        f"- warm soldr build seconds: `{_format_seconds(warm)}`",
+        f"- seconds saved: `{_format_seconds(saved)}`",
+        f"- speedup vs cold control: `{_format_ratio(ratio)}`",
+        f"- setup cache hit: `{_hit_value(payload.get('setup_cache_hit'))}`",
+        f"- zccache build-cache hit: `{_hit_value(payload.get('build_cache_hit'))}`",
+        f"- target-cache hit: `{_hit_value(payload.get('target_cache_hit'))}`",
+        f"- soldr version: `{payload.get('soldr_version') or 'n/a'}`",
+        f"- toolchain: `{payload.get('toolchain') or 'n/a'}`",
+        f"- zccache artifact cache dir: `{payload.get('zccache_artifact_cache_dir') or 'n/a'}`",
+        f"- sub-second target met: `{'yes' if subsecond else 'no'}`",
+        f"- dominant remaining cost: `{_dominant_remaining_cost(payload, warm)}`",
+        "",
+        "zccache status lines:",
+        "",
+        "```text",
+        status_block,
+        "```",
+        "",
+        "Note: `build-cache-hit=false` or `target-cache-hit=false` may still mean a useful restore-key fallback. Inspect the raw cache step logs to distinguish fallback restores from cold misses.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def post_issue_comment(repo: str, issue_number: str, token: str, body: str) -> None:
+    url = f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps({"body": body}).encode("utf-8"),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "setup-soldr-parent-child-probe",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        if response.status >= 300:
+            raise RuntimeError(f"GitHub issue comment failed with HTTP {response.status}")
+
+
+def main() -> None:
+    input_path = Path(os.environ["PROBE_INPUT_JSON"])
+    output_path = Path(os.environ["PROBE_OUTPUT_MD"])
+    payload = json.loads(input_path.read_text(encoding="utf-8"))
+    report = build_report(payload)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report, encoding="utf-8")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with Path(summary_path).open("a", encoding="utf-8") as handle:
+            handle.write(report)
+
+    if os.environ.get("PROBE_POST_COMMENT", "").lower() == "true":
+        post_issue_comment(
+            repo=os.environ["GITHUB_REPOSITORY"],
+            issue_number=os.environ["PROBE_ISSUE_NUMBER"],
+            token=os.environ["GITHUB_TOKEN"],
+            body=report,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/setup-soldr-parent-child-probe.yml
+++ b/.github/workflows/setup-soldr-parent-child-probe.yml
@@ -1,0 +1,159 @@
+name: Setup Soldr Parent Child Probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue-number:
+        description: Issue number to receive the probe report comment.
+        required: true
+        default: "168"
+        type: string
+      post-comment:
+        description: Post the rendered report as an issue comment.
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  probe:
+    name: Parent-to-child cache probe
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - id: setup
+        uses: ./
+        with:
+          cache: true
+          build-cache: true
+          target-cache: true
+
+      - name: Run cold control build
+        id: cold
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import subprocess
+          import time
+          from pathlib import Path
+
+          env = os.environ.copy()
+          env["CARGO_TARGET_DIR"] = str(Path(env["RUNNER_TEMP"]) / "setup-soldr-cold-target")
+          start = time.perf_counter()
+          subprocess.run(
+              ["soldr", "--no-cache", "cargo", "build", "--package", "soldr-cli", "--locked"],
+              check=True,
+              env=env,
+          )
+          elapsed = time.perf_counter() - start
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"seconds={elapsed:.2f}\n")
+          PY
+
+      - name: Run warm soldr build
+        id: warm
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          import subprocess
+          import time
+
+          start = time.perf_counter()
+          subprocess.run(
+              ["soldr", "cargo", "build", "--package", "soldr-cli", "--locked"],
+              check=True,
+          )
+          elapsed = time.perf_counter() - start
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"seconds={elapsed:.2f}\n")
+          PY
+
+      - name: Capture zccache status
+        id: zccache
+        shell: bash
+        run: |
+          set -euo pipefail
+          soldr cache --json > setup-soldr-parent-child-probe-cache.json
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          data = json.loads(Path("setup-soldr-parent-child-probe-cache.json").read_text(encoding="utf-8"))
+          zccache = data.get("zccache", {})
+          status_lines = zccache.get("status_lines") or []
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"artifact_cache_dir={zccache.get('artifact_cache_dir', '')}\n")
+              fh.write("status_lines<<status_lines\n")
+              fh.write("\n".join(status_lines))
+              fh.write("\nstatus_lines\n")
+          PY
+
+      - name: Render probe report
+        shell: bash
+        env:
+          PROBE_ISSUE_NUMBER: ${{ inputs.issue-number }}
+          PROBE_POST_COMMENT: ${{ inputs.post-comment }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PROBE_INPUT_JSON: setup-soldr-parent-child-probe-input.json
+          PROBE_OUTPUT_MD: setup-soldr-parent-child-probe-report.md
+          SETUP_CACHE_HIT: ${{ steps.setup.outputs.cache-hit }}
+          BUILD_CACHE_HIT: ${{ steps.setup.outputs.build-cache-hit }}
+          TARGET_CACHE_HIT: ${{ steps.setup.outputs.target-cache-hit }}
+          SOLDR_VERSION: ${{ steps.setup.outputs.soldr-version }}
+          TOOLCHAIN: ${{ steps.setup.outputs.toolchain }}
+          COLD_SECONDS: ${{ steps.cold.outputs.seconds }}
+          WARM_SECONDS: ${{ steps.warm.outputs.seconds }}
+          ZCCACHE_ARTIFACT_CACHE_DIR: ${{ steps.zccache.outputs.artifact_cache_dir }}
+          ZCCACHE_STATUS_LINES: ${{ steps.zccache.outputs.status_lines }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = {
+              "run_url": f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}",
+              "ref_name": os.environ["GITHUB_REF_NAME"],
+              "sha": os.environ["GITHUB_SHA"],
+              "cold_result": "success",
+              "warm_result": "success",
+              "cold_seconds": os.environ["COLD_SECONDS"],
+              "warm_seconds": os.environ["WARM_SECONDS"],
+              "setup_cache_hit": os.environ["SETUP_CACHE_HIT"],
+              "build_cache_hit": os.environ["BUILD_CACHE_HIT"],
+              "target_cache_hit": os.environ["TARGET_CACHE_HIT"],
+              "soldr_version": os.environ["SOLDR_VERSION"],
+              "toolchain": os.environ["TOOLCHAIN"],
+              "zccache_artifact_cache_dir": os.environ["ZCCACHE_ARTIFACT_CACHE_DIR"],
+              "zccache_status_lines": [
+                  line for line in os.environ.get("ZCCACHE_STATUS_LINES", "").splitlines() if line
+              ],
+          }
+          Path(os.environ["PROBE_INPUT_JSON"]).write_text(
+              json.dumps(payload, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          python3 .github/scripts/setup_soldr_parent_child_probe_report.py
+
+      - name: Upload probe report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: setup-soldr-parent-child-probe
+          path: |
+            setup-soldr-parent-child-probe-input.json
+            setup-soldr-parent-child-probe-report.md
+            setup-soldr-parent-child-probe-cache.json
+          if-no-files-found: warn

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -62,7 +62,7 @@ The root action:
 - preinstalls the exact Rust toolchain resolved from `rust-toolchain.toml` or `toolchain:` via `rustup`
 - sets `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME`
 - restores and saves that runner-local root through GitHub cache when `cache: true`
-- restores and saves the zccache compilation artifact cache at `~/.zccache` by default; set `build-cache: false` to disable that layer
+- restores and saves Soldr's zccache compilation artifact cache under the selected `SOLDR_CACHE_DIR` by default; set `build-cache: false` to disable that layer
 
 Important toolchain rule:
 
@@ -109,7 +109,7 @@ Useful inputs when wiring the action into another repository:
 - `toolchain`: explicit Rust channel override when you do not want to rely on `rust-toolchain.toml`
 - `toolchain-file`: alternate toolchain file path when the repo does not use the default root `rust-toolchain.toml`
 - `cache`: turn the runner-local cache root on or off
-- `build-cache`: turn the `~/.zccache` compilation artifact cache on or off; defaults to `true`
+- `build-cache`: turn the Soldr-owned zccache compilation artifact cache on or off; defaults to `true`
 - `cache-dir`: move the shared Soldr/Cargo/rustup root to a specific path
 - `trust-mode`: set `SOLDR_TRUST_MODE` for stricter fetched-binary policy
 
@@ -134,7 +134,7 @@ The action-managed cache root includes:
 
 That means the Soldr binary, the Rust toolchain, cargo registry state, and Soldr-managed state are reusable on later runs.
 
-Current limitation: soldr still documents managed `zccache` artifact storage as following zccache's current supported/default behavior rather than a fully action-controlled custom artifact path, so the action should not claim more than that.
+Current limitation: Soldr now passes `ZCCACHE_CACHE_DIR` for managed zccache commands, but the pinned managed zccache release must support that upstream override before artifacts physically move off zccache's historical default root.
 
 ### Shortest CI path: install a released soldr
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ That action:
 - bootstraps `rustup` into the cached runner-local root when the runner does not already have it
 - preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
-- restores and saves the zccache compilation artifact cache at `~/.zccache` by default; set `build-cache: false` to disable it
+- restores and saves Soldr's zccache compilation artifact cache under `~/.soldr/cache/zccache` by default; set `build-cache: false` to disable it
 - restores and saves the Cargo target directory by default for no-op CI fast paths; set `target-cache: false` to disable it or `target-dir:` to choose another target directory
 - puts `soldr` on `PATH` for later steps
 - is the extraction source for the planned public `zackees/setup-soldr` action product
@@ -113,7 +113,7 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 
 - **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse. On `0.5.x`, this is still an upstream trust decision rather than a repo-side trust guarantee; see [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md).
 
-- **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring; zccache's artifact store still uses its current default cache root.
+- **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring and sets the managed zccache cache root to `~/.soldr/cache/zccache`.
 
 ```bash
 # Build through soldr's front door:
@@ -150,7 +150,7 @@ soldr maturin build --release
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
 - **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
 - **Real cache controls**: `soldr status`, `soldr cache`, and `soldr clean` report and manage the soldr-managed zccache state instead of placeholder behavior.
-- **One cache boundary, eventually**: soldr keeps its own tools and zccache session state in `~/.soldr/`. Current zccache artifacts still live in zccache's default cache root until upstream exposes a supported cache-dir override.
+- **One cache boundary**: soldr keeps its own tools, zccache artifacts, and zccache session state under `~/.soldr/`. Managed zccache builds use `ZCCACHE_CACHE_DIR=~/.soldr/cache/zccache` when the managed zccache version supports that override.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
 - **Cross-platform**: Linux, macOS, Windows (x86_64 + aarch64).

--- a/action.yml
+++ b/action.yml
@@ -36,9 +36,10 @@ inputs:
     default: ""
   build-cache:
     description: >
-      Restore and save the zccache compilation artifact cache (~/.zccache)
-      across workflow runs. Default "true"; the action restores ~/.zccache
-      with a toolchain-scoped key and saves it at end-of-job, letting
+      Restore and save Soldr's zccache compilation artifact cache under
+      SOLDR_CACHE_DIR across workflow runs. Default "true"; the action
+      restores the Soldr-owned zccache root with a toolchain-scoped key
+      and saves it at end-of-job, letting
       GitHub's own-branch -> PR base -> default-branch restore order seed
       feature-branch runs from the latest main-branch save without any
       repo-side configuration. Set to "false" to opt out.
@@ -72,8 +73,8 @@ outputs:
   build-cache-hit:
     description: >
       Whether the action restored the zccache compilation artifact cache
-      (~/.zccache). "true" for an exact key match, "false" for a
-      restore-key fallback or no cache, empty string when `build-cache`
+      under SOLDR_CACHE_DIR. "true" for an exact key match, "false" for
+      a restore-key fallback or no cache, empty string when `build-cache`
       is explicitly disabled.
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
   target-cache-hit:
@@ -108,7 +109,7 @@ runs:
       if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.cache_root }}
+        path: ${{ steps.resolve.outputs.setup_cache_paths }}
         key: ${{ steps.resolve.outputs.cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
@@ -117,7 +118,7 @@ runs:
       if: ${{ inputs.build-cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ~/.zccache
+        path: ${{ steps.resolve.outputs.build_cache_path }}
         key: ${{ steps.resolve.outputs.build_cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -27,6 +27,12 @@ pub const ZCCACHE_SESSION_ID_ENV_VAR: &str = "ZCCACHE_SESSION_ID";
 /// wrapper-mode children.
 pub const ZCCACHE_BINARY_ENV_VAR: &str = "SOLDR_ZCCACHE_BIN";
 
+/// zccache cache root override used by managed soldr builds.
+pub const ZCCACHE_CACHE_DIR_ENV_VAR: &str = "ZCCACHE_CACHE_DIR";
+
+/// sccache cache root override used for the custom `sccache` wrapper path.
+pub const SCCACHE_DIR_ENV_VAR: &str = "SCCACHE_DIR";
+
 pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
     if enabled {
         CACHE_ENABLED_VALUE
@@ -51,6 +57,10 @@ pub fn cache_enabled_in_current_process() -> bool {
 
 pub fn zccache_dir(paths: &SoldrPaths) -> PathBuf {
     paths.cache.join("zccache")
+}
+
+pub fn sccache_dir(paths: &SoldrPaths) -> PathBuf {
+    paths.cache.join("sccache")
 }
 
 pub fn parse_zccache_session_id(stdout: &str) -> Option<String> {
@@ -96,7 +106,7 @@ struct SessionStartResponse {
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id,
+        cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id, sccache_dir,
         session_journal_path, zccache_dir, CACHE_DISABLED_VALUE, CACHE_ENABLED_VALUE,
     };
     use soldr_core::SoldrPaths;
@@ -139,6 +149,15 @@ mod tests {
         assert_eq!(
             zccache_dir(&paths),
             paths.root.join("cache").join("zccache")
+        );
+    }
+
+    #[test]
+    fn sccache_dir_lives_under_soldr_cache_root() {
+        let paths = SoldrPaths::with_root(Path::new("C:\\soldr-root").to_path_buf());
+        assert_eq!(
+            sccache_dir(&paths),
+            paths.root.join("cache").join("sccache")
         );
     }
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -420,8 +420,12 @@ fn run_wrapper_through_zccache(
     raw_args: &[String],
     zccache: &std::path::Path,
 ) -> Result<i32, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let zccache_cache_dir = resolve_managed_zccache_cache_dir(&paths)?;
+    std::fs::create_dir_all(&zccache_cache_dir)?;
     let mut command = std::process::Command::new(zccache);
     command.args(&raw_args[1..]);
+    command.env(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR, zccache_cache_dir);
 
     // Cargo's jobserver lives on numbered file descriptors that it inherits
     // into the RUSTC_WRAPPER, advertised via CARGO_MAKEFLAGS. On Unix,
@@ -652,6 +656,7 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
 
 struct ZccacheBuildSession {
     binary_path: std::path::PathBuf,
+    cache_dir: std::path::PathBuf,
     session_id: String,
 }
 
@@ -689,6 +694,13 @@ async fn prepare_rustc_wrapper(
     match rustc_wrapper_mode() {
         RustcWrapperMode::ManagedZccache => prepare_zccache_build(cargo, paths).await.map(Some),
         RustcWrapperMode::Custom(wrapper) => {
+            if custom_wrapper_is_sccache(&wrapper)
+                && std::env::var_os(soldr_cache::SCCACHE_DIR_ENV_VAR).is_none()
+            {
+                let sccache_dir = soldr_cache::sccache_dir(paths);
+                std::fs::create_dir_all(&sccache_dir)?;
+                cargo.env(soldr_cache::SCCACHE_DIR_ENV_VAR, sccache_dir);
+            }
             cargo.env("RUSTC_WRAPPER", wrapper);
             cargo.env_remove(soldr_cache::ZCCACHE_BINARY_ENV_VAR);
             cargo.env_remove(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR);
@@ -703,14 +715,21 @@ async fn prepare_rustc_wrapper(
     }
 }
 
+fn custom_wrapper_is_sccache(wrapper: &std::ffi::OsStr) -> bool {
+    std::path::Path::new(wrapper)
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .is_some_and(|stem| stem.eq_ignore_ascii_case("sccache"))
+}
+
 async fn prepare_zccache_build(
     cargo: &mut std::process::Command,
     paths: &SoldrPaths,
 ) -> Result<ZccacheBuildSession, SoldrError> {
     let fetch = fetch_managed_zccache(paths).await?;
-    let zccache_dir = soldr_cache::zccache_dir(paths);
-    std::fs::create_dir_all(&zccache_dir)?;
-    std::fs::create_dir_all(zccache_dir.join("logs"))?;
+    let zccache_cache_dir = resolve_managed_zccache_cache_dir(paths)?;
+    std::fs::create_dir_all(&zccache_cache_dir)?;
+    std::fs::create_dir_all(zccache_cache_dir.join("logs"))?;
     if fetch.cached {
         eprintln!(
             "soldr: using managed zccache {}",
@@ -723,13 +742,14 @@ async fn prepare_zccache_build(
         );
     }
 
-    run_zccache_command(&fetch.binary_path, &["start"])?;
+    run_zccache_command(&fetch.binary_path, &["start"], Some(&zccache_cache_dir))?;
 
-    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    let journal_path = soldr_cache::session_journal_path(&zccache_cache_dir);
     let journal_path = journal_path.display().to_string();
     let session_json = run_zccache_command(
         &fetch.binary_path,
         &["session-start", "--stats", "--journal", &journal_path],
+        Some(&zccache_cache_dir),
     )?;
     let session_id =
         soldr_cache::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
@@ -741,16 +761,22 @@ async fn prepare_zccache_build(
 
     cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
     cargo.env(soldr_cache::ZCCACHE_BINARY_ENV_VAR, &fetch.binary_path);
+    cargo.env(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR, &zccache_cache_dir);
     cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
 
     Ok(ZccacheBuildSession {
         binary_path: fetch.binary_path,
+        cache_dir: zccache_cache_dir,
         session_id,
     })
 }
 
 fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
-    let output = run_zccache_command(&session.binary_path, &["session-end", &session.session_id])?;
+    let output = run_zccache_command(
+        &session.binary_path,
+        &["session-end", &session.session_id],
+        Some(&session.cache_dir),
+    )?;
     let stdout = output.stdout.trim();
     if !stdout.is_empty() {
         eprintln!("soldr: zccache session summary");
@@ -761,11 +787,11 @@ fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError>
 
 fn clear_zccache_cache() -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
-    let zccache_dir = soldr_cache::zccache_dir(&paths);
+    let zccache_dir = resolve_managed_zccache_cache_dir(&paths)?;
     let mut cleared_anything = false;
 
     if let Some(fetch) = cached_managed_zccache(&paths)? {
-        let _ = run_zccache_command(&fetch.binary_path, &["clear"])?;
+        let _ = run_zccache_command(&fetch.binary_path, &["clear"], Some(&zccache_dir))?;
         println!("cleared zccache artifact cache");
         cleared_anything = true;
     }
@@ -815,6 +841,7 @@ struct CacheOutput {
 
 #[derive(Serialize)]
 struct ZccacheStatusSnapshot {
+    artifact_cache_dir: String,
     state_dir: String,
     journal_path: String,
     journal_present: bool,
@@ -861,16 +888,17 @@ fn collect_cache_output() -> Result<CacheOutput, SoldrError> {
 }
 
 fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, SoldrError> {
-    let zccache_dir = soldr_cache::zccache_dir(paths);
+    let zccache_dir = resolve_managed_zccache_cache_dir(paths)?;
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
     let journal_present = journal_path.exists();
 
     match cached_managed_zccache(paths)? {
         Some(fetch) => {
-            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
+            let output = run_zccache_command(&fetch.binary_path, &["status"], Some(&zccache_dir))?;
             let stdout = output.stdout.trim();
             let status_lines = stdout.lines().map(str::to_owned).collect();
             Ok(ZccacheStatusSnapshot {
+                artifact_cache_dir: zccache_dir.display().to_string(),
                 state_dir: zccache_dir.display().to_string(),
                 journal_path: journal_path.display().to_string(),
                 journal_present,
@@ -881,6 +909,7 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
             })
         }
         None => Ok(ZccacheStatusSnapshot {
+            artifact_cache_dir: zccache_dir.display().to_string(),
             state_dir: zccache_dir.display().to_string(),
             journal_path: journal_path.display().to_string(),
             journal_present,
@@ -915,6 +944,10 @@ fn print_cache_output(output: &CacheOutput) {
 }
 
 fn print_zccache_status_snapshot(snapshot: &ZccacheStatusSnapshot) {
+    println!(
+        "zccache artifact cache dir: {}",
+        snapshot.artifact_cache_dir
+    );
     println!("soldr zccache state dir: {}", snapshot.state_dir);
     println!(
         "last session journal: {} ({})",
@@ -957,8 +990,14 @@ struct CommandOutput {
 fn run_zccache_command(
     binary: &std::path::Path,
     args: &[&str],
+    cache_dir: Option<&std::path::Path>,
 ) -> Result<CommandOutput, SoldrError> {
-    let output = std::process::Command::new(binary).args(args).output()?;
+    let mut command = std::process::Command::new(binary);
+    command.args(args);
+    if let Some(cache_dir) = cache_dir {
+        command.env(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR, cache_dir);
+    }
+    let output = command.output()?;
     if !output.status.success() {
         return Err(SoldrError::Other(format!(
             "zccache {} failed: {}",
@@ -970,6 +1009,50 @@ fn run_zccache_command(
     Ok(CommandOutput {
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
     })
+}
+
+fn resolve_managed_zccache_cache_dir(paths: &SoldrPaths) -> Result<std::path::PathBuf, SoldrError> {
+    let managed = soldr_cache::zccache_dir(paths);
+    let Some(explicit) = non_empty_env_path(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR) else {
+        return Ok(managed);
+    };
+
+    if paths_refer_to_same_location(&explicit, &managed) {
+        Ok(managed)
+    } else {
+        Err(SoldrError::Other(format!(
+            "{} is set to {}, but managed zccache builds require Soldr's cache root at {}. Unset {} or use `SOLDR_RUSTC_WRAPPER` for an explicitly managed custom wrapper.",
+            soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR,
+            explicit.display(),
+            managed.display(),
+            soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR
+        )))
+    }
+}
+
+fn paths_refer_to_same_location(left: &std::path::Path, right: &std::path::Path) -> bool {
+    normalize_path_for_compare(left) == normalize_path_for_compare(right)
+}
+
+fn normalize_path_for_compare(path: &std::path::Path) -> std::path::PathBuf {
+    let normalized = std::fs::canonicalize(path).unwrap_or_else(|_| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .unwrap_or_else(|_| std::path::PathBuf::from("."))
+                .join(path)
+        }
+    });
+
+    #[cfg(windows)]
+    {
+        std::path::PathBuf::from(normalized.display().to_string().to_ascii_lowercase())
+    }
+    #[cfg(not(windows))]
+    {
+        normalized
+    }
 }
 
 fn toolchain_binary_override(tool: &str) -> Option<std::path::PathBuf> {
@@ -1031,10 +1114,10 @@ fn cached_managed_zccache(
 #[cfg(test)]
 mod tests {
     use super::{
-        cargo_args_specify_target, cargo_args_use_reserved_no_cache, extract_as_pin,
-        first_cargo_subcommand, normalize_version, parse_tool_spec,
-        rustc_wrapper_mode_from_env_var, rustup_resolution_failure, should_trampoline,
-        RustcWrapperMode,
+        cargo_args_specify_target, cargo_args_use_reserved_no_cache, custom_wrapper_is_sccache,
+        extract_as_pin, first_cargo_subcommand, normalize_version, parse_tool_spec,
+        paths_refer_to_same_location, rustc_wrapper_mode_from_env_var, rustup_resolution_failure,
+        should_trampoline, RustcWrapperMode,
     };
     use soldr_fetch::VersionSpec;
     use std::ffi::OsStr;
@@ -1100,6 +1183,26 @@ mod tests {
             rustc_wrapper_mode_from_env_var(Some(OsStr::new("sccache"))),
             RustcWrapperMode::Custom("sccache".into())
         );
+    }
+
+    #[test]
+    fn custom_wrapper_detection_recognizes_sccache_paths() {
+        assert!(custom_wrapper_is_sccache(OsStr::new("sccache")));
+        #[cfg(windows)]
+        assert!(custom_wrapper_is_sccache(OsStr::new(
+            "C:\\tools\\sccache.exe"
+        )));
+        #[cfg(not(windows))]
+        assert!(custom_wrapper_is_sccache(OsStr::new("/tools/sccache")));
+        assert!(!custom_wrapper_is_sccache(OsStr::new("zccache")));
+    }
+
+    #[test]
+    fn path_equivalence_allows_same_managed_cache_root() {
+        assert!(paths_refer_to_same_location(
+            std::path::Path::new("target"),
+            std::path::Path::new("target")
+        ));
     }
 
     #[test]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -88,7 +88,7 @@ fn fake_cargo_script(log_path: &Path) -> String {
     {
         format!(
             "@echo off\n\
-             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID%>>\"{}\"\n\
+             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% zcdir=%ZCCACHE_CACHE_DIR% sccachedir=%SCCACHE_DIR%>>\"{}\"\n\
              if defined RUSTC_WRAPPER (\n\
              call \"%RUSTC_WRAPPER%\" \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
              ) else (\n\
@@ -102,7 +102,7 @@ fn fake_cargo_script(log_path: &Path) -> String {
     {
         format!(
             "#!/bin/sh\n\
-             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}}\" >> \"{}\"\n\
+             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} zcdir=${{ZCCACHE_CACHE_DIR:-}} sccachedir=${{SCCACHE_DIR:-}}\" >> \"{}\"\n\
              if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\
                \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
              else\n\
@@ -243,31 +243,32 @@ fn fake_zccache_script(log_path: &Path) -> String {
         format!(
             "@echo off\n\
              if \"%~1\"==\"start\" (\n\
-               echo zccache start>>\"{0}\"\n\
+               echo zccache start cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                exit /b 0\n\
              )\n\
              if \"%~1\"==\"session-start\" (\n\
-               echo zccache session-start>>\"{0}\"\n\
+               echo zccache session-start cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                if not \"%~4\"==\"\" type nul > \"%~4\"\n\
                echo {{\"session_id\":\"test-session\"}}\n\
                exit /b 0\n\
              )\n\
              if \"%~1\"==\"session-end\" (\n\
-               echo zccache session-end %~2>>\"{0}\"\n\
+               echo zccache session-end %~2 cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                echo hits: 1\n\
                exit /b 0\n\
              )\n\
              if \"%~1\"==\"status\" (\n\
+               echo zccache status cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                echo hits=7\n\
                exit /b 0\n\
              )\n\
              if \"%~1\"==\"clear\" (\n\
-               echo zccache clear>>\"{0}\"\n\
+               echo zccache clear cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                exit /b 0\n\
              )\n\
              set \"rustc=%~1\"\n\
              shift\n\
-             echo zccache wrapper %rustc% %*>>\"{0}\"\n\
+             echo zccache wrapper cache_dir=%ZCCACHE_CACHE_DIR% %rustc% %*>>\"{0}\"\n\
              call \"%rustc%\" %*\n\
              exit /b %ERRORLEVEL%\n",
             log_path.display()
@@ -279,32 +280,33 @@ fn fake_zccache_script(log_path: &Path) -> String {
             "#!/bin/sh\n\
              case \"$1\" in\n\
                start)\n\
-                 echo \"zccache start\" >> \"{0}\"\n\
+                 echo \"zccache start cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  exit 0\n\
                  ;;\n\
                session-start)\n\
-                 echo \"zccache session-start\" >> \"{0}\"\n\
+                 echo \"zccache session-start cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  : > \"$4\"\n\
                  echo '{{\"session_id\":\"test-session\"}}'\n\
                  exit 0\n\
                  ;;\n\
                session-end)\n\
-                 echo \"zccache session-end $2\" >> \"{0}\"\n\
+                 echo \"zccache session-end $2 cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  echo 'hits: 1'\n\
                  exit 0\n\
                  ;;\n\
                status)\n\
+                 echo \"zccache status cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  echo 'hits=7'\n\
                  exit 0\n\
                  ;;\n\
                clear)\n\
-                 echo \"zccache clear\" >> \"{0}\"\n\
+                 echo \"zccache clear cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  exit 0\n\
                  ;;\n\
              esac\n\
              rustc=\"$1\"\n\
              shift\n\
-             echo \"zccache wrapper $rustc $*\" >> \"{0}\"\n\
+             echo \"zccache wrapper cache_dir=${{ZCCACHE_CACHE_DIR:-}} $rustc $*\" >> \"{0}\"\n\
              \"$rustc\" \"$@\"\n",
             log_path.display()
         )
@@ -318,7 +320,7 @@ fn fake_custom_wrapper_script(log_path: &Path, wrapper_name: &str) -> String {
             "@echo off\n\
              set \"rustc=%~1\"\n\
              shift\n\
-             echo {1} wrapper %rustc% %*>>\"{0}\"\n\
+             echo {1} wrapper sccachedir=%SCCACHE_DIR% %rustc% %*>>\"{0}\"\n\
              call \"%rustc%\" %*\n\
              exit /b %ERRORLEVEL%\n",
             log_path.display(),
@@ -331,7 +333,7 @@ fn fake_custom_wrapper_script(log_path: &Path, wrapper_name: &str) -> String {
             "#!/bin/sh\n\
              rustc=\"$1\"\n\
              shift\n\
-             echo \"{1} wrapper $rustc $*\" >> \"{0}\"\n\
+             echo \"{1} wrapper sccachedir=${{SCCACHE_DIR:-}} $rustc $*\" >> \"{0}\"\n\
              \"$rustc\" \"$@\"\n",
             log_path.display(),
             wrapper_name
@@ -600,6 +602,14 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         log.contains("zccache session-end test-session"),
         "managed zccache session should end after cargo finishes: {log}"
     );
+    let zccache_cache_dir = cache_root.join("cache").join("zccache");
+    assert!(
+        path_display_variants(&zccache_cache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("cache_dir={path}"))),
+        "managed zccache commands should use Soldr's zccache cache root at {}: {log}",
+        zccache_cache_dir.display()
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -651,6 +661,14 @@ fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
         log.contains("sccache wrapper"),
         "custom wrapper should be invoked for rustc: {log}"
     );
+    let sccache_dir = cache_root.join("cache").join("sccache");
+    assert!(
+        path_display_variants(&sccache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("sccachedir={path}"))),
+        "custom sccache wrapper should receive Soldr's sccache cache root at {}: {log}",
+        sccache_dir.display()
+    );
     assert!(
         !log.contains(env!("CARGO_BIN_EXE_soldr")),
         "soldr should not stay in the wrapper slot when overridden: {log}"
@@ -667,6 +685,108 @@ fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
     assert!(
         !stderr.contains("soldr: zccache session summary"),
         "custom wrapper path should not emit zccache session output: {stderr}"
+    );
+}
+
+#[test]
+fn explicit_sccache_dir_wins_for_custom_sccache_wrapper() {
+    let cache_root = unique_temp_dir("cargo-custom-sccache-explicit-dir");
+    let explicit_sccache_dir = unique_temp_dir("explicit-sccache-dir");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let wrapper = install_fake_wrapper(&log_path, "sccache");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_RUSTC_WRAPPER", &wrapper)
+        .env("SCCACHE_DIR", &explicit_sccache_dir)
+        .output()
+        .expect("failed to run soldr cargo build with explicit SCCACHE_DIR");
+
+    assert!(
+        output.status.success(),
+        "custom-wrapper front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        path_display_variants(&explicit_sccache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("sccachedir={path}"))),
+        "explicit SCCACHE_DIR should be preserved: {log}"
+    );
+    assert!(
+        !log.contains(
+            &cache_root
+                .join("cache")
+                .join("sccache")
+                .display()
+                .to_string()
+        ),
+        "Soldr's default sccache dir should not override explicit SCCACHE_DIR: {log}"
+    );
+}
+
+#[test]
+fn managed_zccache_rejects_conflicting_explicit_cache_dir() {
+    let cache_root = unique_temp_dir("cargo-zccache-conflicting-dir");
+    let explicit_zccache_dir = unique_temp_dir("explicit-zccache-dir");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("ZCCACHE_CACHE_DIR", &explicit_zccache_dir)
+        .output()
+        .expect("failed to run soldr cargo build with explicit ZCCACHE_CACHE_DIR");
+
+    assert!(
+        !output.status.success(),
+        "managed zccache should reject a conflicting explicit cache dir"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ZCCACHE_CACHE_DIR") && stderr.contains("managed zccache builds require"),
+        "expected explicit cache-dir precedence error: {stderr}"
+    );
+}
+
+#[test]
+fn managed_zccache_accepts_explicit_cache_dir_when_it_matches_soldr_root() {
+    let cache_root = unique_temp_dir("cargo-zccache-matching-dir");
+    let zccache_cache_dir = cache_root.join("cache").join("zccache");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("ZCCACHE_CACHE_DIR", &zccache_cache_dir)
+        .output()
+        .expect("failed to run soldr cargo build with matching ZCCACHE_CACHE_DIR");
+
+    assert!(
+        output.status.success(),
+        "matching explicit cache dir should be accepted\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        path_display_variants(&zccache_cache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("cache_dir={path}"))),
+        "managed zccache should use matching explicit Soldr cache root: {log}"
     );
 }
 
@@ -1034,6 +1154,10 @@ fn status_reports_cache_control_defaults() {
         "status missing zccache version: {stdout}"
     );
     assert!(
+        stdout.contains("zccache artifact cache dir:"),
+        "status missing zccache artifact cache dir: {stdout}"
+    );
+    assert!(
         stdout.contains("not fetched yet"),
         "status should explain unfetched managed zccache state: {stdout}"
     );
@@ -1065,6 +1189,14 @@ fn status_json_reports_stable_machine_fields() {
     );
     assert_eq!(json["zccache"]["binary_fetched"], false);
     assert_eq!(json["zccache"]["journal_present"], false);
+    assert_eq!(
+        json["zccache"]["artifact_cache_dir"],
+        cache_root
+            .join("cache")
+            .join("zccache")
+            .display()
+            .to_string()
+    );
     assert!(
         json["target"].as_str().is_some(),
         "status JSON missing target"
@@ -1098,6 +1230,10 @@ fn cache_command_reports_managed_zccache_status() {
     assert!(
         stdout.contains("soldr zccache state dir:"),
         "cache command missing state dir: {stdout}"
+    );
+    assert!(
+        stdout.contains("zccache artifact cache dir:"),
+        "cache command missing artifact cache dir: {stdout}"
     );
     assert!(
         stdout.contains("last session journal:"),
@@ -1143,6 +1279,14 @@ fn cache_json_reports_managed_zccache_status() {
     assert_eq!(json["managed_zccache_version"], "1.3.0");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
+    assert_eq!(
+        json["zccache"]["artifact_cache_dir"],
+        cache_root
+            .join("cache")
+            .join("zccache")
+            .display()
+            .to_string()
+    );
     assert_eq!(
         json["zccache"]["journal_path"],
         journal.display().to_string()

--- a/docs/API.md
+++ b/docs/API.md
@@ -49,7 +49,7 @@ Behavior:
 - Fetch a pinned managed `zccache` release when caching is enabled
 - Set `RUSTC_WRAPPER` to the current soldr binary
 - Pass the managed `zccache` binary path into wrapper mode through the environment
-- Start a per-build zccache session on zccache's current default daemon endpoint
+- Start a per-build zccache session using Soldr's zccache cache root
 - Delegate to Cargo with the exact flags the user passed
 
 Current cache-control behavior:
@@ -58,7 +58,7 @@ Current cache-control behavior:
 - `soldr --no-cache cargo ...` disables soldr's compilation-cache path for that invocation
 - `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
 - zccache integration currently targets Rust builds through the cargo front door
-- zccache's current artifact store and daemon endpoint remain on zccache's default paths; soldr currently manages the session lifecycle and logs
+- soldr sets `ZCCACHE_CACHE_DIR` to the Soldr-owned zccache cache root for managed zccache commands; the pinned zccache release must support that override for artifacts and daemon state to move there
 - toolchain binaries (`rustc`, `rustfmt`, `clippy-driver`, etc.) are resolved directly from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` before any `rustup` call; `rustup which` is only used as a fallback when the direct probe fails. The sole exception is when `RUSTUP_TOOLCHAIN` is explicitly set to a non-empty value — in that case soldr skips the direct probe and asks `rustup` for the matching toolchain binary so the pinned channel always wins
 
 This is the normal build entry point.
@@ -235,6 +235,8 @@ Commands:
 | `SOLDR_RUSTC_WRAPPER` | Override soldr's managed zccache wrapper with another wrapper binary, or disable wrapper injection with `none` / empty | unset |
 | `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
+| `ZCCACHE_CACHE_DIR` | Managed zccache cache root. For managed zccache, unset or equal to Soldr's `cache/zccache`; conflicting values are rejected. | unset |
+| `SCCACHE_DIR` | sccache cache root. For `SOLDR_RUSTC_WRAPPER=sccache`, Soldr sets this to `cache/sccache` only when the caller has not set it. | unset |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -18,7 +18,7 @@ You get, for free:
 
 - branch-agnostic cache keys the action produces on its own
 - automatic restore on feature branches from the latest `main` cache on a miss
-- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves `~/.zccache` by default
+- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves Soldr's zccache cache root by default
 - `cache-hit` and `build-cache-hit` outputs you can read to confirm warm vs cold runs
 
 The rest of this document explains how and why that works.
@@ -48,7 +48,7 @@ The `zackees/soldr@v1` action (see [`action.yml`](../action.yml)) runs internal 
 - **Restore-keys prefix for partial-match fallback.** The action registers a restore prefix (`setup-soldr-v1-{os}-{arch}-`) so that even if a future toolchain bump changes the exact key, GitHub can still fall back to the most recent compatible cache for the same OS and architecture.
 - **Push-only save semantics come for free.** GitHub's cache scoping already prevents feature-branch runs from overwriting `main`'s cache. You do not need to gate `save-if` yourself the way internal Rust caching wrappers usually make you do.
 - **Rehydrated state.** On a cache hit, the action restores the soldr root, `CARGO_HOME`, and `RUSTUP_HOME` under the runner-local cache/state root. The resolved Rust toolchain and the `soldr` binary are then provisioned on top of whatever was restored.
-- **Build-artifact cache enabled by default.** The action also restores `~/.zccache` with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs unless you opt out with `build-cache: false`.
+- **Build-artifact cache enabled by default.** The action also restores Soldr's zccache cache root under `SOLDR_CACHE_DIR` with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs once the managed zccache release supports `ZCCACHE_CACHE_DIR`. You can opt out with `build-cache: false`.
 
 ## Minimum Config For An External Repo
 
@@ -127,6 +127,8 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
 3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 
+For the dedicated parent-to-child validation in this repository, run the `Setup Soldr Parent Child Probe` workflow from a cache-probe branch after `main` has produced a warm cache. It measures a cold `soldr --no-cache` build against the restored `soldr cargo build`, records `cache-hit`, `build-cache-hit`, `target-cache-hit`, includes `soldr cache --json` status lines, and can post the rendered report to issue #168.
+
 ## Debugging Cold Misses
 
 If feature branches keep rebuilding from scratch, check these in order:
@@ -136,7 +138,7 @@ If feature branches keep rebuilding from scratch, check these in order:
 - **Did `rust-toolchain.toml` change?** The resolved toolchain channel is part of both cache key families. Bumping the toolchain channel or the components/targets list invalidates every existing entry. That is expected behavior; the next push to `main` will write a fresh canonical entry.
 - **Did you pass a `cache-key-suffix` input?** That value is appended to both cache key families (see `action.yml`). A different suffix on a feature branch produces a different key than `main` writes, and the restore will only succeed through the prefix fallback. Make sure the same suffix is used (or omitted) on every branch you want to share a lineage.
 - **Mixed runner OS/arch.** Cache keys are scoped by runner OS and architecture. A cache written on `ubuntu-24.04` will not restore on `macos-15` and vice versa. Each combination needs its own warm lineage from `main`.
-- **Did someone opt out of build caching?** If `build-cache: false` is set in the workflow, `build-cache-hit` will be empty and `~/.zccache` will not be restored or saved.
+- **Did someone opt out of build caching?** If `build-cache: false` is set in the workflow, `build-cache-hit` will be empty and Soldr's zccache cache root will not be restored or saved.
 
 ---
 

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -88,7 +88,7 @@ steps:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
-| `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `"true"`; set to `"false"` to opt out. |
+| `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache under `SOLDR_CACHE_DIR`. Default `"true"`; set to `"false"` to opt out. |
 | `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
 | `target-dir` | Cargo target directory restored by `target-cache`. Default `"target"`. |
 
@@ -104,7 +104,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
-| `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is explicitly disabled. |
+| `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is explicitly disabled. |
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. Empty only when `build-cache` or `target-cache` is explicitly disabled. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
@@ -118,7 +118,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - put the installed `soldr` binary on `PATH`
 - restore and save the action-managed cache/state root when `cache: true`
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
-- when `build-cache: true` (the default), restore `~/.zccache` at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
+- when `build-cache: true` (the default), restore Soldr's zccache cache root under `SOLDR_CACHE_DIR` at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts once the managed zccache release supports `ZCCACHE_CACHE_DIR`. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
 - when `build-cache: true` and `target-cache: true` (the defaults), restore the configured Cargo target directory at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and outputs. Keys include the runner OS, architecture, resolved toolchain digest, `Cargo.lock` hash, and commit SHA, with fallback limited to the same toolchain and lockfile lineage.
 
 ### Current Limits That Must Stay Explicit
@@ -127,7 +127,7 @@ The extracted public action must document these current limits honestly:
 
 - the action rehydrates the Soldr root, Cargo home, and rustup home under the chosen cache/state root
 - the action bootstraps `rustup` on demand via `rustup-init` when it is absent, then uses it to install the requested toolchain; at runtime Soldr prefers direct toolchain binaries from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` and only falls back to `rustup which` when the direct probe fails (or when `RUSTUP_TOOLCHAIN` is explicitly set)
-- managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path
+- managed `zccache` artifact storage depends on the pinned zccache release honoring Soldr's `ZCCACHE_CACHE_DIR` override
 
 ### Non-Contract Details
 

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -120,8 +120,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`; on self-hosted runners, `rustup` must already be available.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- The action restores `~/.zccache` and the Cargo target directory by default so child branches can reuse parent-branch build state.
-- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
+- The action restores Soldr's zccache cache root under `SOLDR_CACHE_DIR` and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- Managed `zccache` artifact storage uses `ZCCACHE_CACHE_DIR` when the managed zccache version supports that override.
 
 ## Development
 

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -104,8 +104,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`; on self-hosted runners, `rustup` must already be available.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- The action restores `~/.zccache` and the Cargo target directory by default so child branches can reuse parent-branch build state.
-- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
+- The action restores Soldr's zccache cache root under `SOLDR_CACHE_DIR` and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- Managed `zccache` artifact storage uses `ZCCACHE_CACHE_DIR` when the managed zccache version supports that override.
 
 ## Development
 

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -32,9 +32,10 @@ inputs:
     default: ""
   build-cache:
     description: >
-      Restore and save the zccache compilation artifact cache (~/.zccache)
-      across workflow runs. Default "true"; the action restores ~/.zccache
-      with a toolchain-scoped key and saves it at end-of-job, letting
+      Restore and save Soldr's zccache compilation artifact cache under
+      SOLDR_CACHE_DIR across workflow runs. Default "true"; the action
+      restores the Soldr-owned zccache root with a toolchain-scoped key
+      and saves it at end-of-job, letting
       GitHub's own-branch -> PR base -> default-branch restore order seed
       feature-branch runs from the latest main-branch save without any
       repo-side configuration. Set to "false" to opt out.
@@ -68,8 +69,8 @@ outputs:
   build-cache-hit:
     description: >
       Whether the action restored the zccache compilation artifact cache
-      (~/.zccache). "true" for an exact key match, "false" for a
-      restore-key fallback or no cache, empty string when `build-cache`
+      under SOLDR_CACHE_DIR. "true" for an exact key match, "false" for
+      a restore-key fallback or no cache, empty string when `build-cache`
       is explicitly disabled.
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
   target-cache-hit:
@@ -103,7 +104,7 @@ runs:
       if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.cache_root }}
+        path: ${{ steps.resolve.outputs.setup_cache_paths }}
         key: ${{ steps.resolve.outputs.cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
@@ -112,7 +113,7 @@ runs:
       if: ${{ inputs.build-cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ~/.zccache
+        path: ${{ steps.resolve.outputs.build_cache_path }}
         key: ${{ steps.resolve.outputs.build_cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -117,6 +117,7 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert cache_root.is_dir()
     assert (cache_root / "soldr").is_dir()
     assert (cache_root / "soldr" / "cache").is_dir()
+    assert (cache_root / "soldr" / "cache" / "zccache").is_dir()
     assert (cache_root / "soldr" / "bin").is_dir()
     assert (cache_root / "cargo").is_dir()
     assert (cache_root / "cargo" / "bin").is_dir()
@@ -125,7 +126,16 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
 
     outputs = github_output.read_text(encoding="utf-8")
     assert f"cache_root={cache_root}" in outputs
+    assert "setup_cache_paths<<" in outputs
+    assert str(cache_root / "soldr" / "bin") in outputs
+    assert str(cache_root / "cargo") in outputs
+    assert str(cache_root / "rustup") in outputs
+    assert f"build_cache_path={cache_root / 'soldr' / 'cache' / 'zccache'}" in outputs
     assert f"target_cache_path={workspace / 'custom-target'}" in outputs
     assert "target_cache_key=setup-soldr-targetcache-v1-linux-x64-" in outputs
     assert outputs.count("-no-lock-abc123") == 1
     assert "toolchain=stable" in outputs
+
+    env = github_env.read_text(encoding="utf-8")
+    assert f"SOLDR_CACHE_DIR={cache_root / 'soldr'}" in env
+    assert f"ZCCACHE_CACHE_DIR={cache_root / 'soldr' / 'cache' / 'zccache'}" in env

--- a/tests/test_setup_soldr_parent_child_probe_report.py
+++ b/tests/test_setup_soldr_parent_child_probe_report.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "setup_soldr_parent_child_probe_report.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "setup_soldr_parent_child_probe_report", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_report_includes_target_cache_and_zccache_status() -> None:
+    module = _load_module()
+
+    report = module.build_report(
+        {
+            "run_url": "https://github.com/zackees/soldr/actions/runs/1",
+            "ref_name": "cache-probe/zccache-parent-child",
+            "sha": "abc123",
+            "cold_result": "success",
+            "warm_result": "success",
+            "cold_seconds": "37.00",
+            "warm_seconds": "0.50",
+            "setup_cache_hit": "true",
+            "build_cache_hit": "true",
+            "target_cache_hit": "true",
+            "soldr_version": "0.7.5",
+            "toolchain": "1.94.1",
+            "zccache_artifact_cache_dir": "/tmp/setup-soldr/soldr/cache/zccache",
+            "zccache_status_lines": [
+                "Compilations: 227 total (181 cached, 0 cold, 44 non-cacheable)",
+                "Hit rate: 100.0%",
+            ],
+        }
+    )
+
+    assert report.startswith("### Parent-to-child zccache cache report\n")
+    assert "- target-cache hit: `true`" in report
+    assert "- warm soldr build seconds: `0.50`" in report
+    assert "- speedup vs cold control: `74.00x`" in report
+    assert "- sub-second target met: `yes`" in report
+    assert "- dominant remaining cost: `none observed; sub-second target met`" in report
+    assert "Compilations: 227 total" in report
+
+
+def test_build_report_identifies_missing_target_cache_as_remaining_cost() -> None:
+    module = _load_module()
+
+    report = module.build_report(
+        {
+            "cold_seconds": "37.00",
+            "warm_seconds": "35.00",
+            "setup_cache_hit": "true",
+            "build_cache_hit": "true",
+            "target_cache_hit": "false",
+            "zccache_status_lines": [],
+        }
+    )
+
+    assert "- sub-second target met: `no`" in report
+    assert (
+        "- dominant remaining cost: `target cache was not an exact hit; inspect restore-key fallback logs`"
+        in report
+    )


### PR DESCRIPTION
## Summary

- routes managed zccache commands and wrapper delegation through Soldr's `cache/zccache` root with `ZCCACHE_CACHE_DIR`
- defaults custom `SOLDR_RUSTC_WRAPPER=sccache` builds to Soldr's `cache/sccache` when `SCCACHE_DIR` is unset
- moves setup-soldr build-cache restore/save to the Soldr-owned zccache root and keeps setup-state caching from overlapping it
- adds a parent-to-child setup-soldr probe workflow and report renderer for issue #168
- updates docs, action exporter fixtures, and focused tests

## Notes

- `zackees/zccache#51` is still the upstream dependency for real managed zccache artifact relocation; this PR wires Soldr's side and documents the current precedence behavior.
- This PR is stacked on `fix/setup-soldr-target-cache-fast-path` so the diff stays focused after #171.

## Validation

```text
python -m pytest tests\test_setup_soldr_parent_child_probe_report.py tests\test_setup_soldr_action.py tests\test_setup_soldr_exporter.py tests\test_cache_benchmark_report.py
14 passed

cargo test -p soldr-cache
9 passed

cargo test -p soldr-cli --test cli zccache
7 passed

cargo test -p soldr-cli --test cli sccache
1 passed

git diff --check
passed
```

Refs #172
Refs #168