### PR TITLE
Prepare setup-soldr beta v0 contract

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -148,7 +148,7 @@ def main() -> None:
     ).hexdigest()[:16]
     runner_os = _sanitize_fragment(os.environ.get("ACTION_OS", os.name).lower())
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
-    cache_prefix = f"setup-soldr-v1-{runner_os}-{runner_arch}"
+    cache_prefix = f"setup-soldr-v0-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
 
     suffix = os.environ.get("INPUT_CACHE_KEY_SUFFIX", "").strip()
@@ -156,12 +156,12 @@ def main() -> None:
         cache_key = f"{cache_key}-{_sanitize_fragment(suffix)}"
 
     # Build-artifact cache (zccache compilation cache at ~/.zccache).
-    # Key shape: setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{sha}.
+    # Key shape: setup-soldr-buildcache-v0-{os}-{arch}-{toolchain-digest}-{sha}.
     # Restore falls back through the same toolchain lineage and then any
     # OS+arch cache, letting GitHub's own-branch -> PR base -> default branch
     # restore order provide parent -> child lineage without user config.
     github_sha = os.environ.get("GITHUB_SHA", "").strip() or "nosha"
-    build_cache_prefix = f"setup-soldr-buildcache-v1-{runner_os}-{runner_arch}"
+    build_cache_prefix = f"setup-soldr-buildcache-v0-{runner_os}-{runner_arch}"
     build_cache_toolchain_prefix = f"{build_cache_prefix}-{digest}-"
     build_cache_key = f"{build_cache_toolchain_prefix}{github_sha}"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.7.5" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.5" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.7.5" }
+soldr-core = { path = "crates/soldr-core", version = "0.7.6" }
+soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.6" }
+soldr-cache = { path = "crates/soldr-cache", version = "0.7.6" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -25,31 +25,32 @@ This repository currently ships an in-repo root GitHub Action for Soldr setup. T
 2. let the action bootstrap `rustup` if needed, then provision the Rust toolchain and restore the Soldr/Cargo/rustup cache root
 3. run `soldr cargo ...`
 
-The stable-major public setup action product is not shipped yet. Today, pin the current in-repo action by full commit SHA or explicit release tag; do not assume a public `@v1` contract yet.
+The public setup action product is not shipped yet. Today, pin the current in-repo action by full commit SHA or explicit release tag; do not assume a public `@v0` beta contract until the beta repository and tag exist.
 
 ### Public-action status
 
-The target public UX after extraction is:
+The target public beta UX after extraction is:
 
 ```yaml
 steps:
   - uses: actions/checkout@v4
 
-  - uses: zackees/setup-soldr@v1
+  - uses: zackees/setup-soldr@v0
     with:
-      version: 0.7.4
+      version: 0.7.5
       cache: true
 
   - run: soldr cargo build --locked --release
   - run: soldr cargo test --locked
 ```
 
-That public repo is not shipped yet. This repository cannot publish it directly to GitHub Marketplace because Marketplace action repositories must keep one root `action.yml` and no workflow files. The extraction plan and intended `@v1` contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md).
+That public repo is not shipped yet. This repository cannot publish it directly to GitHub Marketplace because Marketplace action repositories must keep one root `action.yml` and no workflow files. The extraction plan and intended `@v0` beta contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md).
 
-Stable-major rule for the planned public repo:
+Beta and stable tag rule for the planned public repo:
 
-- `@v1` is the moving major tag for backward-compatible updates
-- `@v2` is introduced only for breaking contract changes
+- `@v0` is the moving beta tag while the action contract is still settling
+- `@v1` should be introduced only when the action is ready for a stable backward-compatible contract
+- later major tags such as `@v2` are introduced only for breaking contract changes after `@v1`
 - the intended normal path is still one `setup-soldr` step plus `soldr cargo ...`; no separate toolchain action is part of the common-case contract
 
 Until that repo exists, no verified public one-line Soldr action exists yet. Use `zackees/soldr@<ref>` or `uses: ./` instead.
@@ -88,7 +89,7 @@ jobs:
 
       - uses: zackees/soldr@<ref>
         with:
-          version: 0.7.4
+          version: 0.7.5
           cache: true
 
       - run: soldr cargo build --locked --release
