### PR TITLE
feat(gc): schema scaffolding for kind + purge_safety (#323 slice 1)

### DIFF
--- a/crates/soldr-cli/src/gc.rs
+++ b/crates/soldr-cli/src/gc.rs
@@ -14,6 +14,19 @@ use std::time::Duration;
 // soldr gc — garbage-collect stale Cargo target/ directories.
 // ---------------------------------------------------------------------------
 
+// Slice 1 of #323: scaffold the kind/purge_safety discriminator on gc JSON
+// entries. Every entry emitted today is a workspace target/ dir, so every
+// entry is tagged `cargo_target` / `derived`. Later slices add walkers that
+// emit entries with other kinds (registry-src, git-checkouts, in-target
+// subtrees, …) without further schema churn.
+const KIND_CARGO_TARGET: &str = "cargo_target";
+const PURGE_SAFETY_DERIVED: &str = "derived";
+
+// gc list / gc summary entries follow their own schema version,
+// independent of the global JSON_SCHEMA_VERSION used by other commands.
+// Bumped from 1 to 2 in #323 slice 1 when kind + purge_safety were added.
+const GC_JSON_SCHEMA_VERSION: u32 = 2;
+
 #[derive(Clone, Copy)]
 pub(crate) enum GcMode {
     Summary,
@@ -36,6 +49,11 @@ struct GcCandidateOutput {
     age_human: String,
     eligible: bool,
     reason: Option<String>,
+    /// Taxonomy discriminator (#323 slice 1). Always `cargo_target` for
+    /// now — later slices emit other kinds from new walkers.
+    kind: &'static str,
+    /// Safety class for purge (#323 slice 1). Always `derived` for now.
+    purge_safety: &'static str,
 }
 
 #[derive(Serialize)]
@@ -129,7 +147,7 @@ pub(crate) fn run_gc_command(invocation: GcInvocation) -> Result<(), SoldrError>
 
     if invocation.json {
         let output = GcOutput {
-            schema_version: JSON_SCHEMA_VERSION,
+            schema_version: GC_JSON_SCHEMA_VERSION,
             command: "gc",
             mode: if is_summary { "summary" } else { "purge" },
             dry_run: is_summary,
@@ -179,6 +197,11 @@ struct GcListEntryOutput {
     size_bytes: u64,
     size_human: String,
     file_count: u64,
+    /// Taxonomy discriminator (#323 slice 1). Always `cargo_target` for
+    /// now — later slices emit other kinds from new walkers.
+    kind: &'static str,
+    /// Safety class for purge (#323 slice 1). Always `derived` for now.
+    purge_safety: &'static str,
 }
 
 #[derive(Serialize)]
@@ -284,6 +307,8 @@ pub(crate) fn run_gc_list_command(json: bool) -> Result<(), SoldrError> {
                 size_bytes,
                 size_human: soldr_cache::target_registry::human_size(size_bytes),
                 file_count,
+                kind: KIND_CARGO_TARGET,
+                purge_safety: PURGE_SAFETY_DERIVED,
             }
         })
         .collect();
@@ -294,7 +319,7 @@ pub(crate) fn run_gc_list_command(json: bool) -> Result<(), SoldrError> {
 
     if json {
         let output = GcListOutput {
-            schema_version: JSON_SCHEMA_VERSION,
+            schema_version: GC_JSON_SCHEMA_VERSION,
             command: "gc",
             mode: "list",
             registry_path: db_path.display().to_string(),
@@ -312,8 +337,8 @@ pub(crate) fn run_gc_list_command(json: bool) -> Result<(), SoldrError> {
         );
         for entry in &entries {
             println!(
-                "  {}  size={}  files={}  age={}",
-                entry.path, entry.size_human, entry.file_count, entry.age_human,
+                "  {}  size={}  files={}  age={}  kind={}",
+                entry.path, entry.size_human, entry.file_count, entry.age_human, entry.kind,
             );
         }
         if pruned_missing > 0 {
@@ -540,6 +565,8 @@ fn gc_candidate_output(c: soldr_cache::gc::GcCandidate) -> GcCandidateOutput {
         age_seconds: c.age_seconds,
         eligible: c.eligible,
         reason: c.reason,
+        kind: KIND_CARGO_TARGET,
+        purge_safety: PURGE_SAFETY_DERIVED,
     }
 }
 

--- a/crates/soldr-cli/tests/cli_gc.rs
+++ b/crates/soldr-cli/tests/cli_gc.rs
@@ -347,7 +347,7 @@ fn gc_list_json_entries_include_kind_and_purge_safety_defaults() {
     let entries = json["entries"].as_array().expect("entries");
     let entry = entries
         .iter()
-        .find(|e| e["path"].as_str().map_or(false, |p| PathBuf::from(p) == target))
+        .find(|e| e["path"].as_str().is_some_and(|p| target == Path::new(p)))
         .expect("seeded target missing from entries");
     assert_eq!(entry["kind"].as_str(), Some("cargo_target"));
     assert_eq!(entry["purge_safety"].as_str(), Some("derived"));

--- a/crates/soldr-cli/tests/cli_gc.rs
+++ b/crates/soldr-cli/tests/cli_gc.rs
@@ -74,7 +74,7 @@ fn gc_summary_json_reports_candidates_without_deleting() {
     );
 
     let json: Value = serde_json::from_slice(&output.stdout).expect("gc --json must be JSON");
-    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["schema_version"], 2);
     assert_eq!(json["command"], "gc");
     assert_eq!(json["mode"], "summary");
     assert_eq!(json["dry_run"], true);
@@ -82,6 +82,9 @@ fn gc_summary_json_reports_candidates_without_deleting() {
     assert!(json["total_reclaimable_bytes"].as_u64().unwrap_or(0) > 0);
     assert_eq!(json["largest_candidates"].as_array().unwrap().len(), 1);
     assert_eq!(json["deleted_paths"].as_array().unwrap().len(), 0);
+    let cand = &json["largest_candidates"].as_array().unwrap()[0];
+    assert_eq!(cand["kind"].as_str(), Some("cargo_target"));
+    assert_eq!(cand["purge_safety"].as_str(), Some("derived"));
 }
 
 #[test]
@@ -266,7 +269,7 @@ fn gc_list_json_reports_built_project_target_dir() {
     );
 
     let json: Value = serde_json::from_slice(&output.stdout).expect("gc list --json must be JSON");
-    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["schema_version"], 2);
     assert_eq!(json["command"], "gc");
     assert_eq!(json["mode"], "list");
     let entry_count = json["entry_count"].as_u64().expect("entry_count");
@@ -321,7 +324,33 @@ fn gc_list_json_reports_built_project_target_dir() {
             entry.get("exists").is_none(),
             "missing rows are pruned, so `exists` should not appear on listed entries"
         );
+        assert_eq!(entry["kind"].as_str(), Some("cargo_target"));
+        assert_eq!(entry["purge_safety"].as_str(), Some("derived"));
     }
+}
+
+#[test]
+fn gc_list_json_entries_include_kind_and_purge_safety_defaults() {
+    let cache_root = unique_temp_dir("gc-list-kind-defaults");
+    let target = seed_gc_candidate(&cache_root, "kind-defaults-project");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "list", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr gc list --json");
+    assert!(output.status.success());
+
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["schema_version"], 2);
+
+    let entries = json["entries"].as_array().expect("entries");
+    let entry = entries
+        .iter()
+        .find(|e| e["path"].as_str().map_or(false, |p| PathBuf::from(p) == target))
+        .expect("seeded target missing from entries");
+    assert_eq!(entry["kind"].as_str(), Some("cargo_target"));
+    assert_eq!(entry["purge_safety"].as_str(), Some("derived"));
 }
 
 #[test]


### PR DESCRIPTION
Refs #323

PR 1 of the rollout described in #323's plan. Pure JSON schema scaffolding: lands the `kind` / `purge_safety` discriminator on `soldr gc list --json` and `soldr gc --json` summary entries so later slices that add new walkers (registry-src, git-checkouts, in-target subtrees, ...) emit additional entries without further schema churn. No new walkers in this PR.

## What changed

- Added `kind: &'static str` and `purge_safety: &'static str` to `GcCandidateOutput` (gc summary / purge candidate entries).
- Added the same two fields to `GcListEntryOutput` (gc list entries).
- Bumped the gc list / gc summary `schema_version` 1 -> 2 via a new local `GC_JSON_SCHEMA_VERSION` const. The global `JSON_SCHEMA_VERSION` used by other commands (cache, doctor, gc cargo, gc locations, gc sweep) is unchanged at 1.
- Appended a `kind=` column to the human-readable `gc list` table (trailing position, minimal disruption).
- TDD: one new isolated integration test (`gc_list_json_entries_include_kind_and_purge_safety_defaults`) plus assertions added to two existing JSON tests.

## Defaults

Every entry emitted today is a workspace `target/` dir, so both fields are hardcoded to:

- `kind = "cargo_target"`
- `purge_safety = "derived"`

Reviewers: no new walkers exist yet — that is intentional. Slice 1 is presentation-layer only.

## Out of scope (later slices)

- New walkers (registry-src, git-checkouts, in-target subtrees).
- A `--kind` CLI flag.
- Library type changes (`GcOptions` / `GcCandidate` stay schema-clean).
- Per-kind `owner_*` JSON fields.
- Unifying the new `derived`/`primary`/... vocabulary with the pre-existing `regenerable`/`user_action` vocabulary used by `gc locations`.

Purge logic is untouched; today it only operates on `cargo_target` entries because that is the only kind emitted.

## Gates (all green locally)

- `cargo build -p soldr-cli`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Pre-existing CI note

The `Verify setup-soldr pin` step is currently failing on `main` due to pin drift. That is pre-existing and not introduced by this PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>