### PR TITLE
Release soldr 0.7.12 with zccache 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "blake3",
  "serde",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "clap",
  "serde",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "serde",
  "tempfile",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1719,7 +1719,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.3.10");
+    assert_eq!(json["managed_zccache_version"], "1.4.0");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -1841,7 +1841,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.3.10");
+    assert_eq!(json["managed_zccache_version"], "1.4.0");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.3.10";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.0";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- Bump `MANAGED_ZCCACHE_VERSION` from `1.3.10` to `1.4.0` (`crates/soldr-fetch/src/lib.rs`)
- Update matching test assertions in `crates/soldr-cli/tests/cli.rs`
- Bump workspace package version `0.7.11` → `0.7.12` in `Cargo.toml` and `package.json`

Merging this into `main` will trigger `Autonomous Release` (workflow listens for `Cargo.toml` / `package.json` changes on `main`) which derives the `v0.7.12` tag and publishes to GitHub Releases / PyPI / npm.

## Test plan
- [x] `cargo build -p soldr-cli`
- [x] `cargo test --workspace --lib --bins`
- [x] `cargo test -p soldr-cli --test cli managed_zccache`
- [x] `cargo test -p soldr-cli --test cli status_json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)