### PR TITLE
Persist zccache session stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "blake3",
  "redb",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "clap",
  "fs2",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "serde",
  "tempfile",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.20"
+version = "0.7.21"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -127,6 +127,10 @@ pub fn session_log_path(zccache_dir: &Path) -> PathBuf {
     zccache_dir.join("logs").join("last-session.log")
 }
 
+pub fn session_stats_path(zccache_dir: &Path) -> PathBuf {
+    zccache_dir.join("logs").join("last-session-stats.json")
+}
+
 #[derive(Debug, Deserialize)]
 struct SessionStartResponse {
     session_id: String,
@@ -136,8 +140,8 @@ struct SessionStartResponse {
 mod tests {
     use super::{
         cache_enabled_env_value, cache_enabled_from_env_var, parse_zccache_session_id, sccache_dir,
-        session_journal_path, session_log_path, zccache_dir, CACHE_DISABLED_VALUE,
-        CACHE_ENABLED_VALUE,
+        session_journal_path, session_log_path, session_stats_path, zccache_dir,
+        CACHE_DISABLED_VALUE, CACHE_ENABLED_VALUE,
     };
     use soldr_core::SoldrPaths;
     use std::{ffi::OsStr, path::Path};
@@ -232,6 +236,17 @@ mod tests {
             Path::new("C:\\soldr-root\\cache\\zccache")
                 .join("logs")
                 .join("last-session.log")
+        );
+    }
+
+    #[test]
+    fn session_stats_path_uses_logs_directory() {
+        let path = session_stats_path(Path::new("C:\\soldr-root\\cache\\zccache"));
+        assert_eq!(
+            path,
+            Path::new("C:\\soldr-root\\cache\\zccache")
+                .join("logs")
+                .join("last-session-stats.json")
         );
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -3108,6 +3108,7 @@ struct ZccacheBuildSession {
     session_id: String,
     session_log_path: std::path::PathBuf,
     journal_path: std::path::PathBuf,
+    session_stats_path: std::path::PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3198,6 +3199,7 @@ async fn prepare_zccache_build(
     let session_log_path_arg = session_log_path.display().to_string();
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
     let journal_path_arg = journal_path.display().to_string();
+    let session_stats_path = soldr_cache::session_stats_path(&zccache_dir);
     let session_json = run_zccache_command_in_cache_dir(
         &fetch.binary_path,
         &[
@@ -3230,13 +3232,14 @@ async fn prepare_zccache_build(
         session_id,
         session_log_path,
         journal_path,
+        session_stats_path,
     })
 }
 
 fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
-    let output = run_zccache_command_in_cache_dir(
+    let output = run_zccache_command_raw_in_cache_dir(
         &session.binary_path,
-        &["session-end", &session.session_id],
+        &["session-end", &session.session_id, "--json"],
         &session.cache_dir,
     )?;
     if session.session_log_path.exists() {
@@ -3245,12 +3248,124 @@ fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError>
             session.session_log_path.display()
         );
     }
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stats_json = stdout.trim();
+        if !stats_json.is_empty() {
+            write_zccache_session_stats_json(session, stats_json)?;
+            let stats = parse_zccache_session_stats_json(stats_json)?;
+            print_zccache_session_stats(&stats, &session.session_stats_path);
+        }
+        return Ok(());
+    }
+
+    if zccache_json_flag_unsupported(&output) {
+        eprintln!(
+            "soldr: zccache JSON session summary unavailable; falling back to text session-end"
+        );
+        finish_zccache_build_text_fallback(session)?;
+        return Ok(());
+    }
+
+    Err(SoldrError::Other(zccache_command_failure_message(
+        &["session-end", &session.session_id, "--json"],
+        &output,
+    )))
+}
+
+fn finish_zccache_build_text_fallback(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
+    let output = run_zccache_command_in_cache_dir(
+        &session.binary_path,
+        &["session-end", &session.session_id],
+        &session.cache_dir,
+    )?;
     let stdout = output.stdout.trim();
     if !stdout.is_empty() {
         eprintln!("soldr: zccache session summary");
         eprintln!("{stdout}");
     }
     Ok(())
+}
+
+fn write_zccache_session_stats_json(
+    session: &ZccacheBuildSession,
+    stats_json: &str,
+) -> Result<(), SoldrError> {
+    if let Some(parent) = session.session_stats_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&session.session_stats_path, stats_json)?;
+    Ok(())
+}
+
+fn parse_zccache_session_stats_json(stats_json: &str) -> Result<serde_json::Value, SoldrError> {
+    serde_json::from_str(stats_json).map_err(|err| {
+        SoldrError::Other(format!(
+            "failed to parse zccache JSON session summary: {err}"
+        ))
+    })
+}
+
+fn print_zccache_session_stats(stats: &serde_json::Value, stats_path: &std::path::Path) {
+    eprintln!("soldr: zccache session summary");
+    eprintln!("  stats file: {}", stats_path.display());
+    match stats.get("status").and_then(serde_json::Value::as_str) {
+        Some("ok") => {
+            let hits = json_u64(stats, "hits").unwrap_or(0);
+            let misses = json_u64(stats, "misses").unwrap_or(0);
+            let non_cacheable = json_u64(stats, "non_cacheable").unwrap_or(0);
+            let errors = json_u64(stats, "errors").unwrap_or(0);
+            let compilations = json_u64(stats, "compilations").unwrap_or(hits + misses);
+            eprintln!(
+                "  compilations: {compilations}; hits: {hits}; misses: {misses}; non-cacheable: {non_cacheable}; errors: {errors}"
+            );
+            if let Some(hit_rate) = json_f64(stats, "hit_rate") {
+                eprintln!("  hit rate: {:.1}%", hit_rate * 100.0);
+            } else {
+                eprintln!("  hit rate: n/a");
+            }
+            let unique_sources = json_u64(stats, "unique_sources").unwrap_or(0);
+            let bytes_read = json_u64(stats, "bytes_read").unwrap_or(0);
+            let bytes_written = json_u64(stats, "bytes_written").unwrap_or(0);
+            eprintln!(
+                "  unique sources: {unique_sources}; bytes read: {bytes_read}; bytes written: {bytes_written}"
+            );
+            let time_saved_ms = json_u64(stats, "time_saved_ms").unwrap_or(0);
+            let duration_ms = json_u64(stats, "duration_ms").unwrap_or(0);
+            eprintln!("  time saved: {time_saved_ms} ms; duration: {duration_ms} ms");
+        }
+        Some("unavailable") => {
+            let reason = stats
+                .get("reason")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown");
+            eprintln!("  status: unavailable ({reason})");
+        }
+        Some("error") => {
+            let error = stats
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown error");
+            eprintln!("  status: error ({error})");
+        }
+        Some(status) => eprintln!("  status: {status}"),
+        None => eprintln!("  status: unknown"),
+    }
+}
+
+fn json_u64(value: &serde_json::Value, key: &str) -> Option<u64> {
+    value.get(key).and_then(serde_json::Value::as_u64)
+}
+
+fn json_f64(value: &serde_json::Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(serde_json::Value::as_f64)
+}
+
+fn zccache_json_flag_unsupported(output: &std::process::Output) -> bool {
+    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+    stderr.contains("unexpected argument")
+        || stderr.contains("unrecognized option")
+        || stderr.contains("found argument")
 }
 
 fn clear_zccache_cache() -> Result<(), SoldrError> {
@@ -3791,6 +3906,8 @@ struct ZccacheStatusSnapshot {
     session_log_present: bool,
     journal_path: String,
     journal_present: bool,
+    session_stats_path: String,
+    session_stats_present: bool,
     binary_path: Option<String>,
     binary_fetched: bool,
     status_lines: Vec<String>,
@@ -3839,6 +3956,8 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
     let session_log_present = session_log_path.exists();
     let journal_path = soldr_cache::session_journal_path(&zccache_dir);
     let journal_present = journal_path.exists();
+    let session_stats_path = soldr_cache::session_stats_path(&zccache_dir);
+    let session_stats_present = session_stats_path.exists();
 
     match cached_managed_zccache(paths)? {
         Some(fetch) => {
@@ -3853,6 +3972,8 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
                 session_log_present,
                 journal_path: journal_path.display().to_string(),
                 journal_present,
+                session_stats_path: session_stats_path.display().to_string(),
+                session_stats_present,
                 binary_path: Some(fetch.binary_path.display().to_string()),
                 binary_fetched: true,
                 status_lines,
@@ -3866,6 +3987,8 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
             session_log_present,
             journal_path: journal_path.display().to_string(),
             journal_present,
+            session_stats_path: session_stats_path.display().to_string(),
+            session_stats_present,
             binary_path: None,
             binary_fetched: false,
             status_lines: Vec::new(),
@@ -3912,6 +4035,15 @@ fn print_zccache_status_snapshot(snapshot: &ZccacheStatusSnapshot) {
         "last session journal: {} ({})",
         snapshot.journal_path,
         if snapshot.journal_present {
+            "present"
+        } else {
+            "missing"
+        }
+    );
+    println!(
+        "last session stats: {} ({})",
+        snapshot.session_stats_path,
+        if snapshot.session_stats_present {
             "present"
         } else {
             "missing"
@@ -4573,6 +4705,7 @@ mod tests {
             session_id: "session-1".to_string(),
             session_log_path: root.join("cache/logs/last-session.log"),
             journal_path: root.join("cache/logs/last-session.jsonl"),
+            session_stats_path: root.join("cache/logs/last-session-stats.json"),
         };
         let args = vec![
             "build".to_string(),
@@ -4767,6 +4900,7 @@ mod tests {
             session_id: "session-thinv2".to_string(),
             session_log_path: root.join("cache/logs/last-session.log"),
             journal_path: root.join("cache/logs/last-session.jsonl"),
+            session_stats_path: root.join("cache/logs/last-session-stats.json"),
         };
 
         let plan = build_rust_artifact_plan(

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -412,10 +412,14 @@ fn fake_zccache_script(log_path: &Path) -> String {
                 if not \"%~6\"==\"\" type nul > \"%~6\"\n\
                 echo {{\"session_id\":\"test-session\"}}\n\
                 exit /b 0\n\
-              )\n\
+             )\n\
              if \"%~1\"==\"session-end\" (\n\
-               echo zccache session-end %~2 cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
-               echo hits: 1\n\
+               echo zccache session-end %~2 %~3 cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+               if \"%~3\"==\"--json\" (\n\
+                 echo {{\"status\":\"ok\",\"session_id\":\"test-session\",\"duration_ms\":1200,\"compilations\":10,\"hits\":7,\"misses\":3,\"non_cacheable\":2,\"errors\":1,\"time_saved_ms\":900,\"unique_sources\":4,\"bytes_read\":111,\"bytes_written\":222,\"hit_rate\":0.7}}\n\
+               ) else (\n\
+                 echo hits: 1\n\
+               )\n\
                exit /b 0\n\
              )\n\
              if \"%~1\"==\"rust-plan\" (\n\
@@ -487,12 +491,16 @@ fn fake_zccache_script(log_path: &Path) -> String {
                   : > \"$6\"\n\
                   echo '{{\"session_id\":\"test-session\"}}'\n\
                   exit 0\n\
-                  ;;\n\
-               session-end)\n\
-                 echo \"zccache session-end $2 cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
-               echo 'hits: 1'\n\
-               exit 0\n\
                ;;\n\
+               session-end)\n\
+                 echo \"zccache session-end $2 $3 cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+                 if [ \"${{3:-}}\" = \"--json\" ]; then\n\
+                   printf '{{\"status\":\"ok\",\"session_id\":\"test-session\",\"duration_ms\":1200,\"compilations\":10,\"hits\":7,\"misses\":3,\"non_cacheable\":2,\"errors\":1,\"time_saved_ms\":900,\"unique_sources\":4,\"bytes_read\":111,\"bytes_written\":222,\"hit_rate\":0.7}}\\n'\n\
+                 else\n\
+                   echo 'hits: 1'\n\
+                 fi\n\
+                 exit 0\n\
+                 ;;\n\
               rust-plan)\n\
                 echo \"zccache rust-plan $2 cache_dir=${{ZCCACHE_CACHE_DIR:-}} args=$*\" >> \"{0}\"\n\
                 if [ \"$2\" = \"restore\" ] && [ -n \"${{SOLDR_TEST_RUST_PLAN_STALE:-}}\" ]; then\n\
@@ -1133,7 +1141,7 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         "real rustc invocation should still happen through the wrapper path: {log}"
     );
     assert!(
-        log.contains("zccache session-end test-session"),
+        log.contains("zccache session-end test-session --json"),
         "managed zccache session should end after cargo finishes: {log}"
     );
 
@@ -1142,9 +1150,16 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         stderr.contains("soldr: zccache session summary"),
         "expected zccache session summary in stderr: {stderr}"
     );
+    assert!(
+        stderr.contains("hits: 7") && stderr.contains("misses: 3"),
+        "expected zccache hit/miss counts in stderr: {stderr}"
+    );
 
     let journal = zccache_cache_dir.join("logs").join("last-session.jsonl");
     let session_log = zccache_cache_dir.join("logs").join("last-session.log");
+    let session_stats = zccache_cache_dir
+        .join("logs")
+        .join("last-session-stats.json");
     assert!(
         session_log.exists(),
         "expected session log at {}",
@@ -1155,6 +1170,14 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         "expected session journal at {}",
         journal.display()
     );
+    let stats_json: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&session_stats)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", session_stats.display())),
+    )
+    .expect("failed to parse zccache session stats JSON");
+    assert_eq!(stats_json["status"], "ok");
+    assert_eq!(stats_json["hits"], 7);
+    assert_eq!(stats_json["misses"], 3);
 }
 
 #[cfg(windows)]
@@ -2513,7 +2536,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.4.7");
+    assert_eq!(json["managed_zccache_version"], "1.4.8");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -2522,6 +2545,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["zccache"]["binary_fetched"], false);
     assert_eq!(json["zccache"]["session_log_present"], false);
     assert_eq!(json["zccache"]["journal_present"], false);
+    assert_eq!(json["zccache"]["session_stats_present"], false);
     assert_eq!(
         json["zccache"]["cache_dir"],
         cache_root
@@ -2544,6 +2568,16 @@ fn status_json_reports_stable_machine_fields() {
             .display()
             .to_string()
     );
+    assert_eq!(
+        json["zccache"]["session_stats_path"],
+        cache_root
+            .join("cache")
+            .join("zccache")
+            .join("logs")
+            .join("last-session-stats.json")
+            .display()
+            .to_string()
+    );
 }
 
 #[test]
@@ -2561,10 +2595,20 @@ fn cache_command_reports_managed_zccache_status() {
         .join("zccache")
         .join("logs")
         .join("last-session.log");
+    let session_stats = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session-stats.json");
     fs::create_dir_all(journal.parent().expect("journal parent missing"))
         .expect("failed to create journal dir");
     fs::write(&session_log, "compile line\n").expect("failed to seed session log");
     fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+    fs::write(
+        &session_stats,
+        "{\"status\":\"ok\",\"hits\":7,\"misses\":3}\n",
+    )
+    .expect("failed to seed session stats");
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .arg("cache")
@@ -2593,6 +2637,10 @@ fn cache_command_reports_managed_zccache_status() {
         "cache command missing journal path: {stdout}"
     );
     assert!(
+        stdout.contains("last session stats:"),
+        "cache command missing session stats path: {stdout}"
+    );
+    assert!(
         stdout.contains(&format!("{}", session_log.display())) && stdout.contains("(present)"),
         "cache command should report present session log: {stdout}"
     );
@@ -2617,10 +2665,20 @@ fn cache_json_reports_managed_zccache_status() {
         .join("zccache")
         .join("logs")
         .join("last-session.log");
+    let session_stats = cache_root
+        .join("cache")
+        .join("zccache")
+        .join("logs")
+        .join("last-session-stats.json");
     fs::create_dir_all(journal.parent().expect("journal parent missing"))
         .expect("failed to create journal dir");
     fs::write(&session_log, "compile line\n").expect("failed to seed session log");
     fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
+    fs::write(
+        &session_stats,
+        "{\"status\":\"ok\",\"hits\":7,\"misses\":3}\n",
+    )
+    .expect("failed to seed session stats");
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["cache", "--json"])
@@ -2635,9 +2693,10 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.4.7");
+    assert_eq!(json["managed_zccache_version"], "1.4.8");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
+    assert_eq!(json["zccache"]["session_stats_present"], true);
     assert_eq!(json["zccache"]["binary_fetched"], true);
     assert_eq!(
         json["zccache"]["cache_dir"],
@@ -2654,6 +2713,10 @@ fn cache_json_reports_managed_zccache_status() {
     assert_eq!(
         json["zccache"]["journal_path"],
         journal.display().to_string()
+    );
+    assert_eq!(
+        json["zccache"]["session_stats_path"],
+        session_stats.display().to_string()
     );
     assert_eq!(
         json["zccache"]["status_lines"][0],

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -47,7 +47,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.7";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.8";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- bump managed zccache to 1.4.8 so soldr can use `session-end --json`
- persist the latest managed zccache final stats to `logs/last-session-stats.json`
- print final hit/miss stats in `soldr cargo` stderr and expose the stats file in `soldr status/cache`
- bump soldr to 0.7.21

Refs zackees/setup-soldr#92.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p soldr-cli`
- [x] `cargo test -p soldr-cache`
- [x] `cargo test -p soldr-cli --bin soldr`
- [x] `cargo test -p soldr-fetch`
- [x] `cargo test -p soldr-cli --test cli` (without `CARGO_TARGET_DIR`; the target-dir env intentionally trips a linker env assertion)
- [x] `npm run test:npm-package`
- [x] `git diff --check`