### PR TITLE
ci: bump setup-soldr to v0.4.3 and flip target-cache=true in dogfood smoke

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -54,9 +54,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: setup
-        # This is zackees/setup-soldr@v0.2.0 / @v0 pinned to a full SHA
+        # This is zackees/setup-soldr@v0.4.3 / @v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2
+        uses: zackees/setup-soldr@6c48a0946390a3520a853e30fe417db7465b9119
         with:
           cache: true
           # Keep the action runtime cache separate from the Soldr build under
@@ -65,7 +65,7 @@ jobs:
           cache-dir: ${{ runner.temp }}/setup-soldr-action-state
           cache-key-suffix: dogfood-action-state
           build-cache: false
-          target-cache: false
+          target-cache: true
 
       - name: Show action outputs
         shell: pwsh


### PR DESCRIPTION
## Summary

Dogfood smoke (`.github/workflows/setup-soldr-action.yml`) has been reporting **0.0% zccache hit rate** on warm builds (#168, #170) despite PR #250 fixing the actions/cache scoping. Root cause per #170: the v0.2.0 `setup-soldr` pin doesn't restore the target-cache bundle or refresh mtimes, so Cargo's `-C extra-filename` hashes and rustc extern paths drift from what zccache recorded -> every lookup misses.

This PR:

- Bumps `zackees/setup-soldr` from `13b2e37` (v0.2.0) to `6c48a09` (v0.4.3). v0.4.x ships target-cache restore + post-restore mtime refresh.
- Flips `target-cache: false` -> `target-cache: true` so the smoke run exercises the fast path.
- Leaves `build-cache: false` untouched on purpose: this workflow tests the build-cache layer through its own `actions/cache` step (#250 territory).

### Diff

```
.github/workflows/setup-soldr-action.yml | 6 +++---
```

### v0.4.3 input compatibility

All five inputs already in use (`cache`, `cache-dir`, `cache-key-suffix`, `build-cache`, `target-cache`) are still supported. No new required inputs. New optional inputs (`build-cache-mode`, `target-cache-mode`, `lockfile`, `target-dir`, `timestamps`) all have safe defaults.

### Caveat

In v0.4.3 the action's target-cache step is gated on `build-cache == 'true'`, so `target-cache: true` here is wired up but stays a no-op for the action's own bundle until `build-cache` is also enabled. The dogfood workflow's separate `actions/cache` step still restores the zccache directory regardless, which is what the smoke run measures.

## Test plan

- [ ] After merge, the next push:main run of `Setup Soldr Action` reports `Hit rate: > 0.0%` from `zccache --show-stats` (the dogfood "Show dogfood cache status" step).
- [ ] Issues #168 and #170 stay open until a human verifies the green run.

Refs #168, #170

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>