### PR TITLE
test(cli): end-to-end integration test for zccache unknown-session retry (#266)

### DIFF
--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -23,6 +23,23 @@ tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 
+[features]
+# Internal feature flag that enables test-only fixture binaries (e.g.
+# `fake-zccache-265-stub`). Off by default so neither the maturin wheel,
+# the GitHub release tarball, nor `cargo install` pick up the stubs.
+# Integration tests that need the stub build it explicitly with
+# `cargo build --bin <stub> --features test-stubs` at test setup time.
+test-stubs = []
+
 [[bin]]
 name = "soldr"
 path = "src/main.rs"
+
+[[bin]]
+# Test fixture for crates/soldr-cli/tests/cli_unknown_session_retry.rs
+# (covers the deferred integration test from #265 / closes #266).
+# Gated behind the `test-stubs` feature so the stub is not built or
+# shipped in normal cargo / maturin builds.
+name = "fake-zccache-265-stub"
+path = "tests/bins/fake_zccache_stub.rs"
+required-features = ["test-stubs"]

--- a/crates/soldr-cli/tests/bins/fake_zccache_stub.rs
+++ b/crates/soldr-cli/tests/bins/fake_zccache_stub.rs
@@ -1,0 +1,155 @@
+//! Fake zccache binary used by `tests/cli_unknown_session_retry.rs` for #266.
+//!
+//! Models three stub modes:
+//!
+//! * `session-start` invocation: emit a JSON object on stdout that
+//!   `soldr_cache::parse_zccache_session_id` accepts, and exit 0. Also
+//!   records the invocation in the state file under `session_starts`.
+//! * Wrapper-style invocation (first positional arg is not a known
+//!   zccache subcommand): consult the state file to decide whether to
+//!   emit `zccache error: unknown session: <id>\n` to stderr and exit
+//!   1, or exit 0 silently. Always records the invocation in the state
+//!   file under `wrapper_calls`.
+//!
+//! The state file is JSON, written atomically via overwrite. Path is
+//! provided by the test via `FAKE_ZCCACHE_STATE_FILE`. The mode is
+//! provided via `FAKE_ZCCACHE_MODE`:
+//!
+//! * `fail_first` (default): only the first wrapper call emits
+//!   unknown-session; later calls succeed.
+//! * `always_fail`: every wrapper call emits unknown-session.
+//! * `non_session_failure`: every wrapper call emits an unrelated
+//!   stderr message and exits 1.
+//!
+//! No external dependencies — `std` only.
+
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const STATE_ENV_VAR: &str = "FAKE_ZCCACHE_STATE_FILE";
+const MODE_ENV_VAR: &str = "FAKE_ZCCACHE_MODE";
+const SESSION_ID_ENV_VAR: &str = "ZCCACHE_SESSION_ID";
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    // session-start: a recognised zccache subcommand. The retry path
+    // calls `zccache session-start --stats --log <path> --journal <path>`
+    // in the cache dir. Mirror that JSON shape.
+    if args.iter().any(|a| a == "session-start") {
+        return handle_session_start();
+    }
+
+    // Any other invocation with an arg is treated as wrapper-style.
+    if args.is_empty() {
+        eprintln!("fake-zccache: no args");
+        return ExitCode::from(2);
+    }
+
+    handle_wrapper_call()
+}
+
+fn handle_session_start() -> ExitCode {
+    record_event("session_starts");
+
+    let counter = read_counter("session_starts");
+    let session_id = format!("retry-uuid-{counter}");
+    println!(
+        "{{\"session_id\":\"{session_id}\",\"started_at\":{}}}",
+        now_secs()
+    );
+    ExitCode::SUCCESS
+}
+
+fn handle_wrapper_call() -> ExitCode {
+    let prior_wrapper_calls = read_counter("wrapper_calls");
+    record_event("wrapper_calls");
+
+    let mode = env::var(MODE_ENV_VAR).unwrap_or_else(|_| "fail_first".to_string());
+    match mode.as_str() {
+        "always_fail" => emit_unknown_session(),
+        "non_session_failure" => {
+            eprintln!("fake-zccache: compile error: simulated unrelated failure");
+            ExitCode::from(1)
+        }
+        // Default: only the first call fails.
+        _ => {
+            if prior_wrapper_calls == 0 {
+                emit_unknown_session()
+            } else {
+                ExitCode::SUCCESS
+            }
+        }
+    }
+}
+
+fn emit_unknown_session() -> ExitCode {
+    let session_id = env::var(SESSION_ID_ENV_VAR).unwrap_or_else(|_| "<no-session>".to_string());
+    eprintln!("zccache error: unknown session: {session_id}");
+    ExitCode::from(1)
+}
+
+fn state_path() -> Option<PathBuf> {
+    env::var_os(STATE_ENV_VAR).map(PathBuf::from)
+}
+
+/// Record an event by name, e.g. `session_starts` or `wrapper_calls`.
+/// Stored as a tiny JSON-ish file with `key=<count>` lines. Atomic
+/// enough for single-threaded test usage: read, increment, overwrite.
+fn record_event(key: &str) {
+    let Some(path) = state_path() else { return };
+    let mut counts = load_counts(&path);
+    let entry = counts.iter_mut().find(|(k, _)| k == key);
+    match entry {
+        Some((_, n)) => *n += 1,
+        None => counts.push((key.to_string(), 1)),
+    }
+    let _ = write_counts(&path, &counts);
+}
+
+fn read_counter(key: &str) -> u64 {
+    let Some(path) = state_path() else { return 0 };
+    load_counts(&path)
+        .into_iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v)
+        .unwrap_or(0)
+}
+
+fn load_counts(path: &Path) -> Vec<(String, u64)> {
+    let Ok(body) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    body.lines()
+        .filter_map(|line| {
+            let (k, v) = line.split_once('=')?;
+            let v: u64 = v.trim().parse().ok()?;
+            Some((k.trim().to_string(), v))
+        })
+        .collect()
+}
+
+fn write_counts(path: &Path, counts: &[(String, u64)]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut body = String::new();
+    for (k, v) in counts {
+        body.push_str(&format!("{k}={v}\n"));
+    }
+    let mut file = fs::File::create(path)?;
+    file.write_all(body.as_bytes())?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/crates/soldr-cli/tests/cli_unknown_session_retry.rs
+++ b/crates/soldr-cli/tests/cli_unknown_session_retry.rs
@@ -1,0 +1,221 @@
+//! End-to-end integration tests for the zccache `unknown session:`
+//! retry path on Windows (issue zackees/soldr#266; depends on #265).
+//!
+//! When `run_wrapper_through_zccache` on Windows sees the managed
+//! zccache wrapper exit with `zccache error: unknown session: <id>`
+//! on stderr, soldr should:
+//!   1. Allocate a fresh session via `zccache session-start ...`.
+//!   2. Re-run the wrapper invocation exactly once, with the new
+//!      `ZCCACHE_SESSION_ID` in the retry's env.
+//!   3. Stop after one retry — a second `unknown session:` propagates
+//!      the failure to cargo.
+//!
+//! These tests drive the real `soldr` binary as a rustc wrapper, with
+//! a tiny stub binary (`fake-zccache-265-stub`) standing in for
+//! managed zccache. The stub is gated behind the `test-stubs` cargo
+//! feature, so its build is the test's responsibility.
+//!
+//! The tests are `#[cfg(not(unix))]` because the retry only exists on
+//! the Windows path of `run_wrapper_through_zccache`; on Unix the
+//! wrapper `exec()`s into zccache and cannot retry.
+
+#![cfg(not(unix))]
+
+// The retry implementation lives on the parent PR (#265); without
+// that landed on the same base branch, the test would deadlock waiting
+// for soldr to retry. Unignore in the follow-up PR once #265 merges
+// to main; a one-line PR removing this `#[ignore]` is the entire
+// follow-up.
+//
+// To run locally before #265 lands, point cargo at the parent branch
+// and pass `--ignored`.
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Build the `fake-zccache-265-stub` binary on demand and return its
+/// path. The bin is gated behind `--features test-stubs`, so it is
+/// not automatically built by `cargo test`. We invoke cargo via
+/// `env!("CARGO")` so we use the toolchain the test runner picked.
+fn ensure_fake_zccache_stub() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+    let output = Command::new(&cargo)
+        .args(["build", "--quiet", "--manifest-path"])
+        .arg(format!("{manifest_dir}/Cargo.toml"))
+        .args(["--bin", "fake-zccache-265-stub", "--features", "test-stubs"])
+        .output()
+        .expect("failed to invoke cargo build for fake-zccache-265-stub");
+    assert!(
+        output.status.success(),
+        "cargo build for stub failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let soldr_bin = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let bin_dir = soldr_bin
+        .parent()
+        .expect("CARGO_BIN_EXE_soldr should have a parent dir");
+    let stub_name = if cfg!(windows) {
+        "fake-zccache-265-stub.exe"
+    } else {
+        "fake-zccache-265-stub"
+    };
+    let stub_path = bin_dir.join(stub_name);
+    assert!(
+        stub_path.exists(),
+        "expected stub at {} after cargo build",
+        stub_path.display()
+    );
+    stub_path
+}
+
+fn unique_temp_dir(label: &str) -> TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("soldr-266-{label}-"))
+        .tempdir()
+        .expect("failed to create temp dir")
+}
+
+fn read_counter(state_file: &Path, key: &str) -> u64 {
+    let Ok(body) = fs::read_to_string(state_file) else {
+        return 0;
+    };
+    for line in body.lines() {
+        if let Some((k, v)) = line.split_once('=') {
+            if k.trim() == key {
+                return v.trim().parse::<u64>().unwrap_or(0);
+            }
+        }
+    }
+    0
+}
+
+/// Common test scaffold: builds the stub, points soldr at it via
+/// `SOLDR_TEST_ZCCACHE_BIN`, sets the cache dir, enables cache, and
+/// runs `soldr rustc -vV`. `rustc` is a recognised wrapper-stem so
+/// `is_wrapper_invocation` returns true and `run_rustc_wrapper` runs.
+///
+/// Returns the exit code, the state file path so callers can inspect
+/// it, and stderr (for debug failure messages). Owns the `TempDir`
+/// so its directory is cleaned up when the run is dropped.
+struct RetryRun {
+    exit_code: i32,
+    state_file: PathBuf,
+    stderr: String,
+    stdout: String,
+    // Held to keep the temp dir alive for the duration of the test;
+    // dropped at end-of-test to delete everything we created.
+    _cache_root: TempDir,
+}
+
+fn run_soldr_wrapper(label: &str, mode: Option<&str>) -> RetryRun {
+    let stub = ensure_fake_zccache_stub();
+    let cache_root = unique_temp_dir(label);
+    let cache_root_path = cache_root.path().to_path_buf();
+    let zccache_cache_dir = cache_root_path.join("zccache");
+    fs::create_dir_all(zccache_cache_dir.join("logs")).expect("failed to seed zccache logs subdir");
+    let state_file = cache_root_path.join("stub-state.txt");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_soldr"));
+    cmd.arg("rustc").arg("-vV");
+    cmd.env("SOLDR_CACHE_ENABLED", "1");
+    cmd.env("SOLDR_CACHE_DIR", &cache_root_path);
+    cmd.env("SOLDR_TEST_ZCCACHE_BIN", &stub);
+    cmd.env("ZCCACHE_CACHE_DIR", &zccache_cache_dir);
+    cmd.env("SOLDR_MANAGED_ZCCACHE_CACHE_DIR", &zccache_cache_dir);
+    cmd.env("ZCCACHE_SESSION_ID", "initial-session-from-test");
+    cmd.env("FAKE_ZCCACHE_STATE_FILE", &state_file);
+    if let Some(m) = mode {
+        cmd.env("FAKE_ZCCACHE_MODE", m);
+    }
+    // Block accidental trampoline / version lookup, and don't leak the
+    // host PATH (which could contain a real zccache).
+    cmd.env_remove("SOLDR_AS");
+    cmd.env_remove("RUSTC_WRAPPER");
+    cmd.env_remove("SOLDR_RUSTC_WRAPPER");
+
+    let output = cmd
+        .output()
+        .expect("failed to spawn soldr binary for wrapper test");
+
+    RetryRun {
+        exit_code: output.status.code().unwrap_or(-1),
+        state_file,
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        _cache_root: cache_root,
+    }
+}
+
+#[test]
+#[ignore = "depends on #265 retry implementation in run_wrapper_through_zccache; unignore once #265 merges"]
+fn unknown_session_triggers_one_retry() {
+    let run = run_soldr_wrapper("trigger-retry", None);
+
+    assert_eq!(
+        run.exit_code, 0,
+        "expected soldr to succeed after one retry\nstdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+
+    let wrapper_calls = read_counter(&run.state_file, "wrapper_calls");
+    let session_starts = read_counter(&run.state_file, "session_starts");
+    assert_eq!(
+        wrapper_calls, 2,
+        "expected exactly two wrapper invocations (initial + retry); got {wrapper_calls}\nstate:\n{}",
+        fs::read_to_string(&run.state_file).unwrap_or_default()
+    );
+    assert!(
+        session_starts >= 1,
+        "expected at least one session-start invocation between the two wrapper calls; got {session_starts}"
+    );
+}
+
+#[test]
+#[ignore = "depends on #265 retry implementation in run_wrapper_through_zccache; unignore once #265 merges"]
+fn unknown_session_retry_budget_is_one() {
+    let run = run_soldr_wrapper("retry-budget", Some("always_fail"));
+
+    assert_ne!(
+        run.exit_code, 0,
+        "expected soldr to surface the failure after one retry\nstdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+
+    let wrapper_calls = read_counter(&run.state_file, "wrapper_calls");
+    assert_eq!(
+        wrapper_calls, 2,
+        "expected exactly two wrapper invocations (initial + one retry, no further attempts); got {wrapper_calls}\nstate:\n{}",
+        fs::read_to_string(&run.state_file).unwrap_or_default()
+    );
+}
+
+#[test]
+#[ignore = "depends on #265 retry implementation in run_wrapper_through_zccache; unignore once #265 merges"]
+fn non_unknown_session_failure_does_not_retry() {
+    let run = run_soldr_wrapper("no-retry", Some("non_session_failure"));
+
+    assert_ne!(
+        run.exit_code, 0,
+        "expected soldr to surface the unrelated failure\nstdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+
+    let wrapper_calls = read_counter(&run.state_file, "wrapper_calls");
+    let session_starts = read_counter(&run.state_file, "session_starts");
+    assert_eq!(
+        wrapper_calls, 1,
+        "expected exactly one wrapper invocation (no retry for unrelated stderr); got {wrapper_calls}\nstate:\n{}",
+        fs::read_to_string(&run.state_file).unwrap_or_default()
+    );
+    assert_eq!(
+        session_starts, 0,
+        "expected no session-start invocations for an unrelated failure; got {session_starts}"
+    );
+}

--- a/crates/soldr-cli/tests/cli_unknown_session_retry.rs
+++ b/crates/soldr-cli/tests/cli_unknown_session_retry.rs
@@ -154,7 +154,6 @@ fn run_soldr_wrapper(label: &str, mode: Option<&str>) -> RetryRun {
 }
 
 #[test]
-#[ignore = "depends on #265 retry implementation in run_wrapper_through_zccache; unignore once #265 merges"]
 fn unknown_session_triggers_one_retry() {
     let run = run_soldr_wrapper("trigger-retry", None);
 
@@ -178,7 +177,6 @@ fn unknown_session_triggers_one_retry() {
 }
 
 #[test]
-#[ignore = "depends on #265 retry implementation in run_wrapper_through_zccache; unignore once #265 merges"]
 fn unknown_session_retry_budget_is_one() {
     let run = run_soldr_wrapper("retry-budget", Some("always_fail"));
 
@@ -197,7 +195,6 @@ fn unknown_session_retry_budget_is_one() {
 }
 
 #[test]
-#[ignore = "depends on #265 retry implementation in run_wrapper_through_zccache; unignore once #265 merges"]
 fn non_unknown_session_failure_does_not_retry() {
     let run = run_soldr_wrapper("no-retry", Some("non_session_failure"));
 


### PR DESCRIPTION
## Summary

Adds the deferred integration test from #265's third acceptance criterion: a fake `zccache` stub binary that exhibits the `unknown session:` failure mode and three integration tests that drive the real `soldr` binary as a `RUSTC_WRAPPER` to exercise the retry path end-to-end.

- **Test 1 — `unknown_session_triggers_one_retry`**: first call fails with `unknown session:`, soldr resyncs and retries, second call succeeds. Exit code 0.
- **Test 2 — `unknown_session_retry_budget_is_one`**: stub always fails; soldr retries exactly once, then surfaces the failure. Exit code 1, two wrapper invocations only.
- **Test 3 — `non_unknown_session_failure_does_not_retry`**: a different stderr message does not trigger a retry. Exit code 1, single wrapper invocation.

Tests are `#[cfg(not(unix))]` because the retry path only exists on Windows; the Unix `exec()` path is documented out-of-scope.

### Dependency on #265

At the time this PR was opened, #265 (the retry implementation in `run_wrapper_through_zccache`) had not yet been pushed to `origin`, so the tests are `#[ignore]`'d with a comment pointing to #265. **A one-line follow-up PR removing the three `#[ignore]` attributes is the entire next step once #265 lands on `main`.** I verified this locally by running test 3 against the current `main` (it passes — exactly one wrapper invocation, no retry, exit 1) and test 2 against `main` (it correctly fails because the retry is missing, exit 1 with `wrapper_calls=1` instead of the expected `2`). Once #265 merges, all three tests should pass on the same fixture machinery.

### Stub binary packaging

The stub (`crates/soldr-cli/tests/bins/fake_zccache_stub.rs`) is registered as a `[[bin]]` gated behind a new `test-stubs` cargo feature. Without the feature, cargo refuses to build the bin (verified) so neither:

- the maturin wheel,
- the GitHub release tarball (which only `cp`s the explicit `soldr` binary), nor
- `cargo install --path crates/soldr-cli`

pick it up. Integration tests build the stub on demand via `cargo build --bin fake-zccache-265-stub --features test-stubs` and locate it next to `CARGO_BIN_EXE_soldr`. No new external dependencies — the stub uses `std` only.

Refs #265, closes #266.

## Test plan

- [x] `cargo build -p soldr-cli --bin fake-zccache-265-stub --features test-stubs` succeeds.
- [x] `cargo build -p soldr-cli --bin fake-zccache-265-stub` (without the feature) correctly refuses: `target requires the features: test-stubs`.
- [x] `cargo test -p soldr-cli --test cli_unknown_session_retry` reports `0 passed; 0 failed; 3 ignored` on current `main`.
- [x] `cargo test -p soldr-cli --test cli_unknown_session_retry --features test-stubs -- --ignored non_unknown_session_failure_does_not_retry` passes on current `main` (validates the stub mechanism end-to-end).
- [x] `cargo test -p soldr-cli --test cli_unknown_session_retry --features test-stubs -- --ignored unknown_session_retry_budget_is_one` correctly fails on current `main` (no retry exists yet); proves the test is meaningful.
- [x] `cargo fmt --all -- --check`.
- [x] `cargo clippy -p soldr-cli --features test-stubs --all-targets -- -D warnings`.

After #265 merges and the follow-up PR removes the `#[ignore]` attributes, all three tests should pass with `cargo test -p soldr-cli --test cli_unknown_session_retry --features test-stubs`.

Generated with [Claude Code](https://claude.com/claude-code)