### PR TITLE
release: bump soldr to 0.7.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "blake3",
  "redb",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "clap",
  "fs2",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "serde",
  "tempfile",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.18"
+version = "0.7.19"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- bump Soldr workspace version from 0.7.18 to 0.7.19
- keep package.json and Cargo.lock in sync with the workspace version

## Verification
- cargo metadata --locked --no-deps --format-version 1
- node scripts/test-npm-package.js
- cargo fmt --all -- --check
- cargo test --workspace --locked
- git diff --check
- git ls-remote --exit-code --tags origin v0.7.19 (confirmed no existing tag)