### PR TITLE
Rely on setup-soldr cache default

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -64,8 +64,6 @@ jobs:
 
       - id: setup-soldr
         uses: zackees/setup-soldr@v0
-        with:
-          cache: "true"
 
       - name: Ensure benchmark target
         shell: bash


### PR DESCRIPTION
## Summary
- remove the redundant `cache: true` input from the benchmark workflow's `setup-soldr@v0` step
- rely on the action default, which already enables setup caching

## Tests
- `git diff --check`
- `actionlint .github/workflows/cache-benchmark.yml`