### PR TITLE
Implement Rust artifact plan integration

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -74,36 +74,66 @@ def _short_file_hash(path: Path, missing: str) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
 
 
-HOT_TARGET_CACHE_PATTERNS = (
-    ".rustc_info.json",
-    "CACHEDIR.TAG",
-    "**/.fingerprint/**",
-    "**/deps/*.d",
-    "**/deps/*.rmeta",
-    "**/build/**/output",
-    "**/build/**/invoked.timestamp",
-    "**/build/**/root-output",
-    "!**/incremental/**",
-)
+def _short_json_hash(value: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+
+
+def _workspace_manifest_hash(workspace: Path) -> str:
+    hasher = hashlib.sha256()
+    matched = False
+    ignored_dirs = {".git", "target", ".soldr", "node_modules"}
+    for path in sorted(workspace.rglob("Cargo.toml")):
+        if any(part in ignored_dirs for part in path.relative_to(workspace).parts):
+            continue
+        matched = True
+        relative = path.relative_to(workspace).as_posix()
+        hasher.update(relative.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(path.read_bytes())
+        hasher.update(b"\0")
+    return hasher.hexdigest()[:16] if matched else "no-manifest"
+
+
+def _cargo_config_hash(workspace: Path) -> str:
+    hasher = hashlib.sha256()
+    matched = False
+    for relative in (".cargo/config.toml", ".cargo/config"):
+        path = workspace / relative
+        if path.exists():
+            matched = True
+            hasher.update(relative.encode("utf-8"))
+            hasher.update(b"\0")
+            hasher.update(path.read_bytes())
+            hasher.update(b"\0")
+    return hasher.hexdigest()[:16] if matched else "no-config"
+
+
+def _target_env_hash() -> str:
+    relevant: dict[str, str] = {}
+    for name, value in os.environ.items():
+        if name in {
+            "CARGO_BUILD_TARGET",
+            "CARGO_ENCODED_RUSTFLAGS",
+            "CARGO_TARGET_DIR",
+            "RUSTFLAGS",
+        } or (name.startswith("CARGO_TARGET_") and name.endswith("_RUSTFLAGS")):
+            relevant[name] = value
+    return _short_json_hash(relevant)
 
 
 def normalize_target_cache_mode(value: str) -> str:
-    mode = value.strip().lower() or "hot"
-    if mode not in {"hot", "full", "off"}:
-        raise RuntimeError(
-            f"invalid target-cache-mode {value!r}; expected hot, full, or off"
+    mode = value.strip().lower() or "thin"
+    if mode == "hot":
+        print(
+            "setup-soldr: target-cache-mode 'hot' is deprecated; using 'thin'.",
+            flush=True,
         )
+        return "thin"
+    if mode not in {"thin", "full", "off"}:
+        raise RuntimeError(f"invalid target-cache-mode {value!r}; expected thin, full, or off")
     return mode
-
-
-def hot_target_cache_paths(target_cache_path: Path) -> str:
-    values: list[str] = []
-    for pattern in HOT_TARGET_CACHE_PATTERNS:
-        negate = pattern.startswith("!")
-        cleaned = pattern[1:] if negate else pattern
-        rendered = str(target_cache_path / cleaned)
-        values.append(f"!{rendered}" if negate else rendered)
-    return "\n".join(values)
 
 
 def _write_env(name: str, value: str) -> None:
@@ -141,8 +171,10 @@ def main() -> None:
     runner_temp = Path(os.environ.get("RUNNER_TEMP", workspace / ".tmp")).resolve()
 
     requested_cache_dir = os.environ.get("INPUT_CACHE_DIR", "").strip()
-    cache_root = Path(requested_cache_dir).expanduser().resolve() if requested_cache_dir else (
-        runner_temp / "setup-soldr"
+    cache_root = (
+        Path(requested_cache_dir).expanduser().resolve()
+        if requested_cache_dir
+        else (runner_temp / "setup-soldr")
     )
     soldr_root = cache_root / "soldr"
     cargo_home = cache_root / "cargo"
@@ -150,6 +182,7 @@ def main() -> None:
     bin_dir = cache_root / "bin"
     shim_dir = cache_root / "shims"
     zccache_cache_dir = soldr_root / "cache" / "zccache"
+    target_cache_bundle_path = cache_root.parent / f"{cache_root.name}-target-thin"
     soldr_binary = "soldr.exe" if os.name == "nt" else "soldr"
     soldr_path = bin_dir / soldr_binary
 
@@ -164,6 +197,7 @@ def main() -> None:
         bin_dir,
         shim_dir,
         zccache_cache_dir,
+        target_cache_bundle_path,
     ):
         path.mkdir(parents=True, exist_ok=True)
 
@@ -193,10 +227,13 @@ def main() -> None:
     cache_prefix = f"setup-soldr-v0-{runner_os}-{runner_arch}"
     cache_key = f"{cache_prefix}-{digest}"
     cargo_lock_hash = _short_file_hash(workspace / "Cargo.lock", "no-lock")
+    workspace_manifest_hash = _workspace_manifest_hash(workspace)
+    cargo_config_hash = _cargo_config_hash(workspace)
 
     suffix = os.environ.get("INPUT_CACHE_KEY_SUFFIX", "").strip()
+    sanitized_suffix = _sanitize_fragment(suffix) if suffix else ""
     if suffix:
-        cache_key = f"{cache_key}-{_sanitize_fragment(suffix)}"
+        cache_key = f"{cache_key}-{sanitized_suffix}"
 
     # Build-artifact cache (Soldr-owned zccache compilation cache).
     # Key shape: setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{sha}.
@@ -214,40 +251,77 @@ def main() -> None:
         target_cache_path = workspace / target_cache_path
     target_cache_path = target_cache_path.resolve()
     target_cache_mode = normalize_target_cache_mode(
-        os.environ.get("INPUT_TARGET_CACHE_MODE", "hot")
+        os.environ.get("INPUT_TARGET_CACHE_MODE", "thin")
     )
     target_cache_enabled = (
         os.environ.get("INPUT_TARGET_CACHE", "true").strip().lower()
         not in {"0", "false", "no", "off"}
         and target_cache_mode != "off"
     )
+    if target_cache_mode == "thin" and cargo_lock_hash == "no-lock":
+        print(
+            "setup-soldr: target-cache-mode 'thin' requires Cargo.lock; target cache disabled.",
+            flush=True,
+        )
+        target_cache_enabled = False
+
+    target_shape_hash = _short_json_hash(
+        {
+            "target_dir": str(target_cache_path),
+            "target_dir_input": target_dir_input,
+            "target_env": _target_env_hash(),
+        }
+    )
+    target_inputs_hash = _short_json_hash(
+        {
+            "cargo_config": cargo_config_hash,
+            "cargo_lock": cargo_lock_hash,
+            "manifest": workspace_manifest_hash,
+            "target_shape": target_shape_hash,
+            "toolchain": digest,
+        }
+    )
     if target_cache_mode == "off":
         target_cache_paths = str(target_cache_path)
         target_cache_effective_mode = "off"
         target_cache_prefix = f"setup-soldr-targetcache-off-v1-{runner_os}-{runner_arch}"
-        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+        target_cache_restore_key = ""
+        target_cache_key = f"{target_cache_prefix}-{target_inputs_hash}"
     elif target_cache_mode == "full":
         target_cache_paths = str(target_cache_path)
         target_cache_effective_mode = "full"
         target_cache_prefix = f"setup-soldr-targetcache-full-v1-{runner_os}-{runner_arch}"
-        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+        target_cache_suffix_fragment = f"{sanitized_suffix}-" if sanitized_suffix else ""
+        target_cache_lock_prefix = (
+            f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
+            f"{target_shape_hash}-{target_cache_suffix_fragment}"
+        )
+        target_cache_restore_key = target_cache_lock_prefix
+        target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
     else:
-        target_cache_paths = hot_target_cache_paths(target_cache_path)
-        target_cache_effective_mode = "hot"
-        target_paths_hash = hashlib.sha256(target_cache_paths.encode("utf-8")).hexdigest()[:16]
-        target_cache_prefix = f"setup-soldr-targetcache-hot-v1-{runner_os}-{runner_arch}"
-        target_cache_lock_prefix = f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-{target_paths_hash}-"
-    target_cache_key = f"{target_cache_lock_prefix}{github_sha}"
+        target_cache_paths = str(target_cache_bundle_path)
+        target_cache_effective_mode = "thin"
+        target_cache_prefix = f"setup-soldr-targetcache-thin-v1-{runner_os}-{runner_arch}"
+        target_cache_suffix_fragment = f"{sanitized_suffix}-" if sanitized_suffix else ""
+        target_cache_restore_key = (
+            f"{target_cache_prefix}-{target_inputs_hash}-{target_cache_suffix_fragment}"
+        )
+        target_cache_key = f"{target_cache_restore_key}{github_sha}"
 
     if suffix:
-        sanitized_suffix = _sanitize_fragment(suffix)
         build_cache_key = f"{build_cache_key}-{sanitized_suffix}"
-        target_cache_key = f"{target_cache_key}-{sanitized_suffix}"
 
     _write_env("SOLDR_CACHE_DIR", str(soldr_root))
     _write_env("CARGO_HOME", str(cargo_home))
     _write_env("RUSTUP_HOME", str(rustup_home))
     _write_env("ZCCACHE_CACHE_DIR", str(zccache_cache_dir))
+    _write_env(
+        "SOLDR_TARGET_CACHE_MODE",
+        target_cache_effective_mode if target_cache_enabled else "off",
+    )
+    _write_env("SOLDR_TARGET_CACHE_DIR", str(target_cache_path))
+    _write_env("SOLDR_TARGET_CACHE_BUNDLE_DIR", str(target_cache_bundle_path))
+    _write_env("SOLDR_TARGET_CACHE_BACKEND", "auto")
     _write_env("SETUP_SOLDR_TOOLCHAIN_CHANNEL", toolchain["channel"])
     _write_env("SETUP_SOLDR_TOOLCHAIN_PROFILE", toolchain["profile"])
     _write_env("SETUP_SOLDR_TOOLCHAIN_COMPONENTS", json.dumps(toolchain["components"]))
@@ -268,11 +342,12 @@ def main() -> None:
             "build_cache_restore_key_os_arch": f"{build_cache_prefix}-",
             "build_cache_path": str(zccache_cache_dir),
             "target_cache_path": str(target_cache_path),
+            "target_cache_bundle_path": str(target_cache_bundle_path),
             "target_cache_paths": target_cache_paths,
             "target_cache_enabled": str(target_cache_enabled).lower(),
             "target_cache_mode": target_cache_effective_mode,
             "target_cache_key": target_cache_key,
-            "target_cache_restore_key_lock": target_cache_lock_prefix,
+            "target_cache_restore_key_lock": target_cache_restore_key,
             "soldr_root": str(soldr_root),
             "cargo_home": str(cargo_home),
             "rustup_home": str(rustup_home),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,6 +1482,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "sha2",
  "soldr-cache",
  "soldr-core",
  "soldr-fetch",

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ That action:
 - preinstalls the exact Rust toolchain from `rust-toolchain.toml` by default via `rustup`
 - restores a cacheable runner-local root for Soldr, Cargo, and rustup state
 - restores and saves the Soldr-owned zccache compilation artifact cache under `SOLDR_CACHE_DIR` by default; set `build-cache: false` to disable it
-- restores and saves a bounded hot Cargo target cache by default for no-op CI fast paths; set `target-cache: false` to disable it, `target-cache-mode: full` to opt into whole-target caching, or `target-dir:` to choose another target directory
+- restores and saves a zccache-owned Rust artifact plan cache by default for no-op CI fast paths; set `target-cache: false` to disable it or `target-cache-mode: full` to opt into explicit whole-target caching
 - puts `soldr` on `PATH` for later steps
 
 For existing workflows where rewriting every `cargo ...` command is high-friction, opt into Cargo PATH shims:

--- a/action.yml
+++ b/action.yml
@@ -50,22 +50,24 @@ inputs:
     default: "true"
   target-cache:
     description: >
-      Restore and save the Cargo target directory across workflow runs.
-      Default "true"; target-cache-mode controls whether this is a bounded hot
-      metadata cache or an explicit full target cache. Set to "false" to cache
-      only zccache compilation artifacts.
+      Restore and save the zccache-owned Rust artifact plan cache across
+      workflow runs.
+      Default "true"; target-cache-mode controls whether this is a bounded thin
+      dependency-artifact cache or an explicit full target cache plan. Set to
+      "false" to cache only zccache compilation artifacts.
     required: false
     default: "true"
   target-cache-mode:
     description: >
-      Cargo target cache mode. "hot" caches Cargo freshness metadata and
-      lightweight type metadata by default. "full" caches the entire target-dir
-      and should only be used for tightly scoped jobs. "off" disables target
-      caching even when target-cache is true.
+      Rust artifact cache mode. "thin" asks soldr to generate a bounded
+      dependency-artifact plan for zccache by default. "full" asks zccache to
+      cache the entire target-dir and should only be used for tightly scoped
+      jobs. "off" disables target caching even when target-cache is true. The
+      previous "hot" value is accepted as a deprecated alias for "thin".
     required: false
-    default: hot
+    default: thin
   target-dir:
-    description: Cargo target directory restored by target-cache.
+    description: Cargo target directory used in target-cache key shaping.
     required: false
     default: target
   tool-shims:
@@ -97,12 +99,12 @@ outputs:
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
   target-cache-hit:
     description: >
-      Whether the action restored the Cargo target directory cache. "true"
+      Whether the action restored the Rust artifact plan cache. "true"
       for an exact key match, "false" for a restore-key fallback or no cache,
-      empty string when `target-cache` or `build-cache` is disabled.
+      empty string when `target-cache` is disabled.
     value: ${{ steps.cache-meta.outputs.target_cache_hit }}
   target-cache-mode:
-    description: Effective Cargo target cache mode.
+    description: Effective Rust artifact target cache mode.
     value: ${{ steps.resolve.outputs.target_cache_mode }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
@@ -152,7 +154,7 @@ runs:
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
     - id: target-cache
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
+      if: ${{ steps.resolve.outputs.target_cache_enabled == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ steps.resolve.outputs.target_cache_paths }}
@@ -187,49 +189,6 @@ runs:
         SETUP_SOLDR_TOOL_SHIMS: ${{ inputs.tool-shims }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/install_tool_shims.py"
 
-    - id: zccache-warm-target
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
-      shell: pwsh
-      env:
-        TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
-      run: |
-        $target = $env:TARGET_CACHE_PATH
-        if ([string]::IsNullOrWhiteSpace($target) -or -not (Test-Path -LiteralPath $target)) {
-          Write-Host "No restored target directory to warm."
-          exit 0
-        }
-
-        $exeName = if ($IsWindows) { "zccache.exe" } else { "zccache" }
-        $zccache = $null
-        if (-not [string]::IsNullOrWhiteSpace($env:SOLDR_CACHE_DIR)) {
-          $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
-          if (Test-Path -LiteralPath $soldrBin) {
-            $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
-              Select-Object -First 1 -ExpandProperty FullName
-          }
-        }
-        if ([string]::IsNullOrWhiteSpace($zccache)) {
-          $command = Get-Command zccache -ErrorAction SilentlyContinue
-          if ($command) {
-            $zccache = $command.Source
-          }
-        }
-        if ([string]::IsNullOrWhiteSpace($zccache)) {
-          Write-Host "zccache binary is not available yet; refreshing target mtimes only."
-        } else {
-          Write-Host "Warming target directory from zccache: $target"
-          & $zccache warm --target-dir $target
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "zccache warm did not complete successfully; continuing."
-          }
-        }
-
-        $stamp = (Get-Date).AddMinutes(1)
-        Get-ChildItem -LiteralPath $target -Recurse -File -Force -ErrorAction SilentlyContinue |
-          ForEach-Object { $_.LastWriteTime = $stamp }
-        Write-Host "Refreshed target file mtimes."
-        exit 0
-
     - id: cache-meta
       shell: pwsh
       env:
@@ -256,7 +215,7 @@ runs:
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") {
+        if ($env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") {
           $targetValue = $env:RAW_TARGET_CACHE_HIT
           if ([string]::IsNullOrWhiteSpace($targetValue)) {
             $targetValue = "false"

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -14,6 +14,7 @@ soldr-cache = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,7 +1,9 @@
 use clap::{Parser, Subcommand};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
+use std::collections::BTreeSet;
 
 const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
 const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
@@ -10,6 +12,9 @@ const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 const JSON_SCHEMA_VERSION: u32 = 1;
 const RUSTC_WRAPPER_OVERRIDE_ENV_VAR: &str = "SOLDR_RUSTC_WRAPPER";
 const REAL_TOOLCHAIN_BINARY_ENV_PREFIX: &str = "SOLDR_REAL_";
+const TARGET_CACHE_MODE_ENV_VAR: &str = "SOLDR_TARGET_CACHE_MODE";
+const TARGET_CACHE_BUNDLE_DIR_ENV_VAR: &str = "SOLDR_TARGET_CACHE_BUNDLE_DIR";
+const TARGET_CACHE_BACKEND_ENV_VAR: &str = "SOLDR_TARGET_CACHE_BACKEND";
 
 /// Pin a specific soldr version to handle this invocation. Explicit
 /// `--as <version>` flag takes precedence over this env var.
@@ -502,10 +507,10 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     // PATH so cargo's subcommand dispatch finds it.
     let extra_bin_dirs = ensure_known_subcommand_tool(args, &paths).await?;
 
-    let mut command = std::process::Command::new(cargo);
+    let mut command = std::process::Command::new(&cargo);
     command.args(args);
     apply_implicit_toolchain_homes(&mut command);
-    command.env("RUSTC", rustc);
+    command.env("RUSTC", &rustc);
     let cache_enabled_for_cargo = cache_enabled && cargo_args_are_cacheable(args);
 
     command.env(
@@ -526,11 +531,581 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
         None
     };
 
+    let rust_plan = if let Some(session) = session.as_ref() {
+        maybe_prepare_rust_artifact_plan(&cargo, &rustc, args, session)?
+    } else {
+        None
+    };
+    if let Some(plan) = rust_plan.as_ref() {
+        run_zccache_rust_plan(plan, "restore", false)?;
+    }
+
     let status = command.status()?;
+    if status.success() {
+        if let Some(plan) = rust_plan.as_ref() {
+            run_zccache_rust_plan(plan, "save", true)?;
+        }
+    }
     if let Some(session) = session {
         finish_zccache_build(&session)?;
     }
     Ok(status.code().unwrap_or(1))
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    packages: Vec<CargoMetadataPackage>,
+    workspace_members: Vec<String>,
+    workspace_root: std::path::PathBuf,
+    target_directory: std::path::PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadataPackage {
+    id: String,
+    source: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RustArtifactPlan {
+    schema_version: u32,
+    mode: String,
+    workspace_root: String,
+    target_dir: String,
+    toolchain: RustToolchainIdentity,
+    target_triple: String,
+    profile: String,
+    inputs: RustPlanInputs,
+    packages: RustPlanPackages,
+    allowed_artifact_classes: Vec<&'static str>,
+    cache_schema_version: u32,
+    journal_log_path: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RustToolchainIdentity {
+    rustc: String,
+    cargo: String,
+    channel: String,
+    host: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RustPlanInputs {
+    features_hash: String,
+    rustflags_hash: String,
+    env_hash: String,
+    lockfile_hash: String,
+    cargo_config_hash: String,
+    manifest_hashes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RustPlanPackages {
+    selected_package_ids: Vec<String>,
+    workspace_package_ids: Vec<String>,
+    excluded_path_package_ids: Vec<String>,
+}
+
+struct RustArtifactPlanContext {
+    path: std::path::PathBuf,
+    zccache_binary: std::path::PathBuf,
+    cache_dir: std::path::PathBuf,
+    session_id: String,
+    journal_path: std::path::PathBuf,
+    backend: String,
+}
+
+fn maybe_prepare_rust_artifact_plan(
+    cargo: &std::path::Path,
+    rustc: &std::path::Path,
+    args: &[String],
+    session: &ZccacheBuildSession,
+) -> Result<Option<RustArtifactPlanContext>, SoldrError> {
+    let Some(mode) = rust_artifact_cache_mode_from_env()? else {
+        return Ok(None);
+    };
+
+    if matches!(first_cargo_subcommand(args), Some("install")) {
+        eprintln!("soldr: rust artifact cache plan skipped for cargo install");
+        return Ok(None);
+    }
+
+    let metadata = cargo_metadata(cargo, args)?;
+    let toolchain = rust_toolchain_identity(cargo, rustc)?;
+    let plan = build_rust_artifact_plan(&metadata, &toolchain, args, &mode, session)?;
+    let plan_dir = session.cache_dir.join("plans");
+    std::fs::create_dir_all(&plan_dir)?;
+    let plan_path = plan_dir.join("last-rust-artifact-plan.json");
+    let plan_json = serde_json::to_string_pretty(&plan)
+        .map_err(|e| SoldrError::Other(format!("failed to serialize Rust artifact plan: {e}")))?;
+    std::fs::write(&plan_path, plan_json)?;
+
+    Ok(Some(RustArtifactPlanContext {
+        path: plan_path,
+        zccache_binary: session.binary_path.clone(),
+        cache_dir: rust_artifact_plan_cache_dir(session)?,
+        session_id: session.session_id.clone(),
+        journal_path: session.journal_path.clone(),
+        backend: rust_artifact_cache_backend_from_env()?,
+    }))
+}
+
+fn rust_artifact_cache_mode_from_env() -> Result<Option<String>, SoldrError> {
+    let raw = std::env::var(TARGET_CACHE_MODE_ENV_VAR).unwrap_or_default();
+    let mode = raw.trim().to_ascii_lowercase();
+    match mode.as_str() {
+        "" | "off" | "false" | "0" | "no" => Ok(None),
+        "hot" | "thin" => Ok(Some("thin".to_string())),
+        "full" => Ok(Some("full".to_string())),
+        _ => Err(SoldrError::Other(format!(
+            "invalid {TARGET_CACHE_MODE_ENV_VAR} value {raw:?}; expected thin, full, or off"
+        ))),
+    }
+}
+
+fn rust_artifact_cache_backend_from_env() -> Result<String, SoldrError> {
+    let raw = std::env::var(TARGET_CACHE_BACKEND_ENV_VAR).unwrap_or_else(|_| "auto".to_string());
+    let backend = raw.trim().to_ascii_lowercase();
+    match backend.as_str() {
+        "" | "auto" => Ok("auto".to_string()),
+        "local" => Ok("local".to_string()),
+        "gha" => Ok("gha".to_string()),
+        _ => Err(SoldrError::Other(format!(
+            "invalid {TARGET_CACHE_BACKEND_ENV_VAR} value {raw:?}; expected auto, local, or gha"
+        ))),
+    }
+}
+
+fn rust_artifact_plan_cache_dir(
+    session: &ZccacheBuildSession,
+) -> Result<std::path::PathBuf, SoldrError> {
+    let cache_dir = non_empty_env_path(TARGET_CACHE_BUNDLE_DIR_ENV_VAR)
+        .unwrap_or_else(|| session.cache_dir.join("rust-plan-cache"));
+    let cache_dir = normalize_path_for_compare(&cache_dir)?;
+    std::fs::create_dir_all(&cache_dir)?;
+    Ok(cache_dir)
+}
+
+fn cargo_metadata(cargo: &std::path::Path, args: &[String]) -> Result<CargoMetadata, SoldrError> {
+    let mut command = std::process::Command::new(cargo);
+    command.args(["metadata", "--format-version", "1"]);
+    command.args(cargo_metadata_passthrough_args(args));
+    apply_implicit_toolchain_homes(&mut command);
+
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(format!(
+            "cargo metadata failed while preparing Rust artifact cache plan: {}",
+            command_stderr(&output)
+        )));
+    }
+
+    serde_json::from_slice(&output.stdout).map_err(|e| {
+        SoldrError::Other(format!(
+            "failed to parse cargo metadata while preparing Rust artifact cache plan: {e}"
+        ))
+    })
+}
+
+fn cargo_metadata_passthrough_args(args: &[String]) -> Vec<std::ffi::OsString> {
+    let mut values = Vec::new();
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        match arg.as_str() {
+            "--locked" | "--offline" | "--frozen" | "--all-features" | "--no-default-features" => {
+                values.push(arg.as_str().into())
+            }
+            "--manifest-path" | "--config" | "--features" | "--filter-platform" => {
+                if let Some(value) = iter.next() {
+                    values.push(arg.as_str().into());
+                    values.push(value.as_str().into());
+                }
+            }
+            _ => {
+                for flag in [
+                    "--manifest-path=",
+                    "--config=",
+                    "--features=",
+                    "--filter-platform=",
+                ] {
+                    if arg.starts_with(flag) {
+                        values.push(arg.as_str().into());
+                    }
+                }
+            }
+        }
+    }
+    values
+}
+
+fn rust_toolchain_identity(
+    cargo: &std::path::Path,
+    rustc: &std::path::Path,
+) -> Result<RustToolchainIdentity, SoldrError> {
+    let rustc_output = tool_output(rustc, &["-Vv"])?;
+    let cargo_output = tool_output(cargo, &["--version"])?;
+    let host = rustc_output
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))
+        .unwrap_or("unknown")
+        .to_string();
+    let channel = std::env::var("RUSTUP_TOOLCHAIN")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            rustc_output
+                .lines()
+                .find_map(|line| line.strip_prefix("release: "))
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    Ok(RustToolchainIdentity {
+        rustc: rustc_output.trim().to_string(),
+        cargo: cargo_output.trim().to_string(),
+        channel,
+        host,
+    })
+}
+
+fn tool_output(tool: &std::path::Path, args: &[&str]) -> Result<String, SoldrError> {
+    let mut command = std::process::Command::new(tool);
+    command.args(args);
+    apply_implicit_toolchain_homes(&mut command);
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(format!(
+            "{} {} failed: {}",
+            tool.display(),
+            args.join(" "),
+            command_stderr(&output)
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn build_rust_artifact_plan(
+    metadata: &CargoMetadata,
+    toolchain: &RustToolchainIdentity,
+    args: &[String],
+    mode: &str,
+    session: &ZccacheBuildSession,
+) -> Result<RustArtifactPlan, SoldrError> {
+    let workspace_root = normalize_path_for_compare(&metadata.workspace_root)?;
+    let target_dir = normalize_path_for_compare(&metadata.target_directory)?;
+    let workspace_members: BTreeSet<&str> = metadata
+        .workspace_members
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let mut selected_package_ids = Vec::new();
+    let mut excluded_path_package_ids = Vec::new();
+
+    for package in &metadata.packages {
+        if workspace_members.contains(package.id.as_str()) {
+            continue;
+        }
+        match package.source.as_deref() {
+            Some(source) if source.starts_with("registry+") || source.starts_with("git+") => {
+                selected_package_ids.push(package.id.clone());
+            }
+            _ => excluded_path_package_ids.push(package.id.clone()),
+        }
+    }
+
+    selected_package_ids.sort();
+    excluded_path_package_ids.sort();
+    let mut workspace_package_ids = metadata.workspace_members.clone();
+    workspace_package_ids.sort();
+
+    Ok(RustArtifactPlan {
+        schema_version: 1,
+        mode: mode.to_string(),
+        workspace_root: path_string(&workspace_root),
+        target_dir: path_string(&target_dir),
+        toolchain: RustToolchainIdentity {
+            rustc: toolchain.rustc.clone(),
+            cargo: toolchain.cargo.clone(),
+            channel: toolchain.channel.clone(),
+            host: toolchain.host.clone(),
+        },
+        target_triple: cargo_target_triple(args, &toolchain.host),
+        profile: cargo_profile(args).to_string(),
+        inputs: RustPlanInputs {
+            features_hash: stable_hash_json(&cargo_feature_inputs(args)),
+            rustflags_hash: stable_hash_json(&rustflags_inputs()),
+            env_hash: stable_hash_json(&build_env_inputs()),
+            lockfile_hash: file_hash_or_missing(&workspace_root.join("Cargo.lock"))?,
+            cargo_config_hash: cargo_config_hash(&workspace_root)?,
+            manifest_hashes: workspace_manifest_hashes(&workspace_root)?,
+        },
+        packages: RustPlanPackages {
+            selected_package_ids,
+            workspace_package_ids,
+            excluded_path_package_ids,
+        },
+        allowed_artifact_classes: allowed_artifact_classes(mode),
+        cache_schema_version: 1,
+        journal_log_path: Some(path_string(&session.journal_path)),
+    })
+}
+
+fn allowed_artifact_classes(mode: &str) -> Vec<&'static str> {
+    if mode == "full" {
+        return Vec::new();
+    }
+    vec![
+        "rlib",
+        "rmeta",
+        "dep_info",
+        "proc_macro",
+        "cargo_fingerprint",
+        "build_script_metadata",
+        "build_script_output",
+    ]
+}
+
+fn run_zccache_rust_plan(
+    plan: &RustArtifactPlanContext,
+    operation: &'static str,
+    include_session: bool,
+) -> Result<(), SoldrError> {
+    let plan_path = path_string(&plan.path);
+    let cache_dir = path_string(&plan.cache_dir);
+    let journal_path = path_string(&plan.journal_path);
+    let mut args = vec![
+        "rust-plan".to_string(),
+        operation.to_string(),
+        "--plan".to_string(),
+        plan_path,
+        "--json".to_string(),
+        "--backend".to_string(),
+        plan.backend.clone(),
+        "--cache-dir".to_string(),
+        cache_dir,
+        "--journal".to_string(),
+        journal_path,
+    ];
+    if include_session {
+        args.push("--session-id".to_string());
+        args.push(plan.session_id.clone());
+    }
+
+    let output =
+        run_zccache_command_strings_in_cache_dir(&plan.zccache_binary, &args, &plan.cache_dir)?;
+    let stdout = output.stdout.trim();
+    if !stdout.is_empty() {
+        eprintln!("soldr: zccache rust-plan {operation} summary");
+        eprintln!("{stdout}");
+    }
+    Ok(())
+}
+
+fn cargo_profile(args: &[String]) -> &str {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--release" {
+            return "release";
+        }
+        if arg == "--profile" {
+            return iter.next().map(String::as_str).unwrap_or("debug");
+        }
+        if let Some(value) = arg.strip_prefix("--profile=") {
+            return value;
+        }
+    }
+    "debug"
+}
+
+fn cargo_target_triple(args: &[String], host: &str) -> String {
+    cargo_target_arg(args)
+        .or_else(|| std::env::var("CARGO_BUILD_TARGET").ok())
+        .unwrap_or_else(|| host.to_string())
+}
+
+fn cargo_target_arg(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--target" {
+            return iter.next().cloned();
+        }
+        if let Some(value) = arg.strip_prefix("--target=") {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn cargo_feature_inputs(args: &[String]) -> Vec<String> {
+    selected_cargo_args(
+        args,
+        &[
+            "--features",
+            "--all-features",
+            "--no-default-features",
+            "--package",
+            "-p",
+            "--workspace",
+            "--exclude",
+            "--all-targets",
+            "--lib",
+            "--bins",
+            "--bin",
+            "--examples",
+            "--example",
+            "--tests",
+            "--test",
+            "--benches",
+            "--bench",
+        ],
+    )
+}
+
+fn selected_cargo_args(args: &[String], names: &[&str]) -> Vec<String> {
+    let mut selected = Vec::new();
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if names.contains(&arg.as_str()) {
+            selected.push(arg.clone());
+            if !matches!(
+                arg.as_str(),
+                "--all-features"
+                    | "--no-default-features"
+                    | "--workspace"
+                    | "--all-targets"
+                    | "--lib"
+                    | "--bins"
+                    | "--examples"
+                    | "--tests"
+                    | "--benches"
+            ) {
+                if let Some(value) = iter.next() {
+                    selected.push(value.clone());
+                }
+            }
+            continue;
+        }
+        if names
+            .iter()
+            .any(|name| arg.starts_with(&format!("{name}=")))
+        {
+            selected.push(arg.clone());
+        }
+    }
+    selected
+}
+
+fn rustflags_inputs() -> Vec<(String, String)> {
+    sorted_env_vars(|name| {
+        name == "RUSTFLAGS"
+            || name == "CARGO_ENCODED_RUSTFLAGS"
+            || (name.starts_with("CARGO_TARGET_") && name.ends_with("_RUSTFLAGS"))
+    })
+}
+
+fn build_env_inputs() -> Vec<(String, String)> {
+    sorted_env_vars(|name| {
+        name == "CARGO_BUILD_TARGET"
+            || name == "CARGO_TARGET_DIR"
+            || name.starts_with("CARGO_PROFILE_")
+            || name.starts_with("CARGO_CFG_")
+    })
+}
+
+fn sorted_env_vars<F>(include: F) -> Vec<(String, String)>
+where
+    F: Fn(&str) -> bool,
+{
+    let mut vars = std::env::vars()
+        .filter(|(name, _)| include(name))
+        .collect::<Vec<_>>();
+    vars.sort_by(|a, b| a.0.cmp(&b.0));
+    vars
+}
+
+fn workspace_manifest_hashes(workspace_root: &std::path::Path) -> Result<Vec<String>, SoldrError> {
+    let mut hashes = Vec::new();
+    collect_manifest_hashes(workspace_root, workspace_root, &mut hashes)?;
+    hashes.sort();
+    Ok(hashes)
+}
+
+fn collect_manifest_hashes(
+    workspace_root: &std::path::Path,
+    dir: &std::path::Path,
+    hashes: &mut Vec<String>,
+) -> Result<(), SoldrError> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            if matches!(
+                entry.file_name().to_str(),
+                Some(".git" | "target" | ".soldr" | "node_modules")
+            ) {
+                continue;
+            }
+            collect_manifest_hashes(workspace_root, &path, hashes)?;
+        } else if file_type.is_file() && entry.file_name() == std::ffi::OsStr::new("Cargo.toml") {
+            let relative = path
+                .strip_prefix(workspace_root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            hashes.push(format!("{relative}:{}", file_hash_or_missing(&path)?));
+        }
+    }
+    Ok(())
+}
+
+fn cargo_config_hash(workspace_root: &std::path::Path) -> Result<String, SoldrError> {
+    let mut inputs = Vec::new();
+    for relative in [".cargo/config.toml", ".cargo/config"] {
+        let path = workspace_root.join(relative);
+        if path.exists() {
+            inputs.push(format!("{relative}:{}", file_hash_or_missing(&path)?));
+        }
+    }
+    Ok(stable_hash_json(&inputs))
+}
+
+fn file_hash_or_missing(path: &std::path::Path) -> Result<String, SoldrError> {
+    if !path.exists() {
+        return Ok("missing".to_string());
+    }
+    Ok(sha256_bytes(&std::fs::read(path)?))
+}
+
+fn stable_hash_json<T: Serialize>(value: &T) -> String {
+    let bytes = serde_json::to_vec(value).unwrap_or_default();
+    sha256_bytes(&bytes)
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}
+
+fn path_string(path: &std::path::Path) -> String {
+    path.display().to_string()
 }
 
 fn default_cargo_build_target(args: &[String]) -> Result<Option<String>, SoldrError> {
@@ -699,27 +1274,146 @@ fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError
     }
 
     let start_dir = std::env::current_dir().ok();
-    if let Some(path) = soldr_core::probe_toolchain_binary(tool, start_dir.as_deref()) {
+    if let Some(path) = probe_direct_toolchain_binary(tool, start_dir.as_deref()) {
         return Ok(path);
     }
 
     let mut command = std::process::Command::new(rustup_binary());
     command.args(["which", tool]);
     apply_implicit_toolchain_homes(&mut command);
-    let output = command.output()?;
+    let output = command.output();
 
-    if !output.status.success() {
-        return Err(rustup_resolution_failure(tool, &output.stderr));
+    match output {
+        Ok(output) if output.status.success() => {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !path.is_empty() {
+                return Ok(path.into());
+            }
+        }
+        Ok(output) => {
+            if let Some(path) = soldr_core::probe_toolchain_binary(tool, start_dir.as_deref()) {
+                return Ok(path);
+            }
+            return Err(rustup_resolution_failure(tool, &output.stderr));
+        }
+        Err(err) => {
+            if let Some(path) = soldr_core::probe_toolchain_binary(tool, start_dir.as_deref()) {
+                return Ok(path);
+            }
+            return Err(SoldrError::Other(format!(
+                "failed to invoke rustup while resolving {tool}: {err}"
+            )));
+        }
     }
 
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if path.is_empty() {
-        return Err(SoldrError::Other(format!(
-            "rustup did not return a path for {tool}"
-        )));
+    if let Some(path) = soldr_core::probe_toolchain_binary(tool, start_dir.as_deref()) {
+        return Ok(path);
     }
 
-    Ok(path.into())
+    Err(SoldrError::Other(format!(
+        "rustup did not return a path for {tool}"
+    )))
+}
+
+fn probe_direct_toolchain_binary(
+    tool: &str,
+    start_dir: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    if std::env::var_os("RUSTUP_TOOLCHAIN").is_some_and(|value| !value.is_empty()) {
+        return None;
+    }
+
+    explicit_rustup_toolchain_binary(tool)
+        .or_else(|| repo_local_rustup_toolchain_binary(tool, start_dir))
+        .or_else(|| explicit_cargo_home_binary(tool))
+        .or_else(|| repo_local_cargo_home_binary(tool, start_dir))
+}
+
+fn explicit_cargo_home_binary(tool: &str) -> Option<std::path::PathBuf> {
+    non_empty_env_path("CARGO_HOME").and_then(|path| executable_in_dir(&path.join("bin"), tool))
+}
+
+fn repo_local_cargo_home_binary(
+    tool: &str,
+    start_dir: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    find_ancestor_dir(start_dir, ".cargo")
+        .and_then(|path| executable_in_dir(&path.join("bin"), tool))
+}
+
+fn explicit_rustup_toolchain_binary(tool: &str) -> Option<std::path::PathBuf> {
+    non_empty_env_path("RUSTUP_HOME")
+        .and_then(|path| rustup_home_single_toolchain_binary(&path, tool))
+}
+
+fn repo_local_rustup_toolchain_binary(
+    tool: &str,
+    start_dir: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    find_ancestor_dir(start_dir, ".rustup")
+        .and_then(|path| rustup_home_single_toolchain_binary(&path, tool))
+}
+
+fn rustup_home_single_toolchain_binary(
+    rustup_home: &std::path::Path,
+    tool: &str,
+) -> Option<std::path::PathBuf> {
+    let mut candidates = std::fs::read_dir(rustup_home.join("toolchains"))
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().join("bin"))
+        .filter_map(|dir| executable_in_dir(&dir, tool))
+        .collect::<Vec<_>>();
+    if candidates.len() == 1 {
+        candidates.pop()
+    } else {
+        None
+    }
+}
+
+fn find_ancestor_dir(
+    start_dir: Option<&std::path::Path>,
+    relative: &str,
+) -> Option<std::path::PathBuf> {
+    let mut current = start_dir?.to_path_buf();
+    loop {
+        let candidate = current.join(relative);
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+fn executable_in_dir(dir: &std::path::Path, tool: &str) -> Option<std::path::PathBuf> {
+    let candidate = dir.join(tool);
+    if candidate.is_file() {
+        return Some(candidate);
+    }
+    #[cfg(windows)]
+    {
+        for suffix in windows_path_exts() {
+            let candidate = dir.join(format!("{tool}{suffix}"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn windows_path_exts() -> Vec<String> {
+    std::env::var_os("PATHEXT")
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string())
+        .split(';')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_lowercase())
+        .collect()
 }
 
 fn apply_implicit_toolchain_homes(command: &mut std::process::Command) {
@@ -748,6 +1442,7 @@ struct ZccacheBuildSession {
     binary_path: std::path::PathBuf,
     cache_dir: std::path::PathBuf,
     session_id: String,
+    journal_path: std::path::PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -835,10 +1530,10 @@ async fn prepare_zccache_build(
     start_zccache_with_recovery(&fetch.binary_path, &zccache_dir)?;
 
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
-    let journal_path = journal_path.display().to_string();
+    let journal_path_arg = journal_path.display().to_string();
     let session_json = run_zccache_command_in_cache_dir(
         &fetch.binary_path,
-        &["session-start", "--stats", "--journal", &journal_path],
+        &["session-start", "--stats", "--journal", &journal_path_arg],
         &zccache_dir,
     )?;
     let session_id =
@@ -859,6 +1554,7 @@ async fn prepare_zccache_build(
         binary_path: fetch.binary_path,
         cache_dir: zccache_dir,
         session_id,
+        journal_path,
     })
 }
 
@@ -1146,6 +1842,30 @@ fn run_zccache_command_in_cache_dir(
     )
 }
 
+fn run_zccache_command_strings_in_cache_dir(
+    binary: &std::path::Path,
+    args: &[String],
+    cache_dir: &std::path::Path,
+) -> Result<CommandOutput, SoldrError> {
+    let output = run_zccache_command_raw_strings_with_env(
+        binary,
+        args,
+        &[(
+            soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR,
+            cache_dir.as_os_str(),
+        )],
+    )?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(zccache_command_failure_message_strings(
+            args, &output,
+        )));
+    }
+
+    Ok(CommandOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+    })
+}
+
 fn start_zccache_with_recovery(
     binary: &std::path::Path,
     cache_dir: &std::path::Path,
@@ -1254,7 +1974,31 @@ fn run_zccache_command_raw_with_env(
     Ok(command.output()?)
 }
 
+fn run_zccache_command_raw_strings_with_env(
+    binary: &std::path::Path,
+    args: &[String],
+    envs: &[(&str, &std::ffi::OsStr)],
+) -> Result<std::process::Output, SoldrError> {
+    let mut command = std::process::Command::new(binary);
+    command.args(args);
+    for &(name, value) in envs {
+        command.env(name, value);
+    }
+    Ok(command.output()?)
+}
+
 fn zccache_command_failure_message(args: &[&str], output: &std::process::Output) -> String {
+    format!(
+        "zccache {} failed: {}",
+        args.join(" "),
+        command_stderr(output)
+    )
+}
+
+fn zccache_command_failure_message_strings(
+    args: &[String],
+    output: &std::process::Output,
+) -> String {
     format!(
         "zccache {} failed: {}",
         args.join(" "),
@@ -1346,10 +2090,12 @@ fn cached_managed_zccache(
 #[cfg(test)]
 mod tests {
     use super::{
-        cargo_args_specify_target, cargo_args_use_reserved_no_cache, extract_as_pin,
-        first_cargo_subcommand, is_sccache_wrapper, normalize_version, parse_tool_spec,
-        rustc_wrapper_mode_from_env_var, rustup_resolution_failure, should_trampoline,
-        RustcWrapperMode,
+        allowed_artifact_classes, build_rust_artifact_plan, cargo_args_specify_target,
+        cargo_args_use_reserved_no_cache, cargo_metadata_passthrough_args, cargo_profile,
+        cargo_target_triple, extract_as_pin, first_cargo_subcommand, is_sccache_wrapper,
+        normalize_version, parse_tool_spec, rustc_wrapper_mode_from_env_var,
+        rustup_resolution_failure, selected_cargo_args, should_trampoline, CargoMetadata,
+        CargoMetadataPackage, RustToolchainIdentity, RustcWrapperMode, ZccacheBuildSession,
     };
     use soldr_fetch::VersionSpec;
     use std::ffi::OsStr;
@@ -1452,6 +2198,115 @@ mod tests {
         assert_eq!(
             first_cargo_subcommand(&["--".into(), "nextest".into()]),
             None
+        );
+    }
+
+    #[test]
+    fn rust_artifact_plan_selects_external_packages_and_path_exclusions() {
+        let root =
+            std::env::temp_dir().join(format!("soldr-rust-plan-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("app/src")).unwrap();
+        std::fs::create_dir_all(root.join("local_dep/src")).unwrap();
+        std::fs::create_dir_all(root.join("target")).unwrap();
+        std::fs::write(root.join("Cargo.lock"), "# lock\n").unwrap();
+        std::fs::write(root.join("Cargo.toml"), "[workspace]\n").unwrap();
+        std::fs::write(root.join("app/Cargo.toml"), "[package]\nname='app'\n").unwrap();
+        std::fs::write(
+            root.join("local_dep/Cargo.toml"),
+            "[package]\nname='local_dep'\n",
+        )
+        .unwrap();
+
+        let metadata = CargoMetadata {
+            workspace_root: root.clone(),
+            target_directory: root.join("target"),
+            workspace_members: vec!["path+file:///repo/app#app@0.1.0".to_string()],
+            packages: vec![
+                CargoMetadataPackage {
+                    id: "path+file:///repo/app#app@0.1.0".to_string(),
+                    source: None,
+                },
+                CargoMetadataPackage {
+                    id: "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0"
+                        .to_string(),
+                    source: Some("registry+https://github.com/rust-lang/crates.io-index".into()),
+                },
+                CargoMetadataPackage {
+                    id: "path+file:///repo/local_dep#local_dep@0.1.0".to_string(),
+                    source: None,
+                },
+            ],
+        };
+        let toolchain = RustToolchainIdentity {
+            rustc: "rustc 1.0.0-test".to_string(),
+            cargo: "cargo 1.0.0-test".to_string(),
+            channel: "test".to_string(),
+            host: "x86_64-unknown-test".to_string(),
+        };
+        let session = ZccacheBuildSession {
+            binary_path: "zccache".into(),
+            cache_dir: root.join("cache"),
+            session_id: "session-1".to_string(),
+            journal_path: root.join("cache/logs/last-session.jsonl"),
+        };
+        let args = vec![
+            "build".to_string(),
+            "--release".to_string(),
+            "--features".to_string(),
+            "serde/derive".to_string(),
+            "--target".to_string(),
+            "x86_64-unknown-linux-gnu".to_string(),
+        ];
+
+        let plan = build_rust_artifact_plan(&metadata, &toolchain, &args, "thin", &session)
+            .expect("build rust artifact plan");
+
+        assert_eq!(plan.schema_version, 1);
+        assert_eq!(plan.mode, "thin");
+        assert_eq!(plan.profile, "release");
+        assert_eq!(plan.target_triple, "x86_64-unknown-linux-gnu");
+        assert_eq!(plan.packages.workspace_package_ids.len(), 1);
+        assert_eq!(plan.packages.selected_package_ids.len(), 1);
+        assert!(plan.packages.selected_package_ids[0].contains("serde"));
+        assert_eq!(plan.packages.excluded_path_package_ids.len(), 1);
+        assert!(plan.allowed_artifact_classes.contains(&"cargo_fingerprint"));
+        assert_eq!(plan.cache_schema_version, 1);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn rust_artifact_plan_helpers_parse_mode_profile_target_and_metadata_args() {
+        let args = vec![
+            "+stable".to_string(),
+            "build".to_string(),
+            "--locked".to_string(),
+            "--features=fast".to_string(),
+            "--target".to_string(),
+            "wasm32-unknown-unknown".to_string(),
+            "--profile".to_string(),
+            "release-lto".to_string(),
+            "--".to_string(),
+            "--ignored".to_string(),
+        ];
+
+        assert_eq!(cargo_profile(&args), "release-lto");
+        assert_eq!(
+            cargo_target_triple(&args, "x86_64-unknown-linux-gnu"),
+            "wasm32-unknown-unknown"
+        );
+        assert_eq!(
+            selected_cargo_args(&args, &["--features"]),
+            vec!["--features=fast".to_string()]
+        );
+        assert_eq!(allowed_artifact_classes("full"), Vec::<&str>::new());
+        assert_eq!(
+            cargo_metadata_passthrough_args(&args)
+                .iter()
+                .map(|value| value.to_string_lossy().to_string())
+                .collect::<Vec<_>>(),
+            vec!["--locked".to_string(), "--features=fast".to_string()]
         );
     }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -88,6 +88,20 @@ fn fake_cargo_script(log_path: &Path) -> String {
     {
         format!(
             "@echo off\n\
+             if \"%~1\"==\"metadata\" (\n\
+               if defined SOLDR_TEST_CARGO_METADATA_PATH (\n\
+                 type \"%SOLDR_TEST_CARGO_METADATA_PATH%\"\n\
+               ) else (\n\
+                 echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR% zccache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+                 echo {{}}\n\
+               )\n\
+               exit /b 0\n\
+             )\n\
+             if \"%~1\"==\"--version\" (\n\
+               echo cargo version>>\"{0}\"\n\
+               echo cargo 1.0.0-test\n\
+               exit /b 0\n\
+             )\n\
              echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR% zccache_dir=%ZCCACHE_CACHE_DIR%>>\"{}\"\n\
              if defined RUSTC_WRAPPER (\n\
              call \"%RUSTC_WRAPPER%\" \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
@@ -102,6 +116,20 @@ fn fake_cargo_script(log_path: &Path) -> String {
     {
         format!(
             "#!/bin/sh\n\
+             if [ \"$1\" = \"metadata\" ]; then\n\
+               if [ -n \"${{SOLDR_TEST_CARGO_METADATA_PATH:-}}\" ]; then\n\
+                 cat \"$SOLDR_TEST_CARGO_METADATA_PATH\"\n\
+               else\n\
+                 echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+                 echo '{{}}'\n\
+               fi\n\
+               exit 0\n\
+             fi\n\
+             if [ \"$1\" = \"--version\" ]; then\n\
+               echo 'cargo version' >> \"{0}\"\n\
+               echo 'cargo 1.0.0-test'\n\
+               exit 0\n\
+             fi\n\
              echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{}\"\n\
              if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\
                \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
@@ -133,6 +161,12 @@ fn fake_rustc_script(log_path: &Path) -> String {
     {
         format!(
             "@echo off\n\
+             if \"%~1\"==\"-Vv\" (\n\
+               echo rustc 1.0.0-test\n\
+               echo host: x86_64-pc-windows-msvc\n\
+               echo release: 1.0.0-test\n\
+               exit /b 0\n\
+             )\n\
              echo rustc %*>>\"{}\"\n",
             log_path.display()
         )
@@ -141,6 +175,12 @@ fn fake_rustc_script(log_path: &Path) -> String {
     {
         format!(
             "#!/bin/sh\n\
+             if [ \"$1\" = \"-Vv\" ]; then\n\
+               echo 'rustc 1.0.0-test'\n\
+               echo 'host: x86_64-unknown-linux-gnu'\n\
+               echo 'release: 1.0.0-test'\n\
+               exit 0\n\
+             fi\n\
              echo \"rustc $*\" >> \"{}\"\n",
             log_path.display()
         )
@@ -274,6 +314,11 @@ fn fake_zccache_script(log_path: &Path) -> String {
                echo hits: 1\n\
                exit /b 0\n\
              )\n\
+             if \"%~1\"==\"rust-plan\" (\n\
+               echo zccache rust-plan %~2 cache_dir=%ZCCACHE_CACHE_DIR% args=%*>>\"{0}\"\n\
+               echo {{\"operation\":\"%~2\",\"compatibility\":{{\"status\":\"ok\",\"errors\":[]}}}}\n\
+               exit /b 0\n\
+             )\n\
              if \"%~1\"==\"status\" (\n\
                echo hits=7\n\
                exit /b 0\n\
@@ -336,12 +381,17 @@ fn fake_zccache_script(log_path: &Path) -> String {
                  ;;\n\
                session-end)\n\
                  echo \"zccache session-end $2 cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
-                 echo 'hits: 1'\n\
-                 exit 0\n\
-                 ;;\n\
-               status)\n\
-                 echo 'hits=7'\n\
-                 exit 0\n\
+               echo 'hits: 1'\n\
+               exit 0\n\
+               ;;\n\
+              rust-plan)\n\
+                echo \"zccache rust-plan $2 cache_dir=${{ZCCACHE_CACHE_DIR:-}} args=$*\" >> \"{0}\"\n\
+                printf '{{\"operation\":\"%s\",\"compatibility\":{{\"status\":\"ok\",\"errors\":[]}}}}\\n' \"$2\"\n\
+                exit 0\n\
+                ;;\n\
+              status)\n\
+                echo 'hits=7'\n\
+                exit 0\n\
                  ;;\n\
                clear)\n\
                  echo \"zccache clear cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
@@ -690,6 +740,101 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         journal.exists(),
         "expected session journal at {}",
         journal.display()
+    );
+}
+
+#[test]
+fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
+    let cache_root = unique_temp_dir("cargo-rust-plan-cache");
+    let workspace = unique_temp_dir("cargo-rust-plan-workspace");
+    let plan_cache = cache_root.join("target-artifact-cache");
+    let log_path = cache_root.join("tool.log");
+    let metadata_path = cache_root.join("metadata.json");
+    let target_dir = workspace.join("target");
+    fs::create_dir_all(workspace.join("app/src")).expect("create app source");
+    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::write(workspace.join("Cargo.lock"), "# lock\n").expect("write lockfile");
+    fs::write(workspace.join("Cargo.toml"), "[workspace]\n").expect("write workspace manifest");
+    fs::write(workspace.join("app/Cargo.toml"), "[package]\nname='app'\n")
+        .expect("write app manifest");
+
+    let metadata = serde_json::json!({
+        "packages": [
+            {
+                "id": "path+file:///repo/app#app@0.1.0",
+                "source": null
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+                "source": "registry+https://github.com/rust-lang/crates.io-index"
+            }
+        ],
+        "workspace_members": ["path+file:///repo/app#app@0.1.0"],
+        "workspace_root": workspace,
+        "target_directory": target_dir
+    });
+    fs::write(&metadata_path, serde_json::to_string(&metadata).unwrap())
+        .expect("write metadata fixture");
+
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build", "--locked"])
+        .current_dir(&workspace)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_TEST_CARGO_METADATA_PATH", &metadata_path)
+        .env("SOLDR_TARGET_CACHE_MODE", "thin")
+        .env("SOLDR_TARGET_CACHE_BUNDLE_DIR", &plan_cache)
+        .output()
+        .expect("failed to run soldr cargo build with rust-plan target cache");
+
+    assert!(
+        output.status.success(),
+        "cache-enabled rust-plan front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("zccache rust-plan restore") && log.contains("zccache rust-plan save"),
+        "soldr should call zccache rust-plan restore/save when target cache is enabled: {log}"
+    );
+    assert!(
+        path_display_variants(&plan_cache)
+            .iter()
+            .any(|path| log.contains(&format!("cache_dir={path}"))),
+        "rust-plan calls should use the zccache-owned target artifact cache dir: {log}"
+    );
+    assert!(
+        log.find("zccache rust-plan restore") < log.find("cargo wrapper=")
+            && log.find("cargo wrapper=") < log.find("zccache rust-plan save"),
+        "rust-plan restore should run before Cargo and save should run after Cargo: {log}"
+    );
+
+    let plan_path = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("plans")
+        .join("last-rust-artifact-plan.json");
+    let plan: Value =
+        serde_json::from_str(&fs::read_to_string(&plan_path).expect("read generated rust plan"))
+            .expect("parse generated rust plan");
+    assert_eq!(plan["schema_version"], 1);
+    assert_eq!(plan["mode"], "thin");
+    assert_eq!(plan["cache_schema_version"], 1);
+    assert_eq!(
+        plan["packages"]["workspace_package_ids"][0],
+        "path+file:///repo/app#app@0.1.0"
+    );
+    assert!(
+        plan["packages"]["selected_package_ids"][0]
+            .as_str()
+            .unwrap()
+            .contains("serde"),
+        "external dependency should be selected in generated plan: {plan}"
     );
 }
 
@@ -1484,7 +1629,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.3.8");
+    assert_eq!(json["managed_zccache_version"], "1.3.9");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -1579,7 +1724,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.3.8");
+    assert_eq!(json["managed_zccache_version"], "1.3.9");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.8";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.9";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -18,7 +18,7 @@ You get, for free:
 
 - branch-agnostic cache keys the action produces on its own
 - automatic restore on feature branches from the latest `main` cache on a miss
-- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves the Soldr-owned zccache cache root and the Cargo target directory by default
+- no separate `actions/cache` step; the action already runs the setup-state cache internally and also restores and saves the Soldr-owned zccache cache root and the zccache-owned Rust artifact plan cache by default
 - `cache-hit`, `build-cache-hit`, and `target-cache-hit` outputs you can read to confirm warm vs cold runs
 
 The rest of this document explains how and why that works.
@@ -49,7 +49,7 @@ The `zackees/setup-soldr@v0` action (generated from [`action.yml`](../action.yml
 - **Push-only save semantics come for free.** GitHub's cache scoping already prevents feature-branch runs from overwriting `main`'s cache. You do not need to gate `save-if` yourself the way internal Rust caching wrappers usually make you do.
 - **Rehydrated state.** On a cache hit, the action restores the soldr root, `CARGO_HOME`, and `RUSTUP_HOME` under the runner-local cache/state root. The resolved Rust toolchain and the `soldr` binary are then provisioned on top of whatever was restored.
 - **Build-artifact cache enabled by default.** The action also restores the Soldr-owned zccache cache root with a toolchain-scoped key and saves it at end-of-job, so zccache compilation artifacts survive across runs unless you opt out with `build-cache: false`.
-- **Hot Cargo target cache enabled by default.** When `build-cache` is enabled, the action restores a bounded hot target cache with Cargo freshness metadata and lightweight type metadata. It does not archive the full `target/` tree unless the workflow explicitly sets `target-cache-mode: full`.
+- **Thin Rust artifact cache enabled by default.** The action restores a zccache-owned Rust artifact plan cache when a `Cargo.lock` is present. `soldr cargo ...` generates a `thin` plan by default and asks zccache to restore/save bounded dependency artifacts. It does not use an action-owned full `target/` snapshot unless the workflow explicitly sets `target-cache-mode: full`, which is still executed by zccache from the soldr-generated plan.
 
 ## Minimum Config For An External Repo
 
@@ -127,7 +127,7 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
    For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
 
-   For the Cargo target layer, inspect the `target-cache` step. Its default hot-cache keys are `setup-soldr-targetcache-hot-v1-{os}-{arch}-{toolchain-digest}-{cargo-lock-hash}-{paths-hash}-{github.sha}` and its restore-key falls back within the same toolchain, lockfile, and cache-shape lineage.
+   For the Rust artifact plan layer, inspect the `target-cache` step. Its default thin-cache keys are `setup-soldr-targetcache-thin-v1-{os}-{arch}-{target-inputs-hash}` and use exact restore only. The target-inputs hash includes the toolchain digest, `Cargo.lock`, workspace manifest hashes, Cargo config, target-dir shape, and relevant Rust flags.
 
 3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 
@@ -137,11 +137,11 @@ After two pushes to the same branch, you should be able to confirm the cache lin
    - run: soldr cache
    ```
 
-   The output includes the managed zccache root and status lines from zccache. For a healthy warm build, look for non-zero cached compilations or hit counts. If `build-cache-hit=true` but zccache still reports zero cached compilations, the build-artifact cache restored but did not produce compiler-cache reuse; check whether the target-cache layer also restored and whether Cargo invalidated fingerprints before zccache could hit.
+   The output includes the managed zccache root and status lines from zccache. For a healthy warm build, look for non-zero cached compilations or hit counts, plus the `zccache rust-plan restore/save` JSON summaries emitted by `soldr cargo ...`. If `build-cache-hit=true` but zccache still reports zero cached compilations, the build-artifact cache restored but did not produce compiler-cache reuse; check whether the target-cache layer also restored and whether Cargo invalidated fingerprints before zccache could hit.
 
 ## Debugging Target-Cache Restores That Still Rebuild
 
-A restored target cache is only a fast path when Cargo still considers the restored fingerprints fresh. Some crates have build scripts that do not declare narrow inputs with `cargo:rerun-if-changed=` or `cargo:rerun-if-env-changed=` lines. For those crates, Cargo can fall back to broad package/source fingerprint inputs. A fresh GitHub checkout may then have different source mtimes than the checkout that produced the restored target directory, so Cargo rebuilds that package even though `target-cache-hit` is `true`.
+A restored Rust artifact plan cache is only a fast path when Cargo still considers the restored fingerprints fresh. Some crates have build scripts that do not declare narrow inputs with `cargo:rerun-if-changed=` or `cargo:rerun-if-env-changed=` lines. For those crates, Cargo can fall back to broad package/source fingerprint inputs. A fresh GitHub checkout may then have different source mtimes than the checkout that produced the restored artifacts, so Cargo rebuilds that package even though `target-cache-hit` is `true`.
 
 Use Cargo's fingerprint diagnostics to confirm this failure mode:
 
@@ -166,12 +166,12 @@ That means the cache restored correctly, but Cargo invalidated a build-script fi
 If feature branches keep rebuilding from scratch, check these in order:
 
 - **Has `main` run successfully recently?** The restore fallback only works if the default branch has written a cache. If the main-branch pipeline is red or was never run on this workflow file, there is no parent to restore from. Fix `main` first.
-- **Is `Cargo.lock` churning on every push?** Lockfile changes do not change the setup-soldr state-cache key, but they do invalidate the Cargo target cache and can reduce downstream zccache reuse. Check whether your workflow keeps regenerating `Cargo.lock` (for example, because `Cargo.lock` is gitignored in an application repo where it should be committed).
+- **Is `Cargo.lock` churning on every push?** Lockfile changes do not change the setup-soldr state-cache key, but they do invalidate the Rust artifact plan cache and can reduce downstream zccache reuse. Check whether your workflow keeps regenerating `Cargo.lock` (for example, because `Cargo.lock` is gitignored in an application repo where it should be committed).
 - **Did `rust-toolchain.toml` change?** The resolved toolchain channel is part of both cache key families. Bumping the toolchain channel or the components/targets list invalidates every existing entry. That is expected behavior; the next push to `main` will write a fresh canonical entry.
 - **Did you pass a `cache-key-suffix` input?** That value is appended to both cache key families (see `action.yml`). A different suffix on a feature branch produces a different key than `main` writes, and the restore will only succeed through the prefix fallback. Make sure the same suffix is used (or omitted) on every branch you want to share a lineage.
 - **Mixed runner OS/arch.** Cache keys are scoped by runner OS and architecture. A cache written on `ubuntu-24.04` will not restore on `macos-15` and vice versa. Each combination needs its own warm lineage from `main`.
 - **Did someone opt out of build caching?** If `build-cache: false` is set in the workflow, `build-cache-hit` will be empty and the Soldr-owned zccache cache root will not be restored or saved.
-- **Did someone opt out of target caching?** If `target-cache: false` is set in the workflow, `target-cache-hit` will be empty and the Cargo target directory will not be restored or saved.
+- **Did someone opt out of target caching?** If `target-cache: false` is set in the workflow, `target-cache-hit` will be empty and soldr will not ask zccache to restore or save Rust target artifacts.
 
 ---
 

--- a/docs/SETUP_SOLDR_PUBLIC_ACTION.md
+++ b/docs/SETUP_SOLDR_PUBLIC_ACTION.md
@@ -90,9 +90,9 @@ steps:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `"true"`; set to `"false"` to opt out. |
-| `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
-| `target-cache-mode` | Target cache mode. Default `"hot"` caches Cargo freshness metadata and lightweight type metadata; `"full"` caches the whole `target-dir`; `"off"` disables target caching. |
-| `target-dir` | Cargo target directory restored by `target-cache`. Default `"target"`. |
+| `target-cache` | Restore and save the zccache-owned Rust artifact plan cache for fast CI rebuilds. Default `"true"`; set to `"false"` to cache only zccache compilation artifacts. |
+| `target-cache-mode` | Target cache mode. Default `"thin"` asks soldr to generate a bounded dependency-artifact plan for zccache; `"full"` asks zccache to cache the whole `target-dir`; `"off"` disables target artifact caching. The old `"hot"` value is accepted as a deprecated alias for `"thin"`. |
+| `target-dir` | Cargo target directory used in target-cache key shaping. Default `"target"`. |
 | `tool-shims` | Optional PATH shim mode. Set to `"cargo"` to make later `cargo ...` steps run through `soldr cargo ...`; default `"false"`. |
 
 The current in-repo action also exposes `repo` as an implementation/testing override. That input is not part of the intended public `v0` beta contract and should not be documented in the extracted public action README.
@@ -108,7 +108,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is explicitly disabled. |
-| `target-cache-hit` | Whether the Cargo target directory cache was restored. Empty only when `build-cache` or `target-cache` is explicitly disabled. |
+| `target-cache-hit` | Whether the Rust artifact plan cache was restored. Empty only when `target-cache` is explicitly disabled. |
 | `target-cache-mode` | Effective target cache mode. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 | `tool-shims-dir` | Directory containing generated tool shims when enabled. |
@@ -125,7 +125,7 @@ The current in-repo action also exposes `repo` as an implementation/testing over
 - export `RUSTUP_TOOLCHAIN` after toolchain installation so later `cargo`, `rustc`, and `soldr cargo ...` steps stay on the same resolved toolchain
 - when `tool-shims: cargo` is enabled, resolve the real Cargo binary before prepending the generated shim directory to `PATH`, then export `SOLDR_REAL_CARGO` so Soldr avoids recursive shim lookup
 - when `build-cache: true` (the default), restore the Soldr-owned zccache cache root at setup time and save it at end-of-job (`if: always()`) so subsequent runs rehydrate zccache compilation artifacts. Keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` with restore-keys that first fall back to the same `{toolchain-digest}` lineage, then any cache for the same `{os}-{arch}`. GitHub's own-branch -> PR base -> default-branch restore order seeds feature-branch runs from the latest main-branch save without user configuration. Consumers that explicitly do not want cross-run cache reuse can set `build-cache: false`.
-- when `build-cache: true` and `target-cache: true` (the defaults), restore a bounded hot Cargo target cache at setup time and save it at end-of-job so no-op child-branch builds can reuse Cargo fingerprints and lightweight metadata without archiving the full `target/` tree. `target-cache-mode: full` remains available only for tightly scoped jobs where the whole target directory is known to stay bounded.
+- when `target-cache: true` (the default), restore the zccache-owned Rust artifact plan cache root at setup time and save it at end-of-job. `soldr cargo ...` generates the versioned plan and asks zccache to restore/save `thin` or explicit `full` target artifacts from that plan.
 
 ### Current Limits That Must Stay Explicit
 
@@ -134,7 +134,7 @@ The extracted public action must document these current limits honestly:
 - the action rehydrates the Soldr root, Cargo home, rustup home, and Soldr-owned zccache artifact cache under the chosen cache/state root
 - the action bootstraps `rustup` on demand via `rustup-init` when it is absent, then uses it to install the requested toolchain; at runtime Soldr prefers direct toolchain binaries from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` and only falls back to `rustup which` when the direct probe fails (or when `RUSTUP_TOOLCHAIN` is explicitly set)
 - the action exports `ZCCACHE_CACHE_DIR` to the Soldr-owned zccache artifact cache under `SOLDR_CACHE_DIR`
-- restored Cargo target directories are fast paths, not freshness overrides; build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ
+- restored Rust artifact plan caches are fast paths, not freshness overrides; build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ
 
 ### Non-Contract Details
 

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -7,14 +7,14 @@ from pathlib import Path
 
 
 HELPER_SCRIPT_PATHS = (
-    Path('.github/actions/setup-soldr/resolve_setup.py'),
-    Path('.github/actions/setup-soldr/ensure_rust_toolchain.py'),
-    Path('.github/actions/setup-soldr/ensure_soldr.py'),
-    Path('.github/actions/setup-soldr/install_tool_shims.py'),
-    Path('.github/actions/setup-soldr/verify_soldr.py'),
+    Path(".github/actions/setup-soldr/resolve_setup.py"),
+    Path(".github/actions/setup-soldr/ensure_rust_toolchain.py"),
+    Path(".github/actions/setup-soldr/ensure_soldr.py"),
+    Path(".github/actions/setup-soldr/install_tool_shims.py"),
+    Path(".github/actions/setup-soldr/verify_soldr.py"),
 )
 
-PUBLIC_ACTION_REPO = 'zackees/setup-soldr'
+PUBLIC_ACTION_REPO = "zackees/setup-soldr"
 PUBLIC_README = """# setup-soldr
 
 Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring a cacheable runner-local root for Soldr, Cargo, and rustup state.
@@ -98,9 +98,9 @@ jobs:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. |
-| `target-cache-mode` | Target cache mode. Default `hot` caches Cargo freshness metadata and lightweight type metadata; `full` caches the whole `target-dir`; `off` disables target caching. |
-| `target-dir` | Cargo target directory restored by `target-cache`. |
+| `target-cache` | Restore and save the zccache-owned Rust artifact plan cache for fast CI rebuilds. |
+| `target-cache-mode` | Target cache mode. Default `thin` asks soldr to generate a bounded dependency-artifact plan for zccache; `full` asks zccache to cache the whole `target-dir`; `off` disables target artifact caching. The old `hot` value is accepted as a deprecated alias for `thin`. |
+| `target-dir` | Cargo target directory used in target-cache key shaping. |
 | `tool-shims` | Optional PATH shim mode. Set to `cargo` to make later `cargo ...` steps run through `soldr cargo ...`; default `false`. |
 
 ## Outputs
@@ -112,7 +112,7 @@ jobs:
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
-| `target-cache-hit` | Whether the Cargo target directory cache was restored. |
+| `target-cache-hit` | Whether the Rust artifact plan cache was restored. |
 | `target-cache-mode` | Effective target cache mode. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 | `tool-shims-dir` | Directory containing generated tool shims when enabled. |
@@ -123,7 +123,7 @@ jobs:
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
 - The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
-- The default target cache mode is `hot`, which avoids archiving the full Cargo `target/` tree and caches only Cargo freshness metadata plus lightweight type metadata. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
+- The default target cache mode is `thin`, which avoids action-owned `target/` snapshots by having soldr pass a bounded Rust artifact plan to zccache. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 - `tool-shims: cargo` prepends a Cargo shim for existing workflows that cannot rewrite every `cargo ...` command to `soldr cargo ...`.
 - A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.
@@ -140,13 +140,13 @@ def _module_repo_root() -> Path:
 
 def _write_text(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding='utf-8')
+    path.write_text(content, encoding="utf-8")
 
 
 def _copy_file(source_root: Path, destination_root: Path, relative_path: Path) -> None:
     source_path = source_root / relative_path
     if not source_path.is_file():
-        raise FileNotFoundError(f'Missing source file for export: {source_path}')
+        raise FileNotFoundError(f"Missing source file for export: {source_path}")
     destination_path = destination_root / relative_path
     destination_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source_path, destination_path)
@@ -158,25 +158,25 @@ def _strip_repo_input(action_text: str) -> str:
 
     for line in action_text.splitlines():
         if skipping_repo_input:
-            if line.startswith('  ') and not line.startswith('    '):
+            if line.startswith("  ") and not line.startswith("    "):
                 skipping_repo_input = False
             else:
                 continue
 
-        if line == '  repo:':
+        if line == "  repo:":
             skipping_repo_input = True
             continue
 
-        if 'INPUT_REPO:' in line:
+        if "INPUT_REPO:" in line:
             continue
 
         output_lines.append(line)
 
-    return '\n'.join(output_lines) + '\n'
+    return "\n".join(output_lines) + "\n"
 
 
 def render_public_action_yaml(source_root: Path) -> str:
-    return _strip_repo_input((source_root / 'action.yml').read_text(encoding='utf-8'))
+    return _strip_repo_input((source_root / "action.yml").read_text(encoding="utf-8"))
 
 
 def render_public_readme() -> str:
@@ -188,12 +188,12 @@ def export_setup_soldr_bundle(source_root: Path, destination_root: Path) -> Path
     destination_root = destination_root.expanduser().resolve()
 
     if destination_root == source_root:
-        raise ValueError('Destination must not be the source repository root')
+        raise ValueError("Destination must not be the source repository root")
 
     destination_root.mkdir(parents=True, exist_ok=True)
-    _write_text(destination_root / 'action.yml', render_public_action_yaml(source_root))
-    _write_text(destination_root / 'README.md', render_public_readme())
-    _copy_file(source_root, destination_root, Path('LICENSE'))
+    _write_text(destination_root / "action.yml", render_public_action_yaml(source_root))
+    _write_text(destination_root / "README.md", render_public_readme())
+    _copy_file(source_root, destination_root, Path("LICENSE"))
 
     for relative_path in HELPER_SCRIPT_PATHS:
         _copy_file(source_root, destination_root, relative_path)
@@ -203,13 +203,15 @@ def export_setup_soldr_bundle(source_root: Path, destination_root: Path) -> Path
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description='Export the standalone public setup-soldr action bundle.'
+        description="Export the standalone public setup-soldr action bundle."
     )
-    parser.add_argument('destination', help='Directory to materialize as the future public action repository.')
     parser.add_argument(
-        '--source-root',
+        "destination", help="Directory to materialize as the future public action repository."
+    )
+    parser.add_argument(
+        "--source-root",
         default=str(_module_repo_root()),
-        help='Source soldr repository root. Defaults to the current checkout.',
+        help="Source soldr repository root. Defaults to the current checkout.",
     )
     return parser.parse_args(argv)
 
@@ -217,9 +219,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     destination = export_setup_soldr_bundle(Path(args.source_root), Path(args.destination))
-    print(f'Exported setup-soldr bundle to {destination}')
+    print(f"Exported setup-soldr bundle to {destination}")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -81,9 +81,9 @@ jobs:
 | `toolchain-file` | Alternate toolchain file path when `toolchain` is empty. |
 | `trust-mode` | Optional `SOLDR_TRUST_MODE` value. |
 | `build-cache` | Restore and save the Soldr-owned zccache compilation artifact cache across runs. Default `true`; set to `false` to opt out. |
-| `target-cache` | Restore and save Cargo target metadata for no-op CI fast paths. |
-| `target-cache-mode` | Target cache mode. Default `hot` caches Cargo freshness metadata and lightweight type metadata; `full` caches the whole `target-dir`; `off` disables target caching. |
-| `target-dir` | Cargo target directory restored by `target-cache`. |
+| `target-cache` | Restore and save the zccache-owned Rust artifact plan cache for fast CI rebuilds. |
+| `target-cache-mode` | Target cache mode. Default `thin` asks soldr to generate a bounded dependency-artifact plan for zccache; `full` asks zccache to cache the whole `target-dir`; `off` disables target artifact caching. The old `hot` value is accepted as a deprecated alias for `thin`. |
+| `target-dir` | Cargo target directory used in target-cache key shaping. |
 | `tool-shims` | Optional PATH shim mode. Set to `cargo` to make later `cargo ...` steps run through `soldr cargo ...`; default `false`. |
 
 ## Outputs
@@ -95,7 +95,7 @@ jobs:
 | `cache-dir` | Action-managed runner-local cache/state root. |
 | `cache-hit` | Whether the action restored an exact cache hit. |
 | `build-cache-hit` | Whether the Soldr-owned zccache compilation cache was restored. Empty only when `build-cache` is disabled. |
-| `target-cache-hit` | Whether the Cargo target directory cache was restored. |
+| `target-cache-hit` | Whether the Rust artifact plan cache was restored. |
 | `target-cache-mode` | Effective target cache mode. |
 | `toolchain` | Exact Rust toolchain channel configured for the action. |
 | `tool-shims-dir` | Directory containing generated tool shims when enabled. |
@@ -106,7 +106,7 @@ jobs:
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
 - The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
-- The default target cache mode is `hot`, which avoids archiving the full Cargo `target/` tree and caches only Cargo freshness metadata plus lightweight type metadata. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
+- The default target cache mode is `thin`, which avoids action-owned `target/` snapshots by having soldr pass a bounded Rust artifact plan to zccache. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 - `tool-shims: cargo` prepends a Cargo shim for existing workflows that cannot rewrite every `cargo ...` command to `soldr cargo ...`.
 - A restored target directory is a Cargo fast path, not a guarantee: build scripts without precise `cargo:rerun-if-*` inputs can still be dirty on fresh checkouts because source mtimes differ.

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -46,22 +46,24 @@ inputs:
     default: "true"
   target-cache:
     description: >
-      Restore and save the Cargo target directory across workflow runs.
-      Default "true"; target-cache-mode controls whether this is a bounded hot
-      metadata cache or an explicit full target cache. Set to "false" to cache
-      only zccache compilation artifacts.
+      Restore and save the zccache-owned Rust artifact plan cache across
+      workflow runs.
+      Default "true"; target-cache-mode controls whether this is a bounded thin
+      dependency-artifact cache or an explicit full target cache plan. Set to
+      "false" to cache only zccache compilation artifacts.
     required: false
     default: "true"
   target-cache-mode:
     description: >
-      Cargo target cache mode. "hot" caches Cargo freshness metadata and
-      lightweight type metadata by default. "full" caches the entire target-dir
-      and should only be used for tightly scoped jobs. "off" disables target
-      caching even when target-cache is true.
+      Rust artifact cache mode. "thin" asks soldr to generate a bounded
+      dependency-artifact plan for zccache by default. "full" asks zccache to
+      cache the entire target-dir and should only be used for tightly scoped
+      jobs. "off" disables target caching even when target-cache is true. The
+      previous "hot" value is accepted as a deprecated alias for "thin".
     required: false
-    default: hot
+    default: thin
   target-dir:
-    description: Cargo target directory restored by target-cache.
+    description: Cargo target directory used in target-cache key shaping.
     required: false
     default: target
   tool-shims:
@@ -93,12 +95,12 @@ outputs:
     value: ${{ steps.cache-meta.outputs.build_cache_hit }}
   target-cache-hit:
     description: >
-      Whether the action restored the Cargo target directory cache. "true"
+      Whether the action restored the Rust artifact plan cache. "true"
       for an exact key match, "false" for a restore-key fallback or no cache,
-      empty string when `target-cache` or `build-cache` is disabled.
+      empty string when `target-cache` is disabled.
     value: ${{ steps.cache-meta.outputs.target_cache_hit }}
   target-cache-mode:
-    description: Effective Cargo target cache mode.
+    description: Effective Rust artifact target cache mode.
     value: ${{ steps.resolve.outputs.target_cache_mode }}
   toolchain:
     description: Exact Rust toolchain channel configured by rustup for the action.
@@ -147,7 +149,7 @@ runs:
           ${{ steps.resolve.outputs.build_cache_restore_key_os_arch }}
 
     - id: target-cache
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
+      if: ${{ steps.resolve.outputs.target_cache_enabled == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ${{ steps.resolve.outputs.target_cache_paths }}
@@ -182,49 +184,6 @@ runs:
         SETUP_SOLDR_TOOL_SHIMS: ${{ inputs.tool-shims }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/install_tool_shims.py"
 
-    - id: zccache-warm-target
-      if: ${{ inputs.build-cache == 'true' && steps.resolve.outputs.target_cache_enabled == 'true' }}
-      shell: pwsh
-      env:
-        TARGET_CACHE_PATH: ${{ steps.resolve.outputs.target_cache_path }}
-      run: |
-        $target = $env:TARGET_CACHE_PATH
-        if ([string]::IsNullOrWhiteSpace($target) -or -not (Test-Path -LiteralPath $target)) {
-          Write-Host "No restored target directory to warm."
-          exit 0
-        }
-
-        $exeName = if ($IsWindows) { "zccache.exe" } else { "zccache" }
-        $zccache = $null
-        if (-not [string]::IsNullOrWhiteSpace($env:SOLDR_CACHE_DIR)) {
-          $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
-          if (Test-Path -LiteralPath $soldrBin) {
-            $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
-              Select-Object -First 1 -ExpandProperty FullName
-          }
-        }
-        if ([string]::IsNullOrWhiteSpace($zccache)) {
-          $command = Get-Command zccache -ErrorAction SilentlyContinue
-          if ($command) {
-            $zccache = $command.Source
-          }
-        }
-        if ([string]::IsNullOrWhiteSpace($zccache)) {
-          Write-Host "zccache binary is not available yet; refreshing target mtimes only."
-        } else {
-          Write-Host "Warming target directory from zccache: $target"
-          & $zccache warm --target-dir $target
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "zccache warm did not complete successfully; continuing."
-          }
-        }
-
-        $stamp = (Get-Date).AddMinutes(1)
-        Get-ChildItem -LiteralPath $target -Recurse -File -Force -ErrorAction SilentlyContinue |
-          ForEach-Object { $_.LastWriteTime = $stamp }
-        Write-Host "Refreshed target file mtimes."
-        exit 0
-
     - id: cache-meta
       shell: pwsh
       env:
@@ -251,7 +210,7 @@ runs:
         }
         "build_cache_hit=$buildValue" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-        if ($env:BUILD_CACHE_ENABLED -eq "true" -and $env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") {
+        if ($env:EFFECTIVE_TARGET_CACHE_ENABLED -eq "true") {
           $targetValue = $env:RAW_TARGET_CACHE_HIT
           if ([string]::IsNullOrWhiteSpace($targetValue)) {
             $targetValue = "false"

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -98,8 +98,7 @@ def test_action_python_helpers_have_entrypoints() -> None:
     for script_path in script_paths:
         tree = ast.parse(script_path.read_text(encoding="utf-8"))
         assert any(
-            isinstance(node, ast.FunctionDef) and node.name == "main"
-            for node in tree.body
+            isinstance(node, ast.FunctionDef) and node.name == "main" for node in tree.body
         ), f"{script_path.relative_to(REPO_ROOT)} should define main()"
         assert any(
             isinstance(node, ast.If)
@@ -107,8 +106,7 @@ def test_action_python_helpers_have_entrypoints() -> None:
             and isinstance(node.test.left, ast.Name)
             and node.test.left.id == "__name__"
             and any(
-                isinstance(comparator, ast.Constant)
-                and comparator.value == "__main__"
+                isinstance(comparator, ast.Constant) and comparator.value == "__main__"
                 for comparator in node.test.comparators
             )
             for node in tree.body
@@ -116,9 +114,9 @@ def test_action_python_helpers_have_entrypoints() -> None:
 
 
 def test_setup_soldr_smoke_tests_disable_nested_cache() -> None:
-    workflow = (
-        REPO_ROOT / ".github" / "workflows" / "setup-soldr-action.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (REPO_ROOT / ".github" / "workflows" / "setup-soldr-action.yml").read_text(
+        encoding="utf-8"
+    )
 
     assert "Remove-Item Env:ZCCACHE_CACHE_DIR" in workflow
     assert "soldr --no-cache cargo test -p soldr-cli --test cli --locked" in workflow
@@ -182,15 +180,117 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert "build_cache_restore_key_os_arch=setup-soldr-buildcache-v1-linux-x64-" in outputs
     assert f"build_cache_path={cache_root / 'soldr' / 'cache' / 'zccache'}" in outputs
     assert f"target_cache_path={workspace / 'custom-target'}" in outputs
+    bundle_path = runner_temp / "setup-soldr-target-thin"
+    assert f"target_cache_bundle_path={bundle_path}" in outputs
     assert f"shim_dir={cache_root / 'shims'}" in outputs
-    assert "target_cache_key=setup-soldr-targetcache-hot-v1-linux-x64-" in outputs
-    assert "target_cache_enabled=true" in outputs
-    assert "target_cache_mode=hot" in outputs
-    assert ".fingerprint" in outputs
-    assert outputs.count("-no-lock-") >= 1
+    assert "target_cache_key=setup-soldr-targetcache-thin-v1-linux-x64-" in outputs
+    assert "target_cache_enabled=false" in outputs
+    assert "target_cache_mode=thin" in outputs
+    assert f"target_cache_paths={bundle_path}" in outputs
     assert outputs.count("-abc123") >= 1
     assert "toolchain=stable" in outputs
 
     env_text = github_env.read_text(encoding="utf-8")
     assert f"SOLDR_CACHE_DIR={cache_root / 'soldr'}" in env_text
     assert f"ZCCACHE_CACHE_DIR={cache_root / 'soldr' / 'cache' / 'zccache'}" in env_text
+    assert "SOLDR_TARGET_CACHE_MODE=off" in env_text
+    assert "SOLDR_TARGET_CACHE_BACKEND=auto" in env_text
+
+
+def test_main_treats_hot_as_thin_alias_with_lockfile(tmp_path: Path, monkeypatch) -> None:
+    module = _load_module()
+    workspace = tmp_path / "workspace"
+    runner_temp = tmp_path / "runner-temp"
+    workspace.mkdir()
+    runner_temp.mkdir()
+    (workspace / "Cargo.lock").write_text("# lock\n", encoding="utf-8")
+    (workspace / "Cargo.toml").write_text("[workspace]\n", encoding="utf-8")
+
+    github_env = tmp_path / "github.env"
+    github_output = tmp_path / "github.output"
+    github_path = tmp_path / "github.path"
+
+    monkeypatch.setenv("ACTION_WORKSPACE", str(workspace))
+    monkeypatch.setenv("RUNNER_TEMP", str(runner_temp))
+    monkeypatch.setenv("ACTION_OS", "Linux")
+    monkeypatch.setenv("ACTION_ARCH", "X64")
+    monkeypatch.setenv("INPUT_REPO", "zackees/soldr")
+    monkeypatch.setenv("INPUT_VERSION", "")
+    monkeypatch.setenv("INPUT_CACHE_DIR", "")
+    monkeypatch.setenv("INPUT_CACHE_KEY_SUFFIX", "")
+    monkeypatch.setenv("INPUT_TOOLCHAIN", "")
+    monkeypatch.setenv("INPUT_TOOLCHAIN_FILE", "missing.toml")
+    monkeypatch.setenv("INPUT_TRUST_MODE", "")
+    monkeypatch.setenv("INPUT_TARGET_CACHE", "true")
+    monkeypatch.setenv("INPUT_TARGET_CACHE_MODE", "hot")
+    monkeypatch.setenv("INPUT_TARGET_DIR", "target")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    monkeypatch.setenv("GITHUB_ENV", str(github_env))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setenv("GITHUB_PATH", str(github_path))
+
+    module.main()
+
+    cache_root = runner_temp / "setup-soldr"
+    bundle_path = runner_temp / "setup-soldr-target-thin"
+    outputs = github_output.read_text(encoding="utf-8")
+    assert "target_cache_enabled=true" in outputs
+    assert "target_cache_mode=thin" in outputs
+    assert "target_cache_key=setup-soldr-targetcache-thin-v1-linux-x64-" in outputs
+    assert f"target_cache_paths={bundle_path}" in outputs
+    assert "target_cache_restore_key_lock=setup-soldr-targetcache-thin-v1-linux-x64-" in outputs
+
+    env_text = github_env.read_text(encoding="utf-8")
+    assert "SOLDR_TARGET_CACHE_MODE=thin" in env_text
+    assert f"SOLDR_TARGET_CACHE_DIR={workspace / 'target'}" in env_text
+    assert f"SOLDR_TARGET_CACHE_BUNDLE_DIR={bundle_path}" in env_text
+    assert "SOLDR_TARGET_CACHE_BACKEND=auto" in env_text
+    assert bundle_path == runner_temp / "setup-soldr-target-thin"
+
+
+def test_full_target_cache_suffix_restore_prefix_matches_key_shape(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_module()
+    workspace = tmp_path / "workspace"
+    runner_temp = tmp_path / "runner-temp"
+    workspace.mkdir()
+    runner_temp.mkdir()
+    (workspace / "Cargo.lock").write_text("# lock\n", encoding="utf-8")
+    (workspace / "Cargo.toml").write_text("[workspace]\n", encoding="utf-8")
+
+    github_env = tmp_path / "github.env"
+    github_output = tmp_path / "github.output"
+    github_path = tmp_path / "github.path"
+
+    monkeypatch.setenv("ACTION_WORKSPACE", str(workspace))
+    monkeypatch.setenv("RUNNER_TEMP", str(runner_temp))
+    monkeypatch.setenv("ACTION_OS", "Linux")
+    monkeypatch.setenv("ACTION_ARCH", "X64")
+    monkeypatch.setenv("INPUT_REPO", "zackees/soldr")
+    monkeypatch.setenv("INPUT_VERSION", "")
+    monkeypatch.setenv("INPUT_CACHE_DIR", "")
+    monkeypatch.setenv("INPUT_CACHE_KEY_SUFFIX", "feature-a")
+    monkeypatch.setenv("INPUT_TOOLCHAIN", "")
+    monkeypatch.setenv("INPUT_TOOLCHAIN_FILE", "missing.toml")
+    monkeypatch.setenv("INPUT_TRUST_MODE", "")
+    monkeypatch.setenv("INPUT_TARGET_CACHE", "true")
+    monkeypatch.setenv("INPUT_TARGET_CACHE_MODE", "full")
+    monkeypatch.setenv("INPUT_TARGET_DIR", "target")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    monkeypatch.setenv("GITHUB_ENV", str(github_env))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setenv("GITHUB_PATH", str(github_path))
+
+    module.main()
+
+    outputs = dict(
+        line.split("=", 1)
+        for line in github_output.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+    key = outputs["target_cache_key"]
+    restore_prefix = outputs["target_cache_restore_key_lock"]
+    assert key.startswith(restore_prefix)
+    assert key.endswith("abc123")
+    assert "feature-a" in restore_prefix


### PR DESCRIPTION
## Summary

Implements the soldr side of issue #221.

- Generates a v1 Rust artifact plan from soldr cargo metadata, target/profile/features/env/toolchain inputs, workspace/package IDs, and artifact class policy.
- Calls zccache rust-plan restore before Cargo and zccache rust-plan save after successful builds, with JSON summaries and session/journal context.
- Switches setup-soldr target caching to persist the zccache-owned Rust artifact plan cache directory instead of action-owned target restoration/warming.
- Bumps managed zccache to 1.3.9, which contains the merged rust-plan API.
- Tightens toolchain resolution so rustup wins over polluted PATH shims while explicit/repo-local toolchains still bypass rustup.

## Tests

- cargo test --workspace
- pytest
- git diff --check

Closes #221