### PR TITLE
chore(deps): bump managed zccache from 1.4.2 to 1.4.3

### DIFF
--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1719,7 +1719,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.4.2");
+    assert_eq!(json["managed_zccache_version"], "1.4.3");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -1841,7 +1841,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.4.2");
+    assert_eq!(json["managed_zccache_version"], "1.4.3");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.2";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.3";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),


### PR DESCRIPTION
## Summary

[zccache 1.4.3](https://github.com/zackees/zccache/releases/tag/1.4.3) was published 2026-05-12, one day after 1.4.2. Bumps the single pinned constant in `soldr-fetch` plus the two `soldr status --json` / `soldr cache --json` test assertions that read it back. Mirrors the shape of #270 (1.4.0 → 1.4.2).

## Diff

- `crates/soldr-fetch/src/lib.rs` — `MANAGED_ZCCACHE_VERSION` constant
- `crates/soldr-cli/tests/cli.rs` — two assertion strings in `status_json_reports_stable_machine_fields` and `cache_json_reports_managed_zccache_status`

`release_tag_candidates` already tries both `1.4.3` and `v1.4.3`, so no fetch-path code change is needed. The `v1.4.0` references in `main.rs` are deliberately preserved — they document a wire-compat invariant for zccache ≤1.4.0 (`#[serde(deny_unknown_fields)]`).

## Test plan

- [x] `cargo build -p soldr-fetch -p soldr-cli` — clean
- [x] `cargo test -p soldr-cli --test cli -- status_json_reports_stable_machine_fields cache_json_reports_managed_zccache_status` — 2 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)