### PR TITLE
fix(wrapper): spill stdin to tempfile so zccache can't exhaust it before rustc (#324)

### DIFF
--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -21,10 +21,10 @@ tracing-subscriber = { workspace = true }
 rayon = { workspace = true }
 fs2 = { workspace = true }
 toml = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 
 [features]
 # Internal feature flag that enables test-only fixture binaries (e.g.

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -636,11 +636,41 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
         record_target_dir_in_registry(&raw_args[2..]);
     }
 
+    // When the source argument is "-" (stdin), rustc reads the source from
+    // the process's stdin. If we pass this invocation to zccache as-is,
+    // zccache reads stdin to hash the source content, exhausting the pipe
+    // before rustc is spawned. Rustc then receives an empty stdin, compiles
+    // nothing, and exits 0 — masking any real compile error (e.g. E0554 from
+    // build-script feature probes like rustix 0.37's `can_compile()`).
+    //
+    // Fix: spill stdin to a temp file so both zccache and rustc see a real
+    // path. The temp file is created in the system temp directory and removed
+    // after the child exits. This keeps zccache in the loop (it can hash the
+    // file normally) while preserving the correct exit code.
+    let stdin_tempfile = if raw_args[2..].iter().any(|a| a == "-") {
+        Some(spill_stdin_to_tempfile()?)
+    } else {
+        None
+    };
+
+    // Build the effective arg list, replacing "-" with the temp file path.
+    let effective_args: std::borrow::Cow<[String]> = if let Some(ref tmp) = stdin_tempfile {
+        let tmp_str = tmp.path().to_string_lossy().into_owned();
+        let replaced: Vec<String> = raw_args
+            .iter()
+            .cloned()
+            .map(|a| if a == "-" { tmp_str.clone() } else { a })
+            .collect();
+        std::borrow::Cow::Owned(replaced)
+    } else {
+        std::borrow::Cow::Borrowed(raw_args)
+    };
+
     // Only route through zccache for actual rustc invocations, not
     // clippy-driver or other workspace wrappers.
     if tool_stem == "rustc" && soldr_cache::cache_enabled_in_current_process() {
         if let Some(zccache) = zccache_binary_override() {
-            return run_wrapper_through_zccache(raw_args, &zccache);
+            return run_wrapper_through_zccache(&effective_args, &zccache);
         }
     }
 
@@ -653,12 +683,33 @@ fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
     };
 
     let mut command = std::process::Command::new(tool_path);
-    command.args(&raw_args[2..]);
+    command.args(&effective_args[2..]);
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
     let status = command.status()?;
 
     Ok(status.code().unwrap_or(1))
+}
+
+/// Read all of stdin into a named temporary file and return the file.
+///
+/// The file has a `.rs` extension so rustc accepts it without flags, and
+/// lives in the system temp directory. It is deleted when the returned
+/// `NamedTempFile` value is dropped (i.e. after the child process exits).
+fn spill_stdin_to_tempfile() -> Result<tempfile::NamedTempFile, SoldrError> {
+    use std::io::{Read, Write as _};
+    let mut tmp = tempfile::Builder::new()
+        .prefix("soldr-stdin-")
+        .suffix(".rs")
+        .tempfile()
+        .map_err(|e| SoldrError::Other(format!("failed to create stdin temp file: {e}")))?;
+    let mut buf = Vec::new();
+    std::io::stdin()
+        .read_to_end(&mut buf)
+        .map_err(|e| SoldrError::Other(format!("failed to read stdin: {e}")))?;
+    tmp.write_all(&buf)
+        .map_err(|e| SoldrError::Other(format!("failed to write stdin temp file: {e}")))?;
+    Ok(tmp)
 }
 
 /// Run a rustup-managed toolchain binary with pass-through args.

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -3235,3 +3235,60 @@ fn cargo_front_door_forces_msvc_target_even_with_polluted_path() {
         artifact.display()
     );
 }
+
+/// Regression test for issue #324: RUSTC_WRAPPER mode must propagate the
+/// rustc exit code even when the source is read from stdin ("-").
+///
+/// Before the fix, zccache consumed stdin to hash the source. Rustc then
+/// received an empty stdin, compiled nothing, and exited 0 — masking E0554
+/// and similar errors that build-script feature probes depend on.
+///
+/// The test exercises the direct-to-rustc path (no zccache configured) to
+/// keep it self-contained and fast. The spill-to-tempfile logic runs
+/// regardless of whether zccache is in the chain.
+#[test]
+fn wrapper_mode_stdin_source_propagates_nonzero_exit_code() {
+    let rustc = rustup_which("rustc");
+    let out_dir = unique_temp_dir("wrapper-stdin-exit");
+
+    // A source that is valid Rust but uses an unstable feature gate.
+    // On stable rustc this must fail with E0554 (exit != 0).
+    let probe_source = b"#![allow(stable_features)]\n#![feature(rustc_attrs)]\n";
+
+    // Invoke soldr as RUSTC_WRAPPER: soldr <rustc-path> - <flags...>
+    // Disable the cache to avoid a zccache binary being required.
+    let mut child = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            rustc.as_str(),
+            "-",
+            "--crate-type=lib",
+            "--emit=metadata",
+            "--out-dir",
+            out_dir.to_str().expect("non-UTF-8 temp dir"),
+        ])
+        .env("SOLDR_CACHE_ENABLED", "0")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn soldr in wrapper mode");
+
+    child
+        .stdin
+        .take()
+        .expect("stdin should be piped")
+        .write_all(probe_source)
+        .expect("failed to write probe source to soldr stdin");
+
+    let output = child
+        .wait_with_output()
+        .expect("failed to wait for soldr wrapper");
+
+    assert!(
+        !output.status.success(),
+        "soldr wrapper mode with stdin source must propagate non-zero rustc exit code\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #324.

When `RUSTC_WRAPPER=soldr` and rustc reads source from stdin (`-`), zccache was consuming stdin to hash the source before spawning rustc. Rustc then received an empty stdin, compiled nothing, and exited 0 — masking compile errors. The most visible impact: build-script feature probes like rustix 0.37's `can_compile()` falsely succeeded on stable, then enabled `#![feature(rustc_attrs)]` in actual compilation and failed with E0554.

## Root cause

In `run_rustc_wrapper`, stdin-source invocations were delegated to zccache unchanged. zccache read stdin to compute a hash, exhausting the pipe. Rustc (spawned after) got an empty stdin → compiled empty source → exit 0.

## Fix

Detect a `-` source arg in `run_rustc_wrapper` and buffer stdin into a `NamedTempFile` (`.rs` extension, system temp dir) **before** delegating. Replace every `-` in the arg list with the temp file path. The file is cleaned up when the `NamedTempFile` is dropped after the child exits.

- zccache stays in the loop and hashes the file normally
- rustc reads from the file (never empty)
- exit code propagates correctly
- `tempfile` moved from `dev-dependencies` → `dependencies` in `soldr-cli/Cargo.toml`

## Test

`wrapper_mode_stdin_source_propagates_nonzero_exit_code` in `tests/cli.rs`: pipes an unstable-feature probe (`#![feature(rustc_attrs)]`) through soldr in RUSTC_WRAPPER mode with `SOLDR_CACHE_ENABLED=0` (no zccache) and asserts exit code is non-zero. Exercises the tempfile spill path; extending to the zccache path requires a fake-zccache stub and is left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)