### PR TITLE
chore(deps): bump managed zccache from 1.4.4 to 1.4.5

### DIFF
--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1739,7 +1739,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.4.4");
+    assert_eq!(json["managed_zccache_version"], "1.4.5");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -1861,7 +1861,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.4.4");
+    assert_eq!(json["managed_zccache_version"], "1.4.5");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -45,7 +45,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.4";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.5";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),


### PR DESCRIPTION
## Summary

[zccache 1.4.5](https://github.com/zackees/zccache/releases/tag/1.4.5) was published 2026-05-13. Bumps the single pinned constant in `soldr-fetch` plus the two `soldr status --json` / `soldr cache --json` test assertions that read it back. Mirrors the shape of #276 (1.4.2 → 1.4.3) and #279 (1.4.3 → 1.4.4).

## Diff

- `crates/soldr-fetch/src/lib.rs` — `MANAGED_ZCCACHE_VERSION` constant
- `crates/soldr-cli/tests/cli.rs` — two assertion strings in `status_json_reports_stable_machine_fields` and `cache_json_reports_managed_zccache_status`

3 lines changed across 2 files. `release_tag_candidates` already tries both `1.4.5` and `v1.4.5`, so no fetch-path code change is needed.

## Test plan

- [x] `cargo build -p soldr-fetch -p soldr-cli` — clean
- [x] `cargo test -p soldr-cli --test cli -- status_json_reports_stable_machine_fields cache_json_reports_managed_zccache_status` — 2 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] No untracked files (`git ls-files --others --exclude-standard` empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)