### PR TITLE
feat(gc): add `soldr gc list --json` that prunes missing rows

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
           linker: platform-default

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -430,7 +430,7 @@ jobs:
       - id: setup-soldr
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6
+        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db
         with:
           linker: platform-default
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
           # Formatting does not benefit from a restored target directory, but
@@ -71,7 +71,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
 
@@ -108,7 +108,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
 
@@ -145,7 +145,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -215,7 +215,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6 # @v0
+        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
         with:
           linker: platform-default
           cache-key-suffix: release-${{ matrix.target }}

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -66,7 +66,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@81a358ea263b035cc2652ec73b42178085b06bc6
+        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db
         with:
           cache: true
           linker: platform-default

--- a/crates/soldr-cache/src/target_registry.rs
+++ b/crates/soldr-cache/src/target_registry.rs
@@ -156,6 +156,28 @@ impl TargetRegistry {
         Ok(removed)
     }
 
+    /// Remove rows for every path in `paths` in a single write
+    /// transaction. Missing rows are skipped. Returns the number of
+    /// rows that were actually removed.
+    pub fn remove_many(&self, paths: &[PathBuf]) -> Result<usize, RegistryError> {
+        if paths.is_empty() {
+            return Ok(0);
+        }
+        let write_txn = self.db.begin_write()?;
+        let mut removed = 0usize;
+        {
+            let mut table = write_txn.open_table(TARGETS)?;
+            for path in paths {
+                let key = path_to_string(path);
+                if table.remove(key.as_str())?.is_some() {
+                    removed += 1;
+                }
+            }
+        }
+        write_txn.commit()?;
+        Ok(removed)
+    }
+
     /// Total number of tracked rows.
     pub fn len(&self) -> Result<usize, RegistryError> {
         let read_txn = self.db.begin_read()?;
@@ -240,6 +262,48 @@ pub fn directory_size(path: &Path) -> u64 {
         }
     }
     total
+}
+
+/// Recursively measure both on-disk size (bytes) and file count for
+/// a directory in a single walk. Same symlink/error semantics as
+/// [`directory_size`]: symlinks are not followed, individual entry
+/// errors are swallowed. Returns `(total_bytes, file_count)`.
+pub fn directory_size_and_files(path: &Path) -> (u64, u64) {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(_) => return (0, 0),
+    };
+    if metadata.file_type().is_symlink() {
+        return (0, 0);
+    }
+    if metadata.is_file() {
+        return (metadata.len(), 1);
+    }
+    let mut total_bytes: u64 = 0;
+    let mut total_files: u64 = 0;
+    let entries = match std::fs::read_dir(path) {
+        Ok(e) => e,
+        Err(_) => return (0, 0),
+    };
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        let entry_meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if entry_meta.file_type().is_symlink() {
+            continue;
+        }
+        if entry_meta.is_dir() {
+            let (sub_bytes, sub_files) = directory_size_and_files(&entry_path);
+            total_bytes = total_bytes.saturating_add(sub_bytes);
+            total_files = total_files.saturating_add(sub_files);
+        } else if entry_meta.is_file() {
+            total_bytes = total_bytes.saturating_add(entry_meta.len());
+            total_files = total_files.saturating_add(1);
+        }
+    }
+    (total_bytes, total_files)
 }
 
 /// Resolve the workspace `target/` dir from an arbitrary path that
@@ -453,6 +517,36 @@ mod tests {
         assert!(registry.remove(&path).unwrap());
         assert!(!registry.remove(&path).unwrap());
         assert_eq!(registry.len().unwrap(), 0);
+    }
+
+    #[test]
+    fn remove_many_batches_deletes_and_counts_hits() {
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let a = PathBuf::from("/tmp/a/target");
+        let b = PathBuf::from("/tmp/b/target");
+        let c = PathBuf::from("/tmp/c/target");
+        let ghost = PathBuf::from("/tmp/ghost/target");
+        registry.upsert_with_time(&a, 10).unwrap();
+        registry.upsert_with_time(&b, 20).unwrap();
+        registry.upsert_with_time(&c, 30).unwrap();
+
+        let removed = registry
+            .remove_many(&[a.clone(), ghost.clone(), b.clone()])
+            .unwrap();
+        assert_eq!(removed, 2);
+        assert!(registry.get(&a).unwrap().is_none());
+        assert!(registry.get(&b).unwrap().is_none());
+        assert!(registry.get(&c).unwrap().is_some());
+        assert!(registry.get(&ghost).unwrap().is_none());
+    }
+
+    #[test]
+    fn remove_many_on_empty_input_is_a_noop() {
+        let registry = TargetRegistry::open_in_memory().unwrap();
+        let path = PathBuf::from("/tmp/keep/target");
+        registry.upsert_with_time(&path, 5).unwrap();
+        assert_eq!(registry.remove_many(&[]).unwrap(), 0);
+        assert!(registry.get(&path).unwrap().is_some());
     }
 
     #[test]

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -205,6 +205,13 @@ enum GcSubcommand {
         #[arg(long)]
         json: bool,
     },
