### PR TITLE
fix(release): verify only the wheel-spec scripts path against tarball

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -271,42 +271,48 @@ jobs:
           if len(wheels) != 1:
               raise SystemExit(f"expected exactly one wheel, found {len(wheels)}: {wheels}")
 
+          # Pin the verification to the exact PEP 491 `.data/scripts/`
+          # entry that pip installs to the bin directory. Anchored to
+          # the wheel root so we never accept a nested or look-alike
+          # path. Per PEP 491 the wheel filename's first two
+          # `-`-separated tokens are `<distname>-<version>` and the
+          # data directory is `<distname>-<version>.data/`.
+          wheel_stem = wheels[0].stem  # filename without `.whl`
+          parts = wheel_stem.split("-")
+          if len(parts) < 2:
+              raise SystemExit(f"unexpected wheel filename: {wheels[0].name}")
+          distname_version = f"{parts[0]}-{parts[1]}"
+          script_entry = f"{distname_version}.data/scripts/{binary_name}"
+
+          # Maturin 1.13.2 emits the bin-binding script under both
+          # `<distname>-<version>.data/scripts/<binary>` (the wheel-spec
+          # location pip puts on PATH) and an extra
+          # `<distname>.scripts/<binary>` purelib copy on macOS. Maturin
+          # also post-processes one of those copies (delocate-style
+          # rewrite of external dylib load paths, e.g. `liblzma`), so
+          # the bytes diverge between paths. The user-facing binary is
+          # the `.data/scripts/` one — that is what must match the
+          # standalone release tarball binary. Anything else in the
+          # wheel is purelib bloat that pip never puts on PATH.
           expected = hashlib.sha256(release_binary.read_bytes()).hexdigest()
           with zipfile.ZipFile(wheels[0]) as wheel:
-              candidates = [
-                  name
-                  for name in wheel.namelist()
-                  if Path(name).name == binary_name and not name.endswith("/")
-              ]
-              if not candidates:
+              names = wheel.namelist()
+              if names.count(script_entry) != 1:
+                  matches = [n for n in names if n == script_entry]
                   raise SystemExit(
-                      f"no {binary_name} found in {wheels[0].name}"
+                      f"expected exactly one `{script_entry}` entry in "
+                      f"{wheels[0].name}, found {matches}"
                   )
-              # maturin 1.13.2 emits the bin-binding script under both
-              # `<name>-<version>.data/scripts/<binary>` (the wheel-spec
-              # location pip puts on PATH) and an extra `<name>.scripts/
-              # <binary>` under purelib on macOS wheels. The duplicate
-              # is harmless wheel bloat — pip only installs the
-              # `.data/scripts/` copy to bin — but we still require
-              # every copy to be byte-identical to the release tarball
-              # binary so we never silently ship a stale duplicate.
-              actuals = {
-                  hashlib.sha256(wheel.read(name)).hexdigest()
-                  for name in candidates
-              }
-              if len(actuals) != 1:
-                  raise SystemExit(
-                      f"{binary_name} copies in {wheels[0].name} have "
-                      f"differing sha256 across paths {candidates}: {sorted(actuals)}"
-                  )
-              actual = next(iter(actuals))
+              actual = hashlib.sha256(wheel.read(script_entry)).hexdigest()
 
           if actual != expected:
               print(f"release binary sha256: {expected}", file=sys.stderr)
               print(f"wheel binary sha256:   {actual}", file=sys.stderr)
-              raise SystemExit("wheel does not contain the shared release binary")
+              raise SystemExit(
+                  f"`{script_entry}` does not match the shared release binary"
+              )
 
-          print(f"{wheels[0].name} contains the shared {binary_name} binary")
+          print(f"{wheels[0].name} ships the shared {binary_name} at `{script_entry}`")
 
       - name: Smoke test wheel
         shell: bash


### PR DESCRIPTION
## Summary
Replaces the dedupe-by-sha approach (#253) with one that verifies **only** the user-facing wheel binary at the PEP 491-mandated path, anchored to the wheel filename so we never pick a look-alike or nested entry.

## What the previous fix got wrong

PR #253 assumed maturin 1.13.2's two macOS wheel copies were byte-identical and rejected wheels where they differed. The v0.7.13 retry ([run 25635048460 macOS ARM64](https://github.com/zackees/soldr/actions/runs/25635048460/job/75245347793)) showed they actually diverge:

    soldr-0.7.13.data/scripts/soldr   sha256 5db82f6b...
    soldr.scripts/soldr               sha256 e0b9ad96...

Maturin 1.13.2 post-processes one of the two copies (delocate-style rewrite of external dylib load paths — `liblzma.5.dylib` is called out in the build log) so the bytes diverge. The dedupe approach was wrong about reality.

## What this PR does

Per PEP 491, only `<distname>-<version>.data/scripts/<binary>` is installed to the bin directory at `pip install` time. Anything else in the wheel — including the `<distname>.scripts/<binary>` purelib copy maturin 1.13.2 emits on macOS — lands inside site-packages and is never put on PATH. So the verifier now:

1. **Derives the expected path from the wheel filename.** PEP 491 mandates the wheel filename's first two `-`-separated tokens are `<distname>-<version>`, and that the data directory is `<distname>-<version>.data/`. That's the only legal place pip will look for scripts.
2. **Requires exactly one exact-match entry** at `<distname>-<version>.data/scripts/<binary>` at the wheel root. Anchored, not suffix-matched — so a hypothetical nested `evil/<distname>-<version>.data/scripts/<binary>` would be ignored, not silently accepted.
3. **SHA256-compares that one entry** to the standalone release tarball binary at `dist/package/<binary>`.

The purelib duplicate is allowed to exist and to differ — pip ignores it, so we do too.

## Why this is "picking the right one"

We're not picking the first listed candidate. We're picking the **only path pip itself will install to bin**, derived from the wheel filename per the wheel format spec. If the wheel doesn't ship that exact entry (or ships more than one), the verifier fails loudly.

## Validated locally against

- The actual failing namelist from run 25635048460 (picks `.data/scripts/soldr`, ignores `soldr.scripts/soldr`).
- A single-entry Linux wheel (one match).
- A Windows `.exe` wheel (`<...>.data/scripts/soldr.exe`).
- A wheel with a fake nested `evil/<distname>-<version>.data/scripts/<binary>` (correctly rejected — no root match).
- A wheel missing the `.data/scripts/<binary>` entry (correctly rejected).

## Test plan
- [ ] CI passes on this PR.
- [ ] After merge, `workflow_dispatch` of `Autonomous Release` on `main` produces success on all six build matrix entries (including macOS arm64/x64 with maturin 1.13.2).
- [ ] `pip install soldr==0.7.13` on macOS arm64 puts a working `soldr` on PATH.
- [ ] Tag `v0.7.13` is created on `main`; PyPI + npm pick up 0.7.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)