### PR TITLE
ci: add parent-child zccache cache probe workflow

### DIFF
--- a/.github/scripts/cache_benchmark_child_branch_report.py
+++ b/.github/scripts/cache_benchmark_child_branch_report.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Generate the parent-to-child cache probe report for issue #168.
+
+This turns the `cache-benchmark-child-branch.yml` workflow's step outputs
+into a markdown comment body matching the suggested report shape from
+https://github.com/zackees/soldr/issues/168.
+
+Environment variables expected (all optional except where noted):
+    COLD_RESULT, COLD_SECONDS
+    WARM_RESULT, WARM_SECONDS
+    CACHE_HIT, BUILD_CACHE_HIT, TARGET_CACHE_HIT
+    SOLDR_VERSION, TOOLCHAIN
+    CHILD_BRANCH_INPUT
+    OUTPUT_PATH              - where to write the markdown body (required)
+
+    GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID,
+    GITHUB_REF_NAME, GITHUB_SHA, GITHUB_OUTPUT
+        - standard GitHub Actions env vars. Missing values are rendered as
+          `n/a` so the script stays runnable locally for smoke testing.
+
+The script never raises on missing / malformed input: it degrades to `n/a`
+so the comment still posts on partial failures. Exit code is 0 on success.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+from typing import Optional
+
+
+def _env(name: str, default: str = "") -> str:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def _float_or_none(value: str) -> Optional[float]:
+    if value in ("", "n/a"):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _metric(value: Optional[float], suffix: str = "") -> str:
+    return "n/a" if value is None else f"{value:.2f}{suffix}"
+
+
+def _cache_hit_state(cache_hit: str, build_cache_hit: str) -> str:
+    """One-line human summary of the cache-hit triple, for the report."""
+    if build_cache_hit == "true":
+        return "exact build-cache key match"
+    if build_cache_hit == "false" and cache_hit == "true":
+        return (
+            "setup-state cache exact hit; build-cache restored via restore-keys "
+            "fallback or was a cold miss (inspect `build-cache-restore` logs to "
+            "distinguish)"
+        )
+    if build_cache_hit == "false":
+        return "no exact build-cache match; inspect raw log for restore-key fallback"
+    return "build-cache not enabled or unknown"
+
+
+def build_report_body(
+    cold_result: str,
+    cold_seconds: Optional[float],
+    warm_result: str,
+    warm_seconds: Optional[float],
+    cache_hit: str,
+    build_cache_hit: str,
+    target_cache_hit: str,
+    soldr_version: str,
+    toolchain: str,
+    workflow_run_url: str,
+    branch_ref: str,
+    commit_sha: str,
+) -> str:
+    ratio: Optional[float] = None
+    saved: Optional[float] = None
+    if cold_seconds is not None and warm_seconds not in (None, 0):
+        ratio = cold_seconds / warm_seconds  # type: ignore[operator]
+        saved = cold_seconds - warm_seconds  # type: ignore[operator]
+
+    subsecond = "yes" if warm_seconds is not None and warm_seconds < 1.0 else "no"
+    cache_state = _cache_hit_state(cache_hit, build_cache_hit)
+
+    lines = [
+        "### Parent-to-child zccache cache report",
+        "",
+        f"- workflow run: {workflow_run_url}",
+        f"- branch/ref: `{branch_ref}`",
+        f"- commit: `{commit_sha}`",
+        f"- cold control result: `{cold_result or 'n/a'}`",
+        f"- warm setup-soldr result: `{warm_result or 'n/a'}`",
+        f"- cold build seconds: `{_metric(cold_seconds)}`",
+        f"- warm soldr build seconds: `{_metric(warm_seconds)}`",
+        f"- seconds saved: `{_metric(saved)}`",
+        f"- speedup vs cold control: `{_metric(ratio, 'x')}`",
+        f"- setup cache hit: `{cache_hit or 'n/a'}`",
+        f"- zccache build-cache hit: `{build_cache_hit or 'n/a'}`",
+        f"- target-cache hit: `{target_cache_hit or 'n/a'}`",
+        f"- cache-restore summary: {cache_state}",
+        f"- soldr version: `{soldr_version or 'n/a'}`",
+        f"- toolchain: `{toolchain or 'n/a'}`",
+        f"- sub-second target met: `{subsecond}`",
+        "",
+        (
+            "Note: `build-cache-hit=false` can still indicate a useful restore "
+            "via the restore-keys prefix fallback. Inspect the "
+            "`build-cache-restore` step's raw log to confirm whether the "
+            "parent (main) branch seeded this run or whether the cache was a "
+            "cold miss. Re-run this workflow against the same child branch a "
+            "second time to force the same-branch warm path."
+        ),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    output_path = _env("OUTPUT_PATH")
+    if not output_path:
+        sys.stderr.write("OUTPUT_PATH is required\n")
+        return 1
+
+    workflow_run_url = "n/a"
+    server = _env("GITHUB_SERVER_URL")
+    repo = _env("GITHUB_REPOSITORY")
+    run_id = _env("GITHUB_RUN_ID")
+    if server and repo and run_id:
+        workflow_run_url = f"{server}/{repo}/actions/runs/{run_id}"
+
+    child_branch_input = _env("CHILD_BRANCH_INPUT")
+    branch_ref = child_branch_input or _env("GITHUB_REF_NAME", "n/a")
+    commit_sha = _env("GITHUB_SHA", "n/a")
+
+    body = build_report_body(
+        cold_result=_env("COLD_RESULT"),
+        cold_seconds=_float_or_none(_env("COLD_SECONDS")),
+        warm_result=_env("WARM_RESULT"),
+        warm_seconds=_float_or_none(_env("WARM_SECONDS")),
+        cache_hit=_env("CACHE_HIT"),
+        build_cache_hit=_env("BUILD_CACHE_HIT"),
+        target_cache_hit=_env("TARGET_CACHE_HIT"),
+        soldr_version=_env("SOLDR_VERSION"),
+        toolchain=_env("TOOLCHAIN"),
+        workflow_run_url=workflow_run_url,
+        branch_ref=branch_ref,
+        commit_sha=commit_sha,
+    )
+
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as fh:
+            fh.write(f"body_path={path}\n")
+
+    sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/cache-benchmark-child-branch.yml
+++ b/.github/workflows/cache-benchmark-child-branch.yml
@@ -1,0 +1,262 @@
+name: Cache Benchmark Child Branch
+
+# Parent-to-child cache probe for issue #168.
+#
+# Runs the minimal consumer workflow (see examples/ci-minimal.yml) against a
+# selected branch, captures the setup-soldr action outputs and build timings,
+# and emits a markdown report matching the suggested shape in issue #168.
+#
+# This is a workflow-dispatch probe. Re-run it against the same child branch
+# twice back-to-back to distinguish:
+#   - run 1: parent (main) restore-key fallback
+#   - run 2: same-branch warm restore
+#
+# Acceptance criteria checks this probe supports (issue #168):
+#   - demonstrates parent-seeded restore of the zccache build cache
+#   - demonstrates same-branch warm restore
+#   - reports cold vs warm wall-clock, speedup ratio, and seconds saved
+#   - reports whether the stretch "sub-second no-op build" target is met
+#   - posts an issue comment with the merged findings and run URLs
+
+on:
+  workflow_dispatch:
+    inputs:
+      child_branch:
+        description: Child branch to probe. Defaults to the ref this workflow was dispatched on.
+        required: false
+        default: ""
+        type: string
+      post_comment:
+        description: Post the generated report as a comment on the tracking issue.
+        required: false
+        default: "true"
+        type: string
+      issue_number:
+        description: Tracking issue to comment on.
+        required: false
+        default: "168"
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  cold-control:
+    name: Cold cargo control (no cache)
+    runs-on: ubuntu-24.04
+    outputs:
+      seconds: ${{ steps.measure.outputs.seconds }}
+      result: ${{ steps.measure.outputs.result }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.child_branch != '' && inputs.child_branch || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+
+      - name: Time cold cargo build
+        id: measure
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p probe-results
+          python3 - <<'PY'
+          import os
+          import pathlib
+          import subprocess
+          import sys
+          import time
+
+          command = [
+              "cargo",
+              "build",
+              "--package",
+              "soldr-cli",
+              "--locked",
+              "--timings",
+          ]
+          start = time.perf_counter()
+          proc = subprocess.run(
+              command,
+              stdout=subprocess.PIPE,
+              stderr=subprocess.STDOUT,
+              text=True,
+              check=False,
+          )
+          elapsed = time.perf_counter() - start
+          sys.stdout.write(proc.stdout)
+          sys.stdout.flush()
+
+          result = "success" if proc.returncode == 0 else "failure"
+          pathlib.Path("probe-results/cold-build.log").write_text(
+              proc.stdout, encoding="utf-8"
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"seconds={elapsed:.2f}\n")
+              fh.write(f"result={result}\n")
+
+          if proc.returncode != 0:
+              sys.exit(proc.returncode)
+          PY
+
+      - name: Upload cold timing artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: child-branch-probe-cold
+          path: |
+            target/cargo-timings
+            probe-results/cold-build.log
+          if-no-files-found: warn
+
+  warm-soldr:
+    name: Warm setup-soldr build on child branch
+    runs-on: ubuntu-24.04
+    outputs:
+      seconds: ${{ steps.measure.outputs.seconds }}
+      result: ${{ steps.measure.outputs.result }}
+      cache_hit: ${{ steps.setup.outputs.cache-hit }}
+      build_cache_hit: ${{ steps.setup.outputs.build-cache-hit }}
+      target_cache_hit: ${{ steps.setup.outputs.target-cache-hit }}
+      soldr_version: ${{ steps.setup.outputs.soldr-version }}
+      toolchain: ${{ steps.setup.outputs.toolchain }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.child_branch != '' && inputs.child_branch || github.ref }}
+
+      # Use the repo-local composite action so the probe validates the
+      # action.yml under test, not a pinned release. External consumers would
+      # use `uses: zackees/setup-soldr@v0` here.
+      - id: setup
+        uses: ./
+        with:
+          cache: true
+          build-cache: true
+          target-cache: true
+
+      - name: Show setup-soldr outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "cache-hit=${{ steps.setup.outputs.cache-hit }}"
+            echo "build-cache-hit=${{ steps.setup.outputs.build-cache-hit }}"
+            echo "target-cache-hit=${{ steps.setup.outputs.target-cache-hit }}"
+            echo "toolchain=${{ steps.setup.outputs.toolchain }}"
+            echo "soldr-version=${{ steps.setup.outputs.soldr-version }}"
+          } | tee probe-setup-outputs.txt
+
+      - name: Time soldr cargo build
+        id: measure
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p probe-results
+          python3 - <<'PY'
+          import os
+          import pathlib
+          import subprocess
+          import sys
+          import time
+
+          command = [
+              "soldr",
+              "cargo",
+              "build",
+              "--package",
+              "soldr-cli",
+              "--locked",
+              "--timings",
+          ]
+          start = time.perf_counter()
+          proc = subprocess.run(
+              command,
+              stdout=subprocess.PIPE,
+              stderr=subprocess.STDOUT,
+              text=True,
+              check=False,
+          )
+          elapsed = time.perf_counter() - start
+          sys.stdout.write(proc.stdout)
+          sys.stdout.flush()
+
+          result = "success" if proc.returncode == 0 else "failure"
+          pathlib.Path("probe-results/warm-build.log").write_text(
+              proc.stdout, encoding="utf-8"
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"seconds={elapsed:.2f}\n")
+              fh.write(f"result={result}\n")
+
+          if proc.returncode != 0:
+              sys.exit(proc.returncode)
+          PY
+
+      - name: Capture soldr cache status
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          soldr cache --json > probe-results/soldr-cache.json 2>&1 || true
+          soldr cache > probe-results/soldr-cache.txt 2>&1 || true
+
+      - name: Upload warm timing artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: child-branch-probe-warm
+          path: |
+            target/cargo-timings
+            probe-results
+            probe-setup-outputs.txt
+          if-no-files-found: warn
+
+  report:
+    name: Report parent-child speedup
+    if: always()
+    needs:
+      - cold-control
+      - warm-soldr
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Build report
+        id: report
+        shell: bash
+        env:
+          COLD_RESULT: ${{ needs.cold-control.outputs.result }}
+          COLD_SECONDS: ${{ needs.cold-control.outputs.seconds }}
+          WARM_RESULT: ${{ needs.warm-soldr.outputs.result }}
+          WARM_SECONDS: ${{ needs.warm-soldr.outputs.seconds }}
+          CACHE_HIT: ${{ needs.warm-soldr.outputs.cache_hit }}
+          BUILD_CACHE_HIT: ${{ needs.warm-soldr.outputs.build_cache_hit }}
+          TARGET_CACHE_HIT: ${{ needs.warm-soldr.outputs.target_cache_hit }}
+          SOLDR_VERSION: ${{ needs.warm-soldr.outputs.soldr_version }}
+          TOOLCHAIN: ${{ needs.warm-soldr.outputs.toolchain }}
+          CHILD_BRANCH_INPUT: ${{ inputs.child_branch }}
+          OUTPUT_PATH: parent-child-zccache-report.md
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/cache_benchmark_child_branch_report.py
+
+      - name: Upload report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: child-branch-probe-report
+          path: parent-child-zccache-report.md
+          if-no-files-found: error
+
+      - name: Comment on tracking issue
+        if: ${{ inputs.post_comment == 'true' && github.repository == 'zackees/soldr' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          gh issue comment "$ISSUE_NUMBER" --body-file parent-child-zccache-report.md


### PR DESCRIPTION
## Summary

Adds a workflow-dispatch probe that makes it cheap to re-run the parent-to-child cache validation from issue #168 without hand-crafting a benchmark each time.

- `.github/workflows/cache-benchmark-child-branch.yml` — three-job probe (cold cargo control, warm `setup-soldr` build, report) that checks out a caller-selected `child_branch`, uses the repo-local `setup-soldr` composite action with `build-cache: true` / `target-cache: true`, times `soldr cargo build`, and uploads cargo timing artifacts plus `soldr cache` output.
- `.github/scripts/cache_benchmark_child_branch_report.py` — tested Python generator that turns the job outputs into the markdown shape suggested in #168 (run URL, cold/warm seconds, speedup, `cache-hit`, `build-cache-hit`, `target-cache-hit`, soldr version, toolchain, sub-second verdict) and posts it as a comment on the tracking issue.

The report generator also emits a one-line interpretation of the cache-hit pair (exact build-cache hit vs setup-state-only hit with possible restore-key fallback vs cold miss), which is the distinction #168 specifically calls out as needing manual raw-log inspection today.

Running the probe twice against the same child branch distinguishes parent-cache fallback (first run) from same-branch warm restore (second run), which is the core validation #168 is asking for. The probe intentionally does NOT include measured numbers from an actual run in this PR — the point is to land the scaffolding so future dispatches are a one-click operation.

Refs #168

## Test plan

- [ ] Workflow passes `actionlint` / GitHub YAML parsing
- [ ] Dispatch `Cache Benchmark Child Branch` against a `cache-probe/*` branch created from a commit where `main` has a recent `setup-soldr` cache
- [ ] Confirm the comment on #168 shows `setup cache hit: true` and some restore evidence for the child's first run
- [ ] Re-dispatch the same probe against the same child branch and confirm `build-cache-hit=true` on the second run
- [ ] If `warm seconds >= 1s`, follow up by pointing at the bottleneck captured in the `warm-soldr` artifact bundle (`soldr-cache.json`, `cargo-timings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)