### PR TITLE
Update managed zccache to 1.3.7

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -121,7 +121,7 @@ jobs:
           shared-key: ${{ inputs.target }}
           save-cache: ${{ inputs.save_cache }}
           target-dir: soldr/target
-          zccache-version: "1.3.4"
+          zccache-version: "1.3.7"
 
       - name: Share bootstrap zccache binary with soldr
         shell: pwsh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1264,7 +1264,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.3.4");
+    assert_eq!(json["managed_zccache_version"], "1.3.7");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -1359,7 +1359,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.3.4");
+    assert_eq!(json["managed_zccache_version"], "1.3.7");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.4";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.7";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),


### PR DESCRIPTION
## Summary
- update managed zccache from 1.3.4 to 1.3.7
- bump soldr workspace patch version from 0.7.6 to 0.7.7 for pipeline integration
- update CLI JSON status/cache assertions and bootstrap E2E zccache input to match the new managed version

## Release Check
- Confirmed `zackees/zccache` release tag `1.3.7` is published and marked latest: https://github.com/zackees/zccache/releases/tag/1.3.7

## Base
- Requested remote master rebase; this repository has no `origin/master`, so this branch was rebased from the remote default `origin/main` at `3a2d787`.

## Verification
- `cargo check --workspace`
- `cargo check --workspace --locked`
- `cargo test -p soldr-fetch`
- `cargo test -p soldr-cli status_json_reports_stable_machine_fields`
- `cargo test -p soldr-cli cache_json_reports_managed_zccache_status`
- `cargo fmt --check`
- YAML parse for `.github/workflows/_bootstrap-e2e.yml`
- `actionlint .github/workflows/_bootstrap-e2e.yml`
- `git diff --check`
