### PR TITLE
ci: migrate bootstrap caches to setup-soldr

### DIFF
--- a/.github/actions/setup-soldr/ensure_rust_toolchain.py
+++ b/.github/actions/setup-soldr/ensure_rust_toolchain.py
@@ -139,3 +139,10 @@ def main() -> None:
     if output:
         with open(output, "a", encoding="utf-8") as fh:
             fh.write(f"toolchain={channel}\n")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (RuntimeError, OSError, subprocess.CalledProcessError) as exc:
+        sys.exit(str(exc))

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -56,29 +56,18 @@ jobs:
           ref: ${{ inputs.third_party_ref }}
           path: ${{ inputs.third_party_path }}
 
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
-        if: ${{ inputs.runner != 'windows-11-arm' }}
+      - name: Setup Soldr cache and toolchain
+        uses: ./soldr
         with:
-          targets: ${{ inputs.target }}
+          toolchain-file: soldr/rust-toolchain.toml
+          cache-key-suffix: bootstrap-${{ inputs.target }}
+          target-cache-mode: full
+          target-dir: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}/target-${{ inputs.target }}
 
-      - name: Install Rust toolchain on Windows ARM
-        if: ${{ inputs.runner == 'windows-11-arm' }}
+      - name: Install target toolchain support
         shell: pwsh
         run: |
-          rustup toolchain install 1.94.1 --profile minimal --component rustfmt --component clippy --target "${{ inputs.target }}"
-          rustup default 1.94.1
-
-      - name: Share bootstrap zccache with soldr
-        shell: pwsh
-        run: |
-          $cacheRoot = Join-Path $env:RUNNER_TEMP "soldr-bootstrap"
-          $soldrRoot = Join-Path $cacheRoot "soldr"
-          $zccacheDir = Join-Path (Join-Path $soldrRoot "cache") "zccache"
-          New-Item -ItemType Directory -Force -Path $zccacheDir | Out-Null
-
-          "SOLDR_CACHE_DIR=$soldrRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "ZCCACHE_CACHE_DIR=$zccacheDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "Sharing bootstrap zccache cache dir: $zccacheDir"
+          rustup target add "${{ inputs.target }}"
 
       - name: Install musl tools
         if: contains(inputs.target, 'musl')
@@ -113,28 +102,11 @@ jobs:
           done
           dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
-      - uses: ./soldr/.github/actions/cache-benchmark-zccache
-        with:
-          # Keep branch-agnostic restore keys so feature branches can warm from
-          # canonical main caches, while push builds on feature branches can
-          # also save their own preferred branch-local cache entries.
-          shared-key: ${{ inputs.target }}
-          save-cache: ${{ inputs.save_cache }}
-          target-dir: soldr/target
-          zccache-version: "1.3.7"
-
-      - name: Share bootstrap zccache binary with soldr
-        shell: pwsh
-        run: |
-          $zccache = Get-Command zccache -ErrorAction Stop
-          "SOLDR_ZCCACHE_BIN=$($zccache.Source)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "Sharing bootstrap zccache binary: $($zccache.Source)"
-
       - name: Build soldr-cli
         shell: pwsh
         working-directory: soldr
         run: |
-          cargo build --package soldr-cli --locked --target "${{ inputs.target }}"
+          soldr cargo build --package soldr-cli --locked --target "${{ inputs.target }}"
 
       - name: Resolve third-party toolchain
         id: third_party_toolchain
@@ -177,6 +149,8 @@ jobs:
       - name: Build third-party app through soldr
         shell: pwsh
         working-directory: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}/target-${{ inputs.target }}
         run: |
           & "${{ steps.soldr_binary.outputs.path }}" cargo build --locked --target "${{ inputs.target }}"
 
@@ -198,5 +172,28 @@ jobs:
           name: soldr-${{ inputs.target }}
           path: ${{ steps.soldr_binary.outputs.path }}
 
