### PR TITLE
Preserve jobserver fds through soldr trampolines

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -108,6 +108,15 @@ async fn main() {
     // Must be checked before clap parsing.
     let raw_args: Vec<String> = std::env::args().collect();
     if raw_args.len() > 1 && is_wrapper_invocation(&raw_args[1]) {
+        if let Some(version) = soldr_as_env_pin() {
+            if should_trampoline(&version) {
+                std::process::exit(
+                    run_trampoline(&version, &raw_args[1..])
+                        .await
+                        .unwrap_or_else(report_and_exit),
+                );
+            }
+        }
         std::process::exit(run_rustc_wrapper(&raw_args).unwrap_or_else(report_and_exit));
     }
 
@@ -120,12 +129,7 @@ async fn main() {
             std::process::exit(1);
         }
     };
-    let pinned_version = pinned_version.or_else(|| {
-        std::env::var(SOLDR_AS_ENV_VAR)
-            .ok()
-            .map(|v| v.trim().to_string())
-            .filter(|v| !v.is_empty())
-    });
+    let pinned_version = pinned_version.or_else(soldr_as_env_pin);
 
     if let Some(version) = pinned_version {
         if should_trampoline(&version) {
@@ -148,6 +152,13 @@ async fn main() {
         .await
         .unwrap_or_else(report_and_exit);
     std::process::exit(rc);
+}
+
+fn soldr_as_env_pin() -> Option<String> {
+    std::env::var(SOLDR_AS_ENV_VAR)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
 }
 
 async fn run_with_args(prog: &str, args: &[String]) -> Result<i32, SoldrError> {
@@ -348,11 +359,26 @@ async fn run_trampoline(version: &str, args: &[String]) -> Result<i32, SoldrErro
         );
     }
 
-    let status = std::process::Command::new(&result.binary_path)
+    let mut command = std::process::Command::new(&result.binary_path);
+    command
         .args(args)
-        .env(SOLDR_TRAMPOLINING_ENV_VAR, env!("CARGO_PKG_VERSION"))
-        .status()
-        .map_err(|e| {
+        .env(SOLDR_TRAMPOLINING_ENV_VAR, env!("CARGO_PKG_VERSION"));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+
+        let err = command.exec();
+        Err(SoldrError::Other(format!(
+            "failed to exec soldr v{} at {}: {err}",
+            result.version,
+            result.binary_path.display()
+        )))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let status = command.status().map_err(|e| {
             SoldrError::Other(format!(
                 "failed to exec soldr v{} at {}: {e}",
                 result.version,
@@ -360,7 +386,8 @@ async fn run_trampoline(version: &str, args: &[String]) -> Result<i32, SoldrErro
             ))
         })?;
 
-    Ok(status.code().unwrap_or(1))
+        Ok(status.code().unwrap_or(1))
+    }
 }
 
 /// Known toolchain binaries that cargo may invoke through RUSTC_WRAPPER

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -113,6 +113,21 @@ fn fake_cargo_script(log_path: &Path) -> String {
     }
 }
 
