### PR TITLE
chore(deps): bump managed zccache from 1.4.0 to 1.4.2

### DIFF
--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1719,7 +1719,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.4.0");
+    assert_eq!(json["managed_zccache_version"], "1.4.2");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -1841,7 +1841,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.4.0");
+    assert_eq!(json["managed_zccache_version"], "1.4.2");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.2";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),


### PR DESCRIPTION
## Summary
- Bump `MANAGED_ZCCACHE_VERSION` in `crates/soldr-fetch/src/lib.rs` from `1.4.0` to `1.4.2` so the runtime fetcher pulls the latest zccache release (crates.io + GitHub Releases both publish 1.4.2 with a tag of `1.4.2`; `release_tag_candidates` already tries both `1.4.2` and `v1.4.2`, so no resolver change is needed).
- Update the two `soldr cache --json` test assertions that read the version back (`crates/soldr-cli/tests/cli.rs`).
- Leave the historical `v1.4.0` references in `crates/soldr-cli/src/main.rs` (cache_profile / dropped_artifact_classes wire-compat) untouched — they document an invariant that still protects downstream users on older zccache builds.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all suites green
- [ ] CI build matrix runs cleanly on linux/macOS/windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)