### PR TITLE
chore(release): bump version to 0.7.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "clap",
  "serde",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "serde",
  "tempfile",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.14"
+version = "0.7.15"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
Bump `[workspace.package].version` and `package.json` `"version"` to `0.7.15`. Merging this auto-triggers `Autonomous Release` (Cargo.toml + package.json are in the `release-auto.yml` path filter).

Verified 0.7.15 is unpublished:
- `git tag v0.7.15` absent on origin
- `pypi.org/pypi/soldr/0.7.15` → 404
- `registry.npmjs.org/@zackees/soldr/0.7.15` → 404

This release bundles the soldr-side completion of #229:
- #260 unit test coverage for warm-restore sentinel filesystem helpers
- #261 docs for `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE`
- #262 struct refactor of `evaluate_warm_restore_skip` (also closes a pre-existing `clippy::too_many_arguments`)
- #263 default-on warm-restore-skip; falsy env var opts out (closed #229)

## Test plan
- [x] `Cargo.toml`, `package.json`, and the four workspace entries in `Cargo.lock` consistently moved 0.7.14 → 0.7.15.
- [x] No other files touched.
- [ ] `Autonomous Release` workflow turns green and publishes the wheel + npm tarball + GitHub release for `v0.7.15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)