+#[cfg(not(windows))]
+fn fake_cargo_with_jobserver_script(log_path: &Path) -> String {
+    format!(
+        "#!/bin/sh\n\
+         echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{}\"\n\
+         exec 3</dev/null\n\
+         exec 4>/dev/null\n\
+         export CARGO_MAKEFLAGS='-j --jobserver-fds=3,4'\n\
+         export SOLDR_TEST_JOBSERVER_READ_FD=3\n\
+         export SOLDR_TEST_JOBSERVER_WRITE_FD=4\n\
+         \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n",
+        log_path.display()
+    )
+}
+
 fn fake_rustc_script(log_path: &Path) -> String {
     #[cfg(windows)]
     {
@@ -304,6 +319,17 @@ fn fake_zccache_script(log_path: &Path) -> String {
              esac\n\
              rustc=\"$1\"\n\
              shift\n\
+             if [ -n \"${{SOLDR_TEST_JOBSERVER_READ_FD:-}}\" ]; then\n\
+               if ! eval \": <&$SOLDR_TEST_JOBSERVER_READ_FD\"; then\n\
+                 echo \"jobserver read fd $SOLDR_TEST_JOBSERVER_READ_FD is not open\" >&2\n\
+                 exit 42\n\
+               fi\n\
+               if ! eval \": >&$SOLDR_TEST_JOBSERVER_WRITE_FD\"; then\n\
+                 echo \"jobserver write fd $SOLDR_TEST_JOBSERVER_WRITE_FD is not open\" >&2\n\
+                 exit 42\n\
+               fi\n\
+               echo \"zccache jobserver fds ok read=$SOLDR_TEST_JOBSERVER_READ_FD write=$SOLDR_TEST_JOBSERVER_WRITE_FD\" >> \"{0}\"\n\
+             fi\n\
              echo \"zccache wrapper cache_dir=${{ZCCACHE_CACHE_DIR:-}} $rustc $*\" >> \"{0}\"\n\
              \"$rustc\" \"$@\"\n",
             log_path.display()
@@ -345,6 +371,19 @@ fn install_fake_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
     let rustc = fake_script_path(&dir, "rustc");
     let zccache = fake_script_path(&dir, "zccache");
     write_fake_script(&cargo, &fake_cargo_script(log_path));
+    write_fake_script(&rustc, &fake_rustc_script(log_path));
+    write_fake_script(&zccache, &fake_zccache_script(log_path));
+    (cargo, rustc, zccache)
+}
+
+#[cfg(not(windows))]
+fn install_fake_jobserver_toolchain(log_path: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let dir = unique_temp_dir("fake-jobserver-toolchain");
+    let cargo = fake_script_path(&dir, "cargo");
+    let rustc = fake_script_path(&dir, "rustc");
+    let zccache = fake_script_path(&dir, "zccache");
+
+    write_fake_script(&cargo, &fake_cargo_with_jobserver_script(log_path));
     write_fake_script(&rustc, &fake_rustc_script(log_path));
     write_fake_script(&zccache, &fake_zccache_script(log_path));
     (cargo, rustc, zccache)
@@ -621,6 +660,41 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         journal.exists(),
         "expected session journal at {}",
         journal.display()
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn cargo_front_door_preserves_jobserver_fds_into_managed_zccache_wrapper() {
+    let cache_root = unique_temp_dir("cargo-jobserver-fds");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_jobserver_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "test", "--no-run"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cargo test --no-run with fake jobserver fds");
+
+    assert!(
+        output.status.success(),
+        "cache-enabled front door lost jobserver fds\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("failed to connect to jobserver"),
+        "jobserver warning should not be emitted: {stderr}"
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("zccache jobserver fds ok read=3 write=4"),
+        "managed zccache wrapper did not observe open jobserver fds: {log}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #193.

- Honor `SOLDR_AS` before wrapper-mode dispatch so env-pinned/versioned soldr invocations also apply when Cargo calls soldr as `RUSTC_WRAPPER`.
- On Unix, `exec` into the fetched `soldr --as` binary instead of spawning it, preserving inherited numbered descriptors such as Cargo jobserver fds.
- Add a Unix-only CLI regression where fake Cargo advertises jobserver fds and fake zccache fails unless those fds are still open in managed wrapper mode.

## Verification

- `git diff --check`
- `cargo fmt --check`
- `cargo check -p soldr-cli`
- `cargo test -p soldr-cli --bin soldr`
- `cargo test -p soldr-cli --test cli cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default -- --nocapture`
- `cargo test -p soldr-cli --test cli cargo_front_door_preserves_jobserver_fds_into_managed_zccache_wrapper` (0 tests on this Windows host; covered on Unix CI)

## Notes

- `cargo test -p soldr-cli --test cli` still fails locally in the pre-existing Windows-only `cargo_front_door_forces_msvc_target_even_with_polluted_path` test: the fake PATH `cargo.cmd` is selected and prints `fake cargo should not be used`.
- `cargo check -p soldr-cli --target x86_64-unknown-linux-gnu` could not run on this host because the active Rust toolchain reports missing target std for `x86_64-unknown-linux-gnu`.