### PR TITLE
fix(cli): warn when rust-plan restore is partial (#228)

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -906,8 +906,37 @@ fn run_zccache_rust_plan(
     if !stdout.is_empty() {
         eprintln!("soldr: zccache rust-plan {operation} summary");
         eprintln!("{stdout}");
+        if operation == "restore" {
+            warn_if_rust_plan_restore_incomplete(stdout);
+        }
     }
     Ok(())
+}
+
+fn warn_if_rust_plan_restore_incomplete(stdout: &str) {
+    let Ok(summary) = serde_json::from_str::<serde_json::Value>(stdout) else {
+        return;
+    };
+    let absent = summary
+        .get("artifact_absent_from_restored_plan")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    if absent == 0 {
+        return;
+    }
+    let restored = summary
+        .get("restored_file_count")
+        .and_then(serde_json::Value::as_u64)
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "?".to_string());
+    eprintln!(
+        "soldr warning: rust-plan restore is partial \
+         (artifact_absent_from_restored_plan={absent}, restored_file_count={restored}); \
+         Cargo is likely to fail with missing .rmeta errors. This usually means two \
+         `soldr cargo build` invocations are sharing the same --target-dir. Use a \
+         distinct --target-dir for each build or clear the target directory before \
+         re-running. See https://github.com/zackees/soldr/issues/228 for context."
+    );
 }
 
 fn cargo_profile(args: &[String]) -> &str {

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -316,6 +316,10 @@ fn fake_zccache_script(log_path: &Path) -> String {
              )\n\
              if \"%~1\"==\"rust-plan\" (\n\
                echo zccache rust-plan %~2 cache_dir=%ZCCACHE_CACHE_DIR% args=%*>>\"{0}\"\n\
+               if /I \"%~2\"==\"restore\" if defined SOLDR_TEST_RUST_PLAN_STALE (\n\
+                 echo {{\"operation\":\"restore\",\"restored_file_count\":0,\"artifact_absent_from_restored_plan\":1,\"compatibility\":{{\"status\":\"ok\",\"errors\":[]}}}}\n\
+                 exit /b 0\n\
+               )\n\
                echo {{\"operation\":\"%~2\",\"compatibility\":{{\"status\":\"ok\",\"errors\":[]}}}}\n\
                exit /b 0\n\
              )\n\
@@ -386,6 +390,10 @@ fn fake_zccache_script(log_path: &Path) -> String {
                ;;\n\
               rust-plan)\n\
                 echo \"zccache rust-plan $2 cache_dir=${{ZCCACHE_CACHE_DIR:-}} args=$*\" >> \"{0}\"\n\
+                if [ \"$2\" = \"restore\" ] && [ -n \"${{SOLDR_TEST_RUST_PLAN_STALE:-}}\" ]; then\n\
+                  printf '{{\"operation\":\"restore\",\"restored_file_count\":0,\"artifact_absent_from_restored_plan\":1,\"compatibility\":{{\"status\":\"ok\",\"errors\":[]}}}}\\n'\n\
+                  exit 0\n\
+                fi\n\
                 printf '{{\"operation\":\"%s\",\"compatibility\":{{\"status\":\"ok\",\"errors\":[]}}}}\\n' \"$2\"\n\
                 exit 0\n\
                 ;;\n\
@@ -843,6 +851,72 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
             .unwrap()
             .contains("serde"),
         "external dependency should be selected in generated plan: {plan}"
+    );
+}
+
+#[test]
+fn cargo_front_door_warns_when_rust_plan_restore_is_partial() {
+    let cache_root = unique_temp_dir("cargo-rust-plan-partial-cache");
+    let workspace = unique_temp_dir("cargo-rust-plan-partial-workspace");
+    let plan_cache = cache_root.join("target-artifact-cache");
+    let log_path = cache_root.join("tool.log");
+    let metadata_path = cache_root.join("metadata.json");
+    let target_dir = workspace.join("target");
+    fs::create_dir_all(workspace.join("app/src")).expect("create app source");
+    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::write(workspace.join("Cargo.lock"), "# lock\n").expect("write lockfile");
+    fs::write(workspace.join("Cargo.toml"), "[workspace]\n").expect("write workspace manifest");
+    fs::write(workspace.join("app/Cargo.toml"), "[package]\nname='app'\n")
+        .expect("write app manifest");
+
+    let metadata = serde_json::json!({
+        "packages": [
+            {
+                "id": "path+file:///repo/app#app@0.1.0",
+                "source": null
+            }
+        ],
+        "workspace_members": ["path+file:///repo/app#app@0.1.0"],
+        "workspace_root": workspace,
+        "target_directory": target_dir
+    });
+    fs::write(&metadata_path, serde_json::to_string(&metadata).unwrap())
+        .expect("write metadata fixture");
+
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build", "--locked"])
+        .current_dir(&workspace)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_TEST_CARGO_METADATA_PATH", &metadata_path)
+        .env("SOLDR_TARGET_CACHE_MODE", "thin")
+        .env("SOLDR_TARGET_CACHE_BUNDLE_DIR", &plan_cache)
+        .env("SOLDR_TEST_RUST_PLAN_STALE", "1")
+        .output()
+        .expect("failed to run soldr cargo build with stale rust-plan restore");
+
+    assert!(
+        output.status.success(),
+        "soldr should continue after a partial rust-plan restore so Cargo can still run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("rust-plan restore is partial"),
+        "soldr should warn when zccache reports artifact_absent_from_restored_plan > 0: {stderr}"
+    );
+    assert!(
+        stderr.contains("target-dir") || stderr.contains("--target-dir"),
+        "warning should point users at the shared target-dir workaround: {stderr}"
+    );
+    assert!(
+        stderr.contains("228"),
+        "warning should reference issue #228 so users can find context: {stderr}"
     );
 }
 


### PR DESCRIPTION
Closes #228.

## Summary
- When two `soldr cargo build` invocations share the same `--target-dir`, the second rust-plan restore returns `artifact_absent_from_restored_plan > 0` and Cargo then fails with a cryptic `extern location for ring does not exist ... libring-*.rmeta`.
- soldr previously echoed the zccache JSON summary and otherwise stayed silent, so CI logs showed the Cargo error with no breadcrumb.
- This PR parses the restore summary in `run_zccache_rust_plan` and emits a loud `soldr warning:` when `artifact_absent_from_restored_plan` is non-zero — naming the likely cause (shared target-dir), pointing at the documented workaround, and linking to issue #228.

This matches the second of the three acceptable behaviors the issue calls out ("soldr emits a clearer diagnostic before Cargo reaches the missing-`.rmeta` failure"). It does **not** attempt to auto-repair the target tree; that is a larger change that belongs in zccache's restore path.

## Test plan (TDD: RED → GREEN)
- [x] `cargo_front_door_warns_when_rust_plan_restore_is_partial` — fails before the fix (fake zccache returns `restored_file_count:0, artifact_absent_from_restored_plan:1`; no warning is emitted); passes after the fix.
- [x] `cargo test --workspace` — all 36 cli-integration + all crate-unit tests still pass.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] `cargo clippy` — skipped locally (pre-existing MSVC/GNU toolchain-artifact mismatch in the dev sandbox unrelated to this change); CI will run it against a fresh build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)