### PR TITLE
fix(setup-soldr): resolve latest release into cache key (#214)

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -5,6 +5,8 @@ import hashlib
 import json
 import os
 import re
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -123,6 +125,54 @@ def _target_env_hash() -> str:
     return _short_json_hash(relevant)
 
 
+def _is_empty_or_latest(value: str) -> bool:
+    normalized = value.strip().lower()
+    return not normalized or normalized == "latest"
+
+
+def _normalize_release_tag(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        return ""
+    return cleaned[1:] if cleaned.startswith("v") else cleaned
+
+
+def resolve_latest_soldr_release(repo: str) -> str:
+    """Resolve the latest published soldr release tag.
+
+    Returns the resolved release tag (without a leading ``v``) when the
+    GitHub API answers successfully. Returns an empty string on any
+    failure so the caller can fall back to the literal ``latest`` label
+    and keep working offline or under GitHub API outages.
+    """
+
+    url = f"https://api.github.com/repos/{repo.strip()}/releases/latest"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "setup-soldr-action",
+    }
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request, timeout=10) as response:
+            payload = json.load(response)
+    except (
+        urllib.error.URLError,
+        urllib.error.HTTPError,
+        TimeoutError,
+        ValueError,
+        OSError,
+    ):
+        return ""
+    tag = payload.get("tag_name")
+    if not isinstance(tag, str):
+        return ""
+    return _normalize_release_tag(tag)
+
+
 def normalize_target_cache_mode(value: str) -> str:
     mode = value.strip().lower() or "thin"
     if mode == "hot":
@@ -132,7 +182,9 @@ def normalize_target_cache_mode(value: str) -> str:
         )
         return "thin"
     if mode not in {"thin", "full", "off"}:
-        raise RuntimeError(f"invalid target-cache-mode {value!r}; expected thin, full, or off")
+        raise RuntimeError(
+            f"invalid target-cache-mode {value!r}; expected thin, full, or off"
+        )
     return mode
 
 
@@ -160,7 +212,9 @@ def _write_outputs(values: dict[str, str]) -> None:
         for key, value in values.items():
             if "\n" in value:
                 # Use GitHub's heredoc delimiter form for multi-line outputs.
-                delimiter = f"ghadelim_{hashlib.sha256(value.encode()).hexdigest()[:16]}"
+                delimiter = (
+                    f"ghadelim_{hashlib.sha256(value.encode()).hexdigest()[:16]}"
+                )
                 fh.write(f"{key}<<{delimiter}\n{value}\n{delimiter}\n")
             else:
                 fh.write(f"{key}={value}\n")
@@ -207,8 +261,23 @@ def main() -> None:
         toolchain_override=os.environ.get("INPUT_TOOLCHAIN", ""),
     )
 
-    soldr_repo = os.environ.get("INPUT_REPO", "zackees/soldr").strip() or "zackees/soldr"
+    soldr_repo = (
+        os.environ.get("INPUT_REPO", "zackees/soldr").strip() or "zackees/soldr"
+    )
     soldr_version = os.environ.get("INPUT_VERSION", "").strip()
