### PR TITLE
fix: deny unused mut warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ tar = "0.4"
 toml = "0.8"
 redb = "4.1.0"
 rayon = "1"
+
+[workspace.lints.rust]
+unused_mut = "deny"

--- a/crates/soldr-cache/Cargo.toml
+++ b/crates/soldr-cache/Cargo.toml
@@ -18,3 +18,6 @@ redb = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/soldr-cache/src/state_db.rs
+++ b/crates/soldr-cache/src/state_db.rs
@@ -152,11 +152,9 @@ fn current_unix_seconds() -> Result<u64, StateDbError> {
 
 fn path_key(path: &Path) -> String {
     let normalized: PathBuf = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let mut key = normalized.to_string_lossy().replace('\\', "/");
+    let key = normalized.to_string_lossy().replace('\\', "/");
     #[cfg(windows)]
-    {
-        key = key.to_ascii_lowercase();
-    }
+    let key = key.to_ascii_lowercase();
     key
 }
 

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -34,6 +34,9 @@ tempfile = { workspace = true }
 # `cargo build --bin <stub> --features test-stubs` at test setup time.
 test-stubs = []
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "soldr"
 path = "src/main.rs"

--- a/crates/soldr-cli/src/self_relocate.rs
+++ b/crates/soldr-cli/src/self_relocate.rs
@@ -156,6 +156,7 @@ fn lock_runtime_root(runtime_root: &Path) -> Result<File, SoldrError> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(lock_path)?;
     file.lock_exclusive()?;
     Ok(file)

--- a/crates/soldr-core/Cargo.toml
+++ b/crates/soldr-core/Cargo.toml
@@ -14,3 +14,6 @@ toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/soldr-fetch/Cargo.toml
+++ b/crates/soldr-fetch/Cargo.toml
@@ -24,3 +24,6 @@ hex = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -771,7 +771,7 @@ fn match_asset<'a>(
             score += 5;
         }
 
-        if best.map_or(true, |(_, s)| score > s) {
+        if best.is_none_or(|(_, s)| score > s) {
             best = Some((asset, score));
         }
     }


### PR DESCRIPTION
## Summary
- deny `unused_mut` through shared Cargo workspace lint settings for all soldr crates
- remove the Linux-target-only `unused_mut` in `soldr-cache` path key normalization
- fix current Clippy warnings in `soldr-fetch` asset matching and `soldr-cli` runtime lock opening

Closes #306

## Verification
- `cargo fmt --all --check`
- `cargo check -p soldr-cache --locked --target x86_64-unknown-linux-gnu`
- `cargo clippy -p soldr-cache --locked --target x86_64-unknown-linux-gnu -- -D warnings`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check --workspace --all-targets --locked`
- `cargo test --workspace --lib --locked`
- `cargo test -p soldr-cli --test cli --locked`
- `cargo test -p soldr-fetch --test fetch_crgx --locked`