### PR TITLE
feat(gc): cargo_registry_src walker (#323 slice 2)

### DIFF
--- a/crates/soldr-cli/src/gc.rs
+++ b/crates/soldr-cli/src/gc.rs
@@ -20,7 +20,29 @@ use std::time::Duration;
 // emit entries with other kinds (registry-src, git-checkouts, in-target
 // subtrees, …) without further schema churn.
 const KIND_CARGO_TARGET: &str = "cargo_target";
+// Slice 2 of #323: `$CARGO_HOME/registry/src/<reg>/<crate>-<vers>/` extracted
+// crate sources. `purge_safety: derived` — cargo regenerates from the
+// matching `.crate` tarball in `registry/cache/` on demand.
+const KIND_CARGO_REGISTRY_SRC: &str = "cargo_registry_src";
 const PURGE_SAFETY_DERIVED: &str = "derived";
+
+/// Taxonomy kinds accepted by `gc list --kind` / `gc purge --kind`
+/// (#323 slice 2). The CLI's clap `ValueEnum` converts into this so the
+/// gc module owns its own taxonomy without re-exporting clap types.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum GcListKindFilter {
+    CargoTarget,
+    CargoRegistrySrc,
+}
+
+impl From<crate::GcListKind> for GcListKindFilter {
+    fn from(value: crate::GcListKind) -> Self {
+        match value {
+            crate::GcListKind::CargoTarget => GcListKindFilter::CargoTarget,
+            crate::GcListKind::CargoRegistrySrc => GcListKindFilter::CargoRegistrySrc,
+        }
+    }
+}
 
 // gc list / gc summary entries follow their own schema version,
 // independent of the global JSON_SCHEMA_VERSION used by other commands.
@@ -197,11 +219,16 @@ struct GcListEntryOutput {
     size_bytes: u64,
     size_human: String,
     file_count: u64,
-    /// Taxonomy discriminator (#323 slice 1). Always `cargo_target` for
-    /// now — later slices emit other kinds from new walkers.
+    /// Taxonomy discriminator (#323 slice 1). `cargo_target` is the
+    /// only kind today; slice 2 also emits `cargo_registry_src`.
     kind: &'static str,
     /// Safety class for purge (#323 slice 1). Always `derived` for now.
     purge_safety: &'static str,
+    /// `<name>@<version>` parsed from the directory name. Present on
+    /// `cargo_registry_src` entries and omitted (via `skip_serializing_if`)
+    /// on `cargo_target` entries that lack the concept (#323 slice 2).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    owner_crate: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -269,7 +296,10 @@ fn fast_directory_size_and_files(path: &std::path::Path) -> (u64, u64) {
         )
 }
 
-pub(crate) fn run_gc_list_command(json: bool) -> Result<(), SoldrError> {
+pub(crate) fn run_gc_list_command(
+    json: bool,
+    kind_filter: Option<GcListKindFilter>,
+) -> Result<(), SoldrError> {
     use rayon::prelude::*;
 
     let paths = SoldrPaths::new()?;
@@ -294,24 +324,40 @@ pub(crate) fn run_gc_list_command(json: bool) -> Result<(), SoldrError> {
         }
     });
 
