### PR TITLE
Default Cargo debug info off with redb state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,18 +20,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,18 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,15 +556,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -601,15 +568,6 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "heck"
@@ -938,17 +896,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -1285,6 +1232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,20 +1308,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]
@@ -1590,7 +1532,7 @@ name = "soldr-cache"
 version = "0.7.18"
 dependencies = [
  "blake3",
- "rusqlite",
+ "redb",
  "serde",
  "serde_json",
  "soldr-core",
@@ -1613,6 +1555,7 @@ dependencies = [
  "soldr-fetch",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2032,12 +1975,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 [workspace.package]
 version = "0.7.18"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.94.1"
 license = "BSD-3-Clause"
 repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
@@ -36,5 +36,5 @@ zip = "2"
 flate2 = "1"
 tar = "0.4"
 toml = "0.8"
-rusqlite = { version = "0.31", features = ["bundled"] }
+redb = "4.1.0"
 rayon = "1"

--- a/crates/soldr-cache/Cargo.toml
+++ b/crates/soldr-cache/Cargo.toml
@@ -14,7 +14,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tempfile = { workspace = true }
-rusqlite = { workspace = true }
+redb = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -11,12 +11,18 @@ use std::{
 };
 
 pub mod gc;
+pub mod state_db;
 pub mod target_registry;
 
-/// Path to the soldr state database (`~/.soldr/data.db`) used by the
-/// target-directory registry and any future state tables.
+/// Path to the soldr state database (`~/.soldr/state.redb`) used by the
+/// target-directory registry.
 pub fn data_db_path(paths: &SoldrPaths) -> PathBuf {
     paths.root.join(target_registry::DATA_DB_FILE)
+}
+
+/// Path to the redb-backed soldr state database (`~/.soldr/state.redb`).
+pub fn state_db_path(paths: &SoldrPaths) -> PathBuf {
+    paths.root.join(state_db::STATE_DB_FILE)
 }
 
 /// Throttle marker for the once-per-day stale-target startup warning.

--- a/crates/soldr-cache/src/state_db.rs
+++ b/crates/soldr-cache/src/state_db.rs
@@ -1,0 +1,207 @@
+//! Redb-backed persistent state for soldr.
+//!
+//! New state that is not relational can land here without growing ad-hoc
+//! marker files under `~/.soldr/`.
+
+#[cfg(test)]
+use redb::ReadableDatabase;
+#[cfg(test)]
+use redb::ReadableTableMetadata;
+use redb::{Database, ReadableTable, TableDefinition};
+use std::{
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+use thiserror::Error;
+
+/// Default redb file name under `~/.soldr/`.
+pub const STATE_DB_FILE: &str = "state.redb";
+
+/// Keep warning rows for recently used repositories. Active repositories refresh
+/// their timestamp on every soldr cargo invocation, so only old/inactive rows
+/// are eligible for cleanup.
+pub const CARGO_DEBUG_WARNING_TTL_SECONDS: u64 = 180 * 24 * 60 * 60;
+
+/// At most one cleanup pass per day.
+pub const CARGO_DEBUG_WARNING_CLEANUP_INTERVAL_SECONDS: u64 = 24 * 60 * 60;
+
+const CARGO_DEBUG_WARNING_REPOS: TableDefinition<&str, u64> =
+    TableDefinition::new("cargo_debug_default_warning_repos");
+const META: TableDefinition<&str, u64> = TableDefinition::new("meta");
+const CARGO_DEBUG_WARNING_LAST_CLEANUP_KEY: &str = "cargo_debug_default_warning_last_cleanup";
+
+#[derive(Debug, Error)]
+pub enum StateDbError {
+    #[error("redb database error: {0}")]
+    Database(#[from] redb::DatabaseError),
+    #[error("redb transaction error: {0}")]
+    Transaction(#[from] redb::TransactionError),
+    #[error("redb table error: {0}")]
+    Table(#[from] redb::TableError),
+    #[error("redb storage error: {0}")]
+    Storage(#[from] redb::StorageError),
+    #[error("redb commit error: {0}")]
+    Commit(#[from] redb::CommitError),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("system clock before unix epoch: {0}")]
+    Clock(String),
+}
+
+pub struct StateDb {
+    db: Database,
+}
+
+impl StateDb {
+    /// Open or create the redb state database. Parent directories are created
+    /// automatically.
+    pub fn open(path: &Path) -> Result<Self, StateDbError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let db = Database::builder().create(path)?;
+        Ok(Self { db })
+    }
+
+    /// Returns true only for the first time a repository path is observed
+    /// before it ages out of the state DB.
+    pub fn should_emit_cargo_debug_default_warning(
+        &self,
+        repo_path: &Path,
+    ) -> Result<bool, StateDbError> {
+        self.should_emit_cargo_debug_default_warning_with_time(repo_path, current_unix_seconds()?)
+    }
+
+    pub fn should_emit_cargo_debug_default_warning_with_time(
+        &self,
+        repo_path: &Path,
+        unix_seconds: u64,
+    ) -> Result<bool, StateDbError> {
+        let key = path_key(repo_path);
+        let write_txn = self.db.begin_write()?;
+
+        let should_emit = {
+            let mut table = write_txn.open_table(CARGO_DEBUG_WARNING_REPOS)?;
+            let existed = table.get(key.as_str())?.is_some();
+            table.insert(key.as_str(), &unix_seconds)?;
+            !existed
+        };
+
+        cleanup_cargo_debug_warnings_if_due(&write_txn, unix_seconds)?;
+        write_txn.commit()?;
+
+        Ok(should_emit)
+    }
+
+    #[cfg(test)]
+    fn cargo_debug_warning_repo_count(&self) -> Result<u64, StateDbError> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(CARGO_DEBUG_WARNING_REPOS)?;
+        Ok(table.len()?)
+    }
+}
+
+fn cleanup_cargo_debug_warnings_if_due(
+    write_txn: &redb::WriteTransaction,
+    unix_seconds: u64,
+) -> Result<(), StateDbError> {
+    let cleanup_due = {
+        let mut meta = write_txn.open_table(META)?;
+        let last_cleanup = meta
+            .get(CARGO_DEBUG_WARNING_LAST_CLEANUP_KEY)?
+            .map(|value| value.value())
+            .unwrap_or(0);
+        let due = last_cleanup == 0
+            || unix_seconds.saturating_sub(last_cleanup)
+                >= CARGO_DEBUG_WARNING_CLEANUP_INTERVAL_SECONDS;
+        if due {
+            meta.insert(CARGO_DEBUG_WARNING_LAST_CLEANUP_KEY, &unix_seconds)?;
+        }
+        due
+    };
+
+    if !cleanup_due {
+        return Ok(());
+    }
+
+    let cutoff = unix_seconds.saturating_sub(CARGO_DEBUG_WARNING_TTL_SECONDS);
+    let mut table = write_txn.open_table(CARGO_DEBUG_WARNING_REPOS)?;
+    let stale_keys = {
+        let mut keys = Vec::new();
+        for row in table.iter()? {
+            let (key, last_seen) = row?;
+            if last_seen.value() < cutoff {
+                keys.push(key.value().to_string());
+            }
+        }
+        keys
+    };
+    for key in stale_keys {
+        table.remove(key.as_str())?;
+    }
+
+    Ok(())
+}
+
+fn current_unix_seconds() -> Result<u64, StateDbError> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| StateDbError::Clock(e.to_string()))?;
+    Ok(duration.as_secs())
+}
+
+fn path_key(path: &Path) -> String {
+    let normalized: PathBuf = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let mut key = normalized.to_string_lossy().replace('\\', "/");
+    #[cfg(windows)]
+    {
+        key = key.to_ascii_lowercase();
+    }
+    key
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cargo_debug_warning_is_once_per_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let db = StateDb::open(&dir.path().join("state.redb")).unwrap();
+
+        assert!(db
+            .should_emit_cargo_debug_default_warning_with_time(&repo, 10)
+            .unwrap());
+        assert!(!db
+            .should_emit_cargo_debug_default_warning_with_time(&repo, 11)
+            .unwrap());
+        assert_eq!(db.cargo_debug_warning_repo_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn cargo_debug_warning_cleanup_removes_old_inactive_repos() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale_repo = dir.path().join("stale");
+        let active_repo = dir.path().join("active");
+        std::fs::create_dir_all(&stale_repo).unwrap();
+        std::fs::create_dir_all(&active_repo).unwrap();
+        let db = StateDb::open(&dir.path().join("state.redb")).unwrap();
+
+        assert!(db
+            .should_emit_cargo_debug_default_warning_with_time(&stale_repo, 1)
+            .unwrap());
+
+        let later =
+            CARGO_DEBUG_WARNING_TTL_SECONDS + CARGO_DEBUG_WARNING_CLEANUP_INTERVAL_SECONDS + 10;
+        assert!(db
+            .should_emit_cargo_debug_default_warning_with_time(&active_repo, later)
+            .unwrap());
+
+        assert_eq!(db.cargo_debug_warning_repo_count().unwrap(), 1);
+        assert!(!db
+            .should_emit_cargo_debug_default_warning_with_time(&active_repo, later + 1)
+            .unwrap());
+    }
+}

--- a/crates/soldr-cache/src/target_registry.rs
+++ b/crates/soldr-cache/src/target_registry.rs
@@ -1,22 +1,24 @@
-//! Sqlite-backed registry of observed Cargo `target/` directories.
+//! Redb-backed registry of observed Cargo `target/` directories.
 //!
 //! Implements the data plane for issue #234: every `RUSTC_WRAPPER`
 //! invocation upserts the resolved workspace `target/` path with the
 //! current unix timestamp. The `soldr gc` command later scans the
 //! registry to find stale candidates for reclamation.
 //!
-//! The store lives at `~/.soldr/data.db` and is intentionally generic:
-//! future state can land in additional tables without renaming.
+//! The store lives in `~/.soldr/state.redb` alongside other soldr state.
 
-use rusqlite::{params, Connection, OptionalExtension};
+use redb::{
+    backends::InMemoryBackend, Database, ReadableDatabase, ReadableTable, ReadableTableMetadata,
+    TableDefinition,
+};
 use std::{
     path::{Path, PathBuf},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
 
 /// Default file name for the soldr state database under `~/.soldr/`.
-pub const DATA_DB_FILE: &str = "data.db";
+pub const DATA_DB_FILE: &str = crate::state_db::STATE_DB_FILE;
 
 /// Default staleness threshold (10 days) used by `soldr gc` and the
 /// startup warning.
@@ -26,12 +28,20 @@ pub const DEFAULT_STALE_AGE_SECONDS: u64 = 10 * 24 * 60 * 60;
 /// startup warning.
 pub const DEFAULT_STALE_SIZE_BYTES: u64 = 256 * 1024 * 1024;
 
-const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+const TARGETS: TableDefinition<&str, i64> = TableDefinition::new("target_registry_targets");
 
 #[derive(Debug, Error)]
 pub enum RegistryError {
-    #[error("sqlite error: {0}")]
-    Sqlite(#[from] rusqlite::Error),
+    #[error("redb database error: {0}")]
+    Database(#[from] redb::DatabaseError),
+    #[error("redb transaction error: {0}")]
+    Transaction(#[from] redb::TransactionError),
+    #[error("redb table error: {0}")]
+    Table(#[from] redb::TableError),
+    #[error("redb storage error: {0}")]
+    Storage(#[from] redb::StorageError),
+    #[error("redb commit error: {0}")]
+    Commit(#[from] redb::CommitError),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("system clock before unix epoch: {0}")]
@@ -46,10 +56,10 @@ pub struct TargetRow {
     pub last_used: i64,
 }
 
-/// Sqlite registry backed by `~/.soldr/data.db` (or a caller-provided
-/// path). The schema is the minimal v1 table from issue #234.
+/// Redb registry backed by `~/.soldr/state.redb` (or a caller-provided
+/// path).
 pub struct TargetRegistry {
-    conn: Connection,
+    db: Database,
 }
 
 impl TargetRegistry {
@@ -59,24 +69,25 @@ impl TargetRegistry {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let conn = Connection::open(path)?;
-        configure_file_connection(&conn)?;
-        Self::init_schema(&conn)?;
-        Ok(Self { conn })
+        let db = Database::builder().create(path)?;
+        Self::init_schema(&db)?;
+        Ok(Self { db })
     }
 
     /// Open an in-memory database. Useful for tests and for callers
     /// that want a registry without touching disk.
     pub fn open_in_memory() -> Result<Self, RegistryError> {
-        let conn = Connection::open_in_memory()?;
-        Self::init_schema(&conn)?;
-        Ok(Self { conn })
+        let db = Database::builder().create_with_backend(InMemoryBackend::new())?;
+        Self::init_schema(&db)?;
+        Ok(Self { db })
     }
 
-    fn init_schema(conn: &Connection) -> Result<(), RegistryError> {
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS targets (\n  id          INTEGER PRIMARY KEY AUTOINCREMENT,\n  path        TEXT NOT NULL UNIQUE,\n  last_used   INTEGER NOT NULL\n);",
-        )?;
+    fn init_schema(db: &Database) -> Result<(), RegistryError> {
+        let write_txn = db.begin_write()?;
+        {
+            let _table = write_txn.open_table(TARGETS)?;
+        }
+        write_txn.commit()?;
         Ok(())
     }
 
@@ -84,10 +95,12 @@ impl TargetRegistry {
     /// timestamp.
     pub fn upsert_with_time(&self, path: &Path, unix_seconds: i64) -> Result<(), RegistryError> {
         let path_str = path_to_string(path);
-        self.conn.execute(
-            "INSERT INTO targets (path, last_used) VALUES (?1, ?2) ON CONFLICT(path) DO UPDATE SET last_used = excluded.last_used",
-            params![path_str, unix_seconds],
-        )?;
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(TARGETS)?;
+            table.insert(path_str.as_str(), &unix_seconds)?;
+        }
+        write_txn.commit()?;
         Ok(())
     }
 
@@ -98,72 +111,62 @@ impl TargetRegistry {
 
     /// Return all tracked rows, ordered by `last_used` ascending.
     pub fn list(&self) -> Result<Vec<TargetRow>, RegistryError> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT path, last_used FROM targets ORDER BY last_used ASC")?;
-        let rows = stmt
-            .query_map([], |row| {
-                let path: String = row.get(0)?;
-                let last_used: i64 = row.get(1)?;
-                Ok(TargetRow {
-                    path: PathBuf::from(path),
-                    last_used,
-                })
-            })?
-            .collect::<Result<Vec<_>, _>>()?;
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(TARGETS)?;
+        let mut rows = Vec::new();
+        for row in table.iter()? {
+            let (path, last_used) = row?;
+            rows.push(TargetRow {
+                path: PathBuf::from(path.value()),
+                last_used: last_used.value(),
+            });
+        }
+        rows.sort_by(|a, b| {
+            a.last_used
+                .cmp(&b.last_used)
+                .then_with(|| a.path.cmp(&b.path))
+        });
         Ok(rows)
     }
 
     /// Look up a single tracked row by path, if present.
     pub fn get(&self, path: &Path) -> Result<Option<TargetRow>, RegistryError> {
         let path_str = path_to_string(path);
-        let row = self
-            .conn
-            .query_row(
-                "SELECT path, last_used FROM targets WHERE path = ?1",
-                params![path_str],
-                |row| {
-                    let path: String = row.get(0)?;
-                    let last_used: i64 = row.get(1)?;
-                    Ok(TargetRow {
-                        path: PathBuf::from(path),
-                        last_used,
-                    })
-                },
-            )
-            .optional()?;
-        Ok(row)
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(TARGETS)?;
+        let Some(last_used) = table.get(path_str.as_str())? else {
+            return Ok(None);
+        };
+        Ok(Some(TargetRow {
+            path: PathBuf::from(path_str),
+            last_used: last_used.value(),
+        }))
     }
 
     /// Remove the row for `path`. No-op if it doesn't exist.
     pub fn remove(&self, path: &Path) -> Result<bool, RegistryError> {
         let path_str = path_to_string(path);
-        let removed = self
-            .conn
-            .execute("DELETE FROM targets WHERE path = ?1", params![path_str])?;
-        Ok(removed > 0)
+        let write_txn = self.db.begin_write()?;
+        let removed = {
+            let mut table = write_txn.open_table(TARGETS)?;
+            let old = table.remove(path_str.as_str())?;
+            old.is_some()
+        };
+        write_txn.commit()?;
+        Ok(removed)
     }
 
     /// Total number of tracked rows.
     pub fn len(&self) -> Result<usize, RegistryError> {
-        let count: i64 = self
-            .conn
-            .query_row("SELECT COUNT(*) FROM targets", [], |row| row.get(0))?;
-        Ok(count as usize)
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(TARGETS)?;
+        Ok(table.len()? as usize)
     }
 
     /// Whether the registry has any rows.
     pub fn is_empty(&self) -> Result<bool, RegistryError> {
         Ok(self.len()? == 0)
     }
-}
-
-fn configure_file_connection(conn: &Connection) -> Result<(), RegistryError> {
-    conn.busy_timeout(SQLITE_BUSY_TIMEOUT)?;
-    let _: String = conn
-        .query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))
-        .unwrap_or_default();
-    Ok(())
 }
 
 /// Human-readable byte size, kibibyte-based (e.g. `12.3 GB`).
@@ -455,7 +458,7 @@ mod tests {
     #[test]
     fn open_persists_to_disk() {
         let dir = tempdir().unwrap();
-        let db_path = dir.path().join("data.db");
+        let db_path = dir.path().join("state.redb");
         {
             let registry = TargetRegistry::open(&db_path).unwrap();
             registry
@@ -471,67 +474,15 @@ mod tests {
     }
 
     #[test]
-    fn open_configures_file_registry_for_concurrent_access() {
-        let dir = tempdir().unwrap();
-        let db_path = dir.path().join("data.db");
-        let registry = TargetRegistry::open(&db_path).unwrap();
-
-        let busy_timeout_ms: i64 = registry
-            .conn
-            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+    fn open_in_memory_uses_isolated_redb_backend() {
+        let first = TargetRegistry::open_in_memory().unwrap();
+        let second = TargetRegistry::open_in_memory().unwrap();
+        first
+            .upsert_with_time(Path::new("/tmp/first/target"), 10)
             .unwrap();
-        assert_eq!(busy_timeout_ms, 2_000);
 
-        let journal_mode: String = registry
-            .conn
-            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
-            .unwrap();
-        assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
-    }
-
-    #[test]
-    fn file_registry_waits_for_brief_concurrent_writer() {
-        let dir = tempdir().unwrap();
-        let db_path = dir.path().join("data.db");
-        let first_path = PathBuf::from("/tmp/concurrent-a/target");
-        let second_path = PathBuf::from("/tmp/concurrent-b/target");
-        let ready = std::sync::Arc::new(std::sync::Barrier::new(2));
-        let (locked_tx, locked_rx) = std::sync::mpsc::channel();
-
-        let writer = std::thread::spawn({
-            let db_path = db_path.clone();
-            let first_path = first_path.clone();
-            let ready = std::sync::Arc::clone(&ready);
-            move || {
-                let registry = TargetRegistry::open(&db_path).unwrap();
-                ready.wait();
-                registry.conn.execute_batch("BEGIN IMMEDIATE;").unwrap();
-                locked_tx.send(()).unwrap();
-                std::thread::sleep(Duration::from_millis(100));
-                registry.upsert_with_time(&first_path, 10).unwrap();
-                registry.conn.execute_batch("COMMIT;").unwrap();
-            }
-        });
-
-        let contender = std::thread::spawn({
-            let db_path = db_path.clone();
-            let second_path = second_path.clone();
-            let ready = std::sync::Arc::clone(&ready);
-            move || {
-                let registry = TargetRegistry::open(&db_path).unwrap();
-                ready.wait();
-                locked_rx.recv().unwrap();
-                registry.upsert_with_time(&second_path, 20).unwrap();
-            }
-        });
-
-        writer.join().unwrap();
-        contender.join().unwrap();
-
-        let registry = TargetRegistry::open(&db_path).unwrap();
-        assert_eq!(registry.len().unwrap(), 2);
-        assert_eq!(registry.get(&first_path).unwrap().unwrap().last_used, 10);
-        assert_eq!(registry.get(&second_path).unwrap().unwrap().last_used, 20);
+        assert_eq!(first.len().unwrap(), 1);
+        assert!(second.is_empty().unwrap());
     }
 
     #[test]

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rayon = { workspace = true }
 fs2 = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -18,6 +18,8 @@ const TEST_FREE_DISK_BYTES_ENV_VAR: &str = "SOLDR_TEST_FREE_DISK_BYTES";
 const JSON_SCHEMA_VERSION: u32 = 1;
 const LOW_DISK_WARNING_THRESHOLD_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const RUSTC_WRAPPER_OVERRIDE_ENV_VAR: &str = "SOLDR_RUSTC_WRAPPER";
+const CARGO_PROFILE_DEV_DEBUG_ENV_VAR: &str = "CARGO_PROFILE_DEV_DEBUG";
+const CARGO_PROFILE_TEST_DEBUG_ENV_VAR: &str = "CARGO_PROFILE_TEST_DEBUG";
 /// Picks the linker injected for `soldr cargo ...` builds. See `linker` module
 /// and `docs/API.md` for the supported values (`default | ld | mold | rust-lld
 /// | fast`).
@@ -152,7 +154,7 @@ enum Commands {
         json: bool,
     },
     /// Review reclaimable Cargo `target/` directories tracked by
-    /// the soldr registry (`~/.soldr/data.db`).
+    /// the soldr registry (`~/.soldr/state.redb`).
     ///
     /// Aliases: `purge-targets` (matches issue #234's `soldr --purge`
     /// wording).
@@ -559,7 +561,7 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
         .unwrap_or(tool_arg);
 
     // Per-build target/ tracking for `soldr gc`. Best-effort: if we
-    // can't resolve a workspace target dir cheaply, or the sqlite
+    // can't resolve a workspace target dir cheaply, or the redb
     // upsert fails for any reason, skip silently — never fail a build.
     if tool_stem == "rustc" {
         record_target_dir_in_registry(&raw_args[2..]);
@@ -833,6 +835,11 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     command.env("RUSTC", &rustc);
     let build_like_cargo = cargo_args_are_cacheable(args);
     let cache_enabled_for_cargo = cache_enabled && build_like_cargo;
+    let cargo_profile_debug_default = if build_like_cargo {
+        maybe_apply_cargo_profile_debug_default(&mut command, args, &paths)?
+    } else {
+        None
+    };
 
     command.env(
         soldr_cache::CACHE_ENABLED_ENV_VAR,
@@ -861,7 +868,13 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
     };
 
     let rust_plan = if let Some(session) = session.as_ref() {
-        maybe_prepare_rust_artifact_plan(&cargo, &rustc, args, session)?
+        maybe_prepare_rust_artifact_plan(
+            &cargo,
+            &rustc,
+            args,
+            session,
+            cargo_profile_debug_default.as_ref(),
+        )?
     } else {
         None
     };
@@ -1003,6 +1016,7 @@ fn maybe_prepare_rust_artifact_plan(
     rustc: &std::path::Path,
     args: &[String],
     session: &ZccacheBuildSession,
+    cargo_profile_debug_default: Option<&CargoProfileDebugDefault>,
 ) -> Result<Option<RustArtifactPlanContext>, SoldrError> {
     let Some(mode) = rust_artifact_cache_mode_from_env()? else {
         return Ok(None);
@@ -1027,7 +1041,15 @@ fn maybe_prepare_rust_artifact_plan(
 
     let metadata = cargo_metadata(cargo, args)?;
     let toolchain = rust_toolchain_identity(cargo, rustc)?;
-    let plan = build_rust_artifact_plan(&metadata, &toolchain, args, &mode, profile, session)?;
+    let plan = build_rust_artifact_plan(
+        &metadata,
+        &toolchain,
+        args,
+        &mode,
+        profile,
+        session,
+        cargo_profile_debug_default,
+    )?;
     let plan_dir = session.cache_dir.join("plans");
     std::fs::create_dir_all(&plan_dir)?;
     let plan_path = plan_dir.join("last-rust-artifact-plan.json");
@@ -1495,6 +1517,7 @@ fn build_rust_artifact_plan(
     mode: &str,
     cache_profile: Option<&'static str>,
     session: &ZccacheBuildSession,
+    cargo_profile_debug_default: Option<&CargoProfileDebugDefault>,
 ) -> Result<RustArtifactPlan, SoldrError> {
     let workspace_root = normalize_path_for_compare(&metadata.workspace_root)?;
     let target_dir = normalize_path_for_compare(&metadata.target_directory)?;
@@ -1547,7 +1570,7 @@ fn build_rust_artifact_plan(
         inputs: RustPlanInputs {
             features_hash: stable_hash_json(&cargo_feature_inputs(args)),
             rustflags_hash: stable_hash_json(&rustflags_inputs()),
-            env_hash: stable_hash_json(&build_env_inputs()),
+            env_hash: stable_hash_json(&build_env_inputs(cargo_profile_debug_default)),
             lockfile_hash: file_hash_or_missing(&workspace_root.join("Cargo.lock"))?,
             cargo_config_hash: cargo_config_hash(&workspace_root)?,
             manifest_hashes: workspace_manifest_hashes(&workspace_root)?,
@@ -2037,13 +2060,22 @@ fn rustflags_inputs() -> Vec<(String, String)> {
     })
 }
 
-fn build_env_inputs() -> Vec<(String, String)> {
-    sorted_env_vars(|name| {
+fn build_env_inputs(
+    cargo_profile_debug_default: Option<&CargoProfileDebugDefault>,
+) -> Vec<(String, String)> {
+    let mut vars = sorted_env_vars(|name| {
         name == "CARGO_BUILD_TARGET"
             || name == "CARGO_TARGET_DIR"
             || name.starts_with("CARGO_PROFILE_")
             || name.starts_with("CARGO_CFG_")
-    })
+    });
+    if let Some(default) = cargo_profile_debug_default {
+        if !vars.iter().any(|(name, _)| name == default.env_var) {
+            vars.push((default.env_var.to_string(), "false".to_string()));
+        }
+        vars.sort_by(|a, b| a.0.cmp(&b.0));
+    }
+    vars
 }
 
 fn sorted_env_vars<F>(include: F) -> Vec<(String, String)>
@@ -2138,6 +2170,393 @@ fn default_cargo_build_target(args: &[String]) -> Result<Option<String>, SoldrEr
     }
 
     Ok(Some(soldr_core::TargetTriple::detect()?.triple()))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CargoProfileDebugDefault {
+    profile: &'static str,
+    env_var: &'static str,
+}
+
+impl CargoProfileDebugDefault {
+    fn for_profile(profile: &str) -> Option<Self> {
+        match profile {
+            "dev" | "debug" => Some(Self {
+                profile: "dev",
+                env_var: CARGO_PROFILE_DEV_DEBUG_ENV_VAR,
+            }),
+            "test" => Some(Self {
+                profile: "test",
+                env_var: CARGO_PROFILE_TEST_DEBUG_ENV_VAR,
+            }),
+            _ => None,
+        }
+    }
+
+    fn lookup_profiles(self) -> &'static [&'static str] {
+        match self.profile {
+            "test" => &["test", "dev"],
+            _ => &["dev"],
+        }
+    }
+}
+
+fn maybe_apply_cargo_profile_debug_default(
+    command: &mut std::process::Command,
+    args: &[String],
+    paths: &SoldrPaths,
+) -> Result<Option<CargoProfileDebugDefault>, SoldrError> {
+    let Some(default) = cargo_profile_debug_default_for_args(args) else {
+        return Ok(None);
+    };
+    if cargo_profile_debug_is_specified(args, default)? {
+        return Ok(None);
+    }
+
+    command.env(default.env_var, "false");
+    let repo_path = cargo_debug_warning_repo_path(args);
+    if should_emit_cargo_debug_default_warning(paths, &repo_path) {
+        eprintln!(
+            "soldr: warning: Cargo profile.{}.debug is unspecified for {}; setting {}=false for this invocation. Add `debug = true` or `debug = false` under `[profile.{}]` in Cargo.toml or .cargo/config.toml to make this explicit.",
+            default.profile,
+            repo_path.display(),
+            default.env_var,
+            default.profile
+        );
+    }
+
+    Ok(Some(default))
+}
+
+fn cargo_profile_debug_default_for_args(args: &[String]) -> Option<CargoProfileDebugDefault> {
+    let subcommand = first_cargo_subcommand(args)?;
+
+    if subcommand == "nextest" {
+        return if cargo_args_contain_release(args) {
+            None
+        } else {
+            CargoProfileDebugDefault::for_profile("test")
+        };
+    }
+
+    if cargo_args_contain_release(args) {
+        return None;
+    }
+
+    if let Some(profile) = cargo_profile_arg_value(args) {
+        return CargoProfileDebugDefault::for_profile(&profile);
+    }
+
+    match subcommand {
+        "t" | "test" => CargoProfileDebugDefault::for_profile("test"),
+        "install" if cargo_install_args_contain_debug(args) => {
+            CargoProfileDebugDefault::for_profile("dev")
+        }
+        "install" | "bench" => None,
+        "b" | "build" | "c" | "check" | "d" | "doc" | "r" | "run" | "rustc" | "clippy" | "fix" => {
+            CargoProfileDebugDefault::for_profile("dev")
+        }
+        _ => None,
+    }
+}
+
+fn cargo_profile_debug_is_specified(
+    args: &[String],
+    default: CargoProfileDebugDefault,
+) -> Result<bool, SoldrError> {
+    let profiles = default.lookup_profiles();
+    if profiles.iter().any(|profile| {
+        cargo_profile_debug_env_var(profile)
+            .is_some_and(|env_var| std::env::var_os(env_var).is_some())
+    }) {
+        return Ok(true);
+    }
+
+    if cargo_config_args_specify_profile_debug(args, profiles)? {
+        return Ok(true);
+    }
+
+    let start_dir = cargo_profile_lookup_start_dir(args)?;
+    if cargo_manifest_specifies_profile_debug(&start_dir, profiles) {
+        return Ok(true);
+    }
+    if cargo_config_files_specify_profile_debug(&start_dir, profiles) {
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+fn cargo_profile_debug_env_var(profile: &str) -> Option<&'static str> {
+    match profile {
+        "dev" => Some(CARGO_PROFILE_DEV_DEBUG_ENV_VAR),
+        "test" => Some(CARGO_PROFILE_TEST_DEBUG_ENV_VAR),
+        _ => None,
+    }
+}
+
+fn cargo_args_contain_release(args: &[String]) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| arg == "--release")
+}
+
+fn cargo_profile_arg_value(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--profile" {
+            return iter.next().cloned();
+        }
+        if let Some(value) = arg.strip_prefix("--profile=") {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn cargo_install_args_contain_debug(args: &[String]) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| arg == "--debug")
+}
+
+fn cargo_config_args_specify_profile_debug(
+    args: &[String],
+    profiles: &[&str],
+) -> Result<bool, SoldrError> {
+    let cwd = std::env::current_dir()?;
+    for value in cargo_config_arg_values(args) {
+        if cargo_config_arg_specifies_profile_debug(&value, &cwd, profiles) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn cargo_config_arg_values(args: &[String]) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--config" {
+            if let Some(value) = iter.next() {
+                values.push(value.clone());
+            }
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--config=") {
+            values.push(value.to_string());
+        }
+    }
+    values
+}
+
+fn cargo_config_arg_specifies_profile_debug(
+    value: &str,
+    cwd: &std::path::Path,
+    profiles: &[&str],
+) -> bool {
+    let raw = value.trim();
+    if raw.is_empty() {
+        return false;
+    }
+
+    let path = std::path::Path::new(raw);
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    if path.is_file() {
+        return toml_file_specifies_profile_debug(&path, profiles);
+    }
+
+    toml_text_specifies_profile_debug(raw, profiles)
+        .unwrap_or_else(|| raw_may_specify_profile_debug(raw, profiles))
+}
+
+fn raw_may_specify_profile_debug(raw: &str, profiles: &[&str]) -> bool {
+    let lowered = raw.to_ascii_lowercase();
+    profiles.iter().any(|profile| {
+        lowered.contains(&format!("profile.{profile}.debug"))
+            || (lowered.contains(&format!("[profile.{profile}]")) && lowered.contains("debug"))
+    })
+}
+
+fn cargo_manifest_specifies_profile_debug(start_dir: &std::path::Path, profiles: &[&str]) -> bool {
+    find_workspace_manifest_path(start_dir)
+        .is_some_and(|manifest| toml_file_specifies_profile_debug(&manifest, profiles))
+}
+
+fn cargo_config_files_specify_profile_debug(
+    start_dir: &std::path::Path,
+    profiles: &[&str],
+) -> bool {
+    cargo_config_paths(start_dir)
+        .iter()
+        .any(|path| toml_file_specifies_profile_debug(path, profiles))
+}
+
+fn cargo_config_paths(start_dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut paths = BTreeSet::new();
+    let mut current = Some(start_dir.to_path_buf());
+    while let Some(dir) = current {
+        for relative in [".cargo/config.toml", ".cargo/config"] {
+            let path = dir.join(relative);
+            if path.is_file() {
+                paths.insert(path);
+            }
+        }
+        current = dir.parent().map(std::path::Path::to_path_buf);
+    }
+
+    if let Some(cargo_home) = cargo_home_dir_for_config() {
+        for name in ["config.toml", "config"] {
+            let path = cargo_home.join(name);
+            if path.is_file() {
+                paths.insert(path);
+            }
+        }
+    }
+
+    paths.into_iter().collect()
+}
+
+fn cargo_home_dir_for_config() -> Option<std::path::PathBuf> {
+    std::env::var_os(soldr_core::CARGO_HOME_ENV_VAR)
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            soldr_core::user_home_dir()
+                .ok()
+                .map(|home| home.join(".cargo"))
+        })
+}
+
+fn toml_file_specifies_profile_debug(path: &std::path::Path, profiles: &[&str]) -> bool {
+    match std::fs::read_to_string(path) {
+        Ok(text) => toml_text_specifies_profile_debug(&text, profiles).unwrap_or(true),
+        Err(_) => true,
+    }
+}
+
+fn toml_text_specifies_profile_debug(text: &str, profiles: &[&str]) -> Option<bool> {
+    let value: toml::Value = text.parse().ok()?;
+    let Some(profile_table) = value.get("profile") else {
+        return Some(false);
+    };
+    Some(profiles.iter().any(|profile| {
+        profile_table
+            .get(*profile)
+            .and_then(|section| section.get("debug"))
+            .is_some()
+    }))
+}
+
+fn cargo_profile_lookup_start_dir(args: &[String]) -> Result<std::path::PathBuf, SoldrError> {
+    let cwd = std::env::current_dir()?;
+    let Some(manifest_path) = cargo_manifest_path_arg(args) else {
+        return Ok(cwd);
+    };
+    let manifest_path = if manifest_path.is_absolute() {
+        manifest_path
+    } else {
+        cwd.join(manifest_path)
+    };
+    let parent = manifest_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or(cwd);
+    Ok(parent)
+}
+
+fn cargo_manifest_path_arg(args: &[String]) -> Option<std::path::PathBuf> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--manifest-path" {
+            return iter.next().map(std::path::PathBuf::from);
+        }
+        if let Some(value) = arg.strip_prefix("--manifest-path=") {
+            return Some(std::path::PathBuf::from(value));
+        }
+    }
+    None
+}
+
+fn find_workspace_manifest_path(start_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let mut current = start_dir.to_path_buf();
+    let mut nearest_manifest = None;
+    let mut workspace_manifest = None;
+
+    loop {
+        let candidate = current.join("Cargo.toml");
+        if candidate.is_file() {
+            if nearest_manifest.is_none() {
+                nearest_manifest = Some(candidate.clone());
+            }
+            if cargo_manifest_declares_workspace(&candidate) {
+                workspace_manifest = Some(candidate);
+            }
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+
+    workspace_manifest.or(nearest_manifest)
+}
+
+fn cargo_manifest_declares_workspace(path: &std::path::Path) -> bool {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(value) = text.parse::<toml::Value>() else {
+        return false;
+    };
+    value.get("workspace").is_some()
+}
+
+fn cargo_debug_warning_repo_path(args: &[String]) -> std::path::PathBuf {
+    let start_dir = cargo_profile_lookup_start_dir(args)
+        .or_else(|_| std::env::current_dir().map_err(SoldrError::from))
+        .unwrap_or_else(|_| std::path::PathBuf::from("."));
+    find_git_root(&start_dir)
+        .or_else(|| {
+            find_workspace_manifest_path(&start_dir)
+                .and_then(|manifest| manifest.parent().map(std::path::Path::to_path_buf))
+        })
+        .unwrap_or(start_dir)
+}
+
+fn find_git_root(start_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let mut current = start_dir.to_path_buf();
+    loop {
+        if current.join(".git").exists() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+fn should_emit_cargo_debug_default_warning(
+    paths: &SoldrPaths,
+    repo_path: &std::path::Path,
+) -> bool {
+    let db_path = soldr_cache::state_db_path(paths);
+    soldr_cache::state_db::StateDb::open(&db_path)
+        .and_then(|db| db.should_emit_cargo_debug_default_warning(repo_path))
+        .unwrap_or(true)
 }
 
 /// Apply the `SOLDR_LINKER` / `config.toml linker = ...` override (issue
@@ -4093,6 +4512,7 @@ mod tests {
             "thin",
             Some("thin-v1"),
             &session,
+            None,
         )
         .expect("build rust artifact plan");
 
@@ -4278,6 +4698,7 @@ mod tests {
             "thin",
             Some("thin-v2"),
             &session,
+            None,
         )
         .expect("build rust artifact plan");
 

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -45,8 +45,9 @@ fn seed_gc_candidate(cache_root: &Path, label: &str) -> PathBuf {
     )
     .expect("failed to write gc config");
 
-    let registry = soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("data.db"))
-        .expect("failed to open target registry");
+    let registry =
+        soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("state.redb"))
+            .expect("failed to open target registry");
     let now = soldr_cache::target_registry::current_unix_seconds()
         .expect("failed to get current unix seconds");
     registry
@@ -67,8 +68,9 @@ fn seed_gc_file_candidate(cache_root: &Path, label: &str) -> PathBuf {
     )
     .expect("failed to write gc config");
 
-    let registry = soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("data.db"))
-        .expect("failed to open target registry");
+    let registry =
+        soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("state.redb"))
+            .expect("failed to open target registry");
     let now = soldr_cache::target_registry::current_unix_seconds()
         .expect("failed to get current unix seconds");
     registry
@@ -146,6 +148,7 @@ fn fake_cargo_script(log_path: &Path) -> String {
                ) else (\n\
                  echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR% zccache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                  for /f \"tokens=1,* delims==\" %%A in ('set CARGO_TARGET_ 2^>nul') do @echo cargo_target_env %%A=%%B>>\"{0}\"\n\
+                 for /f \"tokens=1,* delims==\" %%A in ('set CARGO_PROFILE_ 2^>nul') do @echo cargo_profile_env %%A=%%B>>\"{0}\"\n\
                  echo {{}}\n\
                )\n\
                exit /b 0\n\
@@ -157,6 +160,7 @@ fn fake_cargo_script(log_path: &Path) -> String {
              )\n\
              echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR% zccache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
              for /f \"tokens=1,* delims==\" %%A in ('set CARGO_TARGET_ 2^>nul') do @echo cargo_target_env %%A=%%B>>\"{0}\"\n\
+             for /f \"tokens=1,* delims==\" %%A in ('set CARGO_PROFILE_ 2^>nul') do @echo cargo_profile_env %%A=%%B>>\"{0}\"\n\
              if defined RUSTC_WRAPPER (\n\
              call \"%RUSTC_WRAPPER%\" \"%RUSTC%\" --crate-name demo --emit dep-info,link\n\
              ) else (\n\
@@ -175,12 +179,18 @@ fn fake_cargo_script(log_path: &Path) -> String {
                  echo \"cargo_target_env $line\" >> \"{0}\"\n\
                done\n\
              }}\n\
+             log_cargo_profile_envs() {{\n\
+               env | grep '^CARGO_PROFILE_' | while IFS= read -r line; do\n\
+                 echo \"cargo_profile_env $line\" >> \"{0}\"\n\
+               done\n\
+             }}\n\
              if [ \"$1\" = \"metadata\" ]; then\n\
                if [ -n \"${{SOLDR_TEST_CARGO_METADATA_PATH:-}}\" ]; then\n\
                  cat \"$SOLDR_TEST_CARGO_METADATA_PATH\"\n\
                else\n\
                  echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  log_cargo_target_envs\n\
+                 log_cargo_profile_envs\n\
                  echo '{{}}'\n\
                fi\n\
                exit 0\n\
@@ -192,6 +202,7 @@ fn fake_cargo_script(log_path: &Path) -> String {
              fi\n\
              echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
              log_cargo_target_envs\n\
+             log_cargo_profile_envs\n\
              if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\
                \"$RUSTC_WRAPPER\" \"$RUSTC\" --crate-name demo --emit dep-info,link\n\
              else\n\
@@ -856,8 +867,9 @@ fn gc_purge_all_json_reports_error_log_path_and_keeps_failed_row() {
         log_path.display()
     );
 
-    let registry = soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("data.db"))
-        .expect("failed to open target registry");
+    let registry =
+        soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("state.redb"))
+            .expect("failed to open target registry");
     assert!(
         registry.get(&target).unwrap().is_some(),
         "failed deletion row should remain retryable"
@@ -1111,6 +1123,135 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         journal.exists(),
         "expected session journal at {}",
         journal.display()
+    );
+}
+
+#[test]
+fn cargo_front_door_defaults_dev_debug_off_and_warns_once_per_repo() {
+    let cache_root = unique_temp_dir("cargo-debug-default-off");
+    let repo = unique_temp_dir("cargo-debug-default-repo");
+    fs::write(
+        repo.join("Cargo.toml"),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("failed to seed Cargo.toml");
+    fs::create_dir_all(repo.join("src")).expect("failed to create src dir");
+    fs::write(repo.join("src").join("lib.rs"), "").expect("failed to seed lib.rs");
+
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let cargo_home = cache_root.join("cargo-home");
+
+    let first = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .current_dir(&repo)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("CARGO_PROFILE_DEV_DEBUG")
+        .env_remove("CARGO_PROFILE_TEST_DEBUG")
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run first soldr cargo build");
+    assert!(
+        first.status.success(),
+        "first build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let second = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .current_dir(&repo)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("CARGO_PROFILE_DEV_DEBUG")
+        .env_remove("CARGO_PROFILE_TEST_DEBUG")
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run second soldr cargo build");
+    assert!(
+        second.status.success(),
+        "second build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cargo_profile_env CARGO_PROFILE_DEV_DEBUG=false"),
+        "soldr should inject the dev profile debug override when unspecified: {log}"
+    );
+
+    let first_stderr = String::from_utf8_lossy(&first.stderr);
+    assert!(
+        first_stderr.contains("Cargo profile.dev.debug is unspecified")
+            && first_stderr.contains("CARGO_PROFILE_DEV_DEBUG=false"),
+        "first invocation should warn about the defaulted debug setting: {first_stderr}"
+    );
+    let second_stderr = String::from_utf8_lossy(&second.stderr);
+    assert!(
+        !second_stderr.contains("Cargo profile.dev.debug is unspecified"),
+        "second invocation for the same repo should not repeat the debug-default warning: {second_stderr}"
+    );
+}
+
+#[test]
+fn cargo_front_door_respects_dev_debug_in_cargo_config_toml() {
+    let cache_root = unique_temp_dir("cargo-debug-config-explicit");
+    let repo = unique_temp_dir("cargo-debug-config-repo");
+    fs::write(
+        repo.join("Cargo.toml"),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("failed to seed Cargo.toml");
+    fs::create_dir_all(repo.join(".cargo")).expect("failed to create .cargo dir");
+    fs::write(
+        repo.join(".cargo").join("config.toml"),
+        "[profile.dev]\ndebug = true\n",
+    )
+    .expect("failed to seed .cargo/config.toml");
+
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .current_dir(&repo)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", cache_root.join("cargo-home"))
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("CARGO_PROFILE_DEV_DEBUG")
+        .env_remove("CARGO_PROFILE_TEST_DEBUG")
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run soldr cargo build with explicit config debug");
+
+    assert!(
+        output.status.success(),
+        "build with explicit cargo config debug failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        !log.contains("cargo_profile_env CARGO_PROFILE_DEV_DEBUG=false"),
+        "explicit .cargo/config.toml profile.dev.debug must not be overridden: {log}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Cargo profile.dev.debug is unspecified"),
+        "explicit .cargo/config.toml profile.dev.debug should suppress warning: {stderr}"
     );
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -173,7 +173,7 @@ soldr version --json
 ### `soldr gc`
 
 Review reclaimable Cargo `target/` directories tracked in
-`~/.soldr/data.db`. Implemented by issue #234 and made safe-by-default
+`~/.soldr/state.redb`. Implemented by issue #234 and made safe-by-default
 by issue #289. The wrapper-mode hot path upserts each invocation's
 resolved workspace `target/` path with the current timestamp; `soldr gc`
 walks the registry, drops missing rows, applies safety guards, and
@@ -320,7 +320,7 @@ When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must ma
 |   |-- zccache/   # managed zccache artifact + state root (set via ZCCACHE_CACHE_DIR)
 |   `-- sccache/   # injected when SOLDR_RUSTC_WRAPPER=sccache and SCCACHE_DIR is unset
 |-- config.toml
-|-- data.db                # sqlite registry of tracked target/ dirs (issue #234)
+|-- state.redb             # redb state store, including tracked target/ dirs
 |-- .gc_warning_marker     # last-emitted timestamp for the stale-target startup warning
 `-- daemon.*
 ```

--- a/docs/TARGET_GC_PROPOSAL.md
+++ b/docs/TARGET_GC_PROPOSAL.md
@@ -5,7 +5,7 @@ Tracks: [#233](https://github.com/zackees/soldr/issues/233). Adjacent: [#234](ht
 
 ## TL;DR
 
-Adopt the [#234](https://github.com/zackees/soldr/issues/234) sqlite-registry approach as the data plane, and layer a wrapper-driven, manually-triggered GC on top of it: every `RUSTC_WRAPPER` invocation upserts `(target_dir, last_used_unix_ts)` into `~/.soldr/data.db`, and `soldr gc` (alias `soldr --purge`) is the single user entry point that scans the registry, sizes candidates lazily, and deletes whole `target/` trees that are older than a threshold and not currently locked. **Do not roll our own selective pruner; do not auto-delete on startup; do not try to share `CARGO_TARGET_DIR` across worktrees.** Defer atime, scheduled triggers, and incremental-subtree pruning until we have real telemetry.
+Adopt the [#234](https://github.com/zackees/soldr/issues/234) registry approach as the data plane, and layer a wrapper-driven, manually-triggered GC on top of it: every `RUSTC_WRAPPER` invocation upserts `(target_dir, last_used_unix_ts)` into `~/.soldr/state.redb`, and `soldr gc` (alias `soldr --purge`) is the single user entry point that scans the registry, sizes candidates lazily, and deletes whole `target/` trees that are older than a threshold and not currently locked. **Do not roll our own selective pruner; do not auto-delete on startup; do not try to share `CARGO_TARGET_DIR` across worktrees.** Defer atime, scheduled triggers, and incremental-subtree pruning until we have real telemetry.
 
 The recommendation converges on #234 with three additions: (a) explicit lock-file safety check, (b) wrapper records the *workspace root*, not the `target/` path it deduces from cwd, (c) explicit "do not GC if `Cargo.lock` mtime is younger than threshold" guard.
 
@@ -20,9 +20,9 @@ Reasoning:
 - **atime is unreliable on the user's primary platform.** On Windows 10, `NtfsDisableLastAccessUpdate` defaults to "System Managed" (`0x80000002` / `0x80000003`), which *disables* last-access updates on volumes >128 GiB. The user's pain is on a workstation with 860 GB of dev directories spread across what is almost certainly a >128 GiB volume, so atime is silently off by default. Even when on, NTFS only flushes atime within one hour, and many devs disable it for SSD wear / perf reasons. Linux behaves similarly (`relatime` / `noatime`).
 - **Cargo.toml mtime is the wrong signal.** Editing source under `src/` does not touch `Cargo.toml`. A repo that's been built daily for two years can still have an unchanged `Cargo.toml`. mtime measures *project change*, not *build recency*.
 - **`cargo metadata` is too expensive to run across 41 dirs on every scan,** and it requires the toolchain to still resolve — useless for orphan `target/` dirs whose `Cargo.toml` has been deleted.
-- **Wrapper-recorded `last_used` is exact, free, and platform-independent.** soldr is already in the rustc invocation path on every build. The upsert is one sqlite write per *cargo invocation* (debounce inside the daemon — not per rustc spawn), so cost is negligible.
+- **Wrapper-recorded `last_used` is exact, free, and platform-independent.** soldr is already in the rustc invocation path on every build. The upsert is one redb write per *cargo invocation* (debounce inside the daemon — not per rustc spawn), so cost is negligible.
 
-Cost/benefit: Wrapper-recorded ts is the cheapest accurate signal we can get and avoids a Windows-specific footgun. Cost is the sqlite store (#234 already proposes it).
+Cost/benefit: Wrapper-recorded ts is the cheapest accurate signal we can get and avoids a Windows-specific footgun. Cost is the redb store.
 
 ---
 
@@ -108,7 +108,7 @@ Cost/benefit: All four guards are cheap (stat + path-prefix checks). They turn G
 
 **In:**
 
-1. `~/.soldr/data.db` (sqlite) with the schema from #234.
+1. `~/.soldr/state.redb` with the target registry table from #234.
 2. Wrapper-mode upsert: on every `RUSTC_WRAPPER` invocation, upsert `(workspace_target_dir, now_unix)`. Debounce in-process to one write per cargo invocation.
 3. `soldr gc` command:
    - Default: list candidates (>10 days unused, >256 MB), prompt y/N per dir.
@@ -136,7 +136,7 @@ Cost/benefit: All four guards are cheap (stat + path-prefix checks). They turn G
 ## References
 
 - Issue #233 (this exploration)
-- Issue #234 (the sqlite-registry implementation proposal we're converging on)
+- Issue #234 (the target-registry implementation proposal we're converging on)
 - `cargo-sweep` — selective intra-`target/` pruning by stamp file or age
 - `cargo-cache` — `$CARGO_HOME` cleanup, not `target/`
 - NTFS atime semantics: [Ntfs Last Access Update rules by Windows version (jipegit gist)](https://gist.github.com/jipegit/4f6602456f0c2fe256642cecee09b425), ["The 'Last Access' updates are almost back" — DFIR blog](https://dfir.ru/2018/12/08/the-last-access-updates-are-almost-back/)


### PR DESCRIPTION
## Summary
- default unspecified Cargo dev/test profile debug info off for `soldr cargo` via `CARGO_PROFILE_*_DEBUG=false`
- persist once-per-repo warning state in `~/.soldr/state.redb` with periodic cleanup
- move the target registry from SQLite to redb and remove `rusqlite`/`libsqlite3`
- raise workspace MSRV to Rust 1.94.1 and update state-store docs

## Verification
- `cargo check -p soldr-cache -p soldr-cli`
- `cargo test -p soldr-cache`
- `cargo test -p soldr-cli cargo_front_door_defaults_dev_debug_off_and_warns_once_per_repo`
- `cargo test -p soldr-cli cargo_front_door_respects_dev_debug_in_cargo_config_toml`
- `cargo test -p soldr-cli gc_purge_all_json_reports_error_log_path_and_keeps_failed_row`