### PR TITLE
ci: update setup-soldr workflow pins to v0 d7be70d

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
           linker: platform-default

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -430,7 +430,7 @@ jobs:
       - id: setup-soldr
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6
+        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db
         with:
           linker: platform-default
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
           # Formatting does not benefit from a restored target directory, but
@@ -71,7 +71,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
 
@@ -108,7 +108,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
 
@@ -145,7 +145,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -215,7 +215,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
           cache-key-suffix: release-${{ matrix.target }}

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -66,7 +66,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6
+        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db
         with:
           cache: true
           linker: platform-default


### PR DESCRIPTION
## Summary
- The `@v0` tag for `zackees/setup-soldr` moved to `d7be70d3960d2401a8974a11169429c0c846f7db`.
- The repository ruleset requires full-SHA pins, so `.github/scripts/verify_setup_soldr_pin.py` was failing every job that depends on the bootstrap workflow (e.g. macOS x64 build in run [25876424406](https://github.com/zackees/soldr/actions/runs/25876424406/job/76044728416)).
- Bump every workflow that pins `setup-soldr` (`_bootstrap-e2e.yml`, `cache-benchmark.yml`, `ci.yml`, `release-auto.yml`, `setup-soldr-action.yml`) to the current `@v0` SHA.

## Test plan
- [x] `python .github/scripts/verify_setup_soldr_pin.py` passes locally against the resolved `@v0`
- [ ] CI on this PR runs the pin verifier on every job and proceeds past `Verify setup-soldr pin matches v0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)