### PR TITLE
Add a distinct zccache session log file

### DIFF
--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -98,6 +98,10 @@ pub fn session_journal_path(zccache_dir: &Path) -> PathBuf {
     zccache_dir.join("logs").join("last-session.jsonl")
 }
 
+pub fn session_log_path(zccache_dir: &Path) -> PathBuf {
+    zccache_dir.join("logs").join("last-session.log")
+}
+
 #[derive(Debug, Deserialize)]
 struct SessionStartResponse {
     session_id: String,
@@ -107,7 +111,8 @@ struct SessionStartResponse {
 mod tests {
     use super::{
         cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id, sccache_dir,
-        session_journal_path, zccache_dir, CACHE_DISABLED_VALUE, CACHE_ENABLED_VALUE,
+        session_journal_path, session_log_path, zccache_dir, CACHE_DISABLED_VALUE,
+        CACHE_ENABLED_VALUE,
     };
     use soldr_core::SoldrPaths;
     use std::{ffi::OsStr, path::Path};
@@ -191,6 +196,17 @@ mod tests {
             Path::new("C:\\soldr-root\\cache\\zccache")
                 .join("logs")
                 .join("last-session.jsonl")
+        );
+    }
+
+    #[test]
+    fn session_log_path_uses_logs_directory() {
+        let path = session_log_path(Path::new("C:\\soldr-root\\cache\\zccache"));
+        assert_eq!(
+            path,
+            Path::new("C:\\soldr-root\\cache\\zccache")
+                .join("logs")
+                .join("last-session.log")
         );
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1447,6 +1447,7 @@ struct ZccacheBuildSession {
     binary_path: std::path::PathBuf,
     cache_dir: std::path::PathBuf,
     session_id: String,
+    session_log_path: std::path::PathBuf,
     journal_path: std::path::PathBuf,
 }
 
@@ -1534,11 +1535,20 @@ async fn prepare_zccache_build(
 
     start_zccache_with_recovery(&fetch.binary_path, &zccache_dir)?;
 
+    let session_log_path = soldr_cache::session_log_path(&zccache_dir);
+    let session_log_path_arg = session_log_path.display().to_string();
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
     let journal_path_arg = journal_path.display().to_string();
     let session_json = run_zccache_command_in_cache_dir(
         &fetch.binary_path,
-        &["session-start", "--stats", "--journal", &journal_path_arg],
+        &[
+            "session-start",
+            "--stats",
+            "--log",
+            &session_log_path_arg,
+            "--journal",
+            &journal_path_arg,
+        ],
         &zccache_dir,
     )?;
     let session_id =
@@ -1559,6 +1569,7 @@ async fn prepare_zccache_build(
         binary_path: fetch.binary_path,
         cache_dir: zccache_dir,
         session_id,
+        session_log_path,
         journal_path,
     })
 }
@@ -1569,6 +1580,12 @@ fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError>
         &["session-end", &session.session_id],
         &session.cache_dir,
     )?;
+    if session.session_log_path.exists() {
+        eprintln!(
+            "soldr: zccache session log: {}",
+            session.session_log_path.display()
+        );
+    }
     let stdout = output.stdout.trim();
     if !stdout.is_empty() {
         eprintln!("soldr: zccache session summary");
@@ -1664,6 +1681,8 @@ struct CacheOutput {
 struct ZccacheStatusSnapshot {
     cache_dir: String,
     state_dir: String,
+    session_log_path: String,
+    session_log_present: bool,
     journal_path: String,
     journal_present: bool,
     binary_path: Option<String>,
@@ -1710,6 +1729,8 @@ fn collect_cache_output() -> Result<CacheOutput, SoldrError> {
 
 fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, SoldrError> {
     let zccache_dir = managed_zccache_cache_dir(paths)?;
+    let session_log_path = soldr_cache::session_log_path(&zccache_dir);
+    let session_log_present = session_log_path.exists();
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
     let journal_present = journal_path.exists();
 
@@ -1722,6 +1743,8 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
             Ok(ZccacheStatusSnapshot {
                 cache_dir: zccache_dir.display().to_string(),
                 state_dir: zccache_dir.display().to_string(),
+                session_log_path: session_log_path.display().to_string(),
+                session_log_present,
                 journal_path: journal_path.display().to_string(),
                 journal_present,
                 binary_path: Some(fetch.binary_path.display().to_string()),
@@ -1733,6 +1756,8 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
         None => Ok(ZccacheStatusSnapshot {
             cache_dir: zccache_dir.display().to_string(),
             state_dir: zccache_dir.display().to_string(),
+            session_log_path: session_log_path.display().to_string(),
+            session_log_present,
             journal_path: journal_path.display().to_string(),
             journal_present,
             binary_path: None,
@@ -1768,6 +1793,15 @@ fn print_cache_output(output: &CacheOutput) {
 fn print_zccache_status_snapshot(snapshot: &ZccacheStatusSnapshot) {
     println!("soldr zccache cache dir: {}", snapshot.cache_dir);
     println!("soldr zccache state dir: {}", snapshot.state_dir);
+    println!(
+        "last session log: {} ({})",
+        snapshot.session_log_path,
+        if snapshot.session_log_present {
+            "present"
+        } else {
+            "missing"
+        }
+    );
     println!(
         "last session journal: {} ({})",
         snapshot.journal_path,
@@ -2253,6 +2287,7 @@ mod tests {
             binary_path: "zccache".into(),
             cache_dir: root.join("cache"),
             session_id: "session-1".to_string(),
+            session_log_path: root.join("cache/logs/last-session.log"),
             journal_path: root.join("cache/logs/last-session.jsonl"),
         };
         let args = vec![

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -303,12 +303,13 @@ fn fake_zccache_script(log_path: &Path) -> String {
                if defined SOLDR_TEST_ZCCACHE_STALE_START_ONCE type nul > \"%SOLDR_TEST_ZCCACHE_STALE_START_ONCE%.stopped\"\n\
                exit /b 0\n\
              )\n\
-             if \"%~1\"==\"session-start\" (\n\
-               echo zccache session-start cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
-               if not \"%~4\"==\"\" type nul > \"%~4\"\n\
-               echo {{\"session_id\":\"test-session\"}}\n\
-               exit /b 0\n\
-             )\n\
+              if \"%~1\"==\"session-start\" (\n\
+                echo zccache session-start cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+                if not \"%~4\"==\"\" type nul > \"%~4\"\n\
+                if not \"%~6\"==\"\" type nul > \"%~6\"\n\
+                echo {{\"session_id\":\"test-session\"}}\n\
+                exit /b 0\n\
+              )\n\
              if \"%~1\"==\"session-end\" (\n\
                echo zccache session-end %~2 cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                echo hits: 1\n\
@@ -373,12 +374,13 @@ fn fake_zccache_script(log_path: &Path) -> String {
                  fi\n\
                  exit 0\n\
                  ;;\n\
-               session-start)\n\
-                 echo \"zccache session-start cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
-                 : > \"$4\"\n\
-                 echo '{{\"session_id\":\"test-session\"}}'\n\
-                 exit 0\n\
-                 ;;\n\
+                session-start)\n\
+                  echo \"zccache session-start cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+                  : > \"$4\"\n\
+                  : > \"$6\"\n\
+                  echo '{{\"session_id\":\"test-session\"}}'\n\
+                  exit 0\n\
+                  ;;\n\
                session-end)\n\
                  echo \"zccache session-end $2 cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                echo 'hits: 1'\n\
@@ -736,6 +738,12 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
     );
 
     let journal = zccache_cache_dir.join("logs").join("last-session.jsonl");
+    let session_log = zccache_cache_dir.join("logs").join("last-session.log");
+    assert!(
+        session_log.exists(),
+        "expected session log at {}",
+        session_log.display()
+    );
     assert!(
         journal.exists(),
         "expected session journal at {}",
@@ -1644,6 +1652,7 @@ fn status_json_reports_stable_machine_fields() {
         cache_root.join("cache").display().to_string()
     );
     assert_eq!(json["zccache"]["binary_fetched"], false);
+    assert_eq!(json["zccache"]["session_log_present"], false);
     assert_eq!(json["zccache"]["journal_present"], false);
     assert_eq!(
         json["zccache"]["cache_dir"],
@@ -1657,6 +1666,16 @@ fn status_json_reports_stable_machine_fields() {
         json["target"].as_str().is_some(),
         "status JSON missing target"
     );
+    assert_eq!(
+        json["zccache"]["session_log_path"],
+        cache_root
+            .join("cache")
+            .join("zccache")
+            .join("logs")
+            .join("last-session.log")
+            .display()
+            .to_string()
+    );
 }
 
 #[test]
@@ -1669,8 +1688,14 @@ fn cache_command_reports_managed_zccache_status() {
         .join("zccache")
         .join("logs")
         .join("last-session.jsonl");
+    let session_log = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.log");
     fs::create_dir_all(journal.parent().expect("journal parent missing"))
         .expect("failed to create journal dir");
+    fs::write(&session_log, "compile line\n").expect("failed to seed session log");
     fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -1692,12 +1717,16 @@ fn cache_command_reports_managed_zccache_status() {
         "cache command missing state dir: {stdout}"
     );
     assert!(
+        stdout.contains("last session log:"),
+        "cache command missing session log path: {stdout}"
+    );
+    assert!(
         stdout.contains("last session journal:"),
         "cache command missing journal path: {stdout}"
     );
     assert!(
-        stdout.contains("(present)"),
-        "cache command should report present journal: {stdout}"
+        stdout.contains(&format!("{}", session_log.display())) && stdout.contains("(present)"),
+        "cache command should report present session log: {stdout}"
     );
     assert!(
         stdout.contains("zccache: hits=7"),
@@ -1715,8 +1744,14 @@ fn cache_json_reports_managed_zccache_status() {
         .join("zccache")
         .join("logs")
         .join("last-session.jsonl");
+    let session_log = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session.log");
     fs::create_dir_all(journal.parent().expect("journal parent missing"))
         .expect("failed to create journal dir");
+    fs::write(&session_log, "compile line\n").expect("failed to seed session log");
     fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -1733,6 +1768,7 @@ fn cache_json_reports_managed_zccache_status() {
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
     assert_eq!(json["managed_zccache_version"], "1.3.10");
+    assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(
@@ -1742,6 +1778,10 @@ fn cache_json_reports_managed_zccache_status() {
             .join("zccache")
             .display()
             .to_string()
+    );
+    assert_eq!(
+        json["zccache"]["session_log_path"],
+        session_log.display().to_string()
     );
     assert_eq!(
         json["zccache"]["journal_path"],


### PR DESCRIPTION
## Summary
- request both a human-readable zccache session log and the structured compile journal when soldr starts a managed session
- expose both paths separately in soldr status/cache output and JSON
- extend CLI and cache tests to cover the new session log path

Closes #224.

## Validation
- cargo test -p soldr-cache
- cargo test -p soldr-cli
- git diff --check