+    /// List every `target/` directory currently tracked in the soldr
+    /// registry, without applying any age or size thresholds.
+    List {
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[tokio::main]
@@ -377,6 +384,10 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                     larger_than,
                     json,
                 },
+                Some(GcSubcommand::List { json }) => {
+                    run_gc_list_command(json)?;
+                    return Ok(());
+                }
                 None => GcInvocation {
                     mode: GcMode::Summary,
                     older_than,
@@ -3433,6 +3444,162 @@ fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError> {
             error_log_path: error_log_path.map(|p| p.display().to_string()),
         };
         print_json(&output)?;
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct GcListEntryOutput {
+    path: String,
+    last_used_unix: i64,
+    age_seconds: i64,
+    age_human: String,
+    size_bytes: u64,
+    size_human: String,
+    file_count: u64,
+}
+
+#[derive(Serialize)]
+struct GcListOutput {
+    schema_version: u32,
+    command: &'static str,
+    mode: &'static str,
+    registry_path: String,
+    entry_count: usize,
+    pruned_missing: usize,
+    entries: Vec<GcListEntryOutput>,
+}
+
+fn absolute_path_string(path: &std::path::Path) -> String {
+    std::path::absolute(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .display()
+        .to_string()
+}
+
+/// Compute `(size_bytes, file_count)` for a directory using rayon to
+/// fan out across the top-level entries. The per-entry walk is the
+/// existing sequential routine. This keeps the implementation small
+/// while exploiting the typical cargo `target/` layout where the bulk
+/// of bytes sit under a handful of subdirs (`debug/`, `release/`,
+/// per-target triples, etc.).
+fn fast_directory_size_and_files(path: &std::path::Path) -> (u64, u64) {
+    use rayon::prelude::*;
+
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(_) => return (0, 0),
+    };
+    if metadata.file_type().is_symlink() {
+        return (0, 0);
+    }
+    if metadata.is_file() {
+        return (metadata.len(), 1);
+    }
+    let entries: Vec<std::fs::DirEntry> = match std::fs::read_dir(path) {
+        Ok(iter) => iter.flatten().collect(),
+        Err(_) => return (0, 0),
+    };
+    entries
+        .into_par_iter()
+        .map(|entry| {
+            let entry_path = entry.path();
+            let entry_meta = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => return (0u64, 0u64),
+            };
+            if entry_meta.file_type().is_symlink() {
+                (0, 0)
+            } else if entry_meta.is_dir() {
+                soldr_cache::target_registry::directory_size_and_files(&entry_path)
+            } else if entry_meta.is_file() {
+                (entry_meta.len(), 1)
+            } else {
+                (0, 0)
+            }
+        })
+        .reduce(
+            || (0u64, 0u64),
+            |a, b| (a.0.saturating_add(b.0), a.1.saturating_add(b.1)),
+        )
+}
+
+fn run_gc_list_command(json: bool) -> Result<(), SoldrError> {
+    use rayon::prelude::*;
+
+    let paths = SoldrPaths::new()?;
+    let db_path = soldr_cache::data_db_path(&paths);
+    let registry = soldr_cache::target_registry::TargetRegistry::open(&db_path)
+        .map_err(|e| SoldrError::Other(format!("failed to open soldr registry: {e}")))?;
+    let rows = registry
+        .list()
+        .map_err(|e| SoldrError::Other(format!("gc list failed: {e}")))?;
+    let now = soldr_cache::target_registry::current_unix_seconds()
+        .map_err(|e| SoldrError::Other(format!("gc list clock error: {e}")))?;
+
+    // Partition rows into those still on disk and those that have
+    // disappeared since the registry was written. Missing rows are
+    // never reported — they're swept out of the registry at the end
+    // via a single batched delete.
+    let (live_rows, missing_paths): (Vec<_>, Vec<_>) = rows.into_par_iter().partition_map(|row| {
+        if row.path.exists() {
+            rayon::iter::Either::Left(row)
+        } else {
+            rayon::iter::Either::Right(row.path)
+        }
+    });
+
+    let entries: Vec<GcListEntryOutput> = live_rows
+        .into_par_iter()
+        .map(|row| {
+            let (size_bytes, file_count) = fast_directory_size_and_files(&row.path);
+            let age_seconds = now.saturating_sub(row.last_used);
+            GcListEntryOutput {
+                path: absolute_path_string(&row.path),
+                last_used_unix: row.last_used,
+                age_seconds,
+                age_human: soldr_cache::target_registry::human_age(age_seconds),
+                size_bytes,
+                size_human: soldr_cache::target_registry::human_size(size_bytes),
+                file_count,
+            }
+        })
+        .collect();
+
+    let pruned_missing = registry
+        .remove_many(&missing_paths)
+        .map_err(|e| SoldrError::Other(format!("failed to prune missing registry rows: {e}")))?;
+
+    if json {
+        let output = GcListOutput {
+            schema_version: JSON_SCHEMA_VERSION,
+            command: "gc",
+            mode: "list",
+            registry_path: db_path.display().to_string(),
+            entry_count: entries.len(),
+            pruned_missing,
+            entries,
+        };
+        print_json(&output)?;
+    } else {
+        println!("soldr gc list: registry: {}", db_path.display());
+        println!(
+            "soldr gc list: {} tracked target dir{}",
+            entries.len(),
+            if entries.len() == 1 { "" } else { "s" }
+        );
+        for entry in &entries {
+            println!(
+                "  {}  size={}  files={}  age={}",
+                entry.path, entry.size_human, entry.file_count, entry.age_human,
+            );
+        }
+        if pruned_missing > 0 {
+            println!(
+                "soldr gc list: pruned {pruned_missing} missing row{} from registry",
+                if pruned_missing == 1 { "" } else { "s" }
+            );
+        }
     }
     Ok(())
 }

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -908,6 +908,186 @@ fn gc_purge_all_json_reports_error_log_path_and_keeps_failed_row() {
 }
 
 #[test]
