### PR TITLE
Document release version tag workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,13 @@ Anything not registered falls through the generic External subcommand, which res
 - **Always report the merge URL**: The final user-facing summary must include the PR URL the user should open to review and merge the work.
 - **Fallback if PR creation is blocked**: If the GitHub integration cannot open the PR directly, the agent must still push the branch and provide the exact GitHub URL the user needs to open or complete the PR manually.
 
+## Release Publishing Rules
+
+- **Release PRs must bump the package version**: A release is triggered by merging a PR to `main` that bumps `[workspace.package].version` in `Cargo.toml` and the matching `"version"` in `package.json` to a version that is not already published.
+- **Do not rely on workflow dispatch alone**: Running `Autonomous Release` manually without an unpublished package version will make the prepare job set `should_release=false`, so build and publish jobs will be skipped.
+- **Tags are release outputs, not normal agent inputs**: The release workflow derives `vX.Y.Z` from `Cargo.toml` and creates the matching GitHub tag and release when the tag does not already exist. Do not manually create or push `vX.Y.Z` tags unless the owner explicitly asks for a recovery operation.
+- **Check release state before claiming a release is ready**: Verify `Cargo.toml`, `package.json`, PyPI `soldr`, npm `@zackees/soldr`, and `git ls-remote --tags origin vX.Y.Z`. If the candidate version or tag already exists, either bump to the next patch version or stop and report the conflict.
+
 ## Toolchain
 
 - Rust 1.94.1 (rust-toolchain.toml), edition 2021, MSRV 1.75

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -92,6 +92,16 @@ Before changing the release workflow:
 
 If the live GitHub-side or PyPI-side controls drift from the documented flow, stop and report the drift instead of assuming the release posture is intact.
 
+When preparing a normal release:
+
+1. Bump `[workspace.package].version` in `Cargo.toml`.
+2. Bump `package.json` to the exact same version.
+3. Confirm the candidate is not already published on PyPI as `soldr` and not already published on npm as `@zackees/soldr`.
+4. Confirm `git ls-remote --tags origin vX.Y.Z` does not find the candidate tag.
+5. Open and merge the version-bump PR to `main`; the release workflow creates the `vX.Y.Z` tag and GitHub Release from that merge commit.
+
+If `Autonomous Release` is run manually without an unpublished package version, the prepare job will set `should_release=false` and all build/publish jobs will be skipped. That is expected behavior, not a release failure. For a new release, prepare a new version-bump PR instead of manually rerunning the workflow.
+
 ## Verification Checklist
 
 After an autonomous release:


### PR DESCRIPTION
## Summary

- document the release/version/tag requirements in the agent-facing `CLAUDE.md`
- add normal release-prep steps to `RELEASE.md`
- clarify that manual `Autonomous Release` dispatch without an unpublished version sets `should_release=false` and skips build/publish jobs

## Validation

- `git diff --check`