### PR TITLE
Use Soldr-owned zccache cache root

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -116,6 +116,7 @@ def main() -> None:
     cargo_home = cache_root / "cargo"
     rustup_home = cache_root / "rustup"
     bin_dir = cache_root / "bin"
+    zccache_cache_dir = soldr_root / "cache" / "zccache"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
 
@@ -128,6 +129,7 @@ def main() -> None:
         cargo_home / "bin",
         rustup_home,
         bin_dir,
+        zccache_cache_dir,
     ):
         path.mkdir(parents=True, exist_ok=True)
 
@@ -162,13 +164,13 @@ def main() -> None:
     if suffix:
         cache_key = f"{cache_key}-{_sanitize_fragment(suffix)}"
 
-    # Build-artifact cache (zccache compilation cache at ~/.zccache).
-    # Key shape: setup-soldr-buildcache-v0-{os}-{arch}-{toolchain-digest}-{sha}.
+    # Build-artifact cache (Soldr-owned zccache compilation cache).
+    # Key shape: setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{sha}.
     # Restore falls back through the same toolchain lineage and then any
     # OS+arch cache, letting GitHub's own-branch -> PR base -> default branch
     # restore order provide parent -> child lineage without user config.
     github_sha = os.environ.get("GITHUB_SHA", "").strip() or "nosha"
-    build_cache_prefix = f"setup-soldr-buildcache-v0-{runner_os}-{runner_arch}"
+    build_cache_prefix = f"setup-soldr-buildcache-v1-{runner_os}-{runner_arch}"
     build_cache_toolchain_prefix = f"{build_cache_prefix}-{digest}-"
     build_cache_key = f"{build_cache_toolchain_prefix}{github_sha}"
 
@@ -189,6 +191,7 @@ def main() -> None:
     _write_env("SOLDR_CACHE_DIR", str(soldr_root))
     _write_env("CARGO_HOME", str(cargo_home))
     _write_env("RUSTUP_HOME", str(rustup_home))