+fn gc_list_json_reports_built_project_target_dir() {
+    let cache_root = unique_temp_dir("gc-list-build");
+    let project_dir = unique_temp_dir("gc-list-project");
+
+    fs::write(
+        project_dir.join("Cargo.toml"),
+        "[package]\nname = \"gc_list_demo\"\nversion = \"0.0.1\"\nedition = \"2021\"\n\n[workspace]\n",
+    )
+    .expect("failed to write Cargo.toml");
+    fs::create_dir_all(project_dir.join("src")).expect("failed to create src dir");
+    fs::write(project_dir.join("src/main.rs"), "fn main() {}\n").expect("failed to write main.rs");
+
+    let soldr_bin = env!("CARGO_BIN_EXE_soldr");
+    let cargo = rustup_which("cargo");
+
+    let build = Command::new(&cargo)
+        .args(["build", "--quiet"])
+        .current_dir(&project_dir)
+        .env("RUSTC_WRAPPER", soldr_bin)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        // No zccache binary override → soldr wrapper records the target
+        // dir, then falls through to invoking rustc directly.
+        .env_remove("SOLDR_TEST_ZCCACHE_BIN")
+        .env_remove("ZCCACHE_BINARY")
+        .output()
+        .expect("failed to run cargo build through soldr wrapper");
+
+    assert!(
+        build.status.success(),
+        "cargo build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let target_dir = project_dir.join("target");
+    assert!(target_dir.exists(), "target/ should exist after build");
+
+    let canonical_target = fs::canonicalize(&target_dir).unwrap_or_else(|_| target_dir.clone());
+
+    let output = Command::new(soldr_bin)
+        .args(["gc", "list", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr gc list --json");
+
+    assert!(
+        output.status.success(),
+        "gc list --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gc list --json must be JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "gc");
+    assert_eq!(json["mode"], "list");
+    let entry_count = json["entry_count"].as_u64().expect("entry_count");
+    assert!(entry_count >= 1, "expected at least one tracked target dir");
+
+    let entries = json["entries"].as_array().expect("entries array");
+    let canonical_str = canonical_target.display().to_string();
+    let target_str = target_dir.display().to_string();
+    let matched = entries.iter().find(|e| {
+        let p = e["path"].as_str().unwrap_or("");
+        let pb = PathBuf::from(p);
+        if p == canonical_str || p == target_str || pb == canonical_target || pb == target_dir {
+            return true;
+        }
+        if let Ok(canon_p) = fs::canonicalize(&pb) {
+            return canon_p == canonical_target;
+        }
+        false
+    });
+    let entry = matched.unwrap_or_else(|| {
+        panic!(
+            "target dir {} not found in gc list entries: {}",
+            canonical_target.display(),
+            serde_json::to_string_pretty(entries).unwrap()
+        )
+    });
+
+    let path_str = entry["path"].as_str().expect("entry path");
+    assert!(
+        PathBuf::from(path_str).is_absolute(),
+        "gc list entries must use absolute paths: {path_str}"
+    );
+    let size_bytes = entry["size_bytes"].as_u64().expect("size_bytes");
+    assert!(size_bytes > 0, "built target/ should have non-zero size");
+    let file_count = entry["file_count"].as_u64().expect("file_count");
+    assert!(file_count > 0, "built target/ should contain files");
+
+    for entry in entries {
+        assert!(
+            entry["path"].is_string(),
+            "every entry must have a path string"
+        );
+        assert!(
+            entry["size_bytes"].is_u64(),
+            "every entry must have size_bytes"
+        );
+        assert!(
+            entry["file_count"].is_u64(),
+            "every entry must have file_count"
+        );
+        assert!(
+            entry.get("exists").is_none(),
+            "missing rows are pruned, so `exists` should not appear on listed entries"
+        );
+    }
+}
+
+#[test]
+fn gc_list_json_prunes_missing_registry_rows_in_one_pass() {
+    let cache_root = unique_temp_dir("gc-list-prune");
+    let dev_root = cache_root.join("dev-root");
+
+    let live_workspace = dev_root.join("live-project");
+    let live_target = live_workspace.join("target");
+    fs::create_dir_all(&live_target).expect("failed to create live target dir");
+    fs::write(live_target.join("artifact.bin"), b"keep me").expect("failed to seed live target");
+
+    let missing_target = dev_root.join("ghost-project").join("target");
+
+    {
+        let registry =
+            soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("state.redb"))
+                .expect("failed to open target registry");
+        let now = soldr_cache::target_registry::current_unix_seconds()
+            .expect("failed to read clock for seeding");
+        registry
+            .upsert_with_time(&live_target, now - 30)
+            .expect("failed to seed live row");
+        registry
+            .upsert_with_time(&missing_target, now - 30)
+            .expect("failed to seed missing row");
+        assert!(
+            registry.get(&missing_target).unwrap().is_some(),
+            "missing-row seed precondition"
+        );
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "list", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr gc list --json");
+    assert!(
+        output.status.success(),
+        "gc list --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gc list must be JSON");
+    assert_eq!(json["mode"], "list");
+    assert_eq!(json["entry_count"], 1);
+    assert_eq!(json["pruned_missing"], 1);
+
+    let entries = json["entries"].as_array().expect("entries array");
+    assert_eq!(entries.len(), 1, "missing entry must not be reported");
+    let missing_str = missing_target.display().to_string();
+    for entry in entries {
+        let p = entry["path"].as_str().unwrap_or("");
+        assert_ne!(p, missing_str, "missing path leaked into output");
+    }
+
+    let registry_after =
+        soldr_cache::target_registry::TargetRegistry::open(&cache_root.join("state.redb"))
+            .expect("failed to reopen registry");
+    assert!(
+        registry_after.get(&missing_target).unwrap().is_none(),
+        "missing row should be batched out of the registry"
+    );
+    assert!(
+        registry_after.get(&live_target).unwrap().is_some(),
+        "live row must be preserved"
+    );
+}
+
+#[test]
 fn gc_flat_all_is_rejected_with_purge_hint() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["gc", "--all"])


### PR DESCRIPTION
## Summary

- **New subcommand `soldr gc list [--json]`** — enumerates every `target/` directory currently tracked in the soldr registry (`~/.soldr/state.redb`) without applying any age or size thresholds. Each entry reports an absolute path, recursive size in bytes, file count, and last-used timestamp. JSON mode emits a stable, machine-facing payload with `schema_version`, `command`, `mode`, `registry_path`, `entry_count`, `pruned_missing`, and `entries[]`.
- **Missing rows are pruned in one pass** — paths that no longer exist on disk are removed from the registry in a single batched redb write transaction before the report is emitted, so they never appear in output. `TargetRegistry` gains a `remove_many(&[PathBuf]) -> Result<usize, _>` helper that deletes a slice of paths in one write txn.
- **Fast parallel scan** — size and file-count walks run via `rayon` both across registry rows and across each target dir's top-level entries (`fast_directory_size_and_files`), keeping the listing snappy even with many tracked workspaces.

## Test plan

- [x] `cargo test -p soldr-cache target_registry` — covers `remove_many` (hit counting, empty input is a no-op).
- [x] `cargo test -p soldr-cli --test cli gc_` — 8 gc-prefixed tests, all green.
- [x] `gc_list_json_reports_built_project_target_dir` — creates a tiny hello-world cargo project, runs `cargo build` with `RUSTC_WRAPPER=<soldr>` so the wrapper records the target dir, then runs `soldr gc list --json` and asserts the workspace's `target/` is reported with absolute path, non-zero size, and non-zero file count.
- [x] `gc_list_json_prunes_missing_registry_rows_in_one_pass` — seeds the registry with one live and one missing row, runs `soldr gc list --json`, and asserts `pruned_missing == 1`, the missing row is not in `entries`, and the registry no longer contains it.
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)