### PR TITLE
test(cli): isolate fake-toolchain tests from inherited cache-mode env

### DIFF
--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -681,12 +681,20 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
     let cache_root = unique_temp_dir("cargo-default-cache");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    // CI (setup-soldr) exports `SOLDR_TARGET_CACHE_MODE=full` /
+    // `SOLDR_BUILD_CACHE_MODE=full` in the job environment. Without
+    // stripping them, the spawned soldr triggers its rust-plan path,
+    // shells out to the fake cargo for `cargo metadata`, gets back `{}`,
+    // and fails with "missing field `packages`". Every fake-toolchain
+    // test below clears these the same way for the same reason.
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
         .output()
         .expect("failed to run soldr cargo build with fake zccache");
 
@@ -941,6 +949,8 @@ fn cargo_front_door_recovers_from_stale_zccache_daemon_start() {
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
         .env("SOLDR_TEST_ZCCACHE_STALE_START_ONCE", &stale_marker)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
         .output()
         .expect("failed to run soldr cargo build with stale fake zccache");
 
@@ -992,6 +1002,8 @@ fn cargo_front_door_uses_real_tool_overrides_before_path_probe() {
         .env("SOLDR_REAL_RUSTC", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
         .env("PATH", prepend_to_path(&shim_dir))
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
         .output()
         .expect("failed to run soldr cargo build with real tool overrides");
 
@@ -1059,6 +1071,8 @@ fn cargo_front_door_detects_build_after_global_cargo_options() {
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
         .output()
         .expect("failed to run soldr cargo build with global cargo options");
 
@@ -1088,6 +1102,8 @@ fn cargo_front_door_preserves_jobserver_fds_into_managed_zccache_wrapper() {
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
         .output()
         .expect("failed to run soldr cargo test --no-run with fake jobserver fds");
 
@@ -1124,6 +1140,8 @@ fn cache_enabled_zccache_build_completes_under_20_seconds() {
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
         .output()
         .expect("failed to run soldr cargo build with fake zccache");
     let elapsed = started.elapsed();
@@ -1195,6 +1213,8 @@ fn nested_soldr_ignores_inherited_managed_zccache_cache_dir() {
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
         .output()
         .expect("failed to run nested soldr cargo build with inherited managed ZCCACHE_CACHE_DIR");
 


### PR DESCRIPTION
## Summary

Fixes the long-running CI smoke-test failure visible on every recent main run (e.g. https://github.com/zackees/soldr/actions/runs/25766573648/job/75680494573 — Linux x64, with identical Windows x64 and macOS x64 failures).

## Root cause

CI's setup-soldr action exports `SOLDR_TARGET_CACHE_MODE=full` and `SOLDR_BUILD_CACHE_MODE=full` into the job environment. Seven CLI smoke tests spawn soldr with a fake cargo binary (`SOLDR_TEST_CARGO_BIN`). The spawned soldr inherits the cache-mode env vars, triggers the rust-plan path, runs `cargo metadata` against the fake (which returns `{}`), and panics:

```
soldr: failed to parse cargo metadata while preparing Rust artifact cache plan: missing field `packages` at line 1 column 2
```

Predates this branch — verified the same 7 failures on the 0.7.16 release commit (#271, run 25703498029). Local devs don't see it because no shell exports those env vars at the workstation level.

## Fix

Strip both env vars at the spawn site of every fake-toolchain test:

- `cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default`
- `cargo_front_door_recovers_from_stale_zccache_daemon_start`
- `cargo_front_door_uses_real_tool_overrides_before_path_probe`
- `cargo_front_door_detects_build_after_global_cargo_options`
- `cargo_front_door_preserves_jobserver_fds_into_managed_zccache_wrapper`
- `cache_enabled_zccache_build_completes_under_20_seconds`
- `nested_soldr_ignores_inherited_managed_zccache_cache_dir`

One-line `.env_remove("SOLDR_TARGET_CACHE_MODE")` + `.env_remove("SOLDR_BUILD_CACHE_MODE")` per spawn chain. A short comment at the first occurrence documents the rationale so future fake-toolchain tests follow the same pattern.

Why test-side instead of soldr-side: the fake-cargo `{}` metadata response is a test artifact; it shouldn't dictate soldr CLI behavior. soldr's metadata parsing is correct — the tests just need to opt out of triggering it.

## Test plan

- [x] Reproduce failure locally: `SOLDR_TARGET_CACHE_MODE=full cargo test -p soldr-cli --test cli cache_enabled_zccache_build_completes_under_20_seconds` — fails identically to CI
- [x] Apply fix, rerun under `SOLDR_TARGET_CACHE_MODE=full SOLDR_BUILD_CACHE_MODE=full` — all 6 Windows-visible tests pass
- [x] 7th test (`cargo_front_door_preserves_jobserver_fds...`) is `#[cfg(not(windows))]`; got the same edit so it lands cleanly on Linux/macOS CI
- [x] `cargo test -p soldr-cli` — 72 + 36 + 3 = 111 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] On merge: Linux x64 / macOS x64 / Windows x64 CI jobs flip from failure to success

🤖 Generated with [Claude Code](https://claude.com/claude-code)