### PR TITLE
feat(cli): soldr doctor — drift detector for rust-toolchain.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Anything not registered falls through the generic External subcommand, which res
 
 ## Key Design Rules
 
-- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`, `rustup`, `toolchain` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
+- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`, `rustup`, `toolchain`, `doctor` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
 - **MSVC on Windows always**: Default to `x86_64-pc-windows-msvc` (or aarch64). Only use GNU if `rust-toolchain.toml` explicitly says so. Target resolved at runtime, not compile-time.
 - **Pre-built first**: Try every binary source before `cargo install`. Resolution order matters.
 - **RUSTC_WRAPPER defaults to zccache**: If `RUSTC_WRAPPER` is not set, soldr defaults to using `zccache` as the wrapper.

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -204,6 +204,14 @@ enum Commands {
         #[command(subcommand)]
         subcommand: ToolchainSubcommand,
     },
+    /// Diagnose drift between `rust-toolchain.toml` and the
+    /// currently installed rustup state. Read-only — never mutates
+    /// rustup. Exit code is `1` when drift is detected, `0` otherwise.
+    Doctor {
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
     /// Anything else is a tool to fetch and run
     #[command(external_subcommand)]
     External(Vec<String>),
@@ -493,6 +501,9 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 std::process::exit(run_toolchain_prepare()?);
             }
         },
