### PR TITLE
Dogfood public setup-soldr action

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -36,9 +36,19 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: setup
-        uses: ./
+        # This is zackees/setup-soldr@v0.1.0 / @v0 pinned to a full SHA
+        # because this repository's ruleset requires SHA-pinned actions.
+        uses: zackees/setup-soldr@1937c19529f3690df5553a36dd33f39ccb20b070
         with:
           cache: true
+          # Keep the action runtime cache separate from the Soldr build under
+          # test. The dogfood build below overrides SOLDR_CACHE_DIR and
+          # ZCCACHE_CACHE_DIR so the action cache cannot cross-contaminate the
+          # repository build cache.
+          cache-dir: ${{ runner.temp }}/setup-soldr-action-state
+          cache-key-suffix: dogfood-action-state
+          build-cache: false
+          target-cache: false
 
       - name: Show action outputs
         shell: pwsh
@@ -61,10 +71,34 @@ jobs:
           cargo --version
           rustc --version
 
+      - name: Verify cache isolation
+        shell: pwsh
+        env:
+          ACTION_CACHE_DIR: ${{ steps.setup.outputs.cache-dir }}
+          SOLDR_DOGFOOD_BUILD_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
+        run: |
+          $actionCache = [System.IO.Path]::GetFullPath($env:ACTION_CACHE_DIR)
+          $buildCache = [System.IO.Path]::GetFullPath($env:SOLDR_DOGFOOD_BUILD_CACHE_DIR)
+          $actionPrefix = $actionCache.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+          $buildPrefix = $buildCache.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+          if ($actionCache -eq $buildCache -or $buildCache.StartsWith($actionPrefix) -or $actionCache.StartsWith($buildPrefix)) {
+            throw "setup-soldr action cache must be disjoint from the Soldr build-under-test cache"
+          }
+          New-Item -ItemType Directory -Force -Path $buildCache | Out-Null
+          New-Item -ItemType Directory -Force -Path (Join-Path $buildCache "zccache") | Out-Null
+          Write-Host "action-cache=$actionCache"
+          Write-Host "build-under-test-cache=$buildCache"
+
       - name: Build through soldr
         shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test/zccache
         run: soldr cargo build --package soldr-cli --locked
 
       - name: Test through soldr
         shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test/zccache
         run: soldr cargo test -p soldr-cli --test cli --locked

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -19,17 +19,15 @@ The same pattern applies to `cargo test`, `cargo check`, and similar Cargo invoc
 
 ## GitHub Actions
 
-This repository currently ships an in-repo root GitHub Action for Soldr setup. The current GitHub Actions path is:
+This repository publishes a public setup action for Soldr. The current GitHub Actions path is:
 
-1. use `zackees/soldr@<ref>` or `uses: ./` in the same repository
+1. use `zackees/setup-soldr@v0`
 2. let the action bootstrap `rustup` if needed, then provision the Rust toolchain and restore the Soldr/Cargo/rustup cache root
 3. run `soldr cargo ...`
 
-The public setup action product is not shipped yet. Today, pin the current in-repo action by full commit SHA or explicit release tag; do not assume a public `@v0` beta contract until the beta repository and tag exist.
-
 ### Public-action status
 
-The target public beta UX after extraction is:
+The public beta UX is:
 
 ```yaml
 steps:
@@ -43,16 +41,14 @@ steps:
   - run: soldr cargo test --locked
 ```
 
