### PR TITLE
ci: pin setup-soldr for soldr self-builds

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -56,8 +56,19 @@ jobs:
           ref: ${{ inputs.third_party_ref }}
           path: ${{ inputs.third_party_path }}
 
+      - name: Verify setup-soldr pin matches v0
+        shell: bash
+        working-directory: soldr
+        run: |
+          set -euo pipefail
+          if command -v python3 >/dev/null 2>&1; then
+            python3 .github/scripts/verify_setup_soldr_pin.py
+          else
+            python .github/scripts/verify_setup_soldr_pin.py
+          fi
+
       - name: Setup Soldr cache and toolchain
-        uses: ./soldr
+        uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656 # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
           cache-key-suffix: bootstrap-${{ inputs.target }}

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -204,8 +204,18 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.commit_sha }}
 
+      - name: Verify setup-soldr pin matches v0
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v python3 >/dev/null 2>&1; then
+            python3 .github/scripts/verify_setup_soldr_pin.py
+          else
+            python .github/scripts/verify_setup_soldr_pin.py
+          fi
+
       - name: Setup Soldr cache and toolchain
-        uses: ./
+        uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656 # @v0
         with:
           cache-key-suffix: release-${{ matrix.target }}
 

--- a/tests/test_setup_soldr_pins.py
+++ b/tests/test_setup_soldr_pins.py
@@ -23,3 +23,17 @@ def test_workflows_pin_setup_soldr_to_current_v0_sha() -> None:
     module = load_verify_module()
 
     module.verify_setup_soldr_pins(REPO_ROOT)
+
+
+def test_soldr_self_builds_use_pinned_public_setup_soldr() -> None:
+    bootstrap = (
+        REPO_ROOT / ".github" / "workflows" / "_bootstrap-e2e.yml"
+    ).read_text(encoding="utf-8")
+    release = (REPO_ROOT / ".github" / "workflows" / "release-auto.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "uses: ./soldr" not in bootstrap
+    assert "uses: ./" not in release
+    assert "uses: zackees/setup-soldr@" in bootstrap
+    assert "uses: zackees/setup-soldr@" in release


### PR DESCRIPTION
## Summary
- use the SHA-pinned public setup-soldr action in the CI bootstrap e2e workflow that builds Soldr with Soldr
- use the same pinned setup-soldr action for release binary builds
- run the setup-soldr pin verifier before those self-build setup steps
- add a regression test to prevent those self-build workflows from falling back to local setup actions

## Verification
- uv run pytest tests/test_setup_soldr_pins.py -q
- uv run ruff check tests/test_setup_soldr_pins.py .github/scripts/verify_setup_soldr_pin.py
- python .github/scripts/verify_setup_soldr_pin.py
- git diff --check HEAD~1..HEAD