### PR TITLE
chore(bench): known scratch dir + Defender exclusion helper (#355)

### DIFF
--- a/bench/add_defender_exclusions.ps1
+++ b/bench/add_defender_exclusions.ps1
@@ -1,0 +1,82 @@
+# bench/add_defender_exclusions.ps1
+#
+# Add Windows Defender real-time-scan exclusions for soldr's cache, bench
+# scratch, and runtime self-relocation directories. Must be run as
+# Administrator (Add-MpPreference requires elevation).
+#
+# Why this matters: zccache writes hundreds of MB of compiled artifacts
+# (.rmeta, .rlib, .o, etc.) to its cache. Defender real-time scans every
+# new file before the write completes. On a cold cache, this can add 10+
+# minutes to the wall-clock of a soldr-wrapped Rust build on Windows.
+# Excluding the soldr-owned directories from real-time scanning removes
+# that penalty while leaving Defender active for everything else.
+#
+# Usage (Administrator PowerShell):
+#     powershell -ExecutionPolicy Bypass -File bench/add_defender_exclusions.ps1
+#
+# Idempotent: re-running is safe. Paths already on the exclusion list are
+# silently skipped.
+
+#Requires -RunAsAdministrator
+
+$ErrorActionPreference = "Stop"
+
+$home_dir = [Environment]::GetFolderPath("UserProfile")
+$paths = @(
+    (Join-Path $home_dir ".soldr\cache"),
+    (Join-Path $home_dir ".soldr\bench"),
+    (Join-Path $home_dir ".soldr\runtime"),
+    (Join-Path $home_dir ".soldr\state.redb")
+)
+
+Write-Host "Adding Windows Defender exclusions for soldr paths..."
+
+$existing = @()
+try {
+    $existing = (Get-MpPreference).ExclusionPath
+    if ($null -eq $existing) { $existing = @() }
+} catch {
+    Write-Warning "Could not read existing Defender exclusions: $_"
+    Write-Warning "Will attempt to add anyway."
+}
+
+foreach ($p in $paths) {
+    $already = $existing | Where-Object { $_ -ieq $p }
+    if ($already) {
+        Write-Host "  already excluded: $p"
+        continue
+    }
+    try {
+        Add-MpPreference -ExclusionPath $p
+        Write-Host "  added:            $p"
+    } catch {
+        Write-Warning "  failed to add $p : $_"
+    }
+}
+
+# Verify the resulting exclusion list contains every requested path.
+$after = (Get-MpPreference).ExclusionPath
+if ($null -eq $after) { $after = @() }
+$missing = @()
+foreach ($p in $paths) {
+    if (-not ($after | Where-Object { $_ -ieq $p })) {
+        $missing += $p
+    }
+}
+if ($missing.Count -gt 0) {
+    Write-Warning "The following paths are NOT on the exclusion list:"
+    foreach ($m in $missing) {
+        Write-Warning "  $m"
+    }
+    exit 1
+}
+
+Write-Host ""
+Write-Host "All soldr paths are now excluded from Defender real-time scanning."
+Write-Host "To list current Defender exclusions:"
+Write-Host "    Get-MpPreference | Select-Object -ExpandProperty ExclusionPath"
+Write-Host ""
+Write-Host "To undo (Administrator):"
+foreach ($p in $paths) {
+    Write-Host "    Remove-MpPreference -ExclusionPath '$p'"
+}

--- a/bench/parent_cache_bench.py
+++ b/bench/parent_cache_bench.py
@@ -46,7 +46,6 @@ import os
 import shutil
 import subprocess
 import sys
-import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -54,6 +53,11 @@ from pathlib import Path
 
 ZCCACHE_REPO_URL = "https://github.com/zackees/zccache"
 DEFAULT_THRESHOLD = 5.0
+
+# Scratch directories live under ~/.soldr/bench/ rather than %TEMP%
+# so users can add a single Defender (or other AV) exclusion that covers
+# every bench run. Random suffix avoids collisions between concurrent runs.
+SOLDR_BENCH_ROOT = Path.home() / ".soldr" / "bench"
 
 
 @dataclass
@@ -104,6 +108,54 @@ def resolve_target(target: str) -> str | None:
         file=sys.stderr,
     )
     sys.exit(2)
