### PR TITLE
Add soldr purge command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 soldr cargo build --release
 soldr cargo test
 soldr --no-cache cargo test
+soldr purge
 SOLDR_RUSTC_WRAPPER=sccache soldr cargo build
 SOLDR_RUSTC_WRAPPER=none soldr cargo build
 
@@ -158,7 +159,7 @@ soldr maturin build --release
 - **One obvious command**: Fetch tools, pick the right Windows target, and run through managed zccache through the same entry point.
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
 - **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
-- **Real cache controls**: `soldr status`, `soldr cache`, and `soldr clean` report and manage the soldr-managed zccache state instead of placeholder behavior.
+- **Real cache controls**: `soldr status`, `soldr cache`, and `soldr clean` report and manage the soldr-managed zccache state, while `soldr purge` removes all Soldr-managed cache artifacts for bug clearing and benchmarking.
 - **One cache boundary, eventually**: soldr keeps its own tools and zccache session state in `~/.soldr/`. Current zccache artifacts still live in zccache's default cache root until upstream exposes a supported cache-dir override.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -79,8 +79,10 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Clear caches
+    /// Clear the managed zccache build cache
     Clean,
+    /// Purge all soldr-managed cache artifacts
+    Purge,
     /// Show or set configuration
     Config,
     /// Inspect the compilation cache
@@ -197,6 +199,9 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
         }
         Commands::Clean => {
             clear_zccache_cache()?;
+        }
+        Commands::Purge => {
+            purge_soldr_cache()?;
         }
         Commands::Config => {
             println!("(config not yet implemented)");
@@ -799,6 +804,35 @@ fn clear_zccache_cache() -> Result<(), SoldrError> {
         );
     }
     Ok(())
+}
+
+fn purge_soldr_cache() -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let mut purged_anything = false;
+
+    purged_anything |= remove_soldr_artifact_dir("cache", &paths.cache)?;
+    purged_anything |= remove_soldr_artifact_dir("bin", &paths.bin)?;
+
+    if !purged_anything {
+        println!("soldr cache is already empty: {}", paths.root.display());
+    }
+
+    Ok(())
+}
+
+fn remove_soldr_artifact_dir(label: &str, path: &std::path::Path) -> Result<bool, SoldrError> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    if std::fs::symlink_metadata(path)?.file_type().is_dir() {
+        std::fs::remove_dir_all(path)?;
+        println!("removed soldr {label} dir: {}", path.display());
+    } else {
+        std::fs::remove_file(path)?;
+        println!("removed soldr {label} entry: {}", path.display());
+    }
+    Ok(true)
 }
 
 #[derive(Serialize)]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1281,6 +1281,141 @@ fn clean_clears_managed_zccache_and_state_dir() {
 }
 
 #[test]
+fn purge_removes_soldr_artifact_dirs_and_keeps_config() {
+    let cache_root = unique_temp_dir("purge-command");
+    let bin_dir = cache_root.join("bin");
+    let cache_dir = cache_root.join("cache");
+    let zccache_state_dir = cache_dir.join("zccache").join("logs");
+    let config_file = cache_root.join("config.toml");
+    fs::create_dir_all(&bin_dir).expect("failed to create bin dir");
+    fs::create_dir_all(&zccache_state_dir).expect("failed to create zccache state dir");
+    fs::write(bin_dir.join("soldr-tool"), "cached binary").expect("failed to seed bin cache");
+    fs::write(zccache_state_dir.join("last-session.jsonl"), "{}\n")
+        .expect("failed to seed zccache state");
+    fs::write(&config_file, "cache = true\n").expect("failed to seed config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("purge")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr purge");
+
+    assert!(output.status.success(), "purge command failed");
+    assert!(
+        !bin_dir.exists(),
+        "purge should remove soldr-managed fetched tool artifacts at {}",
+        bin_dir.display()
+    );
+    assert!(
+        !cache_dir.exists(),
+        "purge should remove soldr-managed cache artifacts at {}",
+        cache_dir.display()
+    );
+    assert!(
+        config_file.exists(),
+        "purge should keep non-artifact config at {}",
+        config_file.display()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("removed soldr cache dir:"),
+        "purge should report cache cleanup: {stdout}"
+    );
+    assert!(
+        stdout.contains("removed soldr bin dir:"),
+        "purge should report bin cleanup: {stdout}"
+    );
+}
+
+#[test]
+fn purge_reports_empty_cache_without_creating_dirs() {
+    let cache_root = unique_temp_dir("purge-empty-command");
+    let bin_dir = cache_root.join("bin");
+    let cache_dir = cache_root.join("cache");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("purge")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr purge");
+
+    assert!(output.status.success(), "purge command failed");
+    assert!(
+        !bin_dir.exists(),
+        "purge should not create missing bin dir at {}",
+        bin_dir.display()
+    );
+    assert!(
+        !cache_dir.exists(),
+        "purge should not create missing cache dir at {}",
+        cache_dir.display()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("soldr cache is already empty:"),
+        "purge should report empty cache: {stdout}"
+    );
+}
+
+#[test]
+fn purge_removes_corrupt_artifact_paths() {
+    let cache_root = unique_temp_dir("purge-corrupt-command");
+    let bin_path = cache_root.join("bin");
+    let cache_path = cache_root.join("cache");
+    fs::write(&bin_path, "not a dir").expect("failed to seed corrupt bin path");
+    fs::write(&cache_path, "not a dir").expect("failed to seed corrupt cache path");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .arg("purge")
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr purge");
+
+    assert!(output.status.success(), "purge command failed");
+    assert!(
+        !bin_path.exists(),
+        "purge should remove corrupt soldr bin path at {}",
+        bin_path.display()
+    );
+    assert!(
+        !cache_path.exists(),
+        "purge should remove corrupt soldr cache path at {}",
+        cache_path.display()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("removed soldr cache entry:"),
+        "purge should report corrupt cache path cleanup: {stdout}"
+    );
+    assert!(
+        stdout.contains("removed soldr bin entry:"),
+        "purge should report corrupt bin path cleanup: {stdout}"
+    );
+}
+
+#[test]
+fn purge_rejects_json_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["purge", "--json"])
+        .output()
+        .expect("failed to run soldr purge --json");
+
+    assert!(
+        !output.status.success(),
+        "purge --json should be rejected because JSON is not supported there"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--json"),
+        "expected clap to reject purge --json: {stderr}"
+    );
+}
+
+#[test]
 fn clean_rejects_json_flag() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["clean", "--json"])


### PR DESCRIPTION
## Summary
- add `soldr purge` to remove Soldr-managed artifact directories under `SOLDR_CACHE_DIR`
- keep non-artifact config intact while removing fetched tool artifacts and build cache state
- document `soldr purge` in the README cache controls

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p soldr-cli --test cli purge`
- `cargo test -p soldr-cli --test cli clean`
- `git diff --check`

## Note
- `cargo test -p soldr-cli --test cli` currently fails on `cargo_front_door_forces_msvc_target_even_with_polluted_path` because the fake cargo on PATH is selected. The new purge tests pass and this failure is outside the touched code path.