### PR TITLE
feat(cache): soldr cache prune-target <path> (#316 first slice)

### DIFF
--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
 
 pub mod auto_gc;
 pub mod gc;
+pub mod prune_target;
 pub mod state_db;
 pub mod target_registry;
 

--- a/crates/soldr-cache/src/prune_target.rs
+++ b/crates/soldr-cache/src/prune_target.rs
@@ -1,0 +1,618 @@
+//! Cargo `target/` artifact pruner: keep only the newest build per
+//! `(parent_dir, prefix)` bucket inside `target/<profile>/{deps,
+//! .fingerprint, incremental, build}/`.
+//!
+//! Implements the first slice of issue #316 — a manual subcommand,
+//! `soldr cache prune-target <path>`. Auto pre/post-compile pruning via
+//! `RUSTC_WRAPPER` hooks is deferred.
+//!
+//! ## Algorithm
+//!
+//! 1. Walk top-level entries in `target/<profile>/{deps, .fingerprint,
+//!    incremental, build}/`.
+//! 2. For each entry, look for a trailing `-[A-Za-z0-9]{13,}` suffix.
+//!    Entries that don't match are left untouched.
+//! 3. Strip the suffix to recover the prefix.
+//! 4. Bucket by `(parent_dir, prefix)`. The same prefix appearing in
+//!    `deps/`, `.fingerprint/`, `incremental/`, and `build/` is handled
+//!    in independent buckets, because cargo tolerates orphans in any
+//!    one of these.
+//! 5. Within each bucket: sort by mtime descending, keep `[0]`, mark the
+//!    rest for deletion.
+//! 6. If `target/.cargo-lock` or any `target/<profile>/.cargo-lock` is
+//!    present, refuse to run — that signals an active build.
+
+use crate::target_registry::RegistryError;
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    time::UNIX_EPOCH,
+};
+
+/// What this entry will be done to during this run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PruneAction {
+    Keep,
+    Delete,
+}
+
+/// One artifact entry discovered by the scan.
+#[derive(Debug, Clone)]
+pub struct PruneTargetEntry {
+    /// Absolute path to the matched entry (file or directory).
+    pub path: PathBuf,
+    /// Recovered prefix (everything before the trailing `-<hash>`).
+    pub prefix: String,
+    /// The 13+char alphanumeric suffix.
+    pub hash: String,
+    /// Recursive on-disk size of the entry. Directories are summed.
+    pub size_bytes: u64,
+    /// Last-modified time in unix seconds. Falls back to 0 when
+    /// metadata is unavailable.
+    pub mtime_unix: i64,
+    /// What this entry will be done to during this run.
+    pub action: PruneAction,
+}
+
+/// Options that drive [`prune_target`].
+#[derive(Debug, Clone)]
+pub struct PruneTargetOptions {
+    /// Path to the cargo `target/` directory to scan.
+    pub target_dir: PathBuf,
+    /// When `true`, no entries are deleted. The returned report still
+    /// describes the plan.
+    pub dry_run: bool,
+}
+
+impl PruneTargetOptions {
+    pub fn new(target_dir: PathBuf) -> Self {
+        Self {
+            target_dir,
+            dry_run: true,
+        }
+    }
+}
+
+/// Aggregated scan + delete result.
+#[derive(Debug, Clone, Default)]
+pub struct PruneTargetReport {
+    /// Number of hash-suffixed entries the scan considered.
+    pub scanned: usize,
+    /// Number of entries kept (newest of each bucket).
+    pub kept: usize,
+    /// Number of entries deleted (or that would be deleted in a
+    /// dry-run).
+    pub deleted: usize,
+    /// Bytes reclaimed by the actual or planned deletions.
+    pub reclaimed_bytes: u64,
+    /// Every classified entry, in the order they were scanned.
+    pub entries: Vec<PruneTargetEntry>,
+}
+
+/// Scan a cargo `target/` directory and prune stale per-prefix
+/// artifacts, keeping only the newest build of each `(parent_dir,
+/// prefix)` bucket.
+///
+/// Idempotent: a second run on the same directory is a no-op (every
+/// remaining bucket has a single entry, so nothing is deletable).
+pub fn prune_target(opts: &PruneTargetOptions) -> Result<PruneTargetReport, RegistryError> {
+    let target_dir = &opts.target_dir;
+    let metadata = fs::metadata(target_dir).map_err(RegistryError::Io)?;
+    if !metadata.is_dir() {
+        return Err(RegistryError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "prune-target requires a directory: {}",
+                target_dir.display()
+            ),
+        )));
+    }
+
+    if let Some(lock) = find_active_cargo_lock(target_dir) {
+        return Err(RegistryError::Io(std::io::Error::other(format!(
+            "cargo lock present at {} (active build?); refusing to prune",
+            lock.display()
+        ))));
+    }
+
+    let scan_dirs = collect_scan_dirs(target_dir);
+    let mut entries: Vec<PruneTargetEntry> = Vec::new();
+    let mut buckets: HashMap<(PathBuf, String), Vec<usize>> = HashMap::new();
+
+    for parent in &scan_dirs {
+        let read_dir = match fs::read_dir(parent) {
+            Ok(it) => it,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(RegistryError::Io(err)),
+        };
+        for dirent in read_dir {
+            let dirent = match dirent {
+                Ok(d) => d,
+                Err(err) => return Err(RegistryError::Io(err)),
+            };
+            let path = dirent.path();
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            if name == ".cargo-lock" {
+                // Defensive: collect_scan_dirs already filters by parent,
+                // but skip explicitly so we never even consider the lock.
+                continue;
+            }
+            let Some((prefix, hash)) = split_hash_suffix(&name) else {
+                continue;
+            };
+            let file_metadata = match dirent.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let size_bytes = entry_size_bytes(&path, &file_metadata);
+            let mtime_unix = entry_mtime_unix(&file_metadata);
+            let entry = PruneTargetEntry {
+                path,
+                prefix: prefix.to_string(),
+                hash: hash.to_string(),
+                size_bytes,
+                mtime_unix,
+                action: PruneAction::Keep,
+            };
+            let idx = entries.len();
+            buckets
+                .entry((parent.clone(), prefix.to_string()))
+                .or_default()
+                .push(idx);
+            entries.push(entry);
+        }
+    }
+
+    // Classify within each bucket: newest mtime wins; if mtime ties,
+    // fall back to the lexicographically largest hash so the ordering
+    // is deterministic.
+    for indices in buckets.values_mut() {
+        indices.sort_by(|a, b| {
+            let ea = &entries[*a];
+            let eb = &entries[*b];
+            eb.mtime_unix
+                .cmp(&ea.mtime_unix)
+                .then_with(|| eb.hash.cmp(&ea.hash))
+        });
+        let mut iter = indices.iter().copied();
+        if let Some(keep) = iter.next() {
+            entries[keep].action = PruneAction::Keep;
+        }
+        for idx in iter {
+            entries[idx].action = PruneAction::Delete;
+        }
+    }
+
+    let mut report = PruneTargetReport {
+        scanned: entries.len(),
+        ..PruneTargetReport::default()
+    };
+
+    if !opts.dry_run {
+        for entry in &entries {
+            if entry.action != PruneAction::Delete {
+                continue;
+            }
+            delete_entry(&entry.path).map_err(RegistryError::Io)?;
+        }
+    }
+
+    for entry in &entries {
+        match entry.action {
+            PruneAction::Keep => report.kept += 1,
+            PruneAction::Delete => {
+                report.deleted += 1;
+                report.reclaimed_bytes = report.reclaimed_bytes.saturating_add(entry.size_bytes);
+            }
+        }
+    }
+    report.entries = entries;
+    Ok(report)
+}
+
+/// Standard cargo-managed subdirectories of `target/<profile>/` where
+/// hash-suffixed names live. We also scan the `target/<profile>/build/`
+/// directory because per-build-script output directories carry the
+/// same suffix layout.
+const SUBDIRS_WITH_HASH_SUFFIXES: &[&str] = &["deps", ".fingerprint", "incremental", "build"];
+
+fn collect_scan_dirs(target_dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let profiles = match fs::read_dir(target_dir) {
+        Ok(it) => it,
+        Err(_) => return out,
+    };
+    for entry in profiles.flatten() {
+        let profile_path = entry.path();
+        let metadata = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if !metadata.is_dir() {
+            continue;
+        }
+        for sub in SUBDIRS_WITH_HASH_SUFFIXES {
+            let candidate = profile_path.join(sub);
+            if candidate.is_dir() {
+                out.push(candidate);
+            }
+        }
+    }
+    out
+}
+
+/// Walk the `target/` directory looking for an active cargo lock file.
+/// Returns the first match, if any.
+fn find_active_cargo_lock(target_dir: &Path) -> Option<PathBuf> {
+    let top_lock = target_dir.join(".cargo-lock");
+    if top_lock.exists() {
+        return Some(top_lock);
+    }
+    let profiles = fs::read_dir(target_dir).ok()?;
+    for entry in profiles.flatten() {
+        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let candidate = entry.path().join(".cargo-lock");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Recognize cargo's `<prefix>-<hash>` naming. The hash is 13+ chars
+/// long, ASCII-alphanumeric, and is the suffix after the **last** `-`
+/// in the name. Returns `(prefix, hash)` when matched, or `None`.
+///
+/// File extensions (e.g. `.rlib`, `.d`, `-<hash>.json`) are stripped
+/// before matching so `libfoo-abc1234567890.rlib` collapses into
+/// prefix `libfoo` with hash `abc1234567890`. The leading `lib` prefix
+/// itself is *not* stripped — `libfoo` and `foo` live in different
+/// buckets because cargo names them that way on disk.
+pub fn split_hash_suffix(name: &str) -> Option<(&str, &str)> {
+    let base = match name.rfind('.') {
+        Some(dot) if dot > 0 => &name[..dot],
+        _ => name,
+    };
+    let dash = base.rfind('-')?;
+    if dash == 0 {
+        return None;
+    }
+    let prefix = &base[..dash];
+    let hash = &base[dash + 1..];
+    if hash.len() < 13 {
+        return None;
+    }
+    if !hash.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    Some((prefix, hash))
+}
+
+fn entry_size_bytes(path: &Path, metadata: &fs::Metadata) -> u64 {
+    if metadata.is_file() {
+        return metadata.len();
+    }
+    if metadata.is_dir() {
+        return directory_size(path);
+    }
+    0
+}
+
+fn directory_size(path: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack: Vec<PathBuf> = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let read_dir = match fs::read_dir(&dir) {
+            Ok(it) => it,
+            Err(_) => continue,
+        };
+        for entry in read_dir.flatten() {
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.is_dir() {
+                stack.push(entry.path());
+            } else if metadata.is_file() {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    total
+}
+
+fn entry_mtime_unix(metadata: &fs::Metadata) -> i64 {
+    let modified = match metadata.modified() {
+        Ok(t) => t,
+        Err(_) => return 0,
+    };
+    match modified.duration_since(UNIX_EPOCH) {
+        Ok(d) => d.as_secs() as i64,
+        Err(_) => 0,
+    }
+}
+
+fn delete_entry(path: &Path) -> Result<(), std::io::Error> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+}
+
+/// Convert a unix timestamp to a [`std::time::SystemTime`].
+#[cfg(test)]
+fn system_time_from_unix(seconds: u64) -> std::time::SystemTime {
+    UNIX_EPOCH + std::time::Duration::from_secs(seconds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use tempfile::tempdir;
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        File::create(path).unwrap();
+    }
+
+    fn touch_dir(path: &Path) {
+        fs::create_dir_all(path).unwrap();
+    }
+
+    /// Set the mtime on a file. This is intentionally file-only because
+    /// `set_modified` on a directory handle requires privileged access
+    /// on Windows.
+    fn set_mtime(path: &Path, unix_seconds: u64) {
+        let when = system_time_from_unix(unix_seconds);
+        let f = File::options()
+            .write(true)
+            .open(path)
+            .expect("set_mtime: open writable handle");
+        f.set_modified(when).expect("set_mtime: set_modified");
+    }
+
+    #[test]
+    fn split_hash_suffix_recognizes_directory_names() {
+        let parsed = split_hash_suffix("foo-abc1234567890");
+        assert_eq!(parsed, Some(("foo", "abc1234567890")));
+    }
+
+    #[test]
+    fn split_hash_suffix_recognizes_compound_names() {
+        let parsed = split_hash_suffix("zccache_daemon-3ohgys91001go");
+        assert_eq!(parsed, Some(("zccache_daemon", "3ohgys91001go")));
+    }
+
+    #[test]
+    fn split_hash_suffix_strips_known_extensions() {
+        let parsed = split_hash_suffix("libfoo-abcdef1234567.rlib");
+        assert_eq!(parsed, Some(("libfoo", "abcdef1234567")));
+    }
+
+    #[test]
+    fn split_hash_suffix_rejects_short_hashes() {
+        assert!(split_hash_suffix("foo-abc123").is_none());
+    }
+
+    #[test]
+    fn split_hash_suffix_rejects_non_alphanumeric() {
+        assert!(split_hash_suffix("foo-bar.baz_quux12345").is_none());
+    }
+
+    #[test]
+    fn split_hash_suffix_rejects_no_dash() {
+        assert!(split_hash_suffix("no_hash_here_at_all").is_none());
+    }
+
+    #[test]
+    fn single_entry_prefix_is_kept() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let single = target
+            .join("debug")
+            .join(".fingerprint")
+            .join("foo-abc1234567890");
+        touch_dir(&single);
+
+        let report = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: false,
+        })
+        .unwrap();
+
+        assert_eq!(report.scanned, 1);
+        assert_eq!(report.kept, 1);
+        assert_eq!(report.deleted, 0);
+        assert!(single.exists());
+    }
+
+    #[test]
+    fn multi_entry_prefix_keeps_newest() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let parent = target.join("debug").join("deps");
+        // Use file entries (.rlib) so mtime can be pinned deterministically
+        // on Windows, where set_modified on a directory requires
+        // privileged access.
+        let oldest = parent.join("libfoo-aaaaaaaaaaaaa.rlib");
+        let middle = parent.join("libfoo-bbbbbbbbbbbbb.rlib");
+        let newest = parent.join("libfoo-ccccccccccccc.rlib");
+        for f in [&oldest, &middle, &newest] {
+            touch(f);
+        }
+        set_mtime(&oldest, 1_700_000_000);
+        set_mtime(&middle, 1_700_000_100);
+        set_mtime(&newest, 1_700_000_200);
+
+        let report = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: false,
+        })
+        .unwrap();
+
+        assert_eq!(report.scanned, 3);
+        assert_eq!(report.kept, 1);
+        assert_eq!(report.deleted, 2);
+        assert!(newest.exists(), "newest file must survive");
+        assert!(!oldest.exists(), "oldest must be deleted");
+        assert!(!middle.exists(), "middle must be deleted");
+    }
+
+    #[test]
+    fn non_matching_names_untouched() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        // No hash suffix: should never be scanned.
+        let script = target.join("debug").join("build-script.txt");
+        touch(&script);
+        // Looks like a name with hash but lives at top level (not under
+        // a known subdir): should be ignored.
+        let stray = target.join("debug").join("loose-aaaaaaaaaaaaa");
+        touch_dir(&stray);
+
+        let report = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: false,
+        })
+        .unwrap();
+        assert_eq!(report.scanned, 0, "no entries should match the scan dirs");
+        assert!(script.exists());
+        assert!(stray.exists());
+    }
+
+    #[test]
+    fn buckets_are_per_subdirectory() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let fingerprint = target
+            .join("debug")
+            .join(".fingerprint")
+            .join("foo-aaaaaaaaaaaaa");
+        let deps = target
+            .join("debug")
+            .join("deps")
+            .join("foo-bbbbbbbbbbbbb.rlib");
+        let incremental = target
+            .join("debug")
+            .join("incremental")
+            .join("foo-ccccccccccccc");
+        touch_dir(&fingerprint);
+        touch(&deps);
+        touch_dir(&incremental);
+
+        let report = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: false,
+        })
+        .unwrap();
+        assert_eq!(report.scanned, 3);
+        assert_eq!(report.kept, 3);
+        assert_eq!(report.deleted, 0);
+        assert!(fingerprint.exists());
+        assert!(deps.exists());
+        assert!(incremental.exists());
+    }
+
+    #[test]
+    fn dry_run_does_not_delete() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let parent = target.join("debug").join("deps");
+        let older = parent.join("libfoo-aaaaaaaaaaaaa.rlib");
+        let newer = parent.join("libfoo-bbbbbbbbbbbbb.rlib");
+        touch(&older);
+        touch(&newer);
+        set_mtime(&older, 1_700_000_000);
+        set_mtime(&newer, 1_700_000_500);
+
+        let report = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: true,
+        })
+        .unwrap();
+        assert_eq!(report.scanned, 2);
+        assert_eq!(report.kept, 1);
+        assert_eq!(report.deleted, 1);
+        // Files must remain on disk because we asked for dry-run.
+        assert!(older.exists(), "dry-run must not delete older entry");
+        assert!(newer.exists(), "dry-run must not delete newer entry");
+    }
+
+    #[test]
+    fn refuses_when_cargo_lock_present() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let parent = target.join("debug").join(".fingerprint");
+        let entry = parent.join("foo-aaaaaaaaaaaaa");
+        touch_dir(&entry);
+        touch(&target.join(".cargo-lock"));
+
+        let err = prune_target(&PruneTargetOptions {
+            target_dir: target.clone(),
+            dry_run: false,
+        })
+        .expect_err("must refuse when top-level lock exists");
+        assert!(format!("{err}").contains(".cargo-lock"));
+        assert!(entry.exists(), "no entries may be touched when refusing");
+        assert!(target.join(".cargo-lock").exists(), "lock must survive");
+    }
+
+    #[test]
+    fn refuses_when_profile_cargo_lock_present() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let parent = target.join("debug").join(".fingerprint");
+        let entry = parent.join("foo-aaaaaaaaaaaaa");
+        touch_dir(&entry);
+        touch(&target.join("debug").join(".cargo-lock"));
+
+        let err = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: false,
+        })
+        .expect_err("must refuse when profile lock exists");
+        assert!(format!("{err}").contains(".cargo-lock"));
+        assert!(entry.exists(), "entry must survive a refusal");
+    }
+
+    #[test]
+    fn second_run_is_a_no_op() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let parent = target.join("debug").join("deps");
+        let older = parent.join("libfoo-aaaaaaaaaaaaa.rlib");
+        let newer = parent.join("libfoo-bbbbbbbbbbbbb.rlib");
+        touch(&older);
+        touch(&newer);
+        set_mtime(&older, 1_700_000_000);
+        set_mtime(&newer, 1_700_000_500);
+
+        let _ = prune_target(&PruneTargetOptions {
+            target_dir: target.clone(),
+            dry_run: false,
+        })
+        .unwrap();
+        let second = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: false,
+        })
+        .unwrap();
+        assert_eq!(second.scanned, 1);
+        assert_eq!(second.kept, 1);
+        assert_eq!(second.deleted, 0);
+    }
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -348,6 +348,32 @@ enum CacheSubcommand {
         #[arg(long)]
         json: bool,
     },
