### PR TITLE
feat(zccache): enable parent-cache (worktree) sharing + benchmark workflow (#352)

### DIFF
--- a/.github/workflows/parent-cache-bench.yml
+++ b/.github/workflows/parent-cache-bench.yml
@@ -1,0 +1,193 @@
+name: Parent Cache Bench
+
+# Tier L1.x benchmark for issue #352.
+#
+# Proves the parent-cache (worktree-cache-sharing) speedup is real and acts
+# as a regression gate. Three timed `soldr cargo build` invocations:
+#
+#   A) Build the original checkout to populate zccache.
+#   B) Build a second worktree at the same commit with
+#      ZCCACHE_PATH_REMAP=auto. Should hit the parent cache and finish
+#      much faster than (A).
+#   C) Build the same worktree as control with SOLDR_PATH_REMAP=off and
+#      a fresh target/. Should NOT hit the parent cache, validating that
+#      the speedup is attributable to the remap.
+#
+# The ratio C/B is the parent-cache speedup. Default fail threshold: 5x.
+
+on:
+  workflow_dispatch:
+    inputs:
+      threshold_ratio:
+        description: "Warm-with-remap build must be at least this many times faster than the no-remap control."
+        required: true
+        default: "5"
+        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - "crates/soldr-cache/src/lib.rs"
+      - "crates/soldr-cli/src/zccache.rs"
+      - ".github/workflows/parent-cache-bench.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    name: Parent cache speedup
+    runs-on: ubuntu-24.04
+    env:
+      THRESHOLD: ${{ inputs.threshold_ratio || '5' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Pinned to the current @v0 expected by
+      # .github/scripts/verify_setup_soldr_pin.py.
+      - name: Set up soldr
+        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
+
+      - name: Isolate zccache state
+        id: isolate
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Force a fresh zccache root so the only cache state in the
+          # benchmark comes from worktree A's build. Without this, a
+          # populated cache restored by setup-soldr (or left over from
+          # the runner image) would mask whether worktree B is hitting
+          # the parent cache or its own warm cache.
+          cache_root="$(mktemp -d "${RUNNER_TEMP}/soldr-bench-cache.XXXXXX")"
+          echo "SOLDR_CACHE_DIR=${cache_root}" >> "$GITHUB_ENV"
+          echo "cache_root=${cache_root}" >> "$GITHUB_OUTPUT"
+          echo "isolated SOLDR_CACHE_DIR=${cache_root}"
+
+      - name: Build worktree A (populate parent cache)
+        id: build_a
+        shell: bash
+        run: |
+          set -euo pipefail
+          start=$(date +%s)
+          soldr cargo build --workspace --locked --release
+          end=$(date +%s)
+          seconds=$((end - start))
+          echo "seconds=${seconds}" >> "$GITHUB_OUTPUT"
+          echo "worktree A build: ${seconds}s"
+
+      - name: Add worktree B
+        id: add_b
+        shell: bash
+        run: |
+          set -euo pipefail
+          worktree_b="${RUNNER_TEMP}/worktree-b"
+          # Clean any leftover from a previous run on the same runner.
+          if [ -e "${worktree_b}" ]; then
+            rm -rf "${worktree_b}"
+          fi
+          git worktree add "${worktree_b}" HEAD
+          echo "worktree_b=${worktree_b}" >> "$GITHUB_OUTPUT"
+
+      - name: Build worktree B with ZCCACHE_PATH_REMAP=auto (warm)
+        id: build_b_warm
+        shell: bash
+        env:
+          WORKTREE_B: ${{ steps.add_b.outputs.worktree_b }}
+        run: |
+          set -euo pipefail
+          cd "${WORKTREE_B}"
+          # Explicit even though this is the default — pinning the env
+          # here means a future flip in defaults does not silently change
+          # what this benchmark measures.
+          start=$(date +%s)
+          env ZCCACHE_PATH_REMAP=auto soldr cargo build --workspace --locked --release
+          end=$(date +%s)
+          seconds=$((end - start))
+          echo "seconds=${seconds}" >> "$GITHUB_OUTPUT"
+          echo "worktree B warm-with-remap build: ${seconds}s"
+
+      - name: Reset worktree B target/ for control run
+        shell: bash
+        env:
+          WORKTREE_B: ${{ steps.add_b.outputs.worktree_b }}
+        run: |
+          set -euo pipefail
+          rm -rf "${WORKTREE_B}/target"
+
+      - name: Build worktree B with SOLDR_PATH_REMAP=off (control)
+        id: build_b_control
+        shell: bash
+        env:
+          WORKTREE_B: ${{ steps.add_b.outputs.worktree_b }}
+        run: |
+          set -euo pipefail
+          cd "${WORKTREE_B}"
+          start=$(date +%s)
+          env SOLDR_PATH_REMAP=off soldr cargo build --workspace --locked --release
+          end=$(date +%s)
+          seconds=$((end - start))
+          echo "seconds=${seconds}" >> "$GITHUB_OUTPUT"
+          echo "worktree B control (no remap) build: ${seconds}s"
+
+      - name: Compare timings
+        id: compare
+        shell: bash
+        env:
+          A_SECONDS: ${{ steps.build_a.outputs.seconds }}
+          WARM_SECONDS: ${{ steps.build_b_warm.outputs.seconds }}
+          CONTROL_SECONDS: ${{ steps.build_b_control.outputs.seconds }}
+        run: |
+          set -euo pipefail
+          # Use awk for the ratio so we avoid bash's integer-only math.
+          ratio=$(awk -v c="${CONTROL_SECONDS}" -v w="${WARM_SECONDS}" \
+            'BEGIN { if (w <= 0) { print "inf" } else { printf "%.2f\n", c / w } }')
+          echo "ratio=${ratio}" >> "$GITHUB_OUTPUT"
+          echo ""
+          echo "=== Parent-cache benchmark results ==="
+          echo "  worktree A (populate):           ${A_SECONDS}s"
+          echo "  worktree B warm (PATH_REMAP=auto): ${WARM_SECONDS}s"
+          echo "  worktree B control (PATH_REMAP off, fresh target/): ${CONTROL_SECONDS}s"
+          echo "  speedup ratio (control / warm):  ${ratio}x"
+          echo "  fail threshold:                  ${THRESHOLD}x"
+
+      - name: Write job summary
+        if: ${{ always() }}
+        shell: bash
+        env:
+          A_SECONDS: ${{ steps.build_a.outputs.seconds }}
+          WARM_SECONDS: ${{ steps.build_b_warm.outputs.seconds }}
+          CONTROL_SECONDS: ${{ steps.build_b_control.outputs.seconds }}
+          RATIO: ${{ steps.compare.outputs.ratio }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Parent-cache benchmark (issue #352)"
+            echo ""
+            echo "| Step | Wall seconds |"
+            echo "|---|---|"
+            echo "| Worktree A (populate) | \`${A_SECONDS:-n/a}\` |"
+            echo "| Worktree B warm with \`ZCCACHE_PATH_REMAP=auto\` | \`${WARM_SECONDS:-n/a}\` |"
+            echo "| Worktree B control with \`SOLDR_PATH_REMAP=off\` | \`${CONTROL_SECONDS:-n/a}\` |"
+            echo ""
+            echo "Speedup ratio (control / warm): \`${RATIO:-n/a}\`"
+            echo ""
+            echo "Fail threshold: \`${THRESHOLD}x\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce speedup threshold
+        shell: bash
+        env:
+          RATIO: ${{ steps.compare.outputs.ratio }}
+        run: |
+          set -euo pipefail
+          if [ "${RATIO}" = "inf" ]; then
+            echo "warm build measured 0s; treating as pass."
+            exit 0
+          fi
+          ok=$(awk -v r="${RATIO}" -v t="${THRESHOLD}" \
+            'BEGIN { print (r + 0 >= t + 0) ? "yes" : "no" }')
+          if [ "${ok}" != "yes" ]; then
+            echo "Parent-cache speedup ${RATIO}x is below threshold ${THRESHOLD}x" >&2
+            exit 1
+          fi
+          echo "Parent-cache speedup ${RATIO}x meets threshold ${THRESHOLD}x"

--- a/.github/workflows/parent-cache-bench.yml
+++ b/.github/workflows/parent-cache-bench.yml
@@ -3,21 +3,19 @@ name: Parent Cache Bench
 # Tier L1.x benchmark for issue #352.
 #
 # Proves the parent-cache (worktree-cache-sharing) speedup is real and acts
-# as a regression gate. Three timed `soldr cargo build` invocations:
+# as a regression gate. All real work lives in bench/parent_cache_bench.py
+# so a local developer can run the exact same benchmark by hand:
 #
-#   A) Build the original checkout to populate zccache.
-#   B) Build a second worktree at the same commit with
-#      ZCCACHE_PATH_REMAP=auto. Should hit the parent cache and finish
-#      much faster than (A).
-#   C) Build the same worktree as control with SOLDR_PATH_REMAP=off and
-#      a fresh target/. Should NOT hit the parent cache, validating that
-#      the speedup is attributable to the remap.
-#
-# The ratio C/B is the parent-cache speedup. Default fail threshold: 5x.
+#   uv run --script bench/parent_cache_bench.py --target zccache --threshold 5
 
 on:
   workflow_dispatch:
     inputs:
+      target:
+        description: "Build target ('self', 'zccache', or 'repo:URL')."
+        required: true
+        default: "self"
+        type: string
       threshold_ratio:
         description: "Warm-with-remap build must be at least this many times faster than the no-remap control."
         required: true
@@ -30,6 +28,7 @@ on:
       - "crates/soldr-cache/src/lib.rs"
       - "crates/soldr-cli/src/zccache.rs"
       - ".github/workflows/parent-cache-bench.yml"
+      - "bench/parent_cache_bench.py"
 
 permissions:
   contents: read
@@ -39,155 +38,23 @@ jobs:
     name: Parent cache speedup
     runs-on: ubuntu-24.04
     env:
+      TARGET: ${{ inputs.target || 'self' }}
       THRESHOLD: ${{ inputs.threshold_ratio || '5' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
 
       # Pinned to the current @v0 expected by
       # .github/scripts/verify_setup_soldr_pin.py.
       - name: Set up soldr
         uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
 
-      - name: Isolate zccache state
-        id: isolate
+      - name: Run parent-cache benchmark
         shell: bash
         run: |
           set -euo pipefail
-          # Force a fresh zccache root so the only cache state in the
-          # benchmark comes from worktree A's build. Without this, a
-          # populated cache restored by setup-soldr (or left over from
-          # the runner image) would mask whether worktree B is hitting
-          # the parent cache or its own warm cache.
-          cache_root="$(mktemp -d "${RUNNER_TEMP}/soldr-bench-cache.XXXXXX")"
-          echo "SOLDR_CACHE_DIR=${cache_root}" >> "$GITHUB_ENV"
-          echo "cache_root=${cache_root}" >> "$GITHUB_OUTPUT"
-          echo "isolated SOLDR_CACHE_DIR=${cache_root}"
-
-      - name: Build worktree A (populate parent cache)
-        id: build_a
-        shell: bash
-        run: |
-          set -euo pipefail
-          start=$(date +%s)
-          soldr cargo build --workspace --locked --release
-          end=$(date +%s)
-          seconds=$((end - start))
-          echo "seconds=${seconds}" >> "$GITHUB_OUTPUT"
-          echo "worktree A build: ${seconds}s"
-
-      - name: Add worktree B
-        id: add_b
-        shell: bash
-        run: |
-          set -euo pipefail
-          worktree_b="${RUNNER_TEMP}/worktree-b"
-          # Clean any leftover from a previous run on the same runner.
-          if [ -e "${worktree_b}" ]; then
-            rm -rf "${worktree_b}"
-          fi
-          git worktree add "${worktree_b}" HEAD
-          echo "worktree_b=${worktree_b}" >> "$GITHUB_OUTPUT"
-
-      - name: Build worktree B with ZCCACHE_PATH_REMAP=auto (warm)
-        id: build_b_warm
-        shell: bash
-        env:
-          WORKTREE_B: ${{ steps.add_b.outputs.worktree_b }}
-        run: |
-          set -euo pipefail
-          cd "${WORKTREE_B}"
-          # Explicit even though this is the default — pinning the env
-          # here means a future flip in defaults does not silently change
-          # what this benchmark measures.
-          start=$(date +%s)
-          env ZCCACHE_PATH_REMAP=auto soldr cargo build --workspace --locked --release
-          end=$(date +%s)
-          seconds=$((end - start))
-          echo "seconds=${seconds}" >> "$GITHUB_OUTPUT"
-          echo "worktree B warm-with-remap build: ${seconds}s"
-
-      - name: Reset worktree B target/ for control run
-        shell: bash
-        env:
-          WORKTREE_B: ${{ steps.add_b.outputs.worktree_b }}
-        run: |
-          set -euo pipefail
-          rm -rf "${WORKTREE_B}/target"
-
-      - name: Build worktree B with SOLDR_PATH_REMAP=off (control)
-        id: build_b_control
-        shell: bash
-        env:
-          WORKTREE_B: ${{ steps.add_b.outputs.worktree_b }}
-        run: |
-          set -euo pipefail
-          cd "${WORKTREE_B}"
-          start=$(date +%s)
-          env SOLDR_PATH_REMAP=off soldr cargo build --workspace --locked --release
-          end=$(date +%s)
-          seconds=$((end - start))
-          echo "seconds=${seconds}" >> "$GITHUB_OUTPUT"
-          echo "worktree B control (no remap) build: ${seconds}s"
-
-      - name: Compare timings
-        id: compare
-        shell: bash
-        env:
-          A_SECONDS: ${{ steps.build_a.outputs.seconds }}
-          WARM_SECONDS: ${{ steps.build_b_warm.outputs.seconds }}
-          CONTROL_SECONDS: ${{ steps.build_b_control.outputs.seconds }}
-        run: |
-          set -euo pipefail
-          # Use awk for the ratio so we avoid bash's integer-only math.
-          ratio=$(awk -v c="${CONTROL_SECONDS}" -v w="${WARM_SECONDS}" \
-            'BEGIN { if (w <= 0) { print "inf" } else { printf "%.2f\n", c / w } }')
-          echo "ratio=${ratio}" >> "$GITHUB_OUTPUT"
-          echo ""
-          echo "=== Parent-cache benchmark results ==="
-          echo "  worktree A (populate):           ${A_SECONDS}s"
-          echo "  worktree B warm (PATH_REMAP=auto): ${WARM_SECONDS}s"
-          echo "  worktree B control (PATH_REMAP off, fresh target/): ${CONTROL_SECONDS}s"
-          echo "  speedup ratio (control / warm):  ${ratio}x"
-          echo "  fail threshold:                  ${THRESHOLD}x"
-
-      - name: Write job summary
-        if: ${{ always() }}
-        shell: bash
-        env:
-          A_SECONDS: ${{ steps.build_a.outputs.seconds }}
-          WARM_SECONDS: ${{ steps.build_b_warm.outputs.seconds }}
-          CONTROL_SECONDS: ${{ steps.build_b_control.outputs.seconds }}
-          RATIO: ${{ steps.compare.outputs.ratio }}
-        run: |
-          set -euo pipefail
-          {
-            echo "### Parent-cache benchmark (issue #352)"
-            echo ""
-            echo "| Step | Wall seconds |"
-            echo "|---|---|"
-            echo "| Worktree A (populate) | \`${A_SECONDS:-n/a}\` |"
-            echo "| Worktree B warm with \`ZCCACHE_PATH_REMAP=auto\` | \`${WARM_SECONDS:-n/a}\` |"
-            echo "| Worktree B control with \`SOLDR_PATH_REMAP=off\` | \`${CONTROL_SECONDS:-n/a}\` |"
-            echo ""
-            echo "Speedup ratio (control / warm): \`${RATIO:-n/a}\`"
-            echo ""
-            echo "Fail threshold: \`${THRESHOLD}x\`"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Enforce speedup threshold
-        shell: bash
-        env:
-          RATIO: ${{ steps.compare.outputs.ratio }}
-        run: |
-          set -euo pipefail
-          if [ "${RATIO}" = "inf" ]; then
-            echo "warm build measured 0s; treating as pass."
-            exit 0
-          fi
-          ok=$(awk -v r="${RATIO}" -v t="${THRESHOLD}" \
-            'BEGIN { print (r + 0 >= t + 0) ? "yes" : "no" }')
-          if [ "${ok}" != "yes" ]; then
-            echo "Parent-cache speedup ${RATIO}x is below threshold ${THRESHOLD}x" >&2
-            exit 1
-          fi
-          echo "Parent-cache speedup ${RATIO}x meets threshold ${THRESHOLD}x"
+          uv run --script bench/parent_cache_bench.py \
+            --target "${TARGET}" \
+            --threshold "${THRESHOLD}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Anything not registered falls through the generic External subcommand, which res
 - **Pre-built first**: Try every binary source before `cargo install`. Resolution order matters.
 - **RUSTC_WRAPPER defaults to zccache**: If `RUSTC_WRAPPER` is not set, soldr defaults to using `zccache` as the wrapper.
 - **Daemon auto-starts**: First `RUSTC_WRAPPER` call starts the cache daemon transparently. No manual `soldr start`.
+- **Parent-cache sharing is default-on**: For managed-zccache builds soldr seeds `ZCCACHE_PATH_REMAP=auto` on the child cargo (issue #352, Tier L1.x). zccache then normalizes absolute source paths inside compiled artifacts so two git worktrees of the same repo serve each other's cache hits via hardlinks. Escape hatch: `SOLDR_PATH_REMAP=off` suppresses the injection; setting `ZCCACHE_PATH_REMAP` yourself wins. Requires a real `.git/` checkout — tarball/zip checkouts silently fall back to no remap.
 - **Integrity is default**: every fetch records sha256. Pins are opt-in via `SOLDR_CHECKSUMS_FILE`; `SOLDR_TRUST_MODE=strict` refuses unpinned fetches.
 - **Version independence**: Users install once and forget. CI should pin: `pip install soldr==X.Y.Z`.
 

--- a/bench/parent_cache_bench.py
+++ b/bench/parent_cache_bench.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Parent-cache (worktree-cache-sharing) benchmark -- issue #352.
+
+Runs locally (CLI) and in CI (same script). Three timed builds:
+
+  A) Build the source repo cold -> populates the isolated zccache root.
+  B) Build a sibling git worktree at the same HEAD with
+     ZCCACHE_PATH_REMAP=auto. Should hit the parent cache populated by A.
+  C) Build the same sibling worktree with SOLDR_PATH_REMAP=off and a fresh
+     target/. No remap -> no parent-cache sharing -> full cold-build cost.
+
+Speedup ratio = C / B. Script exits non-zero if ratio < threshold.
+
+Build output streams to stdout with hh:mm:ss timestamps so slow steps are
+visible mid-run. Final summary is a markdown table that pastes cleanly
+into issue / PR comments.
+
+Usage:
+    bench/parent_cache_bench.py                          # build current repo
+    bench/parent_cache_bench.py --target zccache         # clone + build zccache
+    bench/parent_cache_bench.py --target repo:URL        # clone + build arbitrary repo
+    bench/parent_cache_bench.py --threshold 10           # require 10x speedup
+    bench/parent_cache_bench.py --keep                   # keep tmp dirs on exit
+    THRESHOLD=8 bench/parent_cache_bench.py              # threshold via env
+
+Targets:
+    self      Build the current checkout. Lightweight. Default.
+    zccache   git-clone https://github.com/zackees/zccache into a tempdir;
+              use that as the source repo. Adds clone time (~10-30s) but
+              gives a large, real-world build where compile time dominates
+              cargo orchestration -- what you want for measuring the
+              parent-cache speedup.
+    repo:URL  Same as zccache but with an arbitrary repo URL.
+
+Requires: python>=3.10, git, soldr on PATH. uv to launch the script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+ZCCACHE_REPO_URL = "https://github.com/zackees/zccache"
+DEFAULT_THRESHOLD = 5.0
+
+
+@dataclass
+class BuildResult:
+    label: str
+    seconds: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Parent-cache benchmark for soldr issue #352",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--target",
+        default="self",
+        help="Build target: 'self', 'zccache', or 'repo:URL'.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=float(os.environ.get("THRESHOLD", DEFAULT_THRESHOLD)),
+        help=f"Minimum speedup ratio to pass (default {DEFAULT_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Don't delete scratch directories on exit.",
+    )
+    return parser.parse_args()
+
+
+def resolve_target(target: str) -> str | None:
+    """Return the clone URL for non-self targets, None for self."""
+    if target == "self":
+        return None
+    if target == "zccache":
+        return ZCCACHE_REPO_URL
+    if target.startswith("repo:"):
+        url = target[len("repo:"):]
+        if not url:
+            print("error: --target repo: requires a URL after the colon", file=sys.stderr)
+            sys.exit(2)
+        return url
+    print(
+        f"error: unknown --target '{target}' (expected self, zccache, or repo:URL)",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def preflight(target: str) -> None:
+    """Bail with a clear message if the environment is missing pieces."""
+    if shutil.which("git") is None:
+        print("error: git not on PATH", file=sys.stderr)
+        sys.exit(2)
+    if shutil.which("soldr") is None:
+        print(
+            "error: soldr not on PATH. Install soldr or add it to PATH first.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if target == "self":
+        cwd = Path.cwd()
+        if not (cwd / ".git").exists():
+            print(
+                "error: --target self must run from a git repo root "
+                "(no .git found in cwd)",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+
+def run_streaming(
+    label: str,
+    cmd: list[str],
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Run cmd, streaming stdout+stderr with hh:mm:ss timestamps.
+
+    Raises CalledProcessError on non-zero exit.
+    """
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(cwd),
+        env=full_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+        text=True,
+    )
+    assert proc.stdout is not None
+    for raw_line in proc.stdout:
+        line = raw_line.rstrip("\n")
+        stamp = datetime.now().strftime("%H:%M:%S")
+        print(f"[{stamp}] [{label}] {line}", flush=True)
+    rc = proc.wait()
+    if rc != 0:
+        raise subprocess.CalledProcessError(rc, cmd)
+
+
+def time_build(
+    label: str,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> BuildResult:
+    """Time a soldr-wrapped cargo workspace release build."""
+    cmd = ["soldr", "cargo", "build", "--workspace", "--locked", "--release"]
+    start = time.monotonic()
+    run_streaming(label, cmd, cwd, env=env)
+    end = time.monotonic()
+    return BuildResult(label=label, seconds=end - start)
+
+
+def render_table(
+    target: str,
+    target_url: str | None,
+    a: BuildResult,
+    b: BuildResult,
+    c: BuildResult,
+    ratio: float,
+    threshold: float,
+) -> str:
+    lines = [
+        "==========================================================",
+        "                  PARENT CACHE BENCHMARK",
+        "==========================================================",
+        "",
+        f"target: {target}" + (f" ({target_url})" if target_url else ""),
+        "",
+        "| Stage                                                   | Wall seconds |",
+        "|---------------------------------------------------------|--------------|",
+        f"| A: worktree A populate (cold)                           | {a.seconds:12.2f} |",
+        f"| B: worktree B warm with ZCCACHE_PATH_REMAP=auto         | {b.seconds:12.2f} |",
+        f"| C: worktree B control with SOLDR_PATH_REMAP=off         | {c.seconds:12.2f} |",
+        "",
+        f"Speedup ratio (C / B): {ratio:.2f}x",
+        f"Threshold:             {threshold:.2f}x",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def append_github_outputs(
+    a: BuildResult,
+    b: BuildResult,
+    c: BuildResult,
+    ratio: float,
+    threshold: float,
+) -> None:
+    """If running under GitHub Actions, write the standard output files."""
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as fh:
+            fh.write(f"a_seconds={a.seconds:.2f}\n")
+            fh.write(f"b_seconds={b.seconds:.2f}\n")
+            fh.write(f"c_seconds={c.seconds:.2f}\n")
+            fh.write(f"ratio={ratio:.2f}\n")
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write("### Parent-cache benchmark (issue #352)\n\n")
+            fh.write("| Stage | Wall seconds |\n")
+            fh.write("|---|---|\n")
+            fh.write(f"| A: worktree A populate (cold) | `{a.seconds:.2f}` |\n")
+            fh.write(
+                f"| B: worktree B warm `ZCCACHE_PATH_REMAP=auto` | `{b.seconds:.2f}` |\n"
+            )
+            fh.write(
+                f"| C: worktree B control `SOLDR_PATH_REMAP=off` | `{c.seconds:.2f}` |\n"
+            )
+            fh.write(f"\nSpeedup ratio (C / B): `{ratio:.2f}x`\n\n")
+            fh.write(f"Threshold: `{threshold:.2f}x`\n")
+
+
+def main() -> int:
+    args = parse_args()
+    target_url = resolve_target(args.target)
+    preflight(args.target)
+
+    scratch_root = Path(
+        tempfile.mkdtemp(prefix="parent-cache-bench.")
+    )
+    soldr_cache_isolated = scratch_root / "zccache"
+    worktree_b = scratch_root / "worktree-b"
+    cloned_source_root: Path | None = None
+
+    # Force a fresh zccache root so the only cache state in this benchmark
+    # comes from worktree A's build. Without this, a cache left over from
+    # earlier local builds would mask whether worktree B is hitting the
+    # parent cache or its own warm cache.
+    os.environ["SOLDR_CACHE_DIR"] = str(soldr_cache_isolated)
+
+    try:
+        # If a non-self target was selected, clone the source into the
+        # scratch root and use the clone as worktree A. Otherwise A is
+        # whatever git repo the user invoked us from.
+        if target_url:
+            cloned_source_root = scratch_root / "source"
+            print(f"Cloning {target_url} into {cloned_source_root} ...")
+            run_streaming(
+                "clone",
+                ["git", "clone", "--depth", "1", target_url, str(cloned_source_root)],
+                cwd=Path.cwd(),
+            )
+            worktree_a = cloned_source_root
+        else:
+            worktree_a = Path.cwd()
+
+        print(f"=== parent-cache benchmark ({datetime.now().isoformat(timespec='seconds')}) ===")
+        print(f"  target:                          {args.target}")
+        if target_url:
+            print(f"  source URL:                      {target_url}")
+        print(f"  threshold:                       {args.threshold:.2f}x")
+        print(f"  SOLDR_CACHE_DIR (isolated):      {soldr_cache_isolated}")
+        print(f"  worktree A:                      {worktree_a}")
+        print(f"  worktree B (will be created at): {worktree_b}")
+        print()
+
+        # Stage A: build the source repo cold.
+        print("--- Stage A: build worktree A (cold, populate parent cache) ---")
+        a = time_build("A", cwd=worktree_a)
+        print(f"Stage A finished in {a.seconds:.2f}s\n")
+
+        # Stage B setup: add the sibling worktree.
+        print("--- Stage B setup: add sibling worktree at HEAD ---")
+        if worktree_b.exists():
+            shutil.rmtree(worktree_b)
+        run_streaming(
+            "B-setup",
+            ["git", "worktree", "add", str(worktree_b), "HEAD"],
+            cwd=worktree_a,
+        )
+        print()
+
+        # Stage B: warm build with remap explicit (pinned even though it's
+        # the default -- guards against drift if soldr's default flips).
+        print("--- Stage B: build worktree B (warm, ZCCACHE_PATH_REMAP=auto) ---")
+        b = time_build("B-warm", cwd=worktree_b, env={"ZCCACHE_PATH_REMAP": "auto"})
+        print(f"Stage B finished in {b.seconds:.2f}s\n")
+
+        # Stage C: control build, no remap, fresh target/.
+        shutil.rmtree(worktree_b / "target", ignore_errors=True)
+        print(
+            "--- Stage C: build worktree B "
+            "(control, SOLDR_PATH_REMAP=off, fresh target/) ---"
+        )
+        c = time_build("C-control", cwd=worktree_b, env={"SOLDR_PATH_REMAP": "off"})
+        print(f"Stage C finished in {c.seconds:.2f}s\n")
+
+        # Ratio.
+        ratio = float("inf") if b.seconds <= 0 else c.seconds / b.seconds
+
+        # Print the summary.
+        print(render_table(args.target, target_url, a, b, c, ratio, args.threshold))
+
+        # Publish to GitHub Actions output if applicable.
+        append_github_outputs(a, b, c, ratio, args.threshold)
+
+        # Gate.
+        if ratio == float("inf"):
+            print("warm build measured 0s; treating as pass.")
+            return 0
+        if ratio < args.threshold:
+            print(
+                f"FAIL: parent-cache speedup {ratio:.2f}x is below threshold "
+                f"{args.threshold:.2f}x",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"PASS: parent-cache speedup {ratio:.2f}x meets threshold "
+            f"{args.threshold:.2f}x"
+        )
+        return 0
+    except subprocess.CalledProcessError as exc:
+        print(f"command failed (rc={exc.returncode}): {' '.join(exc.cmd)}", file=sys.stderr)
+        return 1
+    finally:
+        if args.keep:
+            print()
+            print("kept scratch dirs:")
+            print(f"  zccache: {soldr_cache_isolated}")
+            print(f"  worktree: {worktree_b}")
+            if cloned_source_root:
+                print(f"  cloned source: {cloned_source_root}")
+        else:
+            # When target is "self", the sibling worktree is registered
+            # against the user's repo. Use git worktree remove so the parent
+            # repo's .git/worktrees bookkeeping is cleaned up too.
+            if worktree_b.exists() and cloned_source_root is None:
+                try:
+                    subprocess.run(
+                        ["git", "worktree", "remove", "--force", str(worktree_b)],
+                        check=False,
+                        capture_output=True,
+                    )
+                except OSError:
+                    pass
+            shutil.rmtree(scratch_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/soldr-cache/src/lib.rs
+++ b/crates/soldr-cache/src/lib.rs
@@ -71,6 +71,16 @@ pub const ZCCACHE_CACHE_DIR_ENV_VAR: &str = "ZCCACHE_CACHE_DIR";
 /// Internal marker for `ZCCACHE_CACHE_DIR` values that were injected by soldr.
 pub const MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR: &str = "SOLDR_MANAGED_ZCCACHE_CACHE_DIR";
 
+/// zccache path-remap mode. `auto` makes zccache normalize absolute source
+/// paths inside compiled artifacts so two git worktrees of the same repo
+/// can share cache hits. See issue #352.
+pub const ZCCACHE_PATH_REMAP_ENV_VAR: &str = "ZCCACHE_PATH_REMAP";
+
+/// Soldr-side escape hatch for the default `ZCCACHE_PATH_REMAP=auto`
+/// injection. Accepts `auto` (default, equivalent to unset) and `off`.
+/// See issue #352.
+pub const SOLDR_PATH_REMAP_ENV_VAR: &str = "SOLDR_PATH_REMAP";
+
 pub fn cache_enabled_env_value(enabled: bool) -> &'static str {
     if enabled {
         CACHE_ENABLED_VALUE

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -42,6 +42,35 @@ pub(crate) fn rustc_wrapper_mode() -> RustcWrapperMode {
     rustc_wrapper_mode_from_env_var(std::env::var_os(RUSTC_WRAPPER_OVERRIDE_ENV_VAR).as_deref())
 }
 
+/// Decide what value (if any) soldr should set for `ZCCACHE_PATH_REMAP` on
+/// the spawned child cargo. Returns `Some("auto")` if soldr should inject
+/// the default parent-cache remap, or `None` if no injection is required
+/// (either the user already set it, or the soldr-side escape hatch
+/// `SOLDR_PATH_REMAP=off` is active).
+///
+/// Issue #352 (Tier L1.x).
+pub(crate) fn resolve_path_remap_env(
+    user_zccache: Option<&str>,
+    soldr_override: Option<&str>,
+) -> Option<&'static str> {
+    // Rule 1: if the user already exported ZCCACHE_PATH_REMAP, never
+    // overwrite. zccache itself decides what to do with their value
+    // (including the empty string).
+    if user_zccache.is_some() {
+        return None;
+    }
+
+    // Rule 2: SOLDR_PATH_REMAP=off (case-insensitive) suppresses the
+    // injection. Anything else, or unset, falls through to auto.
+    if let Some(value) = soldr_override {
+        if value.trim().eq_ignore_ascii_case("off") {
+            return None;
+        }
+    }
+
+    Some("auto")
+}
+
 pub(crate) async fn prepare_rustc_wrapper(
     cargo: &mut std::process::Command,
     paths: &SoldrPaths,
@@ -129,6 +158,17 @@ async fn prepare_zccache_build(
     cargo.env(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR, &zccache_dir);
     cargo.env(soldr_cache::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR, &zccache_dir);
     cargo.env(soldr_cache::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
+
+    // Parent-cache (Tier L1.x, issue #352): seed ZCCACHE_PATH_REMAP=auto so
+    // multiple worktrees of the same repo share zccache hits. Honor any
+    // user-supplied ZCCACHE_PATH_REMAP, and the SOLDR_PATH_REMAP=off
+    // escape hatch.
+    let user_zccache = std::env::var(soldr_cache::ZCCACHE_PATH_REMAP_ENV_VAR).ok();
+    let soldr_override = std::env::var(soldr_cache::SOLDR_PATH_REMAP_ENV_VAR).ok();
+    if let Some(value) = resolve_path_remap_env(user_zccache.as_deref(), soldr_override.as_deref())
+    {
+        cargo.env(soldr_cache::ZCCACHE_PATH_REMAP_ENV_VAR, value);
+    }
 
     Ok(ZccacheBuildSession {
         binary_path: fetch.binary_path,
@@ -575,10 +615,7 @@ mod tests {
     #[test]
     fn path_remap_preserves_user_value_when_zccache_already_set_to_non_auto() {
         assert_eq!(resolve_path_remap_env(Some("disabled"), None), None);
-        assert_eq!(
-            resolve_path_remap_env(Some("disabled"), Some("auto")),
-            None
-        );
+        assert_eq!(resolve_path_remap_env(Some("disabled"), Some("auto")), None);
         assert_eq!(resolve_path_remap_env(Some(""), None), None);
     }
 

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -536,4 +536,58 @@ mod tests {
         assert!(!is_sccache_wrapper(OsStr::new("zccache")));
         assert!(!is_sccache_wrapper(OsStr::new("sccache-proxy")));
     }
+
+    // Parent-cache L1.x env injection (issue #352). The decision function
+    // takes the inherited values of `ZCCACHE_PATH_REMAP` (set by the user)
+    // and `SOLDR_PATH_REMAP` (soldr-side escape hatch) and decides whether
+    // soldr should inject `ZCCACHE_PATH_REMAP=auto` onto the spawned cargo
+    // child. None means do not inject; Some(value) means inject that value.
+    //
+    // Rules:
+    //   1. If the user already set ZCCACHE_PATH_REMAP, do not override.
+    //   2. Otherwise read SOLDR_PATH_REMAP (default `auto`). `off`
+    //      (case-insensitive) suppresses the injection. Anything else, or
+    //      unset, injects `auto`.
+
+    #[test]
+    fn path_remap_injects_auto_when_nothing_set() {
+        assert_eq!(resolve_path_remap_env(None, None), Some("auto"));
+    }
+
+    #[test]
+    fn path_remap_skips_when_soldr_override_is_off() {
+        assert_eq!(resolve_path_remap_env(None, Some("off")), None);
+    }
+
+    #[test]
+    fn path_remap_skips_when_soldr_override_is_off_case_insensitive() {
+        assert_eq!(resolve_path_remap_env(None, Some("OFF")), None);
+        assert_eq!(resolve_path_remap_env(None, Some("Off")), None);
+        assert_eq!(resolve_path_remap_env(None, Some(" off ")), None);
+    }
+
+    #[test]
+    fn path_remap_injects_auto_when_soldr_override_is_auto() {
+        assert_eq!(resolve_path_remap_env(None, Some("auto")), Some("auto"));
+        assert_eq!(resolve_path_remap_env(None, Some("AUTO")), Some("auto"));
+    }
+
+    #[test]
+    fn path_remap_preserves_user_value_when_zccache_already_set_to_non_auto() {
+        assert_eq!(resolve_path_remap_env(Some("disabled"), None), None);
+        assert_eq!(
+            resolve_path_remap_env(Some("disabled"), Some("auto")),
+            None
+        );
+        assert_eq!(resolve_path_remap_env(Some(""), None), None);
+    }
+
+    #[test]
+    fn path_remap_preserves_user_value_when_zccache_already_auto() {
+        // User explicitly set `auto` — soldr must not double-inject. The
+        // decision function returns None because the env is already correct
+        // in the inherited environment.
+        assert_eq!(resolve_path_remap_env(Some("auto"), None), None);
+        assert_eq!(resolve_path_remap_env(Some("auto"), Some("off")), None);
+    }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -579,6 +579,8 @@ Commands:
 | `SOLDR_ORIGINAL_EXE` | Internal path to the original executable when Windows self-relocation is active | unset |
 | `ZCCACHE_CACHE_DIR` | zccache cache-root override set by soldr for managed zccache commands | `~/.soldr/cache/zccache` |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
+| `ZCCACHE_PATH_REMAP` | zccache path-remap mode. soldr seeds `auto` on the child cargo for managed-zccache builds so multiple git worktrees of the same repo share cache hits (issue #352, Tier L1.x). Caller-supplied values are preserved. Requires a real `.git/` checkout — tarball/zip checkouts silently fall back to no remap. | unset (soldr injects `auto`) |
+| `SOLDR_PATH_REMAP` | Escape hatch for the default `ZCCACHE_PATH_REMAP=auto` injection. `off` (case-insensitive) suppresses the injection; any other value, or unset, keeps the default behavior. | unset (`auto`) |
 | `SCCACHE_DIR` | sccache cache-root override soldr injects when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has not set it themselves | `~/.soldr/cache/sccache` |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |


### PR DESCRIPTION
## Summary

Ships Tier L1.x of issue #352:

- soldr now seeds `ZCCACHE_PATH_REMAP=auto` on the child cargo for managed-zccache builds. zccache normalizes absolute source paths in compiled artifacts, so two git worktrees of the same repo serve each other's cache hits via hardlinks.
- Escape hatch: `SOLDR_PATH_REMAP=off` suppresses the injection. A user-supplied `ZCCACHE_PATH_REMAP` always wins.
- Decision logic factored into the pure helper `zccache::resolve_path_remap_env` so unit tests run without spawning cargo.
- New env constants in `soldr-cache`: `ZCCACHE_PATH_REMAP_ENV_VAR`, `SOLDR_PATH_REMAP_ENV_VAR`.

Refs #352. Does not close — this slice ships L1.x and the bench only; the rest of the tier table is out of scope.

## Benchmark workflow

`.github/workflows/parent-cache-bench.yml` does a three-build comparison:

1. Build worktree A (populates the zccache).
2. Build a sibling `git worktree` at the same commit with `ZCCACHE_PATH_REMAP=auto` — should hit the parent cache.
3. Build the same worktree as control with `SOLDR_PATH_REMAP=off` and a fresh `target/` — should not hit the parent cache.

Ratio `control / warm` is the parent-cache speedup. Default threshold: 5x. `workflow_dispatch` input `threshold_ratio` overrides.

Workflow sets a fresh `SOLDR_CACHE_DIR` at job start so the cache state under test is what worktree A populates, not what setup-soldr restored from a prior CI run. Triggers: manual + `push` to `main` filtered to files this benchmark exercises.

## Files touched

- `crates/soldr-cache/src/lib.rs` — env-var constants.
- `crates/soldr-cli/src/zccache.rs` — `resolve_path_remap_env` decision function + seeding in `prepare_zccache_build` + unit tests.
- `CLAUDE.md` — Key Design Rules entry.
- `docs/API.md` — Environment Variables table entries.
- `.github/workflows/parent-cache-bench.yml` — new workflow.

## Local validation gates

All four passed on this branch:

- [x] `cargo build -p soldr-cli`
- [x] `cargo test --workspace` (all suites green, 6 new tests in `zccache::tests::path_remap_*`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

## Notes

The CI `Verify setup-soldr pin` job is already failing on `main` because the in-tree pin (`37ab11d8...`) drifted from the current `@v0` (`4ed67cf4...`). This PR uses the current `@v0` SHA in its new workflow only — the existing files are unchanged. Pin drift is unrelated to L1.x and is tracked elsewhere.

## Test plan

- [ ] CI green on all jobs (modulo the inherited setup-soldr pin failure)
- [ ] Manually trigger `Parent Cache Bench` via workflow_dispatch and confirm the three timings + ratio land in the job summary
- [ ] Run `cargo build` in a fresh worktree against an existing soldr cache locally and observe hits attributable to the path remap

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>