### PR TITLE
Prefer zccache release assets before cargo install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "clap",
  "serde",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "serde",
  "tempfile",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1637,7 +1637,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.3.9");
+    assert_eq!(json["managed_zccache_version"], "1.3.10");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -1732,7 +1732,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.3.9");
+    assert_eq!(json["managed_zccache_version"], "1.3.10");
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.9";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.10";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -112,6 +112,26 @@ pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult,
         return Ok(result);
     }
 
+    let release_version = VersionSpec::Exact(MANAGED_ZCCACHE_VERSION.to_string());
+    match fetch_repo_binary_with_paths(
+        "zccache",
+        &binary_names,
+        &managed_zccache_repo(),
+        &release_version,
+        None,
+        paths,
+    )
+    .await
+    {
+        Ok(result) => return Ok(result),
+        Err(err) if should_fallback_to_managed_zccache_cargo_install(&err) => {
+            eprintln!(
+                "soldr: managed zccache prebuilt unavailable ({err}); falling back to cargo install"
+            );
+        }
+        Err(err) => return Err(err),
+    }
+
     let binary_path = install_zccache_from_crates_io(paths, MANAGED_ZCCACHE_VERSION, &target)?;
 
     Ok(FetchResult {
@@ -130,6 +150,17 @@ pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, 
         &["zccache", "zccache-daemon", "zccache-fp"],
         &target,
     )
+}
+
+fn managed_zccache_repo() -> RepoInfo {
+    RepoInfo {
+        owner: "zackees".to_string(),
+        repo: "zccache".to_string(),
+    }
+}
+
+fn should_fallback_to_managed_zccache_cargo_install(error: &SoldrError) -> bool {
+    matches!(error, SoldrError::ToolNotFound(_) | SoldrError::Network(_))
 }
 
 fn install_zccache_from_crates_io(
@@ -660,9 +691,8 @@ fn match_asset<'a>(
         if target.os == Os::Linux && target.env == Env::Musl && name.contains("gnu") {
             continue;
         }
-        if target.os == Os::Linux && target.env == Env::Gnu && name.contains("musl") {
-            continue;
-        }
+        // zccache currently publishes musl Linux archives; keep those as a
+        // fallback on GNU runners instead of forcing a slow cargo install.
 
         let mut score: u32 = 1;
         if target.os == Os::Windows && name.contains("msvc") {
@@ -935,6 +965,51 @@ mod tests {
 
         let selected = match_asset(&assets, &target).unwrap();
         assert_eq!(selected.name, "tool-x86_64-unknown-linux-musl.tar.gz");
+    }
+
+    #[test]
+    fn match_asset_prefers_linux_gnu_when_both_linux_variants_exist() {
+        let assets = vec![
+            asset("tool-x86_64-unknown-linux-gnu.tar.gz"),
+            asset("tool-x86_64-unknown-linux-musl.tar.gz"),
+        ];
+        let target = TargetTriple {
+            arch: Arch::X86_64,
+            os: Os::Linux,
+            env: Env::Gnu,
+        };
+
+        let selected = match_asset(&assets, &target).unwrap();
+        assert_eq!(selected.name, "tool-x86_64-unknown-linux-gnu.tar.gz");
+    }
+
+    #[test]
+    fn match_asset_accepts_linux_musl_as_gnu_fallback() {
+        let assets = vec![asset("tool-x86_64-unknown-linux-musl.tar.gz")];
+        let target = TargetTriple {
+            arch: Arch::X86_64,
+            os: Os::Linux,
+            env: Env::Gnu,
+        };
+
+        let selected = match_asset(&assets, &target).unwrap();
+        assert_eq!(selected.name, "tool-x86_64-unknown-linux-musl.tar.gz");
+    }
+
+    #[test]
+    fn managed_zccache_cargo_install_fallback_only_handles_unavailable_release_errors() {
+        assert!(should_fallback_to_managed_zccache_cargo_install(
+            &SoldrError::ToolNotFound("missing release".into())
+        ));
+        assert!(should_fallback_to_managed_zccache_cargo_install(
+            &SoldrError::Network("github api unavailable".into())
+        ));
+        assert!(!should_fallback_to_managed_zccache_cargo_install(
+            &SoldrError::Archive("corrupt archive".into())
+        ));
+        assert!(!should_fallback_to_managed_zccache_cargo_install(
+            &SoldrError::Other("checksum mismatch".into())
+        ));
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- try the managed `zccache` GitHub release before falling back to `cargo install`
- allow Linux GNU runners to consume the published musl `zccache` archives when no GNU asset exists
- keep the `cargo install` fallback only for release-unavailable cases, with regression tests for the fallback policy and asset selection

## Validation
- `cargo test --package soldr-fetch`
- `git diff --check`

## Context
- continues the warm-path work tracked from `zackees/setup-soldr#39`
- uses the same branch name as `setup-soldr@codex/prefer-runner-rustup-home` so the existing demo workflow can pick this branch up on the next rerun without another workflow edit