### PR TITLE
feat(target-cache): validate SOLDR_TARGET_CACHE_TAR_THREADS (#272)

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -21,6 +21,15 @@ const TARGET_CACHE_BACKEND_ENV_VAR: &str = "SOLDR_TARGET_CACHE_BACKEND";
 /// outputs as a safety net) and `thin-v2` (fingerprint-aware aggressive prune;
 /// drops library bytes and lets zccache's compilation cache repopulate them).
 const TARGET_CACHE_PROFILE_ENV_VAR: &str = "SOLDR_TARGET_CACHE_PROFILE";
+/// Reader-thread count for the target-cache tar walk in zccache (issue #272).
+/// Forwarded to the `zccache rust-plan save/restore` subprocess via inherited
+/// environment; soldr validates the value early so typos fail before cargo
+/// metadata runs. Values: `auto` (default; zccache picks a vCPU-bounded count
+/// capped at 8), `1` (disable parallelism — sequential tar walk), or any
+/// positive integer for an explicit thread count. The actual parallel walk
+/// lives in zccache; this constant exists so soldr can reject malformed values
+/// at the front door.
+const TARGET_CACHE_TAR_THREADS_ENV_VAR: &str = "SOLDR_TARGET_CACHE_TAR_THREADS";
 /// Filename of the file-list manifest written next to the thin-slice bundle so
 /// downstream tooling can prove what landed in the slice without unpacking it.
 const THIN_MANIFEST_FILENAME: &str = "manifest.v2.json";
@@ -925,6 +934,12 @@ fn maybe_prepare_rust_artifact_plan(
         None
     };
 
+    // Reject a malformed SOLDR_TARGET_CACHE_TAR_THREADS before we kick off
+    // cargo metadata. zccache also validates, but failing here keeps the
+    // error close to the user's typo and avoids spending seconds resolving
+    // the workspace just to die on a one-character env mistake.
+    rust_artifact_cache_tar_threads_from_env()?;
+
     let metadata = cargo_metadata(cargo, args)?;
     let toolchain = rust_toolchain_identity(cargo, rustc)?;
     let plan = build_rust_artifact_plan(&metadata, &toolchain, args, &mode, profile, session)?;
@@ -1247,6 +1262,28 @@ fn rust_artifact_cache_backend_from_env() -> Result<String, SoldrError> {
         "gha" => Ok("gha".to_string()),
         _ => Err(SoldrError::Other(format!(
             "invalid {TARGET_CACHE_BACKEND_ENV_VAR} value {raw:?}; expected auto, local, or gha"
+        ))),
+    }
+}
+
+fn rust_artifact_cache_tar_threads_from_env() -> Result<Option<String>, SoldrError> {
+    parse_rust_artifact_cache_tar_threads(
+        &std::env::var(TARGET_CACHE_TAR_THREADS_ENV_VAR).unwrap_or_default(),
+    )
+}
+
+fn parse_rust_artifact_cache_tar_threads(raw: &str) -> Result<Option<String>, SoldrError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.eq_ignore_ascii_case("auto") {
+        return Ok(Some("auto".to_string()));
+    }
+    match trimmed.parse::<u32>() {
+        Ok(n) if n >= 1 => Ok(Some(n.to_string())),
+        _ => Err(SoldrError::Other(format!(
+            "invalid {TARGET_CACHE_TAR_THREADS_ENV_VAR} value {raw:?}; expected `auto` or a positive integer (use `1` to disable parallelism)"
         ))),
     }
 }
@@ -3139,13 +3176,13 @@ mod tests {
         cargo_metadata_passthrough_args, cargo_profile, cargo_target_triple,
         compute_plan_inputs_hash, dropped_artifact_classes, evaluate_warm_restore_skip,
         extract_as_pin, first_cargo_subcommand, is_sccache_wrapper, normalize_version,
-        parse_tool_spec, rustc_wrapper_mode_from_env_var, rustup_resolution_failure,
-        selected_cargo_args, should_skip_warm_restore, should_trampoline,
-        stderr_indicates_unknown_session, warm_restore_sentinel_path, warm_restore_skip_enabled,
-        write_thin_manifest, write_warm_restore_sentinel, CargoMetadata, CargoMetadataPackage,
-        RustArtifactPlan, RustArtifactPlanContext, RustPlanInputs, RustPlanPackages,
-        RustToolchainIdentity, RustcWrapperMode, ThinSliceManifest, WarmRestoreSentinel,
-        WarmRestoreSkipInputs, ZccacheBuildSession, SKIP_WARM_RESTORE_ENV_VAR,
+        parse_rust_artifact_cache_tar_threads, parse_tool_spec, rustc_wrapper_mode_from_env_var,
+        rustup_resolution_failure, selected_cargo_args, should_skip_warm_restore,
+        should_trampoline, stderr_indicates_unknown_session, warm_restore_sentinel_path,
+        warm_restore_skip_enabled, write_thin_manifest, write_warm_restore_sentinel, CargoMetadata,
+        CargoMetadataPackage, RustArtifactPlan, RustArtifactPlanContext, RustPlanInputs,
+        RustPlanPackages, RustToolchainIdentity, RustcWrapperMode, ThinSliceManifest,
+        WarmRestoreSentinel, WarmRestoreSkipInputs, ZccacheBuildSession, SKIP_WARM_RESTORE_ENV_VAR,
         THIN_MANIFEST_FILENAME, WARM_RESTORE_MAX_AGE_SECONDS,
     };
     use soldr_fetch::VersionSpec;
