### PR TITLE
ci: adopt setup-soldr v0.2.0 and bump to 0.7.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zackees/setup-soldr@1937c19529f3690df5553a36dd33f39ccb20b070 # v0.1.0 / v0
+      - uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2 # v0.2.0 / v0
         with:
           # Formatting does not benefit from a restored target directory, but
           # clippy still uses soldr's compilation cache below.
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zackees/setup-soldr@1937c19529f3690df5553a36dd33f39ccb20b070 # v0.1.0 / v0
+      - uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2 # v0.2.0 / v0
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zackees/setup-soldr@1937c19529f3690df5553a36dd33f39ccb20b070 # v0.1.0 / v0
+      - uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2 # v0.2.0 / v0
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked
@@ -97,7 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zackees/setup-soldr@1937c19529f3690df5553a36dd33f39ccb20b070 # v0.1.0 / v0
+      - uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2 # v0.2.0 / v0
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: setup
-        # This is zackees/setup-soldr@v0.1.0 / @v0 pinned to a full SHA
+        # This is zackees/setup-soldr@v0.2.0 / @v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@1937c19529f3690df5553a36dd33f39ccb20b070
+        uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2
         with:
           cache: true
           # Keep the action runtime cache separate from the Soldr build under

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.7"
+version = "0.7.8"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",

--- a/tests/test_setup_soldr_pins.py
+++ b/tests/test_setup_soldr_pins.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OLD_SETUP_SOLDR_SHA = "1937c19529f3690df5553a36dd33f39ccb20b070"
+SETUP_SOLDR_V0_2_SHA = "13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2"
+
+
+def test_workflows_pin_setup_soldr_v0_2() -> None:
+    workflow_paths = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+    workflow_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in workflow_paths
+    )
+
+    assert OLD_SETUP_SOLDR_SHA not in workflow_text
+    assert workflow_text.count(f"zackees/setup-soldr@{SETUP_SOLDR_V0_2_SHA}") == 5
+    assert "v0.1.0 / v0" not in workflow_text
+    assert "v0.2.0 / v0" in workflow_text


### PR DESCRIPTION
## Summary
- update soldr workflow pins from setup-soldr v0.1.0 SHA to the v0.2.0 hot target-cache SHA
- refresh pinned-action comments to reference v0.2.0 / v0
- add a workflow pin regression test so the old v0.1.0 SHA and comments do not come back
- bump soldr to 0.7.8 across Cargo and npm; PyPI remains dynamically derived from the Cargo package metadata

## Source-sync note
- Compared the public setup-soldr v0.2.0 bundle against the in-repo action source.
- I did not blindly sync the generated action source in this PR because the public v0.2.0 bundle predates newer in-repo `tool-shims` support; copying it back would remove local action functionality. This PR keeps issue #212 scoped to adopting the released hot-cache fix in CI usage.

Fixes #212

## Verification
- `python -m pytest tests/test_setup_soldr_pins.py`
- `cargo fmt --check`
- Cargo/npm/PyPI version check: Cargo metadata reports `0.7.8`, npm package reports `0.7.8`, and `pyproject.toml` keeps `dynamic = [version]`