### PR TITLE
chore(release): bump version to 0.7.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "clap",
  "serde",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "serde",
  "tempfile",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.13"
+version = "0.7.14"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
Cuts 0.7.14, skipping 0.7.13. Three Autonomous Release runs against 0.7.13 failed on macOS at the wheel-verification step (maturin 1.13.2 emits a divergent purelib copy of the binary on macOS — that's now correctly handled by #254). The verifier fixes landed on `main` after the original 0.7.13 version bump; bumping to 0.7.14 makes the published artifacts cleanly include those fixes and avoids leaving a half-broken 0.7.13 in any registry.

Bumps:
- `Cargo.toml` `[workspace.package].version` → `0.7.14`
- `package.json` `"version"` → `0.7.14`
- `Cargo.lock` for the four soldr crates

## What's the tag situation right now

There is no manual tag work to do.

- No `v0.7.13` tag exists on origin.
- No `soldr==0.7.13` on PyPI.
- No `@zackees/soldr@0.7.13` on npm.

So 0.7.13 is cleanly nothing — three failed CI runs, but no published artifacts to clean up. Per `CLAUDE.md` the Autonomous Release workflow creates `vX.Y.Z` itself when it successfully publishes, so we just need a successful run for `0.7.14`.

## Pre-flight check

- `git ls-remote --tags origin v0.7.14` — empty
- `https://pypi.org/pypi/soldr/0.7.14/json` → 404
- `https://registry.npmjs.org/@zackees/soldr/0.7.14` → 404

## What happens on merge

`Cargo.toml` and `package.json` are in the Autonomous Release workflow's `on: push: paths:` filter, so a merge to `main` auto-triggers the release run. The `prepare` job will see 0.7.14 unpublished and set `should_release=true`. Build matrix runs with the unpinned maturin (>=1.7,<2) + the wheel-spec scripts-path verifier from #254. On success, the workflow creates `v0.7.14` on `main` and publishes to PyPI + npm.

## Test plan
- [ ] CI passes on this PR
- [ ] On merge, Autonomous Release triggers automatically (no manual workflow_dispatch needed)
- [ ] All six build matrix jobs succeed — including the previously-failing macOS arm64 / macOS x64
- [ ] Tag `v0.7.14` is created on `main`
- [ ] PyPI `soldr==0.7.14` and npm `@zackees/soldr@0.7.14` are published

🤖 Generated with [Claude Code](https://claude.com/claude-code)