### PR TITLE
Bump release version to 0.7.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "clap",
  "serde",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "serde",
  "tempfile",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.8"
+version = "0.7.9"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

- bump workspace/package release version to `0.7.9`
- update `Cargo.lock` workspace crate package entries to `0.7.9`
- keep managed zccache pinned at `1.3.8`

## Release readiness

Checked before opening:
- PyPI latest `soldr` is `0.7.8`; `0.7.9` is not present
- npm `@zackees/soldr@0.7.9` is not present
- remote tag `v0.7.9` is not present

Merging this PR to `main` should trigger `.github/workflows/release-auto.yml` and allow it to create `v0.7.9` plus publish artifacts.

## Validation

- `node scripts/test-npm-package.js`
- `cargo metadata --locked --no-deps`
- `cargo test -p soldr-core --lib test_version`
- `git diff --check`