### PR TITLE
docs(api): document SOLDR_RUST_PLAN_SKIP_WARM_RESTORE env var (#229)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -281,6 +281,7 @@ Commands:
 | `SCCACHE_DIR` | sccache cache-root override soldr injects when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has not set it themselves | `~/.soldr/cache/sccache` |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
+| `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE` | Opt-in: skip `rust-plan restore` when `target/` is already warm from a prior step in the same GitHub Actions job + attempt (issue #229) | unset (off) |
 
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.
@@ -288,6 +289,8 @@ When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr 
 When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must match the cache root derived from `SOLDR_CACHE_DIR`; conflicting values are rejected. Custom wrapper modes leave caller-provided wrapper environment alone — when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has set `SCCACHE_DIR` themselves, soldr forwards their value rather than overriding it.
 
 `soldr cargo ...` only starts the managed build cache for compile-like Cargo subcommands such as `build`, `check`, `test`, `run`, `doc`, `clippy`, and `nextest`. Non-build Cargo commands such as `cargo metadata` and `cargo --version` pass through without starting zccache.
+
+`SOLDR_RUST_PLAN_SKIP_WARM_RESTORE` is an opt-in short-circuit for the `rust-plan restore` step. After a successful `rust-plan save`, soldr writes a sentinel next to the thin-slice bundle recording the plan inputs hash, target dir, `GITHUB_RUN_ID`, `GITHUB_JOB`, `GITHUB_RUN_ATTEMPT`, zccache session id, and a unix timestamp. On the next invocation, if the sentinel exists and every match field equals the current value — and the sentinel is no older than 5 minutes — soldr skips `rust-plan restore` and leaves the already-warm `target/` tree untouched. This avoids invalidating Cargo's mtime-based fingerprints when split CI steps share a checkout but spawn fresh shells per step (issue #229). Accepted truthy values are `1`, `true`, `yes`, `on` (case-insensitive); anything else, including unset, leaves the feature off. The gate is conservative: a missing, stale, or partially-mismatched sentinel falls through to the normal restore, so the short-circuit can never make a build less correct than the default path. Status: opt-in while CI validation is in flight; the flag will be promoted to default-on only after the verification runs land cleanly.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a spec entry for `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE` to `docs/API.md`. The env var has shipped (#257) and is enabled across CI but was not user-documented.
- Covers match criteria, accepted truthy values, intended use case (#229 split-step scenario), and opt-in status.

## Test plan
- [x] `docs/API.md` renders correctly (markdown sanity check)
- [x] No code changes

Refs #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)