+
+
+def _defender_exclusion_paths() -> list[str] | None:
+    """Return Defender's current exclusion paths, or None if unavailable.
+
+    Quietly returns None if we're not on Windows, PowerShell isn't on PATH,
+    Defender isn't installed, or the user lacks permission to query it.
+    Failure here is informational only -- it should never break the bench.
+    """
+    if sys.platform != "win32":
+        return None
+    if shutil.which("powershell") is None:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                "(Get-MpPreference).ExclusionPath",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _warn_if_no_defender_exclusion(path: Path) -> None:
+    """Print a one-line warning if Defender's exclusion list doesn't cover path."""
+    exclusions = _defender_exclusion_paths()
+    if exclusions is None:
+        return  # silent: not on Windows, or query failed
+    needle = str(path).lower()
+    covered = any(needle.startswith(excl.lower()) for excl in exclusions)
+    if not covered:
+        script = Path(__file__).parent / "add_defender_exclusions.ps1"
+        print(
+            f"WARNING: {path} is not in Windows Defender's exclusion list.\n"
+            f"  Defender real-time scanning of fresh cache writes can add 10+ minutes\n"
+            f"  to cold builds on Windows. Run once as administrator to fix:\n"
+            f"      powershell -ExecutionPolicy Bypass -File {script}\n",
+            file=sys.stderr,
+        )
 
 
 def preflight(target: str) -> None:
@@ -239,12 +291,21 @@ def main() -> int:
     target_url = resolve_target(args.target)
     preflight(args.target)
 
-    scratch_root = Path(
-        tempfile.mkdtemp(prefix="parent-cache-bench.")
-    )
+    # Predictable parent so users can add `~/.soldr/bench` once to their
+    # antivirus exclusion list and never re-pay the per-run flush penalty
+    # we see in Defender real-time scanning of fresh artifact writes.
+    SOLDR_BENCH_ROOT.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    suffix = os.urandom(3).hex()
+    scratch_root = SOLDR_BENCH_ROOT / f"parent-cache.{stamp}.{suffix}"
+    scratch_root.mkdir(parents=True, exist_ok=False)
     soldr_cache_isolated = scratch_root / "zccache"
     worktree_b = scratch_root / "worktree-b"
     cloned_source_root: Path | None = None
+
+    if sys.platform == "win32":
+        _warn_if_no_defender_exclusion(SOLDR_BENCH_ROOT)
+        _warn_if_no_defender_exclusion(Path.home() / ".soldr" / "cache")
 
     # Force a fresh zccache root so the only cache state in this benchmark
     # comes from worktree A's build. Without this, a cache left over from


### PR DESCRIPTION
Refs #355 (tracking issue for Windows Defender exclusions across soldr hot caches). Cross-ref [zackees/zccache#273](https://github.com/zackees/zccache/issues/273) for the zccache-side equivalent.

## Summary

- Bench scratch moves from `%TEMP%` to `~/.soldr/bench/`. One predictable parent directory means one Defender exclusion covers every future bench run.
- New `bench/add_defender_exclusions.ps1` -- idempotent PowerShell helper (requires admin) that adds `~/.soldr/cache`, `~/.soldr/bench`, `~/.soldr/runtime`, and `~/.soldr/state.redb` to Defender's exclusion list. Prints the symmetric `Remove-MpPreference` commands in its final output.
- `bench/parent_cache_bench.py` warns on startup when running on Windows without the exclusions in place, and points at the helper script.

## Why

A live parent-cache bench run on this machine produced a 1m 58s cargo "Finished" line and an 18m 30s Python wall-clock. The 16-minute gap is Defender real-time-scanning hundreds of fresh `.rmeta`/`.rlib`/`.o` writes in the cache dir between zccache's `write()` and the bytes reaching disk. Excluding the soldr-owned cache paths from real-time scanning removes that penalty while leaving Defender active everywhere else.

## Manual verification

`uv run --script bench/parent_cache_bench.py --help` -- script loads via uv, argparse + uv shebang work. With the exclusions absent, the script prints the warning. With exclusions added via the helper, the warning goes away.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>