### PR TITLE
Add npm publishing and setup target cache

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -68,6 +68,12 @@ def _sanitize_fragment(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-") or "default"
 
 
+def _short_file_hash(path: Path, missing: str) -> str:
+    if not path.exists():
+        return missing
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
 def _write_env(name: str, value: str) -> None:
     output = os.environ.get("GITHUB_ENV")
     if not output:
@@ -150,6 +156,7 @@ def main() -> None:
     runner_arch = _sanitize_fragment(os.environ.get("ACTION_ARCH", "unknown").lower())
     cache_prefix = f"setup-soldr-v0-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
+    cargo_lock_hash = _short_file_hash(workspace / "Cargo.lock", "no-lock")
 
     suffix = os.environ.get("INPUT_CACHE_KEY_SUFFIX", "").strip()
     if suffix:
@@ -165,9 +172,19 @@ def main() -> None:
     build_cache_toolchain_prefix = f"{build_cache_prefix}-{digest}-"
     build_cache_key = f"{build_cache_toolchain_prefix}{github_sha}"
 
+    target_dir_input = os.environ.get("INPUT_TARGET_DIR", "target").strip() or "target"
+    target_cache_path = Path(target_dir_input).expanduser()
+    if not target_cache_path.is_absolute():
+        target_cache_path = workspace / target_cache_path
+    target_cache_path = target_cache_path.resolve()
+    target_cache_prefix = f"setup-soldr-targetcache-v0-{runner_os}-{runner_arch}"
+    target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+    target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
+
     if suffix:
         sanitized_suffix = _sanitize_fragment(suffix)
         build_cache_key = f"{build_cache_key}-{sanitized_suffix}"
+        target_cache_key = f"{target_cache_key}-{sanitized_suffix}"
 
     _write_env("SOLDR_CACHE_DIR", str(soldr_root))
     _write_env("CARGO_HOME", str(cargo_home))
@@ -190,6 +207,9 @@ def main() -> None:
             "build_cache_key": build_cache_key,
             "build_cache_restore_key_toolchain": build_cache_toolchain_prefix,
             "build_cache_restore_key_os_arch": f"{build_cache_prefix}-",
+            "target_cache_path": str(target_cache_path),
+            "target_cache_key": target_cache_key,
+            "target_cache_restore_key_lock": target_cache_lock_prefix,
             "soldr_root": str(soldr_root),
             "cargo_home": str(cargo_home),
             "rustup_home": str(rustup_home),

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -162,7 +162,6 @@ jobs:
 
           results = []
           failures = []
-          output_path.parent.mkdir(parents=True, exist_ok=True)
 
           for mutation in selected_mutations:
               for profile in profiles:
@@ -216,6 +215,7 @@ jobs:
 
                       results.append(result)
 
+          output_path.parent.mkdir(parents=True, exist_ok=True)
           output_path.write_text(
               json.dumps(
                   {

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -131,7 +131,7 @@ jobs:
   build:
     name: ${{ matrix.name }}
     needs: prepare
-    if: needs.prepare.outputs.should_publish_github_release == 'true'
+    if: needs.prepare.outputs.should_release == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -201,61 +201,58 @@ jobs:
           Copy-Item "target\${{ matrix.target }}\release\${{ matrix.binary }}" "dist\package\${{ matrix.binary }}"
           Compress-Archive -Path "dist\package\${{ matrix.binary }}" -DestinationPath "dist\$name.zip" -Force
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: release-soldr-${{ matrix.target }}
-          path: dist/soldr-*
-
-  build-pypi:
-    name: PyPI ${{ matrix.name }}
-    needs: prepare
-    if: needs.prepare.outputs.should_publish_pypi == 'true'
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux x64
-            runner: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-          - name: Linux ARM64
-            runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-          - name: macOS x64
-            runner: macos-15-intel
-            target: x86_64-apple-darwin
-          - name: macOS ARM64
-            runner: macos-15
-            target: aarch64-apple-darwin
-          - name: Windows x64
-            runner: windows-2025
-            target: x86_64-pc-windows-msvc
-          - name: Windows ARM64
-            runner: windows-11-arm
-            target: aarch64-pc-windows-msvc
-
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ needs.prepare.outputs.commit_sha }}
-
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
-
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
-
       - name: Install uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
 
-      - name: Build hardened wheel
+      - name: Build hardened wheel from shared target directory
         shell: bash
         run: |
+          set -euo pipefail
           uv tool install "maturin>=1.7,<2"
           maturin build \
             --release \
             --locked \
             --compatibility pypi \
             --target "${{ matrix.target }}" \
+            --target-dir target \
             --out dist
+
+      - name: Verify wheel binary matches release binary
+        shell: python
+        run: |
+          import hashlib
+          import sys
+          import zipfile
+          from pathlib import Path
+
+          binary_name = "${{ matrix.binary }}"
+          release_binary = Path("dist") / "package" / binary_name
+          if not release_binary.exists():
+              raise SystemExit(f"packaged release binary not found: {release_binary}")
+
+          wheels = sorted(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected exactly one wheel, found {len(wheels)}: {wheels}")
+
+          expected = hashlib.sha256(release_binary.read_bytes()).hexdigest()
+          with zipfile.ZipFile(wheels[0]) as wheel:
+              candidates = [
+                  name
+                  for name in wheel.namelist()
+                  if Path(name).name == binary_name and not name.endswith("/")
+              ]
+              if len(candidates) != 1:
+                  raise SystemExit(
+                      f"expected one {binary_name} in {wheels[0].name}, found {candidates}"
+                  )
+              actual = hashlib.sha256(wheel.read(candidates[0])).hexdigest()
+
+          if actual != expected:
+              print(f"release binary sha256: {expected}", file=sys.stderr)
+              print(f"wheel binary sha256:   {actual}", file=sys.stderr)
+              raise SystemExit("wheel does not contain the shared release binary")
+
+          print(f"{wheels[0].name} contains the shared {binary_name} binary")
 
       - name: Smoke test wheel
         shell: bash
@@ -263,6 +260,13 @@ jobs:
           uv venv .venv
           uv pip install --python .venv dist/*.whl
           .venv/bin/soldr --version || .venv/Scripts/soldr.exe --version
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-soldr-${{ matrix.target }}
+          path: |
+            dist/soldr-*.tar.gz
+            dist/soldr-*.zip
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -322,7 +326,7 @@ jobs:
     name: Publish hardened PyPI wheels
     needs:
       - prepare
-      - build-pypi
+      - build
     if: needs.prepare.outputs.should_publish_pypi == 'true'
     runs-on: ubuntu-24.04
 
@@ -343,3 +347,53 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist
+
+  publish-npm:
+    name: Publish npm package
+    needs:
+      - prepare
+      - publish
+    if: needs.prepare.outputs.should_release == 'true' && needs.prepare.outputs.tag_exists == 'false'
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm CLI with trusted publishing support
+        shell: bash
+        run: npm install --global npm@11.12.1
+
+      - name: Validate npm package
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --version
+          npm --version
+          node scripts/test-npm-package.js
+          npm pack --dry-run
+
+      - name: Publish package to npm
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="$(node -p "require('./package.json').version")"
+          package_spec="${package_name}@${package_version}"
+
+          if npm dist-tag ls "$package_name" | awk '{print $2}' | grep -Fx "$package_version" >/dev/null; then
+            echo "$package_spec is already published; skipping npm publish."
+            exit 0
+          fi
+
+          npm publish

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -48,6 +48,7 @@ jobs:
           Write-Host "cache-dir=${{ steps.setup.outputs.cache-dir }}"
           Write-Host "cache-hit=${{ steps.setup.outputs.cache-hit }}"
           Write-Host "build-cache-hit=${{ steps.setup.outputs.build-cache-hit }}"
+          Write-Host "target-cache-hit=${{ steps.setup.outputs.target-cache-hit }}"
           Write-Host "toolchain=${{ steps.setup.outputs.toolchain }}"
 
       - name: Verify setup state

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ Current release line:
 - the supported external integration boundary remains the `soldr` executable, not the internal Rust crates; see [docs/API_BOUNDARY.md](./docs/API_BOUNDARY.md)
 - practical integration examples for local builds and GitHub Actions live in [INTEGRATION.md](./INTEGRATION.md)
 
+## Install from npm
+
+```bash
+npm install -g @zackees/soldr
+soldr --version
+```
+
+The npm package is a small launcher that downloads the matching `soldr` GitHub
+Release binary for your OS and architecture during install, verifies it against
+the published `SHA256SUMS` file, and exposes the `soldr` command.
+
 ## GitHub Actions setup
 
 The current GitHub Actions entry point is the repository root action in this repository:
@@ -63,6 +74,7 @@ That action:
 - preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
 - restores and saves the zccache compilation artifact cache at `~/.zccache` by default; set `build-cache: false` to disable it
+- restores and saves the Cargo target directory by default for no-op CI fast paths; set `target-cache: false` to disable it or `target-dir:` to choose another target directory
 - puts `soldr` on `PATH` for later steps
 - is the extraction source for the planned public `zackees/setup-soldr` action product
 

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,18 @@ inputs:
       repo-side configuration. Set to "false" to opt out.
     required: false
     default: "true"
+  target-cache:
+    description: >
+      Restore and save the Cargo target directory across workflow runs.
+      Default "true"; this gives no-op child-branch builds a fast path when
+      Cargo can reuse restored fingerprints and outputs. Set to "false" to
+      cache only zccache compilation artifacts.
+    required: false
+    default: "true"
+  target-dir:
+    description: Cargo target directory restored by target-cache.
+    required: false
+    default: target
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -67,6 +79,12 @@ outputs:
       restore-key fallback or no cache, empty string when `build-cache`
       is explicitly disabled.
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
+  target-cache-hit:
+    description: >
+      Whether the action restored the Cargo target directory cache. "true"
+      for an exact key match, "false" for a restore-key fallback or no cache,
+      empty string when `target-cache` or `build-cache` is disabled.
+    value: ${{ steps.cache-meta.outputs.target_cache_hit }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
@@ -83,6 +101,7 @@ runs:
         INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
         INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
+        INPUT_TARGET_DIR: ${{ inputs.target-dir }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
@@ -107,6 +126,15 @@ runs:
           ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
+    - id: target-cache
+      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.target_cache_path }}
+        key: ${{ steps.resolve.outputs.target_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+
     - id: toolchain
       shell: pwsh
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_rust_toolchain.py"
@@ -126,12 +154,57 @@ runs:
         SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
 
+    - id: zccache-warm-target
+      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      shell: pwsh
+      env:
+        TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
+      run: |
+        $target = $env:TARGET_CACHE_PATH
+        if ([string]::IsNullOrWhiteSpace($target) -or -not (Test-Path -LiteralPath $target)) {
+          Write-Host "No restored target directory to warm."
+          exit 0
+        }
+
+        $exeName = if ($IsWindows) { "zccache.exe" } else { "zccache" }
+        $zccache = $null
+        if (-not [string]::IsNullOrWhiteSpace($env:SOLDR_CACHE_DIR)) {
+          $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
+          if (Test-Path -LiteralPath $soldrBin) {
+            $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
+              Select-Object -First 1 -ExpandProperty FullName
+          }
+        }
+        if ([string]::IsNullOrWhiteSpace($zccache)) {
+          $command = Get-Command zccache -ErrorAction SilentlyContinue
+          if ($command) {
+            $zccache = $command.Source
+          }
+        }
+        if ([string]::IsNullOrWhiteSpace($zccache)) {
+          Write-Host "zccache binary is not available yet; refreshing target mtimes only."
+        } else {
+          Write-Host "Warming target directory from zccache: $target"
+          & $zccache warm --target-dir $target
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "zccache warm did not complete successfully; continuing."
+          }
+        }
+
+        $stamp = (Get-Date).AddMinutes(1)
+        Get-ChildItem -LiteralPath $target -Recurse -File -Force -ErrorAction SilentlyContinue |
+          ForEach-Object { $_.LastWriteTime = $stamp }
+        Write-Host "Refreshed target file mtimes."
+        exit 0
+
     - id: cache-meta
       shell: pwsh
       env:
         RAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
         RAW_BUILD_CACHE_HIT: ${{ steps.build-cache-restore.outputs.cache-hit }}
+        RAW_TARGET_CACHE_HIT: ${{ steps.target-cache.outputs.cache-hit }}
         BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
+        TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
       run: |
         $value = $env:RAW_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($value)) {
@@ -148,3 +221,13 @@ runs:
           $buildValue = ""
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") {
+          $targetValue = $env:RAW_TARGET_CACHE_HIT
+          if ([string]::IsNullOrWhiteSpace($targetValue)) {
+            $targetValue = "false"
+          }
+        } else {
+          $targetValue = ""
+        }
+        "target_cache_hit=$targetValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/bin/soldr.js
+++ b/bin/soldr.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+"use strict";
+
+const childProcess = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const binaryName = process.platform === "win32" ? "soldr.exe" : "soldr";
+const binaryPath = path.join(__dirname, "native", binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error(
+    [
+      "soldr: native binary is missing from the npm package install.",
+      `expected: ${binaryPath}`,
+      "Try reinstalling the package, or run `npm rebuild soldr`.",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+const child = childProcess.spawn(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+  windowsHide: false,
+});
+
+child.on("error", (error) => {
+  console.error(`soldr: failed to launch ${binaryPath}: ${error.message}`);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code === null ? 1 : code);
+});

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -53,6 +53,10 @@ pub fn zccache_dir(paths: &SoldrPaths) -> PathBuf {
     paths.cache.join("zccache")
 }
 
+pub fn sccache_dir(paths: &SoldrPaths) -> PathBuf {
+    paths.cache.join("sccache")
+}
+
 pub fn parse_zccache_session_id(stdout: &str) -> Option<String> {
     let trimmed = stdout.trim();
     if trimmed.is_empty() {
@@ -96,7 +100,7 @@ struct SessionStartResponse {
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id,
+        cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id, sccache_dir,
         session_journal_path, zccache_dir, CACHE_DISABLED_VALUE, CACHE_ENABLED_VALUE,
     };
     use soldr_core::SoldrPaths;
@@ -139,6 +143,15 @@ mod tests {
         assert_eq!(
             zccache_dir(&paths),
             paths.root.join("cache").join("zccache")
+        );
+    }
+
+    #[test]
+    fn sccache_dir_lives_under_soldr_cache_root() {
+        let paths = SoldrPaths::with_root(Path::new("C:\\soldr-root").to_path_buf());
+        assert_eq!(
+            sccache_dir(&paths),
+            paths.root.join("cache").join("sccache")
         );
     }
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -434,10 +434,10 @@ fn run_wrapper_through_zccache(
     {
         use std::os::unix::process::CommandExt;
         let err = command.exec();
-        return Err(SoldrError::Other(format!(
+        Err(SoldrError::Other(format!(
             "failed to exec zccache at {}: {err}",
             zccache.display()
-        )));
+        )))
     }
 
     #[cfg(not(unix))]
@@ -689,6 +689,9 @@ async fn prepare_rustc_wrapper(
     match rustc_wrapper_mode() {
         RustcWrapperMode::ManagedZccache => prepare_zccache_build(cargo, paths).await.map(Some),
         RustcWrapperMode::Custom(wrapper) => {
+            if is_sccache_wrapper(&wrapper) && std::env::var_os("SCCACHE_DIR").is_none() {
+                cargo.env("SCCACHE_DIR", soldr_cache::sccache_dir(paths));
+            }
             cargo.env("RUSTC_WRAPPER", wrapper);
             cargo.env_remove(soldr_cache::ZCCACHE_BINARY_ENV_VAR);
             cargo.env_remove(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR);
@@ -701,6 +704,13 @@ async fn prepare_rustc_wrapper(
             Ok(None)
         }
     }
+}
+
+fn is_sccache_wrapper(wrapper: &std::ffi::OsStr) -> bool {
+    std::path::Path::new(wrapper)
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .is_some_and(|stem| stem.eq_ignore_ascii_case("sccache"))
 }
 
 async fn prepare_zccache_build(
@@ -1032,7 +1042,7 @@ fn cached_managed_zccache(
 mod tests {
     use super::{
         cargo_args_specify_target, cargo_args_use_reserved_no_cache, extract_as_pin,
-        first_cargo_subcommand, normalize_version, parse_tool_spec,
+        first_cargo_subcommand, is_sccache_wrapper, normalize_version, parse_tool_spec,
         rustc_wrapper_mode_from_env_var, rustup_resolution_failure, should_trampoline,
         RustcWrapperMode,
     };
@@ -1100,6 +1110,15 @@ mod tests {
             rustc_wrapper_mode_from_env_var(Some(OsStr::new("sccache"))),
             RustcWrapperMode::Custom("sccache".into())
         );
+    }
+
+    #[test]
+    fn sccache_wrapper_detection_accepts_binary_names_and_paths() {
+        assert!(is_sccache_wrapper(OsStr::new("sccache")));
+        assert!(is_sccache_wrapper(OsStr::new("sccache.exe")));
+        assert!(is_sccache_wrapper(OsStr::new("/tmp/tools/sccache")));
+        assert!(!is_sccache_wrapper(OsStr::new("zccache")));
+        assert!(!is_sccache_wrapper(OsStr::new("sccache-proxy")));
     }
 
     #[test]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -88,7 +88,7 @@ fn fake_cargo_script(log_path: &Path) -> String {
     {
         format!(
             "@echo off\n\
-             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID%>>\"{}\"\n\
+             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR%>>\"{}\"\n\
              if defined RUSTC_WRAPPER (\n\
              call \"%RUSTC_WRAPPER%\" \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
              ) else (\n\
@@ -102,7 +102,7 @@ fn fake_cargo_script(log_path: &Path) -> String {
     {
         format!(
             "#!/bin/sh\n\
-             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}}\" >> \"{}\"\n\
+             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}}\" >> \"{}\"\n\
              if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\
                \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
              else\n\
@@ -651,6 +651,14 @@ fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
         log.contains("sccache wrapper"),
         "custom wrapper should be invoked for rustc: {log}"
     );
+    let expected_sccache_dir = cache_root.join("cache").join("sccache");
+    assert!(
+        path_display_variants(&expected_sccache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("sccache_dir={path}"))),
+        "cargo should receive soldr-owned SCCACHE_DIR at {}: {log}",
+        expected_sccache_dir.display()
+    );
     assert!(
         !log.contains(env!("CARGO_BIN_EXE_soldr")),
         "soldr should not stay in the wrapper slot when overridden: {log}"
@@ -667,6 +675,49 @@ fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
     assert!(
         !stderr.contains("soldr: zccache session summary"),
         "custom wrapper path should not emit zccache session output: {stderr}"
+    );
+}
+
+#[test]
+fn custom_sccache_wrapper_preserves_caller_sccache_dir() {
+    let cache_root = unique_temp_dir("cargo-custom-wrapper-preserve-sccache-dir");
+    let caller_sccache_dir = unique_temp_dir("caller-sccache-dir");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let wrapper = install_fake_wrapper(&log_path, "sccache");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_RUSTC_WRAPPER", &wrapper)
+        .env("SCCACHE_DIR", &caller_sccache_dir)
+        .output()
+        .expect("failed to run soldr cargo build with caller SCCACHE_DIR");
+
+    assert!(
+        output.status.success(),
+        "custom-wrapper front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        path_display_variants(&caller_sccache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("sccache_dir={path}"))),
+        "cargo should preserve caller-provided SCCACHE_DIR at {}: {log}",
+        caller_sccache_dir.display()
+    );
+    let soldr_sccache_dir = cache_root.join("cache").join("sccache");
+    assert!(
+        !path_display_variants(&soldr_sccache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("sccache_dir={path}"))),
+        "cargo should not override caller SCCACHE_DIR with {}: {log}",
+        soldr_sccache_dir.display()
     );
 }
 

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -18,8 +18,8 @@ You get, for free:
 
 - branch-agnostic cache keys the action produces on its own
 - automatic restore on feature branches from the latest `main` cache on a miss
-- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves `~/.zccache` by default
-- `cache-hit` and `build-cache-hit` outputs you can read to confirm warm vs cold runs
+- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves `~/.zccache` and the Cargo target directory by default
+- `cache-hit`, `build-cache-hit`, and `target-cache-hit` outputs you can read to confirm warm vs cold runs
 
 The rest of this document explains how and why that works.
 
@@ -49,6 +49,7 @@ The `zackees/soldr@v0` action (see [`action.yml`](../action.yml)) runs internal 
 - **Push-only save semantics come for free.** GitHub's cache scoping already prevents feature-branch runs from overwriting `main`'s cache. You do not need to gate `save-if` yourself the way internal Rust caching wrappers usually make you do.
 - **Rehydrated state.** On a cache hit, the action restores the soldr root, `CARGO_HOME`, and `RUSTUP_HOME` under the runner-local cache/state root. The resolved Rust toolchain and the `soldr` binary are then provisioned on top of whatever was restored.
 - **Build-artifact cache enabled by default.** The action also restores `~/.zccache` with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs unless you opt out with `build-cache: false`.
+- **Cargo target cache enabled by default.** When `build-cache` is enabled, the action also restores the configured Cargo target directory with a key scoped to the runner, resolved toolchain, lockfile hash, and commit SHA. It falls back only within the same toolchain and lockfile lineage, which gives no-op feature-branch builds a fast path without reusing stale target outputs across dependency changes.
 
 ## Minimum Config For An External Repo
 
@@ -104,7 +105,7 @@ Add `pull_request` only if you explicitly need CI on the PR merge commit (for ex
 
 After two pushes to the same branch, you should be able to confirm the cache lineage is healthy.
 
-1. **Check the `cache-hit` and `build-cache-hit` outputs of the setup step.** Reference them from a later step like this:
+1. **Check the `cache-hit`, `build-cache-hit`, and `target-cache-hit` outputs of the setup step.** Reference them from a later step like this:
 
    ```yaml
    - id: soldr
@@ -113,6 +114,7 @@ After two pushes to the same branch, you should be able to confirm the cache lin
        cache: true
    - run: echo "cache-hit=${{ steps.soldr.outputs.cache-hit }}"
    - run: echo "build-cache-hit=${{ steps.soldr.outputs.build-cache-hit }}"
+   - run: echo "target-cache-hit=${{ steps.soldr.outputs.target-cache-hit }}"
    ```
 
    `true` means the key matched exactly. `false` means either a fresh key (cold) or a restore-keys fallback match (partial). Both `false` cases show the same literal `false`; distinguish them using the raw log.
@@ -125,6 +127,8 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
    For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v0-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
 
+   For the Cargo target layer, inspect the `target-cache` step. Its exact keys are `setup-soldr-targetcache-v0-{os}-{arch}-{toolchain-digest}-{cargo-lock-hash}-{github.sha}` and its restore-key falls back within the same toolchain and lockfile lineage.
+
 3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 
 ## Debugging Cold Misses
@@ -132,11 +136,12 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 If feature branches keep rebuilding from scratch, check these in order:
 
 - **Has `main` run successfully recently?** The restore fallback only works if the default branch has written a cache. If the main-branch pipeline is red or was never run on this workflow file, there is no parent to restore from. Fix `main` first.
-- **Is `Cargo.lock` churning on every push?** Lockfile changes do not change the setup-soldr state-cache key, but they do invalidate downstream compilation caches managed by zccache. Check whether your workflow keeps regenerating `Cargo.lock` (for example, because `Cargo.lock` is gitignored in an application repo where it should be committed).
+- **Is `Cargo.lock` churning on every push?** Lockfile changes do not change the setup-soldr state-cache key, but they do invalidate the Cargo target cache and can reduce downstream zccache reuse. Check whether your workflow keeps regenerating `Cargo.lock` (for example, because `Cargo.lock` is gitignored in an application repo where it should be committed).
 - **Did `rust-toolchain.toml` change?** The resolved toolchain channel is part of both cache key families. Bumping the toolchain channel or the components/targets list invalidates every existing entry. That is expected behavior; the next push to `main` will write a fresh canonical entry.
 - **Did you pass a `cache-key-suffix` input?** That value is appended to both cache key families (see `action.yml`). A different suffix on a feature branch produces a different key than `main` writes, and the restore will only succeed through the prefix fallback. Make sure the same suffix is used (or omitted) on every branch you want to share a lineage.
 - **Mixed runner OS/arch.** Cache keys are scoped by runner OS and architecture. A cache written on `ubuntu-24.04` will not restore on `macos-15` and vice versa. Each combination needs its own warm lineage from `main`.
 - **Did someone opt out of build caching?** If `build-cache: false` is set in the workflow, `build-cache-hit` will be empty and `~/.zccache` will not be restored or saved.
+- **Did someone opt out of target caching?** If `target-cache: false` is set in the workflow, `target-cache-hit` will be empty and the Cargo target directory will not be restored or saved.
 
 ---
 

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -1,0 +1,87 @@
+# npm Publishing
+
+This repository publishes `soldr` to npm as a thin JavaScript wrapper around the
+official GitHub Release binaries. The npm package does not build Rust from
+source during install.
+
+## Package Shape
+
+- package name: `@zackees/soldr`
+- executable: `soldr`
+- install step: downloads the matching GitHub Release archive for the current
+  OS/architecture
+- verification: checks the downloaded archive against
+  `soldr-vX.Y.Z-SHA256SUMS.txt` before installing the binary
+- binary sharing: npm installs the same GitHub Release binary that the release
+  workflow attests, and PyPI wheels are built from that same per-platform target
+  binary before publication
+
+Supported npm install targets match the release workflow:
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+- `x86_64-apple-darwin`
+- `aarch64-apple-darwin`
+- `x86_64-pc-windows-msvc`
+- `aarch64-pc-windows-msvc`
+
+## Owner Setup
+
+Before automated npm publication can work, configure npm Trusted Publishing for
+the package. The package has already been created manually, so it can now be
+connected to GitHub Actions OIDC.
+
+1. Open the npm package settings for `@zackees/soldr`.
+2. In the package publishing settings, add this GitHub trusted publisher:
+   - repository owner: `zackees`
+   - repository name: `soldr`
+   - workflow filename: `release-auto.yml`
+   - environment: `release`
+3. Keep the repository URL in `package.json` pointed at
+   `git+https://github.com/zackees/soldr.git`; npm checks that for trusted
+   publishing.
+4. Optionally set the package to require 2FA and disallow tokens after the
+   trusted publisher is configured.
+
+The workflow uses npm Trusted Publishing directly:
+
+- `.github/workflows/release-auto.yml`
+- job: `publish-npm`
+- environment: `release`
+- permissions: `id-token: write`, `contents: read`
+- Node: `24`
+- npm CLI: `11.12.1`
+- idempotency: the job skips `npm publish` when an npm dist-tag already points
+  at the exact package version
+
+Do not add `NODE_AUTH_TOKEN` for this job. npm exchanges the GitHub OIDC token
+for publish credentials when the trusted publisher configuration matches.
+
+## Release Order
+
+The npm package version must match `Cargo.toml`. The release workflow publishes
+npm only after the GitHub Release job succeeds, because the npm postinstall
+script downloads artifacts from that release.
+
+For manual validation before publishing:
+
+```bash
+node scripts/test-npm-package.js
+npm pack --dry-run
+```
+
+To test the install script without downloading a release artifact:
+
+```bash
+SOLDR_NPM_SKIP_DOWNLOAD=1 npm install
+```
+
+Do not publish an npm version until the matching GitHub Release has these files:
+
+- `soldr-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz`
+- `soldr-vX.Y.Z-aarch64-unknown-linux-gnu.tar.gz`
+- `soldr-vX.Y.Z-x86_64-apple-darwin.tar.gz`
+- `soldr-vX.Y.Z-aarch64-apple-darwin.tar.gz`
+- `soldr-vX.Y.Z-x86_64-pc-windows-msvc.zip`
+- `soldr-vX.Y.Z-aarch64-pc-windows-msvc.zip`
+- `soldr-vX.Y.Z-SHA256SUMS.txt`

--- a/docs/PYPI_TRUSTED_PUBLISHING.md
+++ b/docs/PYPI_TRUSTED_PUBLISHING.md
@@ -8,6 +8,8 @@ It is intentionally PyPI-only. crates.io publication is not part of the current 
 
 - `.github/workflows/release-auto.yml` is the only release workflow
 - that workflow always builds the hardened `soldr` wheel set as part of a real release
+- each platform job builds `soldr-cli` once, then packages that same target
+  binary into both the GitHub Release archive and the PyPI wheel
 - the workflow publishes those wheels through `pypa/gh-action-pypi-publish` in a dedicated OIDC job
 - the existing PyPI project `soldr` already exists
 - PyPI is the source of truth used by the workflow's "should we publish?" gate
@@ -47,7 +49,9 @@ The release workflow runs whenever a reviewed version bump lands on `main` (it f
 1. Derives the release version from `[workspace.package]` in `Cargo.toml`.
 2. Refuses to publish unless that version is strictly greater than the latest version on PyPI.
 3. Reruns the full lint, test, packaging, and e2e gate on the merged commit.
-4. Builds the platform release archives and hardened wheel set.
+4. Builds each platform binary once, packages it into both the GitHub Release
+   archive and the hardened wheel, and verifies the wheel's embedded `soldr`
+   binary SHA-256 matches the target release binary.
 5. Creates the `vX.Y.Z` GitHub Release with checksums and a build provenance attestation (skipped if the git tag already exists, e.g. PyPI catch-up).
 6. Publishes the wheel set to PyPI from a dedicated Linux job with `id-token: write`.
 
@@ -64,4 +68,5 @@ Until the publisher is registered, the PyPI publish job will not be able to mint
 After a successful publish:
 
 - https://pypi.org/project/soldr/X.Y.Z/ shows `Uploaded using Trusted Publishing? Yes`
-- the wheel set on PyPI matches the artifacts attached to the corresponding `vX.Y.Z` GitHub Release
+- the wheel set on PyPI contains the same per-platform `soldr` binaries as the
+  artifacts attached to the corresponding `vX.Y.Z` GitHub Release

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -30,6 +30,12 @@ For a normal `soldr` release:
 - the published GitHub Release is immutable once published
 - a SHA-256 checksum manifest is published with the release assets
 - GitHub build provenance attestations are generated for the published assets
+- PyPI wheels are built in the same platform jobs as the GitHub Release
+  archives, and the workflow checks that each wheel embeds the same `soldr`
+  binary bytes as the matching release build output
+- the npm package is a JavaScript launcher that downloads and verifies the
+  matching GitHub Release archive, so npm installations use those same release
+  binaries rather than a separate npm-specific build
 
 ## What It Does Not Guarantee Yet
 

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -88,6 +88,8 @@ steps:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `"true"`; set to `"false"` to opt out. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
+| `target-dir` | Cargo target directory restored by `target-cache`. Default `"target"`. |
 
 The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v0` beta contract and should not be documented in the extracted public action README.
 
@@ -102,6 +104,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is explicitly disabled. |
+| `target-cache-hit` | Whether the Cargo target directory cache was restored. Empty only when `build-cache` or `target-cache` is explicitly disabled. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ### Required Behavior
@@ -115,6 +118,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - restore and save the action-managed cache/state root when `cache: true`
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
 - when `build-cache: true` (the default), restore `~/.zccache` at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v0-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
+- when `build-cache: true` and `target-cache: true` (the defaults), restore the configured Cargo target directory at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and outputs. Keys include the runner OS, architecture, resolved toolchain digest, `Cargo.lock` hash, and commit SHA, with fallback limited to the same toolchain and lockfile lineage.
 
 ### Current Limits That Must Stay Explicit
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@zackees/soldr",
+  "version": "0.7.6",
+  "description": "Instant Rust tools and builds from one command.",
+  "license": "BSD-3-Clause",
+  "homepage": "https://github.com/zackees/soldr",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zackees/soldr.git"
+  },
+  "bugs": {
+    "url": "https://github.com/zackees/soldr/issues"
+  },
+  "bin": {
+    "soldr": "bin/soldr.js"
+  },
+  "files": [
+    "bin/soldr.js",
+    "scripts/install.js",
+    "scripts/test-npm-package.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "postinstall": "node scripts/install.js",
+    "prepack": "node scripts/test-npm-package.js",
+    "test:npm-package": "node scripts/test-npm-package.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "keywords": [
+    "rust",
+    "cargo",
+    "build-cache",
+    "zccache",
+    "cli"
+  ]
+}

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+"use strict";
+
+const childProcess = require("child_process");
+const crypto = require("crypto");
+const fs = require("fs");
+const http = require("http");
+const https = require("https");
+const os = require("os");
+const path = require("path");
+
+const PACKAGE_ROOT = path.resolve(__dirname, "..");
+const PACKAGE_JSON = require(path.join(PACKAGE_ROOT, "package.json"));
+
+const TARGETS = {
+  "linux-x64": {
+    triple: "x86_64-unknown-linux-gnu",
+    archive: "tar.gz",
+    binary: "soldr",
+  },
+  "linux-arm64": {
+    triple: "aarch64-unknown-linux-gnu",
+    archive: "tar.gz",
+    binary: "soldr",
+  },
+  "darwin-x64": {
+    triple: "x86_64-apple-darwin",
+    archive: "tar.gz",
+    binary: "soldr",
+  },
+  "darwin-arm64": {
+    triple: "aarch64-apple-darwin",
+    archive: "tar.gz",
+    binary: "soldr",
+  },
+  "win32-x64": {
+    triple: "x86_64-pc-windows-msvc",
+    archive: "zip",
+    binary: "soldr.exe",
+  },
+  "win32-arm64": {
+    triple: "aarch64-pc-windows-msvc",
+    archive: "zip",
+    binary: "soldr.exe",
+  },
+};
+
+function platformTarget(platform = process.platform, arch = process.arch) {
+  const target = TARGETS[`${platform}-${arch}`];
+  if (!target) {
+    throw new Error(`unsupported platform for soldr npm package: ${platform}-${arch}`);
+  }
+  return target;
+}
+
+function releaseBaseUrl(version) {
+  const override = process.env.SOLDR_NPM_RELEASE_BASE_URL;
+  if (override) {
+    return override.replace(/\/+$/, "");
+  }
+  return `https://github.com/zackees/soldr/releases/download/v${version}`;
+}
+
+function download(url, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith("https:") ? https : http;
+    const request = client.get(
+      url,
+      {
+        headers: {
+          "User-Agent": `soldr-npm/${PACKAGE_JSON.version}`,
+        },
+      },
+      (response) => {
+        if (
+          response.statusCode >= 300 &&
+          response.statusCode < 400 &&
+          response.headers.location
+        ) {
+          response.resume();
+          if (redirects >= 5) {
+            reject(new Error(`too many redirects while downloading ${url}`));
+            return;
+          }
+          resolve(download(new URL(response.headers.location, url).toString(), redirects + 1));
+          return;
+        }
+
+        if (response.statusCode !== 200) {
+          response.resume();
+          reject(new Error(`download failed for ${url}: HTTP ${response.statusCode}`));
+          return;
+        }
+
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => resolve(Buffer.concat(chunks)));
+      },
+    );
+    request.on("error", reject);
+  });
+}
+
+function checksumFor(checksumsText, filename) {
+  for (const line of checksumsText.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const [hash, name] = trimmed.split(/\s+/, 2);
+    if (name === filename) {
+      return hash.toLowerCase();
+    }
+  }
+  throw new Error(`checksum entry not found for ${filename}`);
+}
+
+function run(command, args, options = {}) {
+  const result = childProcess.spawnSync(command, args, {
+    stdio: "inherit",
+    ...options,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}`);
+  }
+}
+
+function extractArchive(archivePath, archiveType, destination) {
+  if (archiveType === "tar.gz") {
+    run("tar", ["-xzf", archivePath, "-C", destination]);
+    return;
+  }
+
+  if (archiveType === "zip" && process.platform === "win32") {
+    run("powershell", [
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      "Expand-Archive -LiteralPath $env:SOLDR_NPM_ARCHIVE -DestinationPath $env:SOLDR_NPM_EXTRACT -Force",
+    ], {
+      env: {
+        ...process.env,
+        SOLDR_NPM_ARCHIVE: archivePath,
+        SOLDR_NPM_EXTRACT: destination,
+      },
+    });
+    return;
+  }
+
+  run("tar", ["-xf", archivePath, "-C", destination]);
+}
+
+function findExtractedBinary(root, binaryName) {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const candidate = path.join(root, entry.name);
+    if (entry.isFile() && entry.name === binaryName) {
+      return candidate;
+    }
+    if (entry.isDirectory()) {
+      const nested = findExtractedBinary(candidate, binaryName);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return null;
+}
+
+async function install() {
+  if (process.env.SOLDR_NPM_SKIP_DOWNLOAD) {
+    console.log("soldr: skipping native binary download because SOLDR_NPM_SKIP_DOWNLOAD is set");
+    return;
+  }
+
+  const version = PACKAGE_JSON.version;
+  const target = platformTarget();
+  const filename = `soldr-v${version}-${target.triple}.${target.archive}`;
+  const baseUrl = releaseBaseUrl(version);
+  const archiveUrl = `${baseUrl}/${filename}`;
+  const checksumUrl = `${baseUrl}/soldr-v${version}-SHA256SUMS.txt`;
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "soldr-npm-"));
+
+  try {
+    console.log(`soldr: downloading ${archiveUrl}`);
+    const [archive, checksums] = await Promise.all([
+      download(archiveUrl),
+      download(checksumUrl).then((buffer) => buffer.toString("utf8")),
+    ]);
+
+    const expected = checksumFor(checksums, filename);
+    const actual = crypto.createHash("sha256").update(archive).digest("hex");
+    if (actual !== expected) {
+      throw new Error(`checksum mismatch for ${filename}: expected ${expected}, got ${actual}`);
+    }
+
+    const archivePath = path.join(tmp, filename);
+    const extractDir = path.join(tmp, "extract");
+    fs.writeFileSync(archivePath, archive);
+    fs.mkdirSync(extractDir, { recursive: true });
+    extractArchive(archivePath, target.archive, extractDir);
+
+    const extracted = findExtractedBinary(extractDir, target.binary);
+    if (!extracted) {
+      throw new Error(`release archive did not contain ${target.binary}`);
+    }
+
+    const nativeDir = path.join(PACKAGE_ROOT, "bin", "native");
+    fs.rmSync(nativeDir, { recursive: true, force: true });
+    fs.mkdirSync(nativeDir, { recursive: true });
+
+    const destination = path.join(nativeDir, target.binary);
+    fs.copyFileSync(extracted, destination);
+    if (process.platform !== "win32") {
+      fs.chmodSync(destination, 0o755);
+    }
+
+    console.log(`soldr: installed ${target.triple} binary`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+if (require.main === module) {
+  install().catch((error) => {
+    console.error(`soldr: npm install failed: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  checksumFor,
+  platformTarget,
+  releaseBaseUrl,
+};

--- a/scripts/test-npm-package.js
+++ b/scripts/test-npm-package.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+
+const root = path.resolve(__dirname, "..");
+const pkg = require(path.join(root, "package.json"));
+const install = require(path.join(root, "scripts", "install.js"));
+
+const cargoToml = fs.readFileSync(path.join(root, "Cargo.toml"), "utf8");
+const cargoVersion = cargoToml.match(/\[workspace\.package\][\s\S]*?^version = "([^"]+)"/m);
+assert(cargoVersion, "workspace package version not found in Cargo.toml");
+assert.strictEqual(pkg.version, cargoVersion[1], "package.json version must match Cargo.toml");
+
+assert.strictEqual(pkg.name, "@zackees/soldr");
+assert.strictEqual(pkg.license, "BSD-3-Clause");
+assert.strictEqual(pkg.bin.soldr, "bin/soldr.js");
+assert.strictEqual(pkg.repository.url, "git+https://github.com/zackees/soldr.git");
+assert.deepStrictEqual(pkg.files, [
+  "bin/soldr.js",
+  "scripts/install.js",
+  "scripts/test-npm-package.js",
+  "README.md",
+  "LICENSE",
+]);
+
+const bin = fs.readFileSync(path.join(root, pkg.bin.soldr), "utf8");
+assert(bin.startsWith("#!/usr/bin/env node"), "bin/soldr.js must have a node shebang");
+
+assert.strictEqual(install.platformTarget("linux", "x64").triple, "x86_64-unknown-linux-gnu");
+assert.strictEqual(install.platformTarget("linux", "arm64").triple, "aarch64-unknown-linux-gnu");
+assert.strictEqual(install.platformTarget("darwin", "x64").triple, "x86_64-apple-darwin");
+assert.strictEqual(install.platformTarget("darwin", "arm64").triple, "aarch64-apple-darwin");
+assert.strictEqual(install.platformTarget("win32", "x64").triple, "x86_64-pc-windows-msvc");
+assert.strictEqual(install.platformTarget("win32", "arm64").triple, "aarch64-pc-windows-msvc");
+assert.throws(() => install.platformTarget("freebsd", "x64"), /unsupported platform/);
+
+assert.strictEqual(
+  install.checksumFor("abc123  soldr-v0.7.5-x86_64-unknown-linux-gnu.tar.gz\n", "soldr-v0.7.5-x86_64-unknown-linux-gnu.tar.gz"),
+  "abc123",
+);
+
+console.log("npm package checks passed");

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -97,6 +97,8 @@ jobs:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `true`; set to `false` to opt out. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
+| `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
 
@@ -107,6 +109,7 @@ jobs:
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is disabled. |
+| `target-cache-hit` | Whether the Cargo target directory cache was restored. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
@@ -114,7 +117,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- Managed `zccache` artifact storage uses the default `~/.zccache` path and is controlled by `build-cache`.
+- The action restores `~/.zccache` and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
 
 ## Development
 

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -81,6 +81,8 @@ jobs:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `true`; set to `false` to opt out. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
+| `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
 
@@ -91,6 +93,7 @@ jobs:
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is disabled. |
+| `target-cache-hit` | Whether the Cargo target directory cache was restored. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
@@ -98,7 +101,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- Managed `zccache` artifact storage uses the default `~/.zccache` path and is controlled by `build-cache`.
+- The action restores `~/.zccache` and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
 
 ## Development
 

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -43,6 +43,18 @@ inputs:
       repo-side configuration. Set to "false" to opt out.
     required: false
     default: "true"
+  target-cache:
+    description: >
+      Restore and save the Cargo target directory across workflow runs.
+      Default "true"; this gives no-op child-branch builds a fast path when
+      Cargo can reuse restored fingerprints and outputs. Set to "false" to
+      cache only zccache compilation artifacts.
+    required: false
+    default: "true"
+  target-dir:
+    description: Cargo target directory restored by target-cache.
+    required: false
+    default: target
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -63,6 +75,12 @@ outputs:
       restore-key fallback or no cache, empty string when `build-cache`
       is explicitly disabled.
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
+  target-cache-hit:
+    description: >
+      Whether the action restored the Cargo target directory cache. "true"
+      for an exact key match, "false" for a restore-key fallback or no cache,
+      empty string when `target-cache` or `build-cache` is disabled.
+    value: ${{ steps.cache-meta.outputs.target_cache_hit }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
@@ -78,6 +96,7 @@ runs:
         INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
         INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
+        INPUT_TARGET_DIR: ${{ inputs.target-dir }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
@@ -102,6 +121,15 @@ runs:
           ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
+    - id: target-cache
+      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ steps.resolve.outputs.target_cache_path }}
+        key: ${{ steps.resolve.outputs.target_cache_key }}
+        restore-keys: |
+          ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
+
     - id: toolchain
       shell: pwsh
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_rust_toolchain.py"
@@ -121,12 +149,57 @@ runs:
         SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
 
+    - id: zccache-warm-target
+      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      shell: pwsh
+      env:
+        TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
+      run: |
+        $target = $env:TARGET_CACHE_PATH
+        if ([string]::IsNullOrWhiteSpace($target) -or -not (Test-Path -LiteralPath $target)) {
+          Write-Host "No restored target directory to warm."
+          exit 0
+        }
+
+        $exeName = if ($IsWindows) { "zccache.exe" } else { "zccache" }
+        $zccache = $null
+        if (-not [string]::IsNullOrWhiteSpace($env:SOLDR_CACHE_DIR)) {
+          $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
+          if (Test-Path -LiteralPath $soldrBin) {
+            $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
+              Select-Object -First 1 -ExpandProperty FullName
+          }
+        }
+        if ([string]::IsNullOrWhiteSpace($zccache)) {
+          $command = Get-Command zccache -ErrorAction SilentlyContinue
+          if ($command) {
+            $zccache = $command.Source
+          }
+        }
+        if ([string]::IsNullOrWhiteSpace($zccache)) {
+          Write-Host "zccache binary is not available yet; refreshing target mtimes only."
+        } else {
+          Write-Host "Warming target directory from zccache: $target"
+          & $zccache warm --target-dir $target
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "zccache warm did not complete successfully; continuing."
+          }
+        }
+
+        $stamp = (Get-Date).AddMinutes(1)
+        Get-ChildItem -LiteralPath $target -Recurse -File -Force -ErrorAction SilentlyContinue |
+          ForEach-Object { $_.LastWriteTime = $stamp }
+        Write-Host "Refreshed target file mtimes."
+        exit 0
+
     - id: cache-meta
       shell: pwsh
       env:
         RAW_CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
         RAW_BUILD_CACHE_HIT: ${{ steps.build-cache-restore.outputs.cache-hit }}
+        RAW_TARGET_CACHE_HIT: ${{ steps.target-cache.outputs.cache-hit }}
         BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
+        TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
       run: |
         $value = $env:RAW_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($value)) {
@@ -143,3 +216,13 @@ runs:
           $buildValue = ""
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") {
+          $targetValue = $env:RAW_TARGET_CACHE_HIT
+          if ([string]::IsNullOrWhiteSpace($targetValue)) {
+            $targetValue = "false"
+          }
+        } else {
+          $targetValue = ""
+        }
+        "target_cache_hit=$targetValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -105,6 +105,8 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     monkeypatch.setenv("INPUT_TOOLCHAIN", "")
     monkeypatch.setenv("INPUT_TOOLCHAIN_FILE", "missing.toml")
     monkeypatch.setenv("INPUT_TRUST_MODE", "")
+    monkeypatch.setenv("INPUT_TARGET_DIR", "custom-target")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
     monkeypatch.setenv("GITHUB_ENV", str(github_env))
     monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
     monkeypatch.setenv("GITHUB_PATH", str(github_path))
@@ -128,4 +130,7 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert "build_cache_key=setup-soldr-buildcache-v0-linux-x64-" in outputs
     assert "build_cache_restore_key_toolchain=setup-soldr-buildcache-v0-linux-x64-" in outputs
     assert "build_cache_restore_key_os_arch=setup-soldr-buildcache-v0-linux-x64-" in outputs
+    assert f"target_cache_path={workspace / 'custom-target'}" in outputs
+    assert "target_cache_key=setup-soldr-targetcache-v0-linux-x64-" in outputs
+    assert outputs.count("-no-lock-abc123") == 1
     assert "toolchain=stable" in outputs


### PR DESCRIPTION
## Summary
- add npm package launcher, install-time GitHub Release downloader, and npm Trusted Publishing workflow/docs
- fold PyPI wheel builds into the release matrix and verify wheels embed the packaged release binary
- add setup-soldr Cargo target-directory caching, outputs, exporter fixtures, and docs
- set a soldr-owned SCCACHE_DIR for custom sccache wrappers when callers have not provided one

## Validation
- git diff --check
- YAML parse: action.yml and touched workflow files
- python -m pytest tests/test_setup_soldr_exporter.py tests/test_setup_soldr_action.py tests/test_setup_soldr_ensure_rust_toolchain.py tests/test_setup_soldr_ensure_soldr.py tests/test_setup_soldr_verify_soldr.py
- node scripts/test-npm-package.js
- npm pack --dry-run
- cargo test -p soldr-cache -p soldr-cli sccache