### PR TITLE
Bump release version to 0.7.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "clap",
  "serde",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "serde",
  "tempfile",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.9"
+version = "0.7.10"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- bump workspace package version to 0.7.10
- sync npm package version
- refresh Cargo.lock workspace package versions

## Validation
- cargo metadata --locked --format-version 1 --no-deps
- git diff --check