### PR TITLE
chore(release): bump version to 0.7.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "clap",
  "rayon",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "serde",
  "tempfile",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.17"
+version = "0.7.18"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Triggers the autonomous release workflow. The 0.7.18 line is unpublished on:

- PyPI `soldr` — verified 404
- npm `@zackees/soldr` — verified 404
- git tag `v0.7.18` — verified absent on origin

## Picks up two merges since 0.7.17

- #278 — test(cli): isolate fake-toolchain tests from inherited cache-mode env (fixes the long-running Linux/macOS/Windows x64 CI smoke-test failures)
- #279 — chore(deps): bump managed zccache from 1.4.3 to 1.4.4

## Diff shape

3 files, 6 insertions, 6 deletions — identical shape to the prior release-bump #277:

- `Cargo.toml` — `[workspace.package].version`
- `package.json` — npm version
- `Cargo.lock` — auto-updated for the four internal workspace crates

## Test plan

- [x] `cargo build -p soldr-cli` — compiles at 0.7.18
- [x] No untracked files (`git ls-files --others --exclude-standard` empty)
- [ ] On merge: `Autonomous Release` workflow's `prepare` job sets `should_release=true` and proceeds to build + publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)