### PR TITLE
feat(cache): point zccache and sccache at soldr-owned cache roots (#172)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -238,13 +238,14 @@ Commands:
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
 | `ZCCACHE_CACHE_DIR` | zccache cache-root override set by soldr for managed zccache commands | `~/.soldr/cache/zccache` |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
+| `SCCACHE_DIR` | sccache cache-root override soldr injects when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has not set it themselves | `~/.soldr/cache/sccache` |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.
 
-When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must match the cache root derived from `SOLDR_CACHE_DIR`; conflicting values are rejected. Custom wrapper modes leave caller-provided wrapper environment alone.
+When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must match the cache root derived from `SOLDR_CACHE_DIR`; conflicting values are rejected. Custom wrapper modes leave caller-provided wrapper environment alone — when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has set `SCCACHE_DIR` themselves, soldr forwards their value rather than overriding it.
 
 `soldr cargo ...` only starts the managed build cache for compile-like Cargo subcommands such as `build`, `check`, `test`, `run`, `doc`, `clippy`, and `nextest`. Non-build Cargo commands such as `cargo metadata` and `cargo --version` pass through without starting zccache.
 
@@ -257,9 +258,13 @@ When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must ma
 |-- bin/
 |   `-- <tool>-<version>/
 |-- cache/
+|   |-- zccache/   # managed zccache artifact + state root (set via ZCCACHE_CACHE_DIR)
+|   `-- sccache/   # injected when SOLDR_RUSTC_WRAPPER=sccache and SCCACHE_DIR is unset
 |-- config.toml
 `-- daemon.*
 ```
+
+Both wrapper-cache subdirectories live entirely under the soldr-owned cache root so they never collide with a user-managed `~/.zccache` or the system-default `sccache` location on the same machine.
 
 ---
 


### PR DESCRIPTION
## Summary

Issue #172 ("Use Soldr-owned wrapper cache roots during build commands") was substantially implemented by PR #201, then reinforced by the bump to managed zccache `1.4.0` (which is the version that actually honors `ZCCACHE_CACHE_DIR`). The remaining gap was that the public API reference still only documented the zccache half — the new `SCCACHE_DIR` injection and the wrapper-cache layout under `~/.soldr/cache/` were undocumented.

This PR closes that documentation gap so the runtime contract for both wrapper backends is captured in `docs/API.md`:

- add `SCCACHE_DIR` to the supported environment-variables table with its default (`~/.soldr/cache/sccache`) and the precondition (`SOLDR_RUSTC_WRAPPER=sccache`, caller has not set it themselves)
- restate the caller-precedence rule so the sccache case is explicit alongside the existing `ZCCACHE_CACHE_DIR` rule
- show `cache/zccache/` and `cache/sccache/` in the cache-layout block, with a one-line note about avoiding collision with `~/.zccache` / system-default sccache state

No code changes — the runtime behavior already matches what's now documented (see `prepare_zccache_build` and the sccache branch of `prepare_rustc_wrapper` in `crates/soldr-cli/src/main.rs`, plus `soldr_cache::sccache_dir`).

## Acceptance criteria status (issue #172)

- managed zccache writes to `~/.soldr/cache/zccache` — DONE on main (env var honored by managed zccache 1.4.0)
- `soldr status` / `soldr cache` report the dir — DONE on main
- `soldr clean` clears soldr-owned root only, leaves `~/.zccache` alone — DONE on main, regression-tested by `clean_clears_managed_zccache_and_state_dir`
- `SOLDR_RUSTC_WRAPPER=sccache` uses `~/.soldr/cache/sccache` when `SCCACHE_DIR` unset — DONE on main, tested by `cargo_front_door_uses_custom_rustc_wrapper_from_env_var` and `custom_sccache_wrapper_preserves_caller_sccache_dir`
- caller-provided `ZCCACHE_CACHE_DIR` rejected on conflict, `SCCACHE_DIR` preserved — DONE on main
- documented runtime contract for both wrapper backends — this PR

## Out of scope (deferred to follow-up)

- `setup-soldr` action's build-cache path migration from `~/.zccache` to the soldr-owned dir lives in the separate `zackees/setup-soldr` repo and needs its own PR there
- the Windows `actions/cache` save warning about `index.redb` is an action-side fix (stop the daemon before save); it does not block the soldr-side path change

## Dependency

- Depends on managed zccache `>= 1.4.0` (already on main as of `040f209`). zccache 1.4.0 honors `ZCCACHE_CACHE_DIR` via `zccache-core::config::CACHE_DIR_ENV`, verified against the upstream source.

## Test plan

- [x] `cargo test -p soldr-cache` (10 passed)
- [x] `cargo test -p soldr-cli --test cli -- managed_zccache_rejects_conflicting_cache_dir_override custom_sccache_wrapper_preserves_caller_sccache_dir cargo_front_door_uses_custom_rustc_wrapper_from_env_var clean_clears_managed_zccache_and_state_dir nested_soldr_ignores_inherited_managed_zccache_cache_dir` (5 passed)
- [x] `cargo build -p soldr-cli`
- [x] `cargo fmt --all -- --check`
- [ ] full `cargo clippy --workspace --all-targets -- -D warnings` blocked by a pre-existing `clippy::needless_return` in `crates/soldr-cli/tests/cli.rs:60` introduced in commit `7b89c0d4` on main; not touched in this PR

Closes #172.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>