### PR TITLE
feat(cli): [soldr.plugins] in toolchain prepare

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,18 @@ Two categories, surfaced as first-class subcommands or via the generic fetch pat
 **Rustup front door** (top-level, direct exec of `rustup` itself — `rustup which rustup` doesn't work):
 - `soldr rustup <args>` forwards to the system `rustup` binary. When the first non-flag positional is `target` or `component` and `rust-toolchain.toml` declares a `channel`, soldr injects `--toolchain <channel>` after the verb so per-toolchain state mutations land on the pinned toolchain. Pass `--toolchain` explicitly to opt out of injection.
 - `soldr toolchain install` reads `[toolchain].channel` from `rust-toolchain.toml` and runs `rustup toolchain install <channel> --profile minimal --no-self-update`.
-- `soldr toolchain prepare` chains install + `component add` + `target add` for every declared component / target.
+- `soldr toolchain prepare` chains install + `component add` + `target add` for every declared component / target, then `cargo install`s every entry under `[soldr.plugins]`.
+  - Manifest example:
+    ```toml
+    [toolchain]
+    channel = "1.94.1"
+
+    [soldr.plugins]
+    cargo-nextest = "0.9"
+    cargo-zigbuild = { version = "0.18", locked = true }
+    cargo-deny = "*"          # any version — `--version` is omitted
+    ```
+  - `prepare` invokes the cargo binary resolved via `resolve_toolchain_binary("cargo")` directly (NOT through the rustc wrapper) so installs land in soldr-managed `$CARGO_HOME`. The active cargo already obeys `rust-toolchain.toml`, so no channel is threaded through.
 
 **Ecosystem fetches** (registered in `known_tools`, pulled from GitHub Releases):
 - cargo subcommands invoked via `soldr cargo <sub>`: `nextest`, `deny`, `audit`, `llvm-cov`, `udeps`, `semver-checks`, `expand`, `watch`.

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1030,7 +1030,80 @@ fn run_toolchain_prepare() -> Result<i32, SoldrError> {
         }
     }
 
+    if let Some(soldr_section) = manifest.soldr.as_ref() {
+        if !soldr_section.plugins.is_empty() {
+            let code = install_plugins(&soldr_section.plugins)?;
+            if code != 0 {
+                return Ok(code);
+            }
+        }
+    }
+
     Ok(0)
