### PR TITLE
ci: bump setup-soldr from v0.2.0 to v0.4.3 (SHA-pinned)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2 # v0.2.0 / v0
+      - uses: zackees/setup-soldr@6c48a0946390a3520a853e30fe417db7465b9119 # v0.4.3 / v0
         with:
           # Formatting does not benefit from a restored target directory, but
           # clippy still uses soldr's compilation cache below.
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2 # v0.2.0 / v0
+      - uses: zackees/setup-soldr@6c48a0946390a3520a853e30fe417db7465b9119 # v0.4.3 / v0
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2 # v0.2.0 / v0
+      - uses: zackees/setup-soldr@6c48a0946390a3520a853e30fe417db7465b9119 # v0.4.3 / v0
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: zackees/setup-soldr@13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2 # v0.2.0 / v0
+      - uses: zackees/setup-soldr@6c48a0946390a3520a853e30fe417db7465b9119 # v0.4.3 / v0
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked

--- a/tests/test_setup_soldr_pins.py
+++ b/tests/test_setup_soldr_pins.py
@@ -6,15 +6,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OLD_SETUP_SOLDR_SHA = "1937c19529f3690df5553a36dd33f39ccb20b070"
 SETUP_SOLDR_V0_2_SHA = "13b2e37f3ee8dc6867f08d3b2fe49ece4783dba2"
+SETUP_SOLDR_V0_4_3_SHA = "6c48a0946390a3520a853e30fe417db7465b9119"
 
 
-def test_workflows_pin_setup_soldr_v0_2() -> None:
+def test_workflows_pin_setup_soldr_v0_4_3() -> None:
     workflow_paths = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
     workflow_text = "\n".join(
         path.read_text(encoding="utf-8") for path in workflow_paths
     )
 
     assert OLD_SETUP_SOLDR_SHA not in workflow_text
-    assert workflow_text.count(f"zackees/setup-soldr@{SETUP_SOLDR_V0_2_SHA}") == 5
+    assert SETUP_SOLDR_V0_2_SHA not in workflow_text
+    assert workflow_text.count(f"zackees/setup-soldr@{SETUP_SOLDR_V0_4_3_SHA}") == 5
     assert "v0.1.0 / v0" not in workflow_text
-    assert "v0.2.0 / v0" in workflow_text
+    assert "v0.2.0 / v0" not in workflow_text
+    assert "v0.4.3 / v0" in workflow_text


### PR DESCRIPTION
## Summary

- Bumps the four `zackees/setup-soldr` references in `.github/workflows/ci.yml` from the v0.2.0 SHA (`13b2e37f...`) to the v0.4.3 SHA (`6c48a094...`). The dogfood workflow already runs v0.4.3 (PR #258, merged earlier today); this brings main CI in line.
- Updates `tests/test_setup_soldr_pins.py` to assert on the v0.4.3 SHA across all five workflow occurrences and to confirm no stale v0.2.0 strings remain.
- Pins remain full-length SHAs. An earlier revision tried tag form (`@v0.4.3`) but the repo's branch ruleset rejected it: `The action zackees/setup-soldr@v0.4.3 is not allowed in zackees/soldr because all actions must be pinned to a full-length commit SHA.`

## Why v0.4.3

It's the latest setup-soldr release (2026-04-24). Includes the `target-cache: true` fast path that #168/#170 validation depends on.

## Test plan

- [x] `pytest tests/test_setup_soldr_pins.py` passes locally.
- [ ] CI lint job runs successfully against the v0.4.3 SHA.
- [ ] CI Linux/macOS/Windows build jobs run with `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE=1` and complete without recompile regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)