### PR TITLE
feat(cli): cargo run trampoline — mtime+size oracle (#344)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,7 @@ dependencies = [
 name = "soldr-cli"
 version = "0.7.22"
 dependencies = [
+ "blake3",
  "clap",
  "fs2",
  "rayon",

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -11,6 +11,7 @@ description = "CLI for soldr — instant tools, instant builds"
 soldr-core = { workspace = true }
 soldr-fetch = { workspace = true }
 soldr-cache = { workspace = true }
+blake3 = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/soldr-cli/src/cargo_front_door.rs
+++ b/crates/soldr-cli/src/cargo_front_door.rs
@@ -2,6 +2,7 @@
 //! injection, low-disk warning, and the cargo arg-parsing helpers shared
 //! with `rust_plan`. Extracted from `main.rs` as part of issue #339.
 
+use crate::trampoline::{refresh_sidecar_after_cargo, try_run_trampoline, TrampolineDecision};
 use crate::zccache::{finish_zccache_build, prepare_rustc_wrapper};
 use crate::{
     apply_implicit_toolchain_homes, gc, linker, non_empty_env_path, resolve_toolchain_binary,
@@ -23,6 +24,30 @@ pub(crate) async fn run_cargo_front_door(
             "`--no-cache` must appear before `cargo`, as in `soldr --no-cache cargo build`".into(),
         ));
     }
+
+    // `cargo run` trampoline (issue #344). When the binary is already
+    // up-to-date with the recorded sources, this exec's the binary
+    // directly and never spawns cargo. Otherwise we get back a plan that
+    // strips the soldr-private `--no-trampoline` flag from the arg list
+    // and lets us refresh the sidecar after cargo succeeds.
+    let trampoline_plan = if is_cargo_run_invocation(args) {
+        match try_run_trampoline(args)? {
+            TrampolineDecision::Executed(code) => return Ok(code),
+            TrampolineDecision::FellThrough(plan) => Some(plan),
+        }
+    } else {
+        None
+    };
+    // Use the cleaned arg vector from here on so `--no-trampoline` is
+    // not forwarded to cargo.
+    let owned_cleaned_args;
+    let args: &[String] = match trampoline_plan.as_ref() {
+        Some(plan) => {
+            owned_cleaned_args = plan.cleaned_args.clone();
+            &owned_cleaned_args
+        }
+        None => args,
+    };
 
     let cargo = resolve_toolchain_binary("cargo")?;
     let rustc = resolve_toolchain_binary("rustc")?;
@@ -119,11 +144,20 @@ pub(crate) async fn run_cargo_front_door(
             rust_plan::run_zccache_rust_plan(plan, "save", true)?;
             rust_plan::write_warm_restore_sentinel(plan);
         }
+        if let Some(plan) = trampoline_plan.as_ref() {
+            refresh_sidecar_after_cargo(plan);
+        }
     }
     if let Some(session) = session {
         finish_zccache_build(&session)?;
     }
+    drop(trampoline_plan);
     Ok(status.code().unwrap_or(1))
