### PR TITLE
feat(cli): split gc purge and warn on low disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1603,7 @@ name = "soldr-cli"
 version = "0.7.18"
 dependencies = [
  "clap",
+ "fs2",
  "rayon",
  "serde",
  "serde_json",
@@ -2184,6 +2195,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1"
 blake3 = "1"
 sha2 = "0.10"
 hex = "0.4"
+fs2 = "0.4"
 reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 tempfile = "3"
 zip = "2"

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rayon = { workspace = true }
+fs2 = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -11,7 +11,9 @@ const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
 const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
 const TEST_RUSTUP_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTUP_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
+const TEST_FREE_DISK_BYTES_ENV_VAR: &str = "SOLDR_TEST_FREE_DISK_BYTES";
 const JSON_SCHEMA_VERSION: u32 = 1;
+const LOW_DISK_WARNING_THRESHOLD_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const RUSTC_WRAPPER_OVERRIDE_ENV_VAR: &str = "SOLDR_RUSTC_WRAPPER";
 /// Picks the linker injected for `soldr cargo ...` builds. See `linker` module
 /// and `docs/API.md` for the supported values (`default | ld | mold | rust-lld
@@ -146,16 +148,42 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Garbage-collect stale Cargo `target/` directories tracked by
+    /// Review reclaimable Cargo `target/` directories tracked by
     /// the soldr registry (`~/.soldr/data.db`).
     ///
     /// Aliases: `purge-targets` (matches issue #234's `soldr --purge`
     /// wording).
     #[command(alias = "purge-targets")]
     Gc {
-        /// Show candidates and totals without deleting anything.
-        #[arg(long)]
+        /// Deprecated: `soldr gc` is already a non-destructive summary.
+        #[arg(long, hide = true)]
         dry_run: bool,
+        /// Deprecated: use `soldr gc purge --all`.
+        #[arg(long, hide = true)]
+        all: bool,
+        /// Minimum age before a `target/` is included in the summary
+        /// (e.g. `10d`, `4w`).
+        #[arg(long, default_value = "10d", value_name = "DURATION")]
+        older_than: String,
+        /// Minimum on-disk size before a `target/` is included in the
+        /// summary (e.g. `256M`, `1GB`).
+        #[arg(long, default_value = "256M", value_name = "SIZE")]
+        larger_than: String,
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+        #[command(subcommand)]
+        command: Option<GcSubcommand>,
+    },
+    /// Anything else is a tool to fetch and run
+    #[command(external_subcommand)]
+    External(Vec<String>),
+}
+
+#[derive(Subcommand)]
+enum GcSubcommand {
+    /// Delete eligible Cargo `target/` directories.
+    Purge {
         /// Delete every eligible candidate without prompting.
         #[arg(long)]
         all: bool,
@@ -171,9 +199,6 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Anything else is a tool to fetch and run
-    #[command(external_subcommand)]
-    External(Vec<String>),
 }
 
 #[tokio::main]
@@ -221,10 +246,6 @@ async fn main() {
                 .unwrap_or_else(report_and_exit),
         );
     }
-
-    // Dispatch path only: one-shot stale-target/ warning, throttled
-    // to once per day. Never runs on the rustc-wrapper hot path.
-    emit_startup_target_warning_if_due();
 
     let rc = run_with_args(&raw_args[0], &raw_args[1..])
         .await
@@ -317,14 +338,39 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             older_than,
             larger_than,
             json,
