### PR TITLE
feat(gc): queue target purges asynchronously

### DIFF
--- a/crates/soldr-cache/src/gc.rs
+++ b/crates/soldr-cache/src/gc.rs
@@ -12,9 +12,12 @@ use crate::target_registry::{
     DEFAULT_STALE_AGE_SECONDS, DEFAULT_STALE_SIZE_BYTES,
 };
 use std::{
+    io::Write,
     path::{Path, PathBuf},
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
+
+const GC_LOG_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
 
 #[derive(Debug, Clone)]
 pub struct GcOptions {
@@ -57,6 +60,29 @@ pub struct GcReport {
     /// Number of registry rows whose path didn't exist on disk and
     /// were quietly dropped.
     pub dropped_missing: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct GcDeleteOutcome {
+    pub candidate: GcCandidate,
+    pub removed: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GcPurgeFailure {
+    pub candidate: GcCandidate,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GcPurgeSummary {
+    pub selected_count: usize,
+    pub succeeded_count: usize,
+    pub failed_count: usize,
+    pub reclaimed_bytes: u64,
+    pub deleted_paths: Vec<PathBuf>,
+    pub failures: Vec<GcPurgeFailure>,
 }
 
 /// Pure scan: walk the registry, drop missing rows, apply thresholds
@@ -156,11 +182,131 @@ pub fn purge_one(
         return Ok(false);
     }
     let result = std::fs::remove_dir_all(path);
-    let _ = registry.remove(path);
     match result {
-        Ok(_) => Ok(true),
+        Ok(_) => {
+            let _ = registry.remove(path);
+            Ok(true)
+        }
         Err(e) => Err(RegistryError::Io(e)),
     }
+}
+
+pub fn delete_candidate_dir(candidate: GcCandidate) -> GcDeleteOutcome {
+    if !candidate.path.exists() {
+        return GcDeleteOutcome {
+            candidate,
+            removed: false,
+            error: None,
+        };
+    }
+
+    match std::fs::remove_dir_all(&candidate.path) {
+        Ok(()) => GcDeleteOutcome {
+            candidate,
+            removed: true,
+            error: None,
+        },
+        Err(e) => GcDeleteOutcome {
+            candidate,
+            removed: false,
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+pub fn apply_purge_outcomes(
+    registry: &TargetRegistry,
+    outcomes: Vec<GcDeleteOutcome>,
+) -> Result<GcPurgeSummary, RegistryError> {
+    let mut summary = GcPurgeSummary {
+        selected_count: outcomes.len(),
+        ..GcPurgeSummary::default()
+    };
+
+    for outcome in outcomes {
+        if let Some(error) = outcome.error {
+            summary.failed_count += 1;
+            summary.failures.push(GcPurgeFailure {
+                candidate: outcome.candidate,
+                error,
+            });
+            continue;
+        }
+
+        let _ = registry.remove(&outcome.candidate.path)?;
+        summary.succeeded_count += 1;
+        if outcome.removed {
+            summary.reclaimed_bytes = summary
+                .reclaimed_bytes
+                .saturating_add(outcome.candidate.size_bytes);
+            summary.deleted_paths.push(outcome.candidate.path);
+        }
+    }
+
+    Ok(summary)
+}
+
+pub fn cleanup_old_gc_logs(log_dir: &Path) -> Result<usize, RegistryError> {
+    cleanup_old_gc_logs_with_retention(log_dir, GC_LOG_RETENTION)
+}
+
+pub fn cleanup_old_gc_logs_with_retention(
+    log_dir: &Path,
+    retention: Duration,
+) -> Result<usize, RegistryError> {
+    let entries = match std::fs::read_dir(log_dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(e.into()),
+    };
+    let now = SystemTime::now();
+    let mut removed = 0;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
+        };
+        if !metadata.is_file() {
+            continue;
+        }
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+        let age = now.duration_since(modified).unwrap_or(Duration::ZERO);
+        if age > retention {
+            std::fs::remove_file(&path)?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+pub fn write_gc_error_log(
+    log_dir: &Path,
+    args: &[String],
+    failures: &[GcPurgeFailure],
+) -> Result<PathBuf, RegistryError> {
+    std::fs::create_dir_all(log_dir)?;
+    let now = current_unix_seconds()?;
+    let path = log_dir.join(format!("gc-error-{now}-{}.log", std::process::id()));
+    let mut file = std::fs::File::create(&path)?;
+
+    writeln!(file, "timestamp_unix={now}")?;
+    writeln!(file, "command_args={args:?}")?;
+    writeln!(file, "failure_count={}", failures.len())?;
+    writeln!(file)?;
+
+    for failure in failures {
+        writeln!(file, "path={}", failure.candidate.path.display())?;
+        writeln!(file, "size_bytes={}", failure.candidate.size_bytes)?;
+        writeln!(file, "age_seconds={}", failure.candidate.age_seconds)?;
+        writeln!(file, "error={}", failure.error)?;
+        writeln!(file)?;
+    }
+
+    Ok(path)
 }
 
 /// Information for the once-per-day startup warning. Returns `None`
@@ -365,6 +511,100 @@ mod tests {
         assert!(removed);
         assert!(!target.exists());
         assert!(registry.get(&target).unwrap().is_none());
+    }
+
+    #[test]
+    fn purge_outcomes_remove_only_successful_rows() {
+        let dir = tempdir().unwrap();
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let (_, ok_target) = make_workspace(dir.path(), "ok", 256);
+        let (_, failed_target) = make_workspace(dir.path(), "failed", 512);
+        registry.upsert_with_time(&ok_target, 100).unwrap();
+        registry.upsert_with_time(&failed_target, 100).unwrap();
+
+        let ok_candidate = GcCandidate {
+            path: ok_target.clone(),
+            size_bytes: 256,
+            age_seconds: 1000,
+            eligible: true,
+            reason: None,
+        };
+        let failed_candidate = GcCandidate {
+            path: failed_target.clone(),
+            size_bytes: 512,
+            age_seconds: 1000,
+            eligible: true,
+            reason: None,
+        };
+        let summary = apply_purge_outcomes(
+            &registry,
+            vec![
+                GcDeleteOutcome {
+                    candidate: ok_candidate,
+                    removed: true,
+                    error: None,
+                },
+                GcDeleteOutcome {
+                    candidate: failed_candidate,
+                    removed: false,
+                    error: Some("permission denied".to_string()),
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(summary.selected_count, 2);
+        assert_eq!(summary.succeeded_count, 1);
+        assert_eq!(summary.failed_count, 1);
+        assert_eq!(summary.reclaimed_bytes, 256);
+        assert!(registry.get(&ok_target).unwrap().is_none());
+        assert!(registry.get(&failed_target).unwrap().is_some());
+    }
+
+    #[test]
+    fn gc_error_log_includes_failure_details() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("repo").join("target");
+        let failure = GcPurgeFailure {
+            candidate: GcCandidate {
+                path: target.clone(),
+                size_bytes: 1024,
+                age_seconds: 42,
+                eligible: true,
+                reason: None,
+            },
+            error: "permission denied".to_string(),
+        };
+
+        let log_path = write_gc_error_log(
+            dir.path(),
+            &["soldr".to_string(), "gc".to_string(), "purge".to_string()],
+            &[failure],
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(log_path).unwrap();
+
+        assert!(raw.contains("command_args="));
+        assert!(raw.contains(&target.display().to_string()));
+        assert!(raw.contains("size_bytes=1024"));
+        assert!(raw.contains("permission denied"));
+    }
+
+    #[test]
+    fn gc_log_cleanup_removes_entries_past_retention() {
+        let dir = tempdir().unwrap();
+        let stale = dir.path().join("stale.log");
+        let fresh = dir.path().join("fresh.log");
+        std::fs::write(&stale, b"old").unwrap();
+        std::thread::sleep(Duration::from_millis(30));
+        std::fs::write(&fresh, b"new").unwrap();
+
+        let removed = cleanup_old_gc_logs_with_retention(dir.path(), Duration::from_millis(15))
+            .expect("cleanup old logs");
+
+        assert_eq!(removed, 1);
+        assert!(!stale.exists());
+        assert!(fresh.exists());
     }
 
     #[test]

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -24,6 +24,11 @@ pub fn gc_warning_marker_path(paths: &SoldrPaths) -> PathBuf {
     paths.root.join(".gc_warning_marker")
 }
 
+/// Directory for root-scoped GC error logs.
+pub fn gc_log_dir(paths: &SoldrPaths) -> PathBuf {
+    paths.root.join("logs").join("gc")
+}
+
 /// Environment variable used to carry cache enable/disable state from the
 /// front-door cargo command into child processes.
 pub const CACHE_ENABLED_ENV_VAR: &str = "SOLDR_CACHE_ENABLED";

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -4,6 +4,9 @@ use sha2::{Digest, Sha256};
 use soldr_core::{SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 use std::collections::BTreeSet;
+use std::io::Write;
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::Duration;
 
 mod linker;
 
@@ -2851,10 +2854,19 @@ struct GcOutput {
     skipped: Vec<GcCandidateOutput>,
     dropped_missing: usize,
     deleted_paths: Vec<String>,
+    selected_count: usize,
+    succeeded_count: usize,
+    failed_count: usize,
+    reclaimed_bytes: u64,
+    reclaimed_human: String,
+    error_log_path: Option<String>,
 }
 
 fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
-    use soldr_cache::gc::{parse_duration, parse_size, purge_one, scan, GcOptions};
+    use soldr_cache::gc::{
+        cleanup_old_gc_logs, parse_duration, parse_size, scan, write_gc_error_log, GcOptions,
+        GcPurgeSummary,
+    };
 
     let older_than = parse_duration(&invocation.older_than).map_err(SoldrError::Other)?;
     let larger_than = parse_size(&invocation.larger_than).map_err(SoldrError::Other)?;
@@ -2869,6 +2881,9 @@ fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
     let db_path = soldr_cache::data_db_path(&paths);
     let registry = soldr_cache::target_registry::TargetRegistry::open(&db_path)
         .map_err(|e| SoldrError::Other(format!("failed to open soldr registry: {e}")))?;
+    let gc_log_dir = soldr_cache::gc_log_dir(&paths);
+    cleanup_old_gc_logs(&gc_log_dir)
+        .map_err(|e| SoldrError::Other(format!("failed to clean old gc logs: {e}")))?;
 
     let options = GcOptions {
         older_than_seconds: older_than,
@@ -2882,6 +2897,8 @@ fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
     let total_reclaimable_bytes = gc_total_reclaimable_bytes(&report.candidates);
 
     let mut deleted_paths: Vec<String> = Vec::new();
+    let mut purge_summary = GcPurgeSummary::default();
+    let mut error_log_path: Option<std::path::PathBuf> = None;
 
     if is_summary {
         if !invocation.json {
@@ -2892,39 +2909,21 @@ fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
     }
 
     if !is_summary {
-        for cand in &report.candidates {
-            let should_delete = if purge_all {
-                true
-            } else {
-                prompt_yes_no(&format!(
-                    "soldr gc: delete {} ({}, age {}) ? [y/N] ",
-                    cand.path.display(),
-                    soldr_cache::target_registry::human_size(cand.size_bytes),
-                    soldr_cache::target_registry::human_age(cand.age_seconds),
-                ))
-            };
-
-            if should_delete {
-                match purge_one(&registry, &cand.path, false) {
-                    Ok(true) => {
-                        if !invocation.json {
-                            eprintln!("soldr gc: deleted {}", cand.path.display());
-                        }
-                        deleted_paths.push(cand.path.display().to_string());
-                    }
-                    Ok(false) => {
-                        if !invocation.json {
-                            eprintln!(
-                                "soldr gc: nothing to delete at {} (already gone)",
-                                cand.path.display()
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("soldr gc: failed to delete {}: {e}", cand.path.display());
-                    }
-                }
-            }
+        purge_summary =
+            run_gc_purge_candidates(&registry, &report.candidates, purge_all, invocation.json)?;
+        deleted_paths = purge_summary
+            .deleted_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        if !purge_summary.failures.is_empty() {
+            let args = std::env::args().collect::<Vec<_>>();
+            let path = write_gc_error_log(&gc_log_dir, &args, &purge_summary.failures)
+                .map_err(|e| SoldrError::Other(format!("failed to write gc error log: {e}")))?;
+            error_log_path = Some(path);
+        }
+        if !invocation.json {
+            print_gc_purge_result(&purge_summary, error_log_path.as_deref());
         }
     }
 
@@ -2957,10 +2956,118 @@ fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
                 .collect(),
             dropped_missing: report.dropped_missing,
             deleted_paths,
+            selected_count: purge_summary.selected_count,
+            succeeded_count: purge_summary.succeeded_count,
+            failed_count: purge_summary.failed_count,
+            reclaimed_bytes: purge_summary.reclaimed_bytes,
+            reclaimed_human: soldr_cache::target_registry::human_size(
+                purge_summary.reclaimed_bytes,
+            ),
+            error_log_path: error_log_path.map(|p| p.display().to_string()),
         };
         print_json(&output)?;
     }
     Ok(())
+}
+
+fn run_gc_purge_candidates(
+    registry: &soldr_cache::target_registry::TargetRegistry,
+    candidates: &[soldr_cache::gc::GcCandidate],
+    purge_all: bool,
+    json: bool,
+) -> Result<soldr_cache::gc::GcPurgeSummary, SoldrError> {
+    let worker_count = gc_purge_worker_count();
+    let (job_tx, job_rx) = mpsc::channel::<soldr_cache::gc::GcCandidate>();
+    let (result_tx, result_rx) = mpsc::channel();
+    let job_rx = Arc::new(Mutex::new(job_rx));
+    let mut workers = Vec::new();
+    for idx in 0..worker_count {
+        let job_rx = Arc::clone(&job_rx);
+        let result_tx = result_tx.clone();
+        let builder = std::thread::Builder::new().name(format!("soldr-gc-{idx}"));
+        workers.push(
+            builder
+                .spawn(move || loop {
+                    let next = {
+                        let rx = job_rx.lock().expect("gc worker channel poisoned");
+                        rx.recv()
+                    };
+                    match next {
+                        Ok(candidate) => {
+                            let _ =
+                                result_tx.send(soldr_cache::gc::delete_candidate_dir(candidate));
+                        }
+                        Err(_) => break,
+                    }
+                })
+                .map_err(|e| SoldrError::Other(format!("failed to start gc worker: {e}")))?,
+        );
+    }
+    drop(result_tx);
+
+    let mut selected_count = 0usize;
+    let mut completed_count = 0usize;
+    let mut outcomes = Vec::new();
+
+    for cand in candidates {
+        let should_delete = purge_all || prompt_gc_purge_candidate(cand);
+        if !should_delete {
+            continue;
+        }
+
+        selected_count += 1;
+        job_tx
+            .send(cand.clone())
+            .map_err(|e| SoldrError::Other(format!("failed to queue gc delete: {e}")))?;
+    }
+    drop(job_tx);
+
+    while completed_count < selected_count {
+        match result_rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(outcome) => {
+                completed_count += 1;
+                outcomes.push(outcome);
+                if !json {
+                    print_gc_purge_progress(completed_count, selected_count);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if !json {
+                    print_gc_purge_progress(completed_count, selected_count);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    for worker in workers {
+        worker
+            .join()
+            .map_err(|_| SoldrError::Other("gc worker panicked".to_string()))?;
+    }
+
+    if !json && selected_count > 0 {
+        eprintln!();
+    }
+
+    soldr_cache::gc::apply_purge_outcomes(registry, outcomes)
+        .map_err(|e| SoldrError::Other(format!("failed to update gc registry: {e}")))
+}
+
+fn gc_purge_worker_count() -> usize {
+    let available = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    gc_purge_worker_count_for(available)
+}
+
+fn gc_purge_worker_count_for(available_parallelism: usize) -> usize {
+    available_parallelism.clamp(1, 4)
+}
+
+fn print_gc_purge_progress(completed: usize, selected: usize) {
+    eprint!("\rsoldr gc purge: deleting selected targets {completed}/{selected}");
+    let _ = std::io::stderr().flush();
 }
 
 fn gc_total_reclaimable_bytes(candidates: &[soldr_cache::gc::GcCandidate]) -> u64 {
@@ -3035,6 +3142,25 @@ fn print_gc_purge_scan(
     }
 }
 
+fn print_gc_purge_result(
+    summary: &soldr_cache::gc::GcPurgeSummary,
+    error_log_path: Option<&std::path::Path>,
+) {
+    eprintln!(
+        "soldr gc purge: selected {}; succeeded {}; failed {}; reclaimed {}",
+        summary.selected_count,
+        summary.succeeded_count,
+        summary.failed_count,
+        soldr_cache::target_registry::human_size(summary.reclaimed_bytes)
+    );
+    if let Some(path) = error_log_path {
+        eprintln!(
+            "soldr gc purge: detailed deletion errors written to {}",
+            path.display()
+        );
+    }
+}
+
 fn gc_largest_candidates(
     candidates: &[soldr_cache::gc::GcCandidate],
     limit: usize,
@@ -3061,7 +3187,16 @@ fn gc_candidate_output(c: soldr_cache::gc::GcCandidate) -> GcCandidateOutput {
     }
 }
 
-fn prompt_yes_no(prompt: &str) -> bool {
+fn prompt_gc_purge_candidate(cand: &soldr_cache::gc::GcCandidate) -> bool {
+    prompt_yes_no_default_yes(&format!(
+        "soldr gc: delete {} ({}, age {}) ? [Y/n] ",
+        cand.path.display(),
+        soldr_cache::target_registry::human_size(cand.size_bytes),
+        soldr_cache::target_registry::human_age(cand.age_seconds),
+    ))
+}
+
+fn prompt_yes_no_default_yes(prompt: &str) -> bool {
     use std::io::{BufRead, Write};
     eprint!("{prompt}");
     let _ = std::io::stderr().flush();
@@ -3070,7 +3205,11 @@ fn prompt_yes_no(prompt: &str) -> bool {
     if stdin.lock().read_line(&mut line).is_err() {
         return false;
     }
-    matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+    parse_gc_purge_answer(&line)
+}
+
+fn parse_gc_purge_answer(input: &str) -> bool {
+    matches!(input.trim().to_ascii_lowercase().as_str(), "" | "y" | "yes")
 }
 
 /// Resolve the configured `gc.allowlist_roots`, falling back to
@@ -3633,16 +3772,17 @@ mod tests {
         cargo_args_specify_target, cargo_args_use_reserved_no_cache,
         cargo_metadata_passthrough_args, cargo_profile, cargo_target_triple,
         compute_plan_inputs_hash, dropped_artifact_classes, evaluate_warm_restore_skip,
-        extract_as_pin, first_cargo_subcommand, is_sccache_wrapper,
+        extract_as_pin, first_cargo_subcommand, gc_purge_worker_count_for, is_sccache_wrapper,
         low_disk_warning_for_free_bytes, low_disk_warning_for_path, normalize_version,
-        parse_rust_artifact_cache_tar_threads, parse_tool_spec, resolve_bundle_walk_thread_count,
-        rustc_wrapper_mode_from_env_var, rustup_resolution_failure, selected_cargo_args,
-        should_skip_warm_restore, should_trampoline, stderr_indicates_unknown_session,
-        walk_bundle_files, warm_restore_sentinel_path, warm_restore_skip_enabled,
-        write_thin_manifest, write_warm_restore_sentinel, CargoMetadata, CargoMetadataPackage, Cli,
-        Commands, GcSubcommand, RustArtifactPlan, RustArtifactPlanContext, RustPlanInputs,
-        RustPlanPackages, RustToolchainIdentity, RustcWrapperMode, ThinSliceManifest,
-        WarmRestoreSentinel, WarmRestoreSkipInputs, ZccacheBuildSession, BUNDLE_WALK_THREAD_CAP,
+        parse_gc_purge_answer, parse_rust_artifact_cache_tar_threads, parse_tool_spec,
+        resolve_bundle_walk_thread_count, rustc_wrapper_mode_from_env_var,
+        rustup_resolution_failure, selected_cargo_args, should_skip_warm_restore,
+        should_trampoline, stderr_indicates_unknown_session, walk_bundle_files,
+        warm_restore_sentinel_path, warm_restore_skip_enabled, write_thin_manifest,
+        write_warm_restore_sentinel, CargoMetadata, CargoMetadataPackage, Cli, Commands,
+        GcSubcommand, RustArtifactPlan, RustArtifactPlanContext, RustPlanInputs, RustPlanPackages,
+        RustToolchainIdentity, RustcWrapperMode, ThinSliceManifest, WarmRestoreSentinel,
+        WarmRestoreSkipInputs, ZccacheBuildSession, BUNDLE_WALK_THREAD_CAP,
         LOW_DISK_WARNING_THRESHOLD_BYTES, SKIP_WARM_RESTORE_ENV_VAR, THIN_MANIFEST_FILENAME,
         WARM_RESTORE_MAX_AGE_SECONDS,
     };
@@ -3731,6 +3871,24 @@ mod tests {
             }
             _ => panic!("expected gc purge command"),
         }
+    }
+
+    #[test]
+    fn gc_purge_prompt_defaults_enter_to_yes() {
+        for input in ["", "\n", "y", "Y", "yes", " YES "] {
+            assert!(parse_gc_purge_answer(input), "expected {input:?} to accept");
+        }
+        for input in ["n", "no", "anything else"] {
+            assert!(!parse_gc_purge_answer(input), "expected {input:?} to skip");
+        }
+    }
+
+    #[test]
+    fn gc_purge_worker_count_is_bounded() {
+        assert_eq!(gc_purge_worker_count_for(0), 1);
+        assert_eq!(gc_purge_worker_count_for(1), 1);
+        assert_eq!(gc_purge_worker_count_for(2), 2);
+        assert_eq!(gc_purge_worker_count_for(16), 4);
     }
 
     #[test]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use std::io::Write;
 use std::process::Command;
 use std::{
     fs,
@@ -38,6 +39,28 @@ fn seed_gc_candidate(cache_root: &Path, label: &str) -> PathBuf {
     let target = workspace.join("target");
     fs::create_dir_all(&target).expect("failed to create target dir");
     fs::write(target.join("artifact.bin"), b"reclaim me").expect("failed to seed target file");
+    fs::write(
+        cache_root.join("config.toml"),
+        format!("[gc]\nallowlist_roots = [\"{}\"]\n", toml_string(&dev_root)),
+    )
+    .expect("failed to write gc config");
+
+    let registry = soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("data.db"))
+        .expect("failed to open target registry");
+    let now = soldr_cache::target_registry::current_unix_seconds()
+        .expect("failed to get current unix seconds");
+    registry
+        .upsert_with_time(&target, now - 120)
+        .expect("failed to seed target registry");
+    target
+}
+
+fn seed_gc_file_candidate(cache_root: &Path, label: &str) -> PathBuf {
+    let dev_root = cache_root.join("dev-root");
+    let workspace = dev_root.join(label);
+    fs::create_dir_all(&workspace).expect("failed to create workspace dir");
+    let target = workspace.join("target");
+    fs::write(&target, b"not a directory").expect("failed to seed target file");
     fs::write(
         cache_root.join("config.toml"),
         format!("[gc]\nallowlist_roots = [\"{}\"]\n", toml_string(&dev_root)),
@@ -743,6 +766,101 @@ fn gc_purge_all_deletes_candidates_without_prompt() {
         !target.exists(),
         "soldr gc purge --all should delete {}",
         target.display()
+    );
+}
+
+#[test]
+fn gc_purge_enter_accepts_candidate() {
+    let cache_root = unique_temp_dir("gc-purge-enter");
+    let target = seed_gc_candidate(&cache_root, "purge-enter-project");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "purge", "--older-than", "1s", "--larger-than", "1B"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn soldr gc purge");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin should be piped")
+        .write_all(b"\n")
+        .expect("failed to accept prompt");
+    let output = child
+        .wait_with_output()
+        .expect("failed to wait for soldr gc purge");
+
+    assert!(
+        output.status.success(),
+        "gc purge interactive failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !target.exists(),
+        "Enter should accept and delete {}",
+        target.display()
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[Y/n]"),
+        "prompt should advertise default yes: {stderr}"
+    );
+    assert!(
+        stderr.contains("selected 1; succeeded 1; failed 0"),
+        "final summary should include aggregate counts: {stderr}"
+    );
+}
+
+#[test]
+fn gc_purge_all_json_reports_error_log_path_and_keeps_failed_row() {
+    let cache_root = unique_temp_dir("gc-purge-json-failure");
+    let target = seed_gc_file_candidate(&cache_root, "purge-json-failure-project");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "gc",
+            "purge",
+            "--all",
+            "--json",
+            "--older-than",
+            "1s",
+            "--larger-than",
+            "1B",
+        ])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr gc purge --all --json");
+
+    assert!(
+        output.status.success(),
+        "gc purge --all --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gc purge --json must be JSON");
+    assert_eq!(json["mode"], "purge");
+    assert_eq!(json["selected_count"], 1);
+    assert_eq!(json["succeeded_count"], 0);
+    assert_eq!(json["failed_count"], 1);
+    let log_path = PathBuf::from(
+        json["error_log_path"]
+            .as_str()
+            .expect("failure JSON should include error log path"),
+    );
+    assert!(
+        log_path.exists(),
+        "missing gc error log {}",
+        log_path.display()
+    );
+
+    let registry = soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("data.db"))
+        .expect("failed to open target registry");
+    assert!(
+        registry.get(&target).unwrap().is_some(),
+        "failed deletion row should remain retryable"
     );
 }
 


### PR DESCRIPTION
Closes #288.

## Summary
- Replays the async GC purge implementation from the stacked #292 branch onto current `main`, since #292 merged into `feat/gc-low-disk-summary` after that branch had already landed on `main`.
- Queues interactive `soldr gc purge` selections immediately, with Enter/`y` accepting and `n` skipping.
- Runs selected target deletions through a bounded worker pool, applies registry removals serially only for successful deletions, and keeps failed rows retryable.
- Adds purge aggregation, final-only JSON fields, root-scoped GC error logs, and one-day GC log cleanup.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test -p soldr-cache gc`
- [x] `cargo test -p soldr-cli --test cli gc_`
- [x] `cargo test -p soldr-cli --bin soldr gc_`
- [x] `cargo test -p soldr-cli --bin soldr low_disk`
- [x] `rustup run 1.94.1-x86_64-pc-windows-gnu cargo clippy -p soldr-cache -p soldr-cli --all-targets -- -D warnings`