### PR TITLE
fix(benchmark): remove pre-installed clippy before toolchain install on macOS

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -70,6 +70,11 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Remove pre-installed clippy (macOS runner conflict)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: rustup component remove clippy --toolchain stable 2>/dev/null || true
+
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           targets: ${{ matrix.target }}
@@ -769,3 +774,4 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+


### PR DESCRIPTION
## Summary

- The `Native SQLite (aarch64-apple-darwin)` benchmark job was failing on `macos-15` ARM runners because the runner ships with a pre-installed clippy that conflicts with the `dtolnay/rust-toolchain` installation.
- Added a step before the `dtolnay/rust-toolchain` step to remove the conflicting pre-installed clippy component. The step is gated with `if: runner.os == 'macOS'` so it only runs on macOS runners and does not affect Linux jobs.
- The `|| true` ensures the step never fails even if clippy isn't installed.

## Error fixed

```
error: failed to install component: 'clippy-preview-aarch64-apple-darwin', detected conflict: 'bin/cargo-clippy'
```

## Test plan

- [ ] Verify the `Native SQLite (aarch64-apple-darwin)` job passes on the next benchmark run
- [ ] Verify Linux benchmark jobs are unaffected (step is skipped via `if: runner.os == 'macOS'`)