### PR TITLE
chore: dogfood soldr via test script + add tool_guard pre-tool hook

### DIFF
--- a/.claude/hooks/test_tool_guard.py
+++ b/.claude/hooks/test_tool_guard.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
-"""Unit tests for the shell command tool guard hook."""
+"""Unit tests for the shell command tool guard hook.
+
+Run via uv (sibling-module resolution works because cwd is the hook dir):
+
+    uv run --no-project --directory .claude/hooks python -m unittest test_tool_guard
+"""
 
 import unittest
 
-from tool_guard import check_command, extract_command
+from tool_guard import check_command, extract_command  # type: ignore[import-not-found]
 
 
 class ToolGuardTests(unittest.TestCase):

--- a/.claude/hooks/test_tool_guard.py
+++ b/.claude/hooks/test_tool_guard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 """Unit tests for the shell command tool guard hook.
 
 Run via uv (sibling-module resolution works because cwd is the hook dir):

--- a/.claude/hooks/test_tool_guard.py
+++ b/.claude/hooks/test_tool_guard.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Unit tests for the shell command tool guard hook."""
+
+import unittest
+
+from tool_guard import check_command, extract_command
+
+
+class ToolGuardTests(unittest.TestCase):
+    def test_blocks_bare_rust_tool(self):
+        result = check_command("cargo test")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "cargo")
+
+    def test_blocks_bare_rustc(self):
+        result = check_command("rustc --version")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "rustc")
+
+    def test_blocks_bare_rustfmt(self):
+        result = check_command("rustfmt --check src/lib.rs")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "rustfmt")
+
+    def test_blocks_bare_clippy_driver(self):
+        result = check_command("clippy-driver --version")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "clippy-driver")
+
+    def test_blocks_bare_cargo_clippy(self):
+        result = check_command("cargo-clippy --version")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "cargo-clippy")
+
+    def test_blocks_bare_cargo_fmt(self):
+        result = check_command("cargo-fmt --check")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "cargo-fmt")
+
+    def test_blocks_uv_run_rust_tool_shim(self):
+        commands = (
+            "uv run cargo test",
+            "uv run -- cargo test",
+            "uv run --offline cargo build",
+            "uv run --with foo cargo test",
+            "uv run --with=foo cargo test",
+            "uv run --isolated cargo build",
+            "uv run --project . cargo check",
+            "uv run -q cargo test",
+            "uv run -- --offline cargo test",
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                result = check_command(command)
+                self.assertIsNotNone(result)
+                self.assertEqual(result[0], "cargo")
+
+    def test_allows_soldr_wrapped_rust_tool(self):
+        self.assertIsNone(check_command("soldr cargo test"))
+        self.assertIsNone(check_command("soldr --no-cache cargo build"))
+        self.assertIsNone(check_command("soldr rustc --version"))
+        self.assertIsNone(check_command("soldr rustfmt --check src/lib.rs"))
+        self.assertIsNone(check_command("uv run soldr cargo test"))
+        self.assertIsNone(check_command("uv run soldr rustfmt --check src/lib.rs"))
+
+    def test_blocks_bare_python(self):
+        result = check_command("python ci/script.py")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "python")
+
+    def test_blocks_bare_python3(self):
+        result = check_command("python3 ci/script.py")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "python3")
+
+    def test_allows_uv_run_script(self):
+        self.assertIsNone(check_command("uv run script.py"))
+        self.assertIsNone(check_command("uv run python script.py"))
+
+    def test_blocks_bare_pip(self):
+        result = check_command("pip install foo")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "pip")
+        # Suggestion should mention `uv pip install foo`.
+        self.assertIn("uv pip install foo", result[1])
+
+    def test_blocks_bare_pip3(self):
+        result = check_command("pip3 install foo")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "pip3")
+
+    def test_allows_uv_pip(self):
+        self.assertIsNone(check_command("uv pip install foo"))
+        self.assertIsNone(check_command("uv pip list"))
+
+    def test_extracts_powershell_command_field(self):
+        command = extract_command({
+            "tool_name": "PowerShell",
+            "tool_input": {"command": "cargo test"},
+        })
+        self.assertEqual(command, "cargo test")
+
+    def test_extracts_shell_script_field(self):
+        command = extract_command({
+            "tool_name": "Shell",
+            "tool_input": {"script": "cargo test"},
+        })
+        self.assertEqual(command, "cargo test")
+
+    def test_allows_unrelated_command(self):
+        self.assertIsNone(check_command("ls -la"))
+        self.assertIsNone(check_command("git status"))
+
+    def test_blocks_compound_command(self):
+        # A bare cargo invocation hidden behind && must still trip the guard.
+        result = check_command("git status && cargo test")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "cargo")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tool_guard.py
+++ b/.claude/hooks/tool_guard.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: blocks bare Rust commands and bare python/pip.
+
+All cargo/rustc/rustfmt must go through soldr (ensures correct toolchain).
+All python must go through uv (ensures correct environment).
+
+Exit codes:
+  0 - Allow (outputs JSON hookSpecificOutput to deny if needed)
+"""
+
+import json
+import re
+import sys
+
+
+RUST_TOOLS = {"cargo", "rustc", "rustfmt", "clippy-driver", "cargo-clippy", "cargo-fmt"}
+PYTHON_TOOLS = {"python", "python3", "pip", "pip3"}
+
+SOLDR_PREFIXES = ("soldr ", "uv run soldr ")
+UV_RUN_PREFIX = "uv run "
+UV_PIP_PREFIX = "uv pip "
+UV_RUN_FLAGS_WITH_VALUES = {
+    "--config-setting",
+    "--directory",
+    "--env-file",
+    "--extra",
+    "--find-links",
+    "--from",
+    "--group",
+    "--index-url",
+    "--no-extra",
+    "--no-group",
+    "--only-group",
+    "--project",
+    "--python",
+    "--with",
+    "--with-editable",
+    "--with-requirements",
+    "-m",
+    "-p",
+}
+
+
+def uv_run_target(parts):
+    """Return the uv-run command target after leading uv options."""
+    index = 2
+    while index < len(parts):
+        token = parts[index]
+        if token == "--":
+            index += 1
+            continue
+        if token in UV_RUN_FLAGS_WITH_VALUES:
+            index += 2
+            continue
+        if any(token.startswith(f"{flag}=") for flag in UV_RUN_FLAGS_WITH_VALUES):
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token
+    return ""
+
+
+def check_command(command):
+    """Check a command string for forbidden bare invocations.
+
+    Returns (tool, reason) if forbidden, None if allowed.
+    """
+    # ── Per-segment checks ───────────────────────────────────────────
+    segments = re.split(r"&&|\|\||;", command)
+
+    for seg in segments:
+        seg = seg.strip()
+        if not seg:
+            continue
+
+        # Skip if Rust tooling is explicitly routed through soldr.
+        if any(seg.startswith(p) for p in SOLDR_PREFIXES):
+            continue
+
+        if seg.startswith(UV_PIP_PREFIX):
+            continue
+
+        first_word = seg.split()[0] if seg.split() else ""
+
+        if seg.startswith(UV_RUN_PREFIX):
+            parts = seg.split()
+            # `uv run soldr ...` was handled above. Block the old `uv run cargo`
+            # console-script shim path so Rust tooling has one canonical entry.
+            run_target = uv_run_target(parts)
+            if run_target in RUST_TOOLS:
+                return (
+                    run_target,
+                    f"Use `uv run soldr {run_target} ...` instead of "
+                    f"`uv run {run_target} ...`. soldr resolves the checked-in "
+                    f"Rust toolchain directly via rustup.",
+                )
+            continue
+
+        if first_word in RUST_TOOLS:
+            return (
+                first_word,
+                f"Use `soldr {first_word} ...` or "
+                f"`uv run soldr {first_word} ...` instead of bare "
+                f"`{first_word}`. soldr resolves the checked-in Rust toolchain "
+                f"directly via rustup.",
+            )
+
+        if first_word in PYTHON_TOOLS:
+            if first_word.startswith("pip"):
+                suggestion = f"uv pip {' '.join(seg.split()[1:])}" if len(seg.split()) > 1 else "uv pip ..."
+                return (
+                    first_word,
+                    f"Use `{suggestion}` instead of bare `{first_word}`. "
+                    f"All pip operations must go through uv.",
+                )
+            return (
+                first_word,
+                f"Use `uv run ...` instead of bare `{first_word}`. "
+                f"All Python must be executed through uv.",
+            )
+
+    return None
+
+
+def deny(reason):
+    """Output a JSON deny response."""
+    json.dump({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }, sys.stdout)
+
+
+def extract_command(data):
+    """Best-effort extraction across shell tool event shapes."""
+    tool_input = data.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        return ""
+    for key in ("command", "script", "cmd"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    if tool_name not in {"Bash", "Shell", "PowerShell"}:
+        sys.exit(0)
+
+    command = extract_command(data)
+    if not command:
+        sys.exit(0)
+
+    result = check_command(command)
+    if result:
+        _, reason = result
+        deny(reason)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/tool_guard.py
+++ b/.claude/hooks/tool_guard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 """PreToolUse hook: blocks bare Rust commands and bare python/pip.
 
 All cargo/rustc/rustfmt must go through soldr (ensures correct toolchain).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project python .claude/hooks/tool_guard.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script .claude/hooks/tool_guard.py",
             "timeout": 5
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Shell|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project python .claude/hooks/tool_guard.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         run: soldr cargo test --workspace --lib --locked
 
       - name: Run CLI smoke tests
