### PR TITLE
ci: enable warm-restore short-circuit to validate #229 fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
     needs: lint
     env:
       GH_TOKEN: ${{ github.token }}
+      SOLDR_RUST_PLAN_SKIP_WARM_RESTORE: "1"
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -71,6 +72,7 @@ jobs:
     needs: lint
     env:
       GH_TOKEN: ${{ github.token }}
+      SOLDR_RUST_PLAN_SKIP_WARM_RESTORE: "1"
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -96,6 +98,7 @@ jobs:
     needs: lint
     env:
       GH_TOKEN: ${{ github.token }}
+      SOLDR_RUST_PLAN_SKIP_WARM_RESTORE: "1"
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary

The fix from PR #247 (commit 1a3388c) shipped in soldr v0.7.14 (released 2026-05-10), but is gated behind `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE=1` so the rollout could be staged. This PR flips the flag on for the three build jobs in CI (`build-linux-x64`, `build-macos-x64`, `build-windows-x64`) — exactly the repro pattern from #229 where a `soldr cargo build` step is followed by separate `soldr cargo test` steps.

The change is one line per job: add `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE: "1"` to the existing job-level `env:` block alongside the pre-existing `GH_TOKEN`. No other files change.

With the flag set, when `target/` was warmed by the prior `soldr cargo build` step in the same job, the rust-plan restore is skipped and the subsequent `soldr cargo test` steps short-circuit rather than recompiling for minutes.

Refs #229 (intentionally not `Closes` — issue stays open until a green CI run with the flag confirms the timing characteristic).

## Test plan

- [ ] CI run on this PR completes successfully on all three platforms
- [ ] On Linux, macOS, and Windows: `Run library tests` (second `soldr cargo test` step after `Build workspace`) completes in <5s
- [ ] On Linux, macOS, and Windows: `Run CLI smoke tests` and `Run fetch integration test` steps similarly short-circuit on the compile phase
- [ ] Compare durations against a recent pre-flag run on `main` to confirm minutes-of-recompilation are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)