### PR TITLE
ci: fix setup-soldr smoke cache isolation

### DIFF
--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -101,10 +101,9 @@ jobs:
       - name: Verify cache isolation
         shell: pwsh
         env:
-          ACTION_CACHE_DIR: ${{ steps.setup.outputs.cache-dir }}
           SOLDR_DOGFOOD_BUILD_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
         run: |
-          $actionCache = [System.IO.Path]::GetFullPath($env:ACTION_CACHE_DIR)
+          $actionCache = [System.IO.Path]::GetFullPath($env:SOLDR_CACHE_DIR)
           $buildCache = [System.IO.Path]::GetFullPath($env:SOLDR_DOGFOOD_BUILD_CACHE_DIR)
           $actionPrefix = $actionCache.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
           $buildPrefix = $buildCache.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -130,6 +130,8 @@ def test_setup_soldr_smoke_tests_disable_nested_cache() -> None:
     assert "dogfood-test-seconds=" in workflow
     assert "Stop dogfood zccache before cache save" in workflow
     assert "& $zccache stop" in workflow
+    assert "ACTION_CACHE_DIR: ${{ steps.setup.outputs.cache-dir }}" not in workflow
+    assert "[System.IO.Path]::GetFullPath($env:SOLDR_CACHE_DIR)" in workflow
 
 
 def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> None:
@@ -244,7 +246,6 @@ def test_main_treats_hot_as_thin_alias_with_lockfile(
 
     module.main()
 
-    cache_root = runner_temp / "setup-soldr"
     bundle_path = runner_temp / "setup-soldr-target-thin"
     outputs = github_output.read_text(encoding="utf-8")
     assert "target_cache_enabled=true" in outputs


### PR DESCRIPTION
## Summary
- fix the Setup Soldr Action smoke workflow to validate cache isolation using the runtime SOLDR_CACHE_DIR exported by setup-soldr
- stop depending on the pinned setup-soldr action's empty cache-dir output for the isolation check
- use the SHA-pinned public setup-soldr action for Soldr self-build workflows in CI e2e and release builds
- add regression assertions for the workflow guards

## Verification
- uv run pytest tests/test_setup_soldr_action.py tests/test_setup_soldr_pins.py -q
- uv run ruff check tests/test_setup_soldr_action.py tests/test_setup_soldr_pins.py .github/scripts/verify_setup_soldr_pin.py
- python .github/scripts/verify_setup_soldr_pin.py
- git diff --check

Fixes the failure from https://github.com/zackees/soldr/actions/runs/25851942357/job/75960362850?pr=302.