### PR TITLE
feat(cache): track target/ dirs in sqlite registry, add soldr gc command (#234)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +401,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +545,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -533,6 +566,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -861,6 +903,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1247,6 +1300,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1535,7 @@ name = "soldr-cache"
 version = "0.7.12"
 dependencies = [
  "blake3",
+ "rusqlite",
  "serde",
  "serde_json",
  "soldr-core",
@@ -1906,6 +1974,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ zip = "2"
 flate2 = "1"
 tar = "0.4"
 toml = "0.8"
+rusqlite = { version = "0.31", features = ["bundled"] }

--- a/crates/soldr-cache/Cargo.toml
+++ b/crates/soldr-cache/Cargo.toml
@@ -14,3 +14,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tempfile = { workspace = true }
+rusqlite = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/soldr-cache/src/gc.rs
+++ b/crates/soldr-cache/src/gc.rs
@@ -1,0 +1,421 @@
+//! `soldr gc` orchestration: scan the target registry, apply safety
+//! guards and thresholds, surface candidates, and (optionally) delete
+//! their `target/` directories.
+//!
+//! This module owns the policy. The CLI layer is a thin shim that
+//! parses flags, builds a [`GcOptions`], and prints the
+//! [`GcReport`] / decides whether to invoke [`GcPlan::apply`].
+
+use crate::target_registry::{
+    current_unix_seconds, directory_size, evaluate_safety_guards, human_age, human_size,
+    workspace_root_for_target, GuardOutcome, RegistryError, TargetRegistry,
+    DEFAULT_STALE_AGE_SECONDS, DEFAULT_STALE_SIZE_BYTES,
+};
+use std::{
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+#[derive(Debug, Clone)]
+pub struct GcOptions {
+    pub older_than_seconds: u64,
+    pub larger_than_bytes: u64,
+    pub dev_roots: Vec<PathBuf>,
+    pub dry_run: bool,
+}
+
+impl Default for GcOptions {
+    fn default() -> Self {
+        Self {
+            older_than_seconds: DEFAULT_STALE_AGE_SECONDS,
+            larger_than_bytes: DEFAULT_STALE_SIZE_BYTES,
+            dev_roots: Vec::new(),
+            dry_run: false,
+        }
+    }
+}
+
+/// One concrete candidate `target/` directory after sizing and
+/// guard evaluation.
+#[derive(Debug, Clone)]
+pub struct GcCandidate {
+    pub path: PathBuf,
+    pub size_bytes: u64,
+    pub age_seconds: i64,
+    pub eligible: bool,
+    pub reason: Option<String>,
+}
+
+/// Aggregated scan result for the registry.
+#[derive(Debug, Clone, Default)]
+pub struct GcReport {
+    /// Eligible candidates (over thresholds, guards passed).
+    pub candidates: Vec<GcCandidate>,
+    /// Skipped entries (guards rejected, under thresholds, or
+    /// missing-on-disk rows that were dropped).
+    pub skipped: Vec<GcCandidate>,
+    /// Number of registry rows whose path didn't exist on disk and
+    /// were quietly dropped.
+    pub dropped_missing: usize,
+}
+
+/// Pure scan: walk the registry, drop missing rows, apply thresholds
+/// and safety guards. Does not delete anything.
+pub fn scan(registry: &TargetRegistry, options: &GcOptions) -> Result<GcReport, RegistryError> {
+    let now = current_unix_seconds()?;
+    let mut report = GcReport::default();
+
+    for row in registry.list()? {
+        if !row.path.exists() {
+            // Drop missing-on-disk row silently per the proposal.
+            let _ = registry.remove(&row.path);
+            report.dropped_missing += 1;
+            continue;
+        }
+
+        let age = now.saturating_sub(row.last_used);
+        let size = directory_size(&row.path);
+
+        if (age as u64) < options.older_than_seconds {
+            report.skipped.push(GcCandidate {
+                path: row.path,
+                size_bytes: size,
+                age_seconds: age,
+                eligible: false,
+                reason: Some(format!(
+                    "younger than threshold ({} < {})",
+                    human_age(age),
+                    human_age(options.older_than_seconds as i64)
+                )),
+            });
+            continue;
+        }
+
+        if size < options.larger_than_bytes {
+            report.skipped.push(GcCandidate {
+                path: row.path,
+                size_bytes: size,
+                age_seconds: age,
+                eligible: false,
+                reason: Some(format!(
+                    "smaller than threshold ({} < {})",
+                    human_size(size),
+                    human_size(options.larger_than_bytes)
+                )),
+            });
+            continue;
+        }
+
+        let workspace = workspace_root_for_target(&row.path);
+        let outcome = evaluate_safety_guards(
+            &row.path,
+            &workspace,
+            &options.dev_roots,
+            options.older_than_seconds,
+            now,
+        );
+        match outcome {
+            GuardOutcome::Eligible => {
+                report.candidates.push(GcCandidate {
+                    path: row.path,
+                    size_bytes: size,
+                    age_seconds: age,
+                    eligible: true,
+                    reason: None,
+                });
+            }
+            GuardOutcome::Skipped(reason) => {
+                report.skipped.push(GcCandidate {
+                    path: row.path,
+                    size_bytes: size,
+                    age_seconds: age,
+                    eligible: false,
+                    reason: Some(reason),
+                });
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Delete the `target/` dir at `path` and drop its registry row. Skips
+/// the actual delete when `dry_run` is true. Returns whether the
+/// directory was removed (`false` when dry-run, when missing, or when
+/// the delete failed).
+pub fn purge_one(
+    registry: &TargetRegistry,
+    path: &Path,
+    dry_run: bool,
+) -> Result<bool, RegistryError> {
+    if dry_run {
+        return Ok(false);
+    }
+    if !path.exists() {
+        let _ = registry.remove(path);
+        return Ok(false);
+    }
+    let result = std::fs::remove_dir_all(path);
+    let _ = registry.remove(path);
+    match result {
+        Ok(_) => Ok(true),
+        Err(e) => Err(RegistryError::Io(e)),
+    }
+}
+
+/// Information for the once-per-day startup warning. Returns `None`
+/// if no candidates qualify or the warning was already emitted today.
+pub fn maybe_build_startup_warning(
+    registry: &TargetRegistry,
+    options: &GcOptions,
+    marker_path: &Path,
+) -> Result<Option<String>, RegistryError> {
+    if !startup_warning_due(marker_path)? {
+        return Ok(None);
+    }
+
+    let report = scan(registry, options)?;
+    if report.candidates.is_empty() {
+        return Ok(None);
+    }
+
+    let total_bytes: u64 = report.candidates.iter().map(|c| c.size_bytes).sum();
+    let n = report.candidates.len();
+    let plural = if n == 1 { "" } else { "s" };
+    let message = format!(
+        "soldr: {n} stale target/ dir{plural} using {} (last used > {}). Run 'soldr gc' to review.",
+        human_size(total_bytes),
+        human_age(options.older_than_seconds as i64),
+    );
+
+    touch_startup_warning_marker(marker_path)?;
+    Ok(Some(message))
+}
+
+/// Whether enough time has passed since the last warning to emit
+/// another one. Missing marker => due now.
+pub fn startup_warning_due(marker_path: &Path) -> Result<bool, RegistryError> {
+    let metadata = match std::fs::metadata(marker_path) {
+        Ok(m) => m,
+        Err(_) => return Ok(true),
+    };
+    let modified = match metadata.modified() {
+        Ok(t) => t,
+        Err(_) => return Ok(true),
+    };
+    let now = SystemTime::now();
+    let elapsed = now
+        .duration_since(modified)
+        .unwrap_or(std::time::Duration::ZERO);
+    Ok(elapsed.as_secs() >= 24 * 60 * 60)
+}
+
+fn touch_startup_warning_marker(path: &Path) -> Result<(), RegistryError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, current_unix_seconds()?.to_string())?;
+    Ok(())
+}
+
+/// Parse human-friendly duration strings like `10d`, `4h`, `30m`,
+/// `90s`. Returns seconds.
+pub fn parse_duration(input: &str) -> Result<u64, String> {
+    let s = input.trim();
+    if s.is_empty() {
+        return Err("empty duration".to_string());
+    }
+    let (num_str, unit) = split_numeric_suffix(s);
+    let value: u64 = num_str
+        .parse()
+        .map_err(|_| format!("invalid duration number in {s:?}"))?;
+    let multiplier: u64 = match unit.to_ascii_lowercase().as_str() {
+        "" | "s" | "sec" | "secs" | "second" | "seconds" => 1,
+        "m" | "min" | "mins" | "minute" | "minutes" => 60,
+        "h" | "hr" | "hrs" | "hour" | "hours" => 3_600,
+        "d" | "day" | "days" => 86_400,
+        "w" | "wk" | "wks" | "week" | "weeks" => 7 * 86_400,
+        other => return Err(format!("unknown duration unit {other:?} in {s:?}")),
+    };
+    value
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("duration overflow in {s:?}"))
+}
+
+/// Parse human-friendly size strings like `256M`, `1GB`, `512KiB`.
+/// Returns bytes. Both decimal (KB, MB) and binary (KiB, MiB)
+/// suffixes resolve to powers of 1024.
+pub fn parse_size(input: &str) -> Result<u64, String> {
+    let s = input.trim();
+    if s.is_empty() {
+        return Err("empty size".to_string());
+    }
+    let (num_str, unit) = split_numeric_suffix(s);
+    let value: u64 = num_str
+        .parse()
+        .map_err(|_| format!("invalid size number in {s:?}"))?;
+    let multiplier: u64 = match unit.to_ascii_lowercase().as_str() {
+        "" | "b" => 1,
+        "k" | "kb" | "kib" => 1024,
+        "m" | "mb" | "mib" => 1024 * 1024,
+        "g" | "gb" | "gib" => 1024 * 1024 * 1024,
+        "t" | "tb" | "tib" => 1024_u64.pow(4),
+        other => return Err(format!("unknown size unit {other:?} in {s:?}")),
+    };
+    value
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("size overflow in {s:?}"))
+}
+
+fn split_numeric_suffix(s: &str) -> (&str, &str) {
+    let split_at = s.find(|c: char| !(c.is_ascii_digit())).unwrap_or(s.len());
+    s.split_at(split_at)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::target_registry::TargetRegistry;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn make_workspace(root: &Path, name: &str, size_bytes: u64) -> (PathBuf, PathBuf) {
+        let workspace = root.join(name);
+        let target = workspace.join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("blob"), vec![0u8; size_bytes as usize]).unwrap();
+        (workspace, target)
+    }
+
+    #[test]
+    fn scan_drops_missing_rows_and_keeps_candidates() {
+        let dir = tempdir().unwrap();
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let (_, target) = make_workspace(dir.path(), "repo-a", 512);
+        let missing = dir.path().join("ghost").join("target");
+
+        let now = current_unix_seconds().unwrap();
+        registry
+            .upsert_with_time(&target, now - 30 * 86_400)
+            .unwrap();
+        registry
+            .upsert_with_time(&missing, now - 30 * 86_400)
+            .unwrap();
+
+        let opts = GcOptions {
+            older_than_seconds: 10 * 86_400,
+            larger_than_bytes: 0, // include everything
+            dev_roots: vec![dir.path().to_path_buf()],
+            dry_run: true,
+        };
+        let report = scan(&registry, &opts).unwrap();
+        assert_eq!(report.dropped_missing, 1);
+        assert_eq!(report.candidates.len(), 1);
+        assert_eq!(report.candidates[0].path, target);
+    }
+
+    #[test]
+    fn scan_filters_by_age_and_size() {
+        let dir = tempdir().unwrap();
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let (_, target_small) = make_workspace(dir.path(), "small", 16);
+        let (_, target_big) = make_workspace(dir.path(), "big", 4096);
+
+        let now = current_unix_seconds().unwrap();
+        // Small but stale
+        registry
+            .upsert_with_time(&target_small, now - 30 * 86_400)
+            .unwrap();
+        // Big but fresh
+        registry.upsert_with_time(&target_big, now - 60).unwrap();
+
+        let opts = GcOptions {
+            older_than_seconds: 10 * 86_400,
+            larger_than_bytes: 1024,
+            dev_roots: vec![dir.path().to_path_buf()],
+            dry_run: true,
+        };
+        let report = scan(&registry, &opts).unwrap();
+        assert!(report.candidates.is_empty());
+        assert_eq!(report.skipped.len(), 2);
+    }
+
+    #[test]
+    fn dry_run_purge_does_not_delete() {
+        let dir = tempdir().unwrap();
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let (_, target) = make_workspace(dir.path(), "repo", 256);
+        registry.upsert_with_time(&target, 100).unwrap();
+
+        let removed = purge_one(&registry, &target, true).unwrap();
+        assert!(!removed);
+        assert!(target.exists(), "dry-run must not delete");
+        // Registry row preserved on dry-run.
+        assert!(registry.get(&target).unwrap().is_some());
+    }
+
+    #[test]
+    fn purge_deletes_directory_and_row() {
+        let dir = tempdir().unwrap();
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let (_, target) = make_workspace(dir.path(), "repo", 256);
+        registry.upsert_with_time(&target, 100).unwrap();
+
+        let removed = purge_one(&registry, &target, false).unwrap();
+        assert!(removed);
+        assert!(!target.exists());
+        assert!(registry.get(&target).unwrap().is_none());
+    }
+
+    #[test]
+    fn safety_guard_short_circuits_on_active_lock() {
+        let dir = tempdir().unwrap();
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let (_, target) = make_workspace(dir.path(), "repo", 4096);
+        std::fs::write(target.join(".cargo-lock"), b"").unwrap();
+
+        let now = current_unix_seconds().unwrap();
+        registry
+            .upsert_with_time(&target, now - 30 * 86_400)
+            .unwrap();
+
+        let opts = GcOptions {
+            older_than_seconds: 10 * 86_400,
+            larger_than_bytes: 0,
+            dev_roots: vec![dir.path().to_path_buf()],
+            dry_run: true,
+        };
+        let report = scan(&registry, &opts).unwrap();
+        assert!(report.candidates.is_empty());
+        assert_eq!(report.skipped.len(), 1);
+    }
+
+    #[test]
+    fn parse_duration_handles_units() {
+        assert_eq!(parse_duration("10d").unwrap(), 10 * 86_400);
+        assert_eq!(parse_duration("4h").unwrap(), 4 * 3_600);
+        assert_eq!(parse_duration("90s").unwrap(), 90);
+        assert_eq!(parse_duration("3W").unwrap(), 3 * 7 * 86_400);
+        assert!(parse_duration("garbage").is_err());
+    }
+
+    #[test]
+    fn parse_size_handles_units() {
+        assert_eq!(parse_size("256M").unwrap(), 256 * 1024 * 1024);
+        assert_eq!(parse_size("1GB").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_size("512KiB").unwrap(), 512 * 1024);
+        assert_eq!(parse_size("42").unwrap(), 42);
+        assert!(parse_size("nopes").is_err());
+    }
+
+    #[test]
+    fn startup_warning_throttle_blocks_repeats() {
+        let dir = tempdir().unwrap();
+        let marker = dir.path().join(".gc_warning_marker");
+        // First call: due.
+        assert!(startup_warning_due(&marker).unwrap());
+        // After we touch it, next call should not be due.
+        touch_startup_warning_marker(&marker).unwrap();
+        assert!(!startup_warning_due(&marker).unwrap());
+    }
+}

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -10,6 +10,20 @@ use std::{
     path::{Path, PathBuf},
 };
 
+pub mod gc;
+pub mod target_registry;
+
+/// Path to the soldr state database (`~/.soldr/data.db`) used by the
+/// target-directory registry and any future state tables.
+pub fn data_db_path(paths: &SoldrPaths) -> PathBuf {
+    paths.root.join(target_registry::DATA_DB_FILE)
+}
+
+/// Throttle marker for the once-per-day stale-target startup warning.
+pub fn gc_warning_marker_path(paths: &SoldrPaths) -> PathBuf {
+    paths.root.join(".gc_warning_marker")
+}
+
 /// Environment variable used to carry cache enable/disable state from the
 /// front-door cargo command into child processes.
 pub const CACHE_ENABLED_ENV_VAR: &str = "SOLDR_CACHE_ENABLED";

--- a/crates/soldr-cache/src/target_registry.rs
+++ b/crates/soldr-cache/src/target_registry.rs
@@ -1,0 +1,608 @@
+//! Sqlite-backed registry of observed Cargo `target/` directories.
+//!
+//! Implements the data plane for issue #234: every `RUSTC_WRAPPER`
+//! invocation upserts the resolved workspace `target/` path with the
+//! current unix timestamp. The `soldr gc` command later scans the
+//! registry to find stale candidates for reclamation.
+//!
+//! The store lives at `~/.soldr/data.db` and is intentionally generic:
+//! future state can land in additional tables without renaming.
+
+use rusqlite::{params, Connection, OptionalExtension};
+use std::{
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+use thiserror::Error;
+
+/// Default file name for the soldr state database under `~/.soldr/`.
+pub const DATA_DB_FILE: &str = "data.db";
+
+/// Default staleness threshold (10 days) used by `soldr gc` and the
+/// startup warning.
+pub const DEFAULT_STALE_AGE_SECONDS: u64 = 10 * 24 * 60 * 60;
+
+/// Default size threshold (256 MiB) used by `soldr gc` and the
+/// startup warning.
+pub const DEFAULT_STALE_SIZE_BYTES: u64 = 256 * 1024 * 1024;
+
+#[derive(Debug, Error)]
+pub enum RegistryError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("system clock before unix epoch: {0}")]
+    Clock(String),
+}
+
+/// One row from the `targets` table augmented with the current
+/// observation time so callers can compute the age cheaply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetRow {
+    pub path: PathBuf,
+    pub last_used: i64,
+}
+
+/// Sqlite registry backed by `~/.soldr/data.db` (or a caller-provided
+/// path). The schema is the minimal v1 table from issue #234.
+pub struct TargetRegistry {
+    conn: Connection,
+}
+
+impl TargetRegistry {
+    /// Open or create the database at the given path. Parent dirs are
+    /// created automatically.
+    pub fn open(path: &Path) -> Result<Self, RegistryError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(path)?;
+        Self::init_schema(&conn)?;
+        Ok(Self { conn })
+    }
+
+    /// Open an in-memory database. Useful for tests and for callers
+    /// that want a registry without touching disk.
+    pub fn open_in_memory() -> Result<Self, RegistryError> {
+        let conn = Connection::open_in_memory()?;
+        Self::init_schema(&conn)?;
+        Ok(Self { conn })
+    }
+
+    fn init_schema(conn: &Connection) -> Result<(), RegistryError> {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS targets (\n  id          INTEGER PRIMARY KEY AUTOINCREMENT,\n  path        TEXT NOT NULL UNIQUE,\n  last_used   INTEGER NOT NULL\n);",
+        )?;
+        Ok(())
+    }
+
+    /// Insert or update the row for `path` with the supplied unix
+    /// timestamp.
+    pub fn upsert_with_time(&self, path: &Path, unix_seconds: i64) -> Result<(), RegistryError> {
+        let path_str = path_to_string(path);
+        self.conn.execute(
+            "INSERT INTO targets (path, last_used) VALUES (?1, ?2) ON CONFLICT(path) DO UPDATE SET last_used = excluded.last_used",
+            params![path_str, unix_seconds],
+        )?;
+        Ok(())
+    }
+
+    /// Convenience wrapper that stamps the row with the current time.
+    pub fn upsert(&self, path: &Path) -> Result<(), RegistryError> {
+        self.upsert_with_time(path, current_unix_seconds()?)
+    }
+
+    /// Return all tracked rows, ordered by `last_used` ascending.
+    pub fn list(&self) -> Result<Vec<TargetRow>, RegistryError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT path, last_used FROM targets ORDER BY last_used ASC")?;
+        let rows = stmt
+            .query_map([], |row| {
+                let path: String = row.get(0)?;
+                let last_used: i64 = row.get(1)?;
+                Ok(TargetRow {
+                    path: PathBuf::from(path),
+                    last_used,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Look up a single tracked row by path, if present.
+    pub fn get(&self, path: &Path) -> Result<Option<TargetRow>, RegistryError> {
+        let path_str = path_to_string(path);
+        let row = self
+            .conn
+            .query_row(
+                "SELECT path, last_used FROM targets WHERE path = ?1",
+                params![path_str],
+                |row| {
+                    let path: String = row.get(0)?;
+                    let last_used: i64 = row.get(1)?;
+                    Ok(TargetRow {
+                        path: PathBuf::from(path),
+                        last_used,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    /// Remove the row for `path`. No-op if it doesn't exist.
+    pub fn remove(&self, path: &Path) -> Result<bool, RegistryError> {
+        let path_str = path_to_string(path);
+        let removed = self
+            .conn
+            .execute("DELETE FROM targets WHERE path = ?1", params![path_str])?;
+        Ok(removed > 0)
+    }
+
+    /// Total number of tracked rows.
+    pub fn len(&self) -> Result<usize, RegistryError> {
+        let count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM targets", [], |row| row.get(0))?;
+        Ok(count as usize)
+    }
+
+    /// Whether the registry has any rows.
+    pub fn is_empty(&self) -> Result<bool, RegistryError> {
+        Ok(self.len()? == 0)
+    }
+}
+
+/// Human-readable byte size, kibibyte-based (e.g. `12.3 GB`).
+pub fn human_size(bytes: u64) -> String {
+    const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB", "PB"];
+    if bytes == 0 {
+        return "0 B".to_string();
+    }
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{} {}", bytes, UNITS[unit])
+    } else {
+        format!("{:.1} {}", size, UNITS[unit])
+    }
+}
+
+/// Human-readable age in days/hours from a delta of seconds.
+pub fn human_age(seconds: i64) -> String {
+    if seconds < 0 {
+        return "future".to_string();
+    }
+    let secs = seconds as u64;
+    let days = secs / 86_400;
+    let hours = (secs % 86_400) / 3_600;
+    if days > 0 {
+        format!("{days}d{hours}h")
+    } else {
+        let minutes = (secs % 3_600) / 60;
+        format!("{hours}h{minutes}m")
+    }
+}
+
+/// Recursively measure the on-disk size of a directory in bytes,
+/// following directory entries but never crossing symlinks. Errors are
+/// silently swallowed for individual entries — partial sizes are still
+/// useful for the GC heuristic.
+pub fn directory_size(path: &Path) -> u64 {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(_) => return 0,
+    };
+    if metadata.file_type().is_symlink() {
+        return 0;
+    }
+    if metadata.is_file() {
+        return metadata.len();
+    }
+    let mut total: u64 = 0;
+    let entries = match std::fs::read_dir(path) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        let entry_meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if entry_meta.file_type().is_symlink() {
+            continue;
+        }
+        if entry_meta.is_dir() {
+            total = total.saturating_add(directory_size(&entry_path));
+        } else if entry_meta.is_file() {
+            total = total.saturating_add(entry_meta.len());
+        }
+    }
+    total
+}
+
+/// Resolve the workspace `target/` dir from an arbitrary path that
+/// sits *inside* a `target/` tree. Walks up until it finds a path
+/// component named `target`. Returns `None` if no such ancestor is
+/// found cheaply — we never walk the whole filesystem.
+pub fn resolve_target_dir_from_descendant(start: &Path) -> Option<PathBuf> {
+    let mut current = start;
+    let mut last_target: Option<PathBuf> = None;
+    while let Some(parent) = current.parent() {
+        if parent.file_name().map(|n| n == "target").unwrap_or(false) {
+            last_target = Some(parent.to_path_buf());
+        }
+        current = parent;
+    }
+    last_target
+}
+
+/// Resolve the canonical workspace `target/` directory from a
+/// rustc-wrapper argv slice. Returns `None` if the path can't be
+/// derived cheaply — callers MUST silently skip in that case rather
+/// than fail the build.
+///
+/// Strategy:
+/// 1. Honor `CARGO_TARGET_DIR` if set and absolute.
+/// 2. Otherwise look at the rustc `--out-dir <DIR>` argument and walk
+///    up to find the enclosing `target/` boundary.
+pub fn resolve_workspace_target_dir(rustc_args: &[String]) -> Option<PathBuf> {
+    if let Some(env_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        let path = PathBuf::from(env_dir);
+        if path.is_absolute() {
+            return Some(canonicalize_or_self(&path));
+        }
+    }
+
+    let out_dir = extract_flag_value(rustc_args, "--out-dir")?;
+    let out_path = PathBuf::from(out_dir);
+    let target = resolve_target_dir_from_descendant(&out_path)?;
+    Some(canonicalize_or_self(&target))
+}
+
+fn extract_flag_value(args: &[String], flag: &str) -> Option<String> {
+    let mut iter = args.iter();
+    let prefix = format!("{flag}=");
+    while let Some(arg) = iter.next() {
+        if arg == flag {
+            return iter.next().cloned();
+        }
+        if let Some(rest) = arg.strip_prefix(&prefix) {
+            return Some(rest.to_string());
+        }
+    }
+    None
+}
+
+fn canonicalize_or_self(path: &Path) -> PathBuf {
+    match std::fs::canonicalize(path) {
+        Ok(canonical) => canonical,
+        Err(_) => path.to_path_buf(),
+    }
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}
+
+/// Current unix timestamp in seconds.
+pub fn current_unix_seconds() -> Result<i64, RegistryError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .map_err(|e| RegistryError::Clock(e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Safety guards (from docs/TARGET_GC_PROPOSAL.md)
+// ---------------------------------------------------------------------------
+
+/// Decision returned by [`evaluate_safety_guards`] for a single
+/// candidate `target/` directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuardOutcome {
+    /// Safe to consider for GC.
+    Eligible,
+    /// Skipped because of an active build lock or recent activity.
+    Skipped(String),
+}
+
+/// Apply the proposal's three safety guards to a candidate `target/`
+/// directory:
+///
+/// (a) `Cargo.lock` mtime within the staleness window — workspace was
+///     built recently so the dir is likely live.
+/// (b) `target/.cargo-lock` exists — cargo is currently holding the
+///     build lock.
+/// (c) `dev_root` allowlist — the `target/` path must sit under one
+///     of the configured roots (defaults to `~/dev`).
+pub fn evaluate_safety_guards(
+    target_dir: &Path,
+    workspace_root: &Path,
+    dev_roots: &[PathBuf],
+    stale_age_seconds: u64,
+    now_unix_seconds: i64,
+) -> GuardOutcome {
+    if !is_under_any_root(target_dir, dev_roots) {
+        return GuardOutcome::Skipped(format!(
+            "outside configured gc.allowlist_roots ({} roots)",
+            dev_roots.len()
+        ));
+    }
+
+    let cargo_lock = workspace_root.join("Cargo.lock");
+    if let Ok(meta) = std::fs::metadata(&cargo_lock) {
+        if let Ok(modified) = meta.modified() {
+            if let Ok(elapsed) = modified
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+            {
+                let age = now_unix_seconds.saturating_sub(elapsed);
+                if (age as u64) < stale_age_seconds {
+                    return GuardOutcome::Skipped(format!(
+                        "Cargo.lock modified {} ago (< staleness threshold)",
+                        human_age(age)
+                    ));
+                }
+            }
+        }
+    }
+
+    let cargo_build_lock = target_dir.join(".cargo-lock");
+    if cargo_build_lock.exists() {
+        return GuardOutcome::Skipped("active cargo build lock present".to_string());
+    }
+
+    GuardOutcome::Eligible
+}
+
+/// Whether `path` lies under any of the supplied `dev_roots` after
+/// canonicalization. An empty `dev_roots` slice rejects everything.
+pub fn is_under_any_root(path: &Path, dev_roots: &[PathBuf]) -> bool {
+    if dev_roots.is_empty() {
+        return false;
+    }
+    let canonical = canonicalize_or_self(path);
+    for root in dev_roots {
+        let root_canonical = canonicalize_or_self(root);
+        if canonical.starts_with(&root_canonical) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Walk up from a `target/` dir to its workspace root. The workspace
+/// root is the parent directory of `target/` (the one containing
+/// `Cargo.toml`).
+pub fn workspace_root_for_target(target_dir: &Path) -> PathBuf {
+    target_dir
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| target_dir.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn fixed_now() -> i64 {
+        1_700_000_000
+    }
+
+    #[test]
+    fn upsert_is_idempotent_and_updates_timestamp() {
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let path = PathBuf::from("/tmp/repo/target");
+        registry.upsert_with_time(&path, 100).unwrap();
+        registry.upsert_with_time(&path, 200).unwrap();
+        registry.upsert_with_time(&path, 200).unwrap();
+
+        let row = registry.get(&path).unwrap().unwrap();
+        assert_eq!(row.last_used, 200);
+        assert_eq!(registry.len().unwrap(), 1);
+    }
+
+    #[test]
+    fn list_returns_all_rows_sorted() {
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        registry
+            .upsert_with_time(Path::new("/a/target"), 300)
+            .unwrap();
+        registry
+            .upsert_with_time(Path::new("/b/target"), 100)
+            .unwrap();
+        registry
+            .upsert_with_time(Path::new("/c/target"), 200)
+            .unwrap();
+
+        let rows = registry.list().unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].path, PathBuf::from("/b/target"));
+        assert_eq!(rows[1].path, PathBuf::from("/c/target"));
+        assert_eq!(rows[2].path, PathBuf::from("/a/target"));
+    }
+
+    #[test]
+    fn remove_deletes_row() {
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let path = PathBuf::from("/tmp/repo/target");
+        registry.upsert_with_time(&path, 100).unwrap();
+        assert!(registry.remove(&path).unwrap());
+        assert!(!registry.remove(&path).unwrap());
+        assert_eq!(registry.len().unwrap(), 0);
+    }
+
+    #[test]
+    fn open_persists_to_disk() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("data.db");
+        {
+            let registry = TargetRegistry::open(&db_path).unwrap();
+            registry
+                .upsert_with_time(Path::new("/tmp/persisted/target"), 555)
+                .unwrap();
+        }
+        let registry = TargetRegistry::open(&db_path).unwrap();
+        let row = registry
+            .get(Path::new("/tmp/persisted/target"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.last_used, 555);
+    }
+
+    #[test]
+    fn human_size_formats_units() {
+        assert_eq!(human_size(0), "0 B");
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(1024), "1.0 KB");
+        assert_eq!(human_size(1024 * 1024), "1.0 MB");
+        assert_eq!(human_size(2u64 * 1024 * 1024 * 1024), "2.0 GB");
+    }
+
+    #[test]
+    fn human_age_formats_days_and_hours() {
+        assert_eq!(human_age(0), "0h0m");
+        assert_eq!(human_age(3600), "1h0m");
+        assert_eq!(human_age(86_400), "1d0h");
+        assert_eq!(human_age(86_400 * 3 + 3600 * 4), "3d4h");
+    }
+
+    #[test]
+    fn directory_size_sums_files() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"hello").unwrap();
+        std::fs::write(dir.path().join("b.bin"), vec![0u8; 1024]).unwrap();
+        let nested = dir.path().join("sub");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("c.bin"), vec![0u8; 256]).unwrap();
+        assert_eq!(directory_size(dir.path()), 5 + 1024 + 256);
+    }
+
+    #[test]
+    fn resolve_target_dir_walks_up_to_target_boundary() {
+        let path = PathBuf::from("/home/user/repo/target/debug/deps/foo-abcdef");
+        let target = resolve_target_dir_from_descendant(&path).unwrap();
+        assert_eq!(target, PathBuf::from("/home/user/repo/target"));
+    }
+
+    #[test]
+    fn resolve_target_dir_returns_none_when_no_target_ancestor() {
+        let path = PathBuf::from("/home/user/some/other/dir");
+        assert!(resolve_target_dir_from_descendant(&path).is_none());
+    }
+
+    #[test]
+    fn extract_flag_value_handles_space_and_equals_forms() {
+        let args: Vec<String> = vec![
+            "--crate-name".into(),
+            "foo".into(),
+            "--out-dir".into(),
+            "/tmp/repo/target/debug/deps".into(),
+        ];
+        assert_eq!(
+            extract_flag_value(&args, "--out-dir"),
+            Some("/tmp/repo/target/debug/deps".into())
+        );
+
+        let args2: Vec<String> = vec!["--out-dir=/tmp/repo/target/debug/deps".into()];
+        assert_eq!(
+            extract_flag_value(&args2, "--out-dir"),
+            Some("/tmp/repo/target/debug/deps".into())
+        );
+    }
+
+    #[test]
+    fn allowlist_guard_short_circuits_outside_dev_roots() {
+        let dir = tempdir().unwrap();
+        let target_dir = dir.path().join("repo").join("target");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let workspace = target_dir.parent().unwrap().to_path_buf();
+        // No dev_roots configured => everything is rejected.
+        let outcome = evaluate_safety_guards(
+            &target_dir,
+            &workspace,
+            &[],
+            DEFAULT_STALE_AGE_SECONDS,
+            fixed_now(),
+        );
+        assert!(matches!(outcome, GuardOutcome::Skipped(_)));
+    }
+
+    #[test]
+    fn allowlist_guard_passes_when_target_is_under_root() {
+        let dir = tempdir().unwrap();
+        let target_dir = dir.path().join("repo").join("target");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let workspace = target_dir.parent().unwrap().to_path_buf();
+
+        let outcome = evaluate_safety_guards(
+            &target_dir,
+            &workspace,
+            &[dir.path().to_path_buf()],
+            DEFAULT_STALE_AGE_SECONDS,
+            fixed_now(),
+        );
+        assert_eq!(outcome, GuardOutcome::Eligible);
+    }
+
+    #[test]
+    fn cargo_build_lock_skips_candidate() {
+        let dir = tempdir().unwrap();
+        let target_dir = dir.path().join("repo").join("target");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let workspace = target_dir.parent().unwrap().to_path_buf();
+        std::fs::write(target_dir.join(".cargo-lock"), b"").unwrap();
+
+        let outcome = evaluate_safety_guards(
+            &target_dir,
+            &workspace,
+            &[dir.path().to_path_buf()],
+            DEFAULT_STALE_AGE_SECONDS,
+            fixed_now(),
+        );
+        match outcome {
+            GuardOutcome::Skipped(reason) => assert!(reason.contains("cargo build lock")),
+            _ => panic!("expected skip"),
+        }
+    }
+
+    #[test]
+    fn fresh_cargo_lock_skips_candidate() {
+        let dir = tempdir().unwrap();
+        let target_dir = dir.path().join("repo").join("target");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let workspace = target_dir.parent().unwrap().to_path_buf();
+        // Cargo.lock that is mtime "now" — newer than the threshold.
+        std::fs::write(workspace.join("Cargo.lock"), b"").unwrap();
+
+        let outcome = evaluate_safety_guards(
+            &target_dir,
+            &workspace,
+            &[dir.path().to_path_buf()],
+            DEFAULT_STALE_AGE_SECONDS,
+            current_unix_seconds().unwrap(),
+        );
+        match outcome {
+            GuardOutcome::Skipped(reason) => assert!(reason.contains("Cargo.lock modified")),
+            _ => panic!("expected skip"),
+        }
+    }
+
+    #[test]
+    fn workspace_root_is_target_parent() {
+        let target = PathBuf::from("/home/me/repo/target");
+        assert_eq!(
+            workspace_root_for_target(&target),
+            PathBuf::from("/home/me/repo")
+        );
+    }
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -103,6 +103,31 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Garbage-collect stale Cargo `target/` directories tracked by
+    /// the soldr registry (`~/.soldr/data.db`).
+    ///
+    /// Aliases: `purge-targets` (matches issue #234's `soldr --purge`
+    /// wording).
+    #[command(alias = "purge-targets")]
+    Gc {
+        /// Show candidates and totals without deleting anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Delete every eligible candidate without prompting.
+        #[arg(long)]
+        all: bool,
+        /// Minimum age before a `target/` is considered stale
+        /// (e.g. `10d`, `4w`).
+        #[arg(long, default_value = "10d", value_name = "DURATION")]
+        older_than: String,
+        /// Minimum on-disk size before a `target/` is considered for
+        /// reclamation (e.g. `256M`, `1GB`).
+        #[arg(long, default_value = "256M", value_name = "SIZE")]
+        larger_than: String,
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
     /// Anything else is a tool to fetch and run
     #[command(external_subcommand)]
     External(Vec<String>),
@@ -153,6 +178,10 @@ async fn main() {
                 .unwrap_or_else(report_and_exit),
         );
     }
+
+    // Dispatch path only: one-shot stale-target/ warning, throttled
+    // to once per day. Never runs on the rustc-wrapper hot path.
+    emit_startup_target_warning_if_due();
 
     let rc = run_with_args(&raw_args[0], &raw_args[1..])
         .await
@@ -238,6 +267,21 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             } else {
                 println!("soldr {}", output.soldr_version);
             }
+        }
+        Commands::Gc {
+            dry_run,
+            all,
+            older_than,
+            larger_than,
+            json,
+        } => {
+            run_gc_command(GcInvocation {
+                dry_run,
+                all,
+                older_than,
+                larger_than,
+                json,
+            })?;
         }
         Commands::External(args) => {
             if args.is_empty() {
@@ -420,6 +464,13 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
         .and_then(std::ffi::OsStr::to_str)
         .unwrap_or(tool_arg);
 
+    // Per-build target/ tracking for `soldr gc`. Best-effort: if we
+    // can't resolve a workspace target dir cheaply, or the sqlite
+    // upsert fails for any reason, skip silently — never fail a build.
+    if tool_stem == "rustc" {
+        record_target_dir_in_registry(&raw_args[2..]);
+    }
+
     // Only route through zccache for actual rustc invocations, not
     // clippy-driver or other workspace wrappers.
     if tool_stem == "rustc" && soldr_cache::cache_enabled_in_current_process() {
@@ -483,6 +534,24 @@ fn run_wrapper_through_zccache(
         let status = command.status()?;
         Ok(status.code().unwrap_or(1))
     }
+}
+
+/// Best-effort upsert of the workspace `target/` dir into the soldr
+/// state registry on every wrapper invocation. Silent on failure.
+///
+/// `rustc_args` is the slice of args that follows the rustc binary
+/// path in the wrapper invocation (i.e. `raw_args[2..]`).
+fn record_target_dir_in_registry(rustc_args: &[String]) {
+    let Some(target) = soldr_cache::target_registry::resolve_workspace_target_dir(rustc_args)
+    else {
+        return;
+    };
+    let Ok(paths) = SoldrPaths::new() else { return };
+    let db_path = soldr_cache::data_db_path(&paths);
+    let Ok(registry) = soldr_cache::target_registry::TargetRegistry::open(&db_path) else {
+        return;
+    };
+    let _ = registry.upsert(&target);
 }
 
 async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i32, SoldrError> {
@@ -1645,6 +1714,222 @@ fn clear_zccache_cache() -> Result<(), SoldrError> {
         );
     }
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// soldr gc — garbage-collect stale Cargo target/ directories.
+// ---------------------------------------------------------------------------
+
+struct GcInvocation {
+    dry_run: bool,
+    all: bool,
+    older_than: String,
+    larger_than: String,
+    json: bool,
+}
+
+#[derive(Serialize)]
+struct GcCandidateOutput {
+    path: String,
+    size_bytes: u64,
+    size_human: String,
+    age_seconds: i64,
+    age_human: String,
+    eligible: bool,
+    reason: Option<String>,
+}
+
+#[derive(Serialize)]
+struct GcOutput {
+    schema_version: u32,
+    command: &'static str,
+    dry_run: bool,
+    candidates: Vec<GcCandidateOutput>,
+    skipped: Vec<GcCandidateOutput>,
+    dropped_missing: usize,
+    deleted_paths: Vec<String>,
+}
+
+fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
+    use soldr_cache::gc::{parse_duration, parse_size, purge_one, scan, GcOptions};
+
+    let older_than = parse_duration(&invocation.older_than).map_err(SoldrError::Other)?;
+    let larger_than = parse_size(&invocation.larger_than).map_err(SoldrError::Other)?;
+
+    let paths = SoldrPaths::new()?;
+    let dev_roots = resolve_gc_dev_roots(&paths);
+    let db_path = soldr_cache::data_db_path(&paths);
+    let registry = soldr_cache::target_registry::TargetRegistry::open(&db_path)
+        .map_err(|e| SoldrError::Other(format!("failed to open soldr registry: {e}")))?;
+
+    let options = GcOptions {
+        older_than_seconds: older_than,
+        larger_than_bytes: larger_than,
+        dev_roots,
+        dry_run: invocation.dry_run,
+    };
+
+    let report =
+        scan(&registry, &options).map_err(|e| SoldrError::Other(format!("gc scan failed: {e}")))?;
+
+    let mut deleted_paths: Vec<String> = Vec::new();
+
+    if !invocation.json {
+        eprintln!(
+            "soldr gc: scanned registry at {} ({} candidate dir{}, {} skipped, {} dropped missing)",
+            db_path.display(),
+            report.candidates.len(),
+            if report.candidates.len() == 1 {
+                ""
+            } else {
+                "s"
+            },
+            report.skipped.len(),
+            report.dropped_missing
+        );
+
+        if report.candidates.is_empty() {
+            eprintln!("soldr gc: nothing to reclaim.");
+        } else {
+            eprintln!("soldr gc: candidates");
+            for cand in &report.candidates {
+                eprintln!(
+                    "  {}  size={}  age={}",
+                    cand.path.display(),
+                    soldr_cache::target_registry::human_size(cand.size_bytes),
+                    soldr_cache::target_registry::human_age(cand.age_seconds),
+                );
+            }
+        }
+    }
+
+    for cand in &report.candidates {
+        let should_delete = if invocation.dry_run {
+            false
+        } else if invocation.all {
+            true
+        } else {
+            prompt_yes_no(&format!(
+                "soldr gc: delete {} ({}, age {}) ? [y/N] ",
+                cand.path.display(),
+                soldr_cache::target_registry::human_size(cand.size_bytes),
+                soldr_cache::target_registry::human_age(cand.age_seconds),
+            ))
+        };
+
+        if should_delete {
+            match purge_one(&registry, &cand.path, false) {
+                Ok(true) => {
+                    if !invocation.json {
+                        eprintln!("soldr gc: deleted {}", cand.path.display());
+                    }
+                    deleted_paths.push(cand.path.display().to_string());
+                }
+                Ok(false) => {
+                    if !invocation.json {
+                        eprintln!(
+                            "soldr gc: nothing to delete at {} (already gone)",
+                            cand.path.display()
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!("soldr gc: failed to delete {}: {e}", cand.path.display());
+                }
+            }
+        }
+    }
+
+    if invocation.json {
+        let output = GcOutput {
+            schema_version: JSON_SCHEMA_VERSION,
+            command: "gc",
+            dry_run: invocation.dry_run,
+            candidates: report
+                .candidates
+                .into_iter()
+                .map(gc_candidate_output)
+                .collect(),
+            skipped: report
+                .skipped
+                .into_iter()
+                .map(gc_candidate_output)
+                .collect(),
+            dropped_missing: report.dropped_missing,
+            deleted_paths,
+        };
+        print_json(&output)?;
+    }
+    Ok(())
+}
+
+fn gc_candidate_output(c: soldr_cache::gc::GcCandidate) -> GcCandidateOutput {
+    GcCandidateOutput {
+        path: c.path.display().to_string(),
+        size_human: soldr_cache::target_registry::human_size(c.size_bytes),
+        size_bytes: c.size_bytes,
+        age_human: soldr_cache::target_registry::human_age(c.age_seconds),
+        age_seconds: c.age_seconds,
+        eligible: c.eligible,
+        reason: c.reason,
+    }
+}
+
+fn prompt_yes_no(prompt: &str) -> bool {
+    use std::io::{BufRead, Write};
+    eprint!("{prompt}");
+    let _ = std::io::stderr().flush();
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    if stdin.lock().read_line(&mut line).is_err() {
+        return false;
+    }
+    matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+/// Resolve the configured `gc.allowlist_roots`, falling back to
+/// `~/dev` when unset.
+fn resolve_gc_dev_roots(paths: &SoldrPaths) -> Vec<std::path::PathBuf> {
+    let config = paths.load_config();
+    let configured = config
+        .gc
+        .allowlist_roots
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|r| !r.trim().is_empty())
+        .map(|r| soldr_core::expand_user_home(&r))
+        .collect::<Vec<_>>();
+    if !configured.is_empty() {
+        return configured;
+    }
+    if let Ok(home) = soldr_core::user_home_dir() {
+        return vec![home.join("dev")];
+    }
+    Vec::new()
+}
+
+fn emit_startup_target_warning_if_due() {
+    let Ok(paths) = SoldrPaths::new() else { return };
+    let db_path = soldr_cache::data_db_path(&paths);
+    if !db_path.exists() {
+        return;
+    }
+    let Ok(registry) = soldr_cache::target_registry::TargetRegistry::open(&db_path) else {
+        return;
+    };
+    let options = soldr_cache::gc::GcOptions {
+        older_than_seconds: soldr_cache::target_registry::DEFAULT_STALE_AGE_SECONDS,
+        larger_than_bytes: soldr_cache::target_registry::DEFAULT_STALE_SIZE_BYTES,
+        dev_roots: resolve_gc_dev_roots(&paths),
+        dry_run: true,
+    };
+    let marker = soldr_cache::gc_warning_marker_path(&paths);
+    match soldr_cache::gc::maybe_build_startup_warning(&registry, &options, &marker) {
+        Ok(Some(message)) => eprintln!("{message}"),
+        Ok(None) => {}
+        Err(_) => {}
+    }
 }
 
 fn purge_soldr_cache() -> Result<(), SoldrError> {

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -57,7 +57,7 @@ fn log_contains_toolchain_homes(
 fn fake_script_path(dir: &Path, name: &str) -> PathBuf {
     #[cfg(windows)]
     {
-        return dir.join(format!("{name}.cmd"));
+        dir.join(format!("{name}.cmd"))
     }
     #[cfg(not(windows))]
     {

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -513,6 +513,71 @@ impl SoldrPaths {
         std::fs::create_dir_all(&self.cache)?;
         Ok(())
     }
+
+    /// Load the soldr config from `config.toml` if it exists. Missing
+    /// or malformed files yield `Default::default()` so callers can
+    /// proceed with reasonable defaults.
+    pub fn load_config(&self) -> SoldrConfig {
+        SoldrConfig::load(&self.config_file)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config — `~/.soldr/config.toml`
+// ---------------------------------------------------------------------------
+
+/// Top-level soldr configuration. Currently only carries the
+/// `[gc]` section (issue #234); future sections can be added freely.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SoldrConfig {
+    #[serde(default)]
+    pub gc: GcConfig,
+}
+
+/// `gc` section of `config.toml`.
+///
+/// ```toml
+/// [gc]
+/// allowlist_roots = ["~/dev", "/work/repos"]
+/// ```
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct GcConfig {
+    /// Roots that `soldr gc` will consider for reclamation. If unset
+    /// (or empty after expansion), callers should fall back to
+    /// `~/dev`. `~` is expanded to the user's home directory.
+    #[serde(default)]
+    pub allowlist_roots: Option<Vec<String>>,
+}
+
+impl SoldrConfig {
+    pub fn load(path: &Path) -> Self {
+        let Ok(text) = std::fs::read_to_string(path) else {
+            return Self::default();
+        };
+        toml::from_str(&text).unwrap_or_default()
+    }
+}
+
+/// Public accessor for the soldr home directory used by the `gc`
+/// allowlist default (`~/dev`). Returns `Err` when no home dir can be
+/// resolved.
+pub fn user_home_dir() -> Result<PathBuf, SoldrError> {
+    home_dir()
+}
+
+/// Expand `~` and `~/...` strings to absolute paths under the user's
+/// home directory. Other inputs pass through unchanged.
+pub fn expand_user_home(input: &str) -> PathBuf {
+    if let Some(rest) = input.strip_prefix("~") {
+        if let Ok(home) = home_dir() {
+            let trimmed = rest.trim_start_matches(['/', '\\']);
+            if trimmed.is_empty() {
+                return home;
+            }
+            return home.join(trimmed);
+        }
+    }
+    PathBuf::from(input)
 }
 
 fn soldr_root_from_env_var(value: Option<&OsStr>) -> Option<Result<PathBuf, SoldrError>> {

--- a/docs/API.md
+++ b/docs/API.md
@@ -170,6 +170,45 @@ Stable machine-facing mode:
 soldr version --json
 ```
 
+### `soldr gc`
+
+Reclaim stale Cargo `target/` directories tracked in
+`~/.soldr/data.db`. Implemented by issue #234. The wrapper-mode hot
+path upserts each invocation's resolved workspace `target/` path with
+the current timestamp; `soldr gc` walks the registry, drops missing
+rows, applies safety guards, and (with confirmation) deletes the
+matching directories.
+
+```bash
+soldr gc                                     # interactive, y/N per dir
+soldr gc --dry-run                            # list candidates only
+soldr gc --all                                # delete every eligible candidate
+soldr gc --older-than 30d --larger-than 1GB   # tunable thresholds
+soldr gc --json                               # machine-readable report
+```
+
+Defaults:
+
+- `--older-than 10d`
+- `--larger-than 256M`
+
+Safety guards (from `docs/TARGET_GC_PROPOSAL.md`):
+
+- skip a candidate whose workspace `Cargo.lock` was modified within
+  the staleness window
+- skip a candidate whose `target/.cargo-lock` exists (active build)
+- only consider paths under `gc.allowlist_roots` (default: `~/dev`)
+
+Configure additional allowlist roots via `~/.soldr/config.toml`:
+
+```toml
+[gc]
+allowlist_roots = ["~/dev", "/work/repos"]
+```
+
+A passive once-per-day startup warning is also emitted on the
+dispatch path when stale candidates exist.
+
 ---
 
 ## Structured JSON Output
@@ -222,6 +261,7 @@ Commands:
   config   Show or set configuration
   cache    Inspect the compilation cache
   version  Show version
+  gc       Reclaim stale Cargo target/ directories (issue #234)
 ```
 
 ---
@@ -258,6 +298,8 @@ When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must ma
 |   `-- <tool>-<version>/
 |-- cache/
 |-- config.toml
+|-- data.db                # sqlite registry of tracked target/ dirs (issue #234)
+|-- .gc_warning_marker     # last-emitted timestamp for the stale-target startup warning
 `-- daemon.*
 ```
 


### PR DESCRIPTION
## Summary

Closes #234. Implements the minimal v1 of issue #234 (sqlite-backed
registry of observed `target/` directories) plus the three safety
guards from #233's [`docs/TARGET_GC_PROPOSAL.md`](https://github.com/zackees/soldr/blob/main/docs/TARGET_GC_PROPOSAL.md).

### Data plane (issue #234)

- New `crates/soldr-cache/src/target_registry.rs`: opens
  `~/.soldr/data.db` via the new `rusqlite` workspace dep
  (`bundled` feature, no system sqlite), creates the `targets` table
  verbatim from the issue, exposes idempotent
  `INSERT ... ON CONFLICT(path) DO UPDATE SET last_used` upserts.
- Wrapper hot path (`run_rustc_wrapper` in `crates/soldr-cli/src/main.rs`)
  resolves the workspace `target/` dir from `CARGO_TARGET_DIR` or by
  walking up from rustc's `--out-dir`, then upserts. Strictly
  best-effort: every failure mode (no env var, weird argv, sqlite
  open error) silently no-ops so builds never break.
- New `crates/soldr-cache/src/gc.rs`: pure scan / purge / warning
  helpers consumed by both the CLI command and the startup warning.

### `soldr gc` command

```bash
soldr gc                                     # interactive y/N per dir
soldr gc --dry-run                            # list candidates only
soldr gc --all                                # delete every eligible
soldr gc --older-than 30d --larger-than 1GB   # tunable thresholds
soldr gc --json                               # machine-readable report
```

Output shows `path / size (human) / age (human)`. Defaults: 10 days,
256 MiB. Includes a `--json` mode following the existing
`schema_version` / `command` envelope.

### Safety guards (from #233's proposal)

Applied before any `remove_dir_all`:

- (a) `Cargo.lock` mtime in the workspace root within the staleness
  window => skip (active project).
- (b) `target/.cargo-lock` present => skip (cargo holds the build
  lock).
- (c) `dev_root` allowlist: refuse anything not under the configured
  roots. Defaults to `~/dev` (or `%USERPROFILE%\dev`). Override via
  `~/.soldr/config.toml`:

  ```toml
  [gc]
  allowlist_roots = ["~/dev", "/work/repos"]
  ```

Missing-on-disk rows are dropped silently during scans, per the
issue.

### Startup-time warning

Dispatch path (never the wrapper hot path) calls
`emit_startup_target_warning_if_due` which scans the registry,
applies thresholds + guards, and emits one line if any candidates
qualify. Throttled to once per day via
`~/.soldr/.gc_warning_marker` carrying a unix timestamp.

### Built-in command list note

Per CLAUDE.md, the built-in command list is "frozen" in principle.
Issue #234 explicitly proposes this command, and #233's proposal
(merged in PR #240) endorses adding `soldr gc`. CLAUDE.md was left
untouched per the task's "DO NOT touch CLAUDE.md" rule. **Reviewer
ratification of the new built-in is requested here.** I chose `gc`
as the canonical name and added `purge-targets` as an alias for
discoverability vs. issue #234's `--purge` wording. The issue's
exact `soldr --purge` flag form would conflict with the existing
`soldr purge` cache subcommand, so I did not implement that flag
spelling.

### Tests

15 new unit tests across `target_registry` and `gc`:

- upsert idempotency and timestamp-update semantics
- list ordering, get/remove round-trips, on-disk persistence
- size + age filtering produces expected eligible/skipped split
- dry-run does not delete (file system + registry row both intact)
- safety guard short-circuits for active `.cargo-lock` and fresh
  `Cargo.lock` mtime, and for paths outside the allowlist
- duration / size parsing (`10d`, `1GB`, `512KiB`, `4w`)
- startup-warning marker throttle blocks repeats
- `--out-dir` resolution covers space and `=` forms

### Quality bar

- `cargo build -p soldr-cli` — passes
- `cargo test --workspace` — passes (33 + 27 + 36 + 21 + 24 + 1 = 142 tests)
- `cargo clippy --workspace --all-targets -- -D warnings` — passes
  (also picked up one pre-existing `clippy::needless_return` in
  `crates/soldr-cli/tests/cli.rs:60` that the local MSVC clippy
  flagged; trivial 1-line fix included)
- `cargo fmt --all -- --check` — passes

### Deferred (out of v1, per the proposal)

- Selective intra-`target/` pruning (use `cargo-sweep`).
- Move-to-trash. v1 hard-deletes; users opt in via `--all` or
  per-prompt.
- Disk-threshold / scheduled / opportunistic GC triggers.
- Worktree-aware HEAD-date heuristics.
- The proposal's third optional guard (release-binary + dirty repo
  detection) was left out as best-effort heuristic noise; the two
  authoritative guards (`Cargo.lock` mtime + `.cargo-lock`) cover
  the in-progress build case.

## Test plan

- [ ] `cargo build -p soldr-cli`
- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] Smoke: `soldr gc --dry-run --json` prints the empty-registry
      JSON envelope on a fresh `SOLDR_CACHE_DIR`
- [ ] Smoke: `soldr gc --help` shows the new flags
- [ ] Manual: run a `soldr cargo build`, then `soldr gc --dry-run`
      and confirm the workspace `target/` shows up in the registry
- [ ] Manual: confirm CI runs continue to succeed with the new
      sqlite dependency on Linux/macOS/Windows MSVC