### PR TITLE
Centralize release version source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
 [workspace.dependencies]
-soldr-core = { path = "crates/soldr-core", version = "0.7.6" }
-soldr-fetch = { path = "crates/soldr-fetch", version = "0.7.6" }
-soldr-cache = { path = "crates/soldr-cache", version = "0.7.6" }
+soldr-core = { path = "crates/soldr-core" }
+soldr-fetch = { path = "crates/soldr-fetch" }
+soldr-cache = { path = "crates/soldr-cache" }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -37,7 +37,6 @@ steps:
 
   - uses: zackees/setup-soldr@v0
     with:
-      version: 0.7.6
       cache: true
 
   - run: soldr cargo build --locked --release
@@ -89,7 +88,6 @@ jobs:
 
       - uses: zackees/soldr@<ref>
         with:
-          version: 0.7.6
           cache: true
 
       - run: soldr cargo build --locked --release
@@ -101,7 +99,6 @@ For same-repository testing, use:
 ```yaml
 - uses: ./
   with:
-    version: 0.7.6
     cache: true
 ```
 
@@ -158,10 +155,10 @@ jobs:
         with:
           toolchain: 1.94.1
 
-      - name: Install soldr 0.7.6
+      - name: Install latest soldr release
         shell: bash
         run: |
-          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.6/install.sh | bash -s -- --version 0.7.6
+          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/main/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Build through soldr
@@ -195,7 +192,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: zackees/soldr
-          ref: v0.7.6
+          ref: main
           path: soldr
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ The current GitHub Actions entry point is the repository root action in this rep
 ```yaml
 - uses: zackees/soldr@<ref>
   with:
-    version: 0.7.6
     cache: true
 
 - run: soldr cargo build --locked --release

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -68,7 +68,6 @@ steps:
 
   - uses: zackees/setup-soldr@v0
     with:
-      version: 0.7.6
       cache: true
 
   - run: soldr cargo build --locked --release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ build-backend = "maturin"
 
 [project]
 name = "soldr"
+# Version source of truth: Cargo.toml [workspace.package].version.
+# maturin derives the Python package version from the Rust package metadata.
 dynamic = ["version"]
 description = "Instant tools. Instant builds. One command."
 readme = "README.md"

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -38,7 +38,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -60,7 +59,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -82,7 +80,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -44,7 +43,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked
@@ -66,7 +64,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          version: 0.7.6
           cache: true
       - run: soldr cargo build --locked --release
       - run: soldr cargo test --locked


### PR DESCRIPTION
## Summary
- make `Cargo.toml` `[workspace.package].version` the only editable Soldr release version source
- document why `pyproject.toml` keeps `dynamic = ["version"]` for maturin/PyPI
- remove repeated local workspace crate dependency version constraints
- stop hardcoding the current release version in setup-action docs and exported README examples

## Version-source notes
- Canonical editable source: `Cargo.toml` `[workspace.package].version`
- Generated/derived places: `Cargo.lock`, maturin/PyPI metadata
- User-facing examples now rely on the action/install defaults for latest release rather than embedding `0.7.x`

## Tests
- cargo check --workspace
- python -m pytest
- python -c "import tomllib, pathlib; p=tomllib.loads(pathlib.Path('pyproject.toml').read_text()); c=tomllib.loads(pathlib.Path('Cargo.toml').read_text()); assert p['project']['dynamic'] == ['version']; assert c['workspace']['package']['version'] == '0.7.6'; print('metadata ok')"
- git diff --check