@@ -4531,5 +4568,48 @@ mod tests {
         // only resync on the exact daemon-emitted marker.
         let stderr = b"unknown sessio\n";
         assert!(!stderr_indicates_unknown_session(stderr));
+    }
+
+    #[test]
+    fn tar_threads_unset_or_blank_yields_none() {
+        assert!(parse_rust_artifact_cache_tar_threads("").unwrap().is_none());
+        assert!(parse_rust_artifact_cache_tar_threads("   ")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn tar_threads_auto_is_normalized_lowercase() {
+        assert_eq!(
+            parse_rust_artifact_cache_tar_threads("auto").unwrap(),
+            Some("auto".to_string())
+        );
+        assert_eq!(
+            parse_rust_artifact_cache_tar_threads("  AUTO ").unwrap(),
+            Some("auto".to_string())
+        );
+    }
+
+    #[test]
+    fn tar_threads_positive_integer_passes_through() {
+        for raw in ["1", "4", "8", "16"] {
+            assert_eq!(
+                parse_rust_artifact_cache_tar_threads(raw).unwrap(),
+                Some(raw.to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn tar_threads_rejects_zero_negative_and_garbage() {
+        for raw in ["0", "-1", "1.5", "twelve", "auto4", "4 threads"] {
+            let err = parse_rust_artifact_cache_tar_threads(raw)
+                .expect_err(&format!("expected error for {raw:?}"));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("SOLDR_TARGET_CACHE_TAR_THREADS"),
+                "error for {raw:?} must mention the env var, got {msg}"
+            );
+        }
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -282,6 +282,7 @@ Commands:
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 | `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE` | Default-on: skip `rust-plan restore` when `target/` is already warm from a prior step in the same GitHub Actions job + attempt (issue #229). Set to a falsy value (`0` / `false` / `no` / `off`) to opt out. | unset (on) |
+| `SOLDR_TARGET_CACHE_TAR_THREADS` | Reader-thread count for the target-cache tar walk in zccache (issue #272). `auto` lets zccache pick a vCPU-bounded count (capped at 8). `1` disables parallelism (sequential walk). Any positive integer sets an explicit count. soldr validates the value at the cargo front door; the parallel walk itself lives in zccache. | unset (`auto`) |
 
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.


### PR DESCRIPTION
## Summary

Front-door validation for the new tar-walk thread-count env var introduced by issue #272.

The actual parallel tar walk lives in **zccache** (separate repo) — soldr only generates a plan JSON and shells out to `zccache rust-plan save/restore`. The env var flows through to that subprocess via inherited environment, exactly like `SOLDR_TARGET_CACHE_COMPRESS{,_LEVEL}` does from setup-soldr#70.

This PR is the soldr-side half: reject malformed values at the cargo front door so a typo (`twleve`, `auto4`, `0`, `1.5`) fails immediately instead of after seconds of `cargo metadata`. Mirrors the existing `rust_artifact_cache_{mode,profile,backend}_from_env` validators.

Closes a portion of #272 — the soldr-side scope. The walk-parallelization implementation itself remains a zccache change.

## What's in here

- New constant `TARGET_CACHE_TAR_THREADS_ENV_VAR = "SOLDR_TARGET_CACHE_TAR_THREADS"` next to the other target-cache env var constants.
- `parse_rust_artifact_cache_tar_threads(raw)` pure-function parser + `rust_artifact_cache_tar_threads_from_env()` env-reading wrapper, matching the established pattern.
- Validation hook in `maybe_prepare_rust_artifact_plan` so the check runs before `cargo metadata` kicks off.
- 4 unit tests covering blank/`auto`/integer/garbage inputs.
- API docs row in `docs/API.md`.

Accepted values:
- `auto` (default — zccache picks a vCPU-bounded count, capped at 8)
- `1` to disable parallelism (sequential walk)
- any positive integer for an explicit count

## Test plan

- [x] `cargo build -p soldr-cli` — clean
- [x] `cargo test --workspace` — all 183 tests pass (including 4 new `tar_threads_*` tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] After zccache lands the parallel walk, end-to-end benchmark on Windows runner (acceptance criterion from #272)

🤖 Generated with [Claude Code](https://claude.com/claude-code)