### PR TITLE
feat(ci): assert thin-v2 manifest contents in verifier (#237)

### DIFF
--- a/.github/scripts/assert_thin_manifest.py
+++ b/.github/scripts/assert_thin_manifest.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Assert that a thin-v2 ``manifest.v2.json`` is well-formed and on-disk.
+
+This script is the second half of the thin-v2 verifier (issue #237). The
+companion ``assert_thin_noop.py`` only inspects cargo stdout to confirm the
+second build was a no-op. That tells us cargo was happy, but it does not
+prove the Phase 1 contract: that soldr-cli emitted a ``manifest.v2.json``
+next to the bundle that truthfully enumerates the files present and never
+re-lists any of the artifact categories thin-v2 is supposed to drop
+(``.rlib``, ``.rmeta``, incremental DB, build-script binaries, etc.).
+
+If a future regression silently stops emitting the manifest, or starts
+re-listing dropped categories, this script fails the gate.
+
+Schema (mirrors ``ThinSliceManifest`` in
+``crates/soldr-cli/src/main.rs``):
+
+    {
+      "schema_version": 2,
+      "cache_profile": "thin-v2",
+      "bundle_root": "<absolute path>",
+      "generated_at_unix_seconds": 1700000000,
+      "files": [
+        { "path": "rel/forward/slashed.json", "size_bytes": 12 },
+        ...
+      ]
+    }
+
+Exit codes:
+
+- ``0``: manifest is valid and matches the bundle.
+- ``1``: hard validation failure (missing manifest, drift, dropped-category
+  hit, bad schema, etc.). Human-readable reason printed to stderr.
+- ``2``: usage / I/O error before validation could start.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Patterns that must NEVER appear in a thin-v2 manifest. These are the
+# artifact classes the slice is explicitly supposed to drop; cargo
+# repopulates them through zccache on demand. Anything matching here in the
+# manifest means the prune policy regressed.
+#
+# Patterns are evaluated against the manifest's forward-slashed relative
+# path. We use simple regex over the full string rather than fnmatch so the
+# directory boundaries are explicit.
+_DROPPED_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("incremental directory", re.compile(r"(^|/)incremental/")),
+    ("rlib output", re.compile(r"\.rlib$")),
+    ("rmeta output", re.compile(r"\.rmeta$")),
+    ("split debug-info (.dwo)", re.compile(r"\.dwo$")),
+    ("Windows pdb", re.compile(r"\.pdb$")),
+    ("macOS dSYM bundle", re.compile(r"\.dSYM(/|$)")),
+    ("build-script binary (Unix)", re.compile(r"(^|/)build-script-build$")),
+    ("build-script binary (Windows)", re.compile(r"(^|/)build-script-build\.exe$")),
+]
+
+
+def _format_drop_hits(hits: list[tuple[str, str]]) -> str:
+    """Render dropped-pattern hits as a multi-line bulleted string."""
+    lines = []
+    for pattern_label, path in hits:
+        lines.append(f"    - {path}  (matches {pattern_label})")
+    return "\n".join(lines)
+
+
+def _to_local_path(bundle_dir: Path, rel_posix: str) -> Path:
+    """Resolve a forward-slashed manifest path to the OS-native bundle path."""
+    parts = [p for p in rel_posix.split("/") if p not in ("", ".")]
+    return bundle_dir.joinpath(*parts) if parts else bundle_dir
+
+
+def _walk_bundle_files(bundle_dir: Path) -> list[str]:
+    """Return forward-slashed relative paths of all files under ``bundle_dir``.
+
+    The manifest itself (``manifest.v2.json``) is excluded so a strict-mode
+    check does not trivially fail on the file we just read. Mirrors
+    ``walk_bundle_files`` in ``crates/soldr-cli/src/main.rs`` which also
+    drops the manifest from its own listing.
+    """
+    out: list[str] = []
+    for path in bundle_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(bundle_dir).as_posix()
+        if rel == "manifest.v2.json":
+            continue
+        out.append(rel)
+    return out
+
+
+def _validate_schema(manifest: object) -> list[str]:
+    """Return a list of schema errors; empty list means OK."""
+    errors: list[str] = []
+    if not isinstance(manifest, dict):
+        return [f"manifest root must be a JSON object, got {type(manifest).__name__}"]
+
+    required: dict[str, type | tuple[type, ...]] = {
+        "schema_version": int,
+        "cache_profile": str,
+        "bundle_root": str,
+        "generated_at_unix_seconds": int,
+        "files": list,
+    }
+    for key, expected_type in required.items():
+        if key not in manifest:
+            errors.append(f"missing required key: {key!r}")
+            continue
+        if not isinstance(manifest[key], expected_type):
+            errors.append(
+                f"key {key!r} has wrong type: expected "
+                f"{getattr(expected_type, '__name__', expected_type)}, got "
+                f"{type(manifest[key]).__name__}"
+            )
+
+    if "schema_version" in manifest and manifest.get("schema_version") != 2:
+        errors.append(
+            "schema_version must be 2 for thin-v2 manifests; "
+            f"got {manifest.get('schema_version')!r}"
+        )
+
+    files = manifest.get("files")
+    if isinstance(files, list):
+        for idx, entry in enumerate(files):
+            if not isinstance(entry, dict):
+                errors.append(f"files[{idx}] is not an object")
+                continue
+            if "path" not in entry or not isinstance(entry["path"], str):
+                errors.append(f"files[{idx}] missing string 'path'")
+                continue
+            # size_bytes is optional / may be null per the Rust schema.
+            if "size_bytes" in entry and entry["size_bytes"] is not None:
+                if not isinstance(entry["size_bytes"], int):
+                    errors.append(
+                        f"files[{idx}] size_bytes must be int or null, "
+                        f"got {type(entry['size_bytes']).__name__}"
+                    )
+
+    return errors
+
+
+def assert_manifest(
+    manifest_path: Path,
+    bundle_dir: Path,
+    *,
+    strict: bool = False,
+) -> list[str]:
+    """Validate the manifest. Returns a list of errors (empty == OK)."""
+    errors: list[str] = []
+
+    if not manifest_path.is_file():
+        return [f"manifest file does not exist: {manifest_path}"]
+    if not bundle_dir.is_dir():
+        return [f"bundle directory does not exist: {bundle_dir}"]
+
+    try:
+        raw = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"could not read manifest {manifest_path}: {exc}"]
+
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return [f"manifest is not valid JSON: {exc}"]
+
+    schema_errors = _validate_schema(manifest)
+    errors.extend(schema_errors)
+    # If schema is broken at the top level, downstream checks would crash on
+    # the wrong shape. Stop early.
+    if schema_errors:
+        return errors
+
+    files = manifest["files"]
+    manifest_rel_paths: list[str] = [entry["path"] for entry in files]
+
+    # 1. No dropped-category paths in the manifest. This is the strict
+    #    invariant: thin-v2 must NEVER carry these classes.
+    drop_hits: list[tuple[str, str]] = []
+    for rel in manifest_rel_paths:
+        for label, pattern in _DROPPED_PATTERNS:
+            if pattern.search(rel):
+                drop_hits.append((label, rel))
+                break
+    if drop_hits:
+        errors.append(
+            "manifest references files in dropped artifact classes "
+            "(thin-v2 is supposed to prune these):\n" + _format_drop_hits(drop_hits)
+        )
+
+    # 2. Every entry in the manifest must exist on disk under bundle_dir.
+    missing: list[str] = []
+    for rel in manifest_rel_paths:
+        local = _to_local_path(bundle_dir, rel)
+        if not local.is_file():
+            missing.append(rel)
+    if missing:
+        errors.append(
+            f"manifest lists {len(missing)} file(s) that do not exist on disk; "
+            f"first few: {missing[:5]}"
+        )
+
+    # 3. Strict mode: every file under bundle_dir must be in the manifest.
+    if strict:
+        on_disk = set(_walk_bundle_files(bundle_dir))
+        in_manifest = set(manifest_rel_paths)
+        orphans = sorted(on_disk - in_manifest)
+        if orphans:
+            errors.append(
+                f"strict mode: {len(orphans)} file(s) on disk are not listed "
+                f"in the manifest; first few: {orphans[:5]}"
+            )
+
+    return errors
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a thin-v2 manifest.v2.json against its bundle directory. "
+            "Confirms schema, file presence, and that no dropped-category "
+            "artifacts (rlib/rmeta/incremental/dwo/pdb/dSYM/build-script-build) "
+            "are listed."
+        ),
+    )
+    parser.add_argument(
+        "manifest_path",
+        type=Path,
+        help="Path to the thin-v2 manifest.v2.json file.",
+    )
+    parser.add_argument(
+        "bundle_dir",
+        type=Path,
+        help="Path to the bundle directory the manifest enumerates.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Also fail if any file under bundle_dir is missing from the "
+            "manifest (orphan detection). Off by default because some bundle "
+            "writers may legitimately leave scratch state behind."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_argparser().parse_args(argv)
+
+    errors = assert_manifest(
+        args.manifest_path,
+        args.bundle_dir,
+        strict=args.strict,
+    )
+
+    if errors:
+        print("assert_thin_manifest: FAIL", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(
+        f"assert_thin_manifest: OK ({args.manifest_path} matches "
+        f"{args.bundle_dir}, strict={args.strict})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/thin-v2-verify.yml
+++ b/.github/workflows/thin-v2-verify.yml
@@ -20,6 +20,10 @@
 #
 # TODO(#237 Phase 4): flip continue-on-error to false, expand matrix to
 # Windows and macOS, and consider running on the soldr workspace itself.
+# TODO(#237 Phase 4): wire the workflow through `soldr cargo build` with
+# SOLDR_TARGET_CACHE_BUNDLE_DIR set so the manifest assertion below has a
+# real artifact to inspect on every run. The gate is added now (guarded on
+# the env var) so the assertion script and CI surface stay in lockstep.
 
 name: thin-v2-verify
 
@@ -30,12 +34,14 @@ on:
       - "crates/soldr-cli/src/main.rs"
       - "crates/soldr-cache/**"
       - ".github/scripts/assert_thin_noop.py"
+      - ".github/scripts/assert_thin_manifest.py"
       - ".github/workflows/thin-v2-verify.yml"
   pull_request:
     paths:
       - "crates/soldr-cli/src/main.rs"
       - "crates/soldr-cache/**"
       - ".github/scripts/assert_thin_noop.py"
+      - ".github/scripts/assert_thin_manifest.py"
       - ".github/workflows/thin-v2-verify.yml"
 
 permissions:
@@ -85,6 +91,22 @@ jobs:
           python ${{ github.workspace }}/.github/scripts/assert_thin_noop.py \
             ${{ runner.temp }}/verify-noop/first.log \
             ${{ runner.temp }}/verify-noop/second.log
+
+      # Phase 3.5 / issue #237: validate the thin-v2 manifest the soldr-cli
+      # writes alongside the bundle directory. Guarded on
+      # SOLDR_TARGET_CACHE_BUNDLE_DIR being set because today this workflow
+      # runs `cargo build` directly, not `soldr cargo build`, so no manifest
+      # is produced. Once the workflow is upgraded to drive the full save
+      # path (TODO above), this step starts firing automatically and catches:
+      #   - manifest.v2.json never written
+      #   - manifest lists files not on disk (drift)
+      #   - manifest re-lists dropped categories (rlib/rmeta/incremental/...)
+      - name: Assert thin-v2 manifest matches bundle
+        if: env.SOLDR_TARGET_CACHE_BUNDLE_DIR != ''
+        run: |
+          python ${{ github.workspace }}/.github/scripts/assert_thin_manifest.py \
+            "${SOLDR_TARGET_CACHE_BUNDLE_DIR}/manifest.v2.json" \
+            "${SOLDR_TARGET_CACHE_BUNDLE_DIR}"
 
       - name: Upload build logs
         if: always()

--- a/docs/THIN_TARGET_CACHE_PRUNING.md
+++ b/docs/THIN_TARGET_CACHE_PRUNING.md
@@ -361,6 +361,47 @@ The CI gate that runs this script lives at
 quirks; flip it to a hard required check once it has been green for a week
 on `main`.
 
+#### 5.1.b Manifest assertion (`assert_thin_manifest.py`)
+
+The cargo-output verifier above only proves that cargo was happy with the
+restored slice. It does **not** prove that soldr-cli actually wrote
+`manifest.v2.json` next to the bundle, that the manifest enumerates the
+files present, or that it never re-lists artifact classes thin-v2 is
+supposed to drop. A second script,
+`.github/scripts/assert_thin_manifest.py`, closes that gap:
+
+```bash
+python .github/scripts/assert_thin_manifest.py \
+  <bundle_dir>/manifest.v2.json \
+  <bundle_dir> \
+  [--strict]
+```
+
+What it checks:
+
+- `manifest.v2.json` exists, parses as JSON, and matches the
+  `ThinSliceManifest` schema emitted by
+  `crates/soldr-cli/src/main.rs::write_thin_manifest` (`schema_version: 2`,
+  `cache_profile`, `bundle_root`, `generated_at_unix_seconds`, `files[]`).
+- Every entry in `files[]` exists as a regular file under `bundle_dir`
+  (drift detection).
+- `--strict` additionally fails if any file under `bundle_dir` is missing
+  from the manifest (orphan detection). Off by default because some bundle
+  writers may legitimately leave scratch state behind.
+- No path in the manifest matches the dropped-category patterns:
+  `*/incremental/*`, `*.rlib`, `*.rmeta`, `*.dwo`, `*.pdb`, `*.dSYM/*`,
+  `*/build-script-build`, `*/build-script-build.exe`. A regression that
+  starts re-listing any of these classes hard-fails the gate.
+
+Exit codes mirror `assert_thin_noop.py`: `0` ok / `1` validation failure
+(human-readable reason printed to stderr) / `2` usage error.
+
+The CI workflow runs this script in a step guarded on
+`SOLDR_TARGET_CACHE_BUNDLE_DIR` being set, so it no-ops cleanly until the
+workflow is upgraded to actually drive the `soldr cargo build` save path
+that produces a manifest. The assertion script is in place ahead of time
+so the day the workflow is wired up, the gate fires immediately.
+
 ### 5.2 Counter-tests
 
 | Counter-test | What it catches |

--- a/tests/test_assert_thin_manifest.py
+++ b/tests/test_assert_thin_manifest.py
@@ -1,0 +1,308 @@
+"""Tests for the thin-v2 manifest verifier (issue #237).
+
+Covers schema validation, file-presence checks, dropped-category detection,
+strict-mode orphan detection, and the CLI subprocess surface. Fixtures are
+synthesized inline with ``tempfile`` so the suite never needs to invoke
+cargo or soldr.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "assert_thin_manifest.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("assert_thin_manifest", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["assert_thin_manifest"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_file(path: Path, body: bytes = b"x") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(body)
+
+
+def _make_manifest(
+    bundle_dir: Path,
+    files: list[tuple[str, int]],
+    *,
+    cache_profile: str = "thin-v2",
+    schema_version: int = 2,
+) -> Path:
+    """Write a thin-v2-shaped manifest at ``bundle_dir/manifest.v2.json``.
+
+    ``files`` is a list of ``(rel_posix_path, size_bytes)`` pairs. The
+    payload mirrors ``ThinSliceManifest`` in
+    ``crates/soldr-cli/src/main.rs``.
+    """
+    manifest = {
+        "schema_version": schema_version,
+        "cache_profile": cache_profile,
+        "bundle_root": str(bundle_dir),
+        "generated_at_unix_seconds": int(time.time()),
+        "files": [{"path": rel, "size_bytes": size} for rel, size in files],
+    }
+    manifest_path = bundle_dir / "manifest.v2.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def _populate_bundle(bundle_dir: Path, rel_paths: list[str]) -> None:
+    """Create empty placeholder files for each ``rel_path`` under ``bundle_dir``."""
+    for rel in rel_paths:
+        _write_file(bundle_dir / rel)
+
+
+# ---------------------------------------------------------------------------
+# happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_matches_bundle(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    files = [
+        "debug/.fingerprint/serde-abc/invoked.timestamp",
+        "debug/deps/serde-abc.d",
+        "debug/build/ring-xyz/output",
+    ]
+    _populate_bundle(bundle, files)
+    manifest_path = _make_manifest(bundle, [(p, 1) for p in files])
+
+    errors = mod.assert_manifest(manifest_path, bundle)
+    assert errors == [], errors
+
+
+def test_happy_path_strict_mode(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    files = [
+        "debug/.fingerprint/serde-abc/dep-lib-serde",
+        "debug/deps/serde-abc.d",
+    ]
+    _populate_bundle(bundle, files)
+    manifest_path = _make_manifest(bundle, [(p, 1) for p in files])
+
+    errors = mod.assert_manifest(manifest_path, bundle, strict=True)
+    assert errors == [], errors
+
+
+def test_empty_manifest_ok_in_non_strict(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    manifest_path = _make_manifest(bundle, [])
+
+    errors = mod.assert_manifest(manifest_path, bundle)
+    assert errors == [], errors
+
+
+# ---------------------------------------------------------------------------
+# negative path: missing / malformed manifest
+# ---------------------------------------------------------------------------
+
+
+def test_missing_manifest_file(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+
+    errors = mod.assert_manifest(bundle / "manifest.v2.json", bundle)
+    assert errors
+    assert any("does not exist" in e for e in errors)
+
+
+def test_missing_bundle_dir(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    manifest_path = _make_manifest(bundle, [])
+    # Now remove the bundle dir to simulate a stale manifest path.
+    manifest_path.unlink()
+    bundle.rmdir()
+
+    errors = mod.assert_manifest(
+        tmp_path / "no-bundle" / "manifest.v2.json", tmp_path / "no-bundle"
+    )
+    assert errors
+
+
+def test_invalid_json_manifest(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    manifest_path = bundle / "manifest.v2.json"
+    manifest_path.write_text("{not valid json", encoding="utf-8")
+
+    errors = mod.assert_manifest(manifest_path, bundle)
+    assert any("not valid JSON" in e for e in errors)
+
+
+def test_wrong_schema_version(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    manifest_path = _make_manifest(bundle, [], schema_version=1)
+
+    errors = mod.assert_manifest(manifest_path, bundle)
+    assert any("schema_version" in e for e in errors)
+
+
+def test_missing_required_key(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    manifest_path = bundle / "manifest.v2.json"
+    manifest_path.write_text(
+        json.dumps({"schema_version": 2, "files": []}),
+        encoding="utf-8",
+    )
+
+    errors = mod.assert_manifest(manifest_path, bundle)
+    assert any("missing required key" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# negative path: drift (manifest <-> disk)
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_lists_file_not_on_disk(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    manifest_path = _make_manifest(
+        bundle,
+        [("debug/deps/serde-abc.d", 1)],
+    )
+    # Note: no actual file written.
+
+    errors = mod.assert_manifest(manifest_path, bundle)
+    assert any("do not exist on disk" in e for e in errors)
+
+
+def test_strict_mode_catches_orphan(mod, tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    listed = ["debug/deps/serde-abc.d"]
+    _populate_bundle(bundle, listed + ["debug/deps/orphan.d"])
+    manifest_path = _make_manifest(bundle, [(p, 1) for p in listed])
+
+    errors = mod.assert_manifest(manifest_path, bundle, strict=True)
+    assert any("orphan.d" in e for e in errors)
+    # And the same fixture should pass without --strict.
+    errors_loose = mod.assert_manifest(manifest_path, bundle, strict=False)
+    assert errors_loose == [], errors_loose
+
+
+# ---------------------------------------------------------------------------
+# negative path: dropped-category patterns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rel_path,label_substr",
+    [
+        ("debug/incremental/foo.bin", "incremental"),
+        ("debug/deps/libserde-abc.rlib", "rlib"),
+        ("debug/deps/libserde-abc.rmeta", "rmeta"),
+        ("debug/deps/serde-abc.dwo", "dwo"),
+        ("debug/deps/soldr.pdb", "pdb"),
+        ("debug/deps/soldr.dSYM/Contents/Info.plist", "dSYM"),
+        ("debug/build/serde-abc/build-script-build", "Unix"),
+        ("debug/build/serde-abc/build-script-build.exe", "Windows"),
+    ],
+)
+def test_dropped_category_triggers_failure(
+    mod, tmp_path: Path, rel_path: str, label_substr: str
+) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    _populate_bundle(bundle, [rel_path])
+    manifest_path = _make_manifest(bundle, [(rel_path, 1)])
+
+    errors = mod.assert_manifest(manifest_path, bundle)
+    assert errors, f"expected failure for {rel_path}"
+    joined = "\n".join(errors)
+    assert "dropped artifact classes" in joined
+    assert label_substr in joined
+
+
+# ---------------------------------------------------------------------------
+# CLI subprocess surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_exits_zero_on_clean_bundle(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    files = ["debug/deps/serde-abc.d", "debug/.fingerprint/serde-abc/invoked.timestamp"]
+    _populate_bundle(bundle, files)
+    manifest_path = bundle / "manifest.v2.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "cache_profile": "thin-v2",
+                "bundle_root": str(bundle),
+                "generated_at_unix_seconds": 1700000000,
+                "files": [{"path": p, "size_bytes": 1} for p in files],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(manifest_path), str(bundle)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "assert_thin_manifest: OK" in result.stdout
+
+
+def test_cli_exits_one_on_dropped_category(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    rlib = "debug/deps/libserde-abc.rlib"
+    _populate_bundle(bundle, [rlib])
+    manifest_path = bundle / "manifest.v2.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "cache_profile": "thin-v2",
+                "bundle_root": str(bundle),
+                "generated_at_unix_seconds": 1700000000,
+                "files": [{"path": rlib, "size_bytes": 1}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(manifest_path), str(bundle)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "FAIL" in result.stderr
+    assert "rlib" in result.stderr


### PR DESCRIPTION
## Summary

Closes the gap in the just-merged thin-v2 verifier (#246): the cargo-output
check proves cargo was happy, but it does not prove that
`manifest.v2.json` was actually written, that it matches the bundle on
disk, or that it never re-lists artifact classes thin-v2 is supposed to
drop. A future regression that silently stopped emitting the manifest, or
started carrying `.rlib`/`.rmeta`/incremental/etc., would slip past the
existing gate. This PR plugs that hole.

- New `.github/scripts/assert_thin_manifest.py`: validates schema (mirrors
  `ThinSliceManifest` in `crates/soldr-cli/src/main.rs`), checks that every
  manifest entry exists on disk under the bundle dir, optional `--strict`
  flag for orphan detection, and hard-fails on any path matching the
  dropped-category patterns: `*/incremental/*`, `*.rlib`, `*.rmeta`,
  `*.dwo`, `*.pdb`, `*.dSYM/*`, `*/build-script-build`,
  `*/build-script-build.exe`.
- New `tests/test_assert_thin_manifest.py`: 20 tests covering happy path,
  missing manifest, drift, strict-mode orphans, every dropped-category
  pattern, and a CLI subprocess smoke check. All synthesized with
  `tempfile`; no cargo dependency.
- `docs/THIN_TARGET_CACHE_PRUNING.md`: new "Manifest assertion" subsection
  documenting the script and CLI.
- `.github/workflows/thin-v2-verify.yml`: wires the script into the
  workflow.

## Wiring choice: option (b)

The current workflow runs `cargo build` directly, not `soldr cargo build`,
so no `manifest.v2.json` is produced today. Going to full option (a) (drive
the entire soldr cargo save path with `SOLDR_TARGET_CACHE_BUNDLE_DIR` set)
would require adding a zccache install, switching to `soldr cargo build`,
and validating the rust-plan save flow — a workflow restructure that is
better landed as its own follow-up so this PR stays focused.

Picked option (b): the manifest-assertion step is added but guarded on
`if: env.SOLDR_TARGET_CACHE_BUNDLE_DIR != ''`, so it no-ops cleanly today
and fires automatically once the workflow is upgraded. The script + tests
+ doc are merge-worthy on their own as a regression backstop. A `[follow-up]`
TODO is in the workflow header.

The whole job stays `continue-on-error: true` consistent with the existing
verifier — both gates remain informational this round.

Refs #237

## Test plan

- [x] `python -m pytest tests/test_assert_thin_manifest.py -v` — 20/20 pass
  locally
- [x] `actionlint .github/workflows/thin-v2-verify.yml` — clean
- [x] `ruff check`, `black --check`, `mypy` clean on the new script and
  test file
- [ ] CI: thin-v2-verify workflow still runs and remains informational
- [ ] CI: manifest assertion step is properly skipped (guarded condition)
  while `SOLDR_TARGET_CACHE_BUNDLE_DIR` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)