### PR TITLE
Fix rust-plan session stats endpoint on fast-gh-rebuild

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -611,6 +611,7 @@ struct RustArtifactPlanContext {
     path: std::path::PathBuf,
     zccache_binary: std::path::PathBuf,
     cache_dir: std::path::PathBuf,
+    zccache_daemon_cache_dir: std::path::PathBuf,
     session_id: String,
     journal_path: std::path::PathBuf,
     backend: String,
@@ -645,6 +646,7 @@ fn maybe_prepare_rust_artifact_plan(
         path: plan_path,
         zccache_binary: session.binary_path.clone(),
         cache_dir: rust_artifact_plan_cache_dir(session)?,
+        zccache_daemon_cache_dir: session.cache_dir.clone(),
         session_id: session.session_id.clone(),
         journal_path: session.journal_path.clone(),
         backend: rust_artifact_cache_backend_from_env()?,
@@ -895,8 +897,11 @@ fn run_zccache_rust_plan(
         args.push(plan.session_id.clone());
     }
 
-    let output =
-        run_zccache_command_strings_in_cache_dir(&plan.zccache_binary, &args, &plan.cache_dir)?;
+    let output = run_zccache_command_strings_in_cache_dir(
+        &plan.zccache_binary,
+        &args,
+        &plan.zccache_daemon_cache_dir,
+    )?;
     let stdout = output.stdout.trim();
     if !stdout.is_empty() {
         eprintln!("soldr: zccache rust-plan {operation} summary");

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -748,6 +748,7 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
     let cache_root = unique_temp_dir("cargo-rust-plan-cache");
     let workspace = unique_temp_dir("cargo-rust-plan-workspace");
     let plan_cache = cache_root.join("target-artifact-cache");
+    let zccache_cache_dir = cache_root.join("cache").join("zccache");
     let log_path = cache_root.join("tool.log");
     let metadata_path = cache_root.join("metadata.json");
     let target_dir = workspace.join("target");
@@ -803,10 +804,17 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
         "soldr should call zccache rust-plan restore/save when target cache is enabled: {log}"
     );
     assert!(
-        path_display_variants(&plan_cache)
+        path_display_variants(&zccache_cache_dir)
             .iter()
             .any(|path| log.contains(&format!("cache_dir={path}"))),
-        "rust-plan calls should use the zccache-owned target artifact cache dir: {log}"
+        "rust-plan calls should query the active managed zccache daemon cache dir: {log}"
+    );
+    assert!(
+        path_display_variants(&plan_cache).iter().any(|path| {
+            log.contains(&format!("--cache-dir {path}"))
+                || log.contains(&format!("--cache-dir \"{path}\""))
+        }),
+        "rust-plan calls should still pass the target artifact bundle path via --cache-dir: {log}"
     );
     assert!(
         log.find("zccache rust-plan restore") < log.find("cargo wrapper=")


### PR DESCRIPTION
## Summary
- keep \\zccache rust-plan --cache-dir\\ pointed at the restored target-artifact bundle
- keep the process \\ZCCACHE_CACHE_DIR\\ pointed at the managed zccache daemon cache root
- add a regression test proving rust-plan uses the managed daemon while still restoring/saving bundle artifacts

## Validation
- \\cargo test -p soldr-cli\\

## Context
Issue: zackees/setup-soldr#39

This is the \\soldr\\ leg of the coordinated \\ast-gh-rebuild\\ loop.