### PR TITLE
fix(cli): include .cargo/config.toml in trampoline fingerprint (#346)

### DIFF
--- a/crates/soldr-cli/src/trampoline.rs
+++ b/crates/soldr-cli/src/trampoline.rs
@@ -718,6 +718,12 @@ struct FingerprintInputs<'a> {
     manifest_path: String,
     rustflags: String,
     rustc_identity: String,
+    /// blake3 hash over the canonical bytes of every `.cargo/config.toml`
+    /// (and legacy `.cargo/config`) found by walking from the manifest dir
+    /// up to the filesystem root, plus `$CARGO_HOME`. See #346 — this is
+    /// intentionally over-aggressive (unrelated edits also bust the
+    /// fingerprint) but cheap and correct.
+    cargo_config_hash: String,
 }
 
 pub(crate) fn compute_fingerprint(parsed: &ParsedRunArgs) -> Result<String, SoldrError> {
@@ -740,6 +746,10 @@ pub(crate) fn compute_fingerprint(parsed: &ParsedRunArgs) -> Result<String, Sold
         .ok_or_else(|| SoldrError::Other("Cargo.toml not found for fingerprint".into()))?;
     let canonical = fs::canonicalize(&manifest_path).unwrap_or(manifest_path);
     let manifest_string = canonical.to_string_lossy().to_string();
+    let manifest_dir = canonical
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
 
     let mut features: Vec<String> = parsed.features.clone();
     features.sort();
@@ -747,6 +757,7 @@ pub(crate) fn compute_fingerprint(parsed: &ParsedRunArgs) -> Result<String, Sold
 
     let rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
     let rustc_identity = rustc_identity_cached()?;
+    let cargo_config_hash = compute_cargo_config_hash(&manifest_dir);
 
     let effective_target = effective_target_triple(parsed);
     let inputs = FingerprintInputs {
@@ -758,6 +769,7 @@ pub(crate) fn compute_fingerprint(parsed: &ParsedRunArgs) -> Result<String, Sold
         manifest_path: manifest_string,
         rustflags,
         rustc_identity,
+        cargo_config_hash,
     };
 
     let bytes = serde_json::to_vec(&inputs)
@@ -795,6 +807,14 @@ fn rustc_identity_cached() -> Result<String, SoldrError> {
 #[path = "trampoline_dep_info.rs"]
 mod dep_info;
 pub(crate) use dep_info::parse_dep_info_for_output;
+
+// ---------------------------------------------------------------------------
+// Cargo config-file hashing — see [`config_hash`] sibling module (#346).
+// ---------------------------------------------------------------------------
+
+#[path = "trampoline_config.rs"]
+mod config_hash;
+pub(crate) use config_hash::compute_cargo_config_hash;
 
 // ---------------------------------------------------------------------------
 // Exec / stat / logging helpers

--- a/crates/soldr-cli/src/trampoline_config.rs
+++ b/crates/soldr-cli/src/trampoline_config.rs
@@ -1,0 +1,243 @@
+//! Cargo config-file content hashing for the `soldr cargo run` trampoline
+//! fingerprint (issue #346, slice 2 of #342).
+//!
+//! Cargo loads rustflags (and other build-affecting settings) from
+//! `.cargo/config.toml` files walked from the manifest dir up to the
+//! filesystem root, plus `$CARGO_HOME/config.toml`. The trampoline's
+//! original fingerprint only hashed the `RUSTFLAGS` env var, so editing
+//! `.cargo/config.toml` could leave the fast path serving a stale binary
+//! whose rustflags no longer match the user's intent.
+//!
+//! We take the cheap fix: collect every relevant config-file path,
+//! sort by canonical path, concatenate `path:\n<bytes>\n` per file, and
+//! blake3-hash the result. That is over-aggressive — editing an unrelated
+//! `[net]` section also busts the fingerprint and forces a rebuild on the
+//! next `soldr cargo run` — but it is mechanically correct and free of
+//! cargo subprocess calls. See issue #346 for the rationale.
+//!
+//! Lives in a sibling file referenced from `trampoline.rs` via `#[path]`
+//! so `trampoline.rs` stays under the 1000-LOC ceiling (post-#339
+//! convention).
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Walk `manifest_dir` upward to the filesystem root, then `$CARGO_HOME`,
+/// and produce a blake3 hash over the canonical bytes of every
+/// `.cargo/config.toml` (and legacy `.cargo/config`) file found. Returns
+/// `"blake3:<hex>"`.
+///
+/// I/O errors on any individual file are swallowed — that file is treated
+/// as absent for hashing purposes. The trampoline must not crash on a
+/// transient read failure; it should simply produce a stable-but-possibly-
+/// stale hash and rely on the rest of the fingerprint to catch problems.
+///
+/// If no config files exist anywhere, the returned hash is the blake3 of
+/// the empty input — a stable sentinel that lets the fingerprint round-
+/// trip identically across runs in that state.
+pub(crate) fn compute_cargo_config_hash(manifest_dir: &Path) -> String {
+    let canonical_dir =
+        fs::canonicalize(manifest_dir).unwrap_or_else(|_| manifest_dir.to_path_buf());
+    let files = collect_config_files(&canonical_dir);
+    let merged = merge_for_hash(&files);
+    let hash = blake3::hash(&merged);
+    format!("blake3:{}", hash.to_hex())
+}
+
+/// Public for tests: enumerate the canonical paths of every existing
+/// cargo config file the hash will consume, sorted by canonical path
+/// string. Files unreadable or missing are simply omitted.
+pub(crate) fn collect_config_files(canonical_manifest_dir: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut by_path: BTreeMap<String, (PathBuf, Vec<u8>)> = BTreeMap::new();
+
+    let mut walk_dir = Some(canonical_manifest_dir.to_path_buf());
+    while let Some(dir) = walk_dir.take() {
+        consider_cargo_dir(&dir.join(".cargo"), &mut by_path);
+        let parent = dir.parent().map(Path::to_path_buf);
+        if let Some(parent) = parent {
+            if parent != dir {
+                walk_dir = Some(parent);
+            }
+        }
+    }
+
+    if let Some(cargo_home) = cargo_home_dir() {
+        consider_cargo_dir(&cargo_home, &mut by_path);
+    }
+
+    by_path.into_values().collect()
+}
+
+fn consider_cargo_dir(dir: &Path, sink: &mut BTreeMap<String, (PathBuf, Vec<u8>)>) {
+    // Cargo prefers `config.toml`; the legacy `config` (no extension) is
+    // still supported. We hash both if both exist — cargo warns in that
+    // case but we want any visible config bytes in the fingerprint.
+    for name in ["config.toml", "config"] {
+        let candidate = dir.join(name);
+        let bytes = match fs::read(&candidate) {
+            Ok(bytes) => bytes,
+            Err(_) => continue,
+        };
+        let canonical = fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
+        let key = canonical.to_string_lossy().to_string();
+        sink.entry(key).or_insert((canonical, bytes));
+    }
+}
+
+fn cargo_home_dir() -> Option<PathBuf> {
+    if let Some(explicit) = std::env::var_os("CARGO_HOME") {
+        if !explicit.is_empty() {
+            return Some(PathBuf::from(explicit));
+        }
+    }
+    home_dir().map(|h| h.join(".cargo"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(profile) = std::env::var_os("USERPROFILE") {
+            if !profile.is_empty() {
+                return Some(PathBuf::from(profile));
+            }
+        }
+        let drive = std::env::var_os("HOMEDRIVE");
+        let path = std::env::var_os("HOMEPATH");
+        if let (Some(d), Some(p)) = (drive, path) {
+            if !d.is_empty() && !p.is_empty() {
+                let mut joined = d;
+                joined.push(p);
+                return Some(PathBuf::from(joined));
+            }
+        }
+        None
+    }
+    #[cfg(not(windows))]
+    {
+        std::env::var_os("HOME")
+            .filter(|h| !h.is_empty())
+            .map(PathBuf::from)
+    }
+}
+
+fn merge_for_hash(files: &[(PathBuf, Vec<u8>)]) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    for (path, bytes) in files {
+        let header = format!("{}:\n", path.to_string_lossy());
+        out.extend_from_slice(header.as_bytes());
+        out.extend_from_slice(bytes);
+        out.push(b'\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    //! These tests assert deltas, not absolute hash values, so they don't
+    //! need to isolate `$CARGO_HOME` / `$HOME` from the developer's real
+    //! environment: whatever ancestor configs (and `~/.cargo/config*`)
+    //! happen to exist contribute the same bytes on both halves of each
+    //! pair, so the diff isolates the change we wrote to the tempdir.
+
+    use super::*;
+    use std::fs;
+
+    fn tempdir(label: &str) -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix(&format!("soldr-cfg-hash-{label}-"))
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    #[test]
+    fn empty_layout_returns_stable_hash() {
+        let temp = tempdir("empty");
+        let manifest_dir = temp.path().join("crate");
+        fs::create_dir_all(&manifest_dir).expect("mk crate");
+
+        let a = compute_cargo_config_hash(&manifest_dir);
+        let b = compute_cargo_config_hash(&manifest_dir);
+        assert_eq!(a, b, "missing-config hash must be deterministic");
+        assert!(a.starts_with("blake3:"));
+    }
+
+    #[test]
+    fn distinct_config_content_produces_distinct_hash() {
+        let temp = tempdir("content");
+        let crate_dir = temp.path().join("crate");
+        let cargo_dir = crate_dir.join(".cargo");
+        fs::create_dir_all(&cargo_dir).expect("mk .cargo");
+        let cfg = cargo_dir.join("config.toml");
+
+        fs::write(&cfg, "[build]\nrustflags = []\n").expect("write cfg");
+        let h1 = compute_cargo_config_hash(&crate_dir);
+
+        fs::write(&cfg, "[build]\nrustflags = [\"-C\", \"opt-level=0\"]\n").expect("rewrite cfg");
+        let h2 = compute_cargo_config_hash(&crate_dir);
+
+        assert_ne!(
+            h1, h2,
+            "editing .cargo/config.toml must change the config hash"
+        );
+    }
+
+    #[test]
+    fn identical_config_content_produces_identical_hash() {
+        let temp = tempdir("identity");
+        let crate_dir = temp.path().join("crate");
+        let cargo_dir = crate_dir.join(".cargo");
+        fs::create_dir_all(&cargo_dir).expect("mk .cargo");
+        let cfg = cargo_dir.join("config.toml");
+        fs::write(&cfg, "[build]\nrustflags = [\"-C\", \"debuginfo=0\"]\n").expect("write cfg");
+
+        let h1 = compute_cargo_config_hash(&crate_dir);
+        let h2 = compute_cargo_config_hash(&crate_dir);
+        assert_eq!(h1, h2, "identical-content reads must hash identically");
+    }
+
+    #[test]
+    fn adding_a_config_file_changes_the_hash() {
+        let temp = tempdir("appear");
+        let crate_dir = temp.path().join("crate");
+        fs::create_dir_all(&crate_dir).expect("mk crate");
+
+        let before = compute_cargo_config_hash(&crate_dir);
+
+        let cargo_dir = crate_dir.join(".cargo");
+        fs::create_dir_all(&cargo_dir).expect("mk .cargo");
+        fs::write(
+            cargo_dir.join("config.toml"),
+            "[build]\nrustflags = [\"-C\", \"opt-level=1\"]\n",
+        )
+        .expect("write cfg");
+
+        let after = compute_cargo_config_hash(&crate_dir);
+        assert_ne!(
+            before, after,
+            "appearance of a new .cargo/config.toml must change the hash"
+        );
+    }
+
+    #[test]
+    fn parent_directory_config_is_included() {
+        let temp = tempdir("parent");
+        let parent = temp.path().join("workspace");
+        let child = parent.join("crate");
+        fs::create_dir_all(&child).expect("mk crate");
+        let parent_cargo = parent.join(".cargo");
+        fs::create_dir_all(&parent_cargo).expect("mk parent .cargo");
+        let parent_cfg = parent_cargo.join("config.toml");
+
+        fs::write(&parent_cfg, "[net]\nretry = 2\n").expect("write parent cfg");
+        let h1 = compute_cargo_config_hash(&child);
+
+        fs::write(&parent_cfg, "[net]\nretry = 7\n").expect("rewrite parent cfg");
+        let h2 = compute_cargo_config_hash(&child);
+
+        assert_ne!(
+            h1, h2,
+            "editing an ancestor .cargo/config.toml must change the hash"
+        );
+    }
+}

--- a/crates/soldr-cli/src/trampoline_tests.rs
+++ b/crates/soldr-cli/src/trampoline_tests.rs
@@ -269,3 +269,119 @@ fn trailing_user_args_extracts_after_separator() {
     );
     assert!(trailing_user_args(&argv(&["run", "--bin", "demo"])).is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// `.cargo/config.toml` fingerprint integration (#346). The standalone
+// `compute_cargo_config_hash` is covered in `trampoline_config.rs::tests`;
+// here we verify the hash actually reaches `compute_fingerprint` via the
+// `ParsedRunArgs` path most callers exercise.
+// ---------------------------------------------------------------------------
+
+/// Build a `ParsedRunArgs` whose `manifest_path` points at a real
+/// `Cargo.toml` inside `dir`, suitable for feeding `compute_fingerprint`.
+fn parsed_for_manifest(manifest: PathBuf) -> ParsedRunArgs {
+    ParsedRunArgs {
+        toolchain: None,
+        bin: Some("demo".to_string()),
+        release: false,
+        profile: None,
+        manifest_path: Some(manifest),
+        target: None,
+        features: vec![],
+        all_features: false,
+        no_default_features: false,
+        target_dir: None,
+        trailing: vec![],
+    }
+}
+
+/// Minimal `Cargo.toml` so `compute_fingerprint`'s canonicalize succeeds.
+fn seed_minimal_crate(dir: &Path) -> PathBuf {
+    fs::create_dir_all(dir).expect("mk crate dir");
+    fs::create_dir_all(dir.join("src")).expect("mk src");
+    fs::write(dir.join("src").join("main.rs"), "fn main() {}\n").expect("write main.rs");
+    let manifest = dir.join("Cargo.toml");
+    fs::write(
+        &manifest,
+        "[package]\nname = \"demo\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    manifest
+}
+
+#[test]
+fn fingerprint_changes_when_cargo_config_changes() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let crate_dir = temp.path().join("crate");
+    let manifest = seed_minimal_crate(&crate_dir);
+    let cargo_dir = crate_dir.join(".cargo");
+    fs::create_dir_all(&cargo_dir).expect("mk .cargo");
+    let cfg = cargo_dir.join("config.toml");
+
+    fs::write(&cfg, "[build]\nrustflags = []\n").expect("write cfg v1");
+    let parsed = parsed_for_manifest(manifest);
+    let fp1 = compute_fingerprint(&parsed).expect("fingerprint v1");
+
+    fs::write(&cfg, "[build]\nrustflags = [\"-C\", \"opt-level=0\"]\n").expect("write cfg v2");
+    let fp2 = compute_fingerprint(&parsed).expect("fingerprint v2");
+
+    assert_ne!(
+        fp1, fp2,
+        "fingerprint must change when .cargo/config.toml rustflags change"
+    );
+}
+
+#[test]
+fn fingerprint_stable_with_unchanged_cargo_config() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let crate_dir = temp.path().join("crate");
+    let manifest = seed_minimal_crate(&crate_dir);
+    let cargo_dir = crate_dir.join(".cargo");
+    fs::create_dir_all(&cargo_dir).expect("mk .cargo");
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\nrustflags = [\"-C\", \"opt-level=1\"]\n",
+    )
+    .expect("write cfg");
+
+    let parsed = parsed_for_manifest(manifest);
+    let fp1 = compute_fingerprint(&parsed).expect("fingerprint v1");
+    let fp2 = compute_fingerprint(&parsed).expect("fingerprint v2");
+    assert_eq!(fp1, fp2, "identical state must yield identical fingerprint");
+}
+
+#[test]
+fn fingerprint_changes_when_cargo_config_appears() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let crate_dir = temp.path().join("crate");
+    let manifest = seed_minimal_crate(&crate_dir);
+
+    let parsed = parsed_for_manifest(manifest);
+    let fp_before = compute_fingerprint(&parsed).expect("fingerprint before");
+
+    let cargo_dir = crate_dir.join(".cargo");
+    fs::create_dir_all(&cargo_dir).expect("mk .cargo");
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\nrustflags = [\"-C\", \"opt-level=0\"]\n",
+    )
+    .expect("write cfg");
+    let fp_after = compute_fingerprint(&parsed).expect("fingerprint after");
+
+    assert_ne!(
+        fp_before, fp_after,
+        "appearance of .cargo/config.toml must change the fingerprint"
+    );
+}
+
+#[test]
+fn fingerprint_stable_when_no_config_present_on_both_runs() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let crate_dir = temp.path().join("crate");
+    let manifest = seed_minimal_crate(&crate_dir);
+    let parsed = parsed_for_manifest(manifest);
+
+    let fp1 = compute_fingerprint(&parsed).expect("fingerprint v1");
+    let fp2 = compute_fingerprint(&parsed).expect("fingerprint v2");
+    assert_eq!(fp1, fp2, "no-config runs must hash identically");
+}

--- a/crates/soldr-cli/tests/cli_cargo_run_trampoline.rs
+++ b/crates/soldr-cli/tests/cli_cargo_run_trampoline.rs
@@ -442,6 +442,82 @@ fn missing_dep_info_falls_through_silently() {
 }
 
 #[test]
+fn cargo_config_change_forces_fall_through() {
+    // Issue #346: editing `.cargo/config.toml` must bust the trampoline
+    // fingerprint so the fast path can't serve a binary compiled with
+    // the old rustflags. After the resulting cargo rebuild, a third
+    // invocation should hit the fast path again with the refreshed
+    // sidecar.
+    let project = make_project("trampoline-cargo-config");
+    let cold = run_cold(&project, &[]);
+    assert!(
+        cold.status.success(),
+        "seed cold build failed:\n{}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+    let sidecar = project_sidecar(&project, "trampoline_demo", "debug");
+    assert!(sidecar.is_file(), "seed sidecar missing");
+    let cold_sidecar_text = fs::read_to_string(&sidecar).expect("read cold sidecar");
+
+    // Drop in a `.cargo/config.toml` that changes rustflags.
+    let cargo_dir = project.join(".cargo");
+    fs::create_dir_all(&cargo_dir).expect("mk .cargo");
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\nrustflags = [\"-C\", \"opt-level=0\"]\n",
+    )
+    .expect("write .cargo/config.toml");
+
+    // With a broken cargo, the trampoline must fall through (because the
+    // fingerprint now includes the config bytes) and the broken stub
+    // must be invoked → non-zero exit.
+    let stub_dir = unique_temp_dir("trampoline-cargo-config-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let fell_through = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run"],
+    );
+    assert!(
+        !fell_through.status.success(),
+        "adding .cargo/config.toml must force fall-through; broken cargo must be invoked"
+    );
+
+    // Now let real cargo rebuild so the sidecar is refreshed with the
+    // updated fingerprint.
+    let rebuild = run_cold(&project, &[]);
+    assert!(
+        rebuild.status.success(),
+        "post-config rebuild failed:\n{}",
+        String::from_utf8_lossy(&rebuild.stderr)
+    );
+    let warm_sidecar_text = fs::read_to_string(&sidecar).expect("read warm sidecar");
+    assert_ne!(
+        cold_sidecar_text, warm_sidecar_text,
+        "sidecar fingerprint should change after .cargo/config.toml edit"
+    );
+
+    // A third invocation should hit the fast path against the new
+    // sidecar even with a broken cargo on PATH.
+    let warm = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run", "--", "post-config"],
+    );
+    let warm_stdout = String::from_utf8_lossy(&warm.stdout);
+    let warm_stderr = String::from_utf8_lossy(&warm.stderr);
+    assert!(
+        warm.status.success(),
+        "warm trampoline path after config edit failed (cargo got spawned?)\nstdout:\n{warm_stdout}\nstderr:\n{warm_stderr}"
+    );
+    assert!(
+        warm_stdout.contains("hello post-config"),
+        "binary stdout missing on warm path after config edit: {warm_stdout}"
+    );
+}
+
+#[test]
 fn trailing_args_pass_through_to_binary() {
     let project = make_project("trampoline-trailing-args");
     let cold = run_cold(&project, &["--", "alpha", "beta"]);


### PR DESCRIPTION
## Summary

The `soldr cargo run` trampoline previously hashed only the `RUSTFLAGS` env var when fingerprinting cargo arguments. A user who edited `.cargo/config.toml` (e.g. `[build] rustflags = [...]`) and then ran `soldr cargo run` would see the trampoline fast-path a stale binary — a real correctness bug for anyone whose only entry point is `soldr cargo run`, since the cargo invocation that would notice the change never happens.

## What's now in the fingerprint

`compute_fingerprint` now feeds a new `cargo_config_hash` field into its blake3 input. The hash is computed by walking from the canonicalized manifest dir up to the filesystem root, then checking `$CARGO_HOME` (defaulting to `~/.cargo`). At each step both `.cargo/config.toml` and the legacy `.cargo/config` are read; whichever files exist contribute their canonical paths and byte content to a sorted, concatenated `path:\n<bytes>\n` blob that is blake3-hashed. I/O errors on any individual file → that file is treated as absent (no crash, no fall-through).

Logic lives in a new sibling file `crates/soldr-cli/src/trampoline_config.rs` (244 LOC) to keep `trampoline.rs` under the 1000-LOC ceiling — same pattern as `trampoline_dep_info.rs` from #339 / #344.

## Tradeoff

This is the cheap fix from issue #346: editing an unrelated section of `.cargo/config.toml` (e.g. `[net]`) also busts the fingerprint and forces a rebuild on the next `soldr cargo run`. The issue body explicitly documents this as preferred over replicating cargo's full config-resolution algorithm in soldr. The user wanted accuracy over peak performance.

## Tests

**Unit tests** in `trampoline_config::tests` (5):
- `empty_layout_returns_stable_hash`
- `distinct_config_content_produces_distinct_hash`
- `identical_config_content_produces_identical_hash`
- `adding_a_config_file_changes_the_hash`
- `parent_directory_config_is_included`

**Unit tests** in `trampoline::tests` (4) that exercise the wiring through `compute_fingerprint`:
- `fingerprint_changes_when_cargo_config_changes`
- `fingerprint_stable_with_unchanged_cargo_config`
- `fingerprint_changes_when_cargo_config_appears`
- `fingerprint_stable_when_no_config_present_on_both_runs`

**Integration test** in `cli_cargo_run_trampoline.rs` (1):
- `cargo_config_change_forces_fall_through` — cold cargo run → sidecar written, add `.cargo/config.toml` with `[build] rustflags`, broken-cargo stub proves trampoline falls through, real rebuild refreshes the sidecar, third invocation hits the fast path again.

All 13 existing trampoline integration tests continue to pass.

## Validation gates passed

- [x] `cargo build -p soldr-cli`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

## CI note

The `Verify setup-soldr pin` workflow is failing on `main` due to pin drift; that's pre-existing and not affected by this PR.

Closes #346
Refs #342 #344

## Test plan

- [ ] CI green on Linux/macOS/Windows
- [ ] Manual smoke: edit `.cargo/config.toml [build] rustflags` in a sample crate and confirm `soldr cargo run` (with `SOLDR_TRAMPOLINE_LOG=1`) logs the fall-through reason for the next invocation

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>