+
+    # When the caller asks for "latest" (explicit or implicit), resolve the
+    # release tag before baking it into the cache key. Without this, the
+    # setup cache records the literal string "latest" and warm runs keep
+    # reusing whichever soldr/zccache bundle was first saved, even after a
+    # newer release ships. Fall back to the literal label when GitHub is
+    # unreachable so the action still works offline or on rate-limited
+    # runners. See issue #214.
+    resolved_soldr_version = soldr_version
+    if _is_empty_or_latest(soldr_version):
+        resolved_soldr_version = resolve_latest_soldr_release(soldr_repo)
+    cache_key_soldr_version = _normalize_release_tag(resolved_soldr_version) or "latest"
+
     toolchain_signature = {
         "channel": toolchain["channel"],
         "profile": toolchain["profile"],
@@ -217,7 +286,7 @@ def main() -> None:
         "source": toolchain["source"],
         "file_hash": toolchain["file_hash"],
         "soldr_repo": soldr_repo,
-        "soldr_version": soldr_version or "latest",
+        "soldr_version": cache_key_soldr_version,
     }
     digest = hashlib.sha256(
         json.dumps(toolchain_signature, sort_keys=True).encode("utf-8")
@@ -284,14 +353,20 @@ def main() -> None:
     if target_cache_mode == "off":
         target_cache_paths = str(target_cache_path)
         target_cache_effective_mode = "off"
-        target_cache_prefix = f"setup-soldr-targetcache-off-v1-{runner_os}-{runner_arch}"
+        target_cache_prefix = (
+            f"setup-soldr-targetcache-off-v1-{runner_os}-{runner_arch}"
+        )
         target_cache_restore_key = ""
         target_cache_key = f"{target_cache_prefix}-{target_inputs_hash}"
     elif target_cache_mode == "full":
         target_cache_paths = str(target_cache_path)
         target_cache_effective_mode = "full"
-        target_cache_prefix = f"setup-soldr-targetcache-full-v1-{runner_os}-{runner_arch}"
-        target_cache_suffix_fragment = f"{sanitized_suffix}-" if sanitized_suffix else ""
+        target_cache_prefix = (
+            f"setup-soldr-targetcache-full-v1-{runner_os}-{runner_arch}"
+        )
+        target_cache_suffix_fragment = (
+            f"{sanitized_suffix}-" if sanitized_suffix else ""
+        )
         target_cache_lock_prefix = (
             f"{target_cache_prefix}-{digest}-{cargo_lock_hash}-"
             f"{target_shape_hash}-{target_cache_suffix_fragment}"
@@ -301,8 +376,12 @@ def main() -> None:
     else:
         target_cache_paths = str(target_cache_bundle_path)
         target_cache_effective_mode = "thin"
-        target_cache_prefix = f"setup-soldr-targetcache-thin-v1-{runner_os}-{runner_arch}"
-        target_cache_suffix_fragment = f"{sanitized_suffix}-" if sanitized_suffix else ""
+        target_cache_prefix = (
+            f"setup-soldr-targetcache-thin-v1-{runner_os}-{runner_arch}"
+        )
+        target_cache_suffix_fragment = (
+            f"{sanitized_suffix}-" if sanitized_suffix else ""
+        )
         target_cache_restore_key = (
             f"{target_cache_prefix}-{target_inputs_hash}-{target_cache_suffix_fragment}"
         )
@@ -356,6 +435,7 @@ def main() -> None:
             "soldr_path": str(soldr_path),
             "soldr_repo": soldr_repo,
             "soldr_version_requested": soldr_version,
+            "soldr_version_resolved": resolved_soldr_version,
             "toolchain_channel": toolchain["channel"],
             "toolchain_profile": toolchain["profile"],
             "toolchain_source": toolchain["source"],

--- a/action.yml
+++ b/action.yml
@@ -172,7 +172,11 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         SOLDR_REPO: ${{ steps.resolve.outputs.soldr_repo }}
         SOLDR_INSTALL_DIR: ${{ steps.resolve.outputs.bin_dir }}
-        SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_requested }}
+        # Prefer the resolved release tag so the installed binary matches
+        # the tag baked into the cache key. Falls back to the original
+        # requested value (possibly empty for "latest") when the resolver
+        # could not reach the GitHub API. See issue #214.
+        SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_resolved || steps.resolve.outputs.soldr_version_requested }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_soldr.py"
 
     - id: verify

--- a/tests/fixtures/setup_soldr_exporter/expected_action.yml
+++ b/tests/fixtures/setup_soldr_exporter/expected_action.yml
@@ -167,7 +167,11 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         SOLDR_REPO: ${{ steps.resolve.outputs.soldr_repo }}
         SOLDR_INSTALL_DIR: ${{ steps.resolve.outputs.bin_dir }}
