### PR TITLE
Stabilize CI soldr path test diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  RUST_BACKTRACE: "1"
+
 jobs:
   lint:
     name: Lint

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -490,7 +490,11 @@ pub struct SoldrPaths {
 
 impl SoldrPaths {
     pub fn new() -> Result<Self, SoldrError> {
-        let root = soldr_root_from_env_var(std::env::var_os(SOLDR_CACHE_DIR_ENV_VAR).as_deref())
+        Self::from_root_env_value(std::env::var_os(SOLDR_CACHE_DIR_ENV_VAR).as_deref())
+    }
+
+    fn from_root_env_value(value: Option<&OsStr>) -> Result<Self, SoldrError> {
+        let root = soldr_root_from_env_var(value)
             .unwrap_or_else(|| home_dir().map(|home| home.join(".soldr")))?;
         Ok(Self::with_root(root))
     }
@@ -740,7 +744,7 @@ mod tests {
 
     #[test]
     fn test_paths() {
-        let paths = SoldrPaths::new().unwrap();
+        let paths = SoldrPaths::from_root_env_value(None).unwrap();
         assert!(paths.root.ends_with(".soldr"));
         assert!(paths.bin.ends_with("bin"));
         assert!(paths.cache.ends_with("cache"));


### PR DESCRIPTION
## Summary

- make `soldr-core::tests::test_paths` independent of ambient `SOLDR_CACHE_DIR`
- keep `SoldrPaths::new()` behavior unchanged while testing the default-root path directly
- set `RUST_BACKTRACE=1` in CI so unit-test failures include backtraces

## CI failure investigated

Run/job: https://github.com/zackees/soldr/actions/runs/24813381949/job/72622742092

The failed `Linux x64` job had `SOLDR_CACHE_DIR=/home/runner/work/_temp/setup-soldr/soldr` exported by setup-soldr. `SoldrPaths::new()` correctly honored that override, but `test_paths` asserted the root ends with `.soldr`, which only holds for the default home-root path.

## Validation

- `cargo test -p soldr-core --lib`
- `$env:SOLDR_CACHE_DIR='C:\temp\setup-soldr\soldr'; cargo test -p soldr-core --lib test_paths`
- `cargo fmt --check`
- `git diff --check`