### PR TITLE
Dogfood public setup-soldr action

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -42,9 +42,8 @@ jobs:
         with:
           cache: true
           # Keep the action runtime cache separate from the Soldr build under
-          # test. The dogfood build below overrides SOLDR_CACHE_DIR and
-          # ZCCACHE_CACHE_DIR so the action cache cannot cross-contaminate the
-          # repository build cache.
+          # test. The dogfood build below overrides SOLDR_CACHE_DIR and clears
+          # ZCCACHE_CACHE_DIR so soldr owns zccache under that separate root.
           cache-dir: ${{ runner.temp }}/setup-soldr-action-state
           cache-key-suffix: dogfood-action-state
           build-cache: false
@@ -85,7 +84,6 @@ jobs:
             throw "setup-soldr action cache must be disjoint from the Soldr build-under-test cache"
           }
           New-Item -ItemType Directory -Force -Path $buildCache | Out-Null
-          New-Item -ItemType Directory -Force -Path (Join-Path $buildCache "zccache") | Out-Null
           Write-Host "action-cache=$actionCache"
           Write-Host "build-under-test-cache=$buildCache"
 
@@ -93,12 +91,12 @@ jobs:
         shell: pwsh
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
-          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test/zccache
+          ZCCACHE_CACHE_DIR: ""
         run: soldr cargo build --package soldr-cli --locked
 
       - name: Test through soldr
         shell: pwsh
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
-          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test/zccache
+          ZCCACHE_CACHE_DIR: ""
         run: soldr cargo test -p soldr-cli --test cli --locked


### PR DESCRIPTION
## Summary

- publish docs and examples against `zackees/setup-soldr@v0`
- dogfood the public setup action in the Soldr setup-action smoke workflow, pinned to the `v0.1.0` commit SHA to satisfy this repo's action-pinning ruleset
- keep the action runtime cache separate from the Soldr build-under-test cache by using a dedicated setup cache dir, disabling the action build/target cache layers in the dogfood job, and running the build with a separate `SOLDR_CACHE_DIR`

## Published action

- `zackees/setup-soldr` now has `main`
- `v0.1.0` release: https://github.com/zackees/setup-soldr/releases/tag/v0.1.0
- moving compatibility tag: `v0`

## Validation

- `python -m pytest tests\test_setup_soldr_exporter.py`
- `git diff --check`
- parsed `.github/workflows/setup-soldr-action.yml` with PyYAML

Supersedes #184.
Closes #183