### PR TITLE
feat(cli): relocate Windows wrapper executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ soldr rustfmt src/main.rs
 ```text
 soldr cargo build --release
   +-- resolve the real cargo binary
+  +-- on Windows, re-run from a soldr-owned runtime copy when needed
   +-- fetch/start managed zccache when cache is enabled
   +-- set soldr as the compiler wrapper for this build
   +-- have soldr wrapper mode delegate to managed zccache
@@ -205,6 +206,7 @@ If you also have many separate test binaries, consider consolidating them under 
 - **Invisible caching**: `soldr cargo ...` uses a soldr-managed zccache by default, with `soldr --no-cache cargo ...` as the opt-out.
 - **Real cache controls**: `soldr status`, `soldr cache`, and `soldr clean` report and manage the soldr-managed zccache state, while `soldr purge` removes all Soldr-managed cache artifacts for bug clearing and benchmarking.
 - **One cache boundary**: soldr keeps its own tools, zccache session state, and managed zccache artifacts under `~/.soldr/` by default. Use `SOLDR_CACHE_DIR` to move that root.
+- **Disposable-worktree friendly on Windows**: for build orchestration, soldr can relocate itself under `~/.soldr/runtime/soldr-self/` so `RUSTC_WRAPPER` does not keep using a worktree-local `soldr.exe`; stale runtime copies are cleaned up periodically.
 - **Pre-built first**: Download a pre-built binary before compiling from source. Fall back gracefully.
 - **Cargo-compatible**: soldr preserves normal cargo arguments instead of forcing a separate workflow.
 - **Cross-platform**: Linux, macOS, Windows (x86_64 + aarch64).

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -9,6 +9,7 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 
 mod linker;
+mod self_relocate;
 
 const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";
 const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
@@ -211,6 +212,14 @@ async fn main() {
     // RUSTC_WRAPPER mode: cargo passes `soldr /path/to/rustc <args...>`
     // Must be checked before clap parsing.
     let raw_args: Vec<String> = std::env::args().collect();
+    if should_self_relocate_for_invocation(&raw_args) {
+        match self_relocate::maybe_reexec_from_runtime(&raw_args) {
+            Ok(Some(code)) => std::process::exit(code),
+            Ok(None) => {}
+            Err(error) => std::process::exit(report_and_exit(error)),
+        }
+    }
+
     if raw_args.len() > 1 && is_wrapper_invocation(&raw_args[1]) {
         if let Some(version) = soldr_as_env_pin() {
             if should_trampoline(&version) {
@@ -410,6 +419,34 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
 fn report_and_exit(error: SoldrError) -> i32 {
     eprintln!("soldr: {error}");
     1
+}
+
+fn should_self_relocate_for_invocation(raw_args: &[String]) -> bool {
+    let user_args = raw_args.get(1..).unwrap_or(&[]);
+    let Ok((_, args)) = extract_as_pin(user_args) else {
+        return false;
+    };
+
+    let mut cache_enabled = true;
+    let mut idx = 0usize;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--no-cache" => {
+                cache_enabled = false;
+                idx += 1;
+            }
+            "--" => return false,
+            arg if arg.starts_with('-') => idx += 1,
+            "cargo" => {
+                return cache_enabled
+                    && cargo_args_are_cacheable(&args[idx + 1..])
+                    && matches!(rustc_wrapper_mode(), RustcWrapperMode::ManagedZccache);
+            }
+            _ => return false,
+        }
+    }
+
+    false
 }
 
 /// Extract `--as <version>` or `--as=<version>` from the leading flag
@@ -4208,15 +4245,15 @@ mod tests {
         low_disk_warning_for_free_bytes, low_disk_warning_for_path, normalize_version,
         parse_gc_purge_answer, parse_rust_artifact_cache_tar_threads, parse_tool_spec,
         resolve_bundle_walk_thread_count, rustc_wrapper_mode_from_env_var,
-        rustup_resolution_failure, selected_cargo_args, should_skip_warm_restore,
-        should_trampoline, stderr_indicates_unknown_session, walk_bundle_files,
-        warm_restore_sentinel_path, warm_restore_skip_enabled, write_thin_manifest,
-        write_warm_restore_sentinel, CargoMetadata, CargoMetadataPackage, Cli, Commands,
-        GcSubcommand, RustArtifactPlan, RustArtifactPlanContext, RustPlanInputs, RustPlanPackages,
-        RustToolchainIdentity, RustcWrapperMode, ThinSliceManifest, WarmRestoreSentinel,
-        WarmRestoreSkipInputs, ZccacheBuildSession, BUNDLE_WALK_THREAD_CAP,
-        LOW_DISK_WARNING_THRESHOLD_BYTES, SKIP_WARM_RESTORE_ENV_VAR, THIN_MANIFEST_FILENAME,
-        WARM_RESTORE_MAX_AGE_SECONDS,
+        rustup_resolution_failure, selected_cargo_args, should_self_relocate_for_invocation,
+        should_skip_warm_restore, should_trampoline, stderr_indicates_unknown_session,
+        walk_bundle_files, warm_restore_sentinel_path, warm_restore_skip_enabled,
+        write_thin_manifest, write_warm_restore_sentinel, CargoMetadata, CargoMetadataPackage, Cli,
+        Commands, GcSubcommand, RustArtifactPlan, RustArtifactPlanContext, RustPlanInputs,
+        RustPlanPackages, RustToolchainIdentity, RustcWrapperMode, ThinSliceManifest,
+        WarmRestoreSentinel, WarmRestoreSkipInputs, ZccacheBuildSession, BUNDLE_WALK_THREAD_CAP,
+        LOW_DISK_WARNING_THRESHOLD_BYTES, RUSTC_WRAPPER_OVERRIDE_ENV_VAR,
+        SKIP_WARM_RESTORE_ENV_VAR, THIN_MANIFEST_FILENAME, WARM_RESTORE_MAX_AGE_SECONDS,
     };
     use clap::Parser;
     use soldr_fetch::VersionSpec;
@@ -4406,6 +4443,47 @@ mod tests {
             rustc_wrapper_mode_from_env_var(Some(OsStr::new("sccache"))),
             RustcWrapperMode::Custom("sccache".into())
         );
+    }
+
+    #[test]
+    fn self_relocate_gate_targets_managed_cacheable_cargo_builds() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _wrapper = EnvVarGuard::remove(RUSTC_WRAPPER_OVERRIDE_ENV_VAR);
+
+        assert!(should_self_relocate_for_invocation(&[
+            "soldr".into(),
+            "cargo".into(),
+            "build".into(),
+        ]));
+        assert!(should_self_relocate_for_invocation(&[
+            "soldr".into(),
+            "--as".into(),
+            env!("CARGO_PKG_VERSION").into(),
+            "cargo".into(),
+            "test".into(),
+        ]));
+        assert!(!should_self_relocate_for_invocation(&[
+            "soldr".into(),
+            "cargo".into(),
+            "--version".into(),
+        ]));
+        assert!(!should_self_relocate_for_invocation(&[
+            "soldr".into(),
+            "--no-cache".into(),
+            "cargo".into(),
+            "build".into(),
+        ]));
+        assert!(!should_self_relocate_for_invocation(&[
+            "soldr".into(),
+            "version".into(),
+        ]));
+
+        let _custom = EnvVarGuard::set(RUSTC_WRAPPER_OVERRIDE_ENV_VAR, "sccache");
+        assert!(!should_self_relocate_for_invocation(&[
+            "soldr".into(),
+            "cargo".into(),
+            "build".into(),
+        ]));
     }
 
     #[test]

--- a/crates/soldr-cli/src/self_relocate.rs
+++ b/crates/soldr-cli/src/self_relocate.rs
@@ -1,0 +1,466 @@
+use fs2::FileExt;
+use sha2::{Digest, Sha256};
+use soldr_core::{suppress_windows_console_window, SoldrError, SoldrPaths};
+use std::{
+    fs::{self, File, OpenOptions},
+    io::Read,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+pub(crate) const RELOCATED_EXE_ENV_VAR: &str = "SOLDR_RELOCATED_EXE";
+pub(crate) const ORIGINAL_EXE_ENV_VAR: &str = "SOLDR_ORIGINAL_EXE";
+pub(crate) const FORCE_RELOCATION_ENV_VAR: &str = "SOLDR_TEST_SELF_RELOCATE_FORCE";
+
+const RUNTIME_DIR: &str = "runtime";
+const SELF_DIR: &str = "soldr-self";
+const LOCK_FILENAME: &str = ".lock";
+const GC_MARKER_FILENAME: &str = ".last-gc";
+const LAST_USED_FILENAME: &str = "last-used";
+const GC_INTERVAL_SECONDS: u64 = 24 * 60 * 60;
+const STALE_RUNTIME_SECONDS: u64 = 14 * 24 * 60 * 60;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct RuntimeGcSummary {
+    scanned_dirs: usize,
+    removed_dirs: usize,
+    skipped_current_dirs: usize,
+    skipped_fresh_dirs: usize,
+    failed_dirs: usize,
+}
+
+pub(crate) fn maybe_reexec_from_runtime(raw_args: &[String]) -> Result<Option<i32>, SoldrError> {
+    if !relocation_requested() || relocation_guard_active() {
+        return Ok(None);
+    }
+
+    let current_exe = std::env::current_exe()?;
+    let paths = SoldrPaths::new()?;
+    let runtime_root = runtime_root(&paths);
+    fs::create_dir_all(&runtime_root)?;
+
+    if path_is_under(&current_exe, &runtime_root) {
+        return Ok(None);
+    }
+
+    let relocated_exe = ensure_relocated_exe(&paths, &current_exe)?;
+    run_periodic_runtime_gc(&paths, Some(&relocated_exe));
+
+    let mut command = Command::new(&relocated_exe);
+    command
+        .args(raw_args.iter().skip(1))
+        .env(RELOCATED_EXE_ENV_VAR, "1")
+        .env(ORIGINAL_EXE_ENV_VAR, &current_exe);
+    suppress_windows_console_window(&mut command);
+    let status = command.status()?;
+    Ok(Some(status.code().unwrap_or(1)))
+}
+
+pub(crate) fn run_periodic_runtime_gc(paths: &SoldrPaths, current_exe: Option<&Path>) {
+    let runtime_root = runtime_root(paths);
+    let current_dir = current_exe.and_then(Path::parent);
+    let Ok(now) = current_unix_seconds() else {
+        return;
+    };
+    let _ = maybe_run_periodic_gc_at(
+        &runtime_root,
+        current_dir,
+        now,
+        GC_INTERVAL_SECONDS,
+        STALE_RUNTIME_SECONDS,
+    );
+}
+
+fn relocation_requested() -> bool {
+    cfg!(windows) || truthy_env(FORCE_RELOCATION_ENV_VAR)
+}
+
+fn relocation_guard_active() -> bool {
+    std::env::var_os(RELOCATED_EXE_ENV_VAR).is_some()
+}
+
+fn truthy_env(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            let value = value.trim();
+            !(value.is_empty()
+                || value == "0"
+                || value.eq_ignore_ascii_case("false")
+                || value.eq_ignore_ascii_case("no")
+                || value.eq_ignore_ascii_case("off"))
+        })
+        .unwrap_or(false)
+}
+
+fn ensure_relocated_exe(paths: &SoldrPaths, current_exe: &Path) -> Result<PathBuf, SoldrError> {
+    let runtime_root = runtime_root(paths);
+    fs::create_dir_all(&runtime_root)?;
+    let _lock = lock_runtime_root(&runtime_root)?;
+
+    let identity = exe_identity(current_exe)?;
+    let dest_dir = runtime_root.join(&identity.dir_name);
+    fs::create_dir_all(&dest_dir)?;
+
+    let file_name = current_exe.file_name().ok_or_else(|| {
+        SoldrError::Other(format!(
+            "failed to determine current executable filename from {}",
+            current_exe.display()
+        ))
+    })?;
+    let dest = dest_dir.join(file_name);
+
+    if exe_hash_matches(&dest, &identity.hash_hex) {
+        touch_last_used(&dest_dir)?;
+        return Ok(dest);
+    }
+
+    let temp = dest_dir.join(format!(
+        ".{}.{}.tmp",
+        file_name.to_string_lossy(),
+        std::process::id()
+    ));
+    let _ = fs::remove_file(&temp);
+    fs::copy(current_exe, &temp)?;
+    let permissions = fs::metadata(current_exe)?.permissions();
+    fs::set_permissions(&temp, permissions)?;
+
+    if dest.exists() && !exe_hash_matches(&dest, &identity.hash_hex) {
+        let _ = fs::remove_file(&dest);
+    }
+
+    match fs::rename(&temp, &dest) {
+        Ok(()) => {}
+        Err(_err) if exe_hash_matches(&dest, &identity.hash_hex) => {
+            let _ = fs::remove_file(&temp);
+        }
+        Err(err) => {
+            let _ = fs::remove_file(&temp);
+            return Err(SoldrError::Io(err));
+        }
+    }
+
+    touch_last_used(&dest_dir)?;
+    Ok(dest)
+}
+
+fn runtime_root(paths: &SoldrPaths) -> PathBuf {
+    paths.root.join(RUNTIME_DIR).join(SELF_DIR)
+}
+
+fn lock_runtime_root(runtime_root: &Path) -> Result<File, SoldrError> {
+    fs::create_dir_all(runtime_root)?;
+    let lock_path = runtime_root.join(LOCK_FILENAME);
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(lock_path)?;
+    file.lock_exclusive()?;
+    Ok(file)
+}
+
+struct ExeIdentity {
+    dir_name: String,
+    hash_hex: String,
+}
+
+fn exe_identity(path: &Path) -> Result<ExeIdentity, SoldrError> {
+    let hash_hex = hash_file(path)?;
+    Ok(ExeIdentity {
+        dir_name: format!("v{}-{hash_hex}", env!("CARGO_PKG_VERSION")),
+        hash_hex,
+    })
+}
+
+fn exe_hash_matches(path: &Path, expected_hash: &str) -> bool {
+    path.is_file() && hash_file(path).is_ok_and(|actual| actual == expected_hash)
+}
+
+fn hash_file(path: &Path) -> Result<String, SoldrError> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
+    Ok(to_hex(&hasher.finalize()))
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn touch_last_used(dir: &Path) -> Result<(), SoldrError> {
+    fs::write(
+        dir.join(LAST_USED_FILENAME),
+        current_unix_seconds()?.to_string(),
+    )?;
+    Ok(())
+}
+
+fn maybe_run_periodic_gc_at(
+    runtime_root: &Path,
+    current_dir: Option<&Path>,
+    now: u64,
+    interval_seconds: u64,
+    stale_seconds: u64,
+) -> Result<Option<RuntimeGcSummary>, SoldrError> {
+    fs::create_dir_all(runtime_root)?;
+    if !runtime_gc_due(runtime_root, now, interval_seconds) {
+        return Ok(None);
+    }
+
+    let _lock = lock_runtime_root(runtime_root)?;
+    if !runtime_gc_due(runtime_root, now, interval_seconds) {
+        return Ok(None);
+    }
+
+    let summary = purge_stale_runtime_copies(runtime_root, current_dir, now, stale_seconds)?;
+    fs::write(runtime_root.join(GC_MARKER_FILENAME), now.to_string())?;
+    Ok(Some(summary))
+}
+
+fn runtime_gc_due(runtime_root: &Path, now: u64, interval_seconds: u64) -> bool {
+    let marker = runtime_root.join(GC_MARKER_FILENAME);
+    let Ok(raw) = fs::read_to_string(marker) else {
+        return true;
+    };
+    let Ok(last_run) = raw.trim().parse::<u64>() else {
+        return true;
+    };
+    now.saturating_sub(last_run) >= interval_seconds
+}
+
+fn purge_stale_runtime_copies(
+    runtime_root: &Path,
+    current_dir: Option<&Path>,
+    now: u64,
+    stale_seconds: u64,
+) -> Result<RuntimeGcSummary, SoldrError> {
+    let mut summary = RuntimeGcSummary::default();
+    let cutoff = now.saturating_sub(stale_seconds);
+
+    for entry in fs::read_dir(runtime_root)? {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let path = entry.path();
+        summary.scanned_dirs += 1;
+        if current_dir.is_some_and(|current| same_path(current, &path)) {
+            summary.skipped_current_dirs += 1;
+            continue;
+        }
+
+        let last_used = runtime_copy_last_used(&path).unwrap_or(now);
+        if last_used > cutoff {
+            summary.skipped_fresh_dirs += 1;
+            continue;
+        }
+
+        match fs::remove_dir_all(&path) {
+            Ok(()) => summary.removed_dirs += 1,
+            Err(_) => summary.failed_dirs += 1,
+        }
+    }
+
+    Ok(summary)
+}
+
+fn runtime_copy_last_used(path: &Path) -> Option<u64> {
+    fs::read_to_string(path.join(LAST_USED_FILENAME))
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .or_else(|| {
+            fs::metadata(path)
+                .ok()
+                .and_then(|metadata| metadata.modified().ok())
+                .and_then(system_time_to_unix_seconds)
+        })
+}
+
+fn current_unix_seconds() -> Result<u64, SoldrError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|e| SoldrError::Other(format!("system clock is before unix epoch: {e}")))
+}
+
+fn system_time_to_unix_seconds(time: SystemTime) -> Option<u64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+}
+
+fn same_path(a: &Path, b: &Path) -> bool {
+    match (fs::canonicalize(a), fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+fn path_is_under(path: &Path, root: &Path) -> bool {
+    match (fs::canonicalize(path), fs::canonicalize(root)) {
+        (Ok(path), Ok(root)) => path.starts_with(root),
+        _ => path.starts_with(root),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        ffi::{OsStr, OsString},
+        sync::Mutex,
+    };
+    use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn seed_runtime_dir(root: &Path, name: &str, last_used: u64) -> PathBuf {
+        let dir = root.join(name);
+        fs::create_dir_all(&dir).expect("create runtime dir");
+        fs::write(dir.join(LAST_USED_FILENAME), last_used.to_string()).expect("write last-used");
+        dir
+    }
+
+    #[test]
+    fn relocation_guard_prevents_recursive_reexec_even_when_forced() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _force = EnvVarGuard::set(FORCE_RELOCATION_ENV_VAR, "1");
+        let _marker = EnvVarGuard::set(RELOCATED_EXE_ENV_VAR, "1");
+
+        let result =
+            maybe_reexec_from_runtime(&["soldr".to_string(), "version".to_string()]).unwrap();
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn ensure_relocated_exe_copies_to_hash_keyed_runtime_dir() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = temp.path().join("soldr-test.exe");
+        fs::write(&source, b"binary-content").expect("write source");
+        let paths = SoldrPaths::with_root(temp.path().join("soldr-root"));
+
+        let relocated = ensure_relocated_exe(&paths, &source).expect("relocate exe");
+        let expected_hash = hash_file(&source).expect("hash source");
+
+        assert!(relocated.is_file());
+        assert_eq!(
+            fs::read(&relocated).expect("read relocated"),
+            b"binary-content"
+        );
+        assert!(relocated
+            .parent()
+            .expect("relocated exe has parent")
+            .file_name()
+            .and_then(OsStr::to_str)
+            .expect("dir is utf-8")
+            .contains(&expected_hash));
+        assert!(relocated
+            .parent()
+            .expect("relocated exe has parent")
+            .join(LAST_USED_FILENAME)
+            .is_file());
+
+        let second = ensure_relocated_exe(&paths, &source).expect("reuse relocated exe");
+        assert_eq!(second, relocated);
+    }
+
+    #[test]
+    fn runtime_gc_removes_stale_dirs_and_skips_current_and_fresh() {
+        let temp = TempDir::new().expect("tempdir");
+        let root = temp.path().join("runtime").join("soldr-self");
+        fs::create_dir_all(&root).expect("create runtime root");
+        let stale = seed_runtime_dir(&root, "stale", 10);
+        let fresh = seed_runtime_dir(&root, "fresh", 90);
+        let current = seed_runtime_dir(&root, "current", 10);
+
+        let summary =
+            purge_stale_runtime_copies(&root, Some(&current), 100, 50).expect("runtime gc");
+
+        assert_eq!(summary.scanned_dirs, 3);
+        assert_eq!(summary.removed_dirs, 1);
+        assert_eq!(summary.skipped_current_dirs, 1);
+        assert_eq!(summary.skipped_fresh_dirs, 1);
+        assert!(!stale.exists());
+        assert!(fresh.exists());
+        assert!(current.exists());
+    }
+
+    #[test]
+    fn periodic_runtime_gc_respects_marker_interval() {
+        let temp = TempDir::new().expect("tempdir");
+        let root = temp.path().join("runtime").join("soldr-self");
+        fs::create_dir_all(&root).expect("create runtime root");
+        let stale = seed_runtime_dir(&root, "stale", 10);
+        fs::write(root.join(GC_MARKER_FILENAME), "95").expect("write gc marker");
+
+        let summary = maybe_run_periodic_gc_at(&root, None, 100, 10, 50).expect("periodic gc");
+
+        assert!(summary.is_none());
+        assert!(stale.exists());
+    }
+
+    #[test]
+    fn periodic_runtime_gc_deletes_stale_dirs_when_due() {
+        let temp = TempDir::new().expect("tempdir");
+        let root = temp.path().join("runtime").join("soldr-self");
+        fs::create_dir_all(&root).expect("create runtime root");
+        let stale = seed_runtime_dir(&root, "stale", 10);
+        fs::write(root.join(GC_MARKER_FILENAME), "80").expect("write gc marker");
+
+        let summary = maybe_run_periodic_gc_at(&root, None, 100, 10, 50)
+            .expect("periodic gc")
+            .expect("gc should run");
+
+        assert_eq!(summary.removed_dirs, 1);
+        assert!(!stale.exists());
+        assert_eq!(
+            fs::read_to_string(root.join(GC_MARKER_FILENAME)).expect("read marker"),
+            "100"
+        );
+    }
+}

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -90,6 +90,37 @@ fn path_display_variants(path: &Path) -> Vec<String> {
     variants
 }
 
+fn logged_cargo_wrapper(log: &str) -> Option<String> {
+    log.lines().find_map(|line| {
+        let wrapper = line.strip_prefix("cargo wrapper=")?;
+        wrapper
+            .split_once(" rustc=")
+            .map(|(wrapper, _)| wrapper.to_string())
+    })
+}
+
+fn log_contains_owned_soldr_wrapper(log: &str, cache_root: &Path) -> bool {
+    if log.contains(env!("CARGO_BIN_EXE_soldr")) {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        let Some(wrapper) = logged_cargo_wrapper(log) else {
+            return false;
+        };
+        let runtime_root = cache_root.join("runtime").join("soldr-self");
+        path_display_variants(&runtime_root)
+            .iter()
+            .any(|path| wrapper.contains(path))
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = cache_root;
+        false
+    }
+}
+
 fn log_contains_toolchain_homes(
     log: &str,
     prefix: &str,
@@ -1070,7 +1101,7 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         "fake cargo did not record wrapper env: {log}"
     );
     assert!(
-        log.contains(env!("CARGO_BIN_EXE_soldr")),
+        log_contains_owned_soldr_wrapper(&log, &cache_root),
         "soldr should own the wrapper slot in cache-enabled mode: {log}"
     );
     assert!(
@@ -1124,6 +1155,57 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         "expected session journal at {}",
         journal.display()
     );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_worktree_copy_relocates_wrapper_and_original_dir_can_be_removed() {
+    let cache_root = unique_temp_dir("windows-self-relocate-cache");
+    let worktree = unique_temp_dir("windows-self-relocate-worktree");
+    let source_dir = worktree.join("target").join("debug");
+    fs::create_dir_all(&source_dir).expect("failed to create copied exe dir");
+    let copied_soldr = source_dir.join("soldr.exe");
+    fs::copy(env!("CARGO_BIN_EXE_soldr"), &copied_soldr)
+        .expect("failed to copy soldr exe into temporary worktree");
+
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(&copied_soldr)
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run copied soldr exe");
+
+    assert!(
+        output.status.success(),
+        "copied soldr front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    let wrapper = logged_cargo_wrapper(&log).expect("fake cargo should log RUSTC_WRAPPER");
+    assert!(
+        path_display_variants(&cache_root.join("runtime").join("soldr-self"))
+            .iter()
+            .any(|path| wrapper.contains(path)),
+        "RUSTC_WRAPPER should point at the relocated runtime copy: {log}"
+    );
+    assert!(
+        !path_display_variants(&copied_soldr)
+            .iter()
+            .any(|path| wrapper.contains(path)),
+        "RUSTC_WRAPPER should not point at the original worktree copy: {log}"
+    );
+
+    fs::remove_dir_all(&worktree)
+        .expect("temporary worktree should be removable after soldr exits");
+    assert!(!worktree.exists());
 }
 
 #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -290,6 +290,8 @@ Commands:
 | `SOLDR_REAL_CARGO`, `SOLDR_REAL_RUSTC`, ... | Internal real-tool path overrides used by setup-soldr PATH shims to avoid recursive tool lookup | unset |
 | `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
