### PR TITLE
setup-soldr: add cargo tool shims

### DIFF
--- a/.github/actions/setup-soldr/install_tool_shims.py
+++ b/.github/actions/setup-soldr/install_tool_shims.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+
+TOOL_GROUPS = {
+    "cargo": ["cargo"],
+    "rust": ["cargo", "rustc", "rustfmt", "clippy-driver", "rustdoc"],
+    "all": ["cargo", "rustc", "rustfmt", "clippy-driver", "rustdoc"],
+}
+DISABLED_VALUES = {"", "0", "false", "no", "none", "off"}
+
+
+def _write_env(name: str, value: str) -> None:
+    output = os.environ.get("GITHUB_ENV")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def _write_path(value: str) -> None:
+    output = os.environ.get("GITHUB_PATH")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as fh:
+        fh.write(f"{value}\n")
+
+
+def tool_env_name(tool: str) -> str:
+    cleaned = "".join(ch.upper() if ch.isalnum() else "_" for ch in tool)
+    return f"SOLDR_REAL_{cleaned}"
+
+
+def parse_requested_tools(value: str) -> list[str]:
+    normalized = value.strip().lower()
+    if normalized in DISABLED_VALUES:
+        return []
+
+    tools: list[str] = []
+    for part in value.split(","):
+        token = part.strip().lower()
+        if not token:
+            continue
+        expanded = TOOL_GROUPS.get(token, [token])
+        for tool in expanded:
+            if tool not in tools:
+                tools.append(tool)
+    return tools
+
+
+def resolve_tool(tool: str) -> str:
+    rustup = shutil.which("rustup")
+    if rustup:
+        result = subprocess.run(
+            [rustup, "which", tool],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+
+    path = shutil.which(tool)
+    if path:
+        return path
+
+    raise RuntimeError(f"setup-soldr could not resolve requested tool shim target: {tool}")
+
+
+def write_unix_shim(path: Path, soldr_path: str, tool: str) -> None:
+    path.write_text(
+        f"#!/bin/sh\nexec {sh_quote(soldr_path)} {sh_quote(tool)} \"$@\"\n",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def write_windows_shim(path: Path, soldr_path: str, tool: str) -> None:
+    path.write_text(
+        f"@echo off\r\n\"{soldr_path}\" {tool} %*\r\n",
+        encoding="utf-8",
+    )
+
+
+def sh_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def install_shims(shim_dir: Path, soldr_path: str, tools: list[str]) -> None:
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    for tool in tools:
+        real_tool = resolve_tool(tool)
+        _write_env(tool_env_name(tool), real_tool)
+
+        if os.name == "nt":
+            write_windows_shim(shim_dir / f"{tool}.cmd", soldr_path, tool)
+        else:
+            write_unix_shim(shim_dir / tool, soldr_path, tool)
+
+    if tools:
+        _write_path(str(shim_dir))
+
+
+def main() -> None:
+    tools = parse_requested_tools(os.environ.get("SETUP_SOLDR_TOOL_SHIMS", "false"))
+    if not tools:
+        return
+
+    soldr_path = os.environ["SETUP_SOLDR_PATH"]
+    shim_dir = Path(os.environ["SETUP_SOLDR_SHIM_DIR"])
+    install_shims(shim_dir, soldr_path, tools)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -148,6 +148,7 @@ def main() -> None:
     cargo_home = cache_root / "cargo"
     rustup_home = cache_root / "rustup"
     bin_dir = cache_root / "bin"
+    shim_dir = cache_root / "shims"
     zccache_cache_dir = soldr_root / "cache" / "zccache"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
@@ -161,6 +162,7 @@ def main() -> None:
         cargo_home / "bin",
         rustup_home,
         bin_dir,
+        shim_dir,
         zccache_cache_dir,
     ):
         path.mkdir(parents=True, exist_ok=True)
@@ -275,6 +277,7 @@ def main() -> None:
             "cargo_home": str(cargo_home),
             "rustup_home": str(rustup_home),
             "bin_dir": str(bin_dir),
+            "shim_dir": str(shim_dir),
             "soldr_path": str(soldr_path),
             "soldr_repo": soldr_repo,
             "soldr_version_requested": soldr_version,

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -106,8 +106,31 @@ Useful inputs when wiring the action into another repository:
 - `build-cache`: turn the Soldr-owned zccache compilation artifact cache on or off; defaults to `true`
 - `cache-dir`: move the shared Soldr/Cargo/rustup root to a specific path
 - `trust-mode`: set `SOLDR_TRUST_MODE` for stricter fetched-binary policy
+- `tool-shims`: set to `cargo` when an existing workflow should keep commands like `cargo build` while routing them through `soldr cargo build`
 
 The current root `repo` input is an implementation/testing override for the in-repo action source. It is not part of the public `setup-soldr@v0` beta contract.
+
+### Cargo shim mode
+
+The preferred explicit integration is still:
+
+```yaml
+- run: soldr cargo build --locked --release
+- run: soldr cargo test --locked
+```
+
+For dependent repositories that cannot easily rewrite every Cargo invocation, enable the opt-in shim mode:
+
+```yaml
+- uses: zackees/setup-soldr@v0
+  with:
+    tool-shims: cargo
+
+- run: cargo build --locked --release
+- run: cargo test --locked
+```
+
+`tool-shims: cargo` installs a generated `cargo` shim into a dedicated setup-soldr shim directory and prepends it to `PATH` for later steps. The action resolves the real Cargo binary before installing the shim and exports `SOLDR_REAL_CARGO`, so Soldr can bypass the shim when it needs to run the active toolchain.
 
 Useful outputs:
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ That action:
 - restores and saves a bounded hot Cargo target cache by default for no-op CI fast paths; set `target-cache: false` to disable it, `target-cache-mode: full` to opt into whole-target caching, or `target-dir:` to choose another target directory
 - puts `soldr` on `PATH` for later steps
 
+For existing workflows where rewriting every `cargo ...` command is high-friction, opt into Cargo PATH shims:
+
+```yaml
+- uses: zackees/setup-soldr@v0
+  with:
+    tool-shims: cargo
+
+- run: cargo build --locked --release
+- run: cargo test --locked
+```
+
+The shim mode is off by default. When enabled, the action resolves the real Cargo binary before prepending its shim directory, then exports that real path for Soldr so `cargo ...` can safely trampoline into `soldr cargo ...` without recursive PATH lookup.
+
 If your project pins Rust in `rust-toolchain.toml`, let the action read that file or pass the exact value with `toolchain:`. Do not preinstall a different generic toolchain such as `stable` and assume `soldr` will reconcile it later. The action exports `RUSTUP_TOOLCHAIN` after installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the toolchain it just installed instead of asking `rustup` to resolve a pinned file lazily.
 
 On GitHub-hosted runners, this means you usually do not need a separate toolchain setup action for the normal path. The action still uses `rustup` under the hood today, but it bootstraps `rustup` itself when the runner does not already have it.

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,13 @@ inputs:
     description: Cargo target directory restored by target-cache.
     required: false
     default: target
+  tool-shims:
+    description: >
+      Optional PATH shim mode for existing workflows. Set to "cargo" to make
+      later `cargo ...` steps run through `soldr cargo ...` without rewriting
+      them. Default "false" leaves PATH unchanged.
+    required: false
+    default: "false"
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -100,6 +107,9 @@ outputs:
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
+  tool-shims-dir:
+    description: Directory containing generated tool shims when tool-shims is enabled.
+    value: ${{ steps.resolve.outputs.shim_dir }}
 runs:
   using: composite
   steps:
@@ -116,6 +126,7 @@ runs:
         INPUT_TARGET_CACHE: ${{ inputs.target-cache }}
         INPUT_TARGET_CACHE_MODE: ${{ inputs.target-cache-mode }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
+        INPUT_TOOL_SHIMS: ${{ inputs.tool-shims }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
@@ -167,6 +178,14 @@ runs:
       env:
         SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
+
+    - id: tool-shims
+      shell: pwsh
+      env:
+        SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
+        SETUP_SOLDR_SHIM_DIR: ${{ steps.resolve.outputs.shim_dir }}
+        SETUP_SOLDR_TOOL_SHIMS: ${{ inputs.tool-shims }}
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/install_tool_shims.py"
 
     - id: zccache-warm-target
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -9,6 +9,7 @@ const TEST_RUSTUP_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTUP_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 const JSON_SCHEMA_VERSION: u32 = 1;
 const RUSTC_WRAPPER_OVERRIDE_ENV_VAR: &str = "SOLDR_RUSTC_WRAPPER";
+const REAL_TOOLCHAIN_BINARY_ENV_PREFIX: &str = "SOLDR_REAL_";
 
 /// Pin a specific soldr version to handle this invocation. Explicit
 /// `--as <version>` flag takes precedence over this env var.
@@ -505,9 +506,11 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     command.args(args);
     apply_implicit_toolchain_homes(&mut command);
     command.env("RUSTC", rustc);
+    let cache_enabled_for_cargo = cache_enabled && cargo_args_are_cacheable(args);
+
     command.env(
         soldr_cache::CACHE_ENABLED_ENV_VAR,
-        soldr_cache::cache_enabled_env_value(cache_enabled),
+        soldr_cache::cache_enabled_env_value(cache_enabled_for_cargo),
     );
     let mut path_dirs: Vec<std::path::PathBuf> = Vec::with_capacity(1 + extra_bin_dirs.len());
     path_dirs.push(cargo_bin_dir);
@@ -517,7 +520,7 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
         command.env("CARGO_BUILD_TARGET", target);
     }
 
-    let session = if cache_enabled {
+    let session = if cache_enabled_for_cargo {
         prepare_rustc_wrapper(&mut command, &paths).await?
     } else {
         None
@@ -568,6 +571,31 @@ fn cargo_args_use_reserved_no_cache(args: &[String]) -> bool {
     false
 }
 
+fn cargo_args_are_cacheable(args: &[String]) -> bool {
+    let Some(subcommand) = first_cargo_subcommand(args) else {
+        return false;
+    };
+
+    matches!(
+        subcommand,
+        "b" | "build"
+            | "c"
+            | "check"
+            | "t"
+            | "test"
+            | "bench"
+            | "d"
+            | "doc"
+            | "r"
+            | "run"
+            | "rustc"
+            | "clippy"
+            | "fix"
+            | "install"
+            | "nextest"
+    )
+}
+
 fn prepend_paths(
     dirs: &[std::path::PathBuf],
     existing_path: Option<&std::ffi::OsStr>,
@@ -582,9 +610,21 @@ fn prepend_paths(
 /// Return the first positional argument (skipping flags) of the cargo
 /// front-door args, which is conventionally the cargo subcommand.
 fn first_cargo_subcommand(args: &[String]) -> Option<&str> {
+    let mut skip_next = false;
     for arg in args {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
         if arg == "--" {
             break;
+        }
+        if arg.starts_with('+') && arg.len() > 1 {
+            continue;
+        }
+        if cargo_global_arg_takes_value(arg) {
+            skip_next = !arg.contains('=');
+            continue;
         }
         if arg.starts_with('-') {
             continue;
@@ -592,6 +632,28 @@ fn first_cargo_subcommand(args: &[String]) -> Option<&str> {
         return Some(arg.as_str());
     }
     None
+}
+
+fn cargo_global_arg_takes_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "-C" | "-Z"
+            | "-j"
+            | "--color"
+            | "--config"
+            | "--jobs"
+            | "--manifest-path"
+            | "--message-format"
+            | "--target-dir"
+    ) || arg.starts_with("-C=")
+        || arg.starts_with("-Z=")
+        || arg.starts_with("-j=")
+        || arg.starts_with("--color=")
+        || arg.starts_with("--config=")
+        || arg.starts_with("--jobs=")
+        || arg.starts_with("--manifest-path=")
+        || arg.starts_with("--message-format=")
+        || arg.starts_with("--target-dir=")
 }
 
 async fn ensure_known_subcommand_tool(
@@ -1105,9 +1167,25 @@ fn toolchain_binary_override(tool: &str) -> Option<std::path::PathBuf> {
     let env_var = match tool {
         "cargo" => TEST_CARGO_BIN_ENV_VAR,
         "rustc" => TEST_RUSTC_BIN_ENV_VAR,
-        _ => return None,
+        _ => return real_toolchain_binary_override(tool),
     };
-    non_empty_env_path(env_var)
+    non_empty_env_path(env_var).or_else(|| real_toolchain_binary_override(tool))
+}
+
+fn real_toolchain_binary_override(tool: &str) -> Option<std::path::PathBuf> {
+    non_empty_env_path(&real_toolchain_binary_env_var(tool))
+}
+
+fn real_toolchain_binary_env_var(tool: &str) -> String {
+    let mut value = String::from(REAL_TOOLCHAIN_BINARY_ENV_PREFIX);
+    for ch in tool.chars() {
+        if ch.is_ascii_alphanumeric() {
+            value.push(ch.to_ascii_uppercase());
+        } else {
+            value.push('_');
+        }
+    }
+    value
 }
 
 fn rustup_binary() -> std::path::PathBuf {

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -435,7 +435,6 @@ fn install_failing_fake_rustup(log_path: &Path) -> PathBuf {
     rustup
 }
 
-#[cfg(windows)]
 fn prepend_to_path(dir: &Path) -> std::ffi::OsString {
     let existing = std::env::var_os("PATH").unwrap_or_default();
     let mut paths = vec![dir.to_path_buf()];
@@ -660,6 +659,109 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         journal.exists(),
         "expected session journal at {}",
         journal.display()
+    );
+}
+
+#[test]
+fn cargo_front_door_uses_real_tool_overrides_before_path_probe() {
+    let cache_root = unique_temp_dir("cargo-real-tool-overrides");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let shim_dir = unique_temp_dir("cargo-shim-dir");
+    let shim_cargo = fake_script_path(&shim_dir, "cargo");
+    write_fake_script(
+        &shim_cargo,
+        &fake_version_tool_script(&log_path, "shim-cargo"),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_REAL_CARGO", &cargo)
+        .env("SOLDR_REAL_RUSTC", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("PATH", prepend_to_path(&shim_dir))
+        .output()
+        .expect("failed to run soldr cargo build with real tool overrides");
+
+    assert!(
+        output.status.success(),
+        "real-tool override front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cargo wrapper="),
+        "real cargo should have been invoked: {log}"
+    );
+    assert!(
+        !log.contains("shim-cargo"),
+        "PATH shim should not be resolved when SOLDR_REAL_CARGO is set: {log}"
+    );
+}
+
+#[test]
+fn cargo_front_door_does_not_start_cache_for_non_build_subcommands() {
+    let cache_root = unique_temp_dir("cargo-non-build-no-cache");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "metadata"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cargo metadata with fake tools");
+
+    assert!(
+        output.status.success(),
+        "non-build cargo front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cache=0"),
+        "non-build cargo commands should propagate cache disabled: {log}"
+    );
+    assert!(
+        !log.contains("zccache start")
+            && !log.contains("zccache session-start")
+            && !log.contains("zccache wrapper")
+            && !log.contains("zccache session-end"),
+        "managed zccache should be skipped for non-build cargo commands: {log}"
+    );
+}
+
+#[test]
+fn cargo_front_door_detects_build_after_global_cargo_options() {
+    let cache_root = unique_temp_dir("cargo-global-options-cache");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "--manifest-path", "demo/Cargo.toml", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cargo build with global cargo options");
+
+    assert!(
+        output.status.success(),
+        "global-option cargo front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cache=1") && log.contains("zccache start"),
+        "build after global cargo options should still use managed zccache: {log}"
     );
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -233,6 +233,7 @@ Commands:
 | `RUSTC_WRAPPER` | Internal build hook used by `soldr cargo ...` | unset |
 | `SOLDR_CACHE_ENABLED` | Internal toggle propagated from `soldr cargo ...` into wrapper mode | `1` |
 | `SOLDR_RUSTC_WRAPPER` | Override soldr's managed zccache wrapper with another wrapper binary, or disable wrapper injection with `none` / empty | unset |
+| `SOLDR_REAL_CARGO`, `SOLDR_REAL_RUSTC`, ... | Internal real-tool path overrides used by setup-soldr PATH shims to avoid recursive tool lookup | unset |
 | `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
 | `ZCCACHE_CACHE_DIR` | zccache cache-root override set by soldr for managed zccache commands | `~/.soldr/cache/zccache` |
@@ -244,6 +245,8 @@ Commands:
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.
 
 When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must match the cache root derived from `SOLDR_CACHE_DIR`; conflicting values are rejected. Custom wrapper modes leave caller-provided wrapper environment alone.
+
+`soldr cargo ...` only starts the managed build cache for compile-like Cargo subcommands such as `build`, `check`, `test`, `run`, `doc`, `clippy`, and `nextest`. Non-build Cargo commands such as `cargo metadata` and `cargo --version` pass through without starting zccache.
 
 ---
 

--- a/docs/SETUP_SOLDR_EXPORTER.md
+++ b/docs/SETUP_SOLDR_EXPORTER.md
@@ -26,6 +26,7 @@ The exporter writes the standalone repository shape defined in `docs/SETUP_SOLDR
 - `.github/actions/setup-soldr/resolve_setup.py`
 - `.github/actions/setup-soldr/ensure_rust_toolchain.py`
 - `.github/actions/setup-soldr/ensure_soldr.py`
+- `.github/actions/setup-soldr/install_tool_shims.py`
 - `.github/actions/setup-soldr/verify_soldr.py`
 
 ## Behavior

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -27,6 +27,7 @@ The current setup action that should be extracted is:
 - `.github/actions/setup-soldr/resolve_setup.py`
 - `.github/actions/setup-soldr/ensure_rust_toolchain.py`
 - `.github/actions/setup-soldr/ensure_soldr.py`
+- `.github/actions/setup-soldr/install_tool_shims.py`
 - `.github/actions/setup-soldr/verify_soldr.py`
 
 The current smoke validation stays in this repository and is not copied into the public action repository:
@@ -53,6 +54,7 @@ setup-soldr/
             |-- resolve_setup.py
             |-- ensure_rust_toolchain.py
             |-- ensure_soldr.py
+            |-- install_tool_shims.py
             `-- verify_soldr.py
 ```
 
@@ -91,6 +93,7 @@ steps:
 | `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
 | `target-cache-mode` | Target cache mode. Default `"hot"` caches Cargo freshness metadata and lightweight type metadata; `"full"` caches the whole `target-dir`; `"off"` disables target caching. |
 | `target-dir` | Cargo target directory restored by `target-cache`. Default `"target"`. |
+| `tool-shims` | Optional PATH shim mode. Set to `"cargo"` to make later `cargo ...` steps run through `soldr cargo ...`; default `"false"`. |
 
 The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v0` beta contract and should not be documented in the extracted public action README.
 
@@ -108,6 +111,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. Empty only when `build-cache` or `target-cache` is explicitly disabled. |
 | `target-cache-mode` | Effective target cache mode. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
+| `tool-shims-dir` | Directory containing generated tool shims when enabled. |
 
 ### Required Behavior
 
@@ -119,6 +123,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - put the installed `soldr` binary on `PATH`
 - restore and save the action-managed cache/state root when `cache: true`
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
+- when `tool-shims: cargo` is enabled, resolve the real Cargo binary before prepending the generated shim directory to `PATH`, then export `SOLDR_REAL_CARGO` so Soldr avoids recursive shim lookup
 - when `build-cache: true` (the default), restore the Soldr-owned zccache cache root at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
 - when `build-cache: true` and `target-cache: true` (the defaults), restore a bounded hot Cargo target cache at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and lightweight metadata without archiving the full `target/` tree. `target-cache-mode: full` remains available only for tightly scoped jobs where the whole target directory is known to stay bounded.
 

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -10,6 +10,7 @@ HELPER_SCRIPT_PATHS = (
     Path('.github/actions/setup-soldr/resolve_setup.py'),
     Path('.github/actions/setup-soldr/ensure_rust_toolchain.py'),
     Path('.github/actions/setup-soldr/ensure_soldr.py'),
+    Path('.github/actions/setup-soldr/install_tool_shims.py'),
     Path('.github/actions/setup-soldr/verify_soldr.py'),
 )
 
@@ -100,6 +101,7 @@ jobs:
 | `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. |
 | `target-cache-mode` | Target cache mode. Default `hot` caches Cargo freshness metadata and lightweight type metadata; `full` caches the whole `target-dir`; `off` disables target caching. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
+| `tool-shims` | Optional PATH shim mode. Set to `cargo` to make later `cargo ...` steps run through `soldr cargo ...`; default `false`. |
 
 ## Outputs
 
@@ -113,6 +115,7 @@ jobs:
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. |
 | `target-cache-mode` | Effective target cache mode. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
+| `tool-shims-dir` | Directory containing generated tool shims when enabled. |
 
 ## Notes
 
@@ -122,6 +125,7 @@ jobs:
 - The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
 - The default target cache mode is `hot`, which avoids archiving the full Cargo `target/` tree and caches only Cargo freshness metadata plus lightweight type metadata. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
+- `tool-shims: cargo` prepends a Cargo shim for existing workflows that cannot rewrite every `cargo ...` command to `soldr cargo ...`.
 - A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.
 
 ## Development

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -84,6 +84,7 @@ jobs:
 | `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. |
 | `target-cache-mode` | Target cache mode. Default `hot` caches Cargo freshness metadata and lightweight type metadata; `full` caches the whole `target-dir`; `off` disables target caching. |
 | `target-dir` | Cargo target directory restored by `target-cache`. |
+| `tool-shims` | Optional PATH shim mode. Set to `cargo` to make later `cargo ...` steps run through `soldr cargo ...`; default `false`. |
 
 ## Outputs
 
@@ -97,6 +98,7 @@ jobs:
 | `target-cache-hit` | Whether the Cargo target directory cache was restored. |
 | `target-cache-mode` | Effective target cache mode. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
+| `tool-shims-dir` | Directory containing generated tool shims when enabled. |
 
 ## Notes
 
@@ -106,6 +108,7 @@ jobs:
 - The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
 - The default target cache mode is `hot`, which avoids archiving the full Cargo `target/` tree and caches only Cargo freshness metadata plus lightweight type metadata. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
+- `tool-shims: cargo` prepends a Cargo shim for existing workflows that cannot rewrite every `cargo ...` command to `soldr cargo ...`.
 - A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.
 
 ## Development

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -64,6 +64,13 @@ inputs:
     description: Cargo target directory restored by target-cache.
     required: false
     default: target
+  tool-shims:
+    description: >
+      Optional PATH shim mode for existing workflows. Set to "cargo" to make
+      later `cargo ...` steps run through `soldr cargo ...` without rewriting
+      them. Default "false" leaves PATH unchanged.
+    required: false
+    default: "false"
 outputs:
   soldr-path:
     description: Installed Soldr binary path added to PATH for later steps.
@@ -96,6 +103,9 @@ outputs:
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
     value: ${{ steps.resolve.outputs.toolchain }}
+  tool-shims-dir:
+    description: Directory containing generated tool shims when tool-shims is enabled.
+    value: ${{ steps.resolve.outputs.shim_dir }}
 runs:
   using: composite
   steps:
@@ -111,6 +121,7 @@ runs:
         INPUT_TARGET_CACHE: ${{ inputs.target-cache }}
         INPUT_TARGET_CACHE_MODE: ${{ inputs.target-cache-mode }}
         INPUT_TARGET_DIR: ${{ inputs.target-dir }}
+        INPUT_TOOL_SHIMS: ${{ inputs.tool-shims }}
         ACTION_WORKSPACE: ${{ github.workspace }}
         ACTION_OS: ${{ runner.os }}
         ACTION_ARCH: ${{ runner.arch }}
@@ -162,6 +173,14 @@ runs:
       env:
         SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/verify_soldr.py"
+
+    - id: tool-shims
+      shell: pwsh
+      env:
+        SETUP_SOLDR_PATH: ${{ steps.resolve.outputs.soldr_path }}
+        SETUP_SOLDR_SHIM_DIR: ${{ steps.resolve.outputs.shim_dir }}
+        SETUP_SOLDR_TOOL_SHIMS: ${{ inputs.tool-shims }}
+      run: python "${{ github.action_path }}/.github/actions/setup-soldr/install_tool_shims.py"
 
     - id: zccache-warm-target
       if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -123,6 +123,7 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert (cache_root / "cargo" / "bin").is_dir()
     assert (cache_root / "rustup").is_dir()
     assert (cache_root / "bin").is_dir()
+    assert (cache_root / "shims").is_dir()
 
     outputs = github_output.read_text(encoding="utf-8")
     assert f"cache_root={cache_root}" in outputs
@@ -133,6 +134,7 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert "build_cache_restore_key_os_arch=setup-soldr-buildcache-v1-linux-x64-" in outputs
     assert f"build_cache_path={cache_root / 'soldr' / 'cache' / 'zccache'}" in outputs
     assert f"target_cache_path={workspace / 'custom-target'}" in outputs
+    assert f"shim_dir={cache_root / 'shims'}" in outputs
     assert "target_cache_key=setup-soldr-targetcache-hot-v1-linux-x64-" in outputs
     assert "target_cache_enabled=true" in outputs
     assert "target_cache_mode=hot" in outputs

--- a/tests/test_setup_soldr_exporter.py
+++ b/tests/test_setup_soldr_exporter.py
@@ -33,6 +33,7 @@ def test_export_bundle_creates_expected_public_repo_layout(tmp_path: Path) -> No
     ) == [
         ".github/actions/setup-soldr/ensure_rust_toolchain.py",
         ".github/actions/setup-soldr/ensure_soldr.py",
+        ".github/actions/setup-soldr/install_tool_shims.py",
         ".github/actions/setup-soldr/resolve_setup.py",
         ".github/actions/setup-soldr/verify_soldr.py",
         "LICENSE",

--- a/tests/test_setup_soldr_install_tool_shims.py
+++ b/tests/test_setup_soldr_install_tool_shims.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "install_tool_shims.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("install_tool_shims", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_requested_tools_expands_groups() -> None:
+    module = _load_module()
+
+    assert module.parse_requested_tools("false") == []
+    assert module.parse_requested_tools("cargo") == ["cargo"]
+    assert module.parse_requested_tools("cargo,rustc,cargo") == ["cargo", "rustc"]
+    assert module.parse_requested_tools("rust") == [
+        "cargo",
+        "rustc",
+        "rustfmt",
+        "clippy-driver",
+        "rustdoc",
+    ]
+
+
+def test_tool_env_name_sanitizes_tool_names() -> None:
+    module = _load_module()
+
+    assert module.tool_env_name("cargo") == "SOLDR_REAL_CARGO"
+    assert module.tool_env_name("clippy-driver") == "SOLDR_REAL_CLIPPY_DRIVER"
+
+
+def test_main_writes_cargo_shim_and_real_tool_env(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_module()
+    github_env = tmp_path / "github.env"
+    github_path = tmp_path / "github.path"
+    shim_dir = tmp_path / "shims"
+    real_cargo = tmp_path / ("cargo.exe" if os.name == "nt" else "cargo")
+    real_cargo.write_text("real cargo", encoding="utf-8")
+
+    monkeypatch.setenv("SETUP_SOLDR_TOOL_SHIMS", "cargo")
+    monkeypatch.setenv("SETUP_SOLDR_PATH", str(tmp_path / "soldr"))
+    monkeypatch.setenv("SETUP_SOLDR_SHIM_DIR", str(shim_dir))
+    monkeypatch.setenv("GITHUB_ENV", str(github_env))
+    monkeypatch.setenv("GITHUB_PATH", str(github_path))
+    monkeypatch.setattr(module, "resolve_tool", lambda tool: str(real_cargo))
+
+    module.main()
+
+    assert f"SOLDR_REAL_CARGO={real_cargo}\n" == github_env.read_text(encoding="utf-8")
+    assert f"{shim_dir}\n" == github_path.read_text(encoding="utf-8")
+
+    shim_name = "cargo.cmd" if os.name == "nt" else "cargo"
+    shim = shim_dir / shim_name
+    text = shim.read_text(encoding="utf-8")
+    assert "soldr" in text
+    assert "cargo" in text
+    if os.name != "nt":
+        assert os.access(shim, os.X_OK)


### PR DESCRIPTION
## Summary
- add opt-in `tool-shims` support to setup-soldr, with a generated Cargo PATH shim that routes `cargo ...` to `soldr cargo ...`
- export real tool paths such as `SOLDR_REAL_CARGO` so Soldr bypasses its own shim and avoids recursive PATH lookup
- skip zccache startup for non-build Cargo commands routed through Soldr, while preserving caching for build-like commands after global Cargo flags
- document the shim mode and include it in the public setup-soldr exporter bundle

## Verification
- `cargo fmt`
- `python -m pytest tests -q`
- `cargo test -p soldr-cli --test cli cargo_front_door_uses_real_tool_overrides_before_path_probe`
- `cargo test -p soldr-cli --test cli cargo_front_door_does_not_start_cache_for_non_build_subcommands`
- `cargo test -p soldr-cli --test cli cargo_front_door_detects_build_after_global_cargo_options`
- YAML parse: `action.yml`, `_bootstrap-e2e.yml`, `release-auto.yml`, `ci.yml`
- `actionlint .github/workflows/_bootstrap-e2e.yml .github/workflows/release-auto.yml .github/workflows/ci.yml`
- `git diff --check`