### PR TITLE
chore(release): bump version to 0.7.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "clap",
  "serde",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "serde",
  "tempfile",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.15"
+version = "0.7.16"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- Bump `[workspace.package].version` in `Cargo.toml` and the matching `"version"` in `package.json` from `0.7.15` to `0.7.16`.
- Refresh `Cargo.lock` for the workspace crate versions.
- Triggers the Autonomous Release workflow on merge to `main`.

## Pre-flight checks
- `v0.7.16` git tag does not exist on `origin`.
- `0.7.16` is unpublished on PyPI (`soldr`) and npm (`@zackees/soldr`); both still at `0.7.15`.
- Picks up the managed zccache `1.4.2` bump from #270.

## Test plan
- [x] `cargo build --workspace` succeeds with the new version stamped on all four crates.
- [ ] Autonomous Release workflow tags `v0.7.16`, builds platform binaries, and publishes to PyPI + npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)