### PR TITLE
chore: update zccache and suppress Windows child consoles

### DIFF
--- a/crates/soldr-cli/src/linker.rs
+++ b/crates/soldr-cli/src/linker.rs
@@ -11,7 +11,7 @@
 //! and `CARGO_TARGET_*_RUSTFLAGS` via the env hash, so no separate
 //! invalidation hook is required.
 
-use soldr_core::SoldrError;
+use soldr_core::{suppress_windows_console_window, SoldrError};
 use std::ffi::OsStr;
 use std::str::FromStr;
 
@@ -179,7 +179,10 @@ pub fn resolve_for_target_with_probe(
 /// Probe whether `mold` is on `PATH`. Best-effort: any failure (missing
 /// binary, non-zero exit, IO error) returns `false`.
 fn mold_on_path() -> bool {
-    match std::process::Command::new("mold").arg("--version").output() {
+    let mut command = std::process::Command::new("mold");
+    command.arg("--version");
+    suppress_windows_console_window(&mut command);
+    match command.output() {
         Ok(out) => out.status.success(),
         Err(_) => false,
     }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use soldr_core::{SoldrError, SoldrPaths};
+use soldr_core::{suppress_windows_console_window, SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 use std::collections::BTreeSet;
 use std::io::Write;
@@ -393,9 +393,10 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 eprintln!("soldr: downloaded {crate_name} v{}", result.version);
             }
 
-            let status = std::process::Command::new(&result.binary_path)
-                .args(tool_args)
-                .status()?;
+            let mut command = std::process::Command::new(&result.binary_path);
+            command.args(tool_args);
+            suppress_windows_console_window(&mut command);
+            let status = command.status()?;
 
             std::process::exit(status.code().unwrap_or(1));
         }
@@ -505,6 +506,7 @@ async fn run_trampoline(version: &str, args: &[String]) -> Result<i32, SoldrErro
     command
         .args(args)
         .env(SOLDR_TRAMPOLINING_ENV_VAR, env!("CARGO_PKG_VERSION"));
+    suppress_windows_console_window(&mut command);
 
     #[cfg(unix)]
     {
@@ -582,6 +584,7 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     let mut command = std::process::Command::new(tool_path);
     command.args(&raw_args[2..]);
     apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
     let status = command.status()?;
 
     Ok(status.code().unwrap_or(1))
@@ -593,6 +596,7 @@ fn run_toolchain_passthrough(tool: &str, args: &[String]) -> Result<i32, SoldrEr
     let mut command = std::process::Command::new(binary);
     command.args(args);
     apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
     let status = command.status()?;
     Ok(status.code().unwrap_or(1))
 }
@@ -603,6 +607,7 @@ fn run_wrapper_through_zccache(
 ) -> Result<i32, SoldrError> {
     let mut command = std::process::Command::new(zccache);
     command.args(&raw_args[1..]);
+    suppress_windows_console_window(&mut command);
 
     // Cargo's jobserver lives on numbered file descriptors that it inherits
     // into the RUSTC_WRAPPER, advertised via CARGO_MAKEFLAGS. On Unix,
@@ -655,6 +660,7 @@ fn run_wrapper_through_zccache_windows(
     let mut command = std::process::Command::new(zccache);
     command.args(&raw_args[1..]);
     command.stderr(Stdio::piped());
+    suppress_windows_console_window(&mut command);
 
     let mut child = command.spawn()?;
     let stderr = child
@@ -713,6 +719,7 @@ fn run_wrapper_through_zccache_windows(
     let mut retry = std::process::Command::new(zccache);
     retry.args(&raw_args[1..]);
     retry.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &new_session_id);
+    suppress_windows_console_window(&mut retry);
     let retry_status = retry.status()?;
     Ok(retry_status.code().unwrap_or(1))
 }
@@ -816,6 +823,7 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     let mut command = std::process::Command::new(&cargo);
     command.args(args);
     apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
     // soldr cargo is the top of the invocation tree, so any inherited
     // MAKEFLAGS/CARGO_MAKEFLAGS points at jobserver fds that aren't open in
     // our process. Stripping them lets cargo start a fresh jobserver instead
@@ -1380,6 +1388,7 @@ fn cargo_metadata(cargo: &std::path::Path, args: &[String]) -> Result<CargoMetad
     command.args(["metadata", "--format-version", "1"]);
     command.args(cargo_metadata_passthrough_args(args));
     apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
     command.env_remove("MAKEFLAGS");
     command.env_remove("CARGO_MAKEFLAGS");
 
@@ -1466,6 +1475,7 @@ fn tool_output(tool: &std::path::Path, args: &[&str]) -> Result<String, SoldrErr
     let mut command = std::process::Command::new(tool);
     command.args(args);
     apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
     let output = command.output()?;
     if !output.status.success() {
         return Err(SoldrError::Other(format!(
@@ -2478,6 +2488,7 @@ fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf, SoldrError
     let mut command = std::process::Command::new(rustup_binary());
     command.args(["which", tool]);
     apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
     let output = command.output();
 
     match output {
@@ -3649,6 +3660,7 @@ fn run_zccache_command_raw_with_env(
     for &(name, value) in envs {
         command.env(name, value);
     }
+    suppress_windows_console_window(&mut command);
     Ok(command.output()?)
 }
 
@@ -3662,6 +3674,7 @@ fn run_zccache_command_raw_strings_with_env(
     for &(name, value) in envs {
         command.env(name, value);
     }
+    suppress_windows_console_window(&mut command);
     Ok(command.output()?)
 }
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -2290,7 +2290,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.4.5");
+    assert_eq!(json["managed_zccache_version"], "1.4.6");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -2412,7 +2412,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.4.5");
+    assert_eq!(json["managed_zccache_version"], "1.4.6");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -378,6 +378,18 @@ pub fn apply_implicit_toolchain_homes(command: &mut Command, start_dir: Option<&
     ImplicitToolchainHomes::detect(start_dir).apply_to_command(command);
 }
 
+pub fn suppress_windows_console_window(command: &mut Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    #[cfg(not(windows))]
+    let _ = command;
+}
+
 pub fn probe_toolchain_binary(tool: &str, start_dir: Option<&Path>) -> Option<PathBuf> {
     if rustup_toolchain_env_is_explicit(std::env::var_os(RUSTUP_TOOLCHAIN_ENV_VAR).as_deref()) {
         return None;
@@ -395,6 +407,7 @@ fn detect_runtime_rustc_triple(start_dir: Option<&Path>) -> Option<String> {
     let rustc = resolve_runtime_rustc(start_dir)?;
     let mut command = std::process::Command::new(rustc);
     apply_implicit_toolchain_homes(&mut command, start_dir);
+    suppress_windows_console_window(&mut command);
     if let Some(start_dir) = start_dir {
         command.current_dir(start_dir);
     }
@@ -418,6 +431,7 @@ fn resolve_runtime_rustc(start_dir: Option<&Path>) -> Option<PathBuf> {
 
     let mut rustup = std::process::Command::new("rustup");
     apply_implicit_toolchain_homes(&mut rustup, start_dir);
+    suppress_windows_console_window(&mut rustup);
     if let Some(start_dir) = start_dir {
         rustup.current_dir(start_dir);
     }
@@ -995,6 +1009,36 @@ mod tests {
 
         assert_eq!(resolve_runtime_rustc(None), Some(rustc));
         assert_rustup_not_invoked(&log_path);
+    }
+
+    #[test]
+    fn suppress_windows_console_window_preserves_piped_output() {
+        #[cfg(windows)]
+        let mut command = {
+            let mut command = Command::new("cmd");
+            command.args(["/C", "echo soldr-no-window"]);
+            command
+        };
+
+        #[cfg(not(windows))]
+        let mut command = {
+            let mut command = Command::new("sh");
+            command.args(["-c", "printf soldr-no-window"]);
+            command
+        };
+
+        suppress_windows_console_window(&mut command);
+        let output = command.output().expect("failed to run child command");
+        assert!(
+            output.status.success(),
+            "child command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("soldr-no-window"),
+            "missing expected stdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
     }
 
     #[test]

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -15,7 +15,9 @@ pub use trust::{
     CHECKSUMS_FILE_ENV_VAR, TRUST_MODE_ENV_VAR,
 };
 
-use soldr_core::{Arch, Env, Os, SoldrError, SoldrPaths, TargetTriple};
+use soldr_core::{
+    suppress_windows_console_window, Arch, Env, Os, SoldrError, SoldrPaths, TargetTriple,
+};
 use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
@@ -45,7 +47,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.5";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.6";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),
@@ -232,7 +234,8 @@ fn install_zccache_from_crates_io(
         let mut backoff = MANAGED_ZCCACHE_INSTALL_INITIAL_BACKOFF;
         let mut attempt = 1u32;
         loop {
-            let install_status = std::process::Command::new("cargo")
+            let mut command = std::process::Command::new("cargo");
+            command
                 .args([
                     "install",
                     package_name,
@@ -247,13 +250,13 @@ fn install_zccache_from_crates_io(
                 // Strip stale jobserver env so the nested cargo doesn't try
                 // to attach to fds it cannot see (see soldr #283).
                 .env_remove("MAKEFLAGS")
-                .env_remove("CARGO_MAKEFLAGS")
-                .status()
-                .map_err(|e| {
-                    SoldrError::Other(format!(
-                        "failed to invoke cargo install for managed zccache package {package_name}: {e}"
-                    ))
-                })?;
+                .env_remove("CARGO_MAKEFLAGS");
+            suppress_windows_console_window(&mut command);
+            let install_status = command.status().map_err(|e| {
+                SoldrError::Other(format!(
+                    "failed to invoke cargo install for managed zccache package {package_name}: {e}"
+                ))
+            })?;
 
             if install_status.success() {
                 break;


### PR DESCRIPTION
## Summary

- update the managed zccache pin from 1.4.5 to 1.4.6
- add a shared Windows child-process helper that applies CREATE_NO_WINDOW
- apply the helper to soldr-owned cargo/rustup/tool/zccache/trampoline/fallback install process launches
- add a regression test that the no-window helper preserves piped stdout

## Verification

- soldr cargo fmt --all --check
- soldr cargo test -p soldr-core suppress_windows_console_window_preserves_piped_output
- soldr cargo test -p soldr-fetch
- soldr cargo test -p soldr-cli --no-run
- soldr cargo test -p soldr-cli --test cli status_json_reports_stable_machine_fields
- soldr cargo test -p soldr-cli --test cli cache_json_reports_managed_zccache_status
- soldr cargo test -p soldr-cli --test cli_unknown_session_retry
- manual Windows descendant-process probe returned no-console