### PR TITLE
Report zccache stats in setup-soldr smoke

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -100,3 +100,21 @@ jobs:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
           ZCCACHE_CACHE_DIR: ""
         run: soldr cargo test -p soldr-cli --test cli --locked
+
+      - name: Show dogfood cache status
+        if: always()
+        shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
+          ZCCACHE_CACHE_DIR: ""
+        run: |
+          $soldr = Get-Command soldr -ErrorAction SilentlyContinue
+          if (-not $soldr) {
+            Write-Host "soldr is unavailable; skipping dogfood cache status"
+            exit 0
+          }
+          & $soldr.Source cache
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "soldr cache status unavailable after dogfood build"
+            exit 0
+          }

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -131,6 +131,14 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
 3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 
+4. **Inspect zccache stats after the build.** Add a post-build status step when validating a new cache lineage:
+
+   ```yaml
+   - run: soldr cache
+   ```
+
+   The output includes the managed zccache root and status lines from zccache. For a healthy warm build, look for non-zero cached compilations or hit counts. If `build-cache-hit=true` but zccache still reports zero cached compilations, the build-artifact cache restored but did not produce compiler-cache reuse; check whether the target-cache layer also restored and whether Cargo invalidated fingerprints before zccache could hit.
+
 ## Debugging Target-Cache Restores That Still Rebuild
 
 A restored target cache is only a fast path when Cargo still considers the restored fingerprints fresh. Some crates have build scripts that do not declare narrow inputs with `cargo:rerun-if-changed=` or `cargo:rerun-if-env-changed=` lines. For those crates, Cargo can fall back to broad package/source fingerprint inputs. A fresh GitHub checkout may then have different source mtimes than the checkout that produced the restored target directory, so Cargo rebuilds that package even though `target-cache-hit` is `true`.


### PR DESCRIPTION
﻿## Summary
- add a post-build `soldr cache` report to the setup-soldr smoke workflow so zccache hit/artifact status is visible in the CI logs
- document `soldr cache` as the follow-up check when validating parent/child cache lineage and diagnosing `build-cache-hit=true` with zero compiler-cache reuse

Refs #170.
Related: #168, #169, #171, #172.

## Investigation
- #169 fixed the immediate save timing problem by moving build-cache saving to the `actions/cache@v4` post-job phase.
- #171 added the target-cache fast path, target warming, and mtime refresh; the issue comments show sub-second no-op build timings after target cache restore.
- `main` already has the runtime cache-root work from #172/#201, so this PR focuses on preserving the missing evidence trail for #170: zccache status after the dogfood build.

## Verification
- `python -m pytest tests/test_setup_soldr_action.py tests/test_setup_soldr_exporter.py`
- `python -c "import yaml; import sys; [yaml.safe_load(open(p, encoding='utf-8')) for p in sys.argv[1:]]" .github/workflows/setup-soldr-action.yml action.yml`
- `actionlint .github/workflows/setup-soldr-action.yml`
- `git diff --check`