+    _write_env("ZCCACHE_CACHE_DIR", str(zccache_cache_dir))
     _write_env("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain["channel"])
     _write_env("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain["profile"])
     _write_env("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", json.dumps(toolchain["components"]))
@@ -207,6 +210,7 @@ def main() -> None:
             "build_cache_key": build_cache_key,
             "build_cache_restore_key_toolchain": build_cache_toolchain_prefix,
             "build_cache_restore_key_os_arch": f"{build_cache_prefix}-",
+            "build_cache_path": str(zccache_cache_dir),
             "target_cache_path": str(target_cache_path),
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ That action:
 - bootstraps `rustup` into the cached runner-local root when the runner does not already have it
 - preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
-- restores and saves the zccache compilation artifact cache at `~/.zccache` by default; set `build-cache: false` to disable it
+- restores and saves the Soldr-owned zccache compilation artifact cache under `SOLDR_CACHE_DIR` by default; set `build-cache: false` to disable it
 - restores and saves the Cargo target directory by default for no-op CI fast paths; set `target-cache: false` to disable it or `target-dir:` to choose another target directory
 - puts `soldr` on `PATH` for later steps
 - is the extraction source for the planned public `zackees/setup-soldr` action product

--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,10 @@ inputs:
     default: ""
   build-cache:
     description: >
-      Restore and save the zccache compilation artifact cache (~/.zccache)
-      across workflow runs. Default "true"; the action restores ~/.zccache
-      with a toolchain-scoped key and saves it at end-of-job, letting
+      Restore and save the Soldr-owned zccache compilation artifact cache
+      across workflow runs. Default "true"; the action restores the
+      action-managed zccache cache root with a toolchain-scoped key and
+      saves it at end-of-job, letting
       GitHub's own-branch -> PR base -> default-branch restore order seed
       feature-branch runs from the latest main-branch save without any
       repo-side configuration. Set to "false" to opt out.
@@ -74,8 +75,8 @@ outputs:
     value: ${{ steps.cache-meta.outputs.cache_hit }}
   build-cache-hit:
     description: >
-      Whether the action restored the zccache compilation artifact cache
-      (~/.zccache). "true" for an exact key match, "false" for a
+      Whether the action restored the Soldr-owned zccache compilation
+      artifact cache. "true" for an exact key match, "false" for a
       restore-key fallback or no cache, empty string when `build-cache`
       is explicitly disabled.
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
@@ -120,7 +121,7 @@ runs:
       if: ${{ inputs.build-cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ~/.zccache
+        path: ${{ steps.resolve.outputs.build_cache_path }}
         key: ${{ steps.resolve.outputs.build_cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -27,6 +27,9 @@ pub const ZCCACHE_SESSION_ID_ENV_VAR: &str = "ZCCACHE_SESSION_ID";
 /// wrapper-mode children.
 pub const ZCCACHE_BINARY_ENV_VAR: &str = "SOLDR_ZCCACHE_BIN";
 
+/// Supported zccache cache-root override used for Soldr-owned artifact state.
+pub const ZCCACHE_CACHE_DIR_ENV_VAR: &str = "ZCCACHE_CACHE_DIR";
+
 pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
     if enabled {
         CACHE_ENABLED_VALUE

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -652,6 +652,7 @@ fn parse_tool_spec(spec: &str) -> (String, VersionSpec) {
 
 struct ZccacheBuildSession {
     binary_path: std::path::PathBuf,
+    cache_dir: std::path::PathBuf,
     session_id: String,
 }
 
@@ -717,10 +718,10 @@ async fn prepare_zccache_build(
     cargo: &mut std::process::Command,
     paths: &SoldrPaths,
 ) -> Result<ZccacheBuildSession, SoldrError> {
-    let fetch = fetch_managed_zccache(paths).await?;
-    let zccache_dir = soldr_cache::zccache_dir(paths);
+    let zccache_dir = managed_zccache_cache_dir(paths)?;
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
+    let fetch = fetch_managed_zccache(paths).await?;
     if fetch.cached {
         eprintln!(
             "soldr: using managed zccache {}",
@@ -733,13 +734,14 @@ async fn prepare_zccache_build(
         );
     }
 
-    run_zccache_command(&fetch.binary_path, &["start"])?;
+    run_zccache_command_in_cache_dir(&fetch.binary_path, &["start"], &zccache_dir)?;
 
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
     let journal_path = journal_path.display().to_string();
-    let session_json = run_zccache_command(
+    let session_json = run_zccache_command_in_cache_dir(
         &fetch.binary_path,
         &["session-start", "--stats", "--journal", &journal_path],
+        &zccache_dir,
     )?;
     let session_id =
         soldr_cache::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
@@ -751,16 +753,22 @@ async fn prepare_zccache_build(
 
     cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
     cargo.env(soldr_cache::ZCCACHE_BINARY_ENV_VAR, &fetch.binary_path);
+    cargo.env(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR, &zccache_dir);
     cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
 
     Ok(ZccacheBuildSession {
         binary_path: fetch.binary_path,
+        cache_dir: zccache_dir,
         session_id,
     })
 }
 
 fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
-    let output = run_zccache_command(&session.binary_path, &["session-end", &session.session_id])?;
+    let output = run_zccache_command_in_cache_dir(
+        &session.binary_path,
+        &["session-end", &session.session_id],
+        &session.cache_dir,
+    )?;
     let stdout = output.stdout.trim();
     if !stdout.is_empty() {
         eprintln!("soldr: zccache session summary");
@@ -771,11 +779,11 @@ fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError>
 
 fn clear_zccache_cache() -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
-    let zccache_dir = soldr_cache::zccache_dir(&paths);
+    let zccache_dir = managed_zccache_cache_dir(&paths)?;
     let mut cleared_anything = false;
 
     if let Some(fetch) = cached_managed_zccache(&paths)? {
-        let _ = run_zccache_command(&fetch.binary_path, &["clear"])?;
+        let _ = run_zccache_command_in_cache_dir(&fetch.binary_path, &["clear"], &zccache_dir)?;
         println!("cleared zccache artifact cache");
         cleared_anything = true;
     }
@@ -871,13 +879,14 @@ fn collect_cache_output() -> Result<CacheOutput, SoldrError> {
 }
 
 fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, SoldrError> {
-    let zccache_dir = soldr_cache::zccache_dir(paths);
+    let zccache_dir = managed_zccache_cache_dir(paths)?;
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
     let journal_present = journal_path.exists();
 
     match cached_managed_zccache(paths)? {
         Some(fetch) => {
-            let output = run_zccache_command(&fetch.binary_path, &["status"])?;
+            let output =
+                run_zccache_command_in_cache_dir(&fetch.binary_path, &["status"], &zccache_dir)?;
             let stdout = output.stdout.trim();
             let status_lines = stdout.lines().map(str::to_owned).collect();
             Ok(ZccacheStatusSnapshot {
@@ -964,11 +973,54 @@ struct CommandOutput {
     stdout: String,
 }
 
-fn run_zccache_command(
+fn managed_zccache_cache_dir(paths: &SoldrPaths) -> Result<std::path::PathBuf, SoldrError> {
+    let zccache_dir = normalize_path_for_compare(&soldr_cache::zccache_dir(paths))?;
+    if let Some(explicit) = non_empty_env_path(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR) {
+        let explicit = normalize_path_for_compare(&explicit)?;
+        if explicit != zccache_dir {
+            return Err(SoldrError::Other(format!(
+                "{} is managed by soldr for managed zccache builds. Unset it, set SOLDR_CACHE_DIR to choose soldr's cache root, or set SOLDR_RUSTC_WRAPPER to use a custom wrapper.",
+                soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR
+            )));
+        }
+    }
+    Ok(zccache_dir)
+}
+
+fn normalize_path_for_compare(path: &std::path::Path) -> Result<std::path::PathBuf, SoldrError> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(path))
+    }
+}
+
+fn run_zccache_command_in_cache_dir(
     binary: &std::path::Path,
     args: &[&str],
+    cache_dir: &std::path::Path,
 ) -> Result<CommandOutput, SoldrError> {
-    let output = std::process::Command::new(binary).args(args).output()?;
+    run_zccache_command_with_env(
+        binary,
+        args,
+        &[(
+            soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR,
+            cache_dir.as_os_str(),
+        )],
+    )
+}
+
+fn run_zccache_command_with_env(
+    binary: &std::path::Path,
+    args: &[&str],
+    envs: &[(&str, &std::ffi::OsStr)],
+) -> Result<CommandOutput, SoldrError> {
+    let mut command = std::process::Command::new(binary);
+    command.args(args);
+    for &(name, value) in envs {
+        command.env(name, value);
+    }
+    let output = command.output()?;
     if !output.status.success() {
         return Err(SoldrError::Other(format!(
             "zccache {} failed: {}",

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -88,7 +88,7 @@ fn fake_cargo_script(log_path: &Path) -> String {
     {
         format!(
             "@echo off\n\
-             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR%>>\"{}\"\n\
+             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR% zccache_dir=%ZCCACHE_CACHE_DIR%>>\"{}\"\n\
              if defined RUSTC_WRAPPER (\n\
              call \"%RUSTC_WRAPPER%\" \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
              ) else (\n\
@@ -102,7 +102,7 @@ fn fake_cargo_script(log_path: &Path) -> String {
     {
         format!(
             "#!/bin/sh\n\
-             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}}\" >> \"{}\"\n\
+             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{}\"\n\
              if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\
                \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
              else\n\
@@ -243,17 +243,17 @@ fn fake_zccache_script(log_path: &Path) -> String {
         format!(
             "@echo off\n\
              if \"%~1\"==\"start\" (\n\
-               echo zccache start>>\"{0}\"\n\
+               echo zccache start cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                exit /b 0\n\
              )\n\
              if \"%~1\"==\"session-start\" (\n\
-               echo zccache session-start>>\"{0}\"\n\
+               echo zccache session-start cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                if not \"%~4\"==\"\" type nul > \"%~4\"\n\
                echo {{\"session_id\":\"test-session\"}}\n\
                exit /b 0\n\
              )\n\
              if \"%~1\"==\"session-end\" (\n\
-               echo zccache session-end %~2>>\"{0}\"\n\
+               echo zccache session-end %~2 cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                echo hits: 1\n\
                exit /b 0\n\
              )\n\
@@ -262,12 +262,12 @@ fn fake_zccache_script(log_path: &Path) -> String {
                exit /b 0\n\
              )\n\
              if \"%~1\"==\"clear\" (\n\
-               echo zccache clear>>\"{0}\"\n\
+               echo zccache clear cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                exit /b 0\n\
              )\n\
              set \"rustc=%~1\"\n\
              shift\n\
-             echo zccache wrapper %rustc% %*>>\"{0}\"\n\
+             echo zccache wrapper cache_dir=%ZCCACHE_CACHE_DIR% %rustc% %*>>\"{0}\"\n\
              call \"%rustc%\" %*\n\
              exit /b %ERRORLEVEL%\n",
             log_path.display()
@@ -279,17 +279,17 @@ fn fake_zccache_script(log_path: &Path) -> String {
             "#!/bin/sh\n\
              case \"$1\" in\n\
                start)\n\
-                 echo \"zccache start\" >> \"{0}\"\n\
+                 echo \"zccache start cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  exit 0\n\
                  ;;\n\
                session-start)\n\
-                 echo \"zccache session-start\" >> \"{0}\"\n\
+                 echo \"zccache session-start cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  : > \"$4\"\n\
                  echo '{{\"session_id\":\"test-session\"}}'\n\
                  exit 0\n\
                  ;;\n\
                session-end)\n\
-                 echo \"zccache session-end $2\" >> \"{0}\"\n\
+                 echo \"zccache session-end $2 cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  echo 'hits: 1'\n\
                  exit 0\n\
                  ;;\n\
@@ -298,13 +298,13 @@ fn fake_zccache_script(log_path: &Path) -> String {
                  exit 0\n\
                  ;;\n\
                clear)\n\
-                 echo \"zccache clear\" >> \"{0}\"\n\
+                 echo \"zccache clear cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  exit 0\n\
                  ;;\n\
              esac\n\
              rustc=\"$1\"\n\
              shift\n\
-             echo \"zccache wrapper $rustc $*\" >> \"{0}\"\n\
+             echo \"zccache wrapper cache_dir=${{ZCCACHE_CACHE_DIR:-}} $rustc $*\" >> \"{0}\"\n\
              \"$rustc\" \"$@\"\n",
             log_path.display()
         )
@@ -580,6 +580,14 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         log.contains("cache=1"),
         "cache-enabled front door should propagate cache flag: {log}"
     );
+    let zccache_cache_dir = cache_root.join("cache").join("zccache");
+    assert!(
+        path_display_variants(&zccache_cache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("zccache_dir={path}"))
+                && log.contains(&format!("cache_dir={path}"))),
+        "managed zccache commands and cargo wrapper env should use the Soldr-owned cache dir: {log}"
+    );
     assert!(
         log.contains("zccache start"),
         "managed zccache should be started for cache-enabled builds: {log}"
@@ -607,15 +615,41 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         "expected zccache session summary in stderr: {stderr}"
     );
 
-    let journal = cache_root
-        .join("cache")
-        .join("zccache")
-        .join("logs")
-        .join("last-session.jsonl");
+    let journal = zccache_cache_dir.join("logs").join("last-session.jsonl");
     assert!(
         journal.exists(),
         "expected session journal at {}",
         journal.display()
+    );
+}
+
+#[test]
+fn managed_zccache_rejects_conflicting_cache_dir_override() {
+    let cache_root = unique_temp_dir("cargo-conflicting-zccache-dir");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("ZCCACHE_CACHE_DIR", cache_root.join("user-zccache"))
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cargo build with conflicting ZCCACHE_CACHE_DIR");
+
+    assert!(
+        !output.status.success(),
+        "conflicting ZCCACHE_CACHE_DIR should fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ZCCACHE_CACHE_DIR is managed by soldr"),
+        "expected explicit override guidance: {stderr}"
+    );
+    assert!(
+        !log_path.exists(),
+        "zccache should not start after a conflicting cache-dir override"
     );
 }
 
@@ -1108,7 +1142,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.3.0");
+    assert_eq!(json["managed_zccache_version"], "1.3.4");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -1191,7 +1225,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.3.0");
+    assert_eq!(json["managed_zccache_version"], "1.3.4");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.4";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/docs/API.md
+++ b/docs/API.md
@@ -49,7 +49,7 @@ Behavior:
 - Fetch a pinned managed `zccache` release when caching is enabled
 - Set `RUSTC_WRAPPER` to the current soldr binary
 - Pass the managed `zccache` binary path into wrapper mode through the environment
-- Start a per-build zccache session on zccache's current default daemon endpoint
+- Start a per-build zccache session under Soldr's owned zccache cache root
 - Delegate to Cargo with the exact flags the user passed
 
 Current cache-control behavior:
@@ -58,7 +58,7 @@ Current cache-control behavior:
 - `soldr --no-cache cargo ...` disables soldr's compilation-cache path for that invocation
 - `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
 - zccache integration currently targets Rust builds through the cargo front door
-- zccache's current artifact store and daemon endpoint remain on zccache's default paths; soldr currently manages the session lifecycle and logs
+- managed zccache artifacts and daemon state live under Soldr's cache root through `ZCCACHE_CACHE_DIR`
 - toolchain binaries (`rustc`, `rustfmt`, `clippy-driver`, etc.) are resolved directly from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` before any `rustup` call; `rustup which` is only used as a fallback when the direct probe fails. The sole exception is when `RUSTUP_TOOLCHAIN` is explicitly set to a non-empty value — in that case soldr skips the direct probe and asks `rustup` for the matching toolchain binary so the pinned channel always wins
 
 This is the normal build entry point.
@@ -235,12 +235,15 @@ Commands:
 | `SOLDR_RUSTC_WRAPPER` | Override soldr's managed zccache wrapper with another wrapper binary, or disable wrapper injection with `none` / empty | unset |
 | `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
+| `ZCCACHE_CACHE_DIR` | zccache cache-root override set by soldr for managed zccache commands | `~/.soldr/cache/zccache` |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.
+
+When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must match the cache root derived from `SOLDR_CACHE_DIR`; conflicting values are rejected. Custom wrapper modes leave caller-provided wrapper environment alone.
 
 ---
 

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -18,7 +18,7 @@ You get, for free:
 
 - branch-agnostic cache keys the action produces on its own
 - automatic restore on feature branches from the latest `main` cache on a miss
-- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves `~/.zccache` and the Cargo target directory by default
+- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves the Soldr-owned zccache cache root and the Cargo target directory by default
 - `cache-hit`, `build-cache-hit`, and `target-cache-hit` outputs you can read to confirm warm vs cold runs
 
 The rest of this document explains how and why that works.
@@ -48,7 +48,7 @@ The `zackees/soldr@v0` action (see [`action.yml`](../action.yml)) runs internal 
 - **Restore-keys prefix for partial-match fallback.** The action registers a restore prefix (`setup-soldr-v0-{os}-{arch}-`) so that even if a future toolchain bump changes the exact key, GitHub can still fall back to the most recent compatible cache for the same OS and architecture.
 - **Push-only save semantics come for free.** GitHub's cache scoping already prevents feature-branch runs from overwriting `main`'s cache. You do not need to gate `save-if` yourself the way internal Rust caching wrappers usually make you do.
 - **Rehydrated state.** On a cache hit, the action restores the soldr root, `CARGO_HOME`, and `RUSTUP_HOME` under the runner-local cache/state root. The resolved Rust toolchain and the `soldr` binary are then provisioned on top of whatever was restored.
-- **Build-artifact cache enabled by default.** The action also restores `~/.zccache` with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs unless you opt out with `build-cache: false`.
+- **Build-artifact cache enabled by default.** The action also restores the Soldr-owned zccache cache root with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs unless you opt out with `build-cache: false`.
 - **Cargo target cache enabled by default.** When `build-cache` is enabled, the action also restores the configured Cargo target directory with a key scoped to the runner, resolved toolchain, lockfile hash, and commit SHA. It falls back only within the same toolchain and lockfile lineage, which gives no-op feature-branch builds a fast path without reusing stale target outputs across dependency changes.
 
 ## Minimum Config For An External Repo
@@ -125,7 +125,7 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
    A line that says no cache was found at all, with no restore match, indicates a cold miss.
 
-   For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v0-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
+   For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
 
    For the Cargo target layer, inspect the `target-cache` step. Its exact keys are `setup-soldr-targetcache-v0-{os}-{arch}-{toolchain-digest}-{cargo-lock-hash}-{github.sha}` and its restore-key falls back within the same toolchain and lockfile lineage.
 
@@ -140,7 +140,7 @@ If feature branches keep rebuilding from scratch, check these in order:
 - **Did `rust-toolchain.toml` change?** The resolved toolchain channel is part of both cache key families. Bumping the toolchain channel or the components/targets list invalidates every existing entry. That is expected behavior; the next push to `main` will write a fresh canonical entry.
 - **Did you pass a `cache-key-suffix` input?** That value is appended to both cache key families (see `action.yml`). A different suffix on a feature branch produces a different key than `main` writes, and the restore will only succeed through the prefix fallback. Make sure the same suffix is used (or omitted) on every branch you want to share a lineage.
 - **Mixed runner OS/arch.** Cache keys are scoped by runner OS and architecture. A cache written on `ubuntu-24.04` will not restore on `macos-15` and vice versa. Each combination needs its own warm lineage from `main`.
-- **Did someone opt out of build caching?** If `build-cache: false` is set in the workflow, `build-cache-hit` will be empty and `~/.zccache` will not be restored or saved.
+- **Did someone opt out of build caching?** If `build-cache: false` is set in the workflow, `build-cache-hit` will be empty and the Soldr-owned zccache cache root will not be restored or saved.
 - **Did someone opt out of target caching?** If `target-cache: false` is set in the workflow, `target-cache-hit` will be empty and the Cargo target directory will not be restored or saved.
 
 ---

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -87,7 +87,7 @@ steps:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
-| `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `"true"`; set to `"false"` to opt out. |
+| `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `"true"`; set to `"false"` to opt out. |
 | `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
 | `target-dir` | Cargo target directory restored by `target-cache`. Default `"target"`. |
 
@@ -103,7 +103,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
-| `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is explicitly disabled. |
+| `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is explicitly disabled. |
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. Empty only when `build-cache` or `target-cache` is explicitly disabled. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
@@ -117,16 +117,16 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - put the installed `soldr` binary on `PATH`
 - restore and save the action-managed cache/state root when `cache: true`
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
-- when `build-cache: true` (the default), restore `~/.zccache` at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v0-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
+- when `build-cache: true` (the default), restore the Soldr-owned zccache cache root at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
 - when `build-cache: true` and `target-cache: true` (the defaults), restore the configured Cargo target directory at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and outputs. Keys include the runner OS, architecture, resolved toolchain digest, `Cargo.lock` hash, and commit SHA, with fallback limited to the same toolchain and lockfile lineage.
 
 ### Current Limits That Must Stay Explicit
 
 The extracted public action must document these current limits honestly:
 
-- the action rehydrates the Soldr root, Cargo home, and rustup home under the chosen cache/state root
+- the action rehydrates the Soldr root, Cargo home, rustup home, and Soldr-owned zccache artifact cache under the chosen cache/state root
 - the action bootstraps `rustup` on demand via `rustup-init` when it is absent, then uses it to install the requested toolchain; at runtime Soldr prefers direct toolchain binaries from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` and only falls back to `rustup which` when the direct probe fails (or when `RUSTUP_TOOLCHAIN` is explicitly set)
-- managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path
+- the action exports `ZCCACHE_CACHE_DIR` to the Soldr-owned zccache artifact cache under `SOLDR_CACHE_DIR`
 
 ### Non-Contract Details
 

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -96,7 +96,7 @@ jobs:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
-| `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `true`; set to `false` to opt out. |
+| `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
 | `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
 
@@ -108,7 +108,7 @@ jobs:
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
-| `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is disabled. |
+| `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
@@ -117,8 +117,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- The action restores `~/.zccache` and the Cargo target directory by default so child branches can reuse parent-branch build state.
-- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
+- The action restores the Soldr-owned zccache cache root and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 
 ## Development
 

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -80,7 +80,7 @@ jobs:
 | `toolchain` | Explicit Rust toolchain channel override. |
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
-| `build-cache` | Restore and save the zccache compilation artifact cache (`~/.zccache`) across runs. Default `true`; set to `false` to opt out. |
+| `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
 | `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
 
@@ -92,7 +92,7 @@ jobs:
 | `soldr-version` | Installed Soldr version reported by `soldr version --json`. |
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
-| `build-cache-hit` | Whether the zccache compilation cache (`~/.zccache`) was restored. Empty only when `build-cache` is disabled. |
+| `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
@@ -101,8 +101,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- The action restores `~/.zccache` and the Cargo target directory by default so child branches can reuse parent-branch build state.
-- Managed `zccache` artifact storage still follows zccache's current supported/default behavior rather than a fully action-controlled custom artifact path.
+- The action restores the Soldr-owned zccache cache root and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 
 ## Development
 

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -35,9 +35,10 @@ inputs:
     default: ""
   build-cache:
     description: >
-      Restore and save the zccache compilation artifact cache (~/.zccache)
-      across workflow runs. Default "true"; the action restores ~/.zccache
-      with a toolchain-scoped key and saves it at end-of-job, letting
+      Restore and save the Soldr-owned zccache compilation artifact cache
+      across workflow runs. Default "true"; the action restores the
+      action-managed zccache cache root with a toolchain-scoped key and
+      saves it at end-of-job, letting
       GitHub's own-branch -> PR base -> default-branch restore order seed
       feature-branch runs from the latest main-branch save without any
       repo-side configuration. Set to "false" to opt out.
@@ -70,8 +71,8 @@ outputs:
     value: ${{ steps.cache-meta.outputs.cache_hit }}
   build-cache-hit:
     description: >
-      Whether the action restored the zccache compilation artifact cache
-      (~/.zccache). "true" for an exact key match, "false" for a
+      Whether the action restored the Soldr-owned zccache compilation
+      artifact cache. "true" for an exact key match, "false" for a
       restore-key fallback or no cache, empty string when `build-cache`
       is explicitly disabled.
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
@@ -115,7 +116,7 @@ runs:
       if: ${{ inputs.build-cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ~/.zccache
+        path: ${{ steps.resolve.outputs.build_cache_path }}
         key: ${{ steps.resolve.outputs.build_cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.build_cache_restore_key_toolchain }}

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -117,6 +117,7 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert cache_root.is_dir()
     assert (cache_root / "soldr").is_dir()
     assert (cache_root / "soldr" / "cache").is_dir()
+    assert (cache_root / "soldr" / "cache" / "zccache").is_dir()
     assert (cache_root / "soldr" / "bin").is_dir()
     assert (cache_root / "cargo").is_dir()
     assert (cache_root / "cargo" / "bin").is_dir()
@@ -127,10 +128,15 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert f"cache_root={cache_root}" in outputs
     assert "cache_key=setup-soldr-v0-linux-x64-" in outputs
     assert "cache_restore_prefix=setup-soldr-v0-linux-x64-" in outputs
-    assert "build_cache_key=setup-soldr-buildcache-v0-linux-x64-" in outputs
-    assert "build_cache_restore_key_toolchain=setup-soldr-buildcache-v0-linux-x64-" in outputs
-    assert "build_cache_restore_key_os_arch=setup-soldr-buildcache-v0-linux-x64-" in outputs
+    assert "build_cache_key=setup-soldr-buildcache-v1-linux-x64-" in outputs
+    assert "build_cache_restore_key_toolchain=setup-soldr-buildcache-v1-linux-x64-" in outputs
+    assert "build_cache_restore_key_os_arch=setup-soldr-buildcache-v1-linux-x64-" in outputs
+    assert f"build_cache_path={cache_root / 'soldr' / 'cache' / 'zccache'}" in outputs
     assert f"target_cache_path={workspace / 'custom-target'}" in outputs
     assert "target_cache_key=setup-soldr-targetcache-v0-linux-x64-" in outputs
     assert outputs.count("-no-lock-abc123") == 1
     assert "toolchain=stable" in outputs
+
+    env_text = github_env.read_text(encoding="utf-8")
+    assert f"SOLDR_CACHE_DIR={cache_root / 'soldr'}" in env_text
+    assert f"ZCCACHE_CACHE_DIR={cache_root / 'soldr' / 'cache' / 'zccache'}" in env_text


### PR DESCRIPTION
## Summary
- bump managed zccache to published `1.3.4`, which includes `ZCCACHE_CACHE_DIR` support
- route managed zccache commands and wrapper builds through the Soldr-owned zccache cache root
- update setup-soldr to restore/save the Soldr-owned zccache path with `buildcache-v1` keys instead of `~/.zccache`
- update docs, exporter fixtures, and tests for the new cache-root behavior

## Validation
- `uv run pytest tests/test_setup_soldr_action.py tests/test_setup_soldr_exporter.py`
- `cargo test -p soldr-cache`
- `cargo test -p soldr-fetch`
- `cargo test -p soldr-cli cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default`
- `cargo test -p soldr-cli managed_zccache_rejects_conflicting_cache_dir_override`
- `cargo test -p soldr-cli cache_json_reports_managed_zccache_status`
- `cargo test -p soldr-cli clean_clears_managed_zccache_and_state_dir`
- `cargo test -p soldr-cli status_json_reports_stable_machine_fields`
- `git diff --check`

Note: full `cargo test -p soldr-cli` still has the unrelated pre-existing Windows PATH-pollution failure in `cargo_front_door_forces_msvc_target_even_with_polluted_path`.