### PR TITLE
chore(release): bump version to 0.7.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "clap",
  "serde",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "serde",
  "tempfile",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
Triggers the Autonomous Release workflow to ship 0.7.13.

Bumps the patch version in:
- `Cargo.toml` `[workspace.package]` → `0.7.13`
- `package.json` `"version"` → `0.7.13`
- `Cargo.lock` for the four soldr crates (`soldr-core`, `soldr-fetch`, `soldr-cache`, `soldr-cli`)

## What 0.7.13 will include over v0.7.12

v0.7.12 was tagged 2026-05-10 00:34Z. Since then, main has picked up:

- 1a3388c — `fix(cli): skip rust-plan restore when target/ was warmed by same job (#229)` — opt-in warm-restore short-circuit gated on `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE=1`
- f4eb87f — `feat(ci): assert thin-v2 manifest contents in verifier (#237)`
- c06335f — `feat(ci): add assert_thin_noop verifier for thin-v2 slice (#237)`
- c97d289 — `feat(cli): tighten thin target-cache allowlist, emit manifest.v2 (#237)`
- 90844ef — `feat(cache): track target/ dirs in sqlite registry, add soldr gc command (#234)`
- 9a3cf60 — `ci: seed dogfood zccache on main pushes (#249)` (#250)

## Pre-flight check
Verified 0.7.13 is unpublished everywhere:
- `git ls-remote --tags origin v0.7.13` — empty
- `https://pypi.org/pypi/soldr/0.7.13/json` → 404
- `https://registry.npmjs.org/@zackees/soldr/0.7.13` → 404

## Test plan
- [ ] CI passes on this PR
- [ ] On merge, Autonomous Release prepare job sets `should_release=true` (since the bumped Cargo.toml version is unpublished)
- [ ] Build and publish jobs run; tag `v0.7.13` is created on `main`
- [ ] PyPI `soldr==0.7.13` and npm `@zackees/soldr@0.7.13` are published

🤖 Generated with [Claude Code](https://claude.com/claude-code)