+    /// Prune stale per-prefix build artifacts from a cargo `target/`
+    /// directory, keeping only the newest entry per
+    /// `(parent_dir, prefix)` bucket inside
+    /// `target/<profile>/{deps, .fingerprint, incremental, build}/`.
+    ///
+    /// Defaults to a dry run for safety. Pass `--force` (or
+    /// `--no-dry-run`) to actually delete entries.
+    #[command(name = "prune-target")]
+    PruneTarget {
+        /// Path to the cargo `target/` directory to prune.
+        path: std::path::PathBuf,
+        /// Explicit dry-run mode (this is the default). Accepted for
+        /// scriptability; mutually compatible with the default.
+        #[arg(long, conflicts_with_all = ["force", "no_dry_run"])]
+        dry_run: bool,
+        /// Negate the dry-run default and actually delete entries.
+        /// Equivalent to `--force`.
+        #[arg(long = "no-dry-run", conflicts_with = "dry_run")]
+        no_dry_run: bool,
+        /// Actually delete entries. Equivalent to `--no-dry-run`.
+        #[arg(long, conflicts_with = "dry_run")]
+        force: bool,
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[tokio::main]
@@ -487,6 +513,19 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
         Commands::Cache { json, command } => match command {
             Some(CacheSubcommand::Report { json: report_json }) => {
                 run_cache_report_command(report_json || json)?;
+            }
+            Some(CacheSubcommand::PruneTarget {
+                path,
+                dry_run,
+                no_dry_run,
+                force,
+                json: prune_json,
+            }) => {
+                let effective_dry_run = !(force || no_dry_run);
+                // Either flag pair maps onto the same boolean; `dry_run`
+                // is the documented default so we accept it explicitly.
+                let _ = dry_run;
+                run_cache_prune_target_command(path, effective_dry_run, prune_json || json)?;
             }
             None => {
                 let output = collect_cache_output()?;
@@ -5609,6 +5648,131 @@ fn zccache_subcommand_unsupported(output: &std::process::Output, subcommand: &st
     ];
     let combined = format!("{stderr}\n{stdout}");
     needles.iter().any(|n| combined.contains(n)) && combined.contains(subcommand)
+}
+
+fn run_cache_prune_target_command(
+    target_dir: std::path::PathBuf,
+    dry_run: bool,
+    json: bool,
+) -> Result<(), SoldrError> {
+    let canonical = std::path::absolute(&target_dir).unwrap_or_else(|_| target_dir.clone());
+    let opts = soldr_cache::prune_target::PruneTargetOptions {
+        target_dir: canonical.clone(),
+        dry_run,
+    };
+    let report = soldr_cache::prune_target::prune_target(&opts)
+        .map_err(|e| SoldrError::Other(format!("cache prune-target failed: {e}")))?;
+
+    if json {
+        let output = build_cache_prune_target_output(&canonical, dry_run, &report);
+        print_json(&output)?;
+    } else {
+        print_cache_prune_target_text(&canonical, dry_run, &report);
+    }
+    Ok(())
+}
+
+fn build_cache_prune_target_output(
+    target_dir: &std::path::Path,
+    dry_run: bool,
+    report: &soldr_cache::prune_target::PruneTargetReport,
+) -> CachePruneTargetOutput {
+    CachePruneTargetOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "cache prune-target",
+        target_dir: target_dir.display().to_string(),
+        dry_run,
+        scanned: report.scanned,
+        kept: report.kept,
+        deleted: report.deleted,
+        reclaimed_bytes: report.reclaimed_bytes,
+        reclaimed_human: soldr_cache::target_registry::human_size(report.reclaimed_bytes),
+        entries: report
+            .entries
+            .iter()
+            .map(|entry| CachePruneTargetEntryOutput {
+                path: entry.path.display().to_string(),
+                prefix: entry.prefix.clone(),
+                hash: entry.hash.clone(),
+                size_bytes: entry.size_bytes,
+                size_human: soldr_cache::target_registry::human_size(entry.size_bytes),
+                mtime_unix: entry.mtime_unix,
+                action: match entry.action {
+                    soldr_cache::prune_target::PruneAction::Keep => "keep",
+                    soldr_cache::prune_target::PruneAction::Delete => "delete",
+                },
+            })
+            .collect(),
+    }
+}
+
+fn print_cache_prune_target_text(
+    target_dir: &std::path::Path,
+    dry_run: bool,
+    report: &soldr_cache::prune_target::PruneTargetReport,
+) {
+    println!("soldr cache prune-target: {}", target_dir.display());
+    println!(
+        "  mode: {}",
+        if dry_run {
+            "dry-run (use --force to actually delete)"
+        } else {
+            "force"
+        }
+    );
+    println!(
+        "  scanned={} kept={} deleted={} reclaimed={}",
+        report.scanned,
+        report.kept,
+        report.deleted,
+        soldr_cache::target_registry::human_size(report.reclaimed_bytes),
+    );
+    let mut shown = 0usize;
+    for entry in &report.entries {
+        if entry.action != soldr_cache::prune_target::PruneAction::Delete {
+            continue;
+        }
+        if shown == 0 {
+            println!(
+                "  {} entries:",
+                if dry_run { "would delete" } else { "deleted" }
+            );
+        }
+        println!(
+            "    - {} ({})",
+            entry.path.display(),
+            soldr_cache::target_registry::human_size(entry.size_bytes),
+        );
+        shown += 1;
+    }
+    if shown == 0 {
+        println!("  nothing to prune");
+    }
+}
+
+#[derive(Serialize)]
+struct CachePruneTargetOutput {
+    schema_version: u32,
+    command: &'static str,
+    target_dir: String,
+    dry_run: bool,
+    scanned: usize,
+    kept: usize,
+    deleted: usize,
+    reclaimed_bytes: u64,
+    reclaimed_human: String,
+    entries: Vec<CachePruneTargetEntryOutput>,
+}
+
+#[derive(Serialize)]
+struct CachePruneTargetEntryOutput {
+    path: String,
+    prefix: String,
+    hash: String,
+    size_bytes: u64,
+    size_human: String,
+    mtime_unix: i64,
+    action: &'static str,
 }
 
 fn run_cache_report_command(json: bool) -> Result<(), SoldrError> {

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -3745,3 +3745,100 @@ fn gc_sweep_no_cargo_dry_run_runs_end_to_end_without_changes() {
     );
     assert!(json["locations"].is_array());
 }
+
+#[test]
+fn cache_prune_target_dry_run_emits_json() {
+    let cache_root = unique_temp_dir("cache-prune-target-json");
+    let target = cache_root.join("target");
+    let parent = target.join("debug").join("deps");
+    fs::create_dir_all(&parent).expect("failed to create deps dir");
+    // Use file entries (with the cargo-style `.rlib` extension) rather
+    // than directories — `set_modified` on a directory handle requires
+    // privileged access on Windows.
+    let older = parent.join("libfoo-aaaaaaaaaaaaa.rlib");
+    let newer = parent.join("libfoo-bbbbbbbbbbbbb.rlib");
+    fs::write(&older, b"older").expect("failed to seed older content");
+    fs::write(&newer, b"newer-with-more-bytes").expect("failed to seed newer content");
+
+    // Pin mtimes so the test is deterministic on slow filesystems.
+    let older_when = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let newer_when = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_500);
+    {
+        let f = fs::File::options()
+            .write(true)
+            .open(&older)
+            .expect("open older for mtime");
+        f.set_modified(older_when).expect("set older mtime");
+    }
+    {
+        let f = fs::File::options()
+            .write(true)
+            .open(&newer)
+            .expect("open newer for mtime");
+        f.set_modified(newer_when).expect("set newer mtime");
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "prune-target"])
+        .arg(&target)
+        .args(["--dry-run", "--json"])
+        .output()
+        .expect("failed to run soldr cache prune-target --dry-run --json");
+
+    assert!(
+        output.status.success(),
+        "cache prune-target failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Dry-run must leave everything on disk.
+    assert!(older.exists(), "dry-run must not delete older entry");
+    assert!(newer.exists(), "dry-run must not delete newer entry");
+
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("cache prune-target --json must produce parseable JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "cache prune-target");
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["scanned"], 2);
+    assert_eq!(json["kept"], 1);
+    assert_eq!(json["deleted"], 1);
+
+    let entries = json["entries"]
+        .as_array()
+        .expect("entries must be an array");
+    assert_eq!(entries.len(), 2);
+    let mut found_keep = false;
+    let mut found_delete = false;
+    for entry in entries {
+        for field in [
+            "path",
+            "prefix",
+            "hash",
+            "size_bytes",
+            "size_human",
+            "mtime_unix",
+            "action",
+        ] {
+            assert!(
+                entry.get(field).is_some(),
+                "prune-target entry missing field {field}: {entry}"
+            );
+        }
+        assert_eq!(entry["prefix"], "libfoo");
+        match entry["action"].as_str() {
+            Some("keep") => {
+                found_keep = true;
+                assert_eq!(entry["hash"], "bbbbbbbbbbbbb");
+            }
+            Some("delete") => {
+                found_delete = true;
+                assert_eq!(entry["hash"], "aaaaaaaaaaaaa");
+            }
+            other => panic!("unexpected action {other:?} in {entry}"),
+        }
+    }
+    assert!(found_keep, "must have one keep entry");
+    assert!(found_delete, "must have one delete entry");
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -162,6 +162,56 @@ Stable machine-facing mode:
 soldr cache --json
 ```
 
+#### `soldr cache prune-target <path>`
+
+First slice of issue #316. Prune stale per-prefix cargo build artifacts
+inside a given `target/` directory, keeping only the newest entry per
+`(parent_dir, prefix)` bucket. Scanned subdirectories under each
+profile (`debug/`, `release/`, …) are `deps/`, `.fingerprint/`,
+`incremental/`, and `build/`.
+
+```bash
+soldr cache prune-target ./target                  # dry-run report
+soldr cache prune-target ./target --force          # actually delete
+soldr cache prune-target ./target --dry-run --json # machine-readable plan
+```
+
+Defaults to a dry run for safety; pass `--force` (or `--no-dry-run`)
+to actually delete entries. If `target/.cargo-lock` or any
+`target/<profile>/.cargo-lock` is present the command refuses with a
+non-zero exit code (suggests a live build).
+
+JSON schema (`--json`):
+
+```json
+{
+  "schema_version": 1,
+  "command": "cache prune-target",
+  "target_dir": "<absolute path>",
+  "dry_run": true,
+  "scanned": 3,
+  "kept": 1,
+  "deleted": 2,
+  "reclaimed_bytes": 0,
+  "reclaimed_human": "0 B",
+  "entries": [
+    {
+      "path": "<absolute path>",
+      "prefix": "libfoo",
+      "hash": "abcdef1234567",
+      "size_bytes": 0,
+      "size_human": "0 B",
+      "mtime_unix": 1700000500,
+      "action": "keep"
+    }
+  ]
+}
+```
+
+Automatic pruning via `RUSTC_WRAPPER` pre/post-compile hooks is
+deferred to a follow-up — the manual subcommand is intentionally
+opt-in until the behaviour is trusted on real `target/` directories.
+
 ### `soldr version`
 
 Print soldr version.
@@ -352,6 +402,7 @@ The supported JSON protocol currently exists on:
 
 - `soldr status --json`
 - `soldr cache --json`
+- `soldr cache prune-target <path> --json`
 - `soldr version --json`
 
 The JSON response always includes:


### PR DESCRIPTION
## Summary

First slice of #316: ships a manual `soldr cache prune-target <path>` subcommand. Auto pre/post-compile pruning via `RUSTC_WRAPPER` hooks is intentionally deferred to a follow-up — too much hot-path risk to bundle in.

## What lands

- `soldr-cache::prune_target` — new module implementing the prefix-bucket algorithm:
  - Walk `target/<profile>/{deps, .fingerprint, incremental, build}/`.
  - Match the trailing `-[A-Za-z0-9]{13,}` suffix (hand-rolled, no `regex` dep).
  - Bucket by `(parent_dir, prefix)` so the same prefix in `deps/` vs `.fingerprint/` vs `incremental/` is handled independently — cargo tolerates orphans in any one of these.
  - Keep newest by mtime per bucket; deterministic hash tiebreaker on ties.
  - Refuse with a non-zero exit when `target/.cargo-lock` or `target/<profile>/.cargo-lock` is present (suggests a live build).
- `soldr cache prune-target <path> [--dry-run | --force | --no-dry-run] [--json]` — added to `CacheSubcommand`.
- Dry-run is the default for this PR. The user must pass `--force` (or `--no-dry-run`) to actually delete.
- `--json` follows the existing `schema_version: 1` shape with `command: "cache prune-target"`.
- `docs/API.md` documents the new subcommand + JSON schema.

## Tests

Unit (`crates/soldr-cache/src/prune_target.rs`):

- `single_entry_prefix_is_kept`
- `multi_entry_prefix_keeps_newest`
- `non_matching_names_untouched`
- `buckets_are_per_subdirectory`
- `dry_run_does_not_delete`
- `refuses_when_cargo_lock_present`
- `refuses_when_profile_cargo_lock_present`
- `second_run_is_a_no_op` (idempotency)
- 6 `split_hash_suffix_*` cases pinning the suffix detector

Integration (`crates/soldr-cli/tests/cli.rs`):

- `cache_prune_target_dry_run_emits_json` — shells out to the built binary, asserts the JSON shape and `keep`/`delete` actions match what the algorithm picked.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Manual: `soldr cache prune-target --help` shows the subcommand.

## Deferred (follow-up issue)

The original #316 also proposes:

- Automatic GC pass before and after every compile (in the `RUSTC_WRAPPER` slot).
- `--no-gc-target`, `--no-gc-target-before`, `--no-gc-target-after` flags + env-var equivalents.

These are intentionally out of scope here. Bundling them would change every rustc invocation's hot path, and we want the manual subcommand validated against real `target/` directories first. The dry-run-as-default posture in this PR is the conservative bridge — once we trust the algorithm on production-shaped data, hook integration becomes a small follow-up.

## Safety posture

- Dry-run is the default to surface the deletion plan first.
- No `unwrap()` in non-test code.
- Cross-platform path handling: `fs::remove_dir_all` for directories, `fs::remove_file` for files, `fs::symlink_metadata` to avoid following symlinks during delete.
- Refusal on `.cargo-lock` is hard (no force-override) — keeps the command incapable of racing a live cargo build through this entry point.

Closes part of #316 (manual subcommand only).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>