### PR TITLE
ci: cache setup-soldr dogfood zccache

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           cache: true
           # Keep the action runtime cache separate from the Soldr build under
-          # test. The dogfood build below overrides SOLDR_CACHE_DIR and clears
-          # ZCCACHE_CACHE_DIR so soldr owns zccache under that separate root.
+          # test. The dogfood build below overrides SOLDR_CACHE_DIR so soldr
+          # owns zccache under that separate root.
           cache-dir: ${{ runner.temp }}/setup-soldr-action-state
           cache-key-suffix: dogfood-action-state
           build-cache: false
@@ -84,15 +84,35 @@ jobs:
             throw "setup-soldr action cache must be disjoint from the Soldr build-under-test cache"
           }
           New-Item -ItemType Directory -Force -Path $buildCache | Out-Null
+          $zccacheDir = Join-Path -Path (Join-Path -Path $buildCache -ChildPath "cache") -ChildPath "zccache"
+          New-Item -ItemType Directory -Force -Path $zccacheDir | Out-Null
           Write-Host "action-cache=$actionCache"
           Write-Host "build-under-test-cache=$buildCache"
+          Write-Host "build-under-test-zccache=$zccacheDir"
+
+      - id: dogfood-build-cache
+        name: Restore dogfood build cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ runner.temp }}/soldr-build-under-test/cache/zccache
+          key: setup-soldr-dogfood-zccache-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
+          restore-keys: |
+            setup-soldr-dogfood-zccache-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            setup-soldr-dogfood-zccache-v1-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Build through soldr
         shell: pwsh
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
-          ZCCACHE_CACHE_DIR: ""
-        run: soldr cargo build --package soldr-cli --locked
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test/cache/zccache
+        run: |
+          Write-Host "dogfood-build-cache-hit=${{ steps.dogfood-build-cache.outputs.cache-hit }}"
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          soldr cargo build --package soldr-cli --locked
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Write-Host ([string]::Format([Globalization.CultureInfo]::InvariantCulture, "dogfood-build-seconds={0:F3}", $timer.Elapsed.TotalSeconds))
+          exit $exitCode
 
       - name: Test through soldr
         shell: pwsh
@@ -100,14 +120,19 @@ jobs:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
         run: |
           Remove-Item Env:ZCCACHE_CACHE_DIR -ErrorAction SilentlyContinue
+          $timer = [Diagnostics.Stopwatch]::StartNew()
           soldr --no-cache cargo test -p soldr-cli --test cli --locked
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Write-Host ([string]::Format([Globalization.CultureInfo]::InvariantCulture, "dogfood-test-seconds={0:F3}", $timer.Elapsed.TotalSeconds))
+          exit $exitCode
 
       - name: Show dogfood cache status
         if: always()
         shell: pwsh
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
-          ZCCACHE_CACHE_DIR: ""
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test/cache/zccache
         run: |
           $soldr = Get-Command soldr -ErrorAction SilentlyContinue
           if (-not $soldr) {
@@ -119,3 +144,24 @@ jobs:
             Write-Host "soldr cache status unavailable after dogfood build"
             exit 0
           }
+
+      - name: Stop dogfood zccache before cache save
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test/cache/zccache
+        run: |
+          $exeName = if ($IsWindows) { "zccache.exe" } else { "zccache" }
+          $zccache = $null
+          $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
+          if (Test-Path -LiteralPath $soldrBin) {
+            $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
+              Select-Object -First 1 -ExpandProperty FullName
+          }
+          if ([string]::IsNullOrWhiteSpace($zccache)) {
+            Write-Host "zccache binary is unavailable; nothing to stop."
+            exit 0
+          }
+          & $zccache stop

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -122,6 +122,13 @@ def test_setup_soldr_smoke_tests_disable_nested_cache() -> None:
 
     assert "Remove-Item Env:ZCCACHE_CACHE_DIR" in workflow
     assert "soldr --no-cache cargo test -p soldr-cli --test cli --locked" in workflow
+    assert "id: dogfood-build-cache" in workflow
+    assert "setup-soldr-dogfood-zccache-v1-" in workflow
+    assert "dogfood-build-cache-hit=" in workflow
+    assert "dogfood-build-seconds=" in workflow
+    assert "dogfood-test-seconds=" in workflow
+    assert "Stop dogfood zccache before cache save" in workflow
+    assert "& $zccache stop" in workflow
 
 
 def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- restore and save an isolated dogfood zccache cache for the `Setup Soldr Action` smoke build
- print `dogfood-build-cache-hit`, `dogfood-build-seconds`, and `dogfood-test-seconds` in the workflow logs
- stop the dogfood zccache daemon before the cache post step saves files, especially for Windows

## Investigation
Evidence run: https://github.com/zackees/soldr/actions/runs/24799467070?pr=202
PR head: `a42ee40a3218718c689c1544b2962357e124e7d7`

| Platform | Queue/start latency from run creation | setup-soldr step | Build through soldr | Test through soldr | Cache evidence |
| --- | ---: | ---: | ---: | ---: | --- |
| Linux | 3s | 15s | 4m52s | 2s | setup-state hit; build/target cache disabled; zccache 0 cached / 181 cold |
| Windows | 4s | 21s | 6m57s | 5s | setup-state miss; rustup downloaded toolchain; build/target cache disabled; zccache 0 cached / 182 cold |
| macOS | 11m43s | 16s | 5m41s | 2s | setup-state hit; build/target cache disabled; zccache 0 cached / 179 cold |

Findings:
- macOS was mostly runner queue/availability before the job started; after runner acquisition its build was slower than Linux but faster than Windows.
- Windows did not restore the setup-state cache in the evidence run and installed Rust during verification, but the largest delay was still the cold dogfood build.
- The workflow intentionally set `build-cache: false` and `target-cache: false` for the setup action, and the dogfood build used a separate `SOLDR_CACHE_DIR` without any Actions cache restore. That made every platform report a 0% zccache hit rate for the dogfood build.

This PR keeps the action runtime cache isolated while giving the dogfood build its own cache lineage and diagnostics.

Closes #209

## Verification
- `pytest`
- `actionlint .github/workflows/setup-soldr-action.yml`
- `git diff --check`