### PR TITLE
fix(benchmark): pin RUSTUP_TOOLCHAIN to bypass macos-15 clippy conflict

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -30,6 +30,12 @@ jobs:
   native-sqlite:
     name: Native SQLite (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    env:
+      # Bypass rust-toolchain.toml's `components = ["rustfmt", "clippy"]` so
+      # cargo does not ask rustup to install clippy at build time. On macos-15
+      # ARM runners that triggers a `bin/cargo-clippy` conflict against the
+      # runner image's pre-installed toolchain. See zackees/soldr#330.
+      RUSTUP_TOOLCHAIN: "1.94.1"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Adds `RUSTUP_TOOLCHAIN: "1.94.1"` to the `native-sqlite` job's env in `.github/workflows/cache-benchmark.yml`.
- When that env var is set, cargo uses the already-installed toolchain directly and ignores `rust-toolchain.toml` entirely — including its `components = ["rustfmt", "clippy"]` list.
- That sidesteps the `bin/cargo-clippy` conflict that macos-15 ARM runners hit, without modifying rustup state on the runner.

## Why this works

The benchmark only invokes `cargo build`, never `cargo clippy` or `cargo fmt`. There's no need for the components install that `rust-toolchain.toml` would otherwise trigger.

## Supersedes

- #328 (destructive `rustup component remove` approach).
- Closes #330 (which proposed this exact one-line fix).

## Long-term follow-up

The action-level fix lives at zackees/setup-soldr#105 — that change will keep any *other* consumer of setup-soldr on macOS from hitting the same conflict. The benchmark workflow uses `dtolnay/rust-toolchain` directly, so it needs this one-off fix regardless.

## Test plan

- [ ] Verify `Native SQLite (aarch64-apple-darwin)` passes on the next benchmark run
- [ ] Verify all other matrix targets are unaffected (env var doesn't change their behavior — they already had 1.94.1 active via `rust-toolchain.toml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)