-        SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_requested }}
+        # Prefer the resolved release tag so the installed binary matches
+        # the tag baked into the cache key. Falls back to the original
+        # requested value (possibly empty for "latest") when the resolver
+        # could not reach the GitHub API. See issue #214.
+        SETUP_SOLDR_VERSION: ${{ steps.resolve.outputs.soldr_version_resolved || steps.resolve.outputs.soldr_version_requested }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/ensure_soldr.py"
 
     - id: verify

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -90,7 +90,9 @@ def test_action_python_helpers_have_entrypoints() -> None:
     script_paths = sorted(
         {
             REPO_ROOT / match.group(1)
-            for match in re.finditer(r"github\.action_path \}\}/([^\"']+\.py)", action_text)
+            for match in re.finditer(
+                r"github\.action_path \}\}/([^\"']+\.py)", action_text
+            )
         }
     )
 
@@ -98,7 +100,8 @@ def test_action_python_helpers_have_entrypoints() -> None:
     for script_path in script_paths:
         tree = ast.parse(script_path.read_text(encoding="utf-8"))
         assert any(
-            isinstance(node, ast.FunctionDef) and node.name == "main" for node in tree.body
+            isinstance(node, ast.FunctionDef) and node.name == "main"
+            for node in tree.body
         ), f"{script_path.relative_to(REPO_ROOT)} should define main()"
         assert any(
             isinstance(node, ast.If)
@@ -114,9 +117,9 @@ def test_action_python_helpers_have_entrypoints() -> None:
 
 
 def test_setup_soldr_smoke_tests_disable_nested_cache() -> None:
-    workflow = (REPO_ROOT / ".github" / "workflows" / "setup-soldr-action.yml").read_text(
-        encoding="utf-8"
-    )
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "setup-soldr-action.yml"
+    ).read_text(encoding="utf-8")
 
     assert "Remove-Item Env:ZCCACHE_CACHE_DIR" in workflow
     assert "soldr --no-cache cargo test -p soldr-cli --test cli --locked" in workflow
@@ -156,6 +159,7 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     monkeypatch.setenv("GITHUB_ENV", str(github_env))
     monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
     monkeypatch.setenv("GITHUB_PATH", str(github_path))
+    monkeypatch.setattr(module, "resolve_latest_soldr_release", lambda _repo: "")
 
     module.main()
 
@@ -176,8 +180,14 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert "cache_key=setup-soldr-v0-linux-x64-" in outputs
     assert "cache_restore_prefix=setup-soldr-v0-linux-x64-" in outputs
     assert "build_cache_key=setup-soldr-buildcache-v1-linux-x64-" in outputs
-    assert "build_cache_restore_key_toolchain=setup-soldr-buildcache-v1-linux-x64-" in outputs
-    assert "build_cache_restore_key_os_arch=setup-soldr-buildcache-v1-linux-x64-" in outputs
+    assert (
+        "build_cache_restore_key_toolchain=setup-soldr-buildcache-v1-linux-x64-"
+        in outputs
+    )
+    assert (
+        "build_cache_restore_key_os_arch=setup-soldr-buildcache-v1-linux-x64-"
+        in outputs
+    )
     assert f"build_cache_path={cache_root / 'soldr' / 'cache' / 'zccache'}" in outputs
     assert f"target_cache_path={workspace / 'custom-target'}" in outputs
     bundle_path = runner_temp / "setup-soldr-target-thin"
@@ -197,7 +207,9 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     assert "SOLDR_TARGET_CACHE_BACKEND=auto" in env_text
 
 
-def test_main_treats_hot_as_thin_alias_with_lockfile(tmp_path: Path, monkeypatch) -> None:
+def test_main_treats_hot_as_thin_alias_with_lockfile(
+    tmp_path: Path, monkeypatch
+) -> None:
     module = _load_module()
     workspace = tmp_path / "workspace"
     runner_temp = tmp_path / "runner-temp"
@@ -228,6 +240,7 @@ def test_main_treats_hot_as_thin_alias_with_lockfile(tmp_path: Path, monkeypatch
     monkeypatch.setenv("GITHUB_ENV", str(github_env))
     monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
     monkeypatch.setenv("GITHUB_PATH", str(github_path))
+    monkeypatch.setattr(module, "resolve_latest_soldr_release", lambda _repo: "")
 
     module.main()
 
@@ -238,7 +251,10 @@ def test_main_treats_hot_as_thin_alias_with_lockfile(tmp_path: Path, monkeypatch
     assert "target_cache_mode=thin" in outputs
     assert "target_cache_key=setup-soldr-targetcache-thin-v1-linux-x64-" in outputs
     assert f"target_cache_paths={bundle_path}" in outputs
-    assert "target_cache_restore_key_lock=setup-soldr-targetcache-thin-v1-linux-x64-" in outputs
+    assert (
+        "target_cache_restore_key_lock=setup-soldr-targetcache-thin-v1-linux-x64-"
+        in outputs
+    )
 
     env_text = github_env.read_text(encoding="utf-8")
     assert "SOLDR_TARGET_CACHE_MODE=thin" in env_text
@@ -246,6 +262,149 @@ def test_main_treats_hot_as_thin_alias_with_lockfile(tmp_path: Path, monkeypatch
     assert f"SOLDR_TARGET_CACHE_BUNDLE_DIR={bundle_path}" in env_text
     assert "SOLDR_TARGET_CACHE_BACKEND=auto" in env_text
     assert bundle_path == runner_temp / "setup-soldr-target-thin"
+
+
+def _setup_main_env(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    version: str = "",
+) -> tuple[Path, Path, Path]:
+    workspace = tmp_path / "workspace"
+    runner_temp = tmp_path / "runner-temp"
+    workspace.mkdir()
+    runner_temp.mkdir()
+
+    github_env = tmp_path / "github.env"
+    github_output = tmp_path / "github.output"
+    github_path = tmp_path / "github.path"
+
+    monkeypatch.setenv("ACTION_WORKSPACE", str(workspace))
+    monkeypatch.setenv("RUNNER_TEMP", str(runner_temp))
+    monkeypatch.setenv("ACTION_OS", "Linux")
+    monkeypatch.setenv("ACTION_ARCH", "X64")
+    monkeypatch.setenv("INPUT_REPO", "zackees/soldr")
+    monkeypatch.setenv("INPUT_VERSION", version)
+    monkeypatch.setenv("INPUT_CACHE_DIR", "")
+    monkeypatch.setenv("INPUT_CACHE_KEY_SUFFIX", "")
+    monkeypatch.setenv("INPUT_TOOLCHAIN", "")
+    monkeypatch.setenv("INPUT_TOOLCHAIN_FILE", "missing.toml")
+    monkeypatch.setenv("INPUT_TRUST_MODE", "")
+    monkeypatch.setenv("INPUT_TARGET_DIR", "target")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    monkeypatch.setenv("GITHUB_ENV", str(github_env))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setenv("GITHUB_PATH", str(github_path))
+    return github_env, github_output, github_path
+
+
+def _collect_outputs(output_path: Path) -> dict[str, str]:
+    return dict(
+        line.split("=", 1)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+
+
+def test_latest_version_cache_key_changes_when_release_changes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """When input is `latest`, the cache key must be derived from the
+    resolved release tag so that a new soldr release invalidates the
+    setup cache and managed zccache binaries get refreshed. See #214."""
+    module = _load_module()
+
+    calls = {"count": 0}
+
+    def fake_resolver_0(_repo: str) -> str:
+        calls["count"] += 1
+        return "0.7.11"
+
+    run_dir_a = tmp_path / "run-a"
+    run_dir_a.mkdir()
+    _, output_a, _ = _setup_main_env(run_dir_a, monkeypatch)
+    monkeypatch.setattr(module, "resolve_latest_soldr_release", fake_resolver_0)
+    module.main()
+    outputs_a = _collect_outputs(output_a)
+
+    run_dir_b = tmp_path / "run-b"
+    run_dir_b.mkdir()
+    _, output_b, _ = _setup_main_env(run_dir_b, monkeypatch)
+    monkeypatch.setattr(module, "resolve_latest_soldr_release", lambda _repo: "0.7.12")
+    module.main()
+    outputs_b = _collect_outputs(output_b)
+
+    assert outputs_a["cache_key"] != outputs_b["cache_key"]
+    assert outputs_a["soldr_version_resolved"] == "0.7.11"
+    assert outputs_b["soldr_version_resolved"] == "0.7.12"
+    assert outputs_a["soldr_version_requested"] == ""
+    assert calls["count"] == 1
+
+
+def test_latest_version_cache_key_falls_back_to_literal_when_resolution_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If the GitHub API is unreachable, the resolver returns an empty
+    string; the action must still produce a deterministic cache key so
+    the warm-run pipeline keeps working. See #214."""
+    module = _load_module()
+
+    run_dir_a = tmp_path / "run-a"
+    run_dir_a.mkdir()
+    _, output_a, _ = _setup_main_env(run_dir_a, monkeypatch)
+    monkeypatch.setattr(module, "resolve_latest_soldr_release", lambda _repo: "")
+    module.main()
+    outputs_a = _collect_outputs(output_a)
+
+    run_dir_b = tmp_path / "run-b"
+    run_dir_b.mkdir()
+    _, output_b, _ = _setup_main_env(run_dir_b, monkeypatch)
+    monkeypatch.setattr(module, "resolve_latest_soldr_release", lambda _repo: "")
+    module.main()
+    outputs_b = _collect_outputs(output_b)
+
+    assert outputs_a["cache_key"] == outputs_b["cache_key"]
+    assert outputs_a["soldr_version_resolved"] == ""
+
+
+def test_pinned_version_input_skips_latest_resolution(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A pinned `version: 0.7.10` input must not trigger a GitHub API
+    call and must bake that exact version into the cache key."""
+    module = _load_module()
+    calls = {"count": 0}
+
+    def _should_not_call(_repo: str) -> str:
+        calls["count"] += 1
+        return "should-not-be-used"
+
+    _, github_output, _ = _setup_main_env(tmp_path, monkeypatch, version="0.7.10")
+    monkeypatch.setattr(module, "resolve_latest_soldr_release", _should_not_call)
+    module.main()
+
+    outputs = _collect_outputs(github_output)
+    assert calls["count"] == 0
+    assert outputs["soldr_version_resolved"] == "0.7.10"
+    assert outputs["soldr_version_requested"] == "0.7.10"
+
+
+def test_normalize_release_tag_strips_v_prefix() -> None:
+    module = _load_module()
+    assert module._normalize_release_tag("v0.7.11") == "0.7.11"
+    assert module._normalize_release_tag("0.7.11") == "0.7.11"
+    assert module._normalize_release_tag(" v1.0.0 ") == "1.0.0"
+    assert module._normalize_release_tag("") == ""
+
+
+def test_is_empty_or_latest_matches_expected_values() -> None:
+    module = _load_module()
+    assert module._is_empty_or_latest("")
+    assert module._is_empty_or_latest("  ")
+    assert module._is_empty_or_latest("latest")
+    assert module._is_empty_or_latest("LATEST")
+    assert not module._is_empty_or_latest("v0.7.10")
+    assert not module._is_empty_or_latest("0.7.10")
 
 
 def test_full_target_cache_suffix_restore_prefix_matches_key_shape(
@@ -281,6 +440,7 @@ def test_full_target_cache_suffix_restore_prefix_matches_key_shape(
     monkeypatch.setenv("GITHUB_ENV", str(github_env))
     monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
     monkeypatch.setenv("GITHUB_PATH", str(github_path))
+    monkeypatch.setattr(module, "resolve_latest_soldr_release", lambda _repo: "")
 
     module.main()
 


### PR DESCRIPTION
## Summary

Fixes the root cause behind #214 warm-run pauses: when callers use `version: latest` (or omit it), the setup cache key records the literal string `"latest"`. An exact cache hit never triggers a post-job save, so the first cached soldr binary (and the managed zccache binaries it pulled into `soldr/bin`) persist indefinitely even after new soldr releases ship. Subsequent `soldr cargo ...` invocations then re-fetch or `cargo install` managed zccache every run.

This change makes `resolve_setup.py`:

- Resolve the latest release tag via `GET /repos/{repo}/releases/latest` before composing the cache-key signature when the requested version is empty / `latest`.
- Bake the resolved tag (e.g. `0.7.11`) into the key instead of the literal `latest`, so a new release produces a new key and the warm-run save refreshes both the soldr binary and `soldr/bin`.
- Emit a new `soldr_version_resolved` step output.

`action.yml` now passes `soldr_version_resolved || soldr_version_requested` to `ensure_soldr.py` so the installer fetches the same tag the cache key represents (avoiding a race if the resolver and installer saw different "latest" releases).

If the GitHub API is unreachable (offline test, rate limit), the resolver gracefully returns an empty string and the cache key falls back to the literal `latest` label, matching the pre-change behavior.

## What remains for follow-up

The issue also mentions preferring zccache release assets over `cargo install`. Commit `df29e80` ("Prefer zccache release assets before cargo install") already landed that on the Rust side. The `soldr/bin` staleness concern from the issue is addressed implicitly by this change, because the setup cache (which already includes `cache_root`, and therefore `soldr/bin`) now gets a fresh key whenever a new soldr release ships.

## Test plan

- [x] `uv run pytest tests/test_setup_soldr_action.py tests/test_setup_soldr_exporter.py` (18 passed)
- [x] `uv run ruff check .github/actions/setup-soldr/resolve_setup.py`
- [x] `uv run black --check .github/actions/setup-soldr/resolve_setup.py tests/test_setup_soldr_action.py`
- [ ] Confirm on a warm CI run (two consecutive jobs straddling a soldr release) that the cache key differs and the managed zccache `cargo install` path no longer fires.

Refs: #214

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>