-That public repo is not shipped yet. This repository cannot publish it directly to GitHub Marketplace because Marketplace action repositories must keep one root `action.yml` and no workflow files. The extraction plan and intended `@v0` beta contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md).
+The public action repository is [`zackees/setup-soldr`](https://github.com/zackees/setup-soldr). This repository remains the source of truth for the action implementation and exports the standalone action bundle from the root `action.yml` plus helper scripts. The extraction plan and `@v0` beta contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md).
 
-Beta and stable tag rule for the planned public repo:
+Beta and stable tag rule for the public repo:
 
 - `@v0` is the moving beta tag while the action contract is still settling
 - `@v1` should be introduced only when the action is ready for a stable backward-compatible contract
 - later major tags such as `@v2` are introduced only for breaking contract changes after `@v1`
 - the intended normal path is still one `setup-soldr` step plus `soldr cargo ...`; no separate toolchain action is part of the common-case contract
-
-Until that repo exists, no verified public one-line Soldr action exists yet. Use `zackees/soldr@<ref>` or `uses: ./` instead.
 
 ### Preferred setup action path
 
@@ -86,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zackees/soldr@<ref>
+      - uses: zackees/setup-soldr@v0
         with:
           cache: true
 
@@ -94,7 +90,7 @@ jobs:
       - run: soldr cargo test --locked
 ```
 
-For same-repository testing, use:
+For local same-repository action development before exporting a new public release, use:
 
 ```yaml
 - uses: ./
@@ -111,7 +107,7 @@ Useful inputs when wiring the action into another repository:
 - `cache-dir`: move the shared Soldr/Cargo/rustup root to a specific path
 - `trust-mode`: set `SOLDR_TRUST_MODE` for stricter fetched-binary policy
 
-The current `repo` input is an implementation/testing override for the in-repo action. It is not part of the intended public `setup-soldr@v0` beta contract.
+The current root `repo` input is an implementation/testing override for the in-repo action source. It is not part of the public `setup-soldr@v0` beta contract.
 
 Useful outputs:
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ the published `SHA256SUMS` file, and exposes the `soldr` command.
 
 ## GitHub Actions setup
 
-The current GitHub Actions entry point is the repository root action in this repository:
+The current GitHub Actions entry point is the public `setup-soldr` action:
 
 ```yaml
-- uses: zackees/soldr@<ref>
+- uses: zackees/setup-soldr@v0
   with:
     cache: true
 
@@ -76,14 +76,13 @@ That action:
 - restores and saves the Soldr-owned zccache compilation artifact cache under `SOLDR_CACHE_DIR` by default; set `build-cache: false` to disable it
 - restores and saves the Cargo target directory by default for no-op CI fast paths; set `target-cache: false` to disable it or `target-dir:` to choose another target directory
 - puts `soldr` on `PATH` for later steps
-- is the extraction source for the planned public `zackees/setup-soldr` action product
 
 If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later. The action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the toolchain it just installed instead of asking `rustup` to resolve a pinned file lazily.
 
 On GitHub-hosted runners, this means you usually do not need a separate toolchain setup action for the normal path. The action still uses `rustup` under the hood today, but it bootstraps `rustup` itself when the runner does not already have it.
 On runners without `rustup`, the action downloads and installs it into the cached runner-local root before provisioning the requested toolchain.
 
-For same-repository validation, use `uses: ./`. This repository smoke-tests that path in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). GitHub Marketplace publication still requires extracting this action into a separate public action repository because GitHub requires a single root `action.yml` and no workflow files in the published repository. The repo-contained extraction plan and intended beta `zackees/setup-soldr@v0` contract live in [docs/SETUP_SOLDR_PUBLIC_ACTION.md](./docs/SETUP_SOLDR_PUBLIC_ACTION.md). Until that public repo exists, treat `zackees/soldr@<ref>` as the current contract and pin a full commit SHA or explicit release tag instead of assuming `@v0`. For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
+The public action lives in [`zackees/setup-soldr`](https://github.com/zackees/setup-soldr) and is generated from this repository's root action source. This repository dogfoods `zackees/setup-soldr@v0` in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
 
 ### CI cache lineage
 

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -1,16 +1,16 @@
 # CI Cache Guide For External Repos
 
-This is a usage guide for anyone wiring `zackees/soldr@v0` into their own GitHub Actions CI. It explains what you get automatically, what the minimum config looks like, and how to confirm warm builds on feature branches are actually restoring from `main`.
+This is a usage guide for anyone wiring `zackees/setup-soldr@v0` into their own GitHub Actions CI. It explains what you get automatically, what the minimum config looks like, and how to confirm warm builds on feature branches are actually restoring from `main`.
 
 If you want the background on why this repository wires its own workflows the way it does, skip to [Why This Repo Uses This Model](#why-this-repo-uses-this-model) at the bottom.
 
 ## TL;DR
 
-Add `zackees/soldr@v0` to a normal `push`-triggered workflow:
+Add `zackees/setup-soldr@v0` to a normal `push`-triggered workflow:
 
 ```yaml
 - uses: actions/checkout@v4
-- uses: zackees/soldr@v0
+- uses: zackees/setup-soldr@v0
 - run: soldr cargo build --locked
 ```
 
@@ -42,7 +42,7 @@ Two consequences of that scoping rule matter for soldr:
 
 ## What setup-soldr Does For You Automatically
 
-The `zackees/soldr@v0` action (see [`action.yml`](../action.yml)) runs internal cache steps keyed so that the parent-to-child restore works correctly without you configuring anything:
+The `zackees/setup-soldr@v0` action (generated from [`action.yml`](../action.yml)) runs internal cache steps keyed so that the parent-to-child restore works correctly without you configuring anything:
 
 - **Branch-agnostic state-cache keys.** The setup-state cache key is derived from runner OS, runner architecture, the resolved Rust toolchain channel, and the requested soldr version. No branch name is in the key. Two branches with the same toolchain pin produce the same key, so a cache written by `main` is a valid candidate for a run on any feature branch.
 - **Restore-keys prefix for partial-match fallback.** The action registers a restore prefix (`setup-soldr-v0-{os}-{arch}-`) so that even if a future toolchain bump changes the exact key, GitHub can still fall back to the most recent compatible cache for the same OS and architecture.
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: zackees/soldr@v0
+      - uses: zackees/setup-soldr@v0
         with:
           cache: true
 
@@ -109,7 +109,7 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
    ```yaml
    - id: soldr
-     uses: zackees/soldr@v0
+     uses: zackees/setup-soldr@v0
      with:
        cache: true
    - run: echo "cache-hit=${{ steps.soldr.outputs.cache-hit }}"

--- a/docs/SETUP_SOLDR_EXPORTER.md
+++ b/docs/SETUP_SOLDR_EXPORTER.md
@@ -1,6 +1,6 @@
 # setup-soldr Exporter
 
-This repository cannot publish its root `action.yml` directly to GitHub Marketplace, but it now contains an exporter that materializes the releaseable `setup-soldr` action bundle for a future public `zackees/setup-soldr` repository.
+This repository cannot publish its root `action.yml` directly to GitHub Marketplace, but it contains an exporter that materializes the releaseable `setup-soldr` action bundle for the public `zackees/setup-soldr` repository.
 
 ## Command
 

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -2,7 +2,7 @@
 
 This document is the repo-contained delivery for [issue #137](https://github.com/zackees/soldr/issues/137).
 
-`soldr` cannot publish its current root action to GitHub Marketplace directly. The useful work that can land here is to freeze the intended public `setup-soldr` contract, define the extraction boundary, and document the exact release process that turns the current in-repo action into a separate public action product.
+`soldr` cannot publish its current root action to GitHub Marketplace directly. This document freezes the public `setup-soldr` contract, defines the extraction boundary, and documents the release process that turns the current in-repo action into the separate public action product at [`zackees/setup-soldr`](https://github.com/zackees/setup-soldr).
 
 ## Why Extraction Is Required
 
@@ -17,7 +17,7 @@ References:
 - https://docs.github.com/en/actions/how-tos/sharing-automations/creating-actions/publishing-actions-in-github-marketplace
 - https://docs.github.com/actions/how-tos/creating-and-publishing-actions/managing-custom-actions
 
-This repository intentionally contains normal application code and workflow files under `.github/workflows/`, so it is the source repository for the action, not the eventual Marketplace repository.
+This repository intentionally contains normal application code and workflow files under `.github/workflows/`, so it is the source repository for the action, not the Marketplace repository.
 
 ## Current Source Of Truth
 
@@ -157,19 +157,19 @@ Use this release model for `zackees/setup-soldr`:
 
 ## Extraction Checklist
 
-Before the first public release:
+For the public beta release:
 
 1. Create `zackees/setup-soldr` as a public repository.
 2. Accept the GitHub Marketplace Developer Agreement for the owning account or organization if it has not already been accepted.
 3. Copy [action.yml](../action.yml) and the helper scripts listed above into the public repository.
-4. Copy the user-facing setup docs from this repository's `README.md`, `INTEGRATION.md`, and this file into the public repository `README.md`, but remove any mention of the temporary in-repo `zackees/soldr@<ref>` path.
+4. Copy the user-facing setup docs from this repository's `README.md`, `INTEGRATION.md`, and this file into the public repository `README.md`, using `zackees/setup-soldr@v0` as the public action reference.
 5. Ensure the public repository contains no workflow files.
 6. Create the first beta release tag `v0.1.0`, then move `v0` to that commit.
 7. Publish the beta release to GitHub Marketplace from the public repository.
 
 ## What This PR Changes
 
-This repo-contained plan is useful even before the public repository exists because it:
+This repo-contained plan is useful because it:
 
 - defines the exact public contract the extracted action should preserve
 - distinguishes public contract from current implementation-only escape hatches


### PR DESCRIPTION
## Summary

- publish docs and examples against `zackees/setup-soldr@v0`
- dogfood the public setup action in the Soldr setup-action smoke workflow
- keep the action runtime cache separate from the Soldr build-under-test cache by using a dedicated setup cache dir, disabling the action build/target cache layers in the dogfood job, and overriding `SOLDR_CACHE_DIR` / `ZCCACHE_CACHE_DIR` for the build steps

## Published action

- `zackees/setup-soldr` now has `main`
- `v0.1.0` release: https://github.com/zackees/setup-soldr/releases/tag/v0.1.0
- moving compatibility tag: `v0`

## Validation

- `python -m pytest tests\test_setup_soldr_exporter.py`
- `git diff --check origin/main..HEAD`
- parsed `.github/workflows/setup-soldr-action.yml` with PyYAML

Closes #183