@@ -100,7 +101,7 @@ For same-repository testing, use:
 ```yaml
 - uses: ./
   with:
-    version: 0.7.4
+    version: 0.7.5
     cache: true
 ```
 
@@ -113,7 +114,7 @@ Useful inputs when wiring the action into another repository:
 - `cache-dir`: move the shared Soldr/Cargo/rustup root to a specific path
 - `trust-mode`: set `SOLDR_TRUST_MODE` for stricter fetched-binary policy
 
-The current `repo` input is an implementation/testing override for the in-repo action. It is not part of the intended public `setup-soldr@v1` contract.
+The current `repo` input is an implementation/testing override for the in-repo action. It is not part of the intended public `setup-soldr@v0` beta contract.
 
 Useful outputs:
 
@@ -157,10 +158,10 @@ jobs:
         with:
           toolchain: 1.94.1
 
-      - name: Install soldr 0.7.4
+      - name: Install soldr 0.7.5
         shell: bash
         run: |
-          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
+          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.5/install.sh | bash -s -- --version 0.7.5
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Build through soldr
@@ -194,7 +195,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: zackees/soldr
-          ref: v0.7.4
+          ref: v0.7.5
           path: soldr
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -37,7 +37,7 @@ steps:
 
   - uses: zackees/setup-soldr@v0
     with:
-      version: 0.7.5
+      version: 0.7.6
       cache: true
 
   - run: soldr cargo build --locked --release
@@ -89,7 +89,7 @@ jobs:
 
       - uses: zackees/soldr@<ref>
         with:
-          version: 0.7.5
+          version: 0.7.6
           cache: true
 
       - run: soldr cargo build --locked --release
@@ -101,7 +101,7 @@ For same-repository testing, use:
 ```yaml
 - uses: ./
   with:
-    version: 0.7.5
+    version: 0.7.6
     cache: true
 ```
 
@@ -158,10 +158,10 @@ jobs:
         with:
           toolchain: 1.94.1
 
-      - name: Install soldr 0.7.5
+      - name: Install soldr 0.7.6
         shell: bash
         run: |
-          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.5/install.sh | bash -s -- --version 0.7.5
+          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.6/install.sh | bash -s -- --version 0.7.6
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Build through soldr
@@ -195,7 +195,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: zackees/soldr
-          ref: v0.7.5
+          ref: v0.7.6
           path: soldr
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The current GitHub Actions entry point is the repository root action in this rep
 ```yaml
 - uses: zackees/soldr@<ref>
   with:
-    version: 0.7.4
+    version: 0.7.5
     cache: true
 
 - run: soldr cargo build --locked --release
@@ -72,7 +72,7 @@ If your project pins Rust in `rust-toolchain.toml`, let the action read that fil
 On GitHub-hosted runners, this means you usually do not need a separate toolchain setup action for the normal path. The action still uses `rustup` under the hood today, but it bootstraps `rustup` itself when the runner does not already have it.
 On runners without `rustup`, the action downloads and installs it into the cached runner-local root before provisioning the requested toolchain.
 
-For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). GitHub Marketplace publication still requires extracting this action into a separate public action repository because GitHub requires a single root `action.yml` and no workflow files in the published repository. The repo-contained extraction plan and intended `zackees/setup-soldr@v1` contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md). Until that public repo exists, treat `zackees/soldr@<ref>` as the current contract and pin a full commit SHA or explicit release tag instead of assuming `@v1`. For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
+For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). GitHub Marketplace publication still requires extracting this action into a separate public action repository because GitHub requires a single root `action.yml` and no workflow files in the published repository. The repo-contained extraction plan and intended beta `zackees/setup-soldr@v0` contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md). Until that public repo exists, treat `zackees/soldr@<ref>` as the current contract and pin a full commit SHA or explicit release tag instead of assuming `@v0`. For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
 
 ### CI cache lineage
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The current GitHub Actions entry point is the repository root action in this rep
 ```yaml
 - uses: zackees/soldr@<ref>
   with:
-    version: 0.7.5
+    version: 0.7.6
     cache: true
 
 - run: soldr cargo build --locked --release

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,16 @@
 name: setup-soldr
 author: zackees
 description: Extraction-ready Soldr setup action. Installs one soldr binary, bootstraps rustup when needed, provisions the resolved Rust toolchain, and restores a cacheable runner-local Soldr root.
