### PR TITLE
fix(release): pin maturin below 1.13.2 to unblock macOS wheels

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -245,7 +245,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          uv tool install "maturin>=1.7,<2"
+          # maturin 1.13.2 emits the bin-binding script under both
+          # `<name>-<version>.data/scripts/<binary>` (correct) and
+          # `<name>.scripts/<binary>` (extra) on macOS wheels, which
+          # trips the single-binary check in the verify step below
+          # (run 25634356438 macOS ARM64/x64). Pin below 1.13.2 until
+          # the upstream fix lands.
+          uv tool install "maturin>=1.7,<1.13.2"
           maturin build \
             --release \
             --locked \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.7,<2"]
+requires = ["maturin>=1.7,<1.13.2"]
 build-backend = "maturin"
 
 [project]
@@ -26,7 +26,7 @@ Repository = "https://github.com/zackees/soldr"
 
 [dependency-groups]
 dev = [
-    "maturin>=1.7,<2",
+    "maturin>=1.7,<1.13.2",
     "pytest>=8.0",
     "pytest-xdist>=3.0",
     "ruff>=0.4",


### PR DESCRIPTION
## Summary
Unblocks the v0.7.13 release. Both macOS jobs in [run 25634356438](https://github.com/zackees/soldr/actions/runs/25634356438) failed with:

    expected one soldr in soldr-0.7.13-py3-none-macosx_*.whl,
    found ['soldr-0.7.13.data/scripts/soldr', 'soldr.scripts/soldr']

## Root cause
maturin 1.13.2 (released today, 2026-05-10) emits the bin-binding script under both the standard `<name>-<version>.data/scripts/<binary>` location **and** an extra `<name>.scripts/<binary>` entry on macOS wheels. The release verifier (`.github/workflows/release-auto.yml:276-284`) expects exactly one script entry and fails with the message above.

Confirmed:
- v0.7.12 (run 25615521990) used maturin **1.13.1** → single script entry → success.
- v0.7.13 macOS jobs used maturin **1.13.2** → duplicate script entries → failure.
- v0.7.13 Linux ARM64/x64 jobs used maturin **1.13.2** but produced a single entry → success. So the bug is macOS-specific.

The constraint `maturin>=1.7,<2` resolved to 1.13.2 on the v0.7.13 attempt because it was just published.

## Fix
Tighten the upper bound to `<1.13.2` in:

- `.github/workflows/release-auto.yml:248-254` — the `uv tool install` line that selects maturin for the release wheel build job
- `pyproject.toml` `[build-system].requires` — sdist build isolation
- `pyproject.toml` `[dependency-groups].dev` — local dev tooling

The verifier stays strict (one script entry, sha256-equal to the release tarball binary). When upstream maturin ships a 1.13.3 or 1.14 with the duplicate-emission fixed, we can revisit.

## Re-running the v0.7.13 release after this merges

v0.7.13 is still unpublished:
- `git ls-remote --tags origin v0.7.13` — empty
- `https://pypi.org/pypi/soldr/0.7.13/json` → 404
- `https://registry.npmjs.org/@zackees/soldr/0.7.13` → 404

`Cargo.toml` is already at 0.7.13 on `main`. Once this PR merges, run:

    gh workflow run "Autonomous Release" --repo zackees/soldr --ref main

The `prepare` job will see the unpublished version and set `should_release=true`; the build/publish jobs will run with the pinned maturin and complete the release.

(The trigger `on: push: paths: [Cargo.toml, package.json]` does **not** match the files in this PR, so a workflow_dispatch is required — that's intentional.)

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, `workflow_dispatch` of `Autonomous Release` on `main` produces success on all six build matrix entries
- [ ] `pip install soldr==0.7.13` succeeds on macOS arm64 and macOS x86_64
- [ ] Tag `v0.7.13` is created on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)