### PR TITLE
ci: seed dogfood zccache on main pushes (#249)

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -12,6 +12,24 @@ on:
       - Cargo.lock
       - .github/actions/setup-soldr/**
       - .github/workflows/setup-soldr-action.yml
+  # Run on main pushes too so the dogfood zccache gets saved at the base
+  # branch scope (refs/heads/main). GitHub Actions caches are scoped per ref:
+  # a PR run can read caches from its base branch but cannot read other PRs'
+  # caches. Without a push:main trigger every PR starts cold because nothing
+  # has ever populated the prefix at the base scope. See issue #249.
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+      - INTEGRATION.md
+      - action.yml
+      - install.sh
+      - rust-toolchain.toml
+      - Cargo.toml
+      - Cargo.lock
+      - .github/actions/setup-soldr/**
+      - .github/workflows/setup-soldr-action.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Closes #249
- Adds `push: branches: [main]` trigger to `.github/workflows/setup-soldr-action.yml` so the dogfood zccache gets saved at the base branch scope (`refs/heads/main`).

## Root cause
GitHub Actions caches are scoped per ref: a PR run can read caches from its base branch but cannot read other PRs' caches. The dogfood workflow only triggered on `pull_request` and `workflow_dispatch`, so no run ever executed at `refs/heads/main` — meaning the prefix `setup-soldr-dogfood-zccache-v1-<os>-<arch>-` had nothing under it at the base scope, and every PR started cold (0% hit rate).

This matches hypothesis #1 in the issue. Hypothesis #2 (prefix bump) is ruled out by git history: the `v1` prefix was added in commit `92c2b6d` and never renamed. Hypothesis #4 (daemon flush) is unlikely because `actions/cache`'s post step runs after the explicit `zccache stop`; the missing-prefix evidence on the broadest restore-key already explains the 0% hit rate without invoking flush issues.

## Fix
Add a `push: branches: [main]` event with the same `paths:` filter so the workflow runs on `main` after each merge that touches workflow-relevant files. That seeds the cache at `refs/heads/main` scope, making it visible to subsequent PRs through the existing broad restore-key fallback.

## Test plan
- [ ] After merge, the dogfood workflow runs on `main` for the merge commit and saves a cache under `setup-soldr-dogfood-zccache-v1-<os>-<arch>-<hash>-<sha>`.
- [ ] A subsequent PR run restores via the broad prefix and reports `Hit rate: > 0.0%` (target: >= 70% on a no-op-source change).
- [ ] If verification on `main` is needed before another PR lands, re-run the workflow on `main` via `workflow_dispatch` (already wired) to confirm the broad restore-key now hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)