### PR TITLE
ci: update setup-soldr workflow pins to current @v0 (dc7390d)

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
+        uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
           linker: platform-default

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -430,7 +430,7 @@ jobs:
       - id: setup-soldr
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c
+        uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83
         with:
           linker: platform-default
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
+      - uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
         with:
           linker: platform-default
           # Formatting does not benefit from a restored target directory, but
@@ -77,7 +77,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
+      - uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
         with:
           linker: platform-default
 
@@ -114,7 +114,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
+      - uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
         with:
           linker: platform-default
 
@@ -151,7 +151,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
+      - uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
         with:
           linker: platform-default
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -215,7 +215,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c # @v0
+        uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
         with:
           linker: platform-default
           cache-key-suffix: release-${{ matrix.target }}

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -66,7 +66,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@f3f2d86d0908974e746cab3b00a09f98d570bb8c
+        uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83
         with:
           cache: true
           linker: platform-default


### PR DESCRIPTION
## Summary

- Update all `zackees/setup-soldr` SHA pins from `f3f2d86d0908974e746cab3b00a09f98d570bb8c` → `dc7390d816f6251a92d1d837c99f1e1c598caf83` (current `@v0`)
- Files updated: `_bootstrap-e2e.yml`, `ci.yml`, `release-auto.yml`, `cache-benchmark.yml`, `setup-soldr-action.yml`

## Why

`setup-soldr@v0` moved forward to include three recent fixes:
- [#103](https://github.com/zackees/setup-soldr/pull/103) — toolchain auto-detect from `rust-toolchain.toml` when `toolchain-file` input is unset
- [#101](https://github.com/zackees/setup-soldr/pull/101) — `compile-cache-stats` input + 10 new scalar action outputs
- [#99](https://github.com/zackees/setup-soldr/pull/99) — PATH shims for cargo/rustc/rustfmt + dry-run + file logging

The stale pin caused `Verify setup-soldr pin matches v0` to fail on every build, blocking the Autonomous Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)