+branding:
+  icon: terminal
+  color: green
 inputs:
   version:
     description: Soldr version or tag to install. Defaults to the latest release.
     required: false
     default: ""
   repo:
-    description: Release source repository override for extraction or local testing. Not part of the intended public setup-soldr@v1 contract.
+    description: Release source repository override for extraction or local testing. Not part of the intended public setup-soldr@v0 beta contract.
     required: false
     default: zackees/soldr
   cache:

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -1,16 +1,16 @@
 # CI Cache Guide For External Repos
 
-This is a usage guide for anyone wiring `zackees/soldr@v1` into their own GitHub Actions CI. It explains what you get automatically, what the minimum config looks like, and how to confirm warm builds on feature branches are actually restoring from `main`.
+This is a usage guide for anyone wiring `zackees/soldr@v0` into their own GitHub Actions CI. It explains what you get automatically, what the minimum config looks like, and how to confirm warm builds on feature branches are actually restoring from `main`.
 
 If you want the background on why this repository wires its own workflows the way it does, skip to [Why This Repo Uses This Model](#why-this-repo-uses-this-model) at the bottom.
 
 ## TL;DR
 
-Add `zackees/soldr@v1` to a normal `push`-triggered workflow:
+Add `zackees/soldr@v0` to a normal `push`-triggered workflow:
 
 ```yaml
 - uses: actions/checkout@v4
-- uses: zackees/soldr@v1
+- uses: zackees/soldr@v0
 - run: soldr cargo build --locked
 ```
 
@@ -42,10 +42,10 @@ Two consequences of that scoping rule matter for soldr:
 
 ## What setup-soldr Does For You Automatically
 
-The `zackees/soldr@v1` action (see [`action.yml`](../action.yml)) runs internal cache steps keyed so that the parent-to-child restore works correctly without you configuring anything:
+The `zackees/soldr@v0` action (see [`action.yml`](../action.yml)) runs internal cache steps keyed so that the parent-to-child restore works correctly without you configuring anything:
 
 - **Branch-agnostic state-cache keys.** The setup-state cache key is derived from runner OS, runner architecture, the resolved Rust toolchain channel, and the requested soldr version. No branch name is in the key. Two branches with the same toolchain pin produce the same key, so a cache written by `main` is a valid candidate for a run on any feature branch.
-- **Restore-keys prefix for partial-match fallback.** The action registers a restore prefix (`setup-soldr-v1-{os}-{arch}-`) so that even if a future toolchain bump changes the exact key, GitHub can still fall back to the most recent compatible cache for the same OS and architecture.
+- **Restore-keys prefix for partial-match fallback.** The action registers a restore prefix (`setup-soldr-v0-{os}-{arch}-`) so that even if a future toolchain bump changes the exact key, GitHub can still fall back to the most recent compatible cache for the same OS and architecture.
 - **Push-only save semantics come for free.** GitHub's cache scoping already prevents feature-branch runs from overwriting `main`'s cache. You do not need to gate `save-if` yourself the way internal Rust caching wrappers usually make you do.
 - **Rehydrated state.** On a cache hit, the action restores the soldr root, `CARGO_HOME`, and `RUSTUP_HOME` under the runner-local cache/state root. The resolved Rust toolchain and the `soldr` binary are then provisioned on top of whatever was restored.
 - **Build-artifact cache enabled by default.** The action also restores `~/.zccache` with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs unless you opt out with `build-cache: false`.
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: zackees/soldr@v1
+      - uses: zackees/soldr@v0
         with:
           cache: true
 
@@ -108,7 +108,7 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
    ```yaml
    - id: soldr
-     uses: zackees/soldr@v1
+     uses: zackees/soldr@v0
      with:
        cache: true
    - run: echo "cache-hit=${{ steps.soldr.outputs.cache-hit }}"
@@ -118,12 +118,12 @@ After two pushes to the same branch, you should be able to confirm the cache lin
    `true` means the key matched exactly. `false` means either a fresh key (cold) or a restore-keys fallback match (partial). Both `false` cases show the same literal `false`; distinguish them using the raw log.
 
 2. **Open the raw log of the setup step.** Expand the internal cache steps inside the composite action. You want to see either:
-   - `Cache restored from key: setup-soldr-v1-...` for an exact setup-state cache hit, or
-   - `Cache restored successfully` followed by a key that matches the restore prefix `setup-soldr-v1-{os}-{arch}-` for a partial setup-state restore.
+   - `Cache restored from key: setup-soldr-v0-...` for an exact setup-state cache hit, or
+   - `Cache restored successfully` followed by a key that matches the restore prefix `setup-soldr-v0-{os}-{arch}-` for a partial setup-state restore.
 
    A line that says no cache was found at all, with no restore match, indicates a cold miss.
 
-   For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
+   For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v0-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
 
 3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -68,7 +68,7 @@ steps:
 
   - uses: zackees/setup-soldr@v0
     with:
-      version: 0.7.5
+      version: 0.7.6
       cache: true
 
   - run: soldr cargo build --locked --release

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -58,17 +58,17 @@ setup-soldr/
 
 Do not copy any file from `.github/workflows/`.
 
-## Stable Public `v1` Contract
+## Beta Public `v0` Contract
 
-The intended public UX is:
+The intended public beta UX is:
 
 ```yaml
 steps:
   - uses: actions/checkout@v4
 
-  - uses: zackees/setup-soldr@v1
+  - uses: zackees/setup-soldr@v0
     with:
-      version: 0.7.4
+      version: 0.7.5
       cache: true
 
   - run: soldr cargo build --locked --release
@@ -77,7 +77,7 @@ steps:
 
 ### Supported Inputs
 
-`v1` should treat these inputs as the public contract:
+`v0` should treat these inputs as the beta public contract:
 
 | Input | Meaning |
 |---|---|
@@ -90,11 +90,11 @@ steps:
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `"true"`; set to `"false"` to opt out. |
 
-The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v1` contract and should not be documented in the extracted public action README.
+The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v0` beta contract and should not be documented in the extracted public action README.
 
 ### Supported Outputs
 
-`v1` should treat these outputs as the public contract:
+`v0` should treat these outputs as the beta public contract:
 
 | Output | Meaning |
 |---|---|
@@ -107,7 +107,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 
 ### Required Behavior
 
-`v1` should preserve these behaviors:
+`v0` should preserve these behaviors:
 
 - install exactly one released Soldr binary for the active runner OS and architecture
 - provision the normal-path Rust toolchain itself, bootstrapping `rustup` via `rustup-init` when it is not already on the runner; users should not need to preinstall `rustup` or run a separate toolchain-setup action for the common path
@@ -115,7 +115,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - put the installed `soldr` binary on `PATH`
 - restore and save the action-managed cache/state root when `cache: true`
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
-- when `build-cache: true` (the default), restore `~/.zccache` at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
+- when `build-cache: true` (the default), restore `~/.zccache` at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v0-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
 
 ### Current Limits That Must Stay Explicit
 
@@ -127,7 +127,7 @@ The extracted public action must document these current limits honestly:
 
 ### Non-Contract Details
 
-These details can change inside `v1` without forcing `v2`, as long as the supported inputs, outputs, and behaviors above stay compatible:
+These details can change during `v0` while the action is still beta. `v1` should be reserved for the first stable contract with a stronger backward-compatibility promise:
 
 - the exact cache key format
 - the default runner-local filesystem path chosen when `cache-dir` is empty
@@ -147,9 +147,10 @@ Use this release model for `zackees/setup-soldr`:
 
 1. Validate the action changes in this repository first with the existing smoke path.
 2. Copy the release contents into `zackees/setup-soldr` without workflow files.
-3. Publish an immutable release tag such as `v1.0.0`.
-4. Move the major compatibility tag `v1` to the same commit as the latest compatible `v1.x.y` release.
-5. Introduce `v2` only for breaking contract changes such as input removal, output removal, or behavior changes that require workflow edits.
+3. Publish the beta release as an immutable tag such as `v0.1.0`.
+4. Move the beta compatibility tag `v0` to the same commit as the latest compatible beta release.
+5. Publish `v1.0.0` and move `v1` only when the action is ready for a stable backward-compatible contract.
+6. Introduce later major tags only for breaking contract changes such as input removal, output removal, or behavior changes that require workflow edits after `v1`.
 
 ## Extraction Checklist
 
@@ -160,8 +161,8 @@ Before the first public release:
 3. Copy [action.yml](../action.yml) and the helper scripts listed above into the public repository.
 4. Copy the user-facing setup docs from this repository's `README.md`, `INTEGRATION.md`, and this file into the public repository `README.md`, but remove any mention of the temporary in-repo `zackees/soldr@<ref>` path.
 5. Ensure the public repository contains no workflow files.
-6. Create the first release tag `v1.0.0`, then move `v1` to that commit.
-7. Publish the release to GitHub Marketplace from the public repository.
+6. Create the first beta release tag `v0.1.0`, then move `v0` to that commit.
+7. Publish the beta release to GitHub Marketplace from the public repository.
 
 ## What This PR Changes
 
@@ -170,4 +171,4 @@ This repo-contained plan is useful even before the public repository exists beca
 - defines the exact public contract the extracted action should preserve
 - distinguishes public contract from current implementation-only escape hatches
 - gives a mechanical file-copy plan for extraction
-- gives a stable tagging and release model for `@v1` and later `@v2`
+- gives a beta tagging and release model for `@v0`, with `@v1` reserved for the later stable contract

--- a/examples/ci-minimal.yml
+++ b/examples/ci-minimal.yml
@@ -3,7 +3,7 @@
 # Drop this at .github/workflows/ci.yml and you get:
 #  - warm feature-branch builds that restore from the latest main cache on miss
 #  - per-branch cache saves so successive pushes on the same branch are warmer
-#  - no manual actions/cache step: zackees/soldr@v1 runs one internally with
+#  - no manual actions/cache step: zackees/soldr@v0 runs one internally with
 #    a branch-agnostic key + restore-keys prefix for parent (main) -> child
 #    (feature branch) cache sharing
 #
@@ -33,7 +33,7 @@ jobs:
       # rust-toolchain.toml, and runs an internal actions/cache step keyed so
       # main writes the canonical entry and feature branches restore from it.
       - id: soldr
-        uses: zackees/soldr@v1
+        uses: zackees/soldr@v0
         with:
           cache: true
 

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.5
+          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.5
+          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.5
+          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: zackees/setup-soldr@v1
+      - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.4
+          version: 0.7.5
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -58,9 +58,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: zackees/setup-soldr@v1
+      - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.4
+          version: 0.7.5
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -80,9 +80,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: zackees/setup-soldr@v1
+      - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.4
+          version: 0.7.5
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -99,6 +99,7 @@ jobs:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+| `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `true`; set to `false` to opt out. |
 
 ## Outputs
 
@@ -108,14 +109,15 @@ jobs:
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
+| `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is disabled. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
 
 - The action installs exactly one released `soldr` binary for the active runner target.
-- The normal path provisions Rust with `rustup`; on self-hosted runners, `rustup` must already be available.
+- The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
+- Managed `zccache` artifact storage uses the default `~/.zccache` path and is controlled by `build-cache`.
 
 ## Development
 

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: zackees/setup-soldr@v1
+      - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.4
+          version: 0.7.5
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -42,9 +42,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: zackees/setup-soldr@v1
+      - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.4
+          version: 0.7.5
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -64,9 +64,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: zackees/setup-soldr@v1
+      - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.4
+          version: 0.7.5
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -83,6 +83,7 @@ jobs:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
+| `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `true`; set to `false` to opt out. |
 
 ## Outputs
 
@@ -92,14 +93,15 @@ jobs:
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
+| `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is disabled. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
 
 - The action installs exactly one released `soldr` binary for the active runner target.
-- The normal path provisions Rust with `rustup`; on self-hosted runners, `rustup` must already be available.
+- The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
+- Managed `zccache` artifact storage uses the default `~/.zccache` path and is controlled by `build-cache`.
 
 ## Development
 

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.5
+          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.5
+          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.5
+          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -1,6 +1,9 @@
 name: setup-soldr
 author: zackees
-description: Extraction-ready Soldr setup action. Installs one soldr binary, provisions the resolved Rust toolchain via rustup, and restores a cacheable runner-local Soldr root.
+description: Extraction-ready Soldr setup action. Installs one soldr binary, bootstraps rustup when needed, provisions the resolved Rust toolchain, and restores a cacheable runner-local Soldr root.
+branding:
+  icon: terminal
+  color: green
 inputs:
   version:
     description: Soldr version or tag to install. Defaults to the latest release.
@@ -30,6 +33,16 @@ inputs:
     description: Optional value for SOLDR_TRUST_MODE.
     required: false
     default: ""
+  build-cache:
+    description: >
+      Restore and save the zccache compilation artifact cache (~/.zccache)
+      across workflow runs. Default "true"; the action restores ~/.zccache
+      with a toolchain-scoped key and saves it at end-of-job, letting
+      GitHub's own-branch -> PR base -> default-branch restore order seed
+      feature-branch runs from the latest main-branch save without any
+      repo-side configuration. Set to "false" to opt out.
+    required: false
+    default: "true"
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -43,6 +56,13 @@ outputs:
   cache-hit:
     description: Whether the action restored an exact cache hit for the selected cache/state root.
     value: ${{ steps.cache-meta.outputs.cache_hit }}
+  build-cache-hit:
+    description: >
+      Whether the action restored the zccache compilation artifact cache
+      (~/.zccache). "true" for an exact key match, "false" for a
+      restore-key fallback or no cache, empty string when `build-cache`
+      is explicitly disabled.
+    value: ${{ steps.cache-meta.outputs.build_cache_hit }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
@@ -72,6 +92,16 @@ runs:
         restore-keys: |
           ${{ steps.resolve.outputs.cache_restore_prefix }}
 
+    - id: build-cache-restore
+      if: ${{ inputs.build-cache == 'true' }}
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ~/.zccache
+        key: ${{ steps.resolve.outputs.build_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
+          ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
+
     - id: toolchain
       shell: pwsh
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_rust_toolchain.py"
@@ -95,9 +125,21 @@ runs:
       shell: pwsh
       env:
         RAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        RAW_BUILD_CACHE_HIT: ${{ steps.build-cache-restore.outputs.cache-hit }}
+        BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
       run: |
         $value = $env:RAW_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($value)) {
           $value = "false"
         }
         "cache_hit=$value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+        if ($env:BUILD_CACHE_ENABLED -eq "true") {
+          $buildValue = $env:RAW_BUILD_CACHE_HIT
+          if ([string]::IsNullOrWhiteSpace($buildValue)) {
+            $buildValue = "false"
+          }
+        } else {
+          $buildValue = ""
+        }
+        "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -123,4 +123,9 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
 
     outputs = github_output.read_text(encoding="utf-8")
     assert f"cache_root={cache_root}" in outputs
+    assert "cache_key=setup-soldr-v0-linux-x64-" in outputs
+    assert "cache_restore_prefix=setup-soldr-v0-linux-x64-" in outputs
+    assert "build_cache_key=setup-soldr-buildcache-v0-linux-x64-" in outputs
+    assert "build_cache_restore_key_toolchain=setup-soldr-buildcache-v0-linux-x64-" in outputs
+    assert "build_cache_restore_key_os_arch=setup-soldr-buildcache-v0-linux-x64-" in outputs
     assert "toolchain=stable" in outputs

--- a/tests/test_setup_soldr_exporter.py
+++ b/tests/test_setup_soldr_exporter.py
@@ -57,7 +57,7 @@ def test_export_bundle_excludes_internal_repo_override_input(tmp_path: Path) -> 
     action_yaml = destination.joinpath("action.yml").read_text(encoding="utf-8")
     assert "repo:" not in action_yaml
     assert "INPUT_REPO" not in action_yaml
-    assert "Not part of the intended public setup-soldr@v1 contract" not in action_yaml
+    assert "Not part of the intended public setup-soldr@v0 beta contract" not in action_yaml
 
 
 def test_export_bundle_refuses_repo_root_as_destination() -> None:


### PR DESCRIPTION
## Summary
- move the planned setup-soldr public action contract from stable `@v1` language to beta `@v0`
- use `v0` setup and build-cache key namespaces so beta runs do not occupy the future `v1` cache namespace
- add Marketplace-friendly action branding metadata
- refresh exported setup-soldr README/action fixtures for `@v0`, Soldr `0.7.5`, and current build-cache behavior

## Tests
- python -m pytest
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('action.yml').read_text()); yaml.safe_load(pathlib.Path('tests/fixtures/setup_soldr_exporter/expected_action.yml').read_text()); print('action yaml ok')"
- git diff --check

No `v0` or `v1` tag/release was created.