-        run: soldr cargo test -p soldr-cli --test cli --locked
+        run: soldr cargo test -p soldr-cli --tests --locked
 
       - name: Run fetch integration test
         run: soldr cargo test -p soldr-fetch --test fetch_crgx --locked
@@ -125,7 +125,7 @@ jobs:
         run: soldr cargo test --workspace --lib --locked
 
       - name: Run CLI smoke tests
-        run: soldr cargo test -p soldr-cli --test cli --locked
+        run: soldr cargo test -p soldr-cli --tests --locked
 
       - name: Run fetch integration test
         run: soldr cargo test -p soldr-fetch --test fetch_crgx --locked
@@ -162,7 +162,7 @@ jobs:
         run: soldr cargo test --workspace --lib --locked
 
       - name: Run CLI smoke tests
-        run: soldr cargo test -p soldr-cli --test cli --locked
+        run: soldr cargo test -p soldr-cli --tests --locked
 
       - name: Verify Windows defaults to MSVC under Git Bash
         if: runner.os == 'Windows'

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           Remove-Item Env:ZCCACHE_CACHE_DIR -ErrorAction SilentlyContinue
           $timer = [Diagnostics.Stopwatch]::StartNew()
-          soldr --no-cache cargo test -p soldr-cli --test cli --locked
+          soldr --no-cache cargo test -p soldr-cli --tests --locked
           $exitCode = $LASTEXITCODE
           $timer.Stop()
           Write-Host ([string]::Format([Globalization.CultureInfo]::InvariantCulture, "dogfood-test-seconds={0:F3}", $timer.Elapsed.TotalSeconds))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,4 +123,4 @@ The repo builds itself through soldr so every contributor populates and hits the
 
 - `./test` routes every `cargo` step through `soldr cargo` when `soldr` is on `PATH`. On a fresh checkout without soldr the script prints a one-line warning to stderr and falls back to bare `cargo` (no caching).
 - `.claude/hooks/tool_guard.py` is a `PreToolUse` guard wired in `.claude/settings.json`. It denies bare `cargo`, `rustc`, `rustfmt`, `clippy-driver`, `cargo-clippy`, `cargo-fmt`, `python`, `python3`, `pip`, `pip3` in Claude Code shell tools. Route through `soldr cargo ...` / `uv run ...` / `uv pip ...` to satisfy it.