+        Commands::Doctor { json } => {
+            std::process::exit(run_doctor(json)?);
+        }
         Commands::Status { json } => {
             let output = collect_status_output(cache_enabled)?;
             if json {
@@ -1138,6 +1149,329 @@ fn rustup_target_add(channel: &str, target: &str) -> Result<i32, SoldrError> {
     suppress_windows_console_window(&mut command);
     let status = command.status()?;
     Ok(status.code().unwrap_or(1))
+}
+
+#[derive(Serialize)]
+struct DoctorComponent {
+    name: String,
+    installed: bool,
+}
+
+#[derive(Serialize)]
+struct DoctorTarget {
+    triple: String,
+    installed: bool,
+}
+
+#[derive(Serialize)]
+struct DoctorToolchain {
+    channel: String,
+    installed: bool,
+}
+
+#[derive(Serialize)]
+struct DoctorOutput {
+    schema_version: u32,
+    command: &'static str,
+    /// Absolute path to the inspected `rust-toolchain.toml`. `None`
+    /// when no manifest exists in the current working directory.
+    manifest_path: Option<String>,
+    /// `None` when the manifest is missing or omits `channel`.
+    toolchain: Option<DoctorToolchain>,
+    components: Vec<DoctorComponent>,
+    targets: Vec<DoctorTarget>,
+    /// Whether any declared component or target is missing from the
+    /// installed rustup state. Always `false` when no manifest exists.
+    drift: bool,
+    missing_components: Vec<String>,
+    missing_targets: Vec<String>,
+}
+
+/// Implementation of `soldr doctor`. Read-only — never invokes
+/// `rustup component add` / `target add` / `toolchain install`.
+fn run_doctor(json: bool) -> Result<i32, SoldrError> {
+    let workspace_root = std::env::current_dir().map_err(SoldrError::from)?;
+    let manifest_path = workspace_root.join("rust-toolchain.toml");
+    let manifest = soldr_core::read_rust_toolchain_manifest(&workspace_root)?;
+    let manifest_present = manifest_path.exists();
+
+    let Some(channel) = manifest.channel.as_deref() else {
+        if json {
+            let output = DoctorOutput {
+                schema_version: JSON_SCHEMA_VERSION,
+                command: "doctor",
+                manifest_path: manifest_present.then(|| manifest_path.display().to_string()),
+                toolchain: None,
+                components: Vec::new(),
+                targets: Vec::new(),
+                drift: false,
+                missing_components: Vec::new(),
+                missing_targets: Vec::new(),
+            };
+            print_json(&output)?;
+        } else if manifest_present {
+            println!(
+                "manifest: {} (present but no [toolchain] channel declared)",
+                manifest_path.display()
+            );
+            println!("result: no manifest fields to compare; nothing to do");
+        } else {
+            println!(
+                "no rust-toolchain.toml found in {}",
+                workspace_root.display()
+            );
+            println!("result: no manifest found; nothing to compare");
+        }
+        return Ok(0);
+    };
+
+    let toolchain_installed = rustup_toolchain_is_installed(channel)?;
+
+    let declared_components: Vec<String> = manifest.components.clone().unwrap_or_default();
+    let declared_targets: Vec<String> = manifest.targets.clone().unwrap_or_default();
+
+    let installed_components = if toolchain_installed && !declared_components.is_empty() {
+        rustup_installed_components(channel)?
+    } else {
+        Vec::new()
+    };
+    let installed_targets = if toolchain_installed && !declared_targets.is_empty() {
+        rustup_installed_targets(channel)?
+    } else {
+        Vec::new()
+    };
+
+    let component_rows: Vec<DoctorComponent> = declared_components
+        .iter()
+        .map(|declared| DoctorComponent {
+            name: declared.clone(),
+            installed: component_is_installed(declared, &installed_components),
+        })
+        .collect();
+    let target_rows: Vec<DoctorTarget> = declared_targets
+        .iter()
+        .map(|declared| DoctorTarget {
+            triple: declared.clone(),
+            installed: target_is_installed(declared, &installed_targets),
+        })
+        .collect();
+
+    let missing_components: Vec<String> = component_rows
+        .iter()
+        .filter(|row| !row.installed)
+        .map(|row| row.name.clone())
+        .collect();
+    let missing_targets: Vec<String> = target_rows
+        .iter()
+        .filter(|row| !row.installed)
+        .map(|row| row.triple.clone())
+        .collect();
+
+    let drift =
+        !toolchain_installed || !missing_components.is_empty() || !missing_targets.is_empty();
+
+    if json {
+        let output = DoctorOutput {
+            schema_version: JSON_SCHEMA_VERSION,
+            command: "doctor",
+            manifest_path: Some(manifest_path.display().to_string()),
+            toolchain: Some(DoctorToolchain {
+                channel: channel.to_string(),
+                installed: toolchain_installed,
+            }),
+            components: component_rows,
+            targets: target_rows,
+            drift,
+            missing_components,
+            missing_targets,
+        };
+        print_json(&output)?;
+    } else {
+        print_doctor_human(
+            &manifest_path,
+            channel,
+            toolchain_installed,
+            &component_rows,
+            &target_rows,
+            &missing_components,
+            &missing_targets,
+            drift,
+        );
+    }
+
+    Ok(if drift { 1 } else { 0 })
+}
+
+fn component_is_installed(declared: &str, installed: &[String]) -> bool {
+    let prefix = format!("{declared}-");
+    installed
+        .iter()
+        .any(|entry| entry == declared || entry.starts_with(&prefix))
+}
+
+fn target_is_installed(declared: &str, installed: &[String]) -> bool {
+    installed.iter().any(|entry| entry == declared)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_doctor_human(
+    manifest_path: &std::path::Path,
+    channel: &str,
+    toolchain_installed: bool,
+    components: &[DoctorComponent],
+    targets: &[DoctorTarget],
+    missing_components: &[String],
+    missing_targets: &[String],
+    drift: bool,
+) {
+    println!("manifest: {}", manifest_path.display());
+    println!("toolchain: {channel}");
+    println!(
+        "  status: {}",
+        if toolchain_installed {
+            "installed"
+        } else {
+            "MISSING"
+        }
+    );
+
+    if !components.is_empty() {
+        println!();
+        println!("components (declared {}):", components.len());
+        let width = components
+            .iter()
+            .map(|row| row.name.len())
+            .max()
+            .unwrap_or(0);
+        for row in components {
+            println!(
+                "  {:<width$}   {}",
+                row.name,
+                if row.installed {
+                    "installed"
+                } else {
+                    "MISSING"
+                },
+                width = width
+            );
+        }
+    }
+
+    if !targets.is_empty() {
+        println!();
+        println!("targets (declared {}):", targets.len());
+        let width = targets
+            .iter()
+            .map(|row| row.triple.len())
+            .max()
+            .unwrap_or(0);
+        for row in targets {
+            println!(
+                "  {:<width$}   {}",
+                row.triple,
+                if row.installed {
+                    "installed"
+                } else {
+                    "MISSING"
+                },
+                width = width
+            );
+        }
+    }
+
+    println!();
+    if drift {
+        let missing_component_count = missing_components.len();
+        let missing_target_count = missing_targets.len();
+        let mut parts: Vec<String> = Vec::new();
+        if !toolchain_installed {
+            parts.push("toolchain not installed".to_string());
+        }
+        if missing_component_count > 0 {
+            parts.push(format!(
+                "{missing_component_count} missing component{}",
+                if missing_component_count == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            ));
+        }
+        if missing_target_count > 0 {
+            parts.push(format!(
+                "{missing_target_count} missing target{}",
+                if missing_target_count == 1 { "" } else { "s" }
+            ));
+        }
+        println!("result: drift detected ({})", parts.join(", "));
+        println!(
+            "hint: run `soldr toolchain prepare` to bring installed state in sync with manifest"
+        );
+    } else {
+        println!("result: no drift");
+    }
+}
+
+fn rustup_toolchain_is_installed(channel: &str) -> Result<bool, SoldrError> {
+    let mut command = std::process::Command::new(rustup_binary());
+    command.args(["toolchain", "list"]);
+    apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
+    let output = command.output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(SoldrError::Other(format!(
+            "`rustup toolchain list` failed with exit code {}: {stderr}",
+            output.status.code().unwrap_or(-1)
+        )));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed == channel
+            || trimmed.starts_with(&format!("{channel} "))
+            || trimmed.starts_with(&format!("{channel}-"))
+    }))
+}
+
+fn rustup_installed_components(channel: &str) -> Result<Vec<String>, SoldrError> {
+    let mut command = std::process::Command::new(rustup_binary());
+    command.args(["component", "list", "--installed", "--toolchain", channel]);
+    apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
+    let output = command.output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(SoldrError::Other(format!(
+            "`rustup component list --installed --toolchain {channel}` failed with exit code {}: {stderr}",
+            output.status.code().unwrap_or(-1)
+        )));
+    }
+    Ok(parse_rustup_list_output(&output.stdout))
+}
+
+fn rustup_installed_targets(channel: &str) -> Result<Vec<String>, SoldrError> {
+    let mut command = std::process::Command::new(rustup_binary());
+    command.args(["target", "list", "--installed", "--toolchain", channel]);
+    apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
+    let output = command.output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(SoldrError::Other(format!(
+            "`rustup target list --installed --toolchain {channel}` failed with exit code {}: {stderr}",
+            output.status.code().unwrap_or(-1)
+        )));
+    }
+    Ok(parse_rustup_list_output(&output.stdout))
+}
+
+fn parse_rustup_list_output(bytes: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(|line| line.trim().to_string())
+        .filter(|line| !line.is_empty())
+        .collect()
 }
 
 fn run_wrapper_through_zccache(

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -4064,3 +4064,317 @@ fn cache_prune_target_dry_run_emits_json() {
     assert!(found_keep, "must have one keep entry");
     assert!(found_delete, "must have one delete entry");
 }
+
+/// Canned output for `install_doctor_fake_rustup`. Each field maps to one
+/// of the three rustup subcommands invoked by `soldr doctor`. Lines are
+/// written verbatim into the corresponding response files.
+struct DoctorFakeRustupBehavior {
+    toolchain_list: Vec<String>,
+    components_installed: Vec<String>,
+    targets_installed: Vec<String>,
+}
+
+/// Fake rustup that branches on argv to satisfy `soldr doctor` queries:
+/// - `toolchain list` echoes one line per `behavior.toolchain_list`
+/// - `component list --installed --toolchain <ch>` echoes one line per
+///   `behavior.components_installed`
+/// - `target list --installed --toolchain <ch>` echoes one line per
+///   `behavior.targets_installed`
+///
+/// Any other invocation prints an error and exits 1 (the test must fail).
+/// Each invocation is also logged to `log_path` like the logging fake.
+fn install_doctor_fake_rustup(log_path: &Path, behavior: &DoctorFakeRustupBehavior) -> PathBuf {
+    let dir = unique_temp_dir("fake-rustup-doctor");
+    let toolchain_list_path = dir.join("toolchain_list.txt");
+    let components_path = dir.join("components.txt");
+    let targets_path = dir.join("targets.txt");
+    fs::write(&toolchain_list_path, behavior.toolchain_list.join("\n"))
+        .expect("failed to write fake toolchain list");
+    fs::write(&components_path, behavior.components_installed.join("\n"))
+        .expect("failed to write fake components list");
+    fs::write(&targets_path, behavior.targets_installed.join("\n"))
+        .expect("failed to write fake targets list");
+
+    #[cfg(windows)]
+    let rustup = dir.join("rustup.bat");
+    #[cfg(not(windows))]
+    let rustup = fake_script_path(&dir, "rustup");
+
+    let script = doctor_fake_rustup_script(
+        log_path,
+        &toolchain_list_path,
+        &components_path,
+        &targets_path,
+    );
+    write_fake_script(&rustup, &script);
+    rustup
+}
+
+fn doctor_fake_rustup_script(
+    log_path: &Path,
+    toolchain_list_path: &Path,
+    components_path: &Path,
+    targets_path: &Path,
+) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             setlocal enabledelayedexpansion\n\
+             set \"first=%~1\"\n\
+             set \"second=%~2\"\n\
+             set \"line=\"\n\
+             :loop\n\
+             if \"%~1\"==\"\" goto done\n\
+             if defined line (set \"line=!line!\u{1f}%~1\") else (set \"line=%~1\")\n\
+             shift\n\
+             goto loop\n\
+             :done\n\
+             echo !line!>>\"{log}\"\n\
+             if /I \"!first!\"==\"toolchain\" (\n\
+               if /I \"!second!\"==\"list\" (\n\
+                 type \"{toolchain_list}\"\n\
+                 exit /b 0\n\
+               )\n\
+             )\n\
+             if /I \"!first!\"==\"component\" (\n\
+               if /I \"!second!\"==\"list\" (\n\
+                 type \"{components}\"\n\
+                 exit /b 0\n\
+               )\n\
+             )\n\
+             if /I \"!first!\"==\"target\" (\n\
+               if /I \"!second!\"==\"list\" (\n\
+                 type \"{targets}\"\n\
+                 exit /b 0\n\
+               )\n\
+             )\n\
+             echo unsupported rustup invocation 1>&2\n\
+             exit /b 1\n",
+            log = log_path.display(),
+            toolchain_list = toolchain_list_path.display(),
+            components = components_path.display(),
+            targets = targets_path.display(),
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             sep=$(printf '\\037')\n\
+             out=\"\"\n\
+             first=1\n\
+             for arg in \"$@\"; do\n\
+               if [ $first -eq 1 ]; then\n\
+                 out=\"$arg\"\n\
+                 first=0\n\
+               else\n\
+                 out=\"$out${{sep}}$arg\"\n\
+               fi\n\
+             done\n\
+             printf '%s\\n' \"$out\" >> \"{log}\"\n\
+             if [ \"$1\" = \"toolchain\" ] && [ \"$2\" = \"list\" ]; then\n\
+               cat \"{toolchain_list}\"\n\
+               exit 0\n\
+             fi\n\
+             if [ \"$1\" = \"component\" ] && [ \"$2\" = \"list\" ]; then\n\
+               cat \"{components}\"\n\
+               exit 0\n\
+             fi\n\
+             if [ \"$1\" = \"target\" ] && [ \"$2\" = \"list\" ]; then\n\
+               cat \"{targets}\"\n\
+               exit 0\n\
+             fi\n\
+             echo \"unsupported rustup invocation: $*\" >&2\n\
+             exit 1\n",
+            log = log_path.display(),
+            toolchain_list = toolchain_list_path.display(),
+            components = components_path.display(),
+            targets = targets_path.display(),
+        )
+    }
+}
+
+#[test]
+fn doctor_reports_drift_when_component_missing() {
+    let workspace = unique_temp_dir("doctor-drift-component");
+    seed_rust_toolchain_toml(
+        &workspace,
+        "[toolchain]\n\
+         channel = \"1.94.1\"\n\
+         components = [\"clippy\"]\n",
+    );
+    let log_path = workspace.join("rustup.log");
+    let rustup = install_doctor_fake_rustup(
+        &log_path,
+        &DoctorFakeRustupBehavior {
+            toolchain_list: vec!["1.94.1-x86_64-unknown-linux-gnu (default)".to_string()],
+            components_installed: Vec::new(),
+            targets_installed: vec!["x86_64-unknown-linux-gnu".to_string()],
+        },
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["doctor", "--json"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .output()
+        .expect("failed to run soldr doctor --json");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "doctor must exit 1 when drift detected\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("doctor --json must produce JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "doctor");
+    assert_eq!(json["toolchain"]["channel"], "1.94.1");
+    assert_eq!(json["toolchain"]["installed"], true);
+    assert_eq!(json["drift"], true);
+    assert_eq!(
+        json["missing_components"],
+        serde_json::json!(["clippy"]),
+        "missing_components must list clippy"
+    );
+    assert_eq!(
+        json["missing_targets"],
+        serde_json::json!([]),
+        "no targets declared so no targets missing"
+    );
+}
+
+#[test]
+fn doctor_reports_no_drift_when_everything_installed() {
+    let workspace = unique_temp_dir("doctor-no-drift");
+    seed_rust_toolchain_toml(
+        &workspace,
+        "[toolchain]\n\
+         channel = \"1.94.1\"\n\
+         components = [\"clippy\"]\n",
+    );
+    let log_path = workspace.join("rustup.log");
+    // Rustup reports components as target-qualified — soldr doctor must
+    // treat `clippy-x86_64-...` as satisfying a declared `clippy`.
+    let rustup = install_doctor_fake_rustup(
+        &log_path,
+        &DoctorFakeRustupBehavior {
+            toolchain_list: vec!["1.94.1-x86_64-unknown-linux-gnu (default)".to_string()],
+            components_installed: vec!["clippy-x86_64-unknown-linux-gnu".to_string()],
+            targets_installed: vec!["x86_64-unknown-linux-gnu".to_string()],
+        },
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["doctor", "--json"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .output()
+        .expect("failed to run soldr doctor --json");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "doctor must exit 0 when no drift\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("doctor --json must produce JSON");
+    assert_eq!(json["drift"], false);
+    assert_eq!(json["missing_components"], serde_json::json!([]));
+    assert_eq!(json["missing_targets"], serde_json::json!([]));
+    let components = json["components"].as_array().expect("components array");
+    assert_eq!(components.len(), 1);
+    assert_eq!(components[0]["name"], "clippy");
+    assert_eq!(components[0]["installed"], true);
+}
+
+#[test]
+fn doctor_handles_missing_manifest() {
+    let workspace = unique_temp_dir("doctor-no-manifest");
+    let log_path = workspace.join("rustup.log");
+    // Failing fake rustup — if doctor invokes it the test fails because
+    // rustup will write to the log and exit non-zero.
+    let rustup = install_failing_fake_rustup(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["doctor"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .output()
+        .expect("failed to run soldr doctor");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "doctor must exit 0 when manifest is missing\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("no rust-toolchain.toml"),
+        "doctor stdout should mention missing manifest: {stdout}"
+    );
+
+    // The failing fake rustup writes to log_path on every invocation, so
+    // an empty (or non-existent) log proves rustup was never spawned.
+    let log = fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        log.trim().is_empty(),
+        "doctor must not invoke rustup when no manifest exists; log was: {log}"
+    );
+}
+
+#[test]
+fn doctor_reports_missing_target() {
+    let workspace = unique_temp_dir("doctor-missing-target");
+    seed_rust_toolchain_toml(
+        &workspace,
+        "[toolchain]\n\
+         channel = \"1.94.1\"\n\
+         targets = [\"x86_64-unknown-linux-musl\"]\n",
+    );
+    let log_path = workspace.join("rustup.log");
+    let rustup = install_doctor_fake_rustup(
+        &log_path,
+        &DoctorFakeRustupBehavior {
+            toolchain_list: vec!["1.94.1-x86_64-unknown-linux-gnu (default)".to_string()],
+            components_installed: Vec::new(),
+            // Only the host triple is installed — declared musl target
+            // is missing.
+            targets_installed: vec!["x86_64-unknown-linux-gnu".to_string()],
+        },
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["doctor", "--json"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .output()
+        .expect("failed to run soldr doctor --json");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "doctor must exit 1 when target drift detected\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("doctor --json must produce JSON");
+    assert_eq!(json["drift"], true);
+    assert_eq!(
+        json["missing_targets"],
+        serde_json::json!(["x86_64-unknown-linux-musl"])
+    );
+    assert_eq!(json["missing_components"], serde_json::json!([]));
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -276,6 +276,65 @@ into soldr-managed `$CARGO_HOME` while letting the active cargo honor
 through. `cargo install` is idempotent by design, so a second
 `prepare` after a successful one is a no-op for plugins.
 
+### `soldr doctor`
+
+Diagnose drift between `rust-toolchain.toml` and the rustup state
+currently installed for the declared channel. Read-only — `doctor`
+never invokes `rustup toolchain install`, `rustup component add`, or
+`rustup target add`. Exits `1` when drift is detected, `0` otherwise.
+When no `rust-toolchain.toml` exists in the current working directory
+the command exits `0` and reports that no manifest was found.
+
+```bash
+soldr doctor
+soldr doctor --json
+```
+
+Example human output (drift detected):
+
+```text
+manifest: /home/user/project/rust-toolchain.toml
+toolchain: 1.94.1
+  status: installed
+
+components (declared 2):
+  rustfmt   installed
+  clippy    MISSING
+
+targets (declared 1):
+  x86_64-unknown-linux-musl   installed
+
+result: drift detected (1 missing component)
+hint: run `soldr toolchain prepare` to bring installed state in sync with manifest
+```
+
+Example JSON output (`schema_version: 1`):
+
+```json
+{
+  "schema_version": 1,
+  "command": "doctor",
+  "manifest_path": "/home/user/project/rust-toolchain.toml",
+  "toolchain": {"channel": "1.94.1", "installed": true},
+  "components": [
+    {"name": "rustfmt", "installed": true},
+    {"name": "clippy", "installed": false}
+  ],
+  "targets": [
+    {"triple": "x86_64-unknown-linux-musl", "installed": true}
+  ],
+  "drift": true,
+  "missing_components": ["clippy"],
+  "missing_targets": []
+}
+```
+
+Component installed-state matching is target-qualified: rustup's
+`component list --installed` returns names like
+`clippy-x86_64-unknown-linux-gnu`, so a declared `clippy` matches any
+installed entry that either equals `clippy` exactly or starts with
+`clippy-`.
+
 ### `soldr gc`
 
 Review reclaimable Cargo `target/` directories tracked in


### PR DESCRIPTION
## Summary

Follow-up to #331 that extends the toolchain CLI surface landed in #333
with a strictly read-only diagnostic: `soldr doctor` compares the
declared channel / components / targets in `rust-toolchain.toml`
against the rustup state currently installed for that channel and
exits non-zero on drift.

- New `Commands::Doctor { json }` clap variant + `run_doctor` dispatch.
- Three private rustup-query helpers (`rustup_toolchain_is_installed`,
  `rustup_installed_components`, `rustup_installed_targets`) that
  reuse `rustup_binary()` and `apply_implicit_toolchain_homes`.
- **Read-only — never invokes `rustup component add` / `target add` /
  `toolchain install`.** Drift is reported, never mutated.

## Output

### Human (drift detected)

```
manifest: /home/user/project/rust-toolchain.toml
toolchain: 1.94.1
  status: installed

components (declared 2):
  rustfmt   installed
  clippy    MISSING

targets (declared 1):
  x86_64-unknown-linux-musl   installed

result: drift detected (1 missing component)
hint: run `soldr toolchain prepare` to bring installed state in sync with manifest
```

### JSON (`schema_version: 1`)

```json
{
  "schema_version": 1,
  "command": "doctor",
  "manifest_path": "/home/user/project/rust-toolchain.toml",
  "toolchain": {"channel": "1.94.1", "installed": true},
  "components": [{"name": "clippy", "installed": false}],
  "targets": [{"triple": "x86_64-unknown-linux-musl", "installed": true}],
  "drift": true,
  "missing_components": ["clippy"],
  "missing_targets": []
}
```

## Exit codes

| Condition                        | Exit |
| -------------------------------- | ---- |
| No `rust-toolchain.toml`         | 0    |
| Manifest present, no drift       | 0    |
| Drift detected                   | 1    |

## Implementation notes

- Component matching is **target-qualified**: rustup's `component list
  --installed` returns names like `clippy-x86_64-unknown-linux-gnu`,
  so a declared `clippy` matches any installed entry that either
  equals `clippy` exactly or starts with `clippy-`.
- When no manifest exists, doctor exits 0 **without ever invoking
  rustup** — the missing-manifest test uses `install_failing_fake_rustup`
  and asserts the rustup log stays empty to enforce this contract.
- All rustup queries go through the existing `rustup_binary()` +
  `apply_implicit_toolchain_homes()` wrappers, so `SOLDR_TEST_RUSTUP_BIN`
  and repo-local `.cargo`/`.rustup` resolution work the same as for
  `soldr toolchain install` / `prepare`.

## Tests (4, all in `crates/soldr-cli/tests/cli.rs`)

- `doctor_reports_drift_when_component_missing` — declared `clippy`,
  fake rustup returns no components → exit 1,
  `missing_components: ["clippy"]`.
- `doctor_reports_no_drift_when_everything_installed` — fake rustup
  returns `clippy-x86_64-unknown-linux-gnu` → no drift, exit 0
  (covers target-qualified matching).
- `doctor_handles_missing_manifest` — no `rust-toolchain.toml`, fake
  rustup is the failing variant; rustup log must stay empty → exit 0.
- `doctor_reports_missing_target` — declared `x86_64-unknown-linux-musl`
  not in installed-targets list → exit 1, `missing_targets` populated.

A new helper `install_doctor_fake_rustup(log_path, behavior)` installs
a branching fake-rustup script that returns canned per-subcommand
output for the three queries doctor issues.

## Docs

- `CLAUDE.md` — append `doctor` to the frozen built-in commands list.
- `docs/API.md` — new `### soldr doctor` section with human + JSON
  examples, exit-code table, and a note on target-qualified component
  matching.

## Test plan

- [x] `cargo test --workspace` (cli suite includes 4 new doctor tests; full workspace 0 failures)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

Refs #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)