### PR TITLE
ci(setup-soldr): install zstd on windows-arm64 before actions/cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,35 @@ runs:
         ACTION_ARCH: ${{ runner.arch }}
       run: python "${{ github.action_path }}/.github/actions/setup-soldr/resolve_setup.py"
 
+    # actions/cache@v4 picks its tar codec by probing `zstd --quiet --version`
+    # on PATH (see @actions/toolkit/packages/cache/src/internal/cacheUtils.ts).
+    # The windows-11-arm image omits zstd from its preinstalled software
+    # (https://github.com/actions/partner-runner-images), so cache save/restore
+    # silently falls back to single-threaded `tar -z` (gzip). On 2 GB payloads
+    # that turns a ~30s post-step into ~4m on ARM Windows runners. Installing
+    # zstd before any cache step lets actions/cache pick the multi-threaded
+    # `zstd -T0` path that x64 Windows already uses. Tracked upstream as
+    # actions/cache#1622 (unresolved as of v5.0.5). No-op on other platforms
+    # and when a future image starts shipping zstd, thanks to the PATH probe.
+    - id: ensure-zstd-windows-arm64
+      if: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' }}
+      shell: pwsh
+      run: |
+        if (Get-Command zstd -ErrorAction SilentlyContinue) {
+          Write-Host "zstd already on PATH; skipping install."
+          zstd --version
+          exit 0
+        }
+        Write-Host "zstd not on PATH; installing via Chocolatey so actions/cache picks the multi-threaded zstd codec."
+        choco install zstandard -y --no-progress
+        if ($LASTEXITCODE -ne 0) {
+          throw "choco install zstandard exited with code $LASTEXITCODE"
+        }
+        if (-not (Get-Command zstd -ErrorAction SilentlyContinue)) {
+          throw "zstd installation completed but the binary is not on PATH"
+        }
+        zstd --version
+
     - id: cache
       if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4


### PR DESCRIPTION
## Summary

Pre-installs `zstd.exe` via Chocolatey on `windows-arm64` runners before the action's three `actions/cache@v4` calls. The toolkit picks its tar codec by probing `zstd --quiet --version` on PATH and falls back to single-threaded `tar -z` (gzip) when absent. The [`windows-11-arm` image](https://github.com/actions/partner-runner-images/blob/main/images/arm-windows-11-image.md) explicitly omits zstd, so cache save/restore on that runner is gzip-only.

## Observed impact (PR #273, run 25747729093)

| Runner | Post Setup Soldr step | Codec |
|---|---|---|
| `x86_64-pc-windows-msvc` | **41 s** | `tar --use-compress-program "zstd -T0"` |
| `aarch64-pc-windows-msvc` | **4 m 34 s** | `tar -z` (gzip, single-threaded) |

Cache contents are the same (~2.1 GB across three caches on each). The 6.7× gap is pure codec difference, multiplied by ARM64 single-thread perf.

Expected post-step time on `windows-arm64` after this lands: ~30–60 s, dominated by upload (not compression).

## Why this fix and not the alternatives

- **Upgrading to `actions/cache@v5`** — doesn't fix it. The codec probe is unchanged through v5.0.5 (verified in `@actions/toolkit/packages/cache/src/internal/cacheUtils.ts`). Tracked upstream as [actions/cache#1622](https://github.com/actions/cache/issues/1622), unresolved.
- **Pre-tarring with zstd ourselves and handing a `.tar.zst` to `actions/cache/save`** — doesn't work. The action always re-tars and re-compresses its `path` inputs; there's no passthrough mode.
- **Switching to `Swatinem/rust-cache`** — same problem. It [delegates to `@actions/cache`](https://github.com/Swatinem/rust-cache/blob/master/src/utils.ts) and inherits the gzip fallback.
- **Rolling our own cache transport** — same end-state speed (~30–40 s) for substantial complexity. The bottleneck is the bytes, not the framework.

## Behavior

- Gated on `runner.os == 'Windows' && runner.arch == 'ARM64'` — no-op on every other platform.
- Skips install if `zstd` is already on PATH — auto-cleans when a future image starts shipping it.
- Chocolatey is preinstalled on the GitHub-hosted `windows-arm64` image; `C:\ProgramData\chocolatey\bin` is on the machine-wide PATH so subsequent `actions/cache` steps see the new install.

## Test plan

- [ ] PR CI runs through `_bootstrap-e2e.yml` on `aarch64-pc-windows-msvc` — confirm `tar` invocation switches from `cache.tgz -z` to `cache.tzst --use-compress-program "zstd -T0"` in the Post Setup Soldr log.
- [ ] Total Post Setup Soldr step drops from ~4 min to under ~1 min on ARM windows.
- [ ] No regression on `x86_64-pc-windows-msvc` (the gating `if` skips the new step).
- [ ] No regression on Linux/macOS jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)