### PR TITLE
ci: route lint through soldr and re-add rustfmt/clippy components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,14 @@ jobs:
           # clippy still uses soldr's compilation cache below.
           target-cache: false
 
+      # setup-soldr@d7be70d installs a minimal toolchain without rustfmt or
+      # clippy. Once https://github.com/zackees/setup-soldr/issues/93 lands,
+      # the shim layer + default components will make this step unnecessary.
+      - name: Install rustfmt and clippy components
+        run: rustup component add rustfmt clippy
+
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: soldr cargo fmt --all -- --check
 
       - name: Check npm package metadata
         run: node scripts/test-npm-package.js


### PR DESCRIPTION
## Summary

- Switch the Lint job's formatting step to `soldr cargo fmt --all -- --check` so it goes through the same cargo front door clippy already uses.
- Add a `rustup component add rustfmt clippy` step right after `setup-soldr` so the minimal toolchain it provisions actually has the binaries.

The Lint job has been failing on every push to `main` since the setup-soldr pin bump in #315 — the action now installs a minimal stable toolchain with no `rustfmt`/`clippy` component, so `cargo fmt --all -- --check` aborts before any formatting is checked (`'cargo-fmt' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'`). See run [25877039324](https://github.com/zackees/soldr/actions/runs/25877039324/job/76046886320) and four prior identical failures.

This PR is a workaround. The structural fix is filed at [setup-soldr#93](https://github.com/zackees/setup-soldr/issues/93): make setup-soldr install PATH shims for every soldr-routable tool (`cargo`, `rustfmt`, `clippy-driver`, etc.) so naked invocations transparently become `soldr <tool>` calls, and default the components list to include `rustfmt` + `clippy`. Once that lands, both new lines here become unnecessary and we can drop them.

## Test plan

- [x] Re-run CI on this branch; the Lint job should pass.
- [x] Confirm `soldr cargo fmt --all -- --check` is functionally equivalent to `cargo fmt --all -- --check` (soldr's cargo front door is pure passthrough for unknown subcommands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)