+| `SOLDR_RELOCATED_EXE` | Internal recursion guard set after Windows self-relocation | unset |
+| `SOLDR_ORIGINAL_EXE` | Internal path to the original executable when Windows self-relocation is active | unset |
 | `ZCCACHE_CACHE_DIR` | zccache cache-root override set by soldr for managed zccache commands | `~/.soldr/cache/zccache` |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `SCCACHE_DIR` | sccache cache-root override soldr injects when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has not set it themselves | `~/.soldr/cache/sccache` |
@@ -306,6 +308,8 @@ When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must ma
 
 `soldr cargo ...` only starts the managed build cache for compile-like Cargo subcommands such as `build`, `check`, `test`, `run`, `doc`, `clippy`, and `nextest`. Non-build Cargo commands such as `cargo metadata` and `cargo --version` pass through without starting zccache.
 
+On Windows, soldr may copy the running `soldr.exe` into `SOLDR_CACHE_DIR/runtime/soldr-self/<version-and-hash>/soldr.exe` and re-run the command from that relocated copy before build orchestration starts. This keeps disposable worktree builds from repeatedly using the worktree-local `soldr.exe` as `RUSTC_WRAPPER`. The trampoline sets `SOLDR_RELOCATED_EXE=1` and `SOLDR_ORIGINAL_EXE=<original path>` as a recursion guard and preserves argv, inherited environment, stdio, and exit status. Stale relocated copies are purged by a best-effort runtime GC step that runs periodically and skips copies that cannot be removed because they are still locked.
+
 `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE` is a default-on short-circuit for the `rust-plan restore` step. After a successful `rust-plan save`, soldr writes a sentinel next to the thin-slice bundle recording the plan inputs hash, target dir, `GITHUB_RUN_ID`, `GITHUB_JOB`, `GITHUB_RUN_ATTEMPT`, zccache session id, and a unix timestamp. On the next invocation, if the sentinel exists and every match field equals the current value — and the sentinel is no older than 5 minutes — soldr skips `rust-plan restore` and leaves the already-warm `target/` tree untouched. This avoids invalidating Cargo's mtime-based fingerprints when split CI steps share a checkout but spawn fresh shells per step (issue #229). The flag is enabled when unset; set it to a falsy value (`0`, `false`, `no`, `off`, or empty, case-insensitive) to opt out, and any other value (including the historical truthy spellings `1`, `true`, `yes`, `on`) keeps the short-circuit enabled. The gate is conservative: a missing, stale, or partially-mismatched sentinel falls through to the normal restore, so the short-circuit can never make a build less correct than the default path. Promoted to default-on after the #229 CI validation runs (PRs #247, #257, #260, #261, #262) landed cleanly on `main`.
 
 ---