+}
+
+/// True when the cargo argv resolves to `cargo run` (or `cargo r`).
+fn is_cargo_run_invocation(args: &[String]) -> bool {
+    matches!(first_cargo_subcommand(args), Some("run" | "r"))
 }
 
 pub(crate) fn cargo_profile(args: &[String]) -> &str {

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -11,6 +11,7 @@ mod linker;
 mod rust_plan;
 mod self_relocate;
 mod toolchain;
+mod trampoline;
 mod wrapper;
 mod zccache;
 

--- a/crates/soldr-cli/src/trampoline.rs
+++ b/crates/soldr-cli/src/trampoline.rs
@@ -1,0 +1,890 @@
+//! `soldr cargo run` trampoline (issue #344, slice 1 of #342).
+//!
+//! Intercepts `soldr cargo run` before the normal cargo front door spawns
+//! cargo. If a sidecar at
+//! `<target-dir>/<target?>/<profile>/.soldr-trampoline/<bin>.toml` proves
+//! that the recorded source files + the binary haven't changed (mtime+size
+//! oracle, same model cargo itself uses), the trampoline `exec`s the binary
+//! directly. Any uncertainty falls through to real cargo. After a successful
+//! cargo run on the fall-through path, the sidecar is refreshed by walking
+//! the `.d` dep-info file cargo wrote.
+//!
+//! No content hashing — the bar is cargo's own correctness model.
+
+use crate::resolve_toolchain_binary;
+use serde::{Deserialize, Serialize};
+use soldr_core::SoldrError;
+use std::ffi::OsString;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::SystemTime;
+
+/// `--no-trampoline` opt-out flag (soldr-private). Stripped before
+/// forwarding the arg list to cargo.
+pub(crate) const NO_TRAMPOLINE_FLAG: &str = "--no-trampoline";
+
+/// Env-var opt-out (`SOLDR_NO_TRAMPOLINE=1`).
+pub(crate) const NO_TRAMPOLINE_ENV_VAR: &str = "SOLDR_NO_TRAMPOLINE";
+
+/// Verbose tracing of fall-through reasons (`SOLDR_TRAMPOLINE_LOG=1`).
+pub(crate) const TRAMPOLINE_LOG_ENV_VAR: &str = "SOLDR_TRAMPOLINE_LOG";
+
+/// Outcome of `try_run_trampoline`.
+pub(crate) enum TrampolineDecision {
+    /// The trampoline executed the binary; soldr should exit with this code.
+    Executed(i32),
+    /// Fall through to real cargo. After cargo succeeds, the caller should
+    /// invoke `refresh_sidecar_after_cargo` so the next invocation can hit
+    /// the fast path.
+    FellThrough(Box<FellThroughPlan>),
+}
+
+/// Information the caller needs to refresh the sidecar after a successful
+/// cargo run. None of the fields are required for the fall-through itself —
+/// they only feed the post-build sidecar refresh.
+pub(crate) struct FellThroughPlan {
+    pub(crate) parsed: Option<ParsedRunArgs>,
+    /// The cleaned arg vector to forward to cargo (with `--no-trampoline`
+    /// stripped).
+    pub(crate) cleaned_args: Vec<String>,
+    /// Bin path inferred from manifest+args; we'll stat this and its `.d`
+    /// after cargo succeeds.
+    pub(crate) binary_path: Option<PathBuf>,
+    pub(crate) sidecar_path: Option<PathBuf>,
+    pub(crate) dep_info_path: Option<PathBuf>,
+}
+
+/// Try the trampoline fast path. If conditions aren't right, returns
+/// `FellThrough` with everything the caller needs to spawn cargo and then
+/// refresh the sidecar.
+pub(crate) fn try_run_trampoline(args: &[String]) -> Result<TrampolineDecision, SoldrError> {
+    // First, strip `--no-trampoline` from the arg list regardless of what
+    // happens; cargo doesn't understand it.
+    let (cleaned_args, saw_no_trampoline_flag) = strip_no_trampoline_flag(args);
+
+    // Build the fall-through plan up front. Even when opt-outs are set we
+    // still want to refresh the sidecar after a successful build so the
+    // *next* invocation (without the opt-out) hits the fast path.
+    let parsed = parse_run_args(&cleaned_args);
+    let plan = fell_through_plan(parsed.clone(), cleaned_args.clone());
+
+    match try_fast_path(&cleaned_args, parsed, saw_no_trampoline_flag) {
+        FastPathOutcome::Hit(binary, bin_args) => {
+            log_hit(&binary);
+            let code = exec_binary(&binary, &bin_args)?;
+            Ok(TrampolineDecision::Executed(code))
+        }
+        FastPathOutcome::FallThrough(reason) => {
+            log_fall_through(&reason);
+            Ok(TrampolineDecision::FellThrough(Box::new(plan)))
+        }
+    }
+}
+
+enum FastPathOutcome {
+    Hit(PathBuf, Vec<String>),
+    FallThrough(String),
+}
+
+fn try_fast_path(
+    cleaned_args: &[String],
+    parsed: Option<ParsedRunArgs>,
+    saw_no_trampoline_flag: bool,
+) -> FastPathOutcome {
+    if saw_no_trampoline_flag {
+        return FastPathOutcome::FallThrough("opt-out: --no-trampoline flag".into());
+    }
+    if trampoline_env_disabled() {
+        return FastPathOutcome::FallThrough(format!("opt-out: {NO_TRAMPOLINE_ENV_VAR} is set"));
+    }
+    let Some(parsed) = parsed else {
+        return FastPathOutcome::FallThrough("cannot model these cargo args".into());
+    };
+    let bin = match resolve_bin_name(&parsed) {
+        Ok(Some(name)) => name,
+        Ok(None) => {
+            return FastPathOutcome::FallThrough("could not determine unambiguous --bin".into())
+        }
+        Err(err) => return FastPathOutcome::FallThrough(format!("manifest read failed: {err}")),
+    };
+    let layout = compute_layout(&parsed, &bin);
+    let binary = layout.binary_path;
+    let sidecar = layout.sidecar_path;
+    let sidecar_text = match fs::read_to_string(&sidecar) {
+        Ok(text) => text,
+        Err(err) => {
+            return FastPathOutcome::FallThrough(format!(
+                "sidecar missing: {} ({err})",
+                sidecar.display()
+            ))
+        }
+    };
+    let sidecar_data: Sidecar = match toml::from_str(&sidecar_text) {
+        Ok(data) => data,
+        Err(err) => {
+            return FastPathOutcome::FallThrough(format!(
+                "sidecar parse failed: {} ({err})",
+                sidecar.display()
+            ))
+        }
+    };
+    let bin_meta = match fs::metadata(&binary) {
+        Ok(meta) => meta,
+        Err(err) => {
+            return FastPathOutcome::FallThrough(format!(
+                "binary missing: {} ({err})",
+                binary.display()
+            ))
+        }
+    };
+    let bin_mtime = mtime_nanos(&bin_meta);
+    let bin_size = size_as_i64(&bin_meta);
+    if bin_mtime != Some(sidecar_data.binary_mtime_nanos)
+        || bin_size != Some(sidecar_data.binary_size_bytes)
+    {
+        return FastPathOutcome::FallThrough(format!(
+            "binary {} mtime/size changed (sidecar mtime={}, size={}; on-disk mtime={:?}, size={:?})",
+            binary.display(), sidecar_data.binary_mtime_nanos, sidecar_data.binary_size_bytes, bin_mtime, bin_size
+        ));
+    }
+    let fingerprint = match compute_fingerprint(&parsed) {
+        Ok(fp) => fp,
+        Err(err) => {
+            return FastPathOutcome::FallThrough(format!("fingerprint compute failed: {err}"))
+        }
+    };
+    if fingerprint != sidecar_data.cargo_args_fingerprint {
+        return FastPathOutcome::FallThrough(format!(
+            "fingerprint mismatch (sidecar={}, current={})",
+            sidecar_data.cargo_args_fingerprint, fingerprint
+        ));
+    }
+    for entry in &sidecar_data.source_files {
+        match fs::metadata(&entry.path) {
+            Ok(meta) => {
+                let mtime = mtime_nanos(&meta);
+                let size = size_as_i64(&meta);
+                if mtime != Some(entry.mtime_nanos) || size != Some(entry.size_bytes) {
+                    return FastPathOutcome::FallThrough(format!(
+                        "source {} mtime/size changed (recorded mtime={}, size={}; actual mtime={:?}, size={:?})",
+                        entry.path, entry.mtime_nanos, entry.size_bytes, mtime, size
+                    ));
+                }
+            }
+            Err(err) => {
+                return FastPathOutcome::FallThrough(format!(
+                    "source missing: {} ({err})",
+                    entry.path
+                ));
+            }
+        }
+    }
+    FastPathOutcome::Hit(binary, trailing_user_args(cleaned_args))
+}
+
+/// After a successful `cargo run`, walk the dep-info file cargo wrote and
+/// refresh the sidecar so the next invocation can hit the fast path.
+pub(crate) fn refresh_sidecar_after_cargo(plan: &FellThroughPlan) {
+    match build_and_write_sidecar(plan) {
+        Ok(path) => log_event(&format!("wrote sidecar {}", path.display())),
+        Err(reason) => log_fall_through(&format!("post-build: {reason}")),
+    }
+}
+
+fn build_and_write_sidecar(plan: &FellThroughPlan) -> Result<PathBuf, String> {
+    let parsed = plan.parsed.as_ref().ok_or("no parsed args")?;
+    let binary = plan.binary_path.as_ref().ok_or("no binary path")?;
+    let sidecar = plan.sidecar_path.as_ref().ok_or("no sidecar path")?;
+    let dep_info = plan.dep_info_path.as_ref().ok_or("no dep-info path")?;
+
+    let bin_meta = fs::metadata(binary)
+        .map_err(|err| format!("binary stat failed: {} ({err})", binary.display()))?;
+    let bin_mtime = mtime_nanos(&bin_meta).ok_or_else(|| "binary mtime unavailable".to_string())?;
+    let bin_size = size_as_i64(&bin_meta).ok_or_else(|| "binary size unavailable".to_string())?;
+
+    let dep_text = fs::read_to_string(dep_info)
+        .map_err(|err| format!("dep-info missing: {} ({err})", dep_info.display()))?;
+    let sources = parse_dep_info_for_output(&dep_text, binary)
+        .ok_or_else(|| format!("dep-info has no stanza for {}", binary.display()))?;
+    let fingerprint =
+        compute_fingerprint(parsed).map_err(|err| format!("fingerprint compute failed: {err}"))?;
+
+    let mut entries: Vec<SidecarSource> = Vec::with_capacity(sources.len());
+    for src in sources {
+        let meta = fs::metadata(&src)
+            .map_err(|err| format!("source stat failed: {} ({err})", src.display()))?;
+        let mtime = mtime_nanos(&meta)
+            .ok_or_else(|| format!("source mtime unavailable for {}", src.display()))?;
+        let size = size_as_i64(&meta)
+            .ok_or_else(|| format!("source size unavailable for {}", src.display()))?;
+        entries.push(SidecarSource {
+            path: src.to_string_lossy().to_string(),
+            mtime_nanos: mtime,
+            size_bytes: size,
+        });
+    }
+
+    let sidecar_data = Sidecar {
+        binary_path: binary.to_string_lossy().to_string(),
+        binary_mtime_nanos: bin_mtime,
+        binary_size_bytes: bin_size,
+        cargo_args_fingerprint: fingerprint,
+        source_files: entries,
+    };
+    write_sidecar_atomic(sidecar, &sidecar_data)
+        .map_err(|err| format!("sidecar write failed: {} ({err})", sidecar.display()))?;
+    Ok(sidecar.clone())
+}
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ParsedRunArgs {
+    pub(crate) toolchain: Option<String>,
+    pub(crate) bin: Option<String>,
+    pub(crate) release: bool,
+    pub(crate) profile: Option<String>,
+    pub(crate) manifest_path: Option<PathBuf>,
+    pub(crate) target: Option<String>,
+    pub(crate) features: Vec<String>,
+    pub(crate) all_features: bool,
+    pub(crate) no_default_features: bool,
+    pub(crate) target_dir: Option<PathBuf>,
+    pub(crate) trailing: Vec<String>,
+}
+
+/// Strip `--no-trampoline` (soldr-private; not understood by cargo). Returns
+/// the cleaned arg vec and whether the flag was present.
+pub(crate) fn strip_no_trampoline_flag(args: &[String]) -> (Vec<String>, bool) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut saw = false;
+    let mut past_separator = false;
+    for arg in args {
+        if past_separator {
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            past_separator = true;
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == NO_TRAMPOLINE_FLAG {
+            saw = true;
+            continue;
+        }
+        out.push(arg.clone());
+    }
+    (out, saw)
+}
+
+/// Parse the slice of args after `cargo` (i.e. including the `run`
+/// positional). Returns `None` if we encounter an arg we don't model (e.g.
+/// `--example`, custom `--target-dir`, an unknown flag that takes a
+/// value).
+pub(crate) fn parse_run_args(args: &[String]) -> Option<ParsedRunArgs> {
+    let mut toolchain: Option<String> = None;
+    let mut bin: Option<String> = None;
+    let mut release = false;
+    let mut profile: Option<String> = None;
+    let mut manifest_path: Option<PathBuf> = None;
+    let mut target: Option<String> = None;
+    let mut features: Vec<String> = Vec::new();
+    let mut all_features = false;
+    let mut no_default_features = false;
+    let mut target_dir: Option<PathBuf> = None;
+
+    let mut iter = args.iter();
+    // Look for `run`, possibly after `+toolchain` and global flags.
+    let mut saw_run = false;
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            // Not yet at `run` — nothing here for us.
+            return None;
+        }
+        if let Some(rest) = arg.strip_prefix('+') {
+            if rest.is_empty() {
+                return None;
+            }
+            toolchain = Some(rest.to_string());
+            continue;
+        }
+        if global_flag_takes_value(arg) {
+            // Skip the flag and its value (a few global flags like `--config`,
+            // `--manifest-path` etc. can appear *before* the subcommand).
+            // We don't model arbitrary global flags — bail.
+            if arg == "--manifest-path" {
+                manifest_path = iter.next().map(PathBuf::from);
+                continue;
+            }
+            if let Some(value) = arg.strip_prefix("--manifest-path=") {
+                manifest_path = Some(PathBuf::from(value));
+                continue;
+            }
+            return None;
+        }
+        if arg.starts_with('-') {
+            // A non-value-taking global flag we don't model.
+            return None;
+        }
+        if arg == "run" || arg == "r" {
+            saw_run = true;
+            break;
+        }
+        // Some other subcommand.
+        return None;
+    }
+    if !saw_run {
+        return None;
+    }
+
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            // The rest are the binary's argv. Capture them so we can replay.
+            let trailing: Vec<String> = iter.cloned().collect();
+            return Some(ParsedRunArgs {
+                toolchain,
+                bin,
+                release,
+                profile,
+                manifest_path,
+                target,
+                features,
+                all_features,
+                no_default_features,
+                target_dir,
+                trailing,
+            });
+        }
+        match arg.as_str() {
+            "--bin" => {
+                let value = iter.next()?;
+                if bin.is_some() {
+                    return None;
+                }
+                bin = Some(value.clone());
+            }
+            "--release" => release = true,
+            "--profile" => {
+                profile = Some(iter.next()?.clone());
+            }
+            "--manifest-path" => {
+                manifest_path = Some(PathBuf::from(iter.next()?));
+            }
+            "--target" => {
+                target = Some(iter.next()?.clone());
+            }
+            "--features" | "-F" => {
+                features.extend(split_features(iter.next()?));
+            }
+            "--all-features" => all_features = true,
+            "--no-default-features" => no_default_features = true,
+            "--target-dir" => {
+                target_dir = Some(PathBuf::from(iter.next()?));
+            }
+            "--example" => return None,
+            "-q" | "--quiet" | "-v" | "--verbose" | "--locked" | "--frozen" | "--offline" => {}
+            other => {
+                if let Some(value) = other.strip_prefix("--bin=") {
+                    if bin.is_some() {
+                        return None;
+                    }
+                    bin = Some(value.to_string());
+                } else if let Some(value) = other.strip_prefix("--profile=") {
+                    profile = Some(value.to_string());
+                } else if let Some(value) = other.strip_prefix("--manifest-path=") {
+                    manifest_path = Some(PathBuf::from(value));
+                } else if let Some(value) = other.strip_prefix("--target=") {
+                    target = Some(value.to_string());
+                } else if let Some(value) = other.strip_prefix("--features=") {
+                    features.extend(split_features(value));
+                } else if let Some(value) = other.strip_prefix("-F=") {
+                    features.extend(split_features(value));
+                } else if let Some(value) = other.strip_prefix("--target-dir=") {
+                    target_dir = Some(PathBuf::from(value));
+                } else if other.starts_with("--example") {
+                    return None;
+                } else if other.starts_with("-vv") || other.starts_with("--color") {
+                    // Skip multi-v / `--color=...` — these don't affect the
+                    // trampoline decision.
+                } else {
+                    return None;
+                }
+            }
+        }
+    }
+
+    Some(ParsedRunArgs {
+        toolchain,
+        bin,
+        release,
+        profile,
+        manifest_path,
+        target,
+        features,
+        all_features,
+        no_default_features,
+        target_dir,
+        trailing: Vec::new(),
+    })
+}
+
+fn split_features(value: &str) -> Vec<String> {
+    value
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn global_flag_takes_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "-C" | "-Z"
+            | "-j"
+            | "--color"
+            | "--config"
+            | "--jobs"
+            | "--manifest-path"
+            | "--message-format"
+            | "--target-dir"
+    ) || arg.starts_with("-C=")
+        || arg.starts_with("-Z=")
+        || arg.starts_with("-j=")
+        || arg.starts_with("--color=")
+        || arg.starts_with("--config=")
+        || arg.starts_with("--jobs=")
+        || arg.starts_with("--manifest-path=")
+        || arg.starts_with("--message-format=")
+        || arg.starts_with("--target-dir=")
+}
+
+fn trailing_user_args(args: &[String]) -> Vec<String> {
+    let mut iter = args.iter().skip_while(|a| a.as_str() != "--");
+    if iter.next().is_some() {
+        iter.cloned().collect()
+    } else {
+        Vec::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layout / binary / sidecar path resolution
+// ---------------------------------------------------------------------------
+
+pub(crate) struct Layout {
+    pub(crate) binary_path: PathBuf,
+    pub(crate) sidecar_path: PathBuf,
+    pub(crate) dep_info_path: PathBuf,
+}
+
+pub(crate) fn compute_layout(parsed: &ParsedRunArgs, bin: &str) -> Layout {
+    let manifest_path = parsed
+        .manifest_path
+        .clone()
+        .unwrap_or_else(|| find_nearest_manifest().unwrap_or_else(|| PathBuf::from("Cargo.toml")));
+    let manifest_dir = manifest_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let target_dir = resolve_target_dir(parsed, &manifest_dir);
+
+    let mut leaf = target_dir;
+    if let Some(triple) = effective_target_triple(parsed) {
+        leaf.push(triple);
+    }
+    let profile_dir = if parsed.release {
+        "release".to_string()
+    } else if let Some(profile) = parsed.profile.as_deref() {
+        // cargo aliases `dev` to `debug` on disk.
+        if profile == "dev" {
+            "debug".to_string()
+        } else {
+            profile.to_string()
+        }
+    } else {
+        "debug".to_string()
+    };
+    leaf.push(&profile_dir);
+
+    let bin_filename = if cfg!(windows) {
+        format!("{bin}.exe")
+    } else {
+        bin.to_string()
+    };
+    let binary_path = leaf.join(&bin_filename);
+    let sidecar_path = leaf.join(".soldr-trampoline").join(format!("{bin}.toml"));
+    let dep_info_path = leaf.join(format!("{bin}.d"));
+
+    Layout {
+        binary_path,
+        sidecar_path,
+        dep_info_path,
+    }
+}
+
+fn resolve_target_dir(parsed: &ParsedRunArgs, manifest_dir: &Path) -> PathBuf {
+    if let Some(explicit) = parsed.target_dir.as_ref() {
+        return absolutize(explicit.clone(), manifest_dir);
+    }
+    if let Some(env_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        if !env_dir.is_empty() {
+            return absolutize(PathBuf::from(env_dir), manifest_dir);
+        }
+    }
+    manifest_dir.join("target")
+}
+
+/// Determine the target subdirectory cargo will produce artifacts under.
+///
+/// Precedence mirrors `cargo_front_door::default_cargo_build_target`:
+/// explicit `--target`, then `CARGO_BUILD_TARGET` env var, and on Windows
+/// the auto-detected host triple that soldr injects when neither of those
+/// is set. On non-Windows hosts cargo defaults to the unprefixed
+/// `target/<profile>/` layout, so we return `None`.
+fn effective_target_triple(parsed: &ParsedRunArgs) -> Option<String> {
+    if let Some(t) = parsed.target.as_deref() {
+        return Some(t.to_string());
+    }
+    if let Some(v) = std::env::var_os("CARGO_BUILD_TARGET") {
+        if let Some(s) = v.to_str() {
+            let s = s.trim();
+            if !s.is_empty() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    if cfg!(windows) {
+        soldr_core::TargetTriple::detect().ok().map(|t| t.triple())
+    } else {
+        None
+    }
+}
+
+fn absolutize(path: PathBuf, base: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    }
+}
+
+fn find_nearest_manifest() -> Option<PathBuf> {
+    let mut current = std::env::current_dir().ok()?;
+    loop {
+        let candidate = current.join("Cargo.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+/// Resolve the `[bin]` name to build. Slice 1 only handles unambiguous
+/// cases: explicit `--bin <NAME>`, or a crate with exactly one binary.
+/// Returns `Ok(None)` when ambiguity forces fall-through.
+pub(crate) fn resolve_bin_name(parsed: &ParsedRunArgs) -> Result<Option<String>, SoldrError> {
+    if let Some(name) = parsed.bin.as_ref() {
+        return Ok(Some(name.clone()));
+    }
+    let manifest_path = parsed
+        .manifest_path
+        .clone()
+        .or_else(find_nearest_manifest)
+        .ok_or_else(|| SoldrError::Other("Cargo.toml not found".into()))?;
+    let text = fs::read_to_string(&manifest_path).map_err(|err| {
+        SoldrError::Other(format!("read manifest {}: {err}", manifest_path.display()))
+    })?;
+    let value: toml::Value = text.parse().map_err(|err| {
+        SoldrError::Other(format!("parse manifest {}: {err}", manifest_path.display()))
+    })?;
+
+    let bins = value.get("bin").and_then(|v| v.as_array());
+    let package_name = value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(str::to_string);
+
+    let manifest_dir = manifest_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    // Case 1: explicit `[[bin]]` table(s).
+    if let Some(bins) = bins {
+        if bins.len() == 1 {
+            let entry = &bins[0];
+            if let Some(name) = entry.get("name").and_then(|n| n.as_str()) {
+                return Ok(Some(name.to_string()));
+            }
+        }
+        if !bins.is_empty() {
+            return Ok(None);
+        }
+    }
+
+    // Case 2: no `[[bin]]` table, but `src/main.rs` exists → cargo treats it
+    // as a default binary named after the package.
+    let auto_main = manifest_dir.join("src").join("main.rs");
+    let auto_bin_dir = manifest_dir.join("src").join("bin");
+    let auto_bins: Vec<PathBuf> = if auto_bin_dir.is_dir() {
+        match fs::read_dir(&auto_bin_dir) {
+            Ok(rd) => rd
+                .filter_map(Result::ok)
+                .map(|e| e.path())
+                .filter(|p| p.is_file() && p.extension().and_then(|s| s.to_str()) == Some("rs"))
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    } else {
+        Vec::new()
+    };
+
+    let mut candidates: Vec<String> = Vec::new();
+    if auto_main.is_file() {
+        if let Some(name) = package_name.as_deref() {
+            candidates.push(name.to_string());
+        }
+    }
+    for entry in &auto_bins {
+        if let Some(stem) = entry.file_stem().and_then(|s| s.to_str()) {
+            candidates.push(stem.to_string());
+        }
+    }
+
+    if candidates.len() == 1 {
+        return Ok(Some(candidates.remove(0)));
+    }
+    Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar (de)serialization
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct Sidecar {
+    pub(crate) binary_path: String,
+    pub(crate) binary_mtime_nanos: i64,
+    pub(crate) binary_size_bytes: i64,
+    pub(crate) cargo_args_fingerprint: String,
+    #[serde(default, rename = "source_files")]
+    pub(crate) source_files: Vec<SidecarSource>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SidecarSource {
+    pub(crate) path: String,
+    pub(crate) mtime_nanos: i64,
+    pub(crate) size_bytes: i64,
+}
+
+pub(crate) fn write_sidecar_atomic(path: &Path, data: &Sidecar) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let text = toml::to_string(data)
+        .map_err(|err| std::io::Error::other(format!("toml serialize: {err}")))?;
+    let mut tmp_name: OsString = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(".tmp");
+    let tmp = path.with_file_name(tmp_name);
+    {
+        let mut file = fs::File::create(&tmp)?;
+        file.write_all(text.as_bytes())?;
+        file.sync_all().ok();
+    }
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprint
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct FingerprintInputs<'a> {
+    profile: &'a str,
+    target: Option<&'a str>,
+    features: Vec<String>,
+    all_features: bool,
+    no_default_features: bool,
+    manifest_path: String,
+    rustflags: String,
+    rustc_identity: String,
+}
+
+pub(crate) fn compute_fingerprint(parsed: &ParsedRunArgs) -> Result<String, SoldrError> {
+    let profile = if parsed.release {
+        "release"
+    } else if let Some(p) = parsed.profile.as_deref() {
+        if p == "dev" {
+            "debug"
+        } else {
+            p
+        }
+    } else {
+        "debug"
+    };
+
+    let manifest_path = parsed
+        .manifest_path
+        .clone()
+        .or_else(find_nearest_manifest)
+        .ok_or_else(|| SoldrError::Other("Cargo.toml not found for fingerprint".into()))?;
+    let canonical = fs::canonicalize(&manifest_path).unwrap_or(manifest_path);
+    let manifest_string = canonical.to_string_lossy().to_string();
+
+    let mut features: Vec<String> = parsed.features.clone();
+    features.sort();
+    features.dedup();
+
+    let rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
+    let rustc_identity = rustc_identity_cached()?;
+
+    let effective_target = effective_target_triple(parsed);
+    let inputs = FingerprintInputs {
+        profile,
+        target: effective_target.as_deref(),
+        features,
+        all_features: parsed.all_features,
+        no_default_features: parsed.no_default_features,
+        manifest_path: manifest_string,
+        rustflags,
+        rustc_identity,
+    };
+
+    let bytes = serde_json::to_vec(&inputs)
+        .map_err(|err| SoldrError::Other(format!("fingerprint serialize: {err}")))?;
+    let hash = blake3::hash(&bytes);
+    Ok(format!("blake3:{}", hash.to_hex()))
+}
+
+static RUSTC_IDENTITY_CACHE: OnceLock<String> = OnceLock::new();
+
+fn rustc_identity_cached() -> Result<String, SoldrError> {
+    if let Some(cached) = RUSTC_IDENTITY_CACHE.get() {
+        return Ok(cached.clone());
+    }
+    let rustc = resolve_toolchain_binary("rustc")?;
+    let output = std::process::Command::new(&rustc)
+        .arg("-vV")
+        .output()
+        .map_err(|err| SoldrError::Other(format!("rustc -vV: {err}")))?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(format!(
+            "rustc -vV exited with {}",
+            output.status
+        )));
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let _ = RUSTC_IDENTITY_CACHE.set(text.clone());
+    Ok(text)
+}
+
+// ---------------------------------------------------------------------------
+// Dep-info parsing — see [`dep_info`] sibling module.
+// ---------------------------------------------------------------------------
+
+#[path = "trampoline_dep_info.rs"]
+mod dep_info;
+pub(crate) use dep_info::parse_dep_info_for_output;
+
+// ---------------------------------------------------------------------------
+// Exec / stat / logging helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+fn exec_binary(binary: &Path, args: &[String]) -> Result<i32, SoldrError> {
+    use std::os::unix::process::CommandExt;
+    let err = std::process::Command::new(binary).args(args).exec();
+    Err(SoldrError::Other(format!(
+        "failed to exec {}: {err}",
+        binary.display()
+    )))
+}
+
+#[cfg(not(unix))]
+fn exec_binary(binary: &Path, args: &[String]) -> Result<i32, SoldrError> {
+    let status = std::process::Command::new(binary)
+        .args(args)
+        .status()
+        .map_err(|err| SoldrError::Other(format!("failed to spawn {}: {err}", binary.display())))?;
+    Ok(status.code().unwrap_or(1))
+}
+
+fn mtime_nanos(meta: &fs::Metadata) -> Option<i64> {
+    let mtime = meta.modified().ok()?;
+    let dur = mtime.duration_since(SystemTime::UNIX_EPOCH).ok()?;
+    i64::try_from(dur.as_nanos()).ok()
+}
+
+fn size_as_i64(meta: &fs::Metadata) -> Option<i64> {
+    i64::try_from(meta.len()).ok()
+}
+
+fn trampoline_env_disabled() -> bool {
+    matches!(
+        std::env::var(NO_TRAMPOLINE_ENV_VAR).ok().as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
+fn trampoline_log_enabled() -> bool {
+    matches!(
+        std::env::var(TRAMPOLINE_LOG_ENV_VAR).ok().as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
+fn log_fall_through(reason: &str) {
+    if trampoline_log_enabled() {
+        eprintln!("soldr trampoline: fall-through: {reason}");
+    }
+}
+
+fn log_event(message: &str) {
+    if trampoline_log_enabled() {
+        eprintln!("soldr trampoline: {message}");
+    }
+}
+
+fn log_hit(binary: &Path) {
+    if trampoline_log_enabled() {
+        eprintln!("soldr trampoline: hit, exec {}", binary.display());
+    }
+}
+
+fn fell_through_plan(parsed: Option<ParsedRunArgs>, cleaned_args: Vec<String>) -> FellThroughPlan {
+    let (binary_path, sidecar_path, dep_info_path) = match parsed.as_ref() {
+        Some(p) => match resolve_bin_name(p) {
+            Ok(Some(name)) => {
+                let layout = compute_layout(p, &name);
+                (
+                    Some(layout.binary_path),
+                    Some(layout.sidecar_path),
+                    Some(layout.dep_info_path),
+                )
+            }
+            _ => (None, None, None),
+        },
+        None => (None, None, None),
+    };
+    FellThroughPlan {
+        parsed,
+        cleaned_args,
+        binary_path,
+        sidecar_path,
+        dep_info_path,
+    }
+}
+
+#[cfg(test)]
+#[path = "trampoline_tests.rs"]
+mod tests;

--- a/crates/soldr-cli/src/trampoline_dep_info.rs
+++ b/crates/soldr-cli/src/trampoline_dep_info.rs
@@ -1,0 +1,167 @@
+//! Cargo `.d` dep-info parser used by the `soldr cargo run` trampoline
+//! (issue #344). Pulled out of [`crate::trampoline`] to keep that file
+//! under the 1000-LOC ceiling (post-#339 convention).
+//!
+//! cargo emits one `<output>: <space-separated source paths>` line per
+//! output artifact. Lines may end with `\` to continue onto the next
+//! line; embedded spaces in paths are escaped as `\ `. The exact grammar
+//! is documented in cargo's `src/cargo/util/dep_info.rs`. We aim for
+//! tolerance over strict conformance — on any unexpected input the
+//! parser returns `None` and callers fall through silently to real
+//! cargo.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Parse a cargo `.d` dep-info file and return the source file list for the
+/// stanza whose left-hand side (output) matches `binary`. On any parse
+/// failure we return `None`.
+pub(crate) fn parse_dep_info_for_output(text: &str, binary: &Path) -> Option<Vec<PathBuf>> {
+    let logical = join_continuations(text);
+    let stanzas = parse_stanzas(&logical);
+    let raw_sources = select_stanza(&stanzas, binary)?;
+
+    let mut deduped: BTreeSet<PathBuf> = BTreeSet::new();
+    for raw in raw_sources {
+        let p = PathBuf::from(raw);
+        if !p.as_os_str().is_empty() {
+            deduped.insert(p);
+        }
+    }
+    Some(deduped.into_iter().collect())
+}
+
+fn join_continuations(text: &str) -> Vec<String> {
+    let mut pending = String::new();
+    let mut out = Vec::new();
+    for raw in text.lines() {
+        if let Some(stripped) = raw.strip_suffix('\\') {
+            pending.push_str(stripped);
+            pending.push(' ');
+            continue;
+        }
+        pending.push_str(raw);
+        out.push(std::mem::take(&mut pending));
+    }
+    if !pending.is_empty() {
+        out.push(pending);
+    }
+    out
+}
+
+fn parse_stanzas(logical: &[String]) -> Vec<(String, Vec<String>)> {
+    let mut stanzas: Vec<(String, Vec<String>)> = Vec::new();
+    for line in logical {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((lhs, rhs)) = split_dep_info_line(line) else {
+            continue;
+        };
+        let sources = tokenize_dep_info_paths(&rhs);
+        stanzas.push((lhs, sources));
+    }
+    stanzas
+}
+
+fn select_stanza(stanzas: &[(String, Vec<String>)], binary: &Path) -> Option<Vec<String>> {
+    let canonical_bin = fs::canonicalize(binary).ok();
+    let binary_filename = binary.file_name().and_then(|s| s.to_str());
+
+    for (lhs, sources) in stanzas {
+        let lhs_path = PathBuf::from(lhs);
+        let match_full = canonical_bin
+            .as_ref()
+            .and_then(|c| fs::canonicalize(&lhs_path).ok().map(|l| l == *c))
+            .unwrap_or(false);
+        let match_str = lhs_path == *binary;
+        let match_name = binary_filename
+            .map(|n| lhs_path.file_name().and_then(|s| s.to_str()) == Some(n))
+            .unwrap_or(false);
+        if match_full || match_str || match_name {
+            return Some(sources.clone());
+        }
+    }
+    // Fallback: a single stanza is unambiguous.
+    if stanzas.len() == 1 {
+        return Some(stanzas[0].1.clone());
+    }
+    None
+}
+
+/// Split a dep-info line on the first unescaped colon that separates the
+/// output from the source list. Windows drive letters (`C:`) need careful
+/// handling — a single-letter prefix followed by a colon is treated as
+/// part of the path.
+fn split_dep_info_line(line: &str) -> Option<(String, String)> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+        if c == b':' && !is_drive_letter_colon(bytes, i) {
+            return Some((
+                line[..i].trim().to_string(),
+                line[i + 1..].trim().to_string(),
+            ));
+        }
+        i += 1;
+    }
+    None
+}
+
+fn is_drive_letter_colon(bytes: &[u8], i: usize) -> bool {
+    if i + 1 >= bytes.len() {
+        return false;
+    }
+    let separator = bytes[i + 1];
+    if separator != b'\\' && separator != b'/' {
+        return false;
+    }
+    let at_start = i == 1 && bytes[0].is_ascii_alphabetic();
+    let after_space =
+        i >= 2 && bytes[i - 2].is_ascii_whitespace() && bytes[i - 1].is_ascii_alphabetic();
+    at_start || after_space
+}
+
+/// Tokenize the space-separated dep-info RHS, honoring `\ ` (escaped
+/// space) as a literal space inside a path.
+fn tokenize_dep_info_paths(rhs: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let bytes = rhs.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < bytes.len() {
+            let next = bytes[i + 1];
+            if matches!(next, b' ' | b'\t' | b'\\' | b'#' | b':') {
+                let ch = if next == b':' { ':' } else { next as char };
+                current.push(ch);
+                i += 2;
+                continue;
+            }
+            current.push('\\');
+            i += 1;
+            continue;
+        }
+        if c == b' ' || c == b'\t' {
+            if !current.is_empty() {
+                out.push(std::mem::take(&mut current));
+            }
+            i += 1;
+            continue;
+        }
+        current.push(c as char);
+        i += 1;
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}

--- a/crates/soldr-cli/src/trampoline_tests.rs
+++ b/crates/soldr-cli/src/trampoline_tests.rs
@@ -1,0 +1,271 @@
+//! Unit tests for [`crate::trampoline`]: the cargo-run arg parser, the
+//! sidecar (de)serializer, layout resolution, and the dep-info parser.
+//! Lives in a sibling file referenced via `#[path]` so `trampoline.rs`
+//! stays comfortably under the 1000-LOC ceiling (post-#339 convention).
+
+use super::*;
+
+fn argv(parts: &[&str]) -> Vec<String> {
+    parts.iter().map(|s| (*s).to_string()).collect()
+}
+
+#[test]
+fn strips_no_trampoline_flag() {
+    let (cleaned, saw) = strip_no_trampoline_flag(&argv(&[
+        "run",
+        "--no-trampoline",
+        "--release",
+        "--",
+        "--no-trampoline",
+    ]));
+    assert!(saw);
+    assert_eq!(
+        cleaned,
+        argv(&["run", "--release", "--", "--no-trampoline"])
+    );
+}
+
+#[test]
+fn parses_basic_run() {
+    let parsed = parse_run_args(&argv(&["run", "--bin", "demo"])).expect("parsed");
+    assert_eq!(parsed.bin.as_deref(), Some("demo"));
+    assert!(!parsed.release);
+    assert!(parsed.trailing.is_empty());
+}
+
+#[test]
+fn parses_release_and_features() {
+    let parsed = parse_run_args(&argv(&[
+        "run",
+        "--release",
+        "--bin=demo",
+        "--features",
+        "a,b",
+        "-F",
+        "c",
+        "--",
+        "arg1",
+        "arg2",
+    ]))
+    .expect("parsed");
+    assert!(parsed.release);
+    assert_eq!(parsed.bin.as_deref(), Some("demo"));
+    assert_eq!(parsed.features, vec!["a", "b", "c"]);
+    assert_eq!(
+        parsed.trailing,
+        vec!["arg1".to_string(), "arg2".to_string()]
+    );
+}
+
+#[test]
+fn parses_toolchain_prefix() {
+    let parsed = parse_run_args(&argv(&["+nightly", "run", "--bin", "demo"])).expect("parsed");
+    assert_eq!(parsed.toolchain.as_deref(), Some("nightly"));
+    assert_eq!(parsed.bin.as_deref(), Some("demo"));
+}
+
+#[test]
+fn example_falls_through() {
+    assert!(parse_run_args(&argv(&["run", "--example", "demo"])).is_none());
+}
+
+#[test]
+fn unknown_flag_falls_through() {
+    assert!(parse_run_args(&argv(&["run", "--frobnicate"])).is_none());
+}
+
+#[test]
+fn non_run_subcommand_falls_through() {
+    assert!(parse_run_args(&argv(&["build"])).is_none());
+    assert!(parse_run_args(&argv(&["test"])).is_none());
+}
+
+#[test]
+fn run_short_alias_is_recognized() {
+    let parsed = parse_run_args(&argv(&["r", "--bin", "demo"])).expect("parsed");
+    assert_eq!(parsed.bin.as_deref(), Some("demo"));
+}
+
+#[test]
+fn split_features_handles_commas_and_spaces() {
+    assert_eq!(split_features("a,b c"), vec!["a", "b", "c"]);
+    assert_eq!(split_features("  "), Vec::<String>::new());
+}
+
+#[test]
+fn dep_info_parses_simple_stanza() {
+    let text = "/tmp/target/debug/foo: /tmp/src/main.rs /tmp/src/lib.rs\n";
+    let sources =
+        parse_dep_info_for_output(text, Path::new("/tmp/target/debug/foo")).expect("parsed");
+    let strs: Vec<String> = sources
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    assert!(strs.contains(&"/tmp/src/main.rs".to_string()));
+    assert!(strs.contains(&"/tmp/src/lib.rs".to_string()));
+}
+
+#[test]
+fn dep_info_picks_correct_stanza_among_many() {
+    let text = "\
+/tmp/target/debug/foo.rlib: /tmp/src/lib.rs
+/tmp/target/debug/foo: /tmp/src/main.rs
+";
+    let sources =
+        parse_dep_info_for_output(text, Path::new("/tmp/target/debug/foo")).expect("parsed");
+    let strs: Vec<String> = sources
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    assert_eq!(strs, vec!["/tmp/src/main.rs".to_string()]);
+}
+
+#[test]
+fn dep_info_honors_escaped_spaces() {
+    let text = "/tmp/target/debug/foo: /tmp/path\\ with\\ spaces/main.rs\n";
+    let sources =
+        parse_dep_info_for_output(text, Path::new("/tmp/target/debug/foo")).expect("parsed");
+    let strs: Vec<String> = sources
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    assert_eq!(strs, vec!["/tmp/path with spaces/main.rs".to_string()]);
+}
+
+#[test]
+fn dep_info_joins_line_continuations() {
+    let text = "/tmp/target/debug/foo: /tmp/a.rs \\\n /tmp/b.rs \\\n /tmp/c.rs\n";
+    let sources =
+        parse_dep_info_for_output(text, Path::new("/tmp/target/debug/foo")).expect("parsed");
+    let strs: Vec<String> = sources
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    assert!(strs.contains(&"/tmp/a.rs".to_string()));
+    assert!(strs.contains(&"/tmp/b.rs".to_string()));
+    assert!(strs.contains(&"/tmp/c.rs".to_string()));
+}
+
+#[cfg(windows)]
+#[test]
+fn dep_info_handles_windows_drive_letters() {
+    let text = "C:\\target\\debug\\foo.exe: C:\\src\\main.rs C:\\src\\lib.rs\n";
+    let sources =
+        parse_dep_info_for_output(text, Path::new("C:\\target\\debug\\foo.exe")).expect("parsed");
+    let strs: Vec<String> = sources
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    assert!(strs.iter().any(|s| s.ends_with("main.rs")));
+    assert!(strs.iter().any(|s| s.ends_with("lib.rs")));
+}
+
+#[test]
+fn sidecar_roundtrips_through_toml() {
+    let original = Sidecar {
+        binary_path: "target/debug/foo".to_string(),
+        binary_mtime_nanos: 12345,
+        binary_size_bytes: 9999,
+        cargo_args_fingerprint: "blake3:deadbeef".to_string(),
+        source_files: vec![SidecarSource {
+            path: "src/main.rs".to_string(),
+            mtime_nanos: 678,
+            size_bytes: 4096,
+        }],
+    };
+    let text = toml::to_string(&original).expect("serialize");
+    let round: Sidecar = toml::from_str(&text).expect("deserialize");
+    assert_eq!(original, round);
+}
+
+#[test]
+fn write_sidecar_writes_atomically() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("sub").join("foo.toml");
+    let data = Sidecar {
+        binary_path: "x".into(),
+        binary_mtime_nanos: 1,
+        binary_size_bytes: 2,
+        cargo_args_fingerprint: "blake3:0".into(),
+        source_files: vec![],
+    };
+    write_sidecar_atomic(&path, &data).expect("write");
+    assert!(path.is_file());
+    let text = fs::read_to_string(&path).expect("read");
+    assert!(text.contains("blake3:0"));
+    // Ensure the temp file is not lingering.
+    let tmp = path.with_file_name("foo.toml.tmp");
+    assert!(!tmp.exists());
+}
+
+#[test]
+fn compute_layout_uses_release_directory() {
+    let parsed = ParsedRunArgs {
+        toolchain: None,
+        bin: Some("foo".to_string()),
+        release: true,
+        profile: None,
+        manifest_path: Some(PathBuf::from("/tmp/proj/Cargo.toml")),
+        target: None,
+        features: vec![],
+        all_features: false,
+        no_default_features: false,
+        target_dir: None,
+        trailing: vec![],
+    };
+    let layout = compute_layout(&parsed, "foo");
+    assert!(layout.binary_path.to_string_lossy().contains("release"));
+    assert!(layout
+        .sidecar_path
+        .to_string_lossy()
+        .contains(".soldr-trampoline"));
+}
+
+#[test]
+fn compute_layout_with_target_triple() {
+    let parsed = ParsedRunArgs {
+        toolchain: None,
+        bin: Some("foo".to_string()),
+        release: false,
+        profile: None,
+        manifest_path: Some(PathBuf::from("/tmp/proj/Cargo.toml")),
+        target: Some("x86_64-unknown-linux-gnu".to_string()),
+        features: vec![],
+        all_features: false,
+        no_default_features: false,
+        target_dir: None,
+        trailing: vec![],
+    };
+    let layout = compute_layout(&parsed, "foo");
+    let bin_str = layout.binary_path.to_string_lossy();
+    assert!(bin_str.contains("x86_64-unknown-linux-gnu"));
+    assert!(bin_str.contains("debug"));
+}
+
+#[test]
+fn compute_layout_custom_profile_maps_dev_to_debug() {
+    let parsed = ParsedRunArgs {
+        toolchain: None,
+        bin: Some("foo".to_string()),
+        release: false,
+        profile: Some("dev".to_string()),
+        manifest_path: Some(PathBuf::from("/tmp/proj/Cargo.toml")),
+        target: None,
+        features: vec![],
+        all_features: false,
+        no_default_features: false,
+        target_dir: None,
+        trailing: vec![],
+    };
+    let layout = compute_layout(&parsed, "foo");
+    assert!(layout.binary_path.to_string_lossy().contains("debug"));
+}
+
+#[test]
+fn trailing_user_args_extracts_after_separator() {
+    assert_eq!(
+        trailing_user_args(&argv(&["run", "--bin", "demo", "--", "foo", "bar"])),
+        vec!["foo".to_string(), "bar".to_string()]
+    );
+    assert!(trailing_user_args(&argv(&["run", "--bin", "demo"])).is_empty());
+}

--- a/crates/soldr-cli/tests/cli_cargo_run_trampoline.rs
+++ b/crates/soldr-cli/tests/cli_cargo_run_trampoline.rs
@@ -1,0 +1,470 @@
+//! Integration tests for the `soldr cargo run` trampoline (issue #344).
+//!
+//! These tests build a tiny cargo project in a tempdir, run `soldr cargo
+//! run` against it, and assert that:
+//!   - the cold invocation falls through to real cargo and writes a
+//!     sidecar at `.soldr-trampoline/<bin>.toml`,
+//!   - the warm invocation hits the trampoline fast path and exec's the
+//!     binary directly (verified by pointing `SOLDR_TEST_CARGO_BIN` at a
+//!     broken stub — if cargo gets spawned the build fails),
+//!   - editing a source, bumping features, flipping `RUSTFLAGS`,
+//!     switching profile, etc. all fall through correctly,
+//!   - the opt-outs (`--no-trampoline`, `SOLDR_NO_TRAMPOLINE=1`) bypass
+//!     the fast path even when the sidecar is fresh,
+//!   - args passed via `--` reach the binary on both paths.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use std::ffi::OsStr;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime};
+
+fn soldr_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_soldr")
+}
+
+/// Build a tiny project containing a single binary that prints
+/// `hello <args...>` so we can assert it ran and that argv passed
+/// through correctly.
+fn make_project(label: &str) -> PathBuf {
+    let dir = unique_temp_dir(label);
+    let src = dir.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(
+        dir.join("Cargo.toml"),
+        r#"[package]
+name = "trampoline_demo"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = []
+alpha = []
+beta = []
+
+[[bin]]
+name = "trampoline_demo"
+path = "src/main.rs"
+"#,
+    )
+    .expect("write Cargo.toml");
+    fs::write(
+        src.join("main.rs"),
+        r#"fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    println!("hello {}", args.join(" "));
+}
+"#,
+    )
+    .expect("write main.rs");
+    dir
+}
+
+/// Path to a "broken cargo" stub that fails fast. When tests set
+/// `SOLDR_TEST_CARGO_BIN` to this, any cargo invocation through soldr
+/// will fail — which is exactly how we prove the trampoline took the
+/// fast path.
+fn broken_cargo_stub(dir: &Path) -> PathBuf {
+    let path = fake_script_path(dir, "broken-cargo");
+    #[cfg(windows)]
+    let body = "@echo off\necho broken cargo should not have been spawned 1>&2\nexit /b 99\n";
+    #[cfg(not(windows))]
+    let body = "#!/bin/sh\necho 'broken cargo should not have been spawned' >&2\nexit 99\n";
+    write_fake_script(&path, body);
+    path
+}
+
+fn run_soldr<I, S>(project: &Path, env_overrides: &[(&str, &str)], args: I) -> std::process::Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut cmd = Command::new(soldr_bin());
+    cmd.current_dir(project);
+    cmd.args(args);
+    for (k, v) in env_overrides {
+        cmd.env(k, v);
+    }
+    // Trampoline should not pull in zccache or the cache daemon.
+    cmd.env("SOLDR_CACHE_DIR", project.join(".soldr-cache"));
+    cmd.env_remove("SOLDR_TARGET_CACHE_MODE");
+    cmd.env_remove("SOLDR_BUILD_CACHE_MODE");
+    cmd.output().expect("spawn soldr")
+}
+
+fn run_cold(project: &Path, extra_args: &[&str]) -> std::process::Output {
+    let mut argv: Vec<&str> = vec!["--no-cache", "cargo", "run"];
+    argv.extend_from_slice(extra_args);
+    run_soldr(project, &[], argv)
+}
+
+/// Return the effective `target/<triple?>/<profile>/` directory that the
+/// soldr cargo front door will land artifacts in. On Windows soldr
+/// injects `CARGO_BUILD_TARGET=<host>` by default, so artifacts live
+/// under `target/<host_triple>/<profile>/`. On Unix the host triple is
+/// left implicit and artifacts live at `target/<profile>/`.
+fn profile_root(project: &Path, profile: &str) -> PathBuf {
+    let mut root = project.join("target");
+    if cfg!(windows) {
+        let target_root = project.join("target");
+        if let Ok(entries) = fs::read_dir(&target_root) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let probe = path.join(profile);
+                    if probe.is_dir() {
+                        return probe;
+                    }
+                }
+            }
+        }
+    }
+    root.push(profile);
+    root
+}
+
+fn project_sidecar(project: &Path, bin: &str, profile: &str) -> PathBuf {
+    profile_root(project, profile)
+        .join(".soldr-trampoline")
+        .join(format!("{bin}.toml"))
+}
+
+fn project_binary(project: &Path, bin: &str, profile: &str) -> PathBuf {
+    let mut p = profile_root(project, profile).join(bin);
+    if cfg!(windows) {
+        p.set_extension("exe");
+    }
+    p
+}
+
+#[test]
+fn cold_invocation_writes_sidecar_and_runs_binary() {
+    let project = make_project("trampoline-cold");
+    let out = run_cold(&project, &["--", "world"]);
+    assert!(
+        out.status.success(),
+        "cold invocation failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("hello world"),
+        "expected binary stdout to contain 'hello world': {stdout}"
+    );
+    let sidecar = project_sidecar(&project, "trampoline_demo", "debug");
+    assert!(
+        sidecar.is_file(),
+        "sidecar not written: {}",
+        sidecar.display()
+    );
+    let text = fs::read_to_string(&sidecar).expect("read sidecar");
+    assert!(text.contains("cargo_args_fingerprint"));
+    assert!(text.contains("blake3:"));
+    assert!(text.contains("source_files"));
+}
+
+#[test]
+fn warm_invocation_skips_cargo_and_execs_binary() {
+    let project = make_project("trampoline-warm");
+    // Cold build via real cargo to seed the sidecar.
+    let cold = run_cold(&project, &[]);
+    assert!(
+        cold.status.success(),
+        "seed cold build failed:\n{}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+
+    // Now make cargo unusable. If the trampoline works, soldr never
+    // spawns cargo and the binary's stdout still appears.
+    let stub_dir = unique_temp_dir("trampoline-warm-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run", "--", "ping"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "warm trampoline path failed (cargo was spawned?)\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("hello ping"),
+        "binary stdout missing on warm path: {stdout}"
+    );
+    assert!(
+        !stderr.contains("broken cargo should not have been spawned"),
+        "trampoline fell through and broken cargo was invoked: {stderr}"
+    );
+}
+
+#[test]
+fn edit_source_forces_fall_through() {
+    let project = make_project("trampoline-edit");
+    let cold = run_cold(&project, &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    // Bump mtime/size of main.rs by appending a no-op comment.
+    let main_rs = project.join("src").join("main.rs");
+    let mut text = fs::read_to_string(&main_rs).expect("read main.rs");
+    text.push_str("// edit\n");
+    // Wait long enough that the new mtime is unambiguously newer than the
+    // sidecar's recorded value (some filesystems have ~1s mtime resolution).
+    std::thread::sleep(Duration::from_millis(1100));
+    fs::write(&main_rs, text).expect("write main.rs");
+
+    // With a broken cargo and an edited source, the trampoline must
+    // fall through and the broken cargo must be invoked → non-zero exit.
+    let stub_dir = unique_temp_dir("trampoline-edit-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run"],
+    );
+    assert!(
+        !out.status.success(),
+        "edit-source should have forced fall-through to (broken) cargo"
+    );
+}
+
+#[test]
+fn no_trampoline_flag_forces_fall_through_to_cargo() {
+    let project = make_project("trampoline-flag-opt-out");
+    let cold = run_cold(&project, &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    let stub_dir = unique_temp_dir("trampoline-flag-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run", "--no-trampoline"],
+    );
+    assert!(
+        !out.status.success(),
+        "--no-trampoline should have forced fall-through; broken cargo must be invoked"
+    );
+}
+
+#[test]
+fn env_var_opt_out_forces_fall_through() {
+    let project = make_project("trampoline-env-opt-out");
+    let cold = run_cold(&project, &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    let stub_dir = unique_temp_dir("trampoline-env-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[
+            ("SOLDR_TEST_CARGO_BIN", &broken_str),
+            ("SOLDR_NO_TRAMPOLINE", "1"),
+        ],
+        ["--no-cache", "cargo", "run"],
+    );
+    assert!(
+        !out.status.success(),
+        "SOLDR_NO_TRAMPOLINE=1 should have forced fall-through; broken cargo must be invoked"
+    );
+}
+
+#[test]
+fn features_change_forces_fall_through() {
+    let project = make_project("trampoline-features");
+    let cold = run_cold(&project, &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    let stub_dir = unique_temp_dir("trampoline-features-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run", "--features", "alpha"],
+    );
+    assert!(
+        !out.status.success(),
+        "feature flag change should force fall-through"
+    );
+}
+
+#[test]
+fn rustflags_change_forces_fall_through() {
+    let project = make_project("trampoline-rustflags");
+    let cold = run_cold(&project, &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    let stub_dir = unique_temp_dir("trampoline-rustflags-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[
+            ("SOLDR_TEST_CARGO_BIN", &broken_str),
+            ("RUSTFLAGS", "--cfg trampoline_test"),
+        ],
+        ["--no-cache", "cargo", "run"],
+    );
+    assert!(
+        !out.status.success(),
+        "RUSTFLAGS change should force fall-through"
+    );
+}
+
+#[test]
+fn release_profile_has_distinct_sidecar() {
+    let project = make_project("trampoline-release");
+    // Cold debug build.
+    let cold_debug = run_cold(&project, &[]);
+    assert!(cold_debug.status.success(), "cold debug build failed");
+    // Cold release build.
+    let cold_release = run_cold(&project, &["--release"]);
+    assert!(cold_release.status.success(), "cold release build failed");
+
+    let debug_sidecar = project_sidecar(&project, "trampoline_demo", "debug");
+    let release_sidecar = project_sidecar(&project, "trampoline_demo", "release");
+    assert!(debug_sidecar.is_file(), "debug sidecar missing");
+    assert!(release_sidecar.is_file(), "release sidecar missing");
+
+    // Both warm paths should bypass cargo.
+    let stub_dir = unique_temp_dir("trampoline-release-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let warm_debug = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run"],
+    );
+    assert!(
+        warm_debug.status.success(),
+        "warm debug should hit trampoline: {}",
+        String::from_utf8_lossy(&warm_debug.stderr)
+    );
+    let warm_release = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run", "--release"],
+    );
+    assert!(
+        warm_release.status.success(),
+        "warm release should hit trampoline: {}",
+        String::from_utf8_lossy(&warm_release.stderr)
+    );
+}
+
+#[test]
+fn binary_missing_falls_through() {
+    let project = make_project("trampoline-no-bin");
+    let cold = run_cold(&project, &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    // Remove the binary but keep the sidecar.
+    let binary = project_binary(&project, "trampoline_demo", "debug");
+    fs::remove_file(&binary).expect("remove binary");
+    assert!(!binary.exists());
+
+    let stub_dir = unique_temp_dir("trampoline-no-bin-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run"],
+    );
+    assert!(
+        !out.status.success(),
+        "missing binary should force fall-through"
+    );
+}
+
+#[test]
+fn stale_fingerprint_falls_through() {
+    let project = make_project("trampoline-stale-fp");
+    let cold = run_cold(&project, &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    // Corrupt the sidecar's fingerprint by hand.
+    let sidecar = project_sidecar(&project, "trampoline_demo", "debug");
+    let text = fs::read_to_string(&sidecar).expect("read sidecar");
+    let corrupted = text.replace("blake3:", "blake3:deadbeefdeadbeef");
+    assert_ne!(corrupted, text, "sidecar fingerprint pattern not found");
+    fs::write(&sidecar, corrupted).expect("write corrupted sidecar");
+
+    let stub_dir = unique_temp_dir("trampoline-stale-fp-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run"],
+    );
+    assert!(
+        !out.status.success(),
+        "stale fingerprint should force fall-through"
+    );
+}
+
+#[test]
+fn missing_dep_info_falls_through_silently() {
+    let project = make_project("trampoline-no-dep");
+    let cold = run_cold(&project, &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    let sidecar = project_sidecar(&project, "trampoline_demo", "debug");
+    fs::remove_file(&sidecar).expect("remove sidecar");
+
+    // Second invocation: no sidecar → falls through; cargo recompiles
+    // (it's a no-op since artifacts exist) and the sidecar should be
+    // rewritten.
+    let warm = run_cold(&project, &[]);
+    assert!(
+        warm.status.success(),
+        "missing-sidecar fall-through failed: {}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    assert!(
+        sidecar.is_file(),
+        "sidecar should be regenerated after fall-through"
+    );
+}
+
+#[test]
+fn trailing_args_pass_through_to_binary() {
+    let project = make_project("trampoline-trailing-args");
+    let cold = run_cold(&project, &["--", "alpha", "beta"]);
+    assert!(cold.status.success(), "cold trailing-args failed");
+    let stdout = String::from_utf8_lossy(&cold.stdout);
+    assert!(
+        stdout.contains("hello alpha beta"),
+        "cold path missed trailing args: {stdout}"
+    );
+
+    // Warm path.
+    let stub_dir = unique_temp_dir("trampoline-trailing-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let warm = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run", "--", "gamma", "delta"],
+    );
+    let stdout = String::from_utf8_lossy(&warm.stdout);
+    assert!(
+        warm.status.success() && stdout.contains("hello gamma delta"),
+        "warm path missed trailing args: stdout={stdout}, stderr={}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+}


### PR DESCRIPTION
Closes #344
Refs #342

## Summary

Slice 1 of the lazy-rebuild trampoline. Intercepts `soldr cargo run` before the cargo front door spawns cargo. If the recorded sources + binary haven't changed (mtime+size oracle, the same correctness model cargo itself uses), `exec` the binary directly and never spawn cargo. Otherwise fall through to real cargo and refresh the sidecar after a successful build.

## Flow

1. **Intercept** in `cargo_front_door::run_cargo_front_door` before the existing cacheable-check / `prepare_rustc_wrapper` / cargo exec flow. `--no-trampoline` is stripped from the arg list before it reaches cargo.
2. **Fast path**: read sidecar at `<target-dir>/<target?>/<profile>/.soldr-trampoline/<bin>.toml`, stat every source file + binary, compare `mtime_nanos + size_bytes` to recorded values, verify a blake3 fingerprint of `{profile, target, features, all_features, no_default_features, manifest_path, RUSTFLAGS, rustc -vV}`. All match → `exec` the binary. Done — cargo never spawned.
3. **Fall through**: any uncertainty (missing/stale sidecar, fingerprint mismatch, mtime/size mismatch, ambiguous args, `--example`, custom `--target-dir`) → invoke real `cargo run` exactly as it would have been before this change. After cargo succeeds, parse `target/<profile>/<bin>.d`, stat the listed sources, and write the sidecar atomically (temp file + rename).
4. **Opt-out**: `--no-trampoline` flag and `SOLDR_NO_TRAMPOLINE=1` env var both unconditionally skip the fast path. Verbose tracing via `SOLDR_TRAMPOLINE_LOG=1` (stderr, off by default).

## Files added

- `crates/soldr-cli/src/trampoline.rs` (890 LOC) — entry point, sidecar I/O, fingerprint, layout, arg parser.
- `crates/soldr-cli/src/trampoline_dep_info.rs` (167 LOC) — cargo `.d` dep-info parser: line-continuation join, escape-aware tokenizer, Windows drive-letter aware LHS/RHS split, stanza selection by binary path.
- `crates/soldr-cli/src/trampoline_tests.rs` (271 LOC) — 20 unit tests (parser, sidecar roundtrip, layout, dep-info shapes including Windows drive letters and escaped spaces).
- `crates/soldr-cli/tests/cli_cargo_run_trampoline.rs` (470 LOC) — 12 integration tests against a tiny fixture cargo project: cold sidecar write, warm fast path (verified by pointing `SOLDR_TEST_CARGO_BIN` at a broken stub — non-zero on fall-through proves cargo would have been spawned), source edit, feature change, RUSTFLAGS change, profile switch, missing binary, stale fingerprint, missing dep-info, both opt-outs, trailing arg pass-through on both paths.

## Dep-info parser approach

Tolerant, two-phase: (1) join trailing-`\` continuations into logical lines, (2) for each non-comment line, split on the first unescaped colon that is **not** a Windows drive-letter colon (`C:\…`/`C:/…` at line start or after whitespace), then tokenize the RHS honoring `\ `, `\t`, `\`, `\:`, `\#`. Stanzas are matched against the target binary by canonical path, exact path, or filename; with one stanza we fall back to it unambiguously. On any failure the parser returns `None` and callers fall through silently — never panics on weird `.d` input.

## Known limitation

`RUSTFLAGS` is read from the env var only. cargo also reads `[build] rustflags` from `.cargo/config.toml`; honoring that for the fingerprint is out of scope for slice 1 (would force a parse of every applicable `.cargo/config.toml` in the discovery chain). Tracked for follow-up; not a blocker because a build-flags change in `.cargo/config.toml` invalidates Cargo's own fingerprint and triggers a real rebuild, which then refreshes the sidecar.

## Validation gates

All four passed locally on `x86_64-pc-windows-msvc`:

- `cargo build -p soldr-cli`
- `cargo test --workspace` (235 tests across the workspace; 22 new trampoline unit tests, 12 new integration tests, no regressions)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## CI note

The `Verify setup-soldr pin` job is failing on `main` due to v0 tag drift; pre-existing and unrelated to this PR.

## Test plan

- [ ] Cold `soldr cargo run` writes a sidecar and the binary runs as expected.
- [ ] Warm `soldr cargo run` (no source edits) doesn't spawn cargo — verified by `strace`/process audit, or by temporarily renaming `cargo`.
- [ ] Editing `src/main.rs` forces fall-through and cargo rebuilds.
- [ ] `--features X` change forces fall-through.
- [ ] `RUSTFLAGS=...` change forces fall-through.
- [ ] `--release` and default profile use distinct sidecars.
- [ ] `--no-trampoline` and `SOLDR_NO_TRAMPOLINE=1` both skip the fast path.
- [ ] `SOLDR_TRAMPOLINE_LOG=1` prints the fall-through reason.
- [ ] Trailing `-- args` reach the binary on both paths.