### PR TITLE
feat(gc): auto-GC under disk pressure + manual gc cargo / locations / sweep

### DIFF
--- a/crates/soldr-cache/src/auto_gc.rs
+++ b/crates/soldr-cache/src/auto_gc.rs
@@ -1,0 +1,460 @@
+//! Auto-GC under disk pressure (issue #323).
+//!
+//! This module owns the pure policy:
+//!
+//! * group soldr-relevant paths by volume,
+//! * decide whether any volume is below the configured trigger,
+//! * compute the clamped age floor that every tier must respect,
+//! * advance through tiers stopping as soon as the target free-space
+//!   threshold is reached.
+//!
+//! It does **not** perform any disk operations. Disk-free probing, the
+//! shell-out to `cargo -Zgc clean gc`, and the soldr target purge live
+//! in the CLI layer. That separation keeps this module unit-testable
+//! with a mocked disk-free probe and path enumerator.
+//!
+//! See `docs/API.md` and `gh issue 323 zackees/soldr` for the
+//! user-facing brief.
+//!
+//! ```text
+//! Tier 1 — cargo `clean gc` with conservative ages (cargo defaults).
+//! Tier 2 — soldr target/ purge (older_than = max(1h, config min_age),
+//!          larger_than = 256MiB).
+//! Tier 3 — cargo `clean gc` with aggressive ages
+//!          (`--max-src-age=7d --max-crate-age=14d --max-git-co-age=7d`).
+//! Tier 4 — warn and stop. Anything more aggressive requires explicit
+//!          `soldr gc sweep --aggressive`.
+//! ```
+//!
+//! All tier ages are clamped to be ≥ `min_age_secs` before being passed
+//! to cargo or the soldr purge so we never accidentally torch a build
+//! mid-flight.
+
+use soldr_core::AutoGcConfig;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+/// One GiB in bytes — the unit `AutoGcConfig::trigger_free_gb` and
+/// `target_free_gb` are expressed in.
+pub const GIB: u64 = 1024 * 1024 * 1024;
+
+/// A path soldr cares about for auto-GC. The `kind` is informational
+/// only; callers (e.g. the auto-GC orchestrator) decide which kinds to
+/// pass to which tier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AutoGcPath {
+    pub kind: AutoGcPathKind,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AutoGcPathKind {
+    /// `$CARGO_HOME` — registry/git caches, the `.global-cache` SQLite
+    /// file. Touched indirectly by cargo's own GC.
+    CargoHome,
+    /// `$RUSTUP_HOME` — toolchains and update hashes. Never touched by
+    /// auto-GC; included only so its volume contributes to disk-free
+    /// computations.
+    RustupHome,
+    /// `~/.soldr/cache` — soldr's own artifact cache.
+    SoldrCache,
+    /// A workspace `target/` directory from the soldr registry.
+    WorkspaceTarget,
+}
+
+/// Trait abstracting disk-free probing so tests can plug in a fixed
+/// map of `volume_key -> free_bytes`.
+pub trait DiskFreeProbe {
+    /// Return free bytes on the volume that backs `path`, or `None`
+    /// if the volume can't be resolved (missing path, permission
+    /// error, etc.). Implementations should be cheap.
+    fn free_bytes(&self, path: &Path) -> Option<u64>;
+}
+
+/// Trait abstracting "what is this path's volume?" so the per-volume
+/// grouping is testable without touching the filesystem. Real
+/// implementations return e.g. the drive letter on Windows or the
+/// `statvfs` `f_fsid` on Unix. Tests typically return the first
+/// component of the path.
+pub trait VolumeProbe {
+    fn volume_key(&self, path: &Path) -> Option<String>;
+}
+
+/// A volume that is below the configured trigger threshold and has
+/// soldr-owned paths on it. Returned from `plan_auto_gc`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VolumePlan {
+    pub volume_key: String,
+    pub free_bytes: u64,
+    pub trigger_bytes: u64,
+    pub target_bytes: u64,
+    pub paths: Vec<AutoGcPath>,
+}
+
+/// Validate the auto-GC config: `target_free_gb >= trigger_free_gb`.
+/// Returns the (possibly-corrected) config and a list of warnings.
+pub fn validate_config(config: &AutoGcConfig) -> (AutoGcConfig, Vec<String>) {
+    let mut warnings = Vec::new();
+    let mut out = config.clone();
+    if out.target_free_gb < out.trigger_free_gb {
+        warnings.push(format!(
+            "auto_gc.target_free_gb ({}) < trigger_free_gb ({}); clamping target to trigger",
+            out.target_free_gb, out.trigger_free_gb
+        ));
+        out.target_free_gb = out.trigger_free_gb;
+    }
+    (out, warnings)
+}
+
+/// Clamp every age (in seconds) to be at least `floor_secs`. Used to
+/// enforce the `min_age_secs` floor on cargo and soldr purge ages.
+pub fn clamp_age_to_floor(age_secs: u64, floor_secs: u64) -> u64 {
+    age_secs.max(floor_secs)
+}
+
+/// Conservative tier-1 ages used when invoking cargo's `clean gc`.
+/// Mirrors cargo's own defaults (~1 month for sources, ~3 months for
+/// the compressed crate cache). The cargo CLI accepts these as
+/// `--max-src-age` / `--max-crate-age` (etc.).
+pub struct CargoGcAges {
+    pub max_src_age_days: u64,
+    pub max_crate_age_days: u64,
+    pub max_index_age_days: u64,
+    pub max_git_co_age_days: u64,
+    pub max_git_db_age_days: u64,
+    pub max_download_age_days: u64,
+}
+
+pub const TIER1_AGES: CargoGcAges = CargoGcAges {
+    max_src_age_days: 30,
+    max_crate_age_days: 90,
+    max_index_age_days: 90,
+    max_git_co_age_days: 30,
+    max_git_db_age_days: 180,
+    max_download_age_days: 30,
+};
+
+pub const TIER3_AGES: CargoGcAges = CargoGcAges {
+    max_src_age_days: 7,
+    max_crate_age_days: 14,
+    max_index_age_days: 30,
+    max_git_co_age_days: 7,
+    max_git_db_age_days: 30,
+    max_download_age_days: 7,
+};
+
+impl CargoGcAges {
+    /// Convert each age to seconds, clamped to be at least
+    /// `floor_secs`. Returned in a stable order matching the field
+    /// definition.
+    pub fn clamped_seconds(&self, floor_secs: u64) -> CargoGcAgeSeconds {
+        let per_day = 86_400u64;
+        CargoGcAgeSeconds {
+            max_src: clamp_age_to_floor(self.max_src_age_days.saturating_mul(per_day), floor_secs),
+            max_crate: clamp_age_to_floor(
+                self.max_crate_age_days.saturating_mul(per_day),
+                floor_secs,
+            ),
+            max_index: clamp_age_to_floor(
+                self.max_index_age_days.saturating_mul(per_day),
+                floor_secs,
+            ),
+            max_git_co: clamp_age_to_floor(
+                self.max_git_co_age_days.saturating_mul(per_day),
+                floor_secs,
+            ),
+            max_git_db: clamp_age_to_floor(
+                self.max_git_db_age_days.saturating_mul(per_day),
+                floor_secs,
+            ),
+            max_download: clamp_age_to_floor(
+                self.max_download_age_days.saturating_mul(per_day),
+                floor_secs,
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CargoGcAgeSeconds {
+    pub max_src: u64,
+    pub max_crate: u64,
+    pub max_index: u64,
+    pub max_git_co: u64,
+    pub max_git_db: u64,
+    pub max_download: u64,
+}
+
+/// Identify volumes below the trigger threshold, group the supplied
+/// soldr paths by volume, and emit a per-volume plan that the
+/// orchestrator can iterate through.
+///
+/// The returned plans are ordered by ascending free-bytes so callers
+/// reclaim the tightest-volume first.
+pub fn plan_auto_gc<D: DiskFreeProbe, V: VolumeProbe>(
+    config: &AutoGcConfig,
+    paths: &[AutoGcPath],
+    disk: &D,
+    volumes: &V,
+) -> Vec<VolumePlan> {
+    if !config.enabled {
+        return Vec::new();
+    }
+    let trigger_bytes = config.trigger_free_gb.saturating_mul(GIB);
+    let target_bytes = config.target_free_gb.saturating_mul(GIB);
+
+    // Group paths by volume key.
+    let mut by_volume: BTreeMap<String, Vec<AutoGcPath>> = BTreeMap::new();
+    for entry in paths {
+        let Some(key) = volumes.volume_key(&entry.path) else {
+            continue;
+        };
+        by_volume.entry(key).or_default().push(entry.clone());
+    }
+
+    // Probe free space and keep only volumes below the trigger.
+    let mut plans: Vec<VolumePlan> = by_volume
+        .into_iter()
+        .filter_map(|(volume_key, paths)| {
+            let probe_path = paths.first()?.path.clone();
+            let free_bytes = disk.free_bytes(&probe_path)?;
+            if free_bytes >= trigger_bytes {
+                return None;
+            }
+            Some(VolumePlan {
+                volume_key,
+                free_bytes,
+                trigger_bytes,
+                target_bytes,
+                paths,
+            })
+        })
+        .collect();
+    plans.sort_by_key(|p| p.free_bytes);
+    plans
+}
+
+/// Which tier should run next for a given volume? Returns `None` when
+/// the volume has reached its target free-space, otherwise the tier
+/// index (1, 2, 3) the orchestrator should invoke.
+pub fn next_tier(current_free_bytes: u64, target_bytes: u64, last_tier_run: u8) -> Option<u8> {
+    if current_free_bytes >= target_bytes {
+        return None;
+    }
+    if last_tier_run >= 3 {
+        return None;
+    }
+    Some(last_tier_run + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    struct FixedDisk {
+        per_volume: HashMap<String, u64>,
+        volume_for: HashMap<PathBuf, String>,
+    }
+
+    impl FixedDisk {
+        fn new() -> Self {
+            Self {
+                per_volume: HashMap::new(),
+                volume_for: HashMap::new(),
+            }
+        }
+
+        fn add(&mut self, volume: &str, free_bytes: u64) -> &mut Self {
+            self.per_volume.insert(volume.to_string(), free_bytes);
+            self
+        }
+
+        fn map(&mut self, path: &Path, volume: &str) -> &mut Self {
+            self.volume_for.insert(path.to_path_buf(), volume.to_string());
+            self
+        }
+    }
+
+    impl DiskFreeProbe for FixedDisk {
+        fn free_bytes(&self, path: &Path) -> Option<u64> {
+            let key = self.volume_for.get(path)?;
+            self.per_volume.get(key).copied()
+        }
+    }
+
+    impl VolumeProbe for FixedDisk {
+        fn volume_key(&self, path: &Path) -> Option<String> {
+            self.volume_for.get(path).cloned()
+        }
+    }
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn disabled_config_returns_no_plans() {
+        let mut probe = FixedDisk::new();
+        probe.add("C", 1).map(&p("C:/cargo"), "C");
+        let config = AutoGcConfig {
+            enabled: false,
+            ..AutoGcConfig::default()
+        };
+        let plans = plan_auto_gc(
+            &config,
+            &[AutoGcPath {
+                kind: AutoGcPathKind::CargoHome,
+                path: p("C:/cargo"),
+            }],
+            &probe,
+            &probe,
+        );
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn healthy_volume_is_excluded_even_when_other_below_trigger() {
+        // Volume C has 5 GiB free (below 20 GiB trigger);
+        // volume D has 100 GiB free (well above trigger).
+        let mut probe = FixedDisk::new();
+        probe
+            .add("C", 5 * GIB)
+            .add("D", 100 * GIB)
+            .map(&p("C:/cargo"), "C")
+            .map(&p("D:/work/repo/target"), "D");
+        let config = AutoGcConfig::default();
+        let plans = plan_auto_gc(
+            &config,
+            &[
+                AutoGcPath {
+                    kind: AutoGcPathKind::CargoHome,
+                    path: p("C:/cargo"),
+                },
+                AutoGcPath {
+                    kind: AutoGcPathKind::WorkspaceTarget,
+                    path: p("D:/work/repo/target"),
+                },
+            ],
+            &probe,
+            &probe,
+        );
+        assert_eq!(plans.len(), 1, "only the below-trigger volume should plan");
+        assert_eq!(plans[0].volume_key, "C");
+        assert_eq!(plans[0].paths.len(), 1);
+        assert_eq!(plans[0].paths[0].kind, AutoGcPathKind::CargoHome);
+    }
+
+    #[test]
+    fn paths_are_grouped_by_volume() {
+        let mut probe = FixedDisk::new();
+        probe
+            .add("C", 5 * GIB)
+            .map(&p("C:/cargo"), "C")
+            .map(&p("C:/work/a/target"), "C")
+            .map(&p("C:/work/b/target"), "C");
+        let config = AutoGcConfig::default();
+        let plans = plan_auto_gc(
+            &config,
+            &[
+                AutoGcPath {
+                    kind: AutoGcPathKind::CargoHome,
+                    path: p("C:/cargo"),
+                },
+                AutoGcPath {
+                    kind: AutoGcPathKind::WorkspaceTarget,
+                    path: p("C:/work/a/target"),
+                },
+                AutoGcPath {
+                    kind: AutoGcPathKind::WorkspaceTarget,
+                    path: p("C:/work/b/target"),
+                },
+            ],
+            &probe,
+            &probe,
+        );
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].paths.len(), 3);
+    }
+
+    #[test]
+    fn min_age_floor_clamps_aggressive_tiers() {
+        // floor 1h = 3600s. Tier-3 aggressive max_src_age = 7d = 604_800s,
+        // already > 1h, so it stays. But if floor were larger than 7d
+        // (say 30d = 2_592_000s), the floor should win.
+        let s = TIER3_AGES.clamped_seconds(3600);
+        assert_eq!(s.max_src, 7 * 86_400);
+        assert_eq!(s.max_crate, 14 * 86_400);
+        let s = TIER3_AGES.clamped_seconds(30 * 86_400);
+        assert_eq!(s.max_src, 30 * 86_400);
+        assert_eq!(s.max_crate, 30 * 86_400);
+    }
+
+    #[test]
+    fn clamp_age_floor_never_lowers_existing_value() {
+        assert_eq!(clamp_age_to_floor(100, 50), 100);
+        assert_eq!(clamp_age_to_floor(100, 200), 200);
+        assert_eq!(clamp_age_to_floor(0, 3600), 3600);
+    }
+
+    #[test]
+    fn next_tier_stops_when_target_reached() {
+        let target = 30 * GIB;
+        assert_eq!(next_tier(31 * GIB, target, 0), None);
+        assert_eq!(next_tier(31 * GIB, target, 1), None);
+    }
+
+    #[test]
+    fn next_tier_advances_until_three() {
+        let target = 30 * GIB;
+        let free = 5 * GIB;
+        assert_eq!(next_tier(free, target, 0), Some(1));
+        assert_eq!(next_tier(free, target, 1), Some(2));
+        assert_eq!(next_tier(free, target, 2), Some(3));
+        assert_eq!(next_tier(free, target, 3), None);
+    }
+
+    #[test]
+    fn validate_config_clamps_target_below_trigger() {
+        let config = AutoGcConfig {
+            trigger_free_gb: 50,
+            target_free_gb: 20,
+            ..AutoGcConfig::default()
+        };
+        let (out, warnings) = validate_config(&config);
+        assert_eq!(out.target_free_gb, 50);
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn plans_are_sorted_by_ascending_free_bytes() {
+        let mut probe = FixedDisk::new();
+        probe
+            .add("C", 5 * GIB)
+            .add("D", 1 * GIB)
+            .map(&p("C:/cargo"), "C")
+            .map(&p("D:/work/target"), "D");
+        let config = AutoGcConfig::default();
+        let plans = plan_auto_gc(
+            &config,
+            &[
+                AutoGcPath {
+                    kind: AutoGcPathKind::CargoHome,
+                    path: p("C:/cargo"),
+                },
+                AutoGcPath {
+                    kind: AutoGcPathKind::WorkspaceTarget,
+                    path: p("D:/work/target"),
+                },
+            ],
+            &probe,
+            &probe,
+        );
+        assert_eq!(plans.len(), 2);
+        // D (1 GiB) comes before C (5 GiB).
+        assert_eq!(plans[0].volume_key, "D");
+        assert_eq!(plans[1].volume_key, "C");
+    }
+}

--- a/crates/soldr-cache/src/auto_gc.rs
+++ b/crates/soldr-cache/src/auto_gc.rs
@@ -273,7 +273,8 @@ mod tests {
         }
 
         fn map(&mut self, path: &Path, volume: &str) -> &mut Self {
-            self.volume_for.insert(path.to_path_buf(), volume.to_string());
+            self.volume_for
+                .insert(path.to_path_buf(), volume.to_string());
             self
         }
     }

--- a/crates/soldr-cache/src/auto_gc.rs
+++ b/crates/soldr-cache/src/auto_gc.rs
@@ -434,7 +434,7 @@ mod tests {
         let mut probe = FixedDisk::new();
         probe
             .add("C", 5 * GIB)
-            .add("D", 1 * GIB)
+            .add("D", GIB)
             .map(&p("C:/cargo"), "C")
             .map(&p("D:/work/target"), "D");
         let config = AutoGcConfig::default();

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -10,9 +10,21 @@ use std::{
     path::{Path, PathBuf},
 };
 
+pub mod auto_gc;
 pub mod gc;
 pub mod state_db;
 pub mod target_registry;
+
+/// Directory for the auto-GC structured log (`~/.soldr/logs/auto-gc.log`).
+pub fn auto_gc_log_path(paths: &SoldrPaths) -> PathBuf {
+    paths.root.join("logs").join("auto-gc.log")
+}
+
+/// Marker file used to throttle the auto-GC check so we don't hammer
+/// the cargo `.package-cache` lock on every rustc-wrapper invocation.
+pub fn auto_gc_throttle_marker_path(paths: &SoldrPaths) -> PathBuf {
+    paths.root.join(".auto_gc_marker")
+}
 
 /// Path to the soldr state database (`~/.soldr/state.redb`) used by the
 /// target-directory registry.

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -16,6 +16,10 @@ const TEST_RUSTC_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTC_BIN";
 const TEST_RUSTUP_BIN_ENV_VAR: &str = "SOLDR_TEST_RUSTUP_BIN";
 const TEST_ZCCACHE_BIN_ENV_VAR: &str = "SOLDR_TEST_ZCCACHE_BIN";
 const TEST_FREE_DISK_BYTES_ENV_VAR: &str = "SOLDR_TEST_FREE_DISK_BYTES";
+/// Overrides the default `nightly` toolchain used by `soldr gc cargo`
+/// to invoke cargo's unstable `-Zgc clean gc`. The `--toolchain` flag
+/// on `gc cargo` / `gc sweep` always takes precedence.
+const SOLDR_GC_CARGO_TOOLCHAIN_ENV_VAR: &str = "SOLDR_GC_CARGO_TOOLCHAIN";
 const JSON_SCHEMA_VERSION: u32 = 1;
 const LOW_DISK_WARNING_THRESHOLD_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const RUSTC_WRAPPER_OVERRIDE_ENV_VAR: &str = "SOLDR_RUSTC_WRAPPER";
@@ -214,6 +218,94 @@ enum GcSubcommand {
         #[arg(long)]
         json: bool,
     },
+    /// Run cargo's native `clean gc` against `$CARGO_HOME`. Requires
+    /// a nightly toolchain because the command lives behind the
+    /// unstable `-Zgc` flag.
+    Cargo(Box<GcCargoArgs>),
+    /// Read-only enumeration of every cache directory soldr knows
+    /// about. Does not delete anything.
+    Locations {
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Orchestrator that runs `gc locations`, then conservative cargo
+    /// `clean gc`, then the soldr target purge — and, with
+    /// `--aggressive`, a second cargo GC pass with tighter ages.
+    Sweep(Box<GcSweepArgs>),
+}
+
+#[derive(clap::Args)]
+struct GcCargoArgs {
+    /// Report the plan and exit without invoking cargo.
+    #[arg(long)]
+    dry_run: bool,
+    /// Override the nightly toolchain. Defaults to
+    /// `$SOLDR_GC_CARGO_TOOLCHAIN` if set, else `nightly`.
+    #[arg(long, value_name = "TOOLCHAIN")]
+    toolchain: Option<String>,
+    /// Forwarded directly to cargo `--max-src-age`.
+    #[arg(long, value_name = "DURATION")]
+    max_src_age: Option<String>,
+    /// Forwarded directly to cargo `--max-crate-age`.
+    #[arg(long, value_name = "DURATION")]
+    max_crate_age: Option<String>,
+    /// Forwarded directly to cargo `--max-index-age`.
+    #[arg(long, value_name = "DURATION")]
+    max_index_age: Option<String>,
+    /// Forwarded directly to cargo `--max-git-co-age`.
+    #[arg(long, value_name = "DURATION")]
+    max_git_co_age: Option<String>,
+    /// Forwarded directly to cargo `--max-git-db-age`.
+    #[arg(long, value_name = "DURATION")]
+    max_git_db_age: Option<String>,
+    /// Forwarded directly to cargo `--max-download-age`.
+    #[arg(long, value_name = "DURATION")]
+    max_download_age: Option<String>,
+    /// Forwarded directly to cargo `--max-src-size`.
+    #[arg(long, value_name = "SIZE")]
+    max_src_size: Option<String>,
+    /// Forwarded directly to cargo `--max-crate-size`.
+    #[arg(long, value_name = "SIZE")]
+    max_crate_size: Option<String>,
+    /// Forwarded directly to cargo `--max-git-size`.
+    #[arg(long, value_name = "SIZE")]
+    max_git_size: Option<String>,
+    /// Forwarded directly to cargo `--max-download-size`.
+    #[arg(long, value_name = "SIZE")]
+    max_download_size: Option<String>,
+    /// Emit the stable machine-facing JSON form for this command.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(clap::Args)]
+struct GcSweepArgs {
+    /// Delete every eligible target/ candidate without prompting (used
+    /// when the orchestrator runs the soldr target purge stage).
+    #[arg(long)]
+    all: bool,
+    /// Plan and report without deleting anything.
+    #[arg(long)]
+    dry_run: bool,
+    /// Run cargo's `clean gc`. Default is on; pass `--no-cargo-gc` to
+    /// skip cargo entirely. `--cargo-gc` is accepted but is the
+    /// default.
+    #[arg(long, conflicts_with = "no_cargo_gc")]
+    cargo_gc: bool,
+    /// Skip cargo's `clean gc` (e.g. on CI runners with no nightly).
+    #[arg(long, conflicts_with = "cargo_gc")]
+    no_cargo_gc: bool,
+    /// After the standard pipeline, run cargo's `clean gc` again with
+    /// tighter ages
+    /// (`--max-src-age=7days --max-crate-age=14days --max-git-co-age=7days`).
+    /// Floor: each value is clamped to `auto_gc.min_age_secs` before
+    /// being forwarded.
+    #[arg(long)]
+    aggressive: bool,
+    /// Emit the stable machine-facing JSON form for this command.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Subcommand)]
@@ -407,6 +499,18 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 },
                 Some(GcSubcommand::List { json }) => {
                     run_gc_list_command(json)?;
+                    return Ok(());
+                }
+                Some(GcSubcommand::Cargo(args)) => {
+                    run_gc_cargo_command(*args)?;
+                    return Ok(());
+                }
+                Some(GcSubcommand::Locations { json }) => {
+                    run_gc_locations_command(json)?;
+                    return Ok(());
+                }
+                Some(GcSubcommand::Sweep(args)) => {
+                    run_gc_sweep_command(*args)?;
                     return Ok(());
                 }
                 None => GcInvocation {
@@ -4053,6 +4157,538 @@ fn resolve_gc_dev_roots(paths: &SoldrPaths) -> Vec<std::path::PathBuf> {
         return vec![home.join("dev")];
     }
     Vec::new()
+}
+
+// ---------------------------------------------------------------------------
+// soldr gc cargo / gc locations / gc sweep — issue #323 manual surface.
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct GcCargoOutput {
+    schema_version: u32,
+    command: &'static str,
+    mode: &'static str,
+    toolchain: String,
+    exit_code: i32,
+    dry_run: bool,
+    args: Vec<String>,
+    stdout_bytes: u64,
+    stderr_bytes: u64,
+    skipped: bool,
+    skipped_reason: Option<String>,
+}
+
+#[derive(Serialize)]
+struct GcLocationOutput {
+    kind: &'static str,
+    path: String,
+    exists: bool,
+    size_bytes: u64,
+    size_human: String,
+    file_count: u64,
+    owner: &'static str,
+    purge_safety: &'static str,
+}
+
+#[derive(Serialize)]
+struct GcLocationsOutput {
+    schema_version: u32,
+    command: &'static str,
+    mode: &'static str,
+    locations: Vec<GcLocationOutput>,
+    total_size_bytes: u64,
+    total_size_human: String,
+}
+
+#[derive(Serialize)]
+struct GcSweepOutput {
+    schema_version: u32,
+    command: &'static str,
+    mode: &'static str,
+    dry_run: bool,
+    cargo_gc: Option<GcCargoOutput>,
+    cargo_gc_aggressive: Option<GcCargoOutput>,
+    soldr_targets: Option<SoldrTargetsSummary>,
+    locations: Vec<GcLocationOutput>,
+    elapsed_ms: u128,
+}
+
+#[derive(Serialize, Default)]
+struct SoldrTargetsSummary {
+    selected_count: usize,
+    succeeded_count: usize,
+    failed_count: usize,
+    reclaimed_bytes: u64,
+    reclaimed_human: String,
+}
+
+/// `soldr gc cargo` — shell out to nightly cargo's `-Zgc clean gc`.
+fn run_gc_cargo_command(args: GcCargoArgs) -> Result<(), SoldrError> {
+    let outcome = invoke_cargo_native_gc(&args, false)?;
+    if args.json {
+        print_json(&outcome)?;
+    }
+    if outcome.skipped {
+        // Explicit gc cargo treats a missing nightly as a hard error,
+        // unlike gc sweep which downgrades the missing toolchain to a
+        // skip. We surfaced the skip JSON above for callers that care,
+        // but the exit code must reflect the failure.
+        return Err(SoldrError::Other(
+            outcome
+                .skipped_reason
+                .unwrap_or_else(|| "cargo nightly GC unavailable".into()),
+        ));
+    }
+    if outcome.exit_code != 0 {
+        std::process::exit(outcome.exit_code);
+    }
+    Ok(())
+}
+
+/// Common implementation backing `gc cargo` and the cargo-step of
+/// `gc sweep`. When `skip_when_missing` is true (sweep), a missing
+/// nightly toolchain returns a `skipped = true` outcome with
+/// `exit_code = 0` so the orchestrator can continue.
+fn invoke_cargo_native_gc(
+    args: &GcCargoArgs,
+    skip_when_missing: bool,
+) -> Result<GcCargoOutput, SoldrError> {
+    let toolchain = resolve_gc_cargo_toolchain(args.toolchain.as_deref());
+
+    let mut forwarded: Vec<String> = Vec::new();
+    push_optional_flag(&mut forwarded, "--max-src-age", args.max_src_age.as_deref());
+    push_optional_flag(
+        &mut forwarded,
+        "--max-crate-age",
+        args.max_crate_age.as_deref(),
+    );
+    push_optional_flag(
+        &mut forwarded,
+        "--max-index-age",
+        args.max_index_age.as_deref(),
+    );
+    push_optional_flag(
+        &mut forwarded,
+        "--max-git-co-age",
+        args.max_git_co_age.as_deref(),
+    );
+    push_optional_flag(
+        &mut forwarded,
+        "--max-git-db-age",
+        args.max_git_db_age.as_deref(),
+    );
+    push_optional_flag(
+        &mut forwarded,
+        "--max-download-age",
+        args.max_download_age.as_deref(),
+    );
+    push_optional_flag(
+        &mut forwarded,
+        "--max-src-size",
+        args.max_src_size.as_deref(),
+    );
+    push_optional_flag(
+        &mut forwarded,
+        "--max-crate-size",
+        args.max_crate_size.as_deref(),
+    );
+    push_optional_flag(
+        &mut forwarded,
+        "--max-git-size",
+        args.max_git_size.as_deref(),
+    );
+    push_optional_flag(
+        &mut forwarded,
+        "--max-download-size",
+        args.max_download_size.as_deref(),
+    );
+    if args.dry_run {
+        forwarded.push("--dry-run".to_string());
+    }
+
+    // Final `cargo` argv: -Zgc clean gc [forwarded...]
+    let mut cargo_argv: Vec<String> =
+        vec!["-Zgc".to_string(), "clean".to_string(), "gc".to_string()];
+    cargo_argv.extend(forwarded.iter().cloned());
+
+    // We invoke via `rustup run <toolchain> cargo ...` so the
+    // workspace's rust-toolchain.toml override does not silently win.
+    if !rustup_run_available_for(&toolchain) {
+        if skip_when_missing {
+            return Ok(GcCargoOutput {
+                schema_version: JSON_SCHEMA_VERSION,
+                command: "gc",
+                mode: "cargo",
+                toolchain: toolchain.clone(),
+                exit_code: 0,
+                dry_run: args.dry_run,
+                args: cargo_argv,
+                stdout_bytes: 0,
+                stderr_bytes: 0,
+                skipped: true,
+                skipped_reason: Some(format!(
+                    "rustup toolchain {toolchain} not installed; skipping cargo GC"
+                )),
+            });
+        }
+        return Err(SoldrError::Other(format!(
+            "rustup toolchain {toolchain} not installed; install it with `rustup toolchain install {toolchain}` or pass --toolchain <name>"
+        )));
+    }
+
+    let mut command = std::process::Command::new("rustup");
+    command.arg("run").arg(&toolchain).arg("cargo");
+    command.args(&cargo_argv);
+    soldr_core::suppress_windows_console_window(&mut command);
+
+    eprintln!(
+        "soldr gc cargo: rustup run {toolchain} cargo {}",
+        cargo_argv.join(" ")
+    );
+
+    let output = command.output().map_err(|e| {
+        SoldrError::Other(format!(
+            "failed to invoke rustup run {toolchain} cargo: {e}"
+        ))
+    })?;
+
+    // Stream cargo's output through to the user's terminal.
+    use std::io::Write as _;
+    let _ = std::io::stdout().write_all(&output.stdout);
+    let _ = std::io::stderr().write_all(&output.stderr);
+
+    Ok(GcCargoOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "gc",
+        mode: "cargo",
+        toolchain,
+        exit_code: output.status.code().unwrap_or(1),
+        dry_run: args.dry_run,
+        args: cargo_argv,
+        stdout_bytes: output.stdout.len() as u64,
+        stderr_bytes: output.stderr.len() as u64,
+        skipped: false,
+        skipped_reason: None,
+    })
+}
+
+fn push_optional_flag(out: &mut Vec<String>, flag: &str, value: Option<&str>) {
+    if let Some(v) = value {
+        out.push(format!("{flag}={v}"));
+    }
+}
+
+fn resolve_gc_cargo_toolchain(flag: Option<&str>) -> String {
+    flag.map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::env::var(SOLDR_GC_CARGO_TOOLCHAIN_ENV_VAR)
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(|| "nightly".to_string())
+}
+
+/// Best-effort probe: `rustup toolchain list` must list the supplied
+/// channel. We avoid actually shelling into the toolchain here because
+/// `rustup run <missing> cargo --version` will install on demand,
+/// which we don't want for a probe.
+fn rustup_run_available_for(toolchain: &str) -> bool {
+    let mut command = std::process::Command::new("rustup");
+    command.args(["toolchain", "list"]);
+    soldr_core::suppress_windows_console_window(&mut command);
+    let output = match command.output() {
+        Ok(o) => o,
+        Err(_) => return false,
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .any(|line| line.trim().starts_with(toolchain))
+}
+
+/// `soldr gc locations` — read-only enumeration of every cache dir
+/// soldr cares about, with sizes (no last-used derivation yet).
+fn run_gc_locations_command(json: bool) -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let entries = enumerate_cache_locations(&paths);
+    let total_size_bytes: u64 = entries.iter().map(|e| e.size_bytes).sum();
+
+    if json {
+        let output = GcLocationsOutput {
+            schema_version: JSON_SCHEMA_VERSION,
+            command: "gc",
+            mode: "locations",
+            total_size_bytes,
+            total_size_human: soldr_cache::target_registry::human_size(total_size_bytes),
+            locations: entries,
+        };
+        print_json(&output)?;
+    } else {
+        println!("soldr gc locations:");
+        println!(
+            "  total tracked size: {}",
+            soldr_cache::target_registry::human_size(total_size_bytes)
+        );
+        for entry in &entries {
+            println!(
+                "  [{:>8}] {}  size={}  files={}  owner={}  purge_safety={}",
+                entry.kind,
+                entry.path,
+                entry.size_human,
+                entry.file_count,
+                entry.owner,
+                entry.purge_safety,
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Enumerate every directory soldr cares about: cargo home subdirs,
+/// rustup home subdirs, soldr's own cache root, and the state.redb
+/// file. Missing paths are reported with `exists = false` and zero
+/// size so the JSON shape stays predictable.
+fn enumerate_cache_locations(paths: &SoldrPaths) -> Vec<GcLocationOutput> {
+    let mut entries: Vec<GcLocationOutput> = Vec::new();
+
+    if let Some(cargo_home) = soldr_core::resolve_cargo_home() {
+        for (kind, suffix, owner, purge_safety) in &[
+            ("cargo_registry_src", "registry/src", "cargo", "regenerable"),
+            (
+                "cargo_registry_cache",
+                "registry/cache",
+                "cargo",
+                "regenerable",
+            ),
+            (
+                "cargo_registry_index",
+                "registry/index",
+                "cargo",
+                "regenerable",
+            ),
+            ("cargo_git_db", "git/db", "cargo", "regenerable"),
+            (
+                "cargo_git_checkouts",
+                "git/checkouts",
+                "cargo",
+                "regenerable",
+            ),
+        ] {
+            let path = cargo_home.join(suffix);
+            entries.push(gc_location_for(kind, &path, owner, purge_safety));
+        }
+        // .global-cache is a single file in cargo's stable tree.
+        let global_cache = cargo_home.join(".global-cache");
+        entries.push(gc_location_for(
+            "cargo_global_cache",
+            &global_cache,
+            "cargo",
+            "regenerable",
+        ));
+    }
+
+    if let Some(rustup_home) = soldr_core::resolve_rustup_home() {
+        entries.push(gc_location_for(
+            "rustup_toolchains",
+            &rustup_home.join("toolchains"),
+            "rustup",
+            "user_action",
+        ));
+        entries.push(gc_location_for(
+            "rustup_update_hashes",
+            &rustup_home.join("update-hashes"),
+            "rustup",
+            "regenerable",
+        ));
+    }
+
+    entries.push(gc_location_for(
+        "soldr_cache",
+        &paths.cache,
+        "soldr",
+        "regenerable",
+    ));
+    entries.push(gc_location_for(
+        "soldr_state_db",
+        &paths.root.join("state.redb"),
+        "soldr",
+        "user_action",
+    ));
+
+    entries
+}
+
+fn gc_location_for(
+    kind: &'static str,
+    path: &std::path::Path,
+    owner: &'static str,
+    purge_safety: &'static str,
+) -> GcLocationOutput {
+    let exists = path.exists();
+    let (size_bytes, file_count) = if exists {
+        fast_directory_size_and_files(path)
+    } else {
+        (0, 0)
+    };
+    GcLocationOutput {
+        kind,
+        path: path.display().to_string(),
+        exists,
+        size_bytes,
+        size_human: soldr_cache::target_registry::human_size(size_bytes),
+        file_count,
+        owner,
+        purge_safety,
+    }
+}
+
+/// `soldr gc sweep` — orchestrate locations + cargo gc + soldr target
+/// purge in one go.
+fn run_gc_sweep_command(args: GcSweepArgs) -> Result<(), SoldrError> {
+    let start = std::time::Instant::now();
+    let paths = SoldrPaths::new()?;
+    let cargo_gc_enabled = !args.no_cargo_gc;
+
+    // 1. Locations table (always — read-only).
+    let locations = enumerate_cache_locations(&paths);
+
+    // 2. Cargo's clean gc with conservative ages (unless disabled).
+    let cargo_gc_outcome = if cargo_gc_enabled {
+        // Use conservative defaults — let cargo's own ~1mo / ~3mo
+        // policy decide. We don't pass any --max-*-age flags so the
+        // user can configure cargo independently.
+        let cargo_args = GcCargoArgs {
+            dry_run: args.dry_run,
+            toolchain: None,
+            max_src_age: None,
+            max_crate_age: None,
+            max_index_age: None,
+            max_git_co_age: None,
+            max_git_db_age: None,
+            max_download_age: None,
+            max_src_size: None,
+            max_crate_size: None,
+            max_git_size: None,
+            max_download_size: None,
+            json: args.json,
+        };
+        Some(invoke_cargo_native_gc(&cargo_args, true)?)
+    } else {
+        None
+    };
+
+    // 3. soldr's target purge over registered workspaces.
+    let soldr_targets = if args.dry_run {
+        if !args.json {
+            eprintln!("soldr gc sweep: dry-run; skipping soldr target purge");
+        }
+        None
+    } else {
+        Some(run_soldr_target_purge_for_sweep(
+            &paths, args.all, args.json,
+        )?)
+    };
+
+    // 4. Aggressive second cargo pass.
+    let cargo_gc_aggressive = if args.aggressive && cargo_gc_enabled {
+        let cfg = paths.load_config();
+        let floor = cfg.auto_gc.min_age_secs;
+        let aggressive_args = aggressive_cargo_args(args.json, args.dry_run, floor);
+        Some(invoke_cargo_native_gc(&aggressive_args, true)?)
+    } else {
+        None
+    };
+
+    if !args.json {
+        eprintln!("soldr gc sweep: done in {} ms", start.elapsed().as_millis());
+    }
+
+    if args.json {
+        let output = GcSweepOutput {
+            schema_version: JSON_SCHEMA_VERSION,
+            command: "gc",
+            mode: "sweep",
+            dry_run: args.dry_run,
+            cargo_gc: cargo_gc_outcome,
+            cargo_gc_aggressive,
+            soldr_targets,
+            locations,
+            elapsed_ms: start.elapsed().as_millis(),
+        };
+        print_json(&output)?;
+    }
+    Ok(())
+}
+
+fn aggressive_cargo_args(json: bool, dry_run: bool, min_age_secs: u64) -> GcCargoArgs {
+    // Helper: clamp `aggressive_days * 86_400` to the configured min
+    // age. Express the result back in seconds (cargo accepts `s` /
+    // `secs` / `seconds`).
+    let clamp = |days: u64| -> String {
+        let secs =
+            soldr_cache::auto_gc::clamp_age_to_floor(days.saturating_mul(86_400), min_age_secs);
+        format!("{secs}secs")
+    };
+    GcCargoArgs {
+        dry_run,
+        toolchain: None,
+        max_src_age: Some(clamp(7)),
+        max_crate_age: Some(clamp(14)),
+        max_index_age: None,
+        max_git_co_age: Some(clamp(7)),
+        max_git_db_age: None,
+        max_download_age: None,
+        max_src_size: None,
+        max_crate_size: None,
+        max_git_size: None,
+        max_download_size: None,
+        json,
+    }
+}
+
+fn run_soldr_target_purge_for_sweep(
+    _paths: &SoldrPaths,
+    purge_all: bool,
+    json: bool,
+) -> Result<SoldrTargetsSummary, SoldrError> {
+    use soldr_cache::gc::{parse_duration, parse_size, scan, GcOptions};
+    let paths = SoldrPaths::new()?;
+    let dev_roots = resolve_gc_dev_roots(&paths);
+    let db_path = soldr_cache::data_db_path(&paths);
+    let registry = soldr_cache::target_registry::TargetRegistry::open(&db_path)
+        .map_err(|e| SoldrError::Other(format!("failed to open soldr registry: {e}")))?;
+
+    let cfg = paths.load_config();
+    let older_than_seconds = soldr_cache::auto_gc::clamp_age_to_floor(
+        parse_duration("10d").map_err(SoldrError::Other)?,
+        cfg.auto_gc.min_age_secs,
+    );
+    let larger_than_bytes = parse_size("256M").map_err(SoldrError::Other)?;
+
+    let options = GcOptions {
+        older_than_seconds,
+        larger_than_bytes,
+        dev_roots,
+        dry_run: false,
+    };
+    let report =
+        scan(&registry, &options).map_err(|e| SoldrError::Other(format!("gc scan failed: {e}")))?;
+    if report.candidates.is_empty() {
+        return Ok(SoldrTargetsSummary::default());
+    }
+    let purge_summary = run_gc_purge_candidates(&registry, &report.candidates, purge_all, json)?;
+    Ok(SoldrTargetsSummary {
+        selected_count: purge_summary.selected_count,
+        succeeded_count: purge_summary.succeeded_count,
+        failed_count: purge_summary.failed_count,
+        reclaimed_bytes: purge_summary.reclaimed_bytes,
+        reclaimed_human: soldr_cache::target_registry::human_size(purge_summary.reclaimed_bytes),
+    })
 }
 
 fn emit_startup_target_warning_if_due() {

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1073,6 +1073,9 @@ async fn run_cargo_front_door(args: &[String], cache_enabled: bool) -> Result<i3
         // Cargo front door only: keep startup/low-disk warnings off unrelated
         // commands and out of the rustc-wrapper hot path.
         emit_startup_target_warning_if_due();
+        // Best-effort auto-GC trigger (issue #323). Runs on a detached
+        // background thread; never blocks the build.
+        maybe_kick_auto_gc(&paths);
     }
     let mut path_dirs: Vec<std::path::PathBuf> = Vec::with_capacity(1 + extra_bin_dirs.len());
     path_dirs.push(cargo_bin_dir);
@@ -4689,6 +4692,449 @@ fn run_soldr_target_purge_for_sweep(
         reclaimed_bytes: purge_summary.reclaimed_bytes,
         reclaimed_human: soldr_cache::target_registry::human_size(purge_summary.reclaimed_bytes),
     })
+}
+
+// ---------------------------------------------------------------------------
+// Auto-GC under disk pressure (issue #323).
+//
+// Hook lives at the soldr cargo front door. On every cargo invocation
+// the wrapper consults a throttle marker and, if the throttle has
+// expired and the user hasn't opted out, spawns a detached background
+// thread that:
+//
+//   1. enumerates soldr-relevant paths and groups them by volume;
+//   2. probes free space per volume;
+//   3. runs the tiered GC plan only against volumes below the trigger;
+//   4. appends a structured line to ~/.soldr/logs/auto-gc.log.
+//
+// We deliberately spawn instead of running inline so the wrapper never
+// blocks the build. cargo's `.package-cache` mutex handles concurrent
+// invocations of `cargo clean gc` cleanly for us.
+// ---------------------------------------------------------------------------
+
+const AUTO_GC_THROTTLE_SECONDS: u64 = 5 * 60;
+const AUTO_GC_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+const AUTO_GC_DISABLE_ENV_VAR: &str = "SOLDR_AUTO_GC_DISABLED";
+
+fn maybe_kick_auto_gc(paths: &SoldrPaths) {
+    if auto_gc_env_disabled() {
+        return;
+    }
+    let config = paths.load_config().auto_gc;
+    if !config.enabled {
+        return;
+    }
+    let marker = soldr_cache::auto_gc_throttle_marker_path(paths);
+    if !auto_gc_throttle_expired(&marker, AUTO_GC_THROTTLE_SECONDS) {
+        return;
+    }
+    // Touch the marker before spawning so a crashing background thread
+    // doesn't cause us to immediately rerun on the next invocation.
+    let _ = touch_auto_gc_marker(&marker);
+
+    let log_path = soldr_cache::auto_gc_log_path(paths);
+    let paths_root = paths.root.clone();
+    let _ = std::thread::Builder::new()
+        .name("soldr-auto-gc".to_string())
+        .spawn(move || {
+            run_auto_gc_background(paths_root, log_path);
+        });
+}
+
+fn auto_gc_env_disabled() -> bool {
+    match std::env::var(AUTO_GC_DISABLE_ENV_VAR) {
+        Ok(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+        Err(_) => false,
+    }
+}
+
+fn auto_gc_throttle_expired(marker: &std::path::Path, throttle_seconds: u64) -> bool {
+    let Ok(meta) = std::fs::metadata(marker) else {
+        return true;
+    };
+    let Ok(modified) = meta.modified() else {
+        return true;
+    };
+    let elapsed = std::time::SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or(std::time::Duration::ZERO);
+    elapsed.as_secs() >= throttle_seconds
+}
+
+fn touch_auto_gc_marker(marker: &std::path::Path) -> std::io::Result<()> {
+    if let Some(parent) = marker.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(marker, "")
+}
+
+fn run_auto_gc_background(paths_root: std::path::PathBuf, log_path: std::path::PathBuf) {
+    use soldr_cache::auto_gc::DiskFreeProbe as _;
+    let start = std::time::Instant::now();
+    let paths = SoldrPaths::with_root(paths_root);
+    let config = paths.load_config().auto_gc;
+    let (validated, warnings) = soldr_cache::auto_gc::validate_config(&config);
+    for warning in &warnings {
+        let _ = append_auto_gc_log_line(&log_path, &format!("warning: {warning}"));
+    }
+
+    let auto_paths = enumerate_auto_gc_paths(&paths);
+    let probe = SystemVolumeProbe;
+    let plans = soldr_cache::auto_gc::plan_auto_gc(&validated, &auto_paths, &probe, &probe);
+    if plans.is_empty() {
+        return; // Either disabled or no volume is below trigger.
+    }
+
+    for plan in &plans {
+        let line = format!(
+            "auto-gc volume={} free_gib={:.2} trigger_gib={} target_gib={} paths={} status=detected",
+            plan.volume_key,
+            (plan.free_bytes as f64) / (soldr_cache::auto_gc::GIB as f64),
+            validated.trigger_free_gb,
+            validated.target_free_gb,
+            plan.paths.len()
+        );
+        let _ = append_auto_gc_log_line(&log_path, &line);
+
+        // Tier 1: conservative cargo GC (no explicit --max-*-age flags
+        // so cargo uses its own conservative defaults). Only attempt
+        // when the volume holds the cargo home.
+        let mut last_tier = 0u8;
+        let cargo_volume_paths = plan
+            .paths
+            .iter()
+            .filter(|p| matches!(p.kind, soldr_cache::auto_gc::AutoGcPathKind::CargoHome))
+            .count();
+        if cargo_volume_paths > 0 {
+            let outcome = run_conservative_cargo_gc_background(&log_path);
+            last_tier = 1;
+            let _ = append_auto_gc_log_line(
+                &log_path,
+                &format!(
+                    "tier=1 volume={} exit_code={} skipped={} reason={}",
+                    plan.volume_key,
+                    outcome.exit_code,
+                    outcome.skipped,
+                    outcome.reason.as_deref().unwrap_or("ran")
+                ),
+            );
+        }
+
+        // Re-probe and decide whether to escalate.
+        let mut free_bytes = probe.free_bytes(&plan.paths[0].path).unwrap_or(0);
+        let target_bytes = validated
+            .target_free_gb
+            .saturating_mul(soldr_cache::auto_gc::GIB);
+
+        // Tier 2: soldr target purge (only if volume holds workspace
+        // targets and we're still under target).
+        if soldr_cache::auto_gc::next_tier(free_bytes, target_bytes, last_tier).is_some() {
+            let workspace_targets: Vec<_> = plan
+                .paths
+                .iter()
+                .filter(|p| {
+                    matches!(
+                        p.kind,
+                        soldr_cache::auto_gc::AutoGcPathKind::WorkspaceTarget
+                    )
+                })
+                .map(|p| p.path.clone())
+                .collect();
+            if !workspace_targets.is_empty() {
+                let reclaimed = run_soldr_target_purge_background(
+                    &paths,
+                    &workspace_targets,
+                    validated.min_age_secs,
+                );
+                last_tier = 2;
+                free_bytes = probe.free_bytes(&plan.paths[0].path).unwrap_or(free_bytes);
+                let _ = append_auto_gc_log_line(
+                    &log_path,
+                    &format!(
+                        "tier=2 volume={} reclaimed_bytes={} free_gib={:.2}",
+                        plan.volume_key,
+                        reclaimed,
+                        (free_bytes as f64) / (soldr_cache::auto_gc::GIB as f64),
+                    ),
+                );
+            }
+        }
+
+        // Tier 3: aggressive cargo GC (clamped to min_age_secs).
+        if soldr_cache::auto_gc::next_tier(free_bytes, target_bytes, last_tier).is_some()
+            && cargo_volume_paths > 0
+        {
+            let ages = soldr_cache::auto_gc::TIER3_AGES.clamped_seconds(validated.min_age_secs);
+            let outcome = run_aggressive_cargo_gc_background(&log_path, &ages);
+            last_tier = 3;
+            free_bytes = probe.free_bytes(&plan.paths[0].path).unwrap_or(free_bytes);
+            let _ = append_auto_gc_log_line(
+                &log_path,
+                &format!(
+                    "tier=3 volume={} exit_code={} skipped={} reason={} free_gib={:.2}",
+                    plan.volume_key,
+                    outcome.exit_code,
+                    outcome.skipped,
+                    outcome.reason.as_deref().unwrap_or("ran"),
+                    (free_bytes as f64) / (soldr_cache::auto_gc::GIB as f64),
+                ),
+            );
+        }
+
+        if soldr_cache::auto_gc::next_tier(free_bytes, target_bytes, last_tier).is_none()
+            && free_bytes < target_bytes
+        {
+            let _ = append_auto_gc_log_line(
+                &log_path,
+                &format!(
+                    "auto-gc warning volume={} free_gib={:.2} target_gib={} \
+                    tiers exhausted; run `soldr gc sweep --aggressive`",
+                    plan.volume_key,
+                    (free_bytes as f64) / (soldr_cache::auto_gc::GIB as f64),
+                    validated.target_free_gb,
+                ),
+            );
+        }
+    }
+
+    let _ = append_auto_gc_log_line(
+        &log_path,
+        &format!(
+            "auto-gc done elapsed_ms={} volumes={}",
+            start.elapsed().as_millis(),
+            plans.len(),
+        ),
+    );
+    let _ = rotate_auto_gc_log_if_needed(&log_path, AUTO_GC_LOG_MAX_BYTES);
+}
+
+struct AutoGcCargoOutcome {
+    exit_code: i32,
+    skipped: bool,
+    reason: Option<String>,
+}
+
+fn run_conservative_cargo_gc_background(log_path: &std::path::Path) -> AutoGcCargoOutcome {
+    let args = GcCargoArgs {
+        dry_run: false,
+        toolchain: None,
+        max_src_age: None,
+        max_crate_age: None,
+        max_index_age: None,
+        max_git_co_age: None,
+        max_git_db_age: None,
+        max_download_age: None,
+        max_src_size: None,
+        max_crate_size: None,
+        max_git_size: None,
+        max_download_size: None,
+        json: true,
+    };
+    match invoke_cargo_native_gc(&args, true) {
+        Ok(outcome) => AutoGcCargoOutcome {
+            exit_code: outcome.exit_code,
+            skipped: outcome.skipped,
+            reason: outcome.skipped_reason,
+        },
+        Err(e) => {
+            let _ = append_auto_gc_log_line(log_path, &format!("tier=1 invoke_error={e}"));
+            AutoGcCargoOutcome {
+                exit_code: 1,
+                skipped: true,
+                reason: Some(format!("invoke_error: {e}")),
+            }
+        }
+    }
+}
+
+fn run_aggressive_cargo_gc_background(
+    log_path: &std::path::Path,
+    ages: &soldr_cache::auto_gc::CargoGcAgeSeconds,
+) -> AutoGcCargoOutcome {
+    let args = GcCargoArgs {
+        dry_run: false,
+        toolchain: None,
+        max_src_age: Some(format!("{}secs", ages.max_src)),
+        max_crate_age: Some(format!("{}secs", ages.max_crate)),
+        max_index_age: None,
+        max_git_co_age: Some(format!("{}secs", ages.max_git_co)),
+        max_git_db_age: None,
+        max_download_age: None,
+        max_src_size: None,
+        max_crate_size: None,
+        max_git_size: None,
+        max_download_size: None,
+        json: true,
+    };
+    match invoke_cargo_native_gc(&args, true) {
+        Ok(outcome) => AutoGcCargoOutcome {
+            exit_code: outcome.exit_code,
+            skipped: outcome.skipped,
+            reason: outcome.skipped_reason,
+        },
+        Err(e) => {
+            let _ = append_auto_gc_log_line(log_path, &format!("tier=3 invoke_error={e}"));
+            AutoGcCargoOutcome {
+                exit_code: 1,
+                skipped: true,
+                reason: Some(format!("invoke_error: {e}")),
+            }
+        }
+    }
+}
+
+fn run_soldr_target_purge_background(
+    paths: &SoldrPaths,
+    workspace_targets: &[std::path::PathBuf],
+    min_age_secs: u64,
+) -> u64 {
+    use soldr_cache::gc::{parse_size, scan, GcOptions};
+    let db_path = soldr_cache::data_db_path(paths);
+    let Ok(registry) = soldr_cache::target_registry::TargetRegistry::open(&db_path) else {
+        return 0;
+    };
+    let larger_than_bytes = parse_size("256M").unwrap_or(256 * 1024 * 1024);
+    // Auto-GC always honors at least the configured min-age floor.
+    // We never go below 1h.
+    let older_than_seconds = soldr_cache::auto_gc::clamp_age_to_floor(min_age_secs, 3600);
+    let options = GcOptions {
+        older_than_seconds,
+        larger_than_bytes,
+        dev_roots: resolve_gc_dev_roots(paths),
+        dry_run: false,
+    };
+    let report = match scan(&registry, &options) {
+        Ok(r) => r,
+        Err(_) => return 0,
+    };
+    // Filter to candidates that actually live on the affected volumes.
+    let mut reclaimed = 0u64;
+    let on_volume: std::collections::HashSet<&std::path::Path> =
+        workspace_targets.iter().map(|p| p.as_path()).collect();
+    for cand in report.candidates {
+        if !on_volume.contains(cand.path.as_path()) {
+            continue;
+        }
+        let bytes = cand.size_bytes;
+        let outcome = soldr_cache::gc::delete_candidate_dir(cand);
+        if outcome.removed {
+            reclaimed = reclaimed.saturating_add(bytes);
+            let _ = registry.remove(&outcome.candidate.path);
+        }
+    }
+    reclaimed
+}
+
+/// Enumerate every soldr-owned path for the auto-GC orchestrator.
+fn enumerate_auto_gc_paths(paths: &SoldrPaths) -> Vec<soldr_cache::auto_gc::AutoGcPath> {
+    let mut out: Vec<soldr_cache::auto_gc::AutoGcPath> = Vec::new();
+    if let Some(cargo_home) = soldr_core::resolve_cargo_home() {
+        out.push(soldr_cache::auto_gc::AutoGcPath {
+            kind: soldr_cache::auto_gc::AutoGcPathKind::CargoHome,
+            path: cargo_home,
+        });
+    }
+    if let Some(rustup_home) = soldr_core::resolve_rustup_home() {
+        out.push(soldr_cache::auto_gc::AutoGcPath {
+            kind: soldr_cache::auto_gc::AutoGcPathKind::RustupHome,
+            path: rustup_home,
+        });
+    }
+    out.push(soldr_cache::auto_gc::AutoGcPath {
+        kind: soldr_cache::auto_gc::AutoGcPathKind::SoldrCache,
+        path: paths.cache.clone(),
+    });
+    let db_path = soldr_cache::data_db_path(paths);
+    if db_path.exists() {
+        if let Ok(registry) = soldr_cache::target_registry::TargetRegistry::open(&db_path) {
+            if let Ok(rows) = registry.list() {
+                for row in rows {
+                    if row.path.exists() {
+                        out.push(soldr_cache::auto_gc::AutoGcPath {
+                            kind: soldr_cache::auto_gc::AutoGcPathKind::WorkspaceTarget,
+                            path: row.path,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// System volume probe — Windows uses the drive letter (`C`, `D`),
+/// Unix uses the device id from `stat()`. Falls back to the canonical
+/// path's root component when neither is available.
+struct SystemVolumeProbe;
+
+impl soldr_cache::auto_gc::DiskFreeProbe for SystemVolumeProbe {
+    fn free_bytes(&self, path: &std::path::Path) -> Option<u64> {
+        let probe = existing_filesystem_probe_path(path);
+        available_space(&probe).ok()
+    }
+}
+
+impl soldr_cache::auto_gc::VolumeProbe for SystemVolumeProbe {
+    fn volume_key(&self, path: &std::path::Path) -> Option<String> {
+        let probe = existing_filesystem_probe_path(path);
+        volume_key_for_path(&probe)
+    }
+}
+
+#[cfg(windows)]
+fn volume_key_for_path(path: &std::path::Path) -> Option<String> {
+    // On Windows: prefer the canonical path's drive letter (e.g. "C").
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let s = canonical.to_string_lossy().to_string();
+    // Strip UNC prefix \\?\ if present.
+    let trimmed = s.trim_start_matches(r"\\?\");
+    let bytes = trimmed.as_bytes();
+    if bytes.len() >= 2 && bytes[1] == b':' && (bytes[0].is_ascii_alphabetic()) {
+        return Some((bytes[0] as char).to_ascii_uppercase().to_string());
+    }
+    None
+}
+
+#[cfg(unix)]
+fn volume_key_for_path(path: &std::path::Path) -> Option<String> {
+    use std::os::unix::fs::MetadataExt;
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let meta = std::fs::metadata(&canonical).ok()?;
+    Some(meta.dev().to_string())
+}
+
+fn append_auto_gc_log_line(log_path: &std::path::Path, line: &str) -> std::io::Result<()> {
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)?;
+    use std::io::Write as _;
+    writeln!(file, "{ts} {line}")?;
+    Ok(())
+}
+
+fn rotate_auto_gc_log_if_needed(log_path: &std::path::Path, max_bytes: u64) -> std::io::Result<()> {
+    let meta = match std::fs::metadata(log_path) {
+        Ok(m) => m,
+        Err(_) => return Ok(()),
+    };
+    if meta.len() < max_bytes {
+        return Ok(());
+    }
+    let archive = log_path.with_extension("log.old");
+    let _ = std::fs::remove_file(&archive);
+    std::fs::rename(log_path, &archive)?;
+    Ok(())
 }
 
 fn emit_startup_target_warning_if_due() {

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -3292,3 +3292,160 @@ fn wrapper_mode_stdin_source_propagates_nonzero_exit_code() {
         String::from_utf8_lossy(&output.stderr),
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #323 — soldr gc cargo / gc locations / gc sweep coverage.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gc_cargo_help_lists_max_flags_and_dry_run() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "cargo", "--help"])
+        .output()
+        .expect("failed to run soldr gc cargo --help");
+    assert!(output.status.success(), "soldr gc cargo --help failed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for flag in [
+        "--dry-run",
+        "--toolchain",
+        "--max-src-age",
+        "--max-crate-age",
+        "--max-index-age",
+        "--max-git-co-age",
+        "--max-git-db-age",
+        "--max-download-age",
+        "--max-src-size",
+        "--max-crate-size",
+        "--max-git-size",
+        "--max-download-size",
+        "--json",
+    ] {
+        assert!(
+            stdout.contains(flag),
+            "gc cargo --help missing {flag}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn gc_cargo_rejects_unknown_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "cargo", "--bogus-flag"])
+        .output()
+        .expect("failed to run soldr gc cargo --bogus-flag");
+    assert!(!output.status.success(), "unknown flag should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unexpected argument") || stderr.contains("unrecognized"),
+        "expected clap-style unknown-flag error, got: {stderr}"
+    );
+}
+
+#[test]
+fn gc_locations_json_emits_valid_schema_even_without_caches() {
+    let cache_root = unique_temp_dir("gc-locations-json");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "locations", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        // Disable auto-GC so the test isn't affected by background work.
+        .env("SOLDR_AUTO_GC_DISABLED", "1")
+        .output()
+        .expect("failed to run soldr gc locations --json");
+
+    assert!(
+        output.status.success(),
+        "gc locations failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("gc locations --json must be JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "gc");
+    assert_eq!(json["mode"], "locations");
+    let locations = json["locations"]
+        .as_array()
+        .expect("locations must be an array");
+    assert!(!locations.is_empty(), "should report at least soldr_cache");
+    // The kinds we expect to always appear, even when paths don't exist.
+    let kinds: Vec<&str> = locations
+        .iter()
+        .filter_map(|entry| entry["kind"].as_str())
+        .collect();
+    for required in [
+        "cargo_registry_src",
+        "cargo_registry_cache",
+        "cargo_registry_index",
+        "cargo_git_db",
+        "cargo_git_checkouts",
+        "cargo_global_cache",
+        "rustup_toolchains",
+        "rustup_update_hashes",
+        "soldr_cache",
+        "soldr_state_db",
+    ] {
+        assert!(
+            kinds.contains(&required),
+            "gc locations missing kind {required}: {kinds:?}"
+        );
+    }
+    // Each entry must carry the schema fields.
+    for entry in locations {
+        for field in [
+            "kind",
+            "path",
+            "exists",
+            "size_bytes",
+            "size_human",
+            "file_count",
+            "owner",
+            "purge_safety",
+        ] {
+            assert!(
+                entry.get(field).is_some(),
+                "gc locations entry missing field {field}: {entry}"
+            );
+        }
+    }
+}
+
+#[test]
+fn gc_sweep_no_cargo_dry_run_runs_end_to_end_without_changes() {
+    let cache_root = unique_temp_dir("gc-sweep-dryrun");
+    let target = seed_gc_candidate(&cache_root, "sweep-dryrun");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "sweep", "--no-cargo-gc", "--dry-run", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_AUTO_GC_DISABLED", "1")
+        .output()
+        .expect("failed to run soldr gc sweep --no-cargo-gc --dry-run --json");
+
+    assert!(
+        output.status.success(),
+        "gc sweep dry-run failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        target.exists(),
+        "dry-run sweep must not delete {}",
+        target.display()
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gc sweep --json must be JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "gc");
+    assert_eq!(json["mode"], "sweep");
+    assert_eq!(json["dry_run"], true);
+    assert!(
+        json["cargo_gc"].is_null(),
+        "cargo_gc must be null when --no-cargo-gc"
+    );
+    assert!(
+        json["soldr_targets"].is_null(),
+        "dry-run sweep must not run soldr target purge"
+    );
+    assert!(json["locations"].is_array());
+}

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -541,12 +541,16 @@ impl SoldrPaths {
 // ---------------------------------------------------------------------------
 
 /// Top-level soldr configuration. Currently carries the `[gc]` section
-/// (issue #234) and an optional top-level `linker = "..."` field (issue
-/// #285); future sections can be added freely.
+/// (issue #234), the `[auto_gc]` section (issue #323) and an optional
+/// top-level `linker = "..."` field (issue #285); future sections can
+/// be added freely.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct SoldrConfig {
     #[serde(default)]
     pub gc: GcConfig,
+    /// Automatic GC under disk pressure (issue #323).
+    #[serde(default)]
+    pub auto_gc: AutoGcConfig,
     /// User-configured linker choice for `soldr cargo ...`. Mirrors the
     /// `SOLDR_LINKER` env var; the env var wins when both are set.
     /// Accepted values: `default`, `ld`, `mold`, `rust-lld`, `fast`.
@@ -569,6 +573,64 @@ pub struct GcConfig {
     pub allowlist_roots: Option<Vec<String>>,
 }
 
+/// `auto_gc` section of `config.toml` (issue #323 — automatic GC under
+/// disk pressure).
+///
+/// ```toml
+/// [auto_gc]
+/// enabled = true            # opt-out; on by default
+/// trigger_free_gb = 20      # start GC when free space < this
+/// target_free_gb  = 30      # stop GC when free space >= this
+/// min_age_secs    = 3600    # never touch files modified in this window
+/// ```
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AutoGcConfig {
+    /// Whether soldr should automatically reclaim disk space when free
+    /// space on a soldr-relevant volume drops below `trigger_free_gb`.
+    /// Defaults to `true` (opt-out).
+    #[serde(default = "AutoGcConfig::default_enabled")]
+    pub enabled: bool,
+    /// Auto-GC fires when free space on a soldr-relevant volume drops
+    /// below this threshold (in GiB).
+    #[serde(default = "AutoGcConfig::default_trigger_free_gb")]
+    pub trigger_free_gb: u64,
+    /// Auto-GC stops escalating once free space reaches this number of
+    /// GiB on the affected volume. Must be >= `trigger_free_gb`.
+    #[serde(default = "AutoGcConfig::default_target_free_gb")]
+    pub target_free_gb: u64,
+    /// Floor applied uniformly to every age-based filter used by
+    /// auto-GC. Files / directories modified within this many seconds
+    /// of "now" are never touched.
+    #[serde(default = "AutoGcConfig::default_min_age_secs")]
+    pub min_age_secs: u64,
+}
+
+impl AutoGcConfig {
+    pub const fn default_enabled() -> bool {
+        true
+    }
+    pub const fn default_trigger_free_gb() -> u64 {
+        20
+    }
+    pub const fn default_target_free_gb() -> u64 {
+        30
+    }
+    pub const fn default_min_age_secs() -> u64 {
+        3600
+    }
+}
+
+impl Default for AutoGcConfig {
+    fn default() -> Self {
+        Self {
+            enabled: Self::default_enabled(),
+            trigger_free_gb: Self::default_trigger_free_gb(),
+            target_free_gb: Self::default_target_free_gb(),
+            min_age_secs: Self::default_min_age_secs(),
+        }
+    }
+}
+
 impl SoldrConfig {
     pub fn load(path: &Path) -> Self {
         let Ok(text) = std::fs::read_to_string(path) else {
@@ -583,6 +645,24 @@ impl SoldrConfig {
 /// resolved.
 pub fn user_home_dir() -> Result<PathBuf, SoldrError> {
     home_dir()
+}
+
+/// Resolve `$CARGO_HOME` if set and non-empty, otherwise `~/.cargo`.
+/// Returns `None` when neither resolves cleanly.
+pub fn resolve_cargo_home() -> Option<PathBuf> {
+    if let Some(path) = non_empty_env_path(std::env::var_os(CARGO_HOME_ENV_VAR).as_deref()) {
+        return Some(path);
+    }
+    home_dir().ok().map(|home| home.join(".cargo"))
+}
+
+/// Resolve `$RUSTUP_HOME` if set and non-empty, otherwise `~/.rustup`.
+/// Returns `None` when neither resolves cleanly.
+pub fn resolve_rustup_home() -> Option<PathBuf> {
+    if let Some(path) = non_empty_env_path(std::env::var_os(RUSTUP_HOME_ENV_VAR).as_deref()) {
+        return Some(path);
+    }
+    home_dir().ok().map(|home| home.join(".rustup"))
 }
 
 /// Expand `~` and `~/...` strings to absolute paths under the user's
@@ -833,6 +913,38 @@ mod tests {
         assert!(paths.root.ends_with(".soldr"));
         assert!(paths.bin.ends_with("bin"));
         assert!(paths.cache.ends_with("cache"));
+    }
+
+    #[test]
+    fn auto_gc_config_default_round_trip() {
+        let cfg: SoldrConfig = toml::from_str("[auto_gc]\n").unwrap();
+        assert_eq!(cfg.auto_gc, AutoGcConfig::default());
+        assert!(cfg.auto_gc.enabled);
+        assert_eq!(cfg.auto_gc.trigger_free_gb, 20);
+        assert_eq!(cfg.auto_gc.target_free_gb, 30);
+        assert_eq!(cfg.auto_gc.min_age_secs, 3600);
+    }
+
+    #[test]
+    fn auto_gc_config_custom_values_parse() {
+        let toml_text = r#"
+[auto_gc]
+enabled = false
+trigger_free_gb = 10
+target_free_gb = 50
+min_age_secs = 7200
+"#;
+        let cfg: SoldrConfig = toml::from_str(toml_text).unwrap();
+        assert!(!cfg.auto_gc.enabled);
+        assert_eq!(cfg.auto_gc.trigger_free_gb, 10);
+        assert_eq!(cfg.auto_gc.target_free_gb, 50);
+        assert_eq!(cfg.auto_gc.min_age_secs, 7200);
+    }
+
+    #[test]
+    fn missing_auto_gc_section_uses_defaults() {
+        let cfg: SoldrConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.auto_gc, AutoGcConfig::default());
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -223,6 +223,125 @@ When less than 2 GB is available, it emits a yellow stderr warning that
 recommends `soldr gc`. Disk-space detection failures are ignored so they
 never fail the build.
 
+### `soldr gc cargo` (issue #323)
+
+Shells out to nightly cargo's unstable `-Zgc clean gc` against
+`$CARGO_HOME`. The CLI prepends `rustup run <toolchain>` so the workspace
+`rust-toolchain.toml` is bypassed — `cargo` here always means "the cargo
+shipped with the requested toolchain".
+
+```bash
+soldr gc cargo                                  # nightly, conservative defaults
+soldr gc cargo --dry-run --json                 # plan + machine-readable report
+soldr gc cargo --max-src-age 7days --max-crate-age 14days
+soldr gc cargo --toolchain nightly-2026-01-01   # pin the nightly snapshot
+```
+
+Toolchain resolution: `--toolchain` flag → `$SOLDR_GC_CARGO_TOOLCHAIN`
+→ `nightly` default. Missing toolchain is a hard error from explicit
+`gc cargo`; the `gc sweep` orchestrator downgrades it to a skip so CI
+runners without nightly still get the soldr target purge stage.
+
+JSON shape (`schema_version: 1`):
+
+```json
+{
+  "schema_version": 1,
+  "command": "gc",
+  "mode": "cargo",
+  "toolchain": "nightly",
+  "exit_code": 0,
+  "dry_run": false,
+  "args": ["-Zgc", "clean", "gc", "--max-src-age=7days"],
+  "stdout_bytes": 612,
+  "stderr_bytes": 0,
+  "skipped": false,
+  "skipped_reason": null
+}
+```
+
+### `soldr gc locations` (issue #323)
+
+Read-only enumeration of every cache directory soldr cares about. No
+deletion, no last-used derivation. Walks `$CARGO_HOME/{registry/{src,
+cache,index},git/{db,checkouts},.global-cache}`,
+`$RUSTUP_HOME/{toolchains,update-hashes}`, `~/.soldr/cache/`, and
+`~/.soldr/state.redb`. Missing paths are reported with `exists: false`
+and zero size.
+
+```bash
+soldr gc locations
+soldr gc locations --json
+```
+
+Per-entry JSON: `{kind, path, exists, size_bytes, size_human, file_count,
+owner, purge_safety}`. `owner` is `cargo` / `rustup` / `soldr`;
+`purge_safety` is `regenerable` (safe to delete; cargo will refetch) or
+`user_action` (the user installed it on purpose — never auto-purge).
+
+### `soldr gc sweep` (issue #323)
+
+Orchestrator that combines `gc locations`, cargo's `clean gc`, and the
+soldr target purge in one shot. Designed to be the user-facing "free
+me some disk space" command.
+
+```bash
+soldr gc sweep                            # full pipeline, prompt for each target
+soldr gc sweep --all --dry-run --json     # plan everything, delete nothing
+soldr gc sweep --no-cargo-gc              # skip cargo (e.g. no nightly available)
+soldr gc sweep --aggressive               # second cargo pass with tighter ages
+```
+
+Stages, in order:
+
+1. `gc locations` (always — read-only).
+2. cargo `clean gc` with conservative defaults (unless `--no-cargo-gc`
+   or nightly is missing — auto-skipped).
+3. soldr's target purge over registered workspaces. Respects `--all`
+   (no prompt) and the configured `gc.allowlist_roots`.
+4. `--aggressive` only: second cargo pass with
+   `--max-src-age=7days --max-crate-age=14days --max-git-co-age=7days`,
+   each clamped to `auto_gc.min_age_secs`.
+
+### Automatic GC under disk pressure (issue #323)
+
+soldr's cargo front door triggers a background auto-GC pass when free
+space on any soldr-relevant volume drops below the configured trigger.
+Per volume (Windows: drive letter; Unix: device id):
+
+1. tier 1 — cargo `clean gc` with conservative ages,
+2. tier 2 — soldr target purge with `larger_than = 256M` and
+   `older_than = max(1h, auto_gc.min_age_secs)`,
+3. tier 3 — cargo `clean gc` with `--max-src-age=7d
+   --max-crate-age=14d --max-git-co-age=7d`,
+4. stop. Anything more aggressive requires explicit
+   `soldr gc sweep --aggressive`.
+
+Configure in `~/.soldr/config.toml`:
+
+```toml
+[auto_gc]
+enabled = true          # opt-out; on by default
+trigger_free_gb = 20    # start GC when free space < this
+target_free_gb = 30     # stop GC when free space >= this
+min_age_secs = 3600     # never touch anything modified within this window
+```
+
+Behavior:
+
+- Background-only. The GC pass runs on a detached thread named
+  `soldr-auto-gc`, so the build never blocks waiting for it.
+- Throttled to ~once per 5 minutes via `~/.soldr/.auto_gc_marker`.
+- Set `SOLDR_AUTO_GC_DISABLED=1` to disable for a single invocation
+  without editing config.
+- Volumes that already have plenty of free space are skipped, even
+  when another volume on the same machine is below the trigger.
+- Every check that crosses the trigger writes a structured log line to
+  `~/.soldr/logs/auto-gc.log`. The file rotates to
+  `auto-gc.log.old` once it exceeds 10 MiB.
+- Cargo's `.package-cache` mutex serializes auto-GC against any
+  in-flight `cargo build`, so concurrent builds and GC don't race.
+
 ---
 
 ## Structured JSON Output


### PR DESCRIPTION
## Summary

Implements both halves of the disk-pressure GC story tracked in
[zackees/soldr#323](https://github.com/zackees/soldr/issues/323) (and
unblocks [zackees/setup-soldr#102](https://github.com/zackees/setup-soldr/issues/102)).

### Manual subcommands

- `soldr gc cargo [--dry-run] [--toolchain <name>] [--max-*-age <DUR>] [--max-*-size <SIZE>] [--json]` —
  shells out to `rustup run <toolchain> cargo -Zgc clean gc <forwarded>`.
  Toolchain resolution: `--toolchain` flag → `$SOLDR_GC_CARGO_TOOLCHAIN`
  → `nightly` default. Probes `rustup toolchain list` first so absent
  nightly is reported cleanly. Captures `{toolchain, exit_code, dry_run,
  args, stdout_bytes, stderr_bytes}` in JSON.
- `soldr gc locations [--json]` — read-only enumeration of
  `$CARGO_HOME/registry/{src,cache,index}`,
  `$CARGO_HOME/git/{db,checkouts}`, `$CARGO_HOME/.global-cache`,
  `$RUSTUP_HOME/{toolchains,update-hashes}`, `~/.soldr/cache/`, and
  `~/.soldr/state.redb`. Reuses `fast_directory_size_and_files`.
- `soldr gc sweep [--all] [--dry-run] [--cargo-gc | --no-cargo-gc] [--aggressive] [--json]` —
  orchestrates locations + cargo gc + soldr target purge in one shot.
  `--aggressive` runs a second cargo pass with tighter ages clamped to
  `auto_gc.min_age_secs`.

### Automatic GC under disk pressure

- `[auto_gc]` section in `~/.soldr/config.toml`:
  `enabled` (opt-out, default `true`), `trigger_free_gb` (default `20`),
  `target_free_gb` (default `30`), `min_age_secs` (default `3600`).
- Pure policy lives in `soldr_cache::auto_gc`: `plan_auto_gc` groups
  soldr paths by volume, drops volumes above the trigger, and emits a
  per-volume plan sorted by ascending free bytes; `next_tier` walks
  tiers 1 → 2 → 3 (then warn and stop) until the target free-space is
  reached; `clamp_age_to_floor` enforces the `min_age_secs` floor on
  every age forwarded to cargo or the soldr purge.
- Hook fires from `run_cargo_front_door` when cargo is about to run a
  build-like subcommand. Throttled to ~once per 5 minutes via
  `~/.soldr/.auto_gc_marker`; can be disabled per-invocation with
  `SOLDR_AUTO_GC_DISABLED=1`. The orchestrator runs on a detached
  `soldr-auto-gc` background thread, so the build never blocks on it.
- Free-space probing uses `fs2::available_space`. Volume key is the
  Windows drive letter or the Unix `stat()` device id.
- Tier-by-tier reclaim is logged to `~/.soldr/logs/auto-gc.log`,
  rotated to `auto-gc.log.old` at 10 MiB.

## Test plan

- [x] `cargo test --workspace` — 290 tests pass (was 277). New: 9
      `soldr_cache::auto_gc` unit tests, 3 `soldr_core` config
      round-trip tests, 4 `soldr-cli` CLI integration tests.
- [x] `cargo clippy --workspace --all-targets` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `soldr gc cargo --help`, `soldr gc locations --json`, `soldr gc
      sweep --no-cargo-gc --dry-run --json` exercised manually on
      Windows.

## Punted to follow-ups

- `.global-cache` SQLite reader and kinded purges
  (`cargo_registry_src`, `cargo_git_checkouts`, …) — soldr#323 PR2+,
  out of scope per the brief.
- Last-used derivation in `gc locations` — same reason.
- The auto-GC hook fires from the cargo front door (where soldr owns
  the lifecycle) rather than from an in-process daemon, because the
  daemon in soldr's architecture is the external `zccache` binary, not
  a soldr-owned process. A future follow-up can move the trigger into
  zccache if we want sub-cargo-invocation granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)