### PR TITLE
ci: update setup-soldr workflow pins to v0 37ab11d

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
+        uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
           linker: platform-default

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -436,7 +436,7 @@ jobs:
       - id: setup-soldr
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83
+        uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335
         with:
           linker: platform-default
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
+      - uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
         with:
           linker: platform-default
           # Formatting does not benefit from a restored target directory, but
@@ -77,7 +77,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
+      - uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
         with:
           linker: platform-default
 
@@ -114,7 +114,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
+      - uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
         with:
           linker: platform-default
 
@@ -151,7 +151,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
+      - uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
         with:
           linker: platform-default
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -218,7 +218,7 @@ jobs:
           fi
 
       - name: Setup Soldr toolchain
-        uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83 # @v0
+        uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
         with:
           linker: platform-default
           cache: false

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -66,7 +66,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@dc7390d816f6251a92d1d837c99f1e1c598caf83
+        uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335
         with:
           cache: true
           linker: platform-default


### PR DESCRIPTION
## Summary

Bumps the `zackees/setup-soldr` action pin in all 5 workflow files from `dc7390d8` to the current `@v0` SHA `37ab11d8`. The `verify_setup_soldr_pin.py` script was failing on every PR touching Rust code (#335, #336, #337) because @v0 moved upstream.

This is a routine maintenance commit (same pattern as #315).

## Test plan

- [x] `python .github/scripts/verify_setup_soldr_pin.py` returns "pins match"
- [ ] CI workflows pick up the new pin and pass