-      - if: ${{ always() }}
-        uses: ./soldr/.github/actions/cache-benchmark-zccache-cleanup
+      - name: Stop managed zccache before cache save
+        if: ${{ always() }}
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $exeName = if ($IsWindows) { "zccache.exe" } else { "zccache" }
+          $zccache = $null
+          if (-not [string]::IsNullOrWhiteSpace($env:SOLDR_CACHE_DIR)) {
+            $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
+            if (Test-Path -LiteralPath $soldrBin) {
+              $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
+                Select-Object -First 1 -ExpandProperty FullName
+            }
+          }
+          if ([string]::IsNullOrWhiteSpace($zccache)) {
+            $command = Get-Command zccache -ErrorAction SilentlyContinue
+            if ($command) {
+              $zccache = $command.Source
+            }
+          }
+          if ([string]::IsNullOrWhiteSpace($zccache)) {
+            Write-Host "zccache binary is unavailable; nothing to stop."
+            exit 0
+          }
+          & $zccache stop

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -173,12 +173,18 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.commit_sha }}
 
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+      - name: Setup Soldr cache and toolchain
+        uses: ./
+        with:
+          cache-key-suffix: release-${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - name: Install target toolchain support
+        shell: pwsh
+        run: |
+          rustup target add "${{ matrix.target }}"
 
       - name: Build release binary
-        run: cargo build --package soldr-cli --release --locked --target ${{ matrix.target }}
+        run: soldr cargo build --package soldr-cli --release --locked --target ${{ matrix.target }}
 
       - name: Package tarball
         if: matrix.archive == 'tar.gz'

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -98,8 +98,9 @@ jobs:
         shell: pwsh
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
-          ZCCACHE_CACHE_DIR: ""
-        run: soldr cargo test -p soldr-cli --test cli --locked
+        run: |
+          Remove-Item Env:ZCCACHE_CACHE_DIR -ErrorAction SilentlyContinue
+          soldr --no-cache cargo test -p soldr-cli --test cli --locked
 
       - name: Show dogfood cache status
         if: always()

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -30,6 +30,9 @@ pub const ZCCACHE_BINARY_ENV_VAR: &str = "SOLDR_ZCCACHE_BIN";
 /// Supported zccache cache-root override used for Soldr-owned artifact state.
 pub const ZCCACHE_CACHE_DIR_ENV_VAR: &str = "ZCCACHE_CACHE_DIR";
 
+/// Internal marker for `ZCCACHE_CACHE_DIR` values that were injected by soldr.
+pub const MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR: &str = "SOLDR_MANAGED_ZCCACHE_CACHE_DIR";
+
 pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
     if enabled {
         CACHE_ENABLED_VALUE

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -729,12 +729,14 @@ async fn prepare_rustc_wrapper(
             }
             cargo.env("RUSTC_WRAPPER", wrapper);
             cargo.env_remove(soldr_cache::ZCCACHE_BINARY_ENV_VAR);
+            cargo.env_remove(soldr_cache::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR);
             cargo.env_remove(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR);
             Ok(None)
         }
         RustcWrapperMode::Disabled => {
             cargo.env_remove("RUSTC_WRAPPER");
             cargo.env_remove(soldr_cache::ZCCACHE_BINARY_ENV_VAR);
+            cargo.env_remove(soldr_cache::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR);
             cargo.env_remove(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR);
             Ok(None)
         }
@@ -788,6 +790,7 @@ async fn prepare_zccache_build(
     cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
     cargo.env(soldr_cache::ZCCACHE_BINARY_ENV_VAR, &fetch.binary_path);
     cargo.env(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR, &zccache_dir);
+    cargo.env(soldr_cache::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR, &zccache_dir);
     cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
 
     Ok(ZccacheBuildSession {
@@ -1042,9 +1045,13 @@ struct CommandOutput {
 
 fn managed_zccache_cache_dir(paths: &SoldrPaths) -> Result<std::path::PathBuf, SoldrError> {
     let zccache_dir = normalize_path_for_compare(&soldr_cache::zccache_dir(paths))?;
+    let inherited_soldr_managed_dir =
+        non_empty_env_path(soldr_cache::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR)
+            .map(|path| normalize_path_for_compare(&path))
+            .transpose()?;
     if let Some(explicit) = non_empty_env_path(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR) {
         let explicit = normalize_path_for_compare(&explicit)?;
-        if explicit != zccache_dir {
+        if explicit != zccache_dir && inherited_soldr_managed_dir.as_ref() != Some(&explicit) {
             return Err(SoldrError::Other(format!(
                 "{} is managed by soldr for managed zccache builds. Unset it, set SOLDR_CACHE_DIR to choose soldr's cache root, or set SOLDR_RUSTC_WRAPPER to use a custom wrapper.",
                 soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -767,6 +767,48 @@ fn managed_zccache_rejects_conflicting_cache_dir_override() {
 }
 
 #[test]
+fn nested_soldr_ignores_inherited_managed_zccache_cache_dir() {
+    let parent_cache_root = unique_temp_dir("cargo-parent-managed-zccache-dir");
+    let child_cache_root = unique_temp_dir("cargo-child-managed-zccache-dir");
+    let parent_zccache_dir = parent_cache_root.join("cache").join("zccache");
+    let child_zccache_dir = child_cache_root.join("cache").join("zccache");
+    let log_path = child_cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &child_cache_root)
+        .env("ZCCACHE_CACHE_DIR", &parent_zccache_dir)
+        .env("SOLDR_MANAGED_ZCCACHE_CACHE_DIR", &parent_zccache_dir)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run nested soldr cargo build with inherited managed ZCCACHE_CACHE_DIR");
+
+    assert!(
+        output.status.success(),
+        "inherited soldr-managed ZCCACHE_CACHE_DIR should not block nested soldr\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        path_display_variants(&child_zccache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("zccache_dir={path}"))
+                && log.contains(&format!("cache_dir={path}"))),
+        "nested soldr should replace the inherited managed zccache dir with its own cache root: {log}"
+    );
+    assert!(
+        !path_display_variants(&parent_zccache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("cache_dir={path}"))),
+        "nested soldr should not reuse the parent managed zccache dir: {log}"
+    );
+}
+
+#[test]
 fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
     let cache_root = unique_temp_dir("cargo-custom-wrapper");
     let log_path = cache_root.join("tool.log");

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
+import re
 from pathlib import Path
 
 
@@ -81,6 +83,45 @@ def test_toolchain_signature_payload_is_json_serializable() -> None:
     }
 
     assert json.loads(json.dumps(payload))["channel"] == "1.94.1"
+
+
+def test_action_python_helpers_have_entrypoints() -> None:
+    action_text = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+    script_paths = sorted(
+        {
+            REPO_ROOT / match.group(1)
+            for match in re.finditer(r"github\.action_path \}\}/([^\"']+\.py)", action_text)
+        }
+    )
+
+    assert script_paths, "expected action.yml to invoke Python helper scripts"
+    for script_path in script_paths:
+        tree = ast.parse(script_path.read_text(encoding="utf-8"))
+        assert any(
+            isinstance(node, ast.FunctionDef) and node.name == "main"
+            for node in tree.body
+        ), f"{script_path.relative_to(REPO_ROOT)} should define main()"
+        assert any(
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Name)
+            and node.test.left.id == "__name__"
+            and any(
+                isinstance(comparator, ast.Constant)
+                and comparator.value == "__main__"
+                for comparator in node.test.comparators
+            )
+            for node in tree.body
+        ), f"{script_path.relative_to(REPO_ROOT)} should invoke main() as a script"
+
+
+def test_setup_soldr_smoke_tests_disable_nested_cache() -> None:
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "setup-soldr-action.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "Remove-Item Env:ZCCACHE_CACHE_DIR" in workflow
+    assert "soldr --no-cache cargo test -p soldr-cli --test cli --locked" in workflow
 
 
 def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- migrate the bootstrap E2E workflow from hand-rolled rustup/zccache setup to the checked-out setup-soldr action
- build soldr-cli through `soldr cargo` so the bootstrap build uses the managed wrapper cache
- cache the third-party fixture target dir with setup-soldr and stop managed zccache before post-job cache save
- migrate release binary builds from dtolnay/rust-toolchain + Swatinem/rust-cache to setup-soldr + `soldr cargo`

## Investigation
- The slow PR #201 job was in `_bootstrap-e2e.yml`, specifically `Build third-party app through soldr`.
- That workflow was still using `dtolnay/rust-toolchain`, manual `SOLDR_CACHE_DIR`/`ZCCACHE_CACHE_DIR` setup, and the repo-local `cache-benchmark-zccache` action instead of the newer setup-soldr cache policy.
- The remaining old `.zccache` paths are in the dedicated benchmark helper actions/workflows, where they are still part of explicit benchmark backend plumbing.

## Verification
- YAML parse for `_bootstrap-e2e.yml`, `release-auto.yml`, and `ci.yml`
- `actionlint .github/workflows/_bootstrap-e2e.yml .github/workflows/release-auto.yml`
- `git diff --check origin/main..HEAD`