### PR TITLE
fix(release): drop wheel/tarball SHA equality, keep structural checks

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -254,18 +254,14 @@ jobs:
             --target-dir target \
             --out dist
 
-      - name: Verify wheel binary matches release binary
+      - name: Verify wheel ships the bin script at the spec path
         shell: python
         run: |
-          import hashlib
           import sys
           import zipfile
           from pathlib import Path
 
           binary_name = "${{ matrix.binary }}"
-          release_binary = Path("dist") / "package" / binary_name
-          if not release_binary.exists():
-              raise SystemExit(f"packaged release binary not found: {release_binary}")
 
           wheels = sorted(Path("dist").glob("*.whl"))
           if len(wheels) != 1:
@@ -284,17 +280,19 @@ jobs:
           distname_version = f"{parts[0]}-{parts[1]}"
           script_entry = f"{distname_version}.data/scripts/{binary_name}"
 
-          # Maturin 1.13.2 emits the bin-binding script under both
-          # `<distname>-<version>.data/scripts/<binary>` (the wheel-spec
-          # location pip puts on PATH) and an extra
-          # `<distname>.scripts/<binary>` purelib copy on macOS. Maturin
-          # also post-processes one of those copies (delocate-style
-          # rewrite of external dylib load paths, e.g. `liblzma`), so
-          # the bytes diverge between paths. The user-facing binary is
-          # the `.data/scripts/` one — that is what must match the
-          # standalone release tarball binary. Anything else in the
-          # wheel is purelib bloat that pip never puts on PATH.
-          expected = hashlib.sha256(release_binary.read_bytes()).hexdigest()
+          # We do NOT SHA-compare the wheel binary to the standalone
+          # release tarball binary at `dist/package/<binary>`. From
+          # maturin 1.13.2 onward, maturin builds its own binary at
+          # `target/maturin/<binary>` and post-processes it on macOS
+          # (delocate-style rewrite of external dylib load paths,
+          # e.g. `liblzma.5.dylib`). The wheel binary is therefore
+          # intentionally byte-different from cargo's release binary
+          # even though they're functionally equivalent. The
+          # `Smoke test wheel` step that follows installs the wheel
+          # and runs `<binary> --version` — that's the real functional
+          # check. This step's job is to confirm the wheel is
+          # structurally well-formed: exactly one entry at the
+          # PEP 491 scripts path, no nested look-alikes.
           with zipfile.ZipFile(wheels[0]) as wheel:
               names = wheel.namelist()
               if names.count(script_entry) != 1:
@@ -303,16 +301,16 @@ jobs:
                       f"expected exactly one `{script_entry}` entry in "
                       f"{wheels[0].name}, found {matches}"
                   )
-              actual = hashlib.sha256(wheel.read(script_entry)).hexdigest()
+              info = wheel.getinfo(script_entry)
+              if info.file_size == 0:
+                  raise SystemExit(
+                      f"`{script_entry}` in {wheels[0].name} is empty"
+                  )
 
-          if actual != expected:
-              print(f"release binary sha256: {expected}", file=sys.stderr)
-              print(f"wheel binary sha256:   {actual}", file=sys.stderr)
-              raise SystemExit(
-                  f"`{script_entry}` does not match the shared release binary"
-              )
-
-          print(f"{wheels[0].name} ships the shared {binary_name} at `{script_entry}`")
+          print(
+              f"{wheels[0].name} ships {binary_name} at `{script_entry}` "
+              f"({info.file_size} bytes)"
+          )
 
       - name: Smoke test wheel
         shell: bash


### PR DESCRIPTION
## Summary
The 0.7.14 release ([run 25635532226 macOS ARM64](https://github.com/zackees/soldr/actions/runs/25635532226/job/75246618124)) failed with:

    release binary sha256: 871120af495285808151cea7e3884fbb22246ca58db6d3c5c4ea23a012182506
    wheel binary sha256:   e0b9ad964ee1a9b26b274ab19dca2e496659dc46b8328b6504edd08c025cbf6b
    `soldr-0.7.14.data/scripts/soldr` does not match the shared release binary

The picker from #254 worked correctly — it found exactly one entry at the PEP 491 wheel-spec scripts path. The SHA-against-the-standalone-tarball assertion is what failed, and that assertion is no longer valid.

## What changed in maturin 1.13.2

The wheel binary's SHA `e0b9ad96…` is the same SHA we observed in the previous run (#253 era) under `soldr.scripts/soldr`. That tells us maturin 1.13.2:

1. Builds its own binary at `target/maturin/<binary>` rather than reusing cargo's `target/<target>/release/<binary>` output.
2. Post-processes that binary on macOS — the build log warning gives the smoking gun:
   ```
   🔗 External shared libraries to be copied into the wheel:
     /Users/runner/work/soldr/soldr/target/maturin/soldr requires:
       /usr/lib/liblzma.5.dylib => /opt/homebrew/Cellar/xz/5.8.3/lib/liblzma.5.dylib
   ```
   Maturin rewrites those load paths so the installed binary works against system / @rpath dylibs instead of the build-host's homebrew Cellar.

Result: the wheel binary is intentionally byte-different from the cargo binary on macOS, even though they're functionally identical. The "they should SHA-match" invariant we relied on for v0.7.12 (with maturin 1.13.1) was a happy accident of older maturin reusing cargo's output verbatim.

## What this PR does

Drops the SHA-equality check. Keeps the structural guarantees that still matter and adds one more:
- Exactly one wheel artifact in `dist/`.
- Exactly one entry at the wheel-spec scripts path `<distname>-<version>.data/scripts/<binary>` at the wheel root (anchored from the wheel filename per PEP 491; nested look-alikes are rejected — same picker as #254).
- That entry is non-empty.

The functional "does the wheel binary actually run" check is already provided by the existing `Smoke test wheel` step (`pip install dist/*.whl` + `soldr --version`), which is unchanged. The standalone tarball is independently produced earlier in the same job by `soldr cargo build` followed by the `Package tarball` / `Package zip` step.

## Why we don't need a SHA check anymore

The wheel and the tarball both come from the same workflow run on the same runner against the same locked Cargo.lock. Cargo and maturin both use `--locked`. There's no failure mode this SHA-equality check protected against that the rest of the pipeline doesn't already cover:
- Wrong commit / dirty source: blocked by `--locked` + the `Setup Soldr cache and toolchain` step running on the prepare job's verified `commit_sha`.
- Wrong target / arch: would be caught by the smoke test on each matrix runner.
- Empty wheel: now explicitly checked here.
- Missing PEP 491 path: now explicitly checked here (anchored, exact match).

## Test plan
- [ ] CI passes on this PR.
- [ ] After merge, Autonomous Release re-fires for 0.7.14 (still unpublished — `git ls-remote --tags origin v0.7.14` empty, PyPI/npm 404). Wait — Cargo.toml/package.json don't change in this PR, so a manual `gh workflow run "Autonomous Release" --repo zackees/soldr --ref main` is needed to re-trigger.
- [ ] All six build matrix jobs succeed including the previously-failing macOS arm64 / macOS x64.
- [ ] Tag `v0.7.14` is created on `main`.
- [ ] PyPI `soldr==0.7.14` and npm `@zackees/soldr@0.7.14` are published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)