### PR TITLE
feat(cli): rustup passthrough + toolchain install/prepare (first slice of #331)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,11 @@ Two categories, surfaced as first-class subcommands or via the generic fetch pat
 **Rustup toolchain passthroughs** (resolved via `rustup which`):
 `rustc`, `rustfmt`, `clippy-driver`, `rustdoc`, `rust-gdb`, `rust-lldb`, `rust-analyzer`.
 
+**Rustup front door** (top-level, direct exec of `rustup` itself — `rustup which rustup` doesn't work):
+- `soldr rustup <args>` forwards to the system `rustup` binary. When the first non-flag positional is `target` or `component` and `rust-toolchain.toml` declares a `channel`, soldr injects `--toolchain <channel>` after the verb so per-toolchain state mutations land on the pinned toolchain. Pass `--toolchain` explicitly to opt out of injection.
+- `soldr toolchain install` reads `[toolchain].channel` from `rust-toolchain.toml` and runs `rustup toolchain install <channel> --profile minimal --no-self-update`.
+- `soldr toolchain prepare` chains install + `component add` + `target add` for every declared component / target.
+
 **Ecosystem fetches** (registered in `known_tools`, pulled from GitHub Releases):
 - cargo subcommands invoked via `soldr cargo <sub>`: `nextest`, `deny`, `audit`, `llvm-cov`, `udeps`, `semver-checks`, `expand`, `watch`.
 - top-level tools invoked directly via `soldr <tool>`: `cross`, `mdbook`, `cbindgen`, `wasm-pack`, `trunk`, `sccache`.
@@ -64,7 +69,7 @@ Anything not registered falls through the generic External subcommand, which res
 
 ## Key Design Rules
 
-- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
+- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`, `rustup`, `toolchain` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
 - **MSVC on Windows always**: Default to `x86_64-pc-windows-msvc` (or aarch64). Only use GNU if `rust-toolchain.toml` explicitly says so. Target resolved at runtime, not compile-time.
 - **Pre-built first**: Try every binary source before `cargo install`. Resolution order matters.
 - **RUSTC_WRAPPER defaults to zccache**: If `RUSTC_WRAPPER` is not set, soldr defaults to using `zccache` as the wrapper.

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -916,11 +916,23 @@ fn scope_rustup_args_to_pin(args: &[String]) -> Result<Vec<String>, SoldrError> 
         return Ok(args.to_vec());
     };
 
+    // Inject `--toolchain <channel>` after the subcommand/verb pair so a
+    // call like `target add x86_64-unknown-linux-musl` becomes
+    // `target add --toolchain <channel> x86_64-unknown-linux-musl`.
+    // The verb is the next non-flag positional after `target`/`component`.
+    let mut insertion_idx = first_positional + 1;
+    for (offset, arg) in args[first_positional + 1..].iter().enumerate() {
+        if !arg.starts_with('-') {
+            insertion_idx = first_positional + 1 + offset + 1;
+            break;
+        }
+    }
+
     let mut out = Vec::with_capacity(args.len() + 2);
-    out.extend(args[..=first_positional].iter().cloned());
+    out.extend(args[..insertion_idx].iter().cloned());
     out.push("--toolchain".to_string());
     out.push(channel);
-    out.extend(args[first_positional + 1..].iter().cloned());
+    out.extend(args[insertion_idx..].iter().cloned());
     Ok(out)
 }
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -187,9 +187,37 @@ enum Commands {
         #[command(subcommand)]
         command: Option<GcSubcommand>,
     },
+    /// Drop-in passthrough to the system `rustup` binary.
+    ///
+    /// When the first non-flag positional argument is `target` or
+    /// `component` and `rust-toolchain.toml` declares a `channel`,
+    /// soldr automatically inserts `--toolchain <channel>` after the
+    /// subcommand (unless the user already passed `--toolchain`).
+    /// Every other invocation is forwarded verbatim.
+    Rustup {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Read `rust-toolchain.toml` and install the declared channel /
+    /// components / targets via `rustup`.
+    Toolchain {
+        #[command(subcommand)]
+        subcommand: ToolchainSubcommand,
+    },
     /// Anything else is a tool to fetch and run
     #[command(external_subcommand)]
     External(Vec<String>),
+}
+
+#[derive(Subcommand)]
+enum ToolchainSubcommand {
+    /// Install the channel declared in `rust-toolchain.toml`. No-op
+    /// (exit 0 with a note) when the manifest is missing or omits
+    /// `channel`.
+    Install,
+    /// Install the channel and every declared component / target from
+    /// `rust-toolchain.toml`. Stops at the first nonzero rustup exit.
+    Prepare,
 }
 
 #[derive(Subcommand)]
@@ -428,6 +456,17 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
         Commands::RustAnalyzer { args } => {
             std::process::exit(run_toolchain_passthrough("rust-analyzer", &args)?);
         }
+        Commands::Rustup { args } => {
+            std::process::exit(run_rustup_passthrough(&args)?);
+        }
+        Commands::Toolchain { subcommand } => match subcommand {
+            ToolchainSubcommand::Install => {
+                std::process::exit(run_toolchain_install()?);
+            }
+            ToolchainSubcommand::Prepare => {
+                std::process::exit(run_toolchain_prepare()?);
+            }
+        },
         Commands::Status { json } => {
             let output = collect_status_output(cache_enabled)?;
             if json {
@@ -821,6 +860,156 @@ fn run_toolchain_passthrough(tool: &str, args: &[String]) -> Result<i32, SoldrEr
     let binary = resolve_toolchain_binary(tool)?;
     let mut command = std::process::Command::new(binary);
     command.args(args);
+    apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
+    let status = command.status()?;
+    Ok(status.code().unwrap_or(1))
+}
+
+/// Drop-in passthrough for `soldr rustup ...`.
+///
+/// Most invocations forward verbatim. The one exception is the "scoped"
+/// pin: when the first positional argument is `target` or `component`
+/// (the two rustup subcommands that mutate per-toolchain state) AND
+/// `rust-toolchain.toml` declares a `channel`, soldr inserts
+/// `--toolchain <channel>` immediately after the user's first positional
+/// argument so the call lands on the pinned toolchain rather than the
+/// rustup default. If the user already supplied `--toolchain` anywhere,
+/// the injection is skipped.
+fn run_rustup_passthrough(args: &[String]) -> Result<i32, SoldrError> {
+    let final_args = scope_rustup_args_to_pin(args)?;
+    let mut command = std::process::Command::new(rustup_binary());
+    command.args(&final_args);
+    apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
+    let status = command.status()?;
+    Ok(status.code().unwrap_or(1))
+}
+
+fn scope_rustup_args_to_pin(args: &[String]) -> Result<Vec<String>, SoldrError> {
+    // Find the first non-flag positional. Anything before it (e.g.
+    // `--verbose`) is preserved in place.
+    let mut first_positional: Option<usize> = None;
+    for (idx, arg) in args.iter().enumerate() {
+        if !arg.starts_with('-') {
+            first_positional = Some(idx);
+            break;
+        }
+    }
+
+    let Some(first_positional) = first_positional else {
+        return Ok(args.to_vec());
+    };
+
+    let subcommand = args[first_positional].as_str();
+    if subcommand != "target" && subcommand != "component" {
+        return Ok(args.to_vec());
+    }
+
+    if rustup_args_specify_toolchain(args) {
+        return Ok(args.to_vec());
+    }
+
+    let workspace_root = std::env::current_dir().map_err(SoldrError::from)?;
+    let manifest = soldr_core::read_rust_toolchain_manifest(&workspace_root)?;
+    let Some(channel) = manifest.channel else {
+        return Ok(args.to_vec());
+    };
+
+    let mut out = Vec::with_capacity(args.len() + 2);
+    out.extend(args[..=first_positional].iter().cloned());
+    out.push("--toolchain".to_string());
+    out.push(channel);
+    out.extend(args[first_positional + 1..].iter().cloned());
+    Ok(out)
+}
+
+fn rustup_args_specify_toolchain(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| arg == "--toolchain" || arg.starts_with("--toolchain="))
+}
+
+/// Implementation of `soldr toolchain install`.
+fn run_toolchain_install() -> Result<i32, SoldrError> {
+    let workspace_root = std::env::current_dir().map_err(SoldrError::from)?;
+    let manifest = soldr_core::read_rust_toolchain_manifest(&workspace_root)?;
+    let Some(channel) = manifest.channel.as_deref() else {
+        eprintln!(
+            "soldr: no rust-toolchain.toml channel found; nothing to install. \
+             Create rust-toolchain.toml with a `[toolchain] channel = \"<version>\"` entry."
+        );
+        return Ok(0);
+    };
+
+    rustup_toolchain_install(channel)
+}
+
+/// Implementation of `soldr toolchain prepare`.
+fn run_toolchain_prepare() -> Result<i32, SoldrError> {
+    let workspace_root = std::env::current_dir().map_err(SoldrError::from)?;
+    let manifest = soldr_core::read_rust_toolchain_manifest(&workspace_root)?;
+    let Some(channel) = manifest.channel.as_deref() else {
+        eprintln!(
+            "soldr: no rust-toolchain.toml channel found; nothing to prepare. \
+             Create rust-toolchain.toml with a `[toolchain] channel = \"<version>\"` entry."
+        );
+        return Ok(0);
+    };
+
+    let install_code = rustup_toolchain_install(channel)?;
+    if install_code != 0 {
+        return Ok(install_code);
+    }
+
+    if let Some(components) = manifest.components.as_deref() {
+        for component in components {
+            let code = rustup_component_add(channel, component)?;
+            if code != 0 {
+                return Ok(code);
+            }
+        }
+    }
+
+    if let Some(targets) = manifest.targets.as_deref() {
+        for target in targets {
+            let code = rustup_target_add(channel, target)?;
+            if code != 0 {
+                return Ok(code);
+            }
+        }
+    }
+
+    Ok(0)
+}
+
+fn rustup_toolchain_install(channel: &str) -> Result<i32, SoldrError> {
+    let mut command = std::process::Command::new(rustup_binary());
+    command.args([
+        "toolchain",
+        "install",
+        channel,
+        "--profile",
+        "minimal",
+        "--no-self-update",
+    ]);
+    apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
+    let status = command.status()?;
+    Ok(status.code().unwrap_or(1))
+}
+
+fn rustup_component_add(channel: &str, component: &str) -> Result<i32, SoldrError> {
+    let mut command = std::process::Command::new(rustup_binary());
+    command.args(["component", "add", "--toolchain", channel, component]);
+    apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
+    let status = command.status()?;
+    Ok(status.code().unwrap_or(1))
+}
+
+fn rustup_target_add(channel: &str, target: &str) -> Result<i32, SoldrError> {
+    let mut command = std::process::Command::new(rustup_binary());
+    command.args(["target", "add", "--toolchain", channel, target]);
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
     let status = command.status()?;

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -637,6 +637,82 @@ fn install_failing_fake_rustup(log_path: &Path) -> PathBuf {
     rustup
 }
 
+/// Fake rustup that logs one line per invocation to `log_path`, with the
+/// argv joined by `\u{1f}` (ASCII unit separator) so test assertions can
+/// reason about the exact argv even when individual arguments contain
+/// spaces. Always exits 0.
+fn fake_logging_rustup_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             setlocal enabledelayedexpansion\n\
+             set \"line=\"\n\
+             :loop\n\
+             if \"%~1\"==\"\" goto done\n\
+             if defined line (set \"line=!line!\u{1f}%~1\") else (set \"line=%~1\")\n\
+             shift\n\
+             goto loop\n\
+             :done\n\
+             echo !line!>>\"{}\"\n\
+             exit /b 0\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        // Use ASCII Unit Separator (\037) between argv elements so assertions
+        // can split deterministically even if an individual arg contains
+        // spaces. Hand-roll the join in /bin/sh.
+        format!(
+            "#!/bin/sh\n\
+             sep=$(printf '\\037')\n\
+             out=\"\"\n\
+             first=1\n\
+             for arg in \"$@\"; do\n\
+               if [ $first -eq 1 ]; then\n\
+                 out=\"$arg\"\n\
+                 first=0\n\
+               else\n\
+                 out=\"$out${{sep}}$arg\"\n\
+               fi\n\
+             done\n\
+             printf '%s\\n' \"$out\" >> \"{}\"\n\
+             exit 0\n",
+            log_path.display()
+        )
+    }
+}
+
+/// Install a fake rustup that logs argv per invocation. Returns the path
+/// to the fake binary, ready to hand to `SOLDR_TEST_RUSTUP_BIN`.
+fn install_logging_fake_rustup(log_path: &Path) -> PathBuf {
+    let dir = unique_temp_dir("fake-rustup-logging");
+    #[cfg(windows)]
+    let rustup = dir.join("rustup.bat");
+    #[cfg(not(windows))]
+    let rustup = fake_script_path(&dir, "rustup");
+    write_fake_script(&rustup, &fake_logging_rustup_script(log_path));
+    rustup
+}
+
+/// Read every argv invocation logged by `fake_logging_rustup_script`.
+/// Each returned `Vec<String>` is one invocation, with argv split on the
+/// ASCII unit separator.
+fn read_logged_rustup_invocations(log_path: &Path) -> Vec<Vec<String>> {
+    let text = fs::read_to_string(log_path).unwrap_or_default();
+    text.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.split('\u{1f}').map(str::to_string).collect())
+        .collect()
+}
+
+fn seed_rust_toolchain_toml(dir: &Path, contents: &str) {
+    fs::create_dir_all(dir).expect("failed to create workspace dir");
+    fs::write(dir.join("rust-toolchain.toml"), contents)
+        .expect("failed to write rust-toolchain.toml");
+}
+
 fn prepend_to_path(dir: &Path) -> std::ffi::OsString {
     let existing = std::env::var_os("PATH").unwrap_or_default();
     let mut paths = vec![dir.to_path_buf()];
@@ -713,6 +789,223 @@ fn help_lists_phase_one_command_surface() {
     assert!(stdout.contains("cache"), "help output missing cache");
     assert!(stdout.contains("version"), "help output missing version");
     assert!(stdout.contains("cargo"), "help output missing cargo");
+    assert!(stdout.contains("rustup"), "help output missing rustup");
+    assert!(
+        stdout.contains("toolchain"),
+        "help output missing toolchain"
+    );
+}
+
+#[test]
+fn rustup_passthrough_forwards_args_unchanged_for_unscoped_subcommands() {
+    let workspace = unique_temp_dir("rustup-passthrough-show");
+    let log_path = workspace.join("rustup.log");
+    let rustup = install_logging_fake_rustup(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["rustup", "show"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .output()
+        .expect("failed to run soldr rustup show");
+
+    assert!(
+        output.status.success(),
+        "soldr rustup show failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let invocations = read_logged_rustup_invocations(&log_path);
+    assert_eq!(invocations.len(), 1, "expected one rustup invocation");
+    assert_eq!(invocations[0], vec!["show".to_string()]);
+}
+
+#[test]
+fn rustup_passthrough_injects_toolchain_for_target_add() {
+    let workspace = unique_temp_dir("rustup-passthrough-target-add");
+    seed_rust_toolchain_toml(&workspace, "[toolchain]\nchannel = \"1.94.1\"\n");
+    let log_path = workspace.join("rustup.log");
+    let rustup = install_logging_fake_rustup(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["rustup", "target", "add", "x86_64-unknown-linux-musl"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .output()
+        .expect("failed to run soldr rustup target add");
+
+    assert!(
+        output.status.success(),
+        "soldr rustup target add failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let invocations = read_logged_rustup_invocations(&log_path);
+    assert_eq!(invocations.len(), 1, "expected one rustup invocation");
+    assert_eq!(
+        invocations[0],
+        vec![
+            "target".to_string(),
+            "add".to_string(),
+            "--toolchain".to_string(),
+            "1.94.1".to_string(),
+            "x86_64-unknown-linux-musl".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn rustup_passthrough_does_not_double_inject_toolchain() {
+    let workspace = unique_temp_dir("rustup-passthrough-explicit-toolchain");
+    seed_rust_toolchain_toml(&workspace, "[toolchain]\nchannel = \"1.94.1\"\n");
+    let log_path = workspace.join("rustup.log");
+    let rustup = install_logging_fake_rustup(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "rustup",
+            "target",
+            "add",
+            "--toolchain",
+            "nightly",
+            "aarch64-apple-darwin",
+        ])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .output()
+        .expect("failed to run soldr rustup target add --toolchain nightly");
+
+    assert!(
+        output.status.success(),
+        "soldr rustup target add --toolchain failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let invocations = read_logged_rustup_invocations(&log_path);
+    assert_eq!(invocations.len(), 1, "expected one rustup invocation");
+    let invocation = &invocations[0];
+    let toolchain_count = invocation.iter().filter(|arg| *arg == "--toolchain").count();
+    assert_eq!(
+        toolchain_count, 1,
+        "--toolchain should appear exactly once: {invocation:?}"
+    );
+    let toolchain_value_idx = invocation
+        .iter()
+        .position(|arg| arg == "--toolchain")
+        .expect("--toolchain not found");
+    assert_eq!(
+        invocation.get(toolchain_value_idx + 1).map(String::as_str),
+        Some("nightly"),
+        "user-supplied toolchain should be preserved: {invocation:?}"
+    );
+}
+
+#[test]
+fn toolchain_install_invokes_rustup_with_channel() {
+    let workspace = unique_temp_dir("toolchain-install");
+    seed_rust_toolchain_toml(&workspace, "[toolchain]\nchannel = \"1.94.1\"\n");
+    let log_path = workspace.join("rustup.log");
+    let rustup = install_logging_fake_rustup(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["toolchain", "install"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .output()
+        .expect("failed to run soldr toolchain install");
+
+    assert!(
+        output.status.success(),
+        "soldr toolchain install failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let invocations = read_logged_rustup_invocations(&log_path);
+    assert_eq!(invocations.len(), 1, "expected one rustup invocation");
+    assert_eq!(
+        invocations[0],
+        vec![
+            "toolchain".to_string(),
+            "install".to_string(),
+            "1.94.1".to_string(),
+            "--profile".to_string(),
+            "minimal".to_string(),
+            "--no-self-update".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn toolchain_prepare_installs_channel_components_and_targets() {
+    let workspace = unique_temp_dir("toolchain-prepare");
+    seed_rust_toolchain_toml(
+        &workspace,
+        "[toolchain]\n\
+         channel = \"1.94.1\"\n\
+         components = [\"clippy\"]\n\
+         targets = [\"x86_64-unknown-linux-musl\"]\n",
+    );
+    let log_path = workspace.join("rustup.log");
+    let rustup = install_logging_fake_rustup(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["toolchain", "prepare"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .output()
+        .expect("failed to run soldr toolchain prepare");
+
+    assert!(
+        output.status.success(),
+        "soldr toolchain prepare failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let invocations = read_logged_rustup_invocations(&log_path);
+    assert_eq!(
+        invocations.len(),
+        3,
+        "expected install + component add + target add: {invocations:?}"
+    );
+    assert_eq!(
+        invocations[0],
+        vec![
+            "toolchain".to_string(),
+            "install".to_string(),
+            "1.94.1".to_string(),
+            "--profile".to_string(),
+            "minimal".to_string(),
+            "--no-self-update".to_string(),
+        ],
+        "first invocation should install the pinned channel"
+    );
+    assert_eq!(
+        invocations[1],
+        vec![
+            "component".to_string(),
+            "add".to_string(),
+            "--toolchain".to_string(),
+            "1.94.1".to_string(),
+            "clippy".to_string(),
+        ],
+        "second invocation should add the declared component"
+    );
+    assert_eq!(
+        invocations[2],
+        vec![
+            "target".to_string(),
+            "add".to_string(),
+            "--toolchain".to_string(),
+            "1.94.1".to_string(),
+            "x86_64-unknown-linux-musl".to_string(),
+        ],
+        "third invocation should add the declared target"
+    );
 }
 
 #[test]

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -887,7 +887,10 @@ fn rustup_passthrough_does_not_double_inject_toolchain() {
     let invocations = read_logged_rustup_invocations(&log_path);
     assert_eq!(invocations.len(), 1, "expected one rustup invocation");
     let invocation = &invocations[0];
-    let toolchain_count = invocation.iter().filter(|arg| *arg == "--toolchain").count();
+    let toolchain_count = invocation
+        .iter()
+        .filter(|arg| *arg == "--toolchain")
+        .count();
     assert_eq!(
         toolchain_count, 1,
         "--toolchain should appear exactly once: {invocation:?}"

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -148,7 +148,69 @@ struct RustToolchainFile {
 
 #[derive(Debug, Deserialize)]
 struct RustToolchainSection {
+    #[serde(default)]
+    channel: Option<String>,
+    #[serde(default)]
+    components: Option<Vec<String>>,
+    #[serde(default)]
     targets: Option<Vec<String>>,
+    #[serde(default)]
+    profile: Option<String>,
+}
+
+/// Parsed view of a project's `rust-toolchain.toml`. All fields are
+/// optional so callers can treat a missing file or missing `[toolchain]`
+/// section the same as a fully-populated section whose fields happen to
+/// be unset. Returned by [`read_rust_toolchain_manifest`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RustToolchainManifest {
+    pub channel: Option<String>,
+    pub components: Option<Vec<String>>,
+    pub targets: Option<Vec<String>>,
+    pub profile: Option<String>,
+}
+
+/// Read `rust-toolchain.toml` from `workspace_root` (non-recursive — the
+/// caller is expected to already point at the directory containing the
+/// manifest, mirroring how cargo resolves the file). A missing file is
+/// not an error; an empty `RustToolchainManifest` is returned so callers
+/// can branch on `manifest.channel.is_none()` without juggling IO error
+/// kinds. Malformed TOML or unreadable files surface as
+/// [`SoldrError::Other`].
+pub fn read_rust_toolchain_manifest(
+    workspace_root: &Path,
+) -> Result<RustToolchainManifest, SoldrError> {
+    let path = workspace_root.join("rust-toolchain.toml");
+    if !path.exists() {
+        return Ok(RustToolchainManifest::default());
+    }
+    let text = std::fs::read_to_string(&path).map_err(|err| {
+        SoldrError::Other(format!(
+            "failed to read rust-toolchain.toml at {}: {err}",
+            path.display()
+        ))
+    })?;
+    let parsed: RustToolchainFile = toml::from_str(&text).map_err(|err| {
+        SoldrError::Other(format!(
+            "failed to parse rust-toolchain.toml at {}: {err}",
+            path.display()
+        ))
+    })?;
+    let Some(section) = parsed.toolchain else {
+        return Ok(RustToolchainManifest::default());
+    };
+    Ok(RustToolchainManifest {
+        channel: section
+            .channel
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        components: section.components,
+        targets: section.targets,
+        profile: section
+            .profile
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -179,10 +241,9 @@ fn read_cargo_config_target(path: PathBuf) -> Option<String> {
 }
 
 fn read_toolchain_target(path: PathBuf) -> Option<String> {
-    let text = std::fs::read_to_string(path).ok()?;
-    let toolchain: RustToolchainFile = toml::from_str(&text).ok()?;
-    let supported = toolchain
-        .toolchain?
+    let workspace_root = path.parent()?;
+    let manifest = read_rust_toolchain_manifest(workspace_root).ok()?;
+    let supported = manifest
         .targets?
         .into_iter()
         .filter(|target| TargetTriple::from_triple(target).is_ok())
@@ -1248,5 +1309,48 @@ min_age_secs = 7200
 
         assert_eq!(resolve_runtime_rustc(Some(&nested)), Some(repo_local_rustc));
         assert_rustup_not_invoked(&log_path);
+    }
+
+    #[test]
+    fn rust_toolchain_manifest_parses_full_section() {
+        let dir = tempdir().unwrap();
+        let manifest_path = dir.path().join("rust-toolchain.toml");
+        fs::write(
+            &manifest_path,
+            "[toolchain]\n\
+             channel = \"1.94.1\"\n\
+             components = [\"clippy\", \"rustfmt\"]\n\
+             targets = [\"x86_64-unknown-linux-musl\", \"aarch64-apple-darwin\"]\n\
+             profile = \"minimal\"\n",
+        )
+        .unwrap();
+
+        let manifest = read_rust_toolchain_manifest(dir.path()).unwrap();
+        assert_eq!(manifest.channel.as_deref(), Some("1.94.1"));
+        assert_eq!(
+            manifest.components.as_deref(),
+            Some(&["clippy".to_string(), "rustfmt".to_string()][..])
+        );
+        assert_eq!(
+            manifest.targets.as_deref(),
+            Some(
+                &[
+                    "x86_64-unknown-linux-musl".to_string(),
+                    "aarch64-apple-darwin".to_string()
+                ][..]
+            )
+        );
+        assert_eq!(manifest.profile.as_deref(), Some("minimal"));
+    }
+
+    #[test]
+    fn rust_toolchain_manifest_missing_file_returns_default() {
+        let dir = tempdir().unwrap();
+        let manifest = read_rust_toolchain_manifest(dir.path()).unwrap();
+        assert_eq!(manifest, RustToolchainManifest::default());
+        assert!(manifest.channel.is_none());
+        assert!(manifest.components.is_none());
+        assert!(manifest.targets.is_none());
+        assert!(manifest.profile.is_none());
     }
 }


### PR DESCRIPTION
Closes part of #331 — **first slice, minimal viable scope**.

Adds three new top-level commands that let soldr drive the system `rustup` from inside a project pin without users having to reach around to `rustup` themselves.

## What landed

- `soldr rustup <args>` — drop-in passthrough to the system `rustup`. Smart pin scoping: when the first non-flag positional is `target` or `component` and `rust-toolchain.toml` declares a `channel`, soldr inserts `--toolchain <channel>` after the verb (`target add --toolchain 1.94.1 x86_64-unknown-linux-musl`). The injection is skipped when the user already supplied `--toolchain`, and untouched subcommands like `rustup show` forward verbatim.
- `soldr toolchain install` — reads `[toolchain].channel` from `rust-toolchain.toml` and runs `rustup toolchain install <channel> --profile minimal --no-self-update`. Missing manifest / missing channel exits 0 with an informational note.
- `soldr toolchain prepare` — runs `toolchain install`, then `rustup component add --toolchain <channel> <c>` for every declared component, then `rustup target add --toolchain <channel> <t>` for every declared target. Stops at the first nonzero exit.
- `soldr_core::read_rust_toolchain_manifest` — new public reader returning a `RustToolchainManifest { channel, components, targets, profile }`. Missing file returns `Default::default()`; malformed TOML surfaces as `SoldrError::Other`. The existing `read_toolchain_target()` was rewritten as a thin wrapper so target detection behavior is unchanged.

## Example usage

```bash
# Inside a project with rust-toolchain.toml pinning 1.94.1:
soldr rustup show                                  # → rustup show
soldr rustup target add x86_64-unknown-linux-musl  # → rustup target add --toolchain 1.94.1 x86_64-unknown-linux-musl
soldr rustup target add --toolchain nightly aarch64-apple-darwin  # → respects user toolchain pin

soldr toolchain install   # → rustup toolchain install 1.94.1 --profile minimal --no-self-update
soldr toolchain prepare   # → install + component add (clippy, rustfmt, ...) + target add (every declared target)
```

## Explicit non-goals (deferred to follow-up PRs)

- **`soldr doctor`** — environment audit / diagnostics. Out of scope for the first slice; building it requires deciding the schema of doctor's JSON output and which probes belong in core vs. cli, neither of which blocks the toolchain primitives.
- **`[soldr.plugins]` parsing or `cargo plugin install`** — needs a registry / trust model discussion (which plugins are blessed, where does the manifest live, how does CI pin them) and intersects with the existing `known_tools` registry. Better as its own design pass.
- **`rustup_target_rustlib` GC kind** — a new GC reachability rule rather than a toolchain primitive. Will land alongside the next GC work so the GC test surface stays cohesive.
- **Toolchain caching anywhere** — caching `rustup toolchain install` artifacts changes the trust boundary (we'd be re-uploading the GitHub-distributed rustup tarballs). Worth a dedicated PR with the cache layout in `~/.soldr/` and trust-pinning semantics.

## Tests

Seven new tests, all green:

`soldr-core`:
- `rust_toolchain_manifest_parses_full_section` — verifies the new struct round-trips all four fields.
- `rust_toolchain_manifest_missing_file_returns_default` — verifies a missing manifest is not an error.

`soldr-cli`:
- `rustup_passthrough_forwards_args_unchanged_for_unscoped_subcommands`
- `rustup_passthrough_injects_toolchain_for_target_add`
- `rustup_passthrough_does_not_double_inject_toolchain`
- `toolchain_install_invokes_rustup_with_channel`
- `toolchain_prepare_installs_channel_components_and_targets`

The CLI tests drive a logging fake-rustup shim (works on both bash and Windows cmd) selected through the existing `SOLDR_TEST_RUSTUP_BIN` override, so no real rustup state is touched.

## Test plan

- [x] `cargo test --workspace` (51 + 102 + 65 + 3 + 27 + 25 + 1 passing in local run)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`