### PR TITLE
Release soldr 0.7.20 with zccache 1.4.7

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656 # @v0
+        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
           cache-key-suffix: bootstrap-${{ inputs.target }}

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -71,6 +71,7 @@ jobs:
         uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
+          linker: platform-default
           cache-key-suffix: bootstrap-${{ inputs.target }}
           target-cache-mode: full
           target-dir: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}/target-${{ inputs.target }}

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -81,6 +81,8 @@ jobs:
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
         uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6
+        with:
+          linker: platform-default
 
       - name: Ensure benchmark target
         shell: bash

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -80,7 +80,7 @@ jobs:
       - id: setup-soldr
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656
+        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6
 
       - name: Ensure benchmark target
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
 
       - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
         with:
+          linker: platform-default
           # Formatting does not benefit from a restored target directory, but
           # clippy still uses soldr's compilation cache below.
           target-cache: false
@@ -71,6 +72,8 @@ jobs:
           fi
 
       - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+        with:
+          linker: platform-default
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked
@@ -106,6 +109,8 @@ jobs:
           fi
 
       - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+        with:
+          linker: platform-default
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked
@@ -141,6 +146,8 @@ jobs:
           fi
 
       - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+        with:
+          linker: platform-default
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656 # @v0
+      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
         with:
           # Formatting does not benefit from a restored target directory, but
           # clippy still uses soldr's compilation cache below.
@@ -70,7 +70,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656 # @v0
+      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked
@@ -105,7 +105,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656 # @v0
+      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked
@@ -140,7 +140,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656 # @v0
+      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
 
       - name: Build workspace
         run: soldr cargo build --workspace --locked

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -215,7 +215,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656 # @v0
+        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
         with:
           cache-key-suffix: release-${{ matrix.target }}
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -217,6 +217,7 @@ jobs:
       - name: Setup Soldr cache and toolchain
         uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
         with:
+          linker: platform-default
           cache-key-suffix: release-${{ matrix.target }}
 
       - name: Install target toolchain support

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -69,6 +69,7 @@ jobs:
         uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6
         with:
           cache: true
+          linker: platform-default
           # Keep the action runtime cache separate from the Soldr build under
           # test. The dogfood build below overrides SOLDR_CACHE_DIR so soldr
           # owns zccache under that separate root.

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -66,7 +66,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@7ca12d4e2430886fa9b2a4fc889ad0404d213656
+        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6
         with:
           cache: true
           # Keep the action runtime cache separate from the Soldr build under

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "blake3",
  "redb",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "clap",
  "fs2",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "serde",
  "tempfile",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.19"
+version = "0.7.20"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -2513,7 +2513,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.4.6");
+    assert_eq!(json["managed_zccache_version"], "1.4.7");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -2635,7 +2635,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.4.6");
+    assert_eq!(json["managed_zccache_version"], "1.4.7");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -47,7 +47,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.6";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.7";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),
@@ -740,6 +740,9 @@ fn match_asset<'a>(
         if name.contains("src") || name.contains("source") {
             continue;
         }
+        if name.contains("-debug.") {
+            continue;
+        }
 
         // Respect the resolved ABI/libc instead of assuming Windows is always MSVC.
         if target.os == Os::Windows && target.env == Env::Msvc && name.contains("gnu") {
@@ -1054,6 +1057,22 @@ mod tests {
 
         let selected = match_asset(&assets, &target).unwrap();
         assert_eq!(selected.name, "tool-x86_64-unknown-linux-musl.tar.gz");
+    }
+
+    #[test]
+    fn match_asset_skips_debug_sidecar_archives() {
+        let assets = vec![
+            asset("tool-x86_64-pc-windows-msvc-debug.zip"),
+            asset("tool-x86_64-pc-windows-msvc.zip"),
+        ];
+        let target = TargetTriple {
+            arch: Arch::X86_64,
+            os: Os::Windows,
+            env: Env::Msvc,
+        };
+
+        let selected = match_asset(&assets, &target).unwrap();
+        assert_eq!(selected.name, "tool-x86_64-pc-windows-msvc.zip");
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- bump soldr workspace/package version to 0.7.20
- update managed zccache from 1.4.6 to 1.4.7
- skip zccache *-debug release sidecars when selecting executable archives

## Context
setup-soldr issue 83 is caused by stale jobserver environment being replayed by zccache daemon-spawned compiler/linker commands. zccache 1.4.7 contains the daemon-side fix. While smoke-testing this soldr bump, the new debug archives published with zccache 1.4.7 exposed an asset-matching bug, so this PR also prevents soldr from choosing *-debug sidecar archives as executable downloads.

## Test plan
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=E:\\codex-targets\\soldr-zccache-1-4-7 cargo check -p soldr-fetch
- CARGO_TARGET_DIR=E:\\codex-targets\\soldr-zccache-1-4-7 cargo test -p soldr-fetch
- CARGO_TARGET_DIR=E:\\codex-targets\\soldr-zccache-1-4-7 cargo test -p soldr-cli version_command_emits_versioned_json
- CARGO_TARGET_DIR=E:\\codex-targets\\soldr-zccache-1-4-7 cargo test -p soldr-cli json_reports
- npm run test:npm-package
- fresh-cache smoke: soldr cargo check -p soldr-core downloaded zccache 1.4.7 and passed
- git diff --check

Refs zackees/setup-soldr#83
Depends on zackees/zccache#251