+            command,
         } => {
-            run_gc_command(GcInvocation {
-                dry_run,
-                all,
-                older_than,
-                larger_than,
-                json,
-            })?;
+            if all {
+                return Err(SoldrError::Other(
+                    "`soldr gc --all` no longer deletes targets; use `soldr gc purge --all`".into(),
+                ));
+            }
+            if dry_run && command.is_some() {
+                return Err(SoldrError::Other(
+                    "`soldr gc --dry-run` is a summary alias; use `soldr gc` or `soldr gc purge`"
+                        .into(),
+                ));
+            }
+            let invocation = match command {
+                Some(GcSubcommand::Purge {
+                    all,
+                    older_than,
+                    larger_than,
+                    json,
+                }) => GcInvocation {
+                    mode: GcMode::Purge { all },
+                    older_than,
+                    larger_than,
+                    json,
+                },
+                None => GcInvocation {
+                    mode: GcMode::Summary,
+                    older_than,
+                    larger_than,
+                    json,
+                },
+            };
+            run_gc_command(invocation)?;
         }
         Commands::External(args) => {
             if args.is_empty() {
@@ -774,12 +820,18 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     command.env_remove("MAKEFLAGS");
     command.env_remove("CARGO_MAKEFLAGS");
     command.env("RUSTC", &rustc);
-    let cache_enabled_for_cargo = cache_enabled && cargo_args_are_cacheable(args);
+    let build_like_cargo = cargo_args_are_cacheable(args);
+    let cache_enabled_for_cargo = cache_enabled && build_like_cargo;
 
     command.env(
         soldr_cache::CACHE_ENABLED_ENV_VAR,
         soldr_cache::cache_enabled_env_value(cache_enabled_for_cargo),
     );
+    if build_like_cargo {
+        // Cargo front door only: keep startup/low-disk warnings off unrelated
+        // commands and out of the rustc-wrapper hot path.
+        emit_startup_target_warning_if_due();
+    }
     let mut path_dirs: Vec<std::path::PathBuf> = Vec::with_capacity(1 + extra_bin_dirs.len());
     path_dirs.push(cargo_bin_dir);
     path_dirs.extend(extra_bin_dirs);
@@ -802,6 +854,13 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     } else {
         None
     };
+    if build_like_cargo {
+        let probe_path = rust_plan
+            .as_ref()
+            .map(|plan| std::path::PathBuf::from(&plan.target_dir))
+            .unwrap_or_else(|| cargo_disk_space_probe_path(args));
+        maybe_emit_low_disk_warning(&probe_path);
+    }
     if let Some(plan) = rust_plan.as_ref() {
         if let Some(reason) = should_skip_warm_restore(plan) {
             eprintln!("{reason}");
@@ -2195,6 +2254,117 @@ fn cargo_args_are_cacheable(args: &[String]) -> bool {
     )
 }
 
+fn maybe_emit_low_disk_warning(path: &std::path::Path) {
+    if let Some(message) =
+        low_disk_warning_for_path(path, stderr_should_use_color(), available_space)
+    {
+        eprintln!("{message}");
+    }
+}
+
+fn low_disk_warning_for_path<F>(
+    path: &std::path::Path,
+    use_color: bool,
+    available_space: F,
+) -> Option<String>
+where
+    F: FnOnce(&std::path::Path) -> std::io::Result<u64>,
+{
+    let probe_path = existing_filesystem_probe_path(path);
+    let free_bytes = available_space(&probe_path).ok()?;
+    low_disk_warning_for_free_bytes(free_bytes, use_color)
+}
+
+fn low_disk_warning_for_free_bytes(free_bytes: u64, use_color: bool) -> Option<String> {
+    if free_bytes >= LOW_DISK_WARNING_THRESHOLD_BYTES {
+        return None;
+    }
+    let warning = if use_color {
+        "\x1b[33mwarning\x1b[0m"
+    } else {
+        "warning"
+    };
+    Some(format!(
+        "soldr: {warning}: disk space is low ({} free). Run `soldr gc` to review reclaimable Rust target directories.",
+        soldr_cache::target_registry::human_size(free_bytes),
+    ))
+}
+
+fn stderr_should_use_color() -> bool {
+    use std::io::IsTerminal;
+
+    std::env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal()
+}
+
+fn available_space(path: &std::path::Path) -> std::io::Result<u64> {
+    if let Some(raw) = std::env::var_os(TEST_FREE_DISK_BYTES_ENV_VAR) {
+        let raw = raw.to_string_lossy();
+        if raw.eq_ignore_ascii_case("error") {
+            return Err(std::io::Error::other("test disk-space failure"));
+        }
+        return raw.parse::<u64>().map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid {TEST_FREE_DISK_BYTES_ENV_VAR}: {e}"),
+            )
+        });
+    }
+    fs2::available_space(path)
+}
+
+fn existing_filesystem_probe_path(path: &std::path::Path) -> std::path::PathBuf {
+    let mut cursor = if path.as_os_str().is_empty() {
+        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+    } else {
+        path.to_path_buf()
+    };
+    loop {
+        if cursor.exists() {
+            return cursor;
+        }
+        if !cursor.pop() {
+            return std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        }
+    }
+}
+
+fn cargo_disk_space_probe_path(args: &[String]) -> std::path::PathBuf {
+    if let Some(target_dir) = cargo_arg_value(args, "--target-dir") {
+        return absolutize_path(std::path::PathBuf::from(target_dir));
+    }
+    if let Some(target_dir) = non_empty_env_path("CARGO_TARGET_DIR") {
+        return absolutize_path(target_dir);
+    }
+    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+}
+
+fn cargo_arg_value(args: &[String], flag: &str) -> Option<String> {
+    let prefix = format!("{flag}=");
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == flag {
+            return iter.next().cloned();
+        }
+        if let Some(value) = arg.strip_prefix(&prefix) {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn absolutize_path(path: std::path::PathBuf) -> std::path::PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| std::path::PathBuf::from("."))
+            .join(path)
+    }
+}
+
 fn prepend_paths(
     dirs: &[std::path::PathBuf],
     existing_path: Option<&std::ffi::OsStr>,
@@ -2641,9 +2811,14 @@ fn clear_zccache_cache() -> Result<(), SoldrError> {
 // soldr gc — garbage-collect stale Cargo target/ directories.
 // ---------------------------------------------------------------------------
 
+#[derive(Clone, Copy)]
+enum GcMode {
+    Summary,
+    Purge { all: bool },
+}
+
 struct GcInvocation {
-    dry_run: bool,
-    all: bool,
+    mode: GcMode,
     older_than: String,
     larger_than: String,
     json: bool,
@@ -2664,8 +2839,15 @@ struct GcCandidateOutput {
 struct GcOutput {
     schema_version: u32,
     command: &'static str,
+    mode: &'static str,
     dry_run: bool,
+    registry_path: String,
+    candidate_count: usize,
+    skipped_count: usize,
+    total_reclaimable_bytes: u64,
+    total_reclaimable_human: String,
     candidates: Vec<GcCandidateOutput>,
+    largest_candidates: Vec<GcCandidateOutput>,
     skipped: Vec<GcCandidateOutput>,
     dropped_missing: usize,
     deleted_paths: Vec<String>,
@@ -2676,6 +2858,11 @@ fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
 
     let older_than = parse_duration(&invocation.older_than).map_err(SoldrError::Other)?;
     let larger_than = parse_size(&invocation.larger_than).map_err(SoldrError::Other)?;
+    let purge_all = match invocation.mode {
+        GcMode::Summary => false,
+        GcMode::Purge { all } => all,
+    };
+    let is_summary = matches!(invocation.mode, GcMode::Summary);
 
     let paths = SoldrPaths::new()?;
     let dev_roots = resolve_gc_dev_roots(&paths);
@@ -2687,75 +2874,55 @@ fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
         older_than_seconds: older_than,
         larger_than_bytes: larger_than,
         dev_roots,
-        dry_run: invocation.dry_run,
+        dry_run: is_summary,
     };
 
     let report =
         scan(&registry, &options).map_err(|e| SoldrError::Other(format!("gc scan failed: {e}")))?;
+    let total_reclaimable_bytes = gc_total_reclaimable_bytes(&report.candidates);
 
     let mut deleted_paths: Vec<String> = Vec::new();
 
-    if !invocation.json {
-        eprintln!(
-            "soldr gc: scanned registry at {} ({} candidate dir{}, {} skipped, {} dropped missing)",
-            db_path.display(),
-            report.candidates.len(),
-            if report.candidates.len() == 1 {
-                ""
-            } else {
-                "s"
-            },
-            report.skipped.len(),
-            report.dropped_missing
-        );
+    if is_summary {
+        if !invocation.json {
+            print_gc_summary(&db_path, &report, total_reclaimable_bytes);
+        }
+    } else if !invocation.json {
+        print_gc_purge_scan(&db_path, &report, total_reclaimable_bytes);
+    }
 
-        if report.candidates.is_empty() {
-            eprintln!("soldr gc: nothing to reclaim.");
-        } else {
-            eprintln!("soldr gc: candidates");
-            for cand in &report.candidates {
-                eprintln!(
-                    "  {}  size={}  age={}",
+    if !is_summary {
+        for cand in &report.candidates {
+            let should_delete = if purge_all {
+                true
+            } else {
+                prompt_yes_no(&format!(
+                    "soldr gc: delete {} ({}, age {}) ? [y/N] ",
                     cand.path.display(),
                     soldr_cache::target_registry::human_size(cand.size_bytes),
                     soldr_cache::target_registry::human_age(cand.age_seconds),
-                );
-            }
-        }
-    }
+                ))
+            };
 
-    for cand in &report.candidates {
-        let should_delete = if invocation.dry_run {
-            false
-        } else if invocation.all {
-            true
-        } else {
-            prompt_yes_no(&format!(
-                "soldr gc: delete {} ({}, age {}) ? [y/N] ",
-                cand.path.display(),
-                soldr_cache::target_registry::human_size(cand.size_bytes),
-                soldr_cache::target_registry::human_age(cand.age_seconds),
-            ))
-        };
-
-        if should_delete {
-            match purge_one(&registry, &cand.path, false) {
-                Ok(true) => {
-                    if !invocation.json {
-                        eprintln!("soldr gc: deleted {}", cand.path.display());
+            if should_delete {
+                match purge_one(&registry, &cand.path, false) {
+                    Ok(true) => {
+                        if !invocation.json {
+                            eprintln!("soldr gc: deleted {}", cand.path.display());
+                        }
+                        deleted_paths.push(cand.path.display().to_string());
                     }
-                    deleted_paths.push(cand.path.display().to_string());
-                }
-                Ok(false) => {
-                    if !invocation.json {
-                        eprintln!(
-                            "soldr gc: nothing to delete at {} (already gone)",
-                            cand.path.display()
-                        );
+                    Ok(false) => {
+                        if !invocation.json {
+                            eprintln!(
+                                "soldr gc: nothing to delete at {} (already gone)",
+                                cand.path.display()
+                            );
+                        }
                     }
-                }
-                Err(e) => {
-                    eprintln!("soldr gc: failed to delete {}: {e}", cand.path.display());
+                    Err(e) => {
+                        eprintln!("soldr gc: failed to delete {}: {e}", cand.path.display());
+                    }
                 }
             }
         }
@@ -2765,7 +2932,19 @@ fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
         let output = GcOutput {
             schema_version: JSON_SCHEMA_VERSION,
             command: "gc",
-            dry_run: invocation.dry_run,
+            mode: if is_summary { "summary" } else { "purge" },
+            dry_run: is_summary,
+            registry_path: db_path.display().to_string(),
+            candidate_count: report.candidates.len(),
+            skipped_count: report.skipped.len(),
+            total_reclaimable_bytes,
+            total_reclaimable_human: soldr_cache::target_registry::human_size(
+                total_reclaimable_bytes,
+            ),
+            largest_candidates: gc_largest_candidates(&report.candidates, 5)
+                .into_iter()
+                .map(gc_candidate_output)
+                .collect(),
             candidates: report
                 .candidates
                 .into_iter()
@@ -2782,6 +2961,92 @@ fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
         print_json(&output)?;
     }
     Ok(())
+}
+
+fn gc_total_reclaimable_bytes(candidates: &[soldr_cache::gc::GcCandidate]) -> u64 {
+    candidates.iter().map(|c| c.size_bytes).sum()
+}
+
+fn print_gc_summary(
+    db_path: &std::path::Path,
+    report: &soldr_cache::gc::GcReport,
+    total_reclaimable_bytes: u64,
+) {
+    println!("soldr gc: registry: {}", db_path.display());
+    println!(
+        "soldr gc: eligible: {} target dir{}; reclaimable: {}",
+        report.candidates.len(),
+        if report.candidates.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+        soldr_cache::target_registry::human_size(total_reclaimable_bytes)
+    );
+    println!(
+        "soldr gc: skipped: {}; dropped missing rows: {}",
+        report.skipped.len(),
+        report.dropped_missing
+    );
+
+    if report.candidates.is_empty() {
+        println!("soldr gc: nothing to reclaim.");
+    } else {
+        println!("soldr gc: largest eligible target directories:");
+        for cand in gc_largest_candidates(&report.candidates, 5) {
+            println!(
+                "  {}  size={}  last_used={}",
+                cand.path.display(),
+                soldr_cache::target_registry::human_size(cand.size_bytes),
+                soldr_cache::target_registry::human_age(cand.age_seconds),
+            );
+        }
+        println!("Run 'soldr gc purge' to delete eligible target directories.");
+    }
+}
+
+fn print_gc_purge_scan(
+    db_path: &std::path::Path,
+    report: &soldr_cache::gc::GcReport,
+    total_reclaimable_bytes: u64,
+) {
+    eprintln!(
+        "soldr gc purge: scanned registry at {} ({} candidate dir{}, {} skipped, {} dropped missing, {} reclaimable)",
+        db_path.display(),
+        report.candidates.len(),
+        if report.candidates.len() == 1 { "" } else { "s" },
+        report.skipped.len(),
+        report.dropped_missing,
+        soldr_cache::target_registry::human_size(total_reclaimable_bytes)
+    );
+
+    if report.candidates.is_empty() {
+        eprintln!("soldr gc purge: nothing to delete.");
+    } else {
+        eprintln!("soldr gc purge: candidates");
+        for cand in &report.candidates {
+            eprintln!(
+                "  {}  size={}  age={}",
+                cand.path.display(),
+                soldr_cache::target_registry::human_size(cand.size_bytes),
+                soldr_cache::target_registry::human_age(cand.age_seconds),
+            );
+        }
+    }
+}
+
+fn gc_largest_candidates(
+    candidates: &[soldr_cache::gc::GcCandidate],
+    limit: usize,
+) -> Vec<soldr_cache::gc::GcCandidate> {
+    let mut largest = candidates.to_vec();
+    largest.sort_by(|a, b| {
+        b.size_bytes
+            .cmp(&a.size_bytes)
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    largest.truncate(limit);
+    largest
 }
 
 fn gc_candidate_output(c: soldr_cache::gc::GcCandidate) -> GcCandidateOutput {
@@ -3368,17 +3633,20 @@ mod tests {
         cargo_args_specify_target, cargo_args_use_reserved_no_cache,
         cargo_metadata_passthrough_args, cargo_profile, cargo_target_triple,
         compute_plan_inputs_hash, dropped_artifact_classes, evaluate_warm_restore_skip,
-        extract_as_pin, first_cargo_subcommand, is_sccache_wrapper, normalize_version,
+        extract_as_pin, first_cargo_subcommand, is_sccache_wrapper,
+        low_disk_warning_for_free_bytes, low_disk_warning_for_path, normalize_version,
         parse_rust_artifact_cache_tar_threads, parse_tool_spec, resolve_bundle_walk_thread_count,
         rustc_wrapper_mode_from_env_var, rustup_resolution_failure, selected_cargo_args,
         should_skip_warm_restore, should_trampoline, stderr_indicates_unknown_session,
         walk_bundle_files, warm_restore_sentinel_path, warm_restore_skip_enabled,
-        write_thin_manifest, write_warm_restore_sentinel, CargoMetadata, CargoMetadataPackage,
-        RustArtifactPlan, RustArtifactPlanContext, RustPlanInputs, RustPlanPackages,
-        RustToolchainIdentity, RustcWrapperMode, ThinSliceManifest, WarmRestoreSentinel,
-        WarmRestoreSkipInputs, ZccacheBuildSession, BUNDLE_WALK_THREAD_CAP,
-        SKIP_WARM_RESTORE_ENV_VAR, THIN_MANIFEST_FILENAME, WARM_RESTORE_MAX_AGE_SECONDS,
+        write_thin_manifest, write_warm_restore_sentinel, CargoMetadata, CargoMetadataPackage, Cli,
+        Commands, GcSubcommand, RustArtifactPlan, RustArtifactPlanContext, RustPlanInputs,
+        RustPlanPackages, RustToolchainIdentity, RustcWrapperMode, ThinSliceManifest,
+        WarmRestoreSentinel, WarmRestoreSkipInputs, ZccacheBuildSession, BUNDLE_WALK_THREAD_CAP,
+        LOW_DISK_WARNING_THRESHOLD_BYTES, SKIP_WARM_RESTORE_ENV_VAR, THIN_MANIFEST_FILENAME,
+        WARM_RESTORE_MAX_AGE_SECONDS,
     };
+    use clap::Parser;
     use soldr_fetch::VersionSpec;
     use std::ffi::{OsStr, OsString};
     use std::sync::Mutex;
@@ -3421,6 +3689,70 @@ mod tests {
                 std::env::remove_var(self.key);
             }
         }
+    }
+
+    #[test]
+    fn gc_cli_parses_summary_and_purge_modes() {
+        let summary = Cli::try_parse_from(["soldr", "gc", "--json"]).unwrap();
+        match summary.command {
+            Commands::Gc {
+                command: None,
+                json,
+                ..
+            } => assert!(json, "gc --json should parse as summary JSON"),
+            _ => panic!("expected gc summary command"),
+        }
+
+        let purge = Cli::try_parse_from([
+            "soldr",
+            "gc",
+            "purge",
+            "--all",
+            "--older-than",
+            "30d",
+            "--larger-than",
+            "1GB",
+        ])
+        .unwrap();
+        match purge.command {
+            Commands::Gc {
+                command:
+                    Some(GcSubcommand::Purge {
+                        all,
+                        older_than,
+                        larger_than,
+                        ..
+                    }),
+                ..
+            } => {
+                assert!(all);
+                assert_eq!(older_than, "30d");
+                assert_eq!(larger_than, "1GB");
+            }
+            _ => panic!("expected gc purge command"),
+        }
+    }
+
+    #[test]
+    fn low_disk_warning_formats_yellow_below_threshold() {
+        let message = low_disk_warning_for_free_bytes(1536 * 1024 * 1024, true)
+            .expect("expected low-disk warning below threshold");
+        assert!(message.contains("\x1b[33mwarning\x1b[0m"));
+        assert!(message.contains("1.5 GB free"));
+        assert!(message.contains("Run `soldr gc`"));
+    }
+
+    #[test]
+    fn low_disk_warning_omits_at_threshold() {
+        assert!(low_disk_warning_for_free_bytes(LOW_DISK_WARNING_THRESHOLD_BYTES, true).is_none());
+    }
+
+    #[test]
+    fn low_disk_probe_failure_is_nonfatal() {
+        let warning = low_disk_warning_for_path(std::path::Path::new("."), true, |_| {
+            Err(std::io::Error::other("probe failed"))
+        });
+        assert!(warning.is_none());
     }
 
     #[test]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -25,6 +25,35 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     dir
 }
 
+fn toml_string(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn seed_gc_candidate(cache_root: &Path, label: &str) -> PathBuf {
+    let dev_root = cache_root.join("dev-root");
+    let workspace = dev_root.join(label);
+    let target = workspace.join("target");
+    fs::create_dir_all(&target).expect("failed to create target dir");
+    fs::write(target.join("artifact.bin"), b"reclaim me").expect("failed to seed target file");
+    fs::write(
+        cache_root.join("config.toml"),
+        format!("[gc]\nallowlist_roots = [\"{}\"]\n", toml_string(&dev_root)),
+    )
+    .expect("failed to write gc config");
+
+    let registry = soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("data.db"))
+        .expect("failed to open target registry");
+    let now = soldr_cache::target_registry::current_unix_seconds()
+        .expect("failed to get current unix seconds");
+    registry
+        .upsert_with_time(&target, now - 120)
+        .expect("failed to seed target registry");
+    target
+}
+
 fn path_display_variants(path: &Path) -> Vec<String> {
     let mut variants = vec![path.display().to_string()];
     if let Ok(canonical) = fs::canonicalize(path) {
@@ -614,6 +643,129 @@ fn help_lists_phase_one_command_surface() {
 }
 
 #[test]
+fn gc_summary_is_non_destructive_and_lists_largest_candidates() {
+    let cache_root = unique_temp_dir("gc-summary");
+    let target = seed_gc_candidate(&cache_root, "summary-project");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "--older-than", "1s", "--larger-than", "1B"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr gc");
+
+    assert!(
+        output.status.success(),
+        "gc summary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        target.exists(),
+        "soldr gc summary must not delete {}",
+        target.display()
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("reclaimable:"),
+        "summary should include total reclaimable bytes: {stdout}"
+    );
+    assert!(
+        stdout.contains("largest eligible target directories"),
+        "summary should list largest target directories: {stdout}"
+    );
+    assert!(
+        stdout.contains("Run 'soldr gc purge'"),
+        "summary should point to destructive purge command: {stdout}"
+    );
+}
+
+#[test]
+fn gc_summary_json_reports_candidates_without_deleting() {
+    let cache_root = unique_temp_dir("gc-summary-json");
+    let target = seed_gc_candidate(&cache_root, "summary-json-project");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "--json", "--older-than", "1s", "--larger-than", "1B"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr gc --json");
+
+    assert!(
+        output.status.success(),
+        "gc summary json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        target.exists(),
+        "soldr gc --json summary must not delete {}",
+        target.display()
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gc --json must be JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "gc");
+    assert_eq!(json["mode"], "summary");
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["candidate_count"], 1);
+    assert!(json["total_reclaimable_bytes"].as_u64().unwrap_or(0) > 0);
+    assert_eq!(json["largest_candidates"].as_array().unwrap().len(), 1);
+    assert_eq!(json["deleted_paths"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn gc_purge_all_deletes_candidates_without_prompt() {
+    let cache_root = unique_temp_dir("gc-purge-all");
+    let target = seed_gc_candidate(&cache_root, "purge-project");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "gc",
+            "purge",
+            "--all",
+            "--older-than",
+            "1s",
+            "--larger-than",
+            "1B",
+        ])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr gc purge --all");
+
+    assert!(
+        output.status.success(),
+        "gc purge --all failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !target.exists(),
+        "soldr gc purge --all should delete {}",
+        target.display()
+    );
+}
+
+#[test]
+fn gc_flat_all_is_rejected_with_purge_hint() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "--all"])
+        .env("SOLDR_CACHE_DIR", unique_temp_dir("gc-flat-all"))
+        .output()
+        .expect("failed to run soldr gc --all");
+
+    assert!(
+        !output.status.success(),
+        "legacy flat gc --all must not silently delete"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("soldr gc purge --all"),
+        "error should point to the new purge command: {stderr}"
+    );
+}
+
+#[test]
 fn cargo_front_door_runs_real_cargo() {
     let cache_root = unique_temp_dir("cargo-version");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
@@ -661,6 +813,74 @@ fn cargo_front_door_consumes_no_cache_flag() {
     assert!(
         !stderr.contains("unexpected argument '--no-cache'"),
         "--no-cache should be consumed by soldr, not forwarded to cargo: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_build_warns_when_disk_space_is_low() {
+    let cache_root = unique_temp_dir("cargo-low-disk");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["--no-cache", "cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_TEST_FREE_DISK_BYTES", "1500000000")
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run soldr cargo build with low-disk override");
+
+    assert!(
+        output.status.success(),
+        "cargo build with low-disk warning failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("disk space is low"),
+        "low-disk warning missing from stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Run `soldr gc`"),
+        "low-disk warning should recommend soldr gc: {stderr}"
+    );
+}
+
+#[test]
+fn cargo_build_ignores_disk_space_detection_failures() {
+    let cache_root = unique_temp_dir("cargo-low-disk-error");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["--no-cache", "cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_TEST_FREE_DISK_BYTES", "error")
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run soldr cargo build with disk-probe error");
+
+    assert!(
+        output.status.success(),
+        "disk-space detection failure must not fail build\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("disk space is low"),
+        "disk-space probe failure should not emit low-disk warning: {stderr}"
     );
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -172,25 +172,32 @@ soldr version --json
 
 ### `soldr gc`
 
-Reclaim stale Cargo `target/` directories tracked in
-`~/.soldr/data.db`. Implemented by issue #234. The wrapper-mode hot
-path upserts each invocation's resolved workspace `target/` path with
-the current timestamp; `soldr gc` walks the registry, drops missing
-rows, applies safety guards, and (with confirmation) deletes the
-matching directories.
+Review reclaimable Cargo `target/` directories tracked in
+`~/.soldr/data.db`. Implemented by issue #234 and made safe-by-default
+by issue #289. The wrapper-mode hot path upserts each invocation's
+resolved workspace `target/` path with the current timestamp; `soldr gc`
+walks the registry, drops missing rows, applies safety guards, and
+prints an info summary without prompting or deleting anything.
 
 ```bash
-soldr gc                                     # interactive, y/N per dir
-soldr gc --dry-run                            # list candidates only
-soldr gc --all                                # delete every eligible candidate
-soldr gc --older-than 30d --larger-than 1GB   # tunable thresholds
-soldr gc --json                               # machine-readable report
+soldr gc                                      # info summary only
+soldr gc --json                               # machine-readable summary
+soldr gc --older-than 30d --larger-than 1GB   # summary with tunable filters
+soldr gc purge                                # interactive deletion flow
+soldr gc purge --all                          # delete every eligible candidate
+soldr gc purge --older-than 30d --larger-than 1GB
+soldr gc purge --json                         # machine-readable purge report
 ```
 
 Defaults:
 
 - `--older-than 10d`
 - `--larger-than 256M`
+
+Compatibility:
+
+- `soldr gc --dry-run` is accepted as a temporary alias for `soldr gc`
+- `soldr gc --all` is rejected with a pointer to `soldr gc purge --all`
 
 Safety guards (from `docs/TARGET_GC_PROPOSAL.md`):
 
@@ -199,6 +206,10 @@ Safety guards (from `docs/TARGET_GC_PROPOSAL.md`):
 - skip a candidate whose `target/.cargo-lock` exists (active build)
 - only consider paths under `gc.allowlist_roots` (default: `~/dev`)
 
+The summary includes the registry path, eligible candidate count, total
+reclaimable size, skipped/dropped counts, and the largest eligible
+target directories with size and last-used age.
+
 Configure additional allowlist roots via `~/.soldr/config.toml`:
 
 ```toml
@@ -206,8 +217,11 @@ Configure additional allowlist roots via `~/.soldr/config.toml`:
 allowlist_roots = ["~/dev", "/work/repos"]
 ```
 
-A passive once-per-day startup warning is also emitted on the
-dispatch path when stale candidates exist.
+During build-like `soldr cargo ...` invocations, soldr checks free
+space on the relevant target/current filesystem before spawning Cargo.
+When less than 2 GB is available, it emits a yellow stderr warning that
+recommends `soldr gc`. Disk-space detection failures are ignored so they
+never fail the build.
 
 ---
 
@@ -261,7 +275,7 @@ Commands:
   config   Show or set configuration
   cache    Inspect the compilation cache
   version  Show version
-  gc       Reclaim stale Cargo target/ directories (issue #234)
+  gc       Review reclaimable Cargo target/ directories; use gc purge to delete
 ```
 
 ---


### PR DESCRIPTION
Closes #289.

## Summary
- Make `soldr gc` a non-destructive summary command with human and JSON reclaimable-space reports.
- Add `soldr gc purge` for destructive cleanup, including `--all`, threshold filters, and JSON reporting.
- Emit a yellow low-disk warning from the `soldr cargo ...` front door for build-like commands when free space is below 2 GB.
- Update `docs/API.md` and add CLI/unit integration coverage for the new command split and warning behavior.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test -p soldr-cli --bin soldr gc_cli_parses_summary_and_purge_modes`
- [x] `cargo test -p soldr-cli --bin soldr low_disk`
- [x] `cargo test -p soldr-cli --test cli gc_`
- [x] `cargo test -p soldr-cli --test cli cargo_build_warns_when_disk_space_is_low`
- [x] `cargo test -p soldr-cli --test cli cargo_build_ignores_disk_space_detection_failures`
- [x] `cargo test -p soldr-cache gc`
- [x] `cargo test -p soldr-cli`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo clippy --workspace --all-targets -- -D warnings`

Note: plain `cargo clippy ...` on this machine resolves an MSVC `clippy-driver` while the checkout builds with the GNU host toolchain, so the clippy gate was run through the explicit GNU toolchain.