-- Unit tests for the hook live next to it: `python3 -m unittest .claude/hooks/test_tool_guard.py` (or `uv run --no-project python -m unittest ...`).
+- Unit tests for the hook live next to it: `uv run --no-project --directory .claude/hooks python -m unittest test_tool_guard`. The `--directory` flag puts `tool_guard.py` on `sys.path` so the sibling import resolves.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,11 @@ Anything not registered falls through the generic External subcommand, which res
 - `docs/API.md` — Full CLI specification, environment variables, cache layout
 - `docs/TRUST_BOUNDARIES.md` — Runtime fetch policy, what integrity is enforced, what remains follow-up
 - `README.md` — User-facing motivation and prior art comparison
+
+## Dogfooding
+
+The repo builds itself through soldr so every contributor populates and hits the same cache.
+
+- `./test` routes every `cargo` step through `soldr cargo` when `soldr` is on `PATH`. On a fresh checkout without soldr the script prints a one-line warning to stderr and falls back to bare `cargo` (no caching).
+- `.claude/hooks/tool_guard.py` is a `PreToolUse` guard wired in `.claude/settings.json`. It denies bare `cargo`, `rustc`, `rustfmt`, `clippy-driver`, `cargo-clippy`, `cargo-fmt`, `python`, `python3`, `pip`, `pip3` in Claude Code shell tools. Route through `soldr cargo ...` / `uv run ...` / `uv pip ...` to satisfy it.
+- Unit tests for the hook live next to it: `python3 -m unittest .claude/hooks/test_tool_guard.py` (or `uv run --no-project python -m unittest ...`).

--- a/test
+++ b/test
@@ -9,10 +9,17 @@ run_step() {
   "$@"
 }
 
-run_step "Build workspace" cargo build --workspace --locked
-run_step "Run library tests" cargo test --workspace --lib --locked
-run_step "Run CLI smoke tests" cargo test -p soldr-cli --test cli --locked
-run_step "Run fetch integration test" cargo test -p soldr-fetch --test fetch_crgx --locked
+if command -v soldr >/dev/null 2>&1; then
+  CARGO=(soldr cargo)
+else
+  echo "warning: soldr not on PATH; falling back to bare cargo (no caching). Install soldr to get the caching path." >&2
+  CARGO=(cargo)
+fi
+
+run_step "Build workspace" "${CARGO[@]}" build --workspace --locked
+run_step "Run library tests" "${CARGO[@]}" test --workspace --lib --locked
+run_step "Run CLI smoke tests" "${CARGO[@]}" test -p soldr-cli --tests --locked
+run_step "Run fetch integration test" "${CARGO[@]}" test -p soldr-fetch --test fetch_crgx --locked
 run_step "Run Python wrapper tests" uv run pytest -n auto tests -v --durations=0
 
 printf '\nPipeline complete.\n'


### PR DESCRIPTION
## Summary

- Route every cargo step in `./test` through `soldr cargo` when `soldr` is on `PATH`; print a one-line stderr warning and fall back to bare `cargo` on fresh checkouts without soldr. The repo now dogfoods its own caching tool.
- Fix a pre-existing bug: PR #340 deleted `crates/soldr-cli/tests/cli.rs` (split into per-feature `tests/cli_*.rs`), but four call sites still passed `--test cli` to `cargo test` (no matching binary → fails). Replace each with `--tests` to run all integration test binaries — closer to the original "CLI smoke tests" intent. Sites fixed: `./test`, three steps in `.github/workflows/ci.yml`, one step in `.github/workflows/setup-soldr-action.yml`.
- Add `.claude/hooks/tool_guard.py` PreToolUse hook adapted from `fbuild/ci/hooks/tool_guard.py` (minus the fbuild-specific `bench/`/`tests/` `.py` block). Denies bare `cargo`, `rustc`, `rustfmt`, `clippy-driver`, `cargo-clippy`, `cargo-fmt`, `python`, `python3`, `pip`, `pip3` and suggests `soldr <tool>` / `uv run` / `uv pip`. Wired in `.claude/settings.json` on PreToolUse for `Bash|Shell|PowerShell`. Stdlib-only Python.
- Append a short `## Dogfooding` section to `CLAUDE.md` documenting both behaviors.

## Why

- We want every contributor build to populate (and benefit from) the cache that soldr itself provides.
- The pre-existing `--test cli` selector has been broken since PR #340 landed — CI build matrix has been failing the test step on every push to main since.
- Enforce the routing convention in interactive Claude Code sessions so agents and humans alike learn the right path.

## Test plan

- [x] `python3 -m unittest test_tool_guard.py` — 18 tests, all pass (RED→GREEN).
- [x] End-to-end smoke test the hook via piped JSON: `cargo test` → deny JSON; `soldr cargo test` → silent allow; `pip install foo` → deny with `uv pip install foo` suggestion; `uv pip install foo` → allow; `python script.py` → deny; `uv run script.py` → allow; PowerShell tool_name → matched; Edit tool_name → skipped.
- [x] `bash -n test` passes.
- [x] `bash -x ./test` with soldr on PATH → routes through `soldr cargo`. With minimal `PATH=/usr/bin:/bin` → prints the fallback warning and uses bare `cargo`.
- [ ] CI on this branch will exercise the new `--tests` selector across the lint / linux / macos / windows matrices.

## Notes

- This PR is config + scripts + docs only — no Rust source, no `Cargo.toml`, no `Cargo.lock`, no production code changes.
- The CI `Verify setup-soldr pin` step has been failing on main due to inherited pin drift; that is **separate** from the `--test cli` bug this PR fixes. The `--tests` change here may finally let the build matrix get past the test step on green-pin runs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>