### PR TITLE
Document cache fingerprint diagnostics

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -58,7 +58,7 @@ The root action:
 - preinstalls the exact Rust toolchain resolved from `rust-toolchain.toml` or `toolchain:` via `rustup`
 - sets `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME`
 - restores and saves that runner-local root through GitHub cache when `cache: true`
-- restores and saves the zccache compilation artifact cache at `~/.zccache` by default; set `build-cache: false` to disable that layer
+- restores and saves the Soldr-owned zccache compilation artifact cache under `SOLDR_CACHE_DIR` by default; set `build-cache: false` to disable that layer
 
 Important toolchain rule:
 
@@ -103,7 +103,7 @@ Useful inputs when wiring the action into another repository:
 - `toolchain`: explicit Rust channel override when you do not want to rely on `rust-toolchain.toml`
 - `toolchain-file`: alternate toolchain file path when the repo does not use the default root `rust-toolchain.toml`
 - `cache`: turn the runner-local cache root on or off
-- `build-cache`: turn the `~/.zccache` compilation artifact cache on or off; defaults to `true`
+- `build-cache`: turn the Soldr-owned zccache compilation artifact cache on or off; defaults to `true`
 - `cache-dir`: move the shared Soldr/Cargo/rustup root to a specific path
 - `trust-mode`: set `SOLDR_TRUST_MODE` for stricter fetched-binary policy
 
@@ -128,7 +128,7 @@ The action-managed cache root includes:
 
 That means the Soldr binary, the Rust toolchain, cargo registry state, and Soldr-managed state are reusable on later runs.
 
-Current limitation: soldr still documents managed `zccache` artifact storage as following zccache's current supported/default behavior rather than a fully action-controlled custom artifact path, so the action should not claim more than that.
+The managed `zccache` artifact store is controlled by Soldr through `ZCCACHE_CACHE_DIR` and lives under `SOLDR_CACHE_DIR` by default. Use `cache-dir` to move the action-managed root for a workflow.
 
 ### Shortest CI path: install a released soldr
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If soldr solves that one problem well, it becomes a super tool: the command you 
 
 - **Tool acquisition** (the crgx half): Need `maturin`, `cargo-dylint`, or any crate binary? soldr fetches a pre-built binary from GitHub Releases in seconds. No `cargo install` from source. Cached locally for instant reuse. On `0.5.x`, this is still an upstream trust decision rather than a repo-side trust guarantee; see [docs/TRUST_BOUNDARIES.md](./docs/TRUST_BOUNDARIES.md).
 
-- **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring; zccache's artifact store still uses its current default cache root.
+- **Compilation caching** (the zccache half): `soldr cargo ...` now fetches and manages a pinned `zccache` release for Rust builds. soldr owns the zccache daemon/session wiring and keeps managed zccache artifacts under Soldr's cache root.
 
 ```bash
 # Build through soldr's front door:
@@ -160,7 +160,7 @@ soldr maturin build --release
 - **Front-door builds**: `soldr cargo ...` is the primary build UX.
 - **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
 - **Real cache controls**: `soldr status`, `soldr cache`, and `soldr clean` report and manage the soldr-managed zccache state, while `soldr purge` removes all Soldr-managed cache artifacts for bug clearing and benchmarking.
-- **One cache boundary, eventually**: soldr keeps its own tools and zccache session state in `~/.soldr/`. Current zccache artifacts still live in zccache's default cache root until upstream exposes a supported cache-dir override.
+- **One cache boundary**: soldr keeps its own tools, zccache session state, and managed zccache artifacts under `~/.soldr/` by default. Use `SOLDR_CACHE_DIR` to move that root.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
 - **Cross-platform**: Linux, macOS, Windows (x86_64 + aarch64).

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -131,6 +131,28 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
 3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 
+## Debugging Target-Cache Restores That Still Rebuild
+
+A restored target cache is only a fast path when Cargo still considers the restored fingerprints fresh. Some crates have build scripts that do not declare narrow inputs with `cargo:rerun-if-changed=` or `cargo:rerun-if-env-changed=` lines. For those crates, Cargo can fall back to broad package/source fingerprint inputs. A fresh GitHub checkout may then have different source mtimes than the checkout that produced the restored target directory, so Cargo rebuilds that package even though `target-cache-hit` is `true`.
+
+Use Cargo's fingerprint diagnostics to confirm this failure mode:
+
+```yaml
+- name: Build with Cargo fingerprint diagnostics
+  env:
+    CARGO_LOG: cargo::core::compiler::fingerprint=info
+  run: soldr cargo build --locked
+```
+
+Look for lines like:
+
+```text
+fingerprint dirty for <crate> ... target="build-script-build"
+dirty: PrecalculatedComponentsChanged { ... }
+```
+
+That means the cache restored correctly, but Cargo invalidated a build-script fingerprint before zccache had a chance to make the command a no-op. The right fix is usually in the crate that owns the build script: emit precise `cargo:rerun-if-changed=` and `cargo:rerun-if-env-changed=` lines for the real inputs. `setup-soldr` should not hide this by blindly normalizing source mtimes, because that can mask real source changes and make Cargo's invalidation model harder to reason about.
+
 ## Debugging Cold Misses
 
 If feature branches keep rebuilding from scratch, check these in order:

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -127,6 +127,7 @@ The extracted public action must document these current limits honestly:
 - the action rehydrates the Soldr root, Cargo home, rustup home, and Soldr-owned zccache artifact cache under the chosen cache/state root
 - the action bootstraps `rustup` on demand via `rustup-init` when it is absent, then uses it to install the requested toolchain; at runtime Soldr prefers direct toolchain binaries from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` and only falls back to `rustup which` when the direct probe fails (or when `RUSTUP_TOOLCHAIN` is explicitly set)
 - the action exports `ZCCACHE_CACHE_DIR` to the Soldr-owned zccache artifact cache under `SOLDR_CACHE_DIR`
+- restored Cargo target directories are fast paths, not freshness overrides; build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ
 
 ### Non-Contract Details
 

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -119,6 +119,7 @@ jobs:
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
 - The action restores the Soldr-owned zccache cache root and the Cargo target directory by default so child branches can reuse parent-branch build state.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
+- A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.
 
 ## Development
 

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -103,6 +103,7 @@ jobs:
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
 - The action restores the Soldr-owned zccache cache root and the Cargo target directory by default so child branches can reuse parent-branch build state.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
+- A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.
 
 ## Development
 


### PR DESCRIPTION
## Summary

Fixes #192.
Completes the remaining docs cleanup for #172.

- Add setup-soldr target-cache diagnostics for Cargo build-script fingerprint dirtiness.
- Document the CARGO_LOG=cargo::core::compiler::fingerprint=info workflow knob and the PrecalculatedComponentsChanged signature.
- State that the correct mitigation is precise cargo:rerun-if-* inputs rather than source mtime normalization.
- Remove stale public docs that still said managed zccache artifacts live under ~/.zccache / zccache's default cache root.
- Mirror the target-cache caveat into the exported setup-soldr README template and fixture.

## Verification

- git diff --check
- uv run pytest tests/test_setup_soldr_action.py tests/test_setup_soldr_exporter.py -q
- rg old zccache-root claims in public docs (no matches)