@@ -319,6 +323,8 @@ When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must ma
 |-- cache/
 |   |-- zccache/   # managed zccache artifact + state root (set via ZCCACHE_CACHE_DIR)
 |   `-- sccache/   # injected when SOLDR_RUSTC_WRAPPER=sccache and SCCACHE_DIR is unset
+|-- runtime/
+|   `-- soldr-self/ # Windows self-relocated soldr.exe copies plus periodic GC marker
 |-- config.toml
 |-- state.redb             # redb state store, including tracked target/ dirs
 |-- .gc_warning_marker     # last-emitted timestamp for the stale-target startup warning


### PR DESCRIPTION
## Summary
- add Windows self-relocation for managed cache-enabled `soldr cargo ...` builds before Cargo orchestration starts
- copy `soldr.exe` into a hash-keyed `SOLDR_CACHE_DIR/runtime/soldr-self/` runtime path under a lock, then re-run with recursion guard env vars
- set managed `RUSTC_WRAPPER` from the relocated process and add periodic best-effort GC for stale relocated copies
- document the runtime layout and add Windows coverage for deleting the original worktree copy after relocation

Closes #296.

## Test Plan
- [x] `cargo fmt -- --check`
- [x] `cargo test -p soldr-cli self_relocate --locked`
- [x] `cargo test -p soldr-cli --locked`
- [x] `cargo test -p soldr-cli --test cli windows_worktree_copy_relocates_wrapper_and_original_dir_can_be_removed`
- [x] `bash test` Rust build/library/CLI/fetch stages passed
- [ ] `bash test` Python stage failed on existing environment/fixture issues: `test_setup_soldr_exporter.py::test_export_bundle_creates_expected_public_repo_layout` fixture mismatch in `action.yml`, and `test_cache_benchmark_report.py::test_cache_benchmark_report_writes_json_and_summary` missing Pillow for `benchmark.jpg` generation