### PR TITLE
docs: clarify native vs cross-target setup for soldr cargo builds

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -110,6 +110,8 @@ Useful inputs when wiring the action into another repository:
 
 The current root `repo` input is an implementation/testing override for the in-repo action source. It is not part of the public `setup-soldr@v0` beta contract.
 
+Cross-target CI must provision the target's Rust standard library before invoking `soldr cargo --target ...`. Declare it in `rust-toolchain.toml`'s `[toolchain].targets` (the preferred path — `setup-soldr` reads the toolchain file during install) or use `setup-soldr` with an explicit targets input. Otherwise the cross build fails at compile time with `error[E0463]: can't find crate for core/std`. See the [native vs cross targets](./README.md#native-vs-cross-targets) section of the README and the canonical multi-platform tutorial at [`zackees/setup-soldr#90`](https://github.com/zackees/setup-soldr/issues/90).
+
 ### Cargo shim mode
 
 The preferred explicit integration is still:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,35 @@ On runners without `rustup`, the action downloads and installs it into the cache
 
 The public action lives in [`zackees/setup-soldr`](https://github.com/zackees/setup-soldr) and is generated from this repository's root action source. This repository dogfoods `zackees/setup-soldr@v0` in [setup-soldr-action.yml](./.github/workflows/setup-soldr-action.yml). For fuller examples and fallback patterns, see [INTEGRATION.md](./INTEGRATION.md).
 
+### Native vs cross targets
+
+`soldr cargo --target ...` runs the build through soldr/zccache, but it does not fetch a target's Rust standard library. If the active toolchain does not already have that target installed, the canonical failure is `error[E0463]: can't find crate for core/std` (or `compiler_builtins`) at the first compile step.
+
+Native host targets work by default because `rustup` installs the host triple as part of the toolchain. Cross targets must be declared explicitly. Building `aarch64-pc-windows-msvc` from a Windows x86 runner, for example, requires provisioning `aarch64-pc-windows-msvc` before any `soldr cargo --target aarch64-pc-windows-msvc` invocation.
+
+Two equivalent ways to declare a cross target: declaratively via `rust-toolchain.toml`'s `[toolchain].targets` (preferred — `setup-soldr` honors it during toolchain install), or imperatively via `soldr rustup target add` / `soldr toolchain prepare` (see [#331](https://github.com/zackees/soldr/issues/331) and [PR #333](https://github.com/zackees/soldr/pull/333)).
+
+```toml
+# rust-toolchain.toml — declarative (preferred)
+[toolchain]
+channel = "1.94.1"
+targets = ["aarch64-pc-windows-msvc"]
+```
+
+```bash
+# CLI — imperative
+soldr rustup target add aarch64-pc-windows-msvc
+soldr cargo build --target aarch64-pc-windows-msvc
+```
+
+```bash
+# Orchestrated
+soldr toolchain prepare
+soldr cargo build --target aarch64-pc-windows-msvc
+```
+
+The canonical multi-platform GitHub Actions tutorial lives in [`zackees/setup-soldr#90`](https://github.com/zackees/setup-soldr/issues/90).
+
 ### CI cache lineage
 
 GitHub Actions caches are not shared across arbitrary sibling feature branches. A workflow run can restore caches from its own branch, the default branch, and for pull requests the PR base branch. It cannot directly restore caches created on another feature branch.

--- a/docs/API.md
+++ b/docs/API.md
@@ -132,6 +132,8 @@ soldr cargo check -p soldr-cli
 soldr --no-cache cargo test
 ```
 
+For cross-target builds (`soldr cargo --target ...`), the target's Rust standard library must be provisioned separately — see the [native vs cross targets](../README.md#native-vs-cross-targets) section of the README.
+
 ### `soldr status`
 
 Show cache and target information.


### PR DESCRIPTION
Closes #313.

## Summary

Docs-only change. Adds an explicit native-vs-cross-target boundary explanation to soldr's user-facing docs so users hit the `error[E0463]: can't find crate for core/std` failure mode in the docs, not in CI.

- `README.md` — new `### Native vs cross targets` subsection under the GitHub Actions section (before `CI cache lineage`). Three paragraphs covering the failure mode, the native-by-default behavior, and the two equivalent provisioning paths (declarative `rust-toolchain.toml` `[toolchain].targets` vs imperative `soldr rustup target add` / `soldr toolchain prepare`). Includes three `aarch64-pc-windows-msvc` code blocks plus a forward-looking link to [`zackees/setup-soldr#90`](https://github.com/zackees/setup-soldr/issues/90).
- `INTEGRATION.md` — appended one paragraph to the `Preferred setup action path` section: cross-target CI must declare `[toolchain].targets` before `soldr cargo --target ...`. Cross-linked to the new README section and setup-soldr#90.
- `docs/API.md` — one line under `### soldr cargo` pointing to the new README section.

## Acceptance criteria (from #313)

- [x] README has a short note under the GitHub Actions/setup-soldr section explaining native targets vs cross targets.
- [x] `INTEGRATION.md` mentions that cross-target CI must provision `[toolchain].targets` before `soldr cargo --target ...`.
- [x] Docs link to the setup-soldr multi-platform tutorial ([`zackees/setup-soldr#90`](https://github.com/zackees/setup-soldr/issues/90), forward-looking).
- [x] Docs use `aarch64-pc-windows-msvc` as the concrete cross-target example from a Windows x86 runner.

## Related

- Imperative provisioning path lands via [#331](https://github.com/zackees/soldr/issues/331) / [PR #333](https://github.com/zackees/soldr/pull/333) (`soldr rustup target add`, `soldr toolchain prepare`).
- Canonical multi-platform GitHub Actions tutorial tracked in [zackees/setup-soldr#90](https://github.com/zackees/setup-soldr/issues/90).

## Test plan

- [x] Markdown headings nest correctly under existing structure.
- [x] All code blocks carry language hints (`toml`, `bash`).
- [x] Internal anchor links (`./README.md#native-vs-cross-targets`, `../README.md#native-vs-cross-targets`) match the new heading.
- [x] No Rust code touched — no `cargo fmt` / `clippy` impact.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>