+}
+
+/// Install every plugin declared under `[soldr.plugins]` via the
+/// resolved cargo binary (so installs respect soldr-managed
+/// `$CARGO_HOME`). We deliberately do NOT route through the rustc
+/// wrapper machinery — that path is meant for compile units, not
+/// dev-tool installation. The active cargo already honors
+/// `rust-toolchain.toml` at exec time, so no explicit channel is
+/// passed.
+fn install_plugins(
+    plugins: &std::collections::BTreeMap<String, soldr_core::PluginSpec>,
+) -> Result<i32, SoldrError> {
+    for (name, spec) in plugins {
+        let code = cargo_install_plugin(name, spec)?;
+        if code != 0 {
+            return Ok(code);
+        }
+    }
+    Ok(0)
+}
+
+fn cargo_install_plugin(name: &str, spec: &soldr_core::PluginSpec) -> Result<i32, SoldrError> {
+    let cargo = resolve_toolchain_binary("cargo")?;
+    let mut command = std::process::Command::new(&cargo);
+    command.arg("install").arg(name);
+
+    let (version, locked, features, no_default_features) = match spec {
+        soldr_core::PluginSpec::Version(value) => (Some(value.as_str()), None, None, None),
+        soldr_core::PluginSpec::Detailed {
+            version,
+            locked,
+            features,
+            no_default_features,
+        } => (
+            version.as_deref(),
+            *locked,
+            features.as_deref(),
+            *no_default_features,
+        ),
+    };
+
+    if let Some(version) = version {
+        let trimmed = version.trim();
+        if !trimmed.is_empty() && trimmed != "*" {
+            command.arg("--version").arg(trimmed);
+        }
+    }
+    if locked == Some(true) {
+        command.arg("--locked");
+    }
+    if no_default_features == Some(true) {
+        command.arg("--no-default-features");
+    }
+    if let Some(features) = features {
+        let joined = features.join(",");
+        if !joined.is_empty() {
+            command.arg("--features").arg(joined);
+        }
+    }
+
+    apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
+    let status = command.status()?;
+    Ok(status.code().unwrap_or(1))
 }
 
 fn rustup_toolchain_install(channel: &str) -> Result<i32, SoldrError> {

--- a/crates/soldr-cli/tests/cli.rs
+++ b/crates/soldr-cli/tests/cli.rs
@@ -713,6 +713,72 @@ fn seed_rust_toolchain_toml(dir: &Path, contents: &str) {
         .expect("failed to write rust-toolchain.toml");
 }
 
+/// Fake cargo that logs one line per invocation to `log_path`, with the
+/// argv joined by `\u{1f}` (ASCII unit separator) so test assertions can
+/// reason about the exact argv even when individual arguments contain
+/// spaces. Always exits 0. Mirrors `fake_logging_rustup_script` but
+/// writes to a separate log file so concurrent rustup + cargo
+/// invocations under `toolchain prepare` don't interleave.
+fn fake_logging_cargo_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             setlocal enabledelayedexpansion\n\
+             set \"line=\"\n\
+             :loop\n\
+             if \"%~1\"==\"\" goto done\n\
+             if defined line (set \"line=!line!\u{1f}%~1\") else (set \"line=%~1\")\n\
+             shift\n\
+             goto loop\n\
+             :done\n\
+             echo !line!>>\"{}\"\n\
+             exit /b 0\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             sep=$(printf '\\037')\n\
+             out=\"\"\n\
+             first=1\n\
+             for arg in \"$@\"; do\n\
+               if [ $first -eq 1 ]; then\n\
+                 out=\"$arg\"\n\
+                 first=0\n\
+               else\n\
+                 out=\"$out${{sep}}$arg\"\n\
+               fi\n\
+             done\n\
+             printf '%s\\n' \"$out\" >> \"{}\"\n\
+             exit 0\n",
+            log_path.display()
+        )
+    }
+}
+
+/// Install a fake cargo that logs argv per invocation. Returns the path
+/// to the fake binary, ready to hand to `SOLDR_TEST_CARGO_BIN`.
+fn install_logging_fake_cargo(log_path: &Path) -> PathBuf {
+    let dir = unique_temp_dir("fake-cargo-logging");
+    let cargo = fake_script_path(&dir, "cargo");
+    write_fake_script(&cargo, &fake_logging_cargo_script(log_path));
+    cargo
+}
+
+/// Read every argv invocation logged by `fake_logging_cargo_script`.
+/// Each returned `Vec<String>` is one invocation, with argv split on
+/// the ASCII unit separator.
+fn read_logged_cargo_invocations(log_path: &Path) -> Vec<Vec<String>> {
+    let text = fs::read_to_string(log_path).unwrap_or_default();
+    text.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.split('\u{1f}').map(str::to_string).collect())
+        .collect()
+}
+
 fn prepend_to_path(dir: &Path) -> std::ffi::OsString {
     let existing = std::env::var_os("PATH").unwrap_or_default();
     let mut paths = vec![dir.to_path_buf()];
@@ -1008,6 +1074,162 @@ fn toolchain_prepare_installs_channel_components_and_targets() {
             "x86_64-unknown-linux-musl".to_string(),
         ],
         "third invocation should add the declared target"
+    );
+}
+
+#[test]
+fn toolchain_prepare_installs_plugins_with_version() {
+    let workspace = unique_temp_dir("toolchain-prepare-plugin-version");
+    seed_rust_toolchain_toml(
+        &workspace,
+        "[toolchain]\n\
+         channel = \"1.94.1\"\n\
+         \n\
+         [soldr.plugins]\n\
+         cargo-nextest = \"0.9\"\n",
+    );
+    let rustup_log = workspace.join("rustup.log");
+    let cargo_log = workspace.join("cargo.log");
+    let rustup = install_logging_fake_rustup(&rustup_log);
+    let cargo = install_logging_fake_cargo(&cargo_log);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["toolchain", "prepare"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .output()
+        .expect("failed to run soldr toolchain prepare");
+
+    assert!(
+        output.status.success(),
+        "soldr toolchain prepare failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let cargo_invocations = read_logged_cargo_invocations(&cargo_log);
+    assert_eq!(
+        cargo_invocations.len(),
+        1,
+        "expected exactly one cargo install: {cargo_invocations:?}"
+    );
+    let invocation = &cargo_invocations[0];
+    assert_eq!(invocation.first().map(String::as_str), Some("install"));
+    assert_eq!(invocation.get(1).map(String::as_str), Some("cargo-nextest"));
+    let version_idx = invocation
+        .iter()
+        .position(|arg| arg == "--version")
+        .expect("--version should appear");
+    assert_eq!(
+        invocation.get(version_idx + 1).map(String::as_str),
+        Some("0.9")
+    );
+}
+
+#[test]
+fn toolchain_prepare_installs_plugin_with_locked_flag() {
+    let workspace = unique_temp_dir("toolchain-prepare-plugin-locked");
+    seed_rust_toolchain_toml(
+        &workspace,
+        "[toolchain]\n\
+         channel = \"1.94.1\"\n\
+         \n\
+         [soldr.plugins]\n\
+         cargo-zigbuild = { version = \"0.18\", locked = true }\n",
+    );
+    let rustup_log = workspace.join("rustup.log");
+    let cargo_log = workspace.join("cargo.log");
+    let rustup = install_logging_fake_rustup(&rustup_log);
+    let cargo = install_logging_fake_cargo(&cargo_log);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["toolchain", "prepare"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .output()
+        .expect("failed to run soldr toolchain prepare");
+
+    assert!(
+        output.status.success(),
+        "soldr toolchain prepare failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let cargo_invocations = read_logged_cargo_invocations(&cargo_log);
+    assert_eq!(
+        cargo_invocations.len(),
+        1,
+        "expected exactly one cargo install: {cargo_invocations:?}"
+    );
+    let invocation = &cargo_invocations[0];
+    assert_eq!(invocation.first().map(String::as_str), Some("install"));
+    assert_eq!(
+        invocation.get(1).map(String::as_str),
+        Some("cargo-zigbuild")
+    );
+    let version_idx = invocation
+        .iter()
+        .position(|arg| arg == "--version")
+        .expect("--version should appear");
+    assert_eq!(
+        invocation.get(version_idx + 1).map(String::as_str),
+        Some("0.18")
+    );
+    assert!(
+        invocation.iter().any(|arg| arg == "--locked"),
+        "expected --locked in argv: {invocation:?}"
+    );
+}
+
+#[test]
+fn toolchain_prepare_plugin_without_version_uses_no_version_flag() {
+    let workspace = unique_temp_dir("toolchain-prepare-plugin-no-version");
+    seed_rust_toolchain_toml(
+        &workspace,
+        "[toolchain]\n\
+         channel = \"1.94.1\"\n\
+         \n\
+         [soldr.plugins]\n\
+         cargo-deny = \"*\"\n",
+    );
+    let rustup_log = workspace.join("rustup.log");
+    let cargo_log = workspace.join("cargo.log");
+    let rustup = install_logging_fake_rustup(&rustup_log);
+    let cargo = install_logging_fake_cargo(&cargo_log);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["toolchain", "prepare"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .output()
+        .expect("failed to run soldr toolchain prepare");
+
+    assert!(
+        output.status.success(),
+        "soldr toolchain prepare failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let cargo_invocations = read_logged_cargo_invocations(&cargo_log);
+    assert_eq!(
+        cargo_invocations.len(),
+        1,
+        "expected exactly one cargo install: {cargo_invocations:?}"
+    );
+    let invocation = &cargo_invocations[0];
+    assert_eq!(
+        invocation,
+        &vec!["install".to_string(), "cargo-deny".to_string()],
+        "expected bare install argv (no --version for \"*\"): {invocation:?}"
+    );
+    assert!(
+        !invocation.iter().any(|arg| arg == "--version"),
+        "--version should be omitted when spec is \"*\": {invocation:?}"
     );
 }
 

--- a/crates/soldr-core/src/lib.rs
+++ b/crates/soldr-core/src/lib.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use std::{
+    collections::BTreeMap,
     ffi::OsStr,
     path::{Path, PathBuf},
     process::Command,
@@ -144,6 +145,8 @@ impl std::fmt::Display for TargetTriple {
 #[derive(Debug, Deserialize)]
 struct RustToolchainFile {
     toolchain: Option<RustToolchainSection>,
+    #[serde(default)]
+    soldr: Option<SoldrManifestSection>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -158,6 +161,41 @@ struct RustToolchainSection {
     profile: Option<String>,
 }
 
+/// Top-level `[soldr]` section of `rust-toolchain.toml`. Carries
+/// soldr-specific developer-tooling declarations that aren't part of
+/// rustup's own schema. Currently surfaces the `[soldr.plugins]` table
+/// (see [`PluginSpec`]) which `soldr toolchain prepare` translates into
+/// `cargo install` invocations.
+#[derive(Debug, Deserialize, Default, Clone, PartialEq, Eq)]
+pub struct SoldrManifestSection {
+    #[serde(default)]
+    pub plugins: BTreeMap<String, PluginSpec>,
+}
+
+/// One entry in `[soldr.plugins]`. The key is the cargo crate name
+/// (e.g. `cargo-nextest`); the value is either a bare version string or
+/// a detailed table that mirrors `cargo install`'s relevant flags.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum PluginSpec {
+    /// `cargo-nextest = "0.9"` — just a version requirement. The literal
+    /// `"*"` is treated as "any version" and skips `--version`.
+    Version(String),
+    /// `cargo-zigbuild = { version = "0.18", locked = true, ... }`.
+    /// Every field is optional; omitted fields mean "don't pass the
+    /// corresponding cargo install flag".
+    Detailed {
+        #[serde(default)]
+        version: Option<String>,
+        #[serde(default)]
+        locked: Option<bool>,
+        #[serde(default)]
+        features: Option<Vec<String>>,
+        #[serde(default)]
+        no_default_features: Option<bool>,
+    },
+}
+
 /// Parsed view of a project's `rust-toolchain.toml`. All fields are
 /// optional so callers can treat a missing file or missing `[toolchain]`
 /// section the same as a fully-populated section whose fields happen to
@@ -168,6 +206,9 @@ pub struct RustToolchainManifest {
     pub components: Option<Vec<String>>,
     pub targets: Option<Vec<String>>,
     pub profile: Option<String>,
+    /// Parsed `[soldr]` section. `None` when the file omits it
+    /// entirely so callers can short-circuit cleanly.
+    pub soldr: Option<SoldrManifestSection>,
 }
 
 /// Read `rust-toolchain.toml` from `workspace_root` (non-recursive — the
@@ -196,8 +237,12 @@ pub fn read_rust_toolchain_manifest(
             path.display()
         ))
     })?;
+    let soldr = parsed.soldr;
     let Some(section) = parsed.toolchain else {
-        return Ok(RustToolchainManifest::default());
+        return Ok(RustToolchainManifest {
+            soldr,
+            ..RustToolchainManifest::default()
+        });
     };
     Ok(RustToolchainManifest {
         channel: section
@@ -210,6 +255,7 @@ pub fn read_rust_toolchain_manifest(
             .profile
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty()),
+        soldr,
     })
 }
 
@@ -1352,5 +1398,56 @@ min_age_secs = 7200
         assert!(manifest.components.is_none());
         assert!(manifest.targets.is_none());
         assert!(manifest.profile.is_none());
+        assert!(manifest.soldr.is_none());
+    }
+
+    #[test]
+    fn manifest_parses_soldr_plugins_section() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("rust-toolchain.toml"),
+            "[toolchain]\n\
+             channel = \"1.94.1\"\n\
+             \n\
+             [soldr.plugins]\n\
+             cargo-nextest = \"0.9\"\n\
+             cargo-zigbuild = { version = \"0.18\", locked = true }\n\
+             cargo-deny = \"*\"\n",
+        )
+        .unwrap();
+
+        let manifest = read_rust_toolchain_manifest(dir.path()).unwrap();
+        let soldr = manifest.soldr.expect("expected [soldr] section to parse");
+        assert_eq!(soldr.plugins.len(), 3);
+        match soldr
+            .plugins
+            .get("cargo-nextest")
+            .expect("cargo-nextest missing")
+        {
+            PluginSpec::Version(value) => assert_eq!(value, "0.9"),
+            other => panic!("cargo-nextest should parse as Version(\"0.9\"), got {other:?}"),
+        }
+        match soldr
+            .plugins
+            .get("cargo-zigbuild")
+            .expect("cargo-zigbuild missing")
+        {
+            PluginSpec::Detailed {
+                version,
+                locked,
+                features,
+                no_default_features,
+            } => {
+                assert_eq!(version.as_deref(), Some("0.18"));
+                assert_eq!(*locked, Some(true));
+                assert!(features.is_none());
+                assert!(no_default_features.is_none());
+            }
+            other => panic!("cargo-zigbuild should parse as Detailed, got {other:?}"),
+        }
+        match soldr.plugins.get("cargo-deny").expect("cargo-deny missing") {
+            PluginSpec::Version(value) => assert_eq!(value, "*"),
+            other => panic!("cargo-deny should parse as Version(\"*\"), got {other:?}"),
+        }
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -222,6 +222,60 @@ Stable machine-facing mode:
 soldr version --json
 ```
 
+### `soldr toolchain`
+
+Project-aware orchestrators around `rustup` and `cargo install` that
+read `rust-toolchain.toml` so users (and CI) don't have to thread the
+pinned channel through every command.
+
+```bash
+soldr toolchain install   # rustup toolchain install <channel> --profile minimal --no-self-update
+soldr toolchain prepare   # install + component add + target add + cargo install for [soldr.plugins]
+```
+
+`prepare` runs, in order:
+
+1. `rustup toolchain install <channel> --profile minimal --no-self-update`
+2. `rustup component add --toolchain <channel> <component>` for every entry in `[toolchain].components`
+3. `rustup target add --toolchain <channel> <target>` for every entry in `[toolchain].targets`
+4. `cargo install <name> [--version V] [--locked] [--features ...] [--no-default-features]` for every entry in `[soldr.plugins]`
+
+The first non-zero exit short-circuits the chain.
+
+#### `[soldr.plugins]`
+
+Top-level `[soldr]` section of `rust-toolchain.toml`. Currently
+surfaces a `plugins` table keyed by cargo crate name. Each value is
+either a bare version requirement or a detailed table.
+
+```toml
+[toolchain]
+channel = "1.94.1"
+
+[soldr.plugins]
+cargo-nextest = "0.9"
+cargo-zigbuild = { version = "0.18", locked = true }
+cargo-deny    = "*"          # any version — `--version` is omitted
+cargo-llvm-cov = { version = "0.6", features = ["no_cfg_coverage"], no_default_features = true }
+```
+
+Field semantics for the detailed shape:
+
+| Field                 | Type           | Maps to                  |
+|-----------------------|----------------|--------------------------|
+| `version`             | string         | `--version <value>`. `"*"` or unset omits the flag entirely. |
+| `locked`              | bool           | `--locked` when `true`.  |
+| `features`            | list of string | `--features <a,b,c>` when non-empty. |
+| `no_default_features` | bool           | `--no-default-features` when `true`. |
+
+Installs are dispatched to the cargo binary resolved by soldr's
+toolchain probe (`resolve_toolchain_binary("cargo")`) and invoked
+directly — **not** through the rustc wrapper. This routes installs
+into soldr-managed `$CARGO_HOME` while letting the active cargo honor
+`rust-toolchain.toml` at exec time, so no explicit channel is threaded
+through. `cargo install` is idempotent by design, so a second
+`prepare` after a successful one is a no-op for plugins.
+
 ### `soldr gc`
 
 Review reclaimable Cargo `target/` directories tracked in


### PR DESCRIPTION
## Summary

Follow-up to #331. Adds `[soldr.plugins]` to `rust-toolchain.toml` and teaches `soldr toolchain prepare` to install every declared cargo plugin.

```toml
[toolchain]
channel = "1.94.1"

[soldr.plugins]
cargo-nextest  = "0.9"
cargo-zigbuild = { version = "0.18", locked = true }
cargo-deny     = "*"        # any version — `--version` is omitted
```

`PluginSpec` is `#[serde(untagged)]` so both the bare-version and detailed shapes parse into the same `BTreeMap<String, PluginSpec>`.

After the existing component / target loops, `prepare` now shells out to the resolved cargo binary for each plugin with `--version` / `--locked` / `--features` / `--no-default-features` derived from the spec. **Calls the cargo binary directly via `resolve_toolchain_binary("cargo")` + `apply_implicit_toolchain_homes` — not through the rustc wrapper machinery**, so installs respect soldr-managed `$CARGO_HOME` while the active cargo still honors `rust-toolchain.toml` at exec time (no explicit channel threaded through). `cargo install` is idempotent by design, so a second `prepare` is a no-op for plugins.

## Test plan

Four new tests, all green locally:

- [x] `manifest_parses_soldr_plugins_section` (soldr-core) — all three plugin shapes round-trip through `read_rust_toolchain_manifest`.
- [x] `toolchain_prepare_installs_plugins_with_version` (soldr-cli) — `cargo-nextest = "0.9"` shells out as `install cargo-nextest --version 0.9`.
- [x] `toolchain_prepare_installs_plugin_with_locked_flag` — `{ version = "0.18", locked = true }` adds `--locked` alongside `--version 0.18`.
- [x] `toolchain_prepare_plugin_without_version_uses_no_version_flag` — `"*"` produces a bare `install cargo-deny` with no `--version`.

Verification:

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

Test helpers parallel the existing rustup harness: `fake_logging_cargo_script`, `install_logging_fake_cargo`, `read_logged_cargo_invocations`, all logging to a separate `cargo.log` so concurrent rustup + cargo invocations don't interleave.

Docs updated: `CLAUDE.md` toolchain bullet gains an inline example; `docs/API.md` grows a full `### soldr toolchain` section with the four-step prepare ordering and a field-semantics table for `PluginSpec`.

Parent: #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)