-    let entries: Vec<GcListEntryOutput> = live_rows
-        .into_par_iter()
-        .map(|row| {
-            let (size_bytes, file_count) = fast_directory_size_and_files(&row.path);
-            let age_seconds = now.saturating_sub(row.last_used);
-            GcListEntryOutput {
-                path: absolute_path_string(&row.path),
-                last_used_unix: row.last_used,
-                age_seconds,
-                age_human: soldr_cache::target_registry::human_age(age_seconds),
-                size_bytes,
-                size_human: soldr_cache::target_registry::human_size(size_bytes),
-                file_count,
-                kind: KIND_CARGO_TARGET,
-                purge_safety: PURGE_SAFETY_DERIVED,
-            }
-        })
-        .collect();
+    let include_targets =
+        kind_filter.is_none() || matches!(kind_filter, Some(GcListKindFilter::CargoTarget));
+    let include_registry_src =
+        kind_filter.is_none() || matches!(kind_filter, Some(GcListKindFilter::CargoRegistrySrc));
+
+    let mut entries: Vec<GcListEntryOutput> = if include_targets {
+        live_rows
+            .into_par_iter()
+            .map(|row| {
+                let (size_bytes, file_count) = fast_directory_size_and_files(&row.path);
+                let age_seconds = now.saturating_sub(row.last_used);
+                GcListEntryOutput {
+                    path: absolute_path_string(&row.path),
+                    last_used_unix: row.last_used,
+                    age_seconds,
+                    age_human: soldr_cache::target_registry::human_age(age_seconds),
+                    size_bytes,
+                    size_human: soldr_cache::target_registry::human_size(size_bytes),
+                    file_count,
+                    kind: KIND_CARGO_TARGET,
+                    purge_safety: PURGE_SAFETY_DERIVED,
+                    owner_crate: None,
+                }
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    if include_registry_src {
+        if let Some(cargo_home) = soldr_core::resolve_cargo_home() {
+            entries.extend(walk_cargo_registry_src(&cargo_home, now));
+        }
+    }
 
     let pruned_missing = registry
         .remove_many(&missing_paths)
@@ -347,6 +393,211 @@ pub(crate) fn run_gc_list_command(json: bool) -> Result<(), SoldrError> {
                 if pruned_missing == 1 { "" } else { "s" }
             );
         }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// cargo_registry_src walker (#323 slice 2).
+// ---------------------------------------------------------------------------
+
+/// Walk `$CARGO_HOME/registry/src/<registry-hash-dir>/<crate>-<vers>/`
+/// and produce a `GcListEntryOutput` per crate directory.
+///
+/// `last_used` is derived from the directory's own filesystem mtime.
+/// Cargo's `~/.cargo/.global-cache` SQLite database has more accurate
+/// last-access data; reading it is tracked as a follow-up (see issue
+/// linked in the slice 2 PR body).
+fn walk_cargo_registry_src(cargo_home: &std::path::Path, now: i64) -> Vec<GcListEntryOutput> {
+    let registry_src = cargo_home.join("registry").join("src");
+    let registry_dirs = match std::fs::read_dir(&registry_src) {
+        Ok(iter) => iter,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut out: Vec<GcListEntryOutput> = Vec::new();
+    for reg_entry in registry_dirs.flatten() {
+        let reg_path = reg_entry.path();
+        let Ok(reg_meta) = reg_entry.metadata() else {
+            continue;
+        };
+        if !reg_meta.is_dir() {
+            continue;
+        }
+        let crate_dirs = match std::fs::read_dir(&reg_path) {
+            Ok(iter) => iter,
+            Err(_) => continue,
+        };
+        for crate_entry in crate_dirs.flatten() {
+            let crate_path = crate_entry.path();
+            let Ok(meta) = crate_entry.metadata() else {
+                continue;
+            };
+            if !meta.is_dir() {
+                continue;
+            }
+            let dir_name = match crate_path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            let owner_crate = parse_crate_owner(&dir_name);
+            let (size_bytes, file_count) = fast_directory_size_and_files(&crate_path);
+            let last_used_unix = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+            let age_seconds = now.saturating_sub(last_used_unix);
+            out.push(GcListEntryOutput {
+                path: absolute_path_string(&crate_path),
+                last_used_unix,
+                age_seconds,
+                age_human: soldr_cache::target_registry::human_age(age_seconds),
+                size_bytes,
+                size_human: soldr_cache::target_registry::human_size(size_bytes),
+                file_count,
+                kind: KIND_CARGO_REGISTRY_SRC,
+                purge_safety: PURGE_SAFETY_DERIVED,
+                owner_crate,
+            });
+        }
+    }
+    out
+}
+
+/// Parse `<crate>-<vers>` directory names into `Some("<crate>@<vers>")`.
+///
+/// Algorithm: find the **last** `'-'` whose suffix starts with an ASCII
+/// digit. That suffix is the semver; everything before is the crate
+/// name. Returns `None` if the input has no such hyphen (e.g. a bare
+/// `serde/` dir from an aberrant layout).
+fn parse_crate_owner(dir_name: &str) -> Option<String> {
+    let bytes = dir_name.as_bytes();
+    for (idx, &b) in bytes.iter().enumerate().rev() {
+        if b == b'-' && idx + 1 < bytes.len() && bytes[idx + 1].is_ascii_digit() {
+            let (name, rest) = dir_name.split_at(idx);
+            // rest includes the leading '-'; strip it.
+            let version = &rest[1..];
+            if name.is_empty() {
+                return None;
+            }
+            return Some(format!("{name}@{version}"));
+        }
+    }
+    None
+}
+
+#[derive(Serialize)]
+struct GcPurgeRegistrySrcOutput {
+    schema_version: u32,
+    command: &'static str,
+    mode: &'static str,
+    kind: &'static str,
+    selected_count: usize,
+    succeeded_count: usize,
+    failed_count: usize,
+    reclaimed_bytes: u64,
+    reclaimed_human: String,
+    deleted_paths: Vec<String>,
+    failures: Vec<GcPurgeRegistrySrcFailure>,
+}
+
+#[derive(Serialize)]
+struct GcPurgeRegistrySrcFailure {
+    path: String,
+    error: String,
+}
+
+/// `soldr gc purge --registry-src --all` — walk
+/// `$CARGO_HOME/registry/src/<reg>/<crate>-<vers>/` and `remove_dir_all`
+/// each entry. Failures are reported in the JSON summary; the command
+/// exits with success even on per-dir failure so callers can scrape
+/// the summary (matches the existing `gc purge` workspace-target
+/// behavior, which writes failures to a log file).
+pub(crate) fn run_gc_purge_registry_src_command(
+    purge_all: bool,
+    json: bool,
+) -> Result<(), SoldrError> {
+    let cargo_home = soldr_core::resolve_cargo_home().ok_or_else(|| {
+        SoldrError::Other(
+            "could not resolve $CARGO_HOME (no env var, no home directory)".to_string(),
+        )
+    })?;
+    let now = soldr_cache::target_registry::current_unix_seconds()
+        .map_err(|e| SoldrError::Other(format!("gc purge --registry-src clock error: {e}")))?;
+    let entries = walk_cargo_registry_src(&cargo_home, now);
+
+    if !json {
+        eprintln!(
+            "soldr gc purge --registry-src: cargo_home={}",
+            cargo_home.display()
+        );
+        eprintln!(
+            "soldr gc purge --registry-src: {} crate source directory{} on disk",
+            entries.len(),
+            if entries.len() == 1 { "y" } else { "ies" }
+        );
+    }
+
+    let mut selected: Vec<&GcListEntryOutput> = Vec::new();
+    for entry in &entries {
+        let should_delete = purge_all
+            || prompt_yes_no_default_yes(&format!(
+                "soldr gc: delete {} ({}, age {}) ? [Y/n] ",
+                entry.path, entry.size_human, entry.age_human,
+            ));
+        if should_delete {
+            selected.push(entry);
+        }
+    }
+
+    let mut deleted_paths: Vec<String> = Vec::new();
+    let mut failures: Vec<GcPurgeRegistrySrcFailure> = Vec::new();
+    let mut reclaimed_bytes: u64 = 0;
+    for entry in &selected {
+        let path = std::path::PathBuf::from(&entry.path);
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => {
+                reclaimed_bytes = reclaimed_bytes.saturating_add(entry.size_bytes);
+                deleted_paths.push(entry.path.clone());
+            }
+            Err(e) => failures.push(GcPurgeRegistrySrcFailure {
+                path: entry.path.clone(),
+                error: e.to_string(),
+            }),
+        }
+    }
+
+    if !json {
+        eprintln!(
+            "soldr gc purge --registry-src: selected {}; succeeded {}; failed {}; reclaimed {}",
+            selected.len(),
+            deleted_paths.len(),
+            failures.len(),
+            soldr_cache::target_registry::human_size(reclaimed_bytes),
+        );
+        for failure in &failures {
+            eprintln!(
+                "soldr gc purge --registry-src: failed to delete {}: {}",
+                failure.path, failure.error
+            );
+        }
+    } else {
+        let output = GcPurgeRegistrySrcOutput {
+            schema_version: GC_JSON_SCHEMA_VERSION,
+            command: "gc",
+            mode: "purge",
+            kind: KIND_CARGO_REGISTRY_SRC,
+            selected_count: selected.len(),
+            succeeded_count: deleted_paths.len(),
+            failed_count: failures.len(),
+            reclaimed_bytes,
+            reclaimed_human: soldr_cache::target_registry::human_size(reclaimed_bytes),
+            deleted_paths,
+            failures,
+        };
+        print_json(&output)?;
     }
     Ok(())
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -335,6 +335,16 @@ enum GcSubcommand {
         /// Emit the stable machine-facing JSON form for this command.
         #[arg(long)]
         json: bool,
+        /// Narrow the purge to a single taxonomy kind. Mutually exclusive
+        /// with `--registry-src`. Accepted values: `cargo_target`,
+        /// `cargo_registry_src` (#323 slice 2).
+        #[arg(long, value_enum, conflicts_with = "registry_src")]
+        kind: Option<GcListKind>,
+        /// Shorthand for `--kind cargo_registry_src`. Walks
+        /// `$CARGO_HOME/registry/src/<reg>/<crate>-<vers>/` and deletes
+        /// the listed directories (#323 slice 2).
+        #[arg(long, conflicts_with = "kind")]
+        registry_src: bool,
     },
     /// List every `target/` directory currently tracked in the soldr
     /// registry, without applying any age or size thresholds.
@@ -342,6 +352,10 @@ enum GcSubcommand {
         /// Emit the stable machine-facing JSON form for this command.
         #[arg(long)]
         json: bool,
+        /// Narrow the listing to a single taxonomy kind (#323 slice 2).
+        /// Accepted values: `cargo_target`, `cargo_registry_src`.
+        #[arg(long, value_enum)]
+        kind: Option<GcListKind>,
     },
     /// Run cargo's native `clean gc` against `$CARGO_HOME`. Requires
     /// a nightly toolchain because the command lives behind the
@@ -358,6 +372,19 @@ enum GcSubcommand {
     /// `clean gc`, then the soldr target purge — and, with
     /// `--aggressive`, a second cargo GC pass with tighter ages.
     Sweep(Box<GcSweepArgs>),
+}
+
+/// Taxonomy kinds accepted by `gc list --kind` / `gc purge --kind`
+/// (#323 slice 2). Unknown values are rejected at clap-parse time.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum GcListKind {
+    /// Workspace `target/` dirs tracked by the soldr registry.
+    #[value(name = "cargo_target")]
+    CargoTarget,
+    /// `$CARGO_HOME/registry/src/<reg>/<crate>-<vers>/` extracted
+    /// crate sources.
+    #[value(name = "cargo_registry_src")]
+    CargoRegistrySrc,
 }
 
 #[derive(clap::Args)]
@@ -752,14 +779,32 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                     older_than,
                     larger_than,
                     json,
-                }) => gc::GcInvocation {
-                    mode: gc::GcMode::Purge { all },
-                    older_than,
-                    larger_than,
-                    json,
-                },
-                Some(GcSubcommand::List { json }) => {
-                    gc::run_gc_list_command(json)?;
+                    kind,
+                    registry_src,
+                }) => {
+                    // #323 slice 2: --registry-src is a shorthand for
+                    // --kind cargo_registry_src; clap already enforces
+                    // mutual exclusion.
+                    let effective_kind = if registry_src {
+                        Some(GcListKind::CargoRegistrySrc)
+                    } else {
+                        kind
+                    };
+                    match effective_kind {
+                        Some(GcListKind::CargoRegistrySrc) => {
+                            gc::run_gc_purge_registry_src_command(all, json)?;
+                            return Ok(());
+                        }
+                        Some(GcListKind::CargoTarget) | None => gc::GcInvocation {
+                            mode: gc::GcMode::Purge { all },
+                            older_than,
+                            larger_than,
+                            json,
+                        },
+                    }
+                }
+                Some(GcSubcommand::List { json, kind }) => {
+                    gc::run_gc_list_command(json, kind.map(Into::into))?;
                     return Ok(());
                 }
                 Some(GcSubcommand::Cargo(args)) => {

--- a/crates/soldr-cli/tests/cli_gc.rs
+++ b/crates/soldr-cli/tests/cli_gc.rs
@@ -219,6 +219,10 @@ fn gc_purge_all_json_reports_error_log_path_and_keeps_failed_row() {
 fn gc_list_json_reports_built_project_target_dir() {
     let cache_root = unique_temp_dir("gc-list-build");
     let project_dir = unique_temp_dir("gc-list-project");
+    // #323 slice 2: sandbox CARGO_HOME so the registry_src walker
+    // doesn't see the developer's real `~/.cargo` and inject
+    // cargo_registry_src entries into this test's assertions.
+    let sandbox_cargo_home = unique_temp_dir("gc-list-build-cargo-home");
 
     fs::write(
         project_dir.join("Cargo.toml"),
@@ -258,6 +262,7 @@ fn gc_list_json_reports_built_project_target_dir() {
     let output = Command::new(soldr_bin)
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &sandbox_cargo_home)
         .output()
         .expect("failed to run soldr gc list --json");
 
@@ -357,6 +362,9 @@ fn gc_list_json_entries_include_kind_and_purge_safety_defaults() {
 fn gc_list_json_prunes_missing_registry_rows_in_one_pass() {
     let cache_root = unique_temp_dir("gc-list-prune");
     let dev_root = cache_root.join("dev-root");
+    // #323 slice 2: sandbox CARGO_HOME so the registry_src walker
+    // doesn't contribute extra entries to entry_count assertions.
+    let sandbox_cargo_home = unique_temp_dir("gc-list-prune-cargo-home");
 
     let live_workspace = dev_root.join("live-project");
     let live_target = live_workspace.join("target");
@@ -386,6 +394,7 @@ fn gc_list_json_prunes_missing_registry_rows_in_one_pass() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &sandbox_cargo_home)
         .output()
         .expect("failed to run soldr gc list --json");
     assert!(

--- a/crates/soldr-cli/tests/cli_gc_registry_src.rs
+++ b/crates/soldr-cli/tests/cli_gc_registry_src.rs
@@ -1,0 +1,294 @@
+//! Integration tests for the cargo_registry_src walker (#323 slice 2).
+//!
+//! These tests sandbox `$CARGO_HOME` to a tempdir so the walker never
+//! touches the developer's real `~/.cargo`.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Construct a fake `$CARGO_HOME` containing a `registry/src/<reg>`
+/// scaffold so the walker has somewhere to look. Returns the
+/// `$CARGO_HOME` root.
+fn fresh_cargo_home(label: &str) -> PathBuf {
+    let cargo_home = unique_temp_dir(label);
+    let reg_root = cargo_home
+        .join("registry")
+        .join("src")
+        .join("index.crates.io-abc123");
+    fs::create_dir_all(&reg_root).expect("failed to create registry src root");
+    cargo_home
+}
+
+/// Seed a single `<crate>-<vers>` directory under a previously-created
+/// `registry/src/<reg>/` root, with one file inside so size is non-zero.
+fn seed_registry_src_crate(cargo_home: &Path, crate_dir_name: &str) -> PathBuf {
+    let reg_root = cargo_home
+        .join("registry")
+        .join("src")
+        .join("index.crates.io-abc123");
+    fs::create_dir_all(&reg_root).expect("failed to create registry src root");
+    let dir = reg_root.join(crate_dir_name);
+    fs::create_dir_all(&dir).expect("failed to create crate dir");
+    fs::write(dir.join("lib.rs"), b"// vendored crate source\n").expect("failed to seed crate file");
+    dir
+}
+
+#[test]
+fn gc_list_json_walks_cargo_registry_src_under_cargo_home() {
+    let cache_root = unique_temp_dir("gc-reg-src-walk-cache");
+    let cargo_home = fresh_cargo_home("gc-reg-src-walk-cargo");
+    let serde_dir = seed_registry_src_crate(&cargo_home, "serde-1.0.213");
+    let chrono_tz_dir = seed_registry_src_crate(&cargo_home, "chrono-tz-0.8.1");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "list", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .output()
+        .expect("failed to run soldr gc list --json");
+
+    assert!(
+        output.status.success(),
+        "gc list --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gc list --json must be JSON");
+    let entries = json["entries"].as_array().expect("entries array");
+
+    let reg_src_entries: Vec<&Value> = entries
+        .iter()
+        .filter(|e| e["kind"].as_str() == Some("cargo_registry_src"))
+        .collect();
+    assert_eq!(
+        reg_src_entries.len(),
+        2,
+        "expected exactly two cargo_registry_src entries, got: {}",
+        serde_json::to_string_pretty(entries).unwrap()
+    );
+
+    let serde_canonical = fs::canonicalize(&serde_dir).unwrap_or(serde_dir.clone());
+    let chrono_tz_canonical = fs::canonicalize(&chrono_tz_dir).unwrap_or(chrono_tz_dir.clone());
+
+    let serde_entry = reg_src_entries
+        .iter()
+        .find(|e| {
+            let p = e["path"].as_str().unwrap_or("");
+            let pb = PathBuf::from(p);
+            pb == serde_dir
+                || pb == serde_canonical
+                || fs::canonicalize(&pb).ok().as_deref() == Some(&serde_canonical)
+        })
+        .expect("serde entry not present in registry_src walk");
+    let chrono_tz_entry = reg_src_entries
+        .iter()
+        .find(|e| {
+            let p = e["path"].as_str().unwrap_or("");
+            let pb = PathBuf::from(p);
+            pb == chrono_tz_dir
+                || pb == chrono_tz_canonical
+                || fs::canonicalize(&pb).ok().as_deref() == Some(&chrono_tz_canonical)
+        })
+        .expect("chrono-tz entry not present in registry_src walk");
+
+    assert_eq!(
+        serde_entry["owner_crate"].as_str(),
+        Some("serde@1.0.213"),
+        "serde owner_crate parsed wrong"
+    );
+    assert_eq!(
+        chrono_tz_entry["owner_crate"].as_str(),
+        Some("chrono-tz@0.8.1"),
+        "chrono-tz owner_crate must use last-hyphen-before-digit rule"
+    );
+
+    for entry in &reg_src_entries {
+        assert_eq!(
+            entry["purge_safety"].as_str(),
+            Some("derived"),
+            "registry_src entries must be derived"
+        );
+        assert!(
+            entry["size_bytes"].as_u64().is_some(),
+            "size_bytes must be present"
+        );
+        assert!(
+            entry["file_count"].as_u64().is_some(),
+            "file_count must be present"
+        );
+    }
+}
+
+#[test]
+fn gc_list_json_kind_filter_narrows_to_cargo_target() {
+    let cache_root = unique_temp_dir("gc-list-kind-target");
+    let target = seed_gc_candidate(&cache_root, "kind-target-project");
+    let cargo_home = fresh_cargo_home("gc-list-kind-target-cargo");
+    let serde_dir = seed_registry_src_crate(&cargo_home, "serde-1.0.213");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "list", "--json", "--kind", "cargo_target"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .output()
+        .expect("failed to run soldr gc list --json --kind cargo_target");
+
+    assert!(
+        output.status.success(),
+        "gc list --kind cargo_target failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gc list must be JSON");
+    let entries = json["entries"].as_array().expect("entries array");
+    assert!(!entries.is_empty(), "expected at least one cargo_target");
+    for entry in entries {
+        assert_eq!(
+            entry["kind"].as_str(),
+            Some("cargo_target"),
+            "filter must drop non-cargo_target entries: {entry}"
+        );
+    }
+    let _ = target;
+    let _ = serde_dir;
+}
+
+#[test]
+fn gc_list_json_kind_filter_narrows_to_cargo_registry_src() {
+    let cache_root = unique_temp_dir("gc-list-kind-regsrc");
+    let _target = seed_gc_candidate(&cache_root, "kind-regsrc-project");
+    let cargo_home = fresh_cargo_home("gc-list-kind-regsrc-cargo");
+    let _serde_dir = seed_registry_src_crate(&cargo_home, "serde-1.0.213");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "list", "--json", "--kind", "cargo_registry_src"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .output()
+        .expect("failed to run soldr gc list --json --kind cargo_registry_src");
+
+    assert!(
+        output.status.success(),
+        "gc list --kind cargo_registry_src failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gc list must be JSON");
+    let entries = json["entries"].as_array().expect("entries array");
+    assert!(
+        !entries.is_empty(),
+        "expected at least one cargo_registry_src entry"
+    );
+    for entry in entries {
+        assert_eq!(
+            entry["kind"].as_str(),
+            Some("cargo_registry_src"),
+            "filter must drop non-registry_src entries: {entry}"
+        );
+    }
+}
+
+#[test]
+fn gc_list_unknown_kind_value_is_rejected() {
+    let cache_root = unique_temp_dir("gc-list-bogus-kind");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "list", "--json", "--kind", "bogus"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr gc list --kind bogus");
+
+    assert!(
+        !output.status.success(),
+        "unknown --kind value must be rejected with non-zero exit"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("bogus"),
+        "stderr should mention the bad --kind value, got: {stderr}"
+    );
+}
+
+#[test]
+fn gc_purge_registry_src_all_deletes_walked_dirs() {
+    let cache_root = unique_temp_dir("gc-purge-regsrc-cache");
+    let cargo_home = fresh_cargo_home("gc-purge-regsrc-cargo");
+    let serde_dir = seed_registry_src_crate(&cargo_home, "serde-1.0.213");
+    assert!(serde_dir.exists(), "precondition: seeded dir must exist");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "purge", "--registry-src", "--all", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .output()
+        .expect("failed to run soldr gc purge --registry-src --all");
+
+    assert!(
+        output.status.success(),
+        "gc purge --registry-src --all failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !serde_dir.exists(),
+        "registry_src dir {} must be removed",
+        serde_dir.display()
+    );
+}
+
+#[test]
+fn gc_purge_without_kind_does_not_touch_registry_src() {
+    let cache_root = unique_temp_dir("gc-purge-default-cache");
+    let target = seed_gc_candidate(&cache_root, "default-purge-project");
+    let cargo_home = fresh_cargo_home("gc-purge-default-cargo");
+    let serde_dir = seed_registry_src_crate(&cargo_home, "serde-1.0.213");
+    assert!(serde_dir.exists());
+    assert!(target.exists());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "gc",
+            "purge",
+            "--all",
+            "--older-than",
+            "1s",
+            "--larger-than",
+            "1B",
+            "--json",
+        ])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .output()
+        .expect("failed to run soldr gc purge --all (default)");
+
+    assert!(
+        output.status.success(),
+        "gc purge --all failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Back-compat: registry_src must be untouched without --kind/--registry-src.
+    assert!(
+        serde_dir.exists(),
+        "registry_src dir {} must survive default purge (back-compat)",
+        serde_dir.display()
+    );
+
+    // The cargo_target row should have been processed; the seeded dir is deleted.
+    assert!(
+        !target.exists(),
+        "cargo_target {} should have been deleted by default purge",
+        target.display()
+    );
+}

--- a/crates/soldr-cli/tests/cli_gc_registry_src.rs
+++ b/crates/soldr-cli/tests/cli_gc_registry_src.rs
@@ -36,7 +36,8 @@ fn seed_registry_src_crate(cargo_home: &Path, crate_dir_name: &str) -> PathBuf {
     fs::create_dir_all(&reg_root).expect("failed to create registry src root");
     let dir = reg_root.join(crate_dir_name);
     fs::create_dir_all(&dir).expect("failed to create crate dir");
-    fs::write(dir.join("lib.rs"), b"// vendored crate source\n").expect("failed to seed crate file");
+    fs::write(dir.join("lib.rs"), b"// vendored crate source\n")
+        .expect("failed to seed crate file");
     dir
 }
 


### PR DESCRIPTION
Refs #323 (slice 2 of 5; don't close).

This is PR 2 of the typed-taxonomy GC rollout outlined in #323. Slice 1 (#348) added the kind/purge_safety discriminator and bumped the gc JSON schema to v2. Slice 2 plugs in the first new walker — `cargo_registry_src` — which the issue calls out as "the highest absolute size win on most dev boxes."

## Summary

- New walker enumerates `\$CARGO_HOME/registry/src/<registry-hash-dir>/<crate>-<vers>/` and surfaces each as a `gc list --json` entry with `kind: "cargo_registry_src"`, `purge_safety: "derived"`.
- New `gc list --kind <KIND>` flag (clap `ValueEnum`: `cargo_target` | `cargo_registry_src`). Unknown values rejected at parse time.
- New `gc purge --registry-src` shorthand + `--kind cargo_registry_src`, mutually exclusive via clap `conflicts_with`. Walks the dirs, `std::fs::remove_dir_all` each one, reports failures in the JSON summary.
- New `owner_crate: Option<String>` field on `GcListEntryOutput` (e.g. `"chrono-tz@0.8.1"`), parsed with the "last hyphen whose suffix starts with a digit" rule. Tagged `#[serde(skip_serializing_if = "Option::is_none")]` so existing `cargo_target` entries are unchanged on the wire.
- Default `gc purge` (no `--kind`, no `--registry-src`) keeps today's `cargo_target`-only behavior — verified by an explicit back-compat test.

## Last-used signal

`last_used_unix` on registry_src entries is derived from the directory's own filesystem mtime. Cargo's `~/.cargo/.global-cache` SQLite database has more accurate last-access data; reading it is intentionally deferred to a follow-up: #349. That follow-up also unlocks accurate auto-GC tier targeting once the rest of #323's auto-GC slices land.

## Test plan

- [x] Six new integration tests in `crates/soldr-cli/tests/cli_gc_registry_src.rs`, each sandboxing `CARGO_HOME` to a tempdir so the walker never reaches the developer's real `~/.cargo`.
- [x] Two existing `gc list` integration tests in `cli_gc.rs` updated to sandbox `CARGO_HOME` so the walker doesn't pollute their assertions.
- [x] `cargo build -p soldr-cli` — green.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green.
- [x] `cargo fmt --all -- --check` — green.

## CI note

The `Verify setup-soldr pin` CI step has been red on `main` since before this branch was cut — it's not introduced by this PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>