### PR TITLE
chore: ignore .claude local worktrees, settings, and credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ uv.lock
 # skills, hooks, and other repo configuration.
 .claude/scheduled_tasks.lock
 .claude/workspaces/
+.claude/worktrees/
+.claude/settings.local.json
+.claude/.credentials*


### PR DESCRIPTION
## Summary
- Ignore `.claude/worktrees/`, `.claude/settings.local.json`, and `.claude/.credentials*` so local Claude Code state doesn't get committed.

## Test plan
- [ ] `git status` in a fresh worktree no longer surfaces those paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)