### PR TITLE
Make Cargo target caching opt-in

### DIFF
--- a/.github/actions/cache-benchmark-zccache-cleanup/action.yml
+++ b/.github/actions/cache-benchmark-zccache-cleanup/action.yml
@@ -30,7 +30,7 @@ runs:
           echo "save-cache=$(cat "$STATE_DIR/save-cache" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
           echo "cache-compilation=$(cat "$STATE_DIR/cache-compilation" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
           echo "cache-registry=$(cat "$STATE_DIR/cache-registry" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
-          echo "cache-target=$(cat "$STATE_DIR/cache-target" 2>/dev/null || echo 'true')" >> "$GITHUB_OUTPUT"
+          echo "cache-target=$(cat "$STATE_DIR/cache-target" 2>/dev/null || echo 'false')" >> "$GITHUB_OUTPUT"
           echo "target-dir=$(cat "$STATE_DIR/target-dir" 2>/dev/null || echo 'target')" >> "$GITHUB_OUTPUT"
         else
           echo "zccache-dir=$HOME/.zccache" >> "$GITHUB_OUTPUT"
@@ -86,6 +86,7 @@ runs:
         rm -rf "$SNAPSHOT_DIR"
         mkdir -p "$SNAPSHOT_DIR"
         if [ -d "$TARGET" ]; then
+          # Target snapshots are opt-in until zackees/zccache#65 adds bounded GC.
           tar cf "$SNAPSHOT_DIR/target-meta.tar" -C "$TARGET" \
             --exclude='incremental' \
             . 2>/dev/null || true

--- a/.github/actions/cache-benchmark-zccache/action.yml
+++ b/.github/actions/cache-benchmark-zccache/action.yml
@@ -26,9 +26,10 @@ inputs:
     description: >
       Cache cargo target/ metadata (fingerprints, dep-info, build script outputs).
       Allows cargo to skip invoking rustc entirely on warm builds.
-      Only caches lightweight metadata, not full .rlib files.
+      Disabled by default because target snapshots do not have bounded garbage
+      collection yet; see zackees/soldr#197 and zackees/zccache#65.
     required: false
-    default: "true"
+    default: "false"
   compilation-restore-fallback:
     description: >
       Whether restore-key fallback is allowed for the zccache compilation cache.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ That action:
 - preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
 - restores and saves the Soldr-owned zccache compilation artifact cache under `SOLDR_CACHE_DIR` by default; set `build-cache: false` to disable it
-- restores and saves the Cargo target directory by default for no-op CI fast paths; set `target-cache: false` to disable it or `target-dir:` to choose another target directory
+- leaves full Cargo target directory caching off by default because `target/` has no garbage collection and can grow to multi-GB caches; set `target-cache: true` only with intentionally bounded target paths while [zackees/soldr#197](https://github.com/zackees/soldr/issues/197), [zackees/setup-soldr#21](https://github.com/zackees/setup-soldr/issues/21), and [zackees/zccache#65](https://github.com/zackees/zccache/issues/65) are tracked
 - puts `soldr` on `PATH` for later steps
 
 If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later. The action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the toolchain it just installed instead of asking `rustup` to resolve a pinned file lazily.

--- a/action.yml
+++ b/action.yml
@@ -51,11 +51,12 @@ inputs:
   target-cache:
     description: >
       Restore and save the Cargo target directory across workflow runs.
-      Default "true"; this gives no-op child-branch builds a fast path when
-      Cargo can reuse restored fingerprints and outputs. Set to "false" to
-      cache only zccache compilation artifacts.
+      Default "false" because Cargo target directories do not garbage collect
+      themselves and can grow to multi-GB caches that exhaust hosted runners.
+      Enable only for intentionally bounded target paths. See
+      zackees/soldr#197, zackees/setup-soldr#21, and zackees/zccache#65.
     required: false
-    default: "true"
+    default: "false"
   target-dir:
     description: Cargo target directory restored by target-cache.
     required: false

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -18,7 +18,7 @@ You get, for free:
 
 - branch-agnostic cache keys the action produces on its own
 - automatic restore on feature branches from the latest `main` cache on a miss
-- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves the Soldr-owned zccache cache root and the Cargo target directory by default
+- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves the Soldr-owned zccache cache root by default
 - `cache-hit`, `build-cache-hit`, and `target-cache-hit` outputs you can read to confirm warm vs cold runs
 
 The rest of this document explains how and why that works.
@@ -49,7 +49,7 @@ The `zackees/setup-soldr@v0` action (generated from [`action.yml`](../action.yml
 - **Push-only save semantics come for free.** GitHub's cache scoping already prevents feature-branch runs from overwriting `main`'s cache. You do not need to gate `save-if` yourself the way internal Rust caching wrappers usually make you do.
 - **Rehydrated state.** On a cache hit, the action restores the soldr root, `CARGO_HOME`, and `RUSTUP_HOME` under the runner-local cache/state root. The resolved Rust toolchain and the `soldr` binary are then provisioned on top of whatever was restored.
 - **Build-artifact cache enabled by default.** The action also restores the Soldr-owned zccache cache root with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs unless you opt out with `build-cache: false`.
-- **Cargo target cache enabled by default.** When `build-cache` is enabled, the action also restores the configured Cargo target directory with a key scoped to the runner, resolved toolchain, lockfile hash, and commit SHA. It falls back only within the same toolchain and lockfile lineage, which gives no-op feature-branch builds a fast path without reusing stale target outputs across dependency changes.
+- **Cargo target cache opt-in.** Full `target/` snapshots are disabled by default because Cargo does not garbage collect old profiles, test binaries, build-script outputs, or target triples. Enable `target-cache: true` only for intentionally bounded paths while [zackees/soldr#197](https://github.com/zackees/soldr/issues/197), [zackees/setup-soldr#21](https://github.com/zackees/setup-soldr/issues/21), and [zackees/zccache#65](https://github.com/zackees/zccache/issues/65) track bounded cleanup.
 
 ## Minimum Config For An External Repo
 
@@ -127,7 +127,7 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
    For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
 
-   For the Cargo target layer, inspect the `target-cache` step. Its exact keys are `setup-soldr-targetcache-v0-{os}-{arch}-{toolchain-digest}-{cargo-lock-hash}-{github.sha}` and its restore-key falls back within the same toolchain and lockfile lineage.
+   If `target-cache: true` is explicitly enabled, inspect the `target-cache` step. Its exact keys are `setup-soldr-targetcache-v0-{os}-{arch}-{toolchain-digest}-{cargo-lock-hash}-{github.sha}` and its restore-key falls back within the same toolchain and lockfile lineage.
 
 3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 
@@ -163,7 +163,7 @@ If feature branches keep rebuilding from scratch, check these in order:
 - **Did you pass a `cache-key-suffix` input?** That value is appended to both cache key families (see `action.yml`). A different suffix on a feature branch produces a different key than `main` writes, and the restore will only succeed through the prefix fallback. Make sure the same suffix is used (or omitted) on every branch you want to share a lineage.
 - **Mixed runner OS/arch.** Cache keys are scoped by runner OS and architecture. A cache written on `ubuntu-24.04` will not restore on `macos-15` and vice versa. Each combination needs its own warm lineage from `main`.
 - **Did someone opt out of build caching?** If `build-cache: false` is set in the workflow, `build-cache-hit` will be empty and the Soldr-owned zccache cache root will not be restored or saved.
-- **Did someone opt out of target caching?** If `target-cache: false` is set in the workflow, `target-cache-hit` will be empty and the Cargo target directory will not be restored or saved.
+- **Did someone explicitly enable target caching?** Target caching defaults to disabled. If `target-cache: false` is set or omitted, `target-cache-hit` will be empty and the Cargo target directory will not be restored or saved.
 
 ---
 

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -88,7 +88,7 @@ steps:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `"true"`; set to `"false"` to opt out. |
-| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `"false"` because `target/` has no garbage collection and can grow to multi-GB caches; enable only for intentionally bounded paths. Tracked by [zackees/soldr#197](https://github.com/zackees/soldr/issues/197), [zackees/setup-soldr#21](https://github.com/zackees/setup-soldr/issues/21), and [zackees/zccache#65](https://github.com/zackees/zccache/issues/65). |
 | `target-dir` | Cargo target directory restored by `target-cache`. Default `"target"`. |
 
 The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v0` beta contract and should not be documented in the extracted public action README.
@@ -118,7 +118,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - restore and save the action-managed cache/state root when `cache: true`
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
 - when `build-cache: true` (the default), restore the Soldr-owned zccache cache root at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
-- when `build-cache: true` and `target-cache: true` (the defaults), restore the configured Cargo target directory at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and outputs. Keys include the runner OS, architecture, resolved toolchain digest, `Cargo.lock` hash, and commit SHA, with fallback limited to the same toolchain and lockfile lineage.
+- when `build-cache: true` and `target-cache: true` (explicitly enabled), restore the configured Cargo target directory at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and outputs. Keys include the runner OS, architecture, resolved toolchain digest, `Cargo.lock` hash, and commit SHA, with fallback limited to the same toolchain and lockfile lineage. This remains opt-in until target snapshot pruning is bounded.
 
 ### Current Limits That Must Stay Explicit
 
@@ -128,6 +128,7 @@ The extracted public action must document these current limits honestly:
 - the action bootstraps `rustup` on demand via `rustup-init` when it is absent, then uses it to install the requested toolchain; at runtime Soldr prefers direct toolchain binaries from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` and only falls back to `rustup which` when the direct probe fails (or when `RUSTUP_TOOLCHAIN` is explicitly set)
 - the action exports `ZCCACHE_CACHE_DIR` to the Soldr-owned zccache artifact cache under `SOLDR_CACHE_DIR`
 - restored Cargo target directories are fast paths, not freshness overrides; build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ
+- full Cargo target directories are not garbage-collected by Cargo, so broad target caching can accumulate stale profiles, test binaries, build-script outputs, and target triples until the runner disk fills; keep it off or narrowly scoped until [zackees/zccache#65](https://github.com/zackees/zccache/issues/65) has a bounded cleanup policy
 
 ### Non-Contract Details
 

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -97,7 +97,7 @@ jobs:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `false` because `target/` has no garbage collection and can grow to multi-GB caches; enable only for intentionally bounded paths. See zackees/soldr#197, zackees/setup-soldr#21, and zackees/zccache#65. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
@@ -117,7 +117,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- The action restores the Soldr-owned zccache cache root and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
+- Full Cargo target caching is opt-in until target snapshot garbage collection is bounded; prefer the default zccache artifact cache for normal CI.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 - A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.
 

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -81,7 +81,7 @@ jobs:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
+| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `false` because `target/` has no garbage collection and can grow to multi-GB caches; enable only for intentionally bounded paths. See zackees/soldr#197, zackees/setup-soldr#21, and zackees/zccache#65. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
@@ -101,7 +101,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- The action restores the Soldr-owned zccache cache root and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
+- Full Cargo target caching is opt-in until target snapshot garbage collection is bounded; prefer the default zccache artifact cache for normal CI.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 - A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.
 

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -47,11 +47,12 @@ inputs:
   target-cache:
     description: >
       Restore and save the Cargo target directory across workflow runs.
-      Default "true"; this gives no-op child-branch builds a fast path when
-      Cargo can reuse restored fingerprints and outputs. Set to "false" to
-      cache only zccache compilation artifacts.
+      Default "false" because Cargo target directories do not garbage collect
+      themselves and can grow to multi-GB caches that exhaust hosted runners.
+      Enable only for intentionally bounded target paths. See
+      zackees/soldr#197, zackees/setup-soldr#21, and zackees/zccache#65.
     required: false
-    default: "true"
+    default: "false"
   target-dir:
     description: Cargo target directory restored by target-cache.
     required: false


### PR DESCRIPTION
## Summary
- make setup-soldr target caching opt-in in the soldr source action contract
- update the public-action docs, CI cache guide, exporter, and fixtures
- make soldr's vendored zccache benchmark target snapshot cache opt-in and safe on missing setup state
- cross-reference zackees/soldr#197, zackees/setup-soldr#21, and zackees/zccache#65

## Verification
- git diff --check
- actionlint
- python -m pytest tests/test_setup_soldr_exporter.py