### PR TITLE
Track bounded hot target cache contract

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -74,6 +74,38 @@ def _short_file_hash(path: Path, missing: str) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
 
 
+HOT_TARGET_CACHE_PATTERNS = (
+    ".rustc_info.json",
+    "CACHEDIR.TAG",
+    "**/.fingerprint/**",
+    "**/deps/*.d",
+    "**/deps/*.rmeta",
+    "**/build/**/output",
+    "**/build/**/invoked.timestamp",
+    "**/build/**/root-output",
+    "!**/incremental/**",
+)
+
+
+def normalize_target_cache_mode(value: str) -> str:
+    mode = value.strip().lower() or "hot"
+    if mode not in {"hot", "full", "off"}:
+        raise RuntimeError(
+            f"invalid target-cache-mode {value!r}; expected hot, full, or off"
+        )
+    return mode
+
+
+def hot_target_cache_paths(target_cache_path: Path) -> str:
+    values: list[str] = []
+    for pattern in HOT_TARGET_CACHE_PATTERNS:
+        negate = pattern.startswith("!")
+        cleaned = pattern[1:] if negate else pattern
+        rendered = str(target_cache_path / cleaned)
+        values.append(f"!{rendered}" if negate else rendered)
+    return "\n".join(values)
+
+
 def _write_env(name: str, value: str) -> None:
     output = os.environ.get("GITHUB_ENV")
     if not output:
@@ -179,8 +211,30 @@ def main() -> None:
     if not target_cache_path.is_absolute():
         target_cache_path = workspace / target_cache_path
     target_cache_path = target_cache_path.resolve()
-    target_cache_prefix = f"setup-soldr-targetcache-v0-{runner_os}-{runner_arch}"
-    target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+    target_cache_mode = normalize_target_cache_mode(
+        os.environ.get("INPUT_TARGET_CACHE_MODE", "hot")
+    )
+    target_cache_enabled = (
+        os.environ.get("INPUT_TARGET_CACHE", "true").strip().lower()
+        not in {"0", "false", "no", "off"}
+        and target_cache_mode != "off"
+    )
+    if target_cache_mode == "off":
+        target_cache_paths = str(target_cache_path)
+        target_cache_effective_mode = "off"
+        target_cache_prefix = f"setup-soldr-targetcache-off-v1-{runner_os}-{runner_arch}"
+        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+    elif target_cache_mode == "full":
+        target_cache_paths = str(target_cache_path)
+        target_cache_effective_mode = "full"
+        target_cache_prefix = f"setup-soldr-targetcache-full-v1-{runner_os}-{runner_arch}"
+        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+    else:
+        target_cache_paths = hot_target_cache_paths(target_cache_path)
+        target_cache_effective_mode = "hot"
+        target_paths_hash = hashlib.sha256(target_cache_paths.encode("utf-8")).hexdigest()[:16]
+        target_cache_prefix = f"setup-soldr-targetcache-hot-v1-{runner_os}-{runner_arch}"
+        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-{target_paths_hash}-"
     target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
 
     if suffix:
@@ -212,6 +266,9 @@ def main() -> None:
             "build_cache_restore_key_os_arch": f"{build_cache_prefix}-",
             "build_cache_path": str(zccache_cache_dir),
             "target_cache_path": str(target_cache_path),
+            "target_cache_paths": target_cache_paths,
+            "target_cache_enabled": str(target_cache_enabled).lower(),
+            "target_cache_mode": target_cache_effective_mode,
             "target_cache_key": target_cache_key,
             "target_cache_restore_key_lock": target_cache_lock_prefix,
             "soldr_root": str(soldr_root),

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ That action:
 - preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
 - restores and saves the Soldr-owned zccache compilation artifact cache under `SOLDR_CACHE_DIR` by default; set `build-cache: false` to disable it
-- restores and saves the Cargo target directory by default for no-op CI fast paths; set `target-cache: false` to disable it or `target-dir:` to choose another target directory
+- restores and saves a bounded hot Cargo target cache by default for no-op CI fast paths; set `target-cache: false` to disable it, `target-cache-mode: full` to opt into whole-target caching, or `target-dir:` to choose another target directory
 - puts `soldr` on `PATH` for later steps
 
 If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later. The action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the toolchain it just installed instead of asking `rustup` to resolve a pinned file lazily.

--- a/action.yml
+++ b/action.yml
@@ -51,11 +51,19 @@ inputs:
   target-cache:
     description: >
       Restore and save the Cargo target directory across workflow runs.
-      Default "true"; this gives no-op child-branch builds a fast path when
-      Cargo can reuse restored fingerprints and outputs. Set to "false" to
-      cache only zccache compilation artifacts.
+      Default "true"; target-cache-mode controls whether this is a bounded hot
+      metadata cache or an explicit full target cache. Set to "false" to cache
+      only zccache compilation artifacts.
     required: false
     default: "true"
+  target-cache-mode:
+    description: >
+      Cargo target cache mode. "hot" caches Cargo freshness metadata and
+      lightweight type metadata by default. "full" caches the entire target-dir
+      and should only be used for tightly scoped jobs. "off" disables target
+      caching even when target-cache is true.
+    required: false
+    default: hot
   target-dir:
     description: Cargo target directory restored by target-cache.
     required: false
@@ -86,6 +94,9 @@ outputs:
       for an exact key match, "false" for a restore-key fallback or no cache,
       empty string when `target-cache` or `build-cache` is disabled.
     value: ${{ steps.cache-meta.outputs.target_cache_hit }}
+  target-cache-mode:
+    description: Effective Cargo target cache mode.
+    value: ${{ steps.resolve.outputs.target_cache_mode }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
@@ -102,6 +113,8 @@ runs:
         INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
         INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
+        INPUT_TARGET_CACHE: ${{ inputs.target-cache }}
+        INPUT_TARGET_CACHE_MODE: ${{ inputs.target-cache-mode }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
@@ -128,10 +141,10 @@ runs:
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
     - id: target-cache
-      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.target_cache_path }}
+        path: ${{ steps.resolve.outputs.target_cache_paths }}
         key: ${{ steps.resolve.outputs.target_cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
@@ -156,7 +169,7 @@ runs:
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
 
     - id: zccache-warm-target
-      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
       shell: pwsh
       env:
         TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
@@ -206,6 +219,7 @@ runs:
         RAW_TARGET_CACHE_HIT: ${{ steps.target-cache.outputs.cache-hit }}
         BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
         TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
+        EFFECTIVE_TARGET_CACHE_ENABLED: ${{ steps.resolve.outputs.target_cache_enabled }}
       run: |
         $value = $env:RAW_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($value)) {
@@ -223,7 +237,7 @@ runs:
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") {
+        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") {
           $targetValue = $env:RAW_TARGET_CACHE_HIT
           if ([string]::IsNullOrWhiteSpace($targetValue)) {
             $targetValue = "false"

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -49,7 +49,7 @@ The `zackees/setup-soldr@v0` action (generated from [`action.yml`](../action.yml
 - **Push-only save semantics come for free.** GitHub's cache scoping already prevents feature-branch runs from overwriting `main`'s cache. You do not need to gate `save-if` yourself the way internal Rust caching wrappers usually make you do.
 - **Rehydrated state.** On a cache hit, the action restores the soldr root, `CARGO_HOME`, and `RUSTUP_HOME` under the runner-local cache/state root. The resolved Rust toolchain and the `soldr` binary are then provisioned on top of whatever was restored.
 - **Build-artifact cache enabled by default.** The action also restores the Soldr-owned zccache cache root with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs unless you opt out with `build-cache: false`.
-- **Cargo target cache enabled by default.** When `build-cache` is enabled, the action also restores the configured Cargo target directory with a key scoped to the runner, resolved toolchain, lockfile hash, and commit SHA. It falls back only within the same toolchain and lockfile lineage, which gives no-op feature-branch builds a fast path without reusing stale target outputs across dependency changes.
+- **Hot Cargo target cache enabled by default.** When `build-cache` is enabled, the action restores a bounded hot target cache with Cargo freshness metadata and lightweight type metadata. It does not archive the full `target/` tree unless the workflow explicitly sets `target-cache-mode: full`.
 
 ## Minimum Config For An External Repo
 
@@ -127,7 +127,7 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
    For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
 
-   For the Cargo target layer, inspect the `target-cache` step. Its exact keys are `setup-soldr-targetcache-v0-{os}-{arch}-{toolchain-digest}-{cargo-lock-hash}-{github.sha}` and its restore-key falls back within the same toolchain and lockfile lineage.
+   For the Cargo target layer, inspect the `target-cache` step. Its default hot-cache keys are `setup-soldr-targetcache-hot-v1-{os}-{arch}-{toolchain-digest}-{cargo-lock-hash}-{paths-hash}-{github.sha}` and its restore-key falls back within the same toolchain, lockfile, and cache-shape lineage.
 
 3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -88,7 +88,8 @@ steps:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `"true"`; set to `"false"` to opt out. |
-| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
+| `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
+| `target-cache-mode` | Target cache mode. Default `"hot"` caches Cargo freshness metadata and lightweight type metadata; `"full"` caches the whole `target-dir`; `"off"` disables target caching. |
 | `target-dir` | Cargo target directory restored by `target-cache`. Default `"target"`. |
 
 The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v0` beta contract and should not be documented in the extracted public action README.
@@ -105,6 +106,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is explicitly disabled. |
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. Empty only when `build-cache` or `target-cache` is explicitly disabled. |
+| `target-cache-mode` | Effective target cache mode. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ### Required Behavior
@@ -118,7 +120,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - restore and save the action-managed cache/state root when `cache: true`
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
 - when `build-cache: true` (the default), restore the Soldr-owned zccache cache root at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
-- when `build-cache: true` and `target-cache: true` (the defaults), restore the configured Cargo target directory at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and outputs. Keys include the runner OS, architecture, resolved toolchain digest, `Cargo.lock` hash, and commit SHA, with fallback limited to the same toolchain and lockfile lineage.
+- when `build-cache: true` and `target-cache: true` (the defaults), restore a bounded hot Cargo target cache at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and lightweight metadata without archiving the full `target/` tree. `target-cache-mode: full` remains available only for tightly scoped jobs where the whole target directory is known to stay bounded.
 
 ### Current Limits That Must Stay Explicit
 

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -97,7 +97,8 @@ jobs:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
+| `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. |
+| `target-cache-mode` | Target cache mode. Default `hot` caches Cargo freshness metadata and lightweight type metadata; `full` caches the whole `target-dir`; `off` disables target caching. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
@@ -110,6 +111,7 @@ jobs:
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. |
+| `target-cache-mode` | Effective target cache mode. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
@@ -117,7 +119,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- The action restores the Soldr-owned zccache cache root and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
+- The default target cache mode is `hot`, which avoids archiving the full Cargo `target/` tree and caches only Cargo freshness metadata plus lightweight type metadata. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 - A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.
 

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -81,7 +81,8 @@ jobs:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save the Cargo target directory for no-op CI fast paths. |
+| `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. |
+| `target-cache-mode` | Target cache mode. Default `hot` caches Cargo freshness metadata and lightweight type metadata; `full` caches the whole `target-dir`; `off` disables target caching. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
 
 ## Outputs
@@ -94,6 +95,7 @@ jobs:
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. |
+| `target-cache-mode` | Effective target cache mode. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 
 ## Notes
@@ -101,7 +103,8 @@ jobs:
 - The action installs exactly one released `soldr` binary for the active runner target.
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
-- The action restores the Soldr-owned zccache cache root and the Cargo target directory by default so child branches can reuse parent-branch build state.
+- The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
+- The default target cache mode is `hot`, which avoids archiving the full Cargo `target/` tree and caches only Cargo freshness metadata plus lightweight type metadata. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 - A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.
 

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -47,11 +47,19 @@ inputs:
   target-cache:
     description: >
       Restore and save the Cargo target directory across workflow runs.
-      Default "true"; this gives no-op child-branch builds a fast path when
-      Cargo can reuse restored fingerprints and outputs. Set to "false" to
-      cache only zccache compilation artifacts.
+      Default "true"; target-cache-mode controls whether this is a bounded hot
+      metadata cache or an explicit full target cache. Set to "false" to cache
+      only zccache compilation artifacts.
     required: false
     default: "true"
+  target-cache-mode:
+    description: >
+      Cargo target cache mode. "hot" caches Cargo freshness metadata and
+      lightweight type metadata by default. "full" caches the entire target-dir
+      and should only be used for tightly scoped jobs. "off" disables target
+      caching even when target-cache is true.
+    required: false
+    default: hot
   target-dir:
     description: Cargo target directory restored by target-cache.
     required: false
@@ -82,6 +90,9 @@ outputs:
       for an exact key match, "false" for a restore-key fallback or no cache,
       empty string when `target-cache` or `build-cache` is disabled.
     value: ${{ steps.cache-meta.outputs.target_cache_hit }}
+  target-cache-mode:
+    description: Effective Cargo target cache mode.
+    value: ${{ steps.resolve.outputs.target_cache_mode }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
@@ -97,6 +108,8 @@ runs:
         INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
         INPUT_TOOLCHAIN_FILE: ${{ inputs.toolchain-file }}
         INPUT_TRUST_MODE: ${{ inputs.trust-mode }}
+        INPUT_TARGET_CACHE: ${{ inputs.target-cache }}
+        INPUT_TARGET_CACHE_MODE: ${{ inputs.target-cache-mode }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
@@ -123,10 +136,10 @@ runs:
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
     - id: target-cache
-      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: ${{ steps.resolve.outputs.target_cache_path }}
+        path: ${{ steps.resolve.outputs.target_cache_paths }}
         key: ${{ steps.resolve.outputs.target_cache_key }}
         restore-keys: |
           ${{ steps.resolve.outputs.target_cache_restore_key_lock }}
@@ -151,7 +164,7 @@ runs:
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
 
     - id: zccache-warm-target
-      if: ${{ inputs.build-cache == 'true' && inputs.target-cache == 'true' }}
+      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
       shell: pwsh
       env:
         TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
@@ -201,6 +214,7 @@ runs:
         RAW_TARGET_CACHE_HIT: ${{ steps.target-cache.outputs.cache-hit }}
         BUILD_CACHE_ENABLED: ${{ inputs.build-cache }}
         TARGET_CACHE_ENABLED: ${{ inputs.target-cache }}
+        EFFECTIVE_TARGET_CACHE_ENABLED: ${{ steps.resolve.outputs.target_cache_enabled }}
       run: |
         $value = $env:RAW_CACHE_HIT
         if ([string]::IsNullOrWhiteSpace($value)) {
@@ -218,7 +232,7 @@ runs:
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:TARGET_CACHE_ENABLED -eq "true") {
+        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") {
           $targetValue = $env:RAW_TARGET_CACHE_HIT
           if ([string]::IsNullOrWhiteSpace($targetValue)) {
             $targetValue = "false"

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -133,8 +133,12 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert "build_cache_restore_key_os_arch=setup-soldr-buildcache-v1-linux-x64-" in outputs
     assert f"build_cache_path={cache_root / 'soldr' / 'cache' / 'zccache'}" in outputs
     assert f"target_cache_path={workspace / 'custom-target'}" in outputs
-    assert "target_cache_key=setup-soldr-targetcache-v0-linux-x64-" in outputs
-    assert outputs.count("-no-lock-abc123") == 1
+    assert "target_cache_key=setup-soldr-targetcache-hot-v1-linux-x64-" in outputs
+    assert "target_cache_enabled=true" in outputs
+    assert "target_cache_mode=hot" in outputs
+    assert ".fingerprint" in outputs
+    assert outputs.count("-no-lock-") >= 1
+    assert outputs.count("-abc123") >= 1
     assert "toolchain=stable" in outputs
 
     env_text = github_env.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- mirror target-cache-mode in the soldr source setup action contract
- make the generated setup-soldr metadata use hot target-cache paths by default
- update exporter README fixtures and cache docs to describe hot/full/off modes

Closes #199.

## Validation

- python -m pytest tests/test_setup_soldr_action.py tests/test_setup_soldr_exporter.py -q
- Python resolve helper checks
- git diff --check