### PR TITLE
feat(cli): soldr cache report --json + bump zccache pin to 1.5.0 (#320)

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
+        uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
           linker: platform-default

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -430,7 +430,7 @@ jobs:
       - id: setup-soldr
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db
+        uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c
         with:
           linker: platform-default
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
+      - uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
         with:
           linker: platform-default
           # Formatting does not benefit from a restored target directory, but
@@ -71,7 +71,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
+      - uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
         with:
           linker: platform-default
 
@@ -108,7 +108,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
+      - uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
         with:
           linker: platform-default
 
@@ -145,7 +145,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
+      - uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
         with:
           linker: platform-default
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -215,7 +215,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db # @v0
+        uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
         with:
           linker: platform-default
           cache-key-suffix: release-${{ matrix.target }}

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -66,7 +66,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@d7be70d3960d2401a8974a11169429c0c846f7db
+        uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c
         with:
           cache: true
           linker: platform-default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "blake3",
  "redb",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "clap",
  "fs2",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "serde",
  "tempfile",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.21"
+version = "0.7.22"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -147,6 +147,8 @@ enum Commands {
         /// Emit the stable machine-facing JSON form for this command
         #[arg(long)]
         json: bool,
+        #[command(subcommand)]
+        command: Option<CacheSubcommand>,
     },
     /// Show version
     Version {
@@ -208,6 +210,20 @@ enum GcSubcommand {
     /// List every `target/` directory currently tracked in the soldr
     /// registry, without applying any age or size thresholds.
     List {
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum CacheSubcommand {
+    /// Roll up the most recent compile-cache session into an
+    /// AI-readable diagnosis document. Reads
+    /// `<zccache_dir>/logs/last-session-stats.json` (written by soldr
+    /// at session-end) and, when available, calls `zccache analyze` for
+    /// per-tool/per-extension breakdown over the per-session journal.
+    Report {
         /// Emit the stable machine-facing JSON form for this command.
         #[arg(long)]
         json: bool,
@@ -337,14 +353,19 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
         Commands::Config => {
             println!("(config not yet implemented)");
         }
-        Commands::Cache { json } => {
-            let output = collect_cache_output()?;
-            if json {
-                print_json(&output)?;
-            } else {
-                print_cache_output(&output);
+        Commands::Cache { json, command } => match command {
+            Some(CacheSubcommand::Report { json: report_json }) => {
+                run_cache_report_command(report_json || json)?;
             }
-        }
+            None => {
+                let output = collect_cache_output()?;
+                if json {
+                    print_json(&output)?;
+                } else {
+                    print_cache_output(&output);
+                }
+            }
+        },
         Commands::Version { json } => {
             let output = version_output();
             if json {
@@ -4115,6 +4136,207 @@ fn collect_cache_output() -> Result<CacheOutput, SoldrError> {
         managed_zccache_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
         zccache: collect_zccache_status(&paths)?,
     })
+}
+
+#[derive(Serialize)]
+struct CacheReportOutput {
+    schema_version: u32,
+    command: &'static str,
+    soldr_version: String,
+    managed_zccache_version: &'static str,
+    /// Path to the per-session stats JSON file.
+    session_stats_path: String,
+    /// Whether the session-stats file exists on disk.
+    session_stats_present: bool,
+    /// Path to the per-session JSONL journal.
+    journal_path: String,
+    /// Whether the journal file exists on disk.
+    journal_present: bool,
+    /// Verbatim contents of `last-session-stats.json`, parsed into a JSON
+    /// value. `null` if the file is missing or unparseable.
+    last_session: Option<serde_json::Value>,
+    /// Output of `zccache analyze --json` over the per-session journal,
+    /// when the managed zccache supports it. `null` otherwise.
+    rollups: Option<serde_json::Value>,
+    /// Empty for now — populated by future rule passes that turn the
+    /// session + rollups into AI-readable diagnoses.
+    diagnoses: Vec<serde_json::Value>,
+    /// Why a particular field came back null, when relevant. Each entry
+    /// is a short string the user can search the soldr docs for.
+    notes: Vec<String>,
+}
+
+fn collect_cache_report_output() -> Result<CacheReportOutput, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let zccache_dir = managed_zccache_cache_dir(&paths)?;
+    let session_stats_path = soldr_cache::session_stats_path(&zccache_dir);
+    let journal_path = soldr_cache::session_journal_path(&zccache_dir);
+    let session_stats_present = session_stats_path.exists();
+    let journal_present = journal_path.exists();
+
+    let mut notes: Vec<String> = Vec::new();
+
+    let last_session = if session_stats_present {
+        match std::fs::read_to_string(&session_stats_path) {
+            Ok(s) => match serde_json::from_str::<serde_json::Value>(s.trim()) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    notes.push(format!("last_session: unparseable JSON ({e})"));
+                    None
+                }
+            },
+            Err(e) => {
+                notes.push(format!("last_session: read failed ({e})"));
+                None
+            }
+        }
+    } else {
+        notes.push(
+            "last_session: file missing — run a build with managed zccache first".to_string(),
+        );
+        None
+    };
+
+    let rollups = if journal_present {
+        match cached_managed_zccache(&paths)? {
+            Some(fetch) => {
+                let journal_arg = journal_path.display().to_string();
+                let result = run_zccache_command_raw_in_cache_dir(
+                    &fetch.binary_path,
+                    &["analyze", &journal_arg, "--json"],
+                    &zccache_dir,
+                )?;
+                if result.status.success() {
+                    let stdout = String::from_utf8_lossy(&result.stdout);
+                    match serde_json::from_str::<serde_json::Value>(stdout.trim()) {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            notes
+                                .push(format!("rollups: zccache analyze stdout unparseable ({e})"));
+                            None
+                        }
+                    }
+                } else if zccache_subcommand_unsupported(&result, "analyze") {
+                    notes.push(format!(
+                        "rollups: managed zccache {} does not yet support `analyze` — upgrade to 1.5.0+",
+                        soldr_fetch::MANAGED_ZCCACHE_VERSION
+                    ));
+                    None
+                } else {
+                    notes.push(format!(
+                        "rollups: zccache analyze exited with status {:?}",
+                        result.status.code()
+                    ));
+                    None
+                }
+            }
+            None => {
+                notes.push(
+                    "rollups: managed zccache binary not yet fetched (no builds run yet)"
+                        .to_string(),
+                );
+                None
+            }
+        }
+    } else {
+        notes
+            .push("rollups: journal missing — soldr writes it on cache-enabled builds".to_string());
+        None
+    };
+
+    Ok(CacheReportOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "cache report",
+        soldr_version: soldr_core::version().to_string(),
+        managed_zccache_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+        session_stats_path: session_stats_path.display().to_string(),
+        session_stats_present,
+        journal_path: journal_path.display().to_string(),
+        journal_present,
+        last_session,
+        rollups,
+        diagnoses: Vec::new(),
+        notes,
+    })
+}
+
+/// Heuristic: detect whether a `zccache <subcommand>` invocation failed
+/// because the subcommand does not exist in the running binary (clap
+/// emits "error: unrecognized subcommand"). Used to differentiate
+/// version-skew misses from real failures.
+fn zccache_subcommand_unsupported(output: &std::process::Output, subcommand: &str) -> bool {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let needles = [
+        "unrecognized subcommand",
+        "unrecognized command",
+        "error: subcommand",
+        "invalid value for",
+    ];
+    let combined = format!("{stderr}\n{stdout}");
+    needles.iter().any(|n| combined.contains(n)) && combined.contains(subcommand)
+}
+
+fn run_cache_report_command(json: bool) -> Result<(), SoldrError> {
+    let output = collect_cache_report_output()?;
+    if json {
+        print_json(&output)?;
+    } else {
+        print_cache_report_output(&output);
+    }
+    Ok(())
+}
+
+fn print_cache_report_output(output: &CacheReportOutput) {
+    println!("soldr cache report");
+    println!(
+        "  session-stats: {} ({})",
+        output.session_stats_path,
+        if output.session_stats_present {
+            "present"
+        } else {
+            "missing"
+        }
+    );
+    println!(
+        "  journal:       {} ({})",
+        output.journal_path,
+        if output.journal_present {
+            "present"
+        } else {
+            "missing"
+        }
+    );
+    if let Some(stats) = &output.last_session {
+        if let Some(rate) = stats.get("hit_rate").and_then(|v| v.as_f64()) {
+            println!("  hit_rate:      {:.1}%", rate * 100.0);
+        }
+        if let Some(hits) = stats.get("hits").and_then(|v| v.as_u64()) {
+            let misses = stats.get("misses").and_then(|v| v.as_u64()).unwrap_or(0);
+            println!("  hits/misses:   {hits}/{misses}");
+        }
+        if let Some(saved_ms) = stats.get("time_saved_ms").and_then(|v| v.as_u64()) {
+            println!("  time_saved:    {saved_ms} ms");
+        }
+    }
+    if let Some(rollups) = &output.rollups {
+        if let Some(by_ext) = rollups.get("by_extension").and_then(|v| v.as_object()) {
+            if !by_ext.is_empty() {
+                println!("  by extension:");
+                for (ext, bucket) in by_ext {
+                    let h = bucket.get("hits").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let m = bucket.get("misses").and_then(|v| v.as_u64()).unwrap_or(0);
+                    println!("    {ext:<14}  hits={h}  misses={m}");
+                }
+            }
+        }
+    }
+    if !output.notes.is_empty() {
+        println!("  notes:");
+        for note in &output.notes {
+            println!("    - {note}");
+        }
+    }
 }
 
 fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, SoldrError> {

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -2716,7 +2716,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.4.8");
+    assert_eq!(json["managed_zccache_version"], "1.5.0");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -2873,7 +2873,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.4.8");
+    assert_eq!(json["managed_zccache_version"], "1.5.0");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -2902,6 +2902,83 @@ fn cache_json_reports_managed_zccache_status() {
         json["zccache"]["status_lines"][0],
         Value::String("hits=7".to_string())
     );
+}
+
+#[test]
+fn cache_report_json_emits_stable_schema_when_files_missing() {
+    let cache_root = unique_temp_dir("cache-report-empty");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "report", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr cache report --json");
+
+    assert!(
+        output.status.success(),
+        "cache report --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("cache report --json must produce parseable JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "cache report");
+    assert_eq!(json["managed_zccache_version"], "1.5.0");
+    assert_eq!(json["session_stats_present"], false);
+    assert_eq!(json["journal_present"], false);
+    assert!(json["last_session"].is_null());
+    assert!(json["rollups"].is_null());
+    assert!(
+        json["diagnoses"]
+            .as_array()
+            .expect("diagnoses array")
+            .is_empty(),
+        "diagnoses should start empty before rule passes are wired"
+    );
+    let notes = json["notes"]
+        .as_array()
+        .expect("notes should always be an array");
+    assert!(
+        !notes.is_empty(),
+        "missing files should produce explanatory notes"
+    );
+}
+
+#[test]
+fn cache_report_json_surfaces_persisted_session_stats() {
+    let cache_root = unique_temp_dir("cache-report-stats");
+    let zccache_dir = cache_root.join("cache").join("zccache");
+    let stats_path = zccache_dir.join("logs").join("last-session-stats.json");
+    fs::create_dir_all(stats_path.parent().expect("stats parent missing"))
+        .expect("failed to create logs dir");
+    fs::write(
+        &stats_path,
+        r#"{"status":"ok","session_id":"abc","hits":7,"misses":3,"compilations":10,"hit_rate":0.7,"time_saved_ms":12345}"#,
+    )
+    .expect("failed to seed session stats");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "report", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr cache report --json");
+
+    assert!(
+        output.status.success(),
+        "cache report --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("cache report --json must produce JSON");
+    assert_eq!(json["session_stats_present"], true);
+    assert_eq!(json["last_session"]["status"], "ok");
+    assert_eq!(json["last_session"]["hits"], 7);
+    assert_eq!(json["last_session"]["misses"], 3);
+    assert_eq!(json["last_session"]["hit_rate"].as_f64(), Some(0.7));
 }
 
 #[test]

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -47,7 +47,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.4.8";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.5.0";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Second slice of the cache-observability program (#320), building on the recently-merged `feat(cli): persist zccache session stats` (\`bffe132\`) which already captures \`last-session-stats.json\` from \`zccache session-end --json\`.

- **Bump \`MANAGED_ZCCACHE_VERSION\` 1.4.8 → 1.5.0** to pull in \`zccache analyze\` and \`zccache status --json\` from zccache#257.

- **New subcommand \`soldr cache report [--json]\`** that aggregates the persisted session stats with the per-session journal rollup. Stable JSON envelope:

  \`\`\`jsonc
  {
    \"schema_version\": 1,
    \"command\": \"cache report\",
    \"soldr_version\": \"...\",
    \"managed_zccache_version\": \"1.5.0\",
    \"session_stats_path\": \"...\",
    \"session_stats_present\": true,
    \"journal_path\": \"...\",
    \"journal_present\": true,
    \"last_session\": { /* verbatim zccache session-end JSON */ },
    \"rollups\":      { /* zccache analyze --json output */ },
    \"diagnoses\":    [],   // placeholder, filled by future rule passes
    \"notes\":        [\"...\"] // explanatory strings when fields are null
  }
  \`\`\`

  This is the contract that setup-soldr#98 will consume to render per-job compile-cache stats into \`\$GITHUB_STEP_SUMMARY\` and action outputs.

- Workspace version 0.7.21 → 0.7.22.

## What's deferred

- \`SOLDR_CACHE_*\` env-var family (\`SOLDR_CACHE_STATS=summary|detailed|insights\`, \`SOLDR_CACHE_REPORT_FORMAT\`, \`SOLDR_PROFILE\`) — defaults are sensible enough for setup-soldr to consume; env-var knobs go in a follow-up.
- soldr self-profile via \`tracing\` — same.
- Diagnosis rule set (\`diagnoses[]\` is currently always empty) — needs real CI signal first to inform rules.

## Test plan

- [x] \`cargo test -p soldr-cli --test cli cache_\` — 18/18 green, including 2 new tests (\`cache_report_json_emits_stable_schema_when_files_missing\`, \`cache_report_json_surfaces_persisted_session_stats\`).
- [x] \`cargo fmt --all -- --check\` clean.
- [ ] CI workflows green.

## Context

Part of the cache-observability epic at #321. zccache#257 (the upstream cache-side instrumentation) merged and released as 1.5.0 — the pin bump in this PR is what makes \`soldr cache report\`'s \`rollups\` field live. setup-soldr#98 is the next phase: render this JSON into a GitHub Actions step summary + scalar outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)