### PR TITLE
Sync npm package version with release metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      - name: Check npm package metadata
+        run: node scripts/test-npm-package.js
+
       - name: Run clippy
         run: soldr cargo clippy --workspace --all-targets --locked -- -D warnings
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - Cargo.toml
+      - package.json
   workflow_dispatch:
     inputs:
       force_pypi_publish:
@@ -31,9 +32,11 @@ jobs:
       should_release: ${{ steps.validate.outputs.should_release }}
       should_publish_github_release: ${{ steps.validate.outputs.should_publish_github_release }}
       should_publish_pypi: ${{ steps.validate.outputs.should_publish_pypi }}
+      should_publish_npm: ${{ steps.validate.outputs.should_publish_npm }}
       tag_exists: ${{ steps.validate.outputs.tag_exists }}
       pypi_has_version: ${{ steps.validate.outputs.pypi_has_version }}
       pypi_file_count: ${{ steps.validate.outputs.pypi_file_count }}
+      npm_has_version: ${{ steps.validate.outputs.npm_has_version }}
       version: ${{ steps.validate.outputs.version }}
       commit_sha: ${{ steps.validate.outputs.commit_sha }}
 
@@ -69,6 +72,17 @@ jobs:
             exit 1
           fi
 
+          npm_package_name="$(jq -r '.name // ""' package.json)"
+          npm_package_version="$(jq -r '.version // ""' package.json)"
+          if [[ -z "$npm_package_name" || -z "$npm_package_version" ]]; then
+            echo "failed to derive npm package metadata from package.json" >&2
+            exit 1
+          fi
+          if [[ "$npm_package_version" != "$cargo_version" ]]; then
+            echo "package.json version ($npm_package_version) must match Cargo.toml ($cargo_version)" >&2
+            exit 1
+          fi
+
           tag_exists=false
           if git ls-remote --exit-code --tags origin "$version" >/dev/null 2>&1; then
             tag_exists=true
@@ -90,6 +104,13 @@ jobs:
             pypi_has_version=true
           fi
 
+          npm_package_uri="$(jq -rn --arg value "$npm_package_name" '$value | @uri')"
+          npm_json="$(curl -fsSL "https://registry.npmjs.org/${npm_package_uri}")"
+          npm_has_version=false
+          if jq -e --arg candidate "$cargo_version" '.versions[$candidate] != null' <<< "$npm_json" >/dev/null; then
+            npm_has_version=true
+          fi
+
           should_publish_github_release=false
           if [[ "$tag_exists" != "true" ]]; then
             should_publish_github_release=true
@@ -100,8 +121,13 @@ jobs:
             should_publish_pypi=true
           fi
 
+          should_publish_npm=false
+          if [[ "$npm_has_version" != "true" ]]; then
+            should_publish_npm=true
+          fi
+
           should_release=false
-          if [[ "$should_publish_github_release" == "true" || "$should_publish_pypi" == "true" ]]; then
+          if [[ "$should_publish_github_release" == "true" || "$should_publish_pypi" == "true" || "$should_publish_npm" == "true" ]]; then
             should_release=true
           fi
 
@@ -111,19 +137,24 @@ jobs:
             echo "- candidate version: \`$version\`"
             echo "- current PyPI latest: \`v${pypi_version}\`"
             echo "- PyPI files for candidate: \`$pypi_file_count\`"
+            echo "- npm package: \`$npm_package_name@$npm_package_version\`"
+            echo "- npm has candidate: \`$npm_has_version\`"
             echo "- GitHub tag exists: \`$tag_exists\`"
             echo "- force PyPI publish: \`$force_pypi_publish\`"
             echo "- publish GitHub release assets: \`$should_publish_github_release\`"
             echo "- publish PyPI wheels: \`$should_publish_pypi\`"
+            echo "- publish npm package: \`$should_publish_npm\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
           {
             echo "should_release=$should_release"
             echo "should_publish_github_release=$should_publish_github_release"
             echo "should_publish_pypi=$should_publish_pypi"
+            echo "should_publish_npm=$should_publish_npm"
             echo "tag_exists=$tag_exists"
             echo "pypi_has_version=$pypi_has_version"
             echo "pypi_file_count=$pypi_file_count"
+            echo "npm_has_version=$npm_has_version"
             echo "version=$version"
             echo "commit_sha=$commit_sha"
           } >> "$GITHUB_OUTPUT"
@@ -352,8 +383,9 @@ jobs:
     name: Publish npm package
     needs:
       - prepare
+      - build
       - publish
-    if: needs.prepare.outputs.should_release == 'true' && needs.prepare.outputs.tag_exists == 'false'
+    if: always() && needs.prepare.outputs.should_publish_npm == 'true' && ((needs.prepare.outputs.should_publish_github_release == 'true' && needs.publish.result == 'success') || (needs.prepare.outputs.should_publish_github_release != 'true' && needs.build.result == 'success'))
     runs-on: ubuntu-24.04
     environment: release
     permissions:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",

--- a/scripts/test-npm-package.js
+++ b/scripts/test-npm-package.js
@@ -9,10 +9,56 @@ const root = path.resolve(__dirname, "..");
 const pkg = require(path.join(root, "package.json"));
 const install = require(path.join(root, "scripts", "install.js"));
 
+function tomlSection(toml, sectionName) {
+  const header = `[${sectionName}]`;
+  const lines = toml.split(/\r?\n/);
+  const body = [];
+  let found = false;
+
+  for (const line of lines) {
+    if (/^\s*\[.*\]\s*$/.test(line)) {
+      if (found) {
+        break;
+      }
+      found = line.trim() === header;
+      continue;
+    }
+
+    if (found) {
+      body.push(line);
+    }
+  }
+
+  return found ? body.join("\n") : null;
+}
+
 const cargoToml = fs.readFileSync(path.join(root, "Cargo.toml"), "utf8");
 const cargoVersion = cargoToml.match(/\[workspace\.package\][\s\S]*?^version = "([^"]+)"/m);
 assert(cargoVersion, "workspace package version not found in Cargo.toml");
 assert.strictEqual(pkg.version, cargoVersion[1], "package.json version must match Cargo.toml");
+
+const pyprojectToml = fs.readFileSync(path.join(root, "pyproject.toml"), "utf8");
+const pyprojectProject = tomlSection(pyprojectToml, "project");
+assert(pyprojectProject, "[project] section not found in pyproject.toml");
+
+assert(
+  !/^\s*version\s*=/.test(pyprojectProject),
+  'pyproject.toml [project] must not hardcode version; PyPI must derive it from Cargo.toml',
+);
+
+const dynamicVersion = pyprojectProject.match(/^\s*dynamic\s*=\s*\[([^\]]*)\]\s*$/m);
+assert(
+  dynamicVersion,
+  'pyproject.toml [project] must declare dynamic = ["version"] so PyPI derives from Cargo.toml',
+);
+
+const dynamicItems = [...dynamicVersion[1].matchAll(/"([^"]+)"|'([^']+)'/g)].map(
+  (match) => match[1] || match[2],
+);
+assert(
+  dynamicItems.includes("version"),
+  'pyproject.toml [project] dynamic metadata must include "version"',
+);
 
 assert.strictEqual(pkg.name, "@zackees/soldr");
 assert.strictEqual(pkg.license, "BSD-3-Clause");
@@ -42,4 +88,4 @@ assert.strictEqual(
   "abc123",
 );
 
-console.log("npm package checks passed");
+console.log("npm package and PyPI version checks passed");


### PR DESCRIPTION
## Summary
- sync `package.json` to the Cargo workspace version `0.7.7`
- extend the npm package lint so it also verifies `pyproject.toml` keeps PyPI version metadata dynamic from Cargo instead of hardcoding a separate version
- run the existing npm package metadata/version check in CI lint so Cargo/package/PyPI drift is caught before release
- include `package.json` in the autonomous release trigger paths
- teach release detection to check npm registry state and publish npm when the package version is missing, even if the GitHub tag already exists

## Failure
Fixes the publish failure from:
https://github.com/zackees/soldr/actions/runs/24796758854/job/72570386066

The failing assertion was:

```text
package.json version must match Cargo.toml
'0.7.6' !== '0.7.7'
```

## Notes
`v0.7.7` already exists as a GitHub tag, while npm registry lookup reports `@zackees/soldr@0.7.7` is not present. The updated release workflow now models npm as its own publish target so a package-only recovery can proceed.

`pyproject.toml` uses `dynamic = [version]`, so maturin derives the PyPI version from Cargo metadata. The npm package lint now fails if that contract changes or a hardcoded `[project].version` is introduced.

## Verification
- `node scripts/test-npm-package.js`
- `npm run test:npm-package`
- `npm pack --dry-run`
- release prepare npm-registry conditional check for missing `@zackees/soldr@0.7.7`
- YAML parse for `ci.yml` and `release-auto.yml`
- `actionlint .github/workflows/ci.yml .github/workflows/release-auto.yml`
- `git diff --check`