### PR TITLE
feat(cli): soldr optimize with platform-aware Defender exclusions (#358)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Anything not registered falls through the generic External subcommand, which res
 
 ## Key Design Rules
 
-- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`, `rustup`, `toolchain`, `doctor` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
+- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`, `rustup`, `toolchain`, `doctor`, `optimize` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
 - **MSVC on Windows always**: Default to `x86_64-pc-windows-msvc` (or aarch64). Only use GNU if `rust-toolchain.toml` explicitly says so. Target resolved at runtime, not compile-time.
 - **Pre-built first**: Try every binary source before `cargo install`. Resolution order matters.
 - **RUSTC_WRAPPER defaults to zccache**: If `RUSTC_WRAPPER` is not set, soldr defaults to using `zccache` as the wrapper.

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -8,6 +8,9 @@ mod cargo_front_door;
 mod doctor;
 mod gc;
 mod linker;
+mod optimize;
+mod optimize_detect;
+mod optimize_windows;
 mod rust_plan;
 mod self_relocate;
 mod toolchain;
@@ -223,6 +226,10 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Apply platform-specific hot-cache optimizations (Windows
+    /// Defender exclusions today; future platforms TBD). Auto-skips on
+    /// CI. See `docs/API.md` for the full matrix.
+    Optimize(optimize::OptimizeArgs),
     /// Anything else is a tool to fetch and run
     #[command(external_subcommand)]
     External(Vec<String>),
@@ -520,6 +527,9 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
         },
         Commands::Doctor { json } => {
             std::process::exit(doctor::run_doctor(json)?);
+        }
+        Commands::Optimize(args) => {
+            std::process::exit(optimize::run_optimize(args)?);
         }
         Commands::Status { json } => {
             let output = cache::collect_status_output(cache_enabled)?;

--- a/crates/soldr-cli/src/optimize.rs
+++ b/crates/soldr-cli/src/optimize.rs
@@ -656,13 +656,24 @@ fn elevate_or_explain(
                     }
                 }
                 output.note = Some(format!(
-                    "elevated helper exited with code {code} but produced no parseable status"
+                    "elevated helper exited with code {code} and produced no parseable status. \
+                     Likely cause: UAC was declined or the helper crashed before writing output. \
+                     Fallback: open an Administrator PowerShell and run \
+                     `powershell -ExecutionPolicy Bypass -File bench\\add_defender_exclusions.ps1`, \
+                     or invoke `Add-MpPreference -ExclusionPath '<path>'` manually for each soldr cache path."
                 ));
                 emit_output(&output, json)?;
                 Ok(code)
             }
             Err(err) => {
-                output.note = Some(format!("UAC self-relaunch failed: {err}; re-run soldr optimize and accept the prompt, or invoke the helper from an elevated PowerShell."));
+                output.note = Some(format!(
+                    "UAC self-relaunch failed: {err}. \
+                     Fallback options: (1) re-run `soldr optimize` and accept the UAC prompt; \
+                     (2) open an Administrator PowerShell and run \
+                     `powershell -ExecutionPolicy Bypass -File bench\\add_defender_exclusions.ps1`; \
+                     (3) add the exclusions manually with `Add-MpPreference -ExclusionPath '<path>'` \
+                     for each soldr cache directory."
+                ));
                 emit_output(&output, json)?;
                 Ok(1)
             }
@@ -671,8 +682,11 @@ fn elevate_or_explain(
     #[cfg(not(target_os = "windows"))]
     {
         let _ = (powershell, soldr_root, undo);
-        output.note =
-            Some("administrator privileges required, but UAC is only available on Windows.".into());
+        output.note = Some(
+            "Administrator privileges required, but UAC self-relaunch is only available on Windows. \
+             On macOS/Linux this code path is unreachable in normal flow -- file an issue if you hit it."
+                .into(),
+        );
         emit_output(&output, json)?;
         Ok(1)
     }

--- a/crates/soldr-cli/src/optimize.rs
+++ b/crates/soldr-cli/src/optimize.rs
@@ -1,40 +1,92 @@
-//! `soldr optimize` — scaffolding for issue #358. Real implementation
-//! lands in the GREEN commit; this RED commit only ships the test
-//! surface and stub function signatures so the failing tests can be
-//! observed in CI.
+//! `soldr optimize` — platform-aware hot-cache optimization. See
+//! issue #358 for the design rationale.
+//!
+//! On Windows this adds the soldr-owned cache directories (and the
+//! current project's `target/`) to Windows Defender's real-time
+//! scanning exclusion list, falling back to UAC self-relaunch when the
+//! current process is not elevated. On macOS / Linux the subcommand is
+//! a no-op with a clear message.
 
 use clap::{Args, ValueEnum};
 use serde::{Deserialize, Serialize};
-use soldr_core::SoldrError;
+use soldr_cache::zccache_dir;
+use soldr_core::{SoldrError, SoldrPaths, SOLDR_CACHE_DIR_ENV_VAR};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::cache::print_json;
 use crate::JSON_SCHEMA_VERSION;
 
+#[cfg(target_os = "windows")]
+use crate::optimize_windows::{
+    apply_exclusions, current_exclusion_list, is_admin, relaunch_elevated, ELEVATED_HELPER_FLAG,
+};
+#[cfg(not(target_os = "windows"))]
+use crate::optimize_windows::{
+    apply_exclusions, current_exclusion_list, is_admin, ELEVATED_HELPER_FLAG,
+};
+
+use crate::optimize_detect::{detect_ci, detect_platform, detect_tools, find_powershell, Platform};
+
+/// Filename of the soldr-owned tracking file recording which paths
+/// soldr added to Defender's exclusion list. Stored in `~/.soldr/`.
+const MANAGED_EXCLUSIONS_FILE: &str = "managed-defender-exclusions.json";
+
+/// `--scope` accepted values. Maps to the four-way enum described in
+/// issue #358.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[clap(rename_all = "lowercase")]
 pub(crate) enum OptimizeScope {
+    /// `~/.soldr/cache`, `~/.soldr/bench`, `~/.soldr/runtime`,
+    /// `~/.soldr/state.redb`, and the resolved zccache cache dir.
     Global,
+    /// `<workspace_root>/target` (walks up from cwd for `Cargo.toml`).
     Project,
+    /// Apply both `global` and `project` scopes.
     All,
 }
 
+impl OptimizeScope {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Project => "project",
+            Self::All => "all",
+        }
+    }
+}
+
+/// Top-level argument struct for `clap`.
 #[derive(Debug, Args)]
 pub(crate) struct OptimizeArgs {
+    /// What to optimize. Defaults to `all`.
     #[arg(long, value_enum, default_value_t = OptimizeScope::All)]
     pub(crate) scope: OptimizeScope,
+    /// Reverse soldr-added exclusions for the chosen scope. Never
+    /// touches user-added entries.
     #[arg(long)]
     pub(crate) undo: bool,
+    /// Print what would change and exit without invoking PowerShell.
     #[arg(long)]
     pub(crate) dry_run: bool,
+    /// Emit machine-readable JSON.
     #[arg(long)]
     pub(crate) json: bool,
+    /// Path to an explicit `Cargo.toml` for the `project` scope. When
+    /// unset, soldr walks up from cwd.
     #[arg(long, value_name = "PATH")]
     pub(crate) manifest_path: Option<PathBuf>,
+    /// Internal: this process was launched by a parent soldr via UAC
+    /// self-relaunch. Skips re-elevation and writes JSON status to
+    /// the path in `SOLDR_OPTIMIZE_HELPER_OUTPUT`.
     #[arg(long = "as-elevated-helper", hide = true)]
     pub(crate) as_elevated_helper: bool,
 }
 
+/// Tracking JSON written to `~/.soldr/managed-defender-exclusions.json`.
+/// Schema is versioned so future migrations don't silently corrupt
+/// the file.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub(crate) struct ManagedExclusionFile {
     pub(crate) schema_version: u32,
@@ -49,6 +101,7 @@ pub(crate) struct ManagedExclusion {
     pub(crate) scope: String,
 }
 
+/// What the action layer plans to do (or did) for a single path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ExclusionAction {
@@ -56,16 +109,23 @@ pub(crate) enum ExclusionAction {
     Remove,
 }
 
+/// Outcome of a single per-path action.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum ActionStatus {
+    /// Action would run; `--dry-run` exited before invoking it.
     Planned,
+    /// Action ran and reported success.
     Applied,
+    /// Action ran but Defender reported the path was already excluded.
     AlreadyApplied,
+    /// Action was skipped (e.g. undo on a path Defender no longer has).
     Skipped,
+    /// Action ran but failed; see `detail`.
     Failed,
 }
 
+/// One row in the optimize plan / outcome.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct PathAction {
     pub(crate) path: String,
@@ -76,6 +136,7 @@ pub(crate) struct PathAction {
     pub(crate) detail: Option<String>,
 }
 
+/// Top-level JSON shape returned by `soldr optimize --json`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct OptimizeOutput {
     pub(crate) schema_version: u32,
@@ -94,49 +155,542 @@ pub(crate) struct OptimizeOutput {
 }
 
 impl OptimizeOutput {
+    /// Sample value used by JSON round-trip tests.
     #[cfg(test)]
     pub(crate) fn sample() -> Self {
         Self {
             schema_version: JSON_SCHEMA_VERSION,
             command: "optimize".into(),
-            platform: "Stub".into(),
+            platform: "Windows10".into(),
             scope: "global".into(),
             undo: false,
             dry_run: true,
             ci_label: None,
-            defender_present: false,
-            defender_active: false,
-            actions: Vec::new(),
-            note: None,
+            defender_present: true,
+            defender_active: true,
+            actions: vec![PathAction {
+                path: "C:\\Users\\demo\\.soldr\\cache".into(),
+                action: ExclusionAction::Add,
+                scope: "global".into(),
+                status: ActionStatus::Planned,
+                detail: None,
+            }],
+            note: Some("dry run".into()),
         }
     }
 }
 
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Resolve the project's `target/` directory by walking up from
+/// `start_dir` until a `Cargo.toml` is found. Honors the explicit
+/// `manifest_path` override when provided.
 pub(crate) fn resolve_project_target_dir(
-    _start_dir: &Path,
-    _manifest_path: Option<&Path>,
+    start_dir: &Path,
+    manifest_path: Option<&Path>,
 ) -> Result<PathBuf, SoldrError> {
-    Err(SoldrError::Other("not yet implemented".into()))
+    if let Some(manifest) = manifest_path {
+        let dir = manifest.parent().ok_or_else(|| {
+            SoldrError::Other(format!(
+                "--manifest-path {} has no parent directory",
+                manifest.display()
+            ))
+        })?;
+        return Ok(dir.join("target"));
+    }
+    let mut current = start_dir.to_path_buf();
+    loop {
+        let candidate = current.join("Cargo.toml");
+        if candidate.is_file() {
+            return Ok(current.join("target"));
+        }
+        if !current.pop() {
+            return Err(SoldrError::Other(format!(
+                "no Rust project detected from {}; pass --manifest-path to point at a Cargo.toml",
+                start_dir.display()
+            )));
+        }
+    }
 }
 
-pub(crate) fn plan_global_paths(_root: &Path, _zccache: &Path) -> Vec<PathBuf> {
-    Vec::new()
+/// Compute the paths covered by `--scope global`.
+pub(crate) fn plan_global_paths(soldr_root: &Path, resolved_zccache_dir: &Path) -> Vec<PathBuf> {
+    let mut paths = vec![
+        soldr_root.join("cache"),
+        soldr_root.join("bench"),
+        soldr_root.join("runtime"),
+        soldr_root.join("state.redb"),
+    ];
+    let zccache = resolved_zccache_dir.to_path_buf();
+    if !paths.iter().any(|p| p == &zccache) {
+        paths.push(zccache);
+    }
+    paths
 }
 
-pub(crate) fn plan_project_paths(_workspace_root: &Path) -> Vec<PathBuf> {
-    Vec::new()
+/// Compute the paths covered by `--scope project`.
+pub(crate) fn plan_project_paths(workspace_root: &Path) -> Vec<PathBuf> {
+    vec![workspace_root.join("target")]
 }
 
+/// Compute the set of paths to `Remove-MpPreference` during an undo
+/// flow. Only soldr-tracked entries are returned; user-added Defender
+/// exclusions are never touched.
 pub(crate) fn filter_undo_entries(
-    _managed: &ManagedExclusionFile,
-    _current: &[String],
-    _scope: Option<OptimizeScope>,
+    managed: &ManagedExclusionFile,
+    _current_defender_list: &[String],
+    scope: Option<OptimizeScope>,
 ) -> Vec<String> {
-    Vec::new()
+    managed
+        .exclusions
+        .iter()
+        .filter(|e| match scope {
+            None => true,
+            Some(OptimizeScope::All) => true,
+            Some(OptimizeScope::Global) => e.scope == "global",
+            Some(OptimizeScope::Project) => e.scope == "project",
+        })
+        .map(|e| e.path.clone())
+        .collect()
 }
 
-pub(crate) fn run_optimize(_args: OptimizeArgs) -> Result<i32, SoldrError> {
-    Err(SoldrError::Other("optimize: not yet implemented".into()))
+fn load_managed_file(path: &Path) -> ManagedExclusionFile {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return ManagedExclusionFile {
+            schema_version: 1,
+            exclusions: Vec::new(),
+        };
+    };
+    serde_json::from_str(&text).unwrap_or(ManagedExclusionFile {
+        schema_version: 1,
+        exclusions: Vec::new(),
+    })
+}
+
+fn save_managed_file(path: &Path, file: &ManagedExclusionFile) -> Result<(), SoldrError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(SoldrError::Io)?;
+    }
+    let text = serde_json::to_string_pretty(file)
+        .map_err(|e| SoldrError::Other(format!("failed to serialize managed exclusions: {e}")))?;
+    std::fs::write(path, text).map_err(SoldrError::Io)
+}
+
+fn platform_label(platform: Platform) -> &'static str {
+    match platform {
+        Platform::Windows10 => "Windows10",
+        Platform::Windows11Pre22H2 => "Windows11Pre22H2",
+        Platform::Windows11Post22H2 => "Windows11Post22H2",
+        Platform::MacOS => "macOS",
+        Platform::Linux => "Linux",
+        Platform::Other => "Other",
+    }
+}
+
+/// Build a `PathAction` for each path with `ActionStatus::Planned`.
+fn build_plan(
+    scope_for_paths: &[(OptimizeScope, Vec<PathBuf>)],
+    action: ExclusionAction,
+) -> Vec<PathAction> {
+    let mut out = Vec::new();
+    for (scope, paths) in scope_for_paths {
+        for path in paths {
+            out.push(PathAction {
+                path: path.display().to_string(),
+                action,
+                scope: scope.as_str().into(),
+                status: ActionStatus::Planned,
+                detail: None,
+            });
+        }
+    }
+    out
+}
+
+/// Entry point for `soldr optimize ...`. Returns the process exit code.
+pub(crate) fn run_optimize(args: OptimizeArgs) -> Result<i32, SoldrError> {
+    let platform = detect_platform();
+    let scope = args.scope;
+    let ci_label = detect_ci();
+
+    let paths = SoldrPaths::new()?;
+    let zccache_path = zccache_dir(&paths);
+    let zccache_overridden = std::env::var_os(soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR).is_some()
+        && std::env::var_os(soldr_cache::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR).is_none();
+
+    // CI auto-skip.
+    if let Some(label) = ci_label {
+        let mut output = base_output(platform, scope, args.undo, args.dry_run);
+        output.ci_label = Some(label.to_string());
+        output.note = Some(format!(
+            "running in CI ({label}); ephemeral runner image, exclusions would be discarded. Skipping."
+        ));
+        emit_output(&output, args.json)?;
+        return Ok(0);
+    }
+
+    // Non-Windows platforms are no-ops.
+    if !matches!(
+        platform,
+        Platform::Windows10 | Platform::Windows11Pre22H2 | Platform::Windows11Post22H2
+    ) {
+        let mut output = base_output(platform, scope, args.undo, args.dry_run);
+        output.note = Some(match platform {
+            Platform::MacOS => {
+                "macOS does not need cache exclusions for soldr's workloads. Exiting.".into()
+            }
+            Platform::Linux => {
+                "Linux does not need cache exclusions for soldr's workloads. Exiting.".into()
+            }
+            _ => "Unsupported platform; optimize is a no-op.".into(),
+        });
+        emit_output(&output, args.json)?;
+        return Ok(0);
+    }
+
+    let tools = detect_tools(platform);
+
+    if !tools.defender_present {
+        let mut output = base_output(platform, scope, args.undo, args.dry_run);
+        output.defender_present = false;
+        output.defender_active = false;
+        output.note = Some("Defender not active; no exclusions needed.".into());
+        emit_output(&output, args.json)?;
+        return Ok(0);
+    }
+
+    let Some(powershell) = tools.powershell.clone().or_else(find_powershell) else {
+        return Err(SoldrError::Other(
+            "PowerShell not found on PATH. Install PowerShell (pwsh or powershell.exe) or run the helper manually.".into(),
+        ));
+    };
+
+    // Build per-scope path lists.
+    let mut plan_paths: Vec<(OptimizeScope, Vec<PathBuf>)> = Vec::new();
+    let want_global = matches!(scope, OptimizeScope::Global | OptimizeScope::All);
+    let want_project = matches!(scope, OptimizeScope::Project | OptimizeScope::All);
+    let mut warnings: Vec<String> = Vec::new();
+    if want_global {
+        plan_paths.push((
+            OptimizeScope::Global,
+            plan_global_paths(&paths.root, &zccache_path),
+        ));
+        if zccache_overridden {
+            warnings.push(format!(
+                "ZCCACHE_CACHE_DIR is set externally; resolved zccache dir ({}) is being excluded explicitly. Unset {} to revert to soldr's managed location unless you have a specific reason.",
+                zccache_path.display(),
+                soldr_cache::ZCCACHE_CACHE_DIR_ENV_VAR,
+            ));
+        }
+        if std::env::var_os(SOLDR_CACHE_DIR_ENV_VAR).is_some() {
+            warnings.push(format!(
+                "{} is set; soldr's root resolved to {} — exclusions follow accordingly.",
+                SOLDR_CACHE_DIR_ENV_VAR,
+                paths.root.display(),
+            ));
+        }
+    }
+    if want_project {
+        let workspace_root = if let Some(manifest) = args.manifest_path.as_deref() {
+            manifest
+                .parent()
+                .ok_or_else(|| {
+                    SoldrError::Other(format!(
+                        "--manifest-path {} has no parent directory",
+                        manifest.display()
+                    ))
+                })?
+                .to_path_buf()
+        } else {
+            let start = std::env::current_dir().map_err(SoldrError::from)?;
+            let target = resolve_project_target_dir(&start, None)?;
+            target
+                .parent()
+                .ok_or_else(|| {
+                    SoldrError::Other(format!(
+                        "resolved project target {} has no parent",
+                        target.display()
+                    ))
+                })?
+                .to_path_buf()
+        };
+        plan_paths.push((OptimizeScope::Project, plan_project_paths(&workspace_root)));
+    }
+
+    // Undo flow short-circuits the add/plan logic.
+    let managed_path = paths.root.join(MANAGED_EXCLUSIONS_FILE);
+    if args.undo {
+        let managed = load_managed_file(&managed_path);
+        let scope_filter = match scope {
+            OptimizeScope::All => None,
+            other => Some(other),
+        };
+        let existing = current_exclusion_list(&powershell);
+        let to_remove = filter_undo_entries(&managed, &existing, scope_filter);
+
+        let plan: Vec<PathAction> = to_remove
+            .iter()
+            .map(|path| PathAction {
+                path: path.clone(),
+                action: ExclusionAction::Remove,
+                scope: managed
+                    .exclusions
+                    .iter()
+                    .find(|e| e.path == *path)
+                    .map(|e| e.scope.clone())
+                    .unwrap_or_else(|| "unknown".into()),
+                status: ActionStatus::Planned,
+                detail: None,
+            })
+            .collect();
+
+        let mut output = base_output(platform, scope, args.undo, args.dry_run);
+        output.defender_present = tools.defender_present;
+        output.defender_active = tools.defender_active;
+
+        if args.dry_run {
+            output.actions = plan;
+            output.note = Some(format!(
+                "dry-run: {} entries would be removed",
+                output.actions.len()
+            ));
+            emit_output(&output, args.json)?;
+            return Ok(0);
+        }
+
+        if !is_admin() {
+            return elevate_or_explain(&powershell, &paths.root, args.json, output, true);
+        }
+
+        let applied = apply_exclusions(&powershell, &plan, &existing);
+
+        // Prune successfully removed entries from the managed file.
+        let mut new_managed = managed.clone();
+        new_managed.exclusions.retain(|e| {
+            applied
+                .iter()
+                .find(|a| a.path == e.path)
+                .is_none_or(|a| !matches!(a.status, ActionStatus::Applied | ActionStatus::Skipped))
+        });
+        save_managed_file(&managed_path, &new_managed)?;
+
+        output.actions = applied;
+        if !warnings.is_empty() {
+            output.note = Some(warnings.join("; "));
+        }
+        emit_output(&output, args.json)?;
+        return Ok(0);
+    }
+
+    // ----- Add/optimize flow -----
+    let plan: Vec<PathAction> = build_plan(&plan_paths, ExclusionAction::Add);
+
+    let mut output = base_output(platform, scope, args.undo, args.dry_run);
+    output.defender_present = tools.defender_present;
+    output.defender_active = tools.defender_active;
+
+    if args.dry_run {
+        output.actions = plan;
+        let mut notes = warnings;
+        notes.push(format!(
+            "dry-run: would add {} paths to Defender exclusions",
+            output.actions.len()
+        ));
+        if matches!(platform, Platform::Windows11Post22H2) && tools.fsutil_devdrv_supported {
+            notes.push(dev_drive_suggestion());
+        } else if matches!(platform, Platform::Windows11Pre22H2) {
+            notes.push("Dev Drive becomes available in Windows 11 22H2.".into());
+        }
+        output.note = Some(notes.join("; "));
+        emit_output(&output, args.json)?;
+        return Ok(0);
+    }
+
+    if !is_admin() {
+        return elevate_or_explain(&powershell, &paths.root, args.json, output, false);
+    }
+
+    let existing = current_exclusion_list(&powershell);
+    let applied = apply_exclusions(&powershell, &plan, &existing);
+
+    // Persist what we just added.
+    let mut managed = load_managed_file(&managed_path);
+    let now = now_unix();
+    for action in &applied {
+        if matches!(action.status, ActionStatus::Applied)
+            && !managed.exclusions.iter().any(|e| e.path == action.path)
+        {
+            managed.exclusions.push(ManagedExclusion {
+                path: action.path.clone(),
+                added_at_unix: now,
+                scope: action.scope.clone(),
+            });
+        }
+    }
+    if managed.schema_version == 0 {
+        managed.schema_version = 1;
+    }
+    save_managed_file(&managed_path, &managed)?;
+
+    output.actions = applied;
+    let mut notes = warnings;
+    if matches!(platform, Platform::Windows11Post22H2) && tools.fsutil_devdrv_supported {
+        notes.push(dev_drive_suggestion());
+    } else if matches!(platform, Platform::Windows11Pre22H2) {
+        notes.push("Dev Drive becomes available in Windows 11 22H2.".into());
+    }
+    if !notes.is_empty() {
+        output.note = Some(notes.join("; "));
+    }
+
+    emit_output(&output, args.json)?;
+    Ok(0)
+}
+
+fn dev_drive_suggestion() -> String {
+    "For maximum performance, consider creating a Dev Drive and pointing SOLDR_CACHE_DIR at it — see https://learn.microsoft.com/en-us/windows/dev-drive/".into()
+}
+
+fn base_output(
+    platform: Platform,
+    scope: OptimizeScope,
+    undo: bool,
+    dry_run: bool,
+) -> OptimizeOutput {
+    OptimizeOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "optimize".into(),
+        platform: platform_label(platform).to_string(),
+        scope: scope.as_str().to_string(),
+        undo,
+        dry_run,
+        ci_label: None,
+        defender_present: false,
+        defender_active: false,
+        actions: Vec::new(),
+        note: None,
+    }
+}
+
+fn emit_output(output: &OptimizeOutput, json: bool) -> Result<(), SoldrError> {
+    if json {
+        print_json(output)?;
+    } else {
+        print_human(output);
+    }
+    Ok(())
+}
+
+fn print_human(output: &OptimizeOutput) {
+    println!("soldr optimize: platform={}", output.platform);
+    println!("  scope: {}", output.scope);
+    if output.undo {
+        println!("  mode: undo");
+    } else if output.dry_run {
+        println!("  mode: dry-run");
+    } else {
+        println!("  mode: apply");
+    }
+    if let Some(label) = &output.ci_label {
+        println!("  ci: {label}");
+    }
+    println!(
+        "  defender: present={}, active={}",
+        output.defender_present, output.defender_active
+    );
+    if output.actions.is_empty() {
+        println!("  (no actions)");
+    } else {
+        for action in &output.actions {
+            let verb = match action.action {
+                ExclusionAction::Add => "add",
+                ExclusionAction::Remove => "remove",
+            };
+            let status = match action.status {
+                ActionStatus::Planned => "would",
+                ActionStatus::Applied => "ok",
+                ActionStatus::AlreadyApplied => "already",
+                ActionStatus::Skipped => "skip",
+                ActionStatus::Failed => "FAIL",
+            };
+            if let Some(detail) = &action.detail {
+                println!("  [{status}] {verb}: {} ({detail})", action.path);
+            } else {
+                println!("  [{status}] {verb}: {}", action.path);
+            }
+        }
+    }
+    if let Some(note) = &output.note {
+        println!("  note: {note}");
+    }
+}
+
+/// On non-admin invocations: attempt UAC self-relaunch on Windows; on
+/// failure (or non-Windows targets that somehow reach this branch),
+/// emit instructions and exit non-zero.
+fn elevate_or_explain(
+    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] powershell: &Path,
+    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] soldr_root: &Path,
+    json: bool,
+    mut output: OptimizeOutput,
+    undo: bool,
+) -> Result<i32, SoldrError> {
+    #[cfg(target_os = "windows")]
+    {
+        let helper_output_path =
+            soldr_root.join(format!(".soldr-optimize-helper-{}.json", now_unix()));
+        let argv = rebuild_argv_for_helper(&output, undo);
+        match relaunch_elevated(powershell, &argv, &helper_output_path) {
+            Ok(code) => {
+                // Read the helper's JSON output if present and propagate.
+                if let Ok(text) = std::fs::read_to_string(&helper_output_path) {
+                    let _ = std::fs::remove_file(&helper_output_path);
+                    if let Ok(helper_output) = serde_json::from_str::<OptimizeOutput>(&text) {
+                        emit_output(&helper_output, json)?;
+                        return Ok(code);
+                    }
+                }
+                output.note = Some(format!(
+                    "elevated helper exited with code {code} but produced no parseable status"
+                ));
+                emit_output(&output, json)?;
+                Ok(code)
+            }
+            Err(err) => {
+                output.note = Some(format!("UAC self-relaunch failed: {err}; re-run soldr optimize and accept the prompt, or invoke the helper from an elevated PowerShell."));
+                emit_output(&output, json)?;
+                Ok(1)
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (powershell, soldr_root, undo);
+        output.note =
+            Some("administrator privileges required, but UAC is only available on Windows.".into());
+        emit_output(&output, json)?;
+        Ok(1)
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn rebuild_argv_for_helper(output: &OptimizeOutput, undo: bool) -> Vec<String> {
+    let mut argv = vec![
+        "optimize".into(),
+        "--scope".into(),
+        output.scope.clone(),
+        "--json".into(),
+        ELEVATED_HELPER_FLAG.into(),
+    ];
+    if undo {
+        argv.push("--undo".into());
+    }
+    argv
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/src/optimize.rs
+++ b/crates/soldr-cli/src/optimize.rs
@@ -1,0 +1,144 @@
+//! `soldr optimize` — scaffolding for issue #358. Real implementation
+//! lands in the GREEN commit; this RED commit only ships the test
+//! surface and stub function signatures so the failing tests can be
+//! observed in CI.
+
+use clap::{Args, ValueEnum};
+use serde::{Deserialize, Serialize};
+use soldr_core::SoldrError;
+use std::path::{Path, PathBuf};
+
+use crate::JSON_SCHEMA_VERSION;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[clap(rename_all = "lowercase")]
+pub(crate) enum OptimizeScope {
+    Global,
+    Project,
+    All,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OptimizeArgs {
+    #[arg(long, value_enum, default_value_t = OptimizeScope::All)]
+    pub(crate) scope: OptimizeScope,
+    #[arg(long)]
+    pub(crate) undo: bool,
+    #[arg(long)]
+    pub(crate) dry_run: bool,
+    #[arg(long)]
+    pub(crate) json: bool,
+    #[arg(long, value_name = "PATH")]
+    pub(crate) manifest_path: Option<PathBuf>,
+    #[arg(long = "as-elevated-helper", hide = true)]
+    pub(crate) as_elevated_helper: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ManagedExclusionFile {
+    pub(crate) schema_version: u32,
+    #[serde(default)]
+    pub(crate) exclusions: Vec<ManagedExclusion>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ManagedExclusion {
+    pub(crate) path: String,
+    pub(crate) added_at_unix: u64,
+    pub(crate) scope: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ExclusionAction {
+    Add,
+    Remove,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ActionStatus {
+    Planned,
+    Applied,
+    AlreadyApplied,
+    Skipped,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct PathAction {
+    pub(crate) path: String,
+    pub(crate) action: ExclusionAction,
+    pub(crate) scope: String,
+    pub(crate) status: ActionStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct OptimizeOutput {
+    pub(crate) schema_version: u32,
+    pub(crate) command: String,
+    pub(crate) platform: String,
+    pub(crate) scope: String,
+    pub(crate) undo: bool,
+    pub(crate) dry_run: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) ci_label: Option<String>,
+    pub(crate) defender_present: bool,
+    pub(crate) defender_active: bool,
+    pub(crate) actions: Vec<PathAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) note: Option<String>,
+}
+
+impl OptimizeOutput {
+    #[cfg(test)]
+    pub(crate) fn sample() -> Self {
+        Self {
+            schema_version: JSON_SCHEMA_VERSION,
+            command: "optimize".into(),
+            platform: "Stub".into(),
+            scope: "global".into(),
+            undo: false,
+            dry_run: true,
+            ci_label: None,
+            defender_present: false,
+            defender_active: false,
+            actions: Vec::new(),
+            note: None,
+        }
+    }
+}
+
+pub(crate) fn resolve_project_target_dir(
+    _start_dir: &Path,
+    _manifest_path: Option<&Path>,
+) -> Result<PathBuf, SoldrError> {
+    Err(SoldrError::Other("not yet implemented".into()))
+}
+
+pub(crate) fn plan_global_paths(_root: &Path, _zccache: &Path) -> Vec<PathBuf> {
+    Vec::new()
+}
+
+pub(crate) fn plan_project_paths(_workspace_root: &Path) -> Vec<PathBuf> {
+    Vec::new()
+}
+
+pub(crate) fn filter_undo_entries(
+    _managed: &ManagedExclusionFile,
+    _current: &[String],
+    _scope: Option<OptimizeScope>,
+) -> Vec<String> {
+    Vec::new()
+}
+
+pub(crate) fn run_optimize(_args: OptimizeArgs) -> Result<i32, SoldrError> {
+    Err(SoldrError::Other("optimize: not yet implemented".into()))
+}
+
+#[cfg(test)]
+#[path = "optimize_tests.rs"]
+mod tests;

--- a/crates/soldr-cli/src/optimize_detect.rs
+++ b/crates/soldr-cli/src/optimize_detect.rs
@@ -1,20 +1,354 @@
-//! Scaffolding for `soldr optimize` detection. RED commit — real
-//! implementation lands with the GREEN feat commit.
+//! Platform, CI, and tool detection helpers for `soldr optimize`.
+//!
+//! Detection is intentionally a small surface so each helper can be
+//! unit-tested in isolation. Action-layer dispatch lives in
+//! `optimize_windows.rs`.
 
+use std::path::PathBuf;
+
+/// The user-facing platform bucket. Maps Windows build numbers per
+/// Microsoft's published table so the action layer can branch on Dev
+/// Drive availability without reading the build twice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Platform {
     Windows10,
     Windows11Pre22H2,
+    /// Windows 11 22H2 or later — Dev Drive is available.
     Windows11Post22H2,
     MacOS,
     Linux,
     Other,
 }
 
-pub(crate) fn parse_windows_build(_major: u32, _minor: u32, _build: u32) -> Platform {
-    Platform::Other
+/// Map a Windows version triple (`major.minor.build`) to the right
+/// `Platform` bucket. Pure function so the boundary build numbers
+/// (19045, 22000, 22621) are exercised by unit tests without touching
+/// the OS.
+pub(crate) fn parse_windows_build(major: u32, _minor: u32, build: u32) -> Platform {
+    if major < 10 {
+        return Platform::Other;
+    }
+    if build >= 22621 {
+        Platform::Windows11Post22H2
+    } else if build >= 22000 {
+        Platform::Windows11Pre22H2
+    } else {
+        // Anything below the Windows 11 build threshold is reported as
+        // Windows 10. We don't try to distinguish 21H2 from 22H2 here
+        // because Defender behavior is identical and Dev Drive isn't
+        // available on either.
+        Platform::Windows10
+    }
 }
 
-pub(crate) fn detect_ci() -> Option<&'static str> {
+/// Detect the running platform. On Windows, queries the OS build via
+/// `RtlGetVersion` (preferred) so we get the real build number even
+/// under compatibility mode. Falls back to broad bucketing from
+/// `std::env::consts::OS` on every other platform.
+pub(crate) fn detect_platform() -> Platform {
+    match std::env::consts::OS {
+        "windows" => {
+            let (major, minor, build) = current_windows_version();
+            parse_windows_build(major, minor, build)
+        }
+        "macos" => Platform::MacOS,
+        "linux" => Platform::Linux,
+        _ => Platform::Other,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn current_windows_version() -> (u32, u32, u32) {
+    // Try the registry first — it always reflects the host OS, never
+    // the compatibility-mode lie.
+    if let Some(triple) = registry_windows_version() {
+        return triple;
+    }
+    // Fall back to PowerShell. Slow but correct.
+    if let Some(triple) = powershell_windows_version() {
+        return triple;
+    }
+    // Last-resort fallback: assume modern Windows 10 22H2 baseline so
+    // the action layer at least attempts Defender exclusions.
+    (10, 0, 19045)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn current_windows_version() -> (u32, u32, u32) {
+    (0, 0, 0)
+}
+
+#[cfg(target_os = "windows")]
+fn registry_windows_version() -> Option<(u32, u32, u32)> {
+    use std::process::Command;
+    let output = Command::new("reg")
+        .args([
+            "query",
+            r"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion",
+            "/v",
+            "CurrentBuildNumber",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let build: u32 = stdout
+        .lines()
+        .find_map(|line| line.split_whitespace().last())
+        .and_then(|tok| tok.parse().ok())?;
+    Some((10, 0, build))
+}
+
+#[cfg(target_os = "windows")]
+fn powershell_windows_version() -> Option<(u32, u32, u32)> {
+    let output = std::process::Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            "[System.Environment]::OSVersion.Version | Select-Object -Property Major,Minor,Build | ConvertTo-Json -Compress",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_powershell_version_json(&stdout)
+}
+
+#[cfg(target_os = "windows")]
+fn parse_powershell_version_json(stdout: &str) -> Option<(u32, u32, u32)> {
+    #[derive(serde::Deserialize)]
+    struct Version {
+        #[serde(rename = "Major")]
+        major: u32,
+        #[serde(rename = "Minor")]
+        minor: u32,
+        #[serde(rename = "Build")]
+        build: u32,
+    }
+    let trimmed = stdout.trim();
+    let parsed: Version = serde_json::from_str(trimmed).ok()?;
+    Some((parsed.major, parsed.minor, parsed.build))
+}
+
+/// Detect installed tooling relevant to the optimize subcommand.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct InstalledTools {
+    /// Path to a PowerShell executable on `PATH` (`pwsh` preferred,
+    /// then `powershell.exe`). `None` if neither is found.
+    pub(crate) powershell: Option<PathBuf>,
+    /// `True` when Defender's antivirus framework is installed
+    /// (`Get-MpComputerStatus.AntivirusEnabled`).
+    pub(crate) defender_present: bool,
+    /// `True` when Defender real-time scanning is currently active.
+    pub(crate) defender_active: bool,
+    /// `True` when `fsutil devdrv query` is a recognized subcommand
+    /// (Windows 11 22H2+). Always `false` elsewhere.
+    pub(crate) fsutil_devdrv_supported: bool,
+}
+
+/// Detect tools relevant to the optimize subcommand. Runs side-effect-
+/// free helper queries; safe to call without elevation.
+pub(crate) fn detect_tools(platform: Platform) -> InstalledTools {
+    if !matches!(
+        platform,
+        Platform::Windows10 | Platform::Windows11Pre22H2 | Platform::Windows11Post22H2
+    ) {
+        return InstalledTools::default();
+    }
+    let powershell = find_powershell();
+    let defender = powershell
+        .as_ref()
+        .map(|ps| query_defender_status(ps))
+        .unwrap_or_default();
+    let fsutil_devdrv_supported =
+        matches!(platform, Platform::Windows11Post22H2) && fsutil_devdrv_is_supported();
+    InstalledTools {
+        powershell,
+        defender_present: defender.present,
+        defender_active: defender.active,
+        fsutil_devdrv_supported,
+    }
+}
+
+/// Resolve a usable PowerShell binary by checking `pwsh` then
+/// `powershell.exe` on `PATH`. Returns `None` when neither is present.
+pub(crate) fn find_powershell() -> Option<PathBuf> {
+    for candidate in ["pwsh", "powershell"] {
+        if let Some(path) = which_on_path(candidate) {
+            return Some(path);
+        }
+    }
     None
+}
+
+fn which_on_path(tool: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        #[cfg(windows)]
+        {
+            for ext in [".exe", ".cmd", ".bat", ""] {
+                let candidate = dir.join(format!("{tool}{ext}"));
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            let candidate = dir.join(tool);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct DefenderStatus {
+    pub(crate) present: bool,
+    pub(crate) active: bool,
+}
+
+fn query_defender_status(powershell: &std::path::Path) -> DefenderStatus {
+    let output = std::process::Command::new(powershell)
+        .args([
+            "-NoProfile",
+            "-Command",
+            "Get-MpComputerStatus | Select-Object AntivirusEnabled, RealTimeProtectionEnabled | ConvertTo-Json -Compress",
+        ])
+        .output();
+    let Ok(output) = output else {
+        return DefenderStatus::default();
+    };
+    if !output.status.success() {
+        return DefenderStatus::default();
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_defender_status_json(&stdout)
+}
+
+/// Parse the JSON emitted by
+/// `Get-MpComputerStatus | Select-Object ... | ConvertTo-Json`. Public
+/// so tests can verify both shapes (single object vs. array).
+pub(crate) fn parse_defender_status_json(stdout: &str) -> DefenderStatus {
+    #[derive(serde::Deserialize)]
+    struct Raw {
+        #[serde(rename = "AntivirusEnabled")]
+        antivirus_enabled: Option<bool>,
+        #[serde(rename = "RealTimeProtectionEnabled")]
+        real_time_protection_enabled: Option<bool>,
+    }
+    let trimmed = stdout.trim();
+    let raw: Raw = serde_json::from_str(trimmed).unwrap_or(Raw {
+        antivirus_enabled: None,
+        real_time_protection_enabled: None,
+    });
+    DefenderStatus {
+        present: raw.antivirus_enabled.unwrap_or(false),
+        active: raw.real_time_protection_enabled.unwrap_or(false),
+    }
+}
+
+fn fsutil_devdrv_is_supported() -> bool {
+    let output = std::process::Command::new("fsutil")
+        .args(["devdrv", "query"])
+        .output();
+    let Ok(output) = output else {
+        return false;
+    };
+    // On Windows 10 this returns:
+    //   "devdrv" is an invalid parameter.
+    // On Windows 11 22H2+ it either reports info or errors with a different
+    // message ("Usage: ..."). Heuristic: search the merged stdout/stderr
+    // text for the "invalid parameter" sentinel.
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    !combined.to_ascii_lowercase().contains("invalid parameter")
+}
+
+/// Detect whether soldr is currently running inside a CI environment.
+/// Returns a stable label string for telemetry / messaging when one is
+/// detected; `None` otherwise.
+pub(crate) fn detect_ci() -> Option<&'static str> {
+    if env_truthy("GITHUB_ACTIONS") {
+        return Some("github_actions");
+    }
+    if env_truthy("CI") {
+        return Some("ci");
+    }
+    if env_truthy("BUILDKITE") {
+        return Some("buildkite");
+    }
+    if env_truthy("CIRCLECI") {
+        return Some("circleci");
+    }
+    if env_truthy("TRAVIS") {
+        return Some("travis");
+    }
+    if let Ok(value) = std::env::var("JENKINS_URL") {
+        if !value.trim().is_empty() {
+            return Some("jenkins");
+        }
+    }
+    None
+}
+
+fn env_truthy(key: &str) -> bool {
+    match std::env::var(key) {
+        Ok(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defender_status_parses_object_form() {
+        let json = r#"{"AntivirusEnabled":true,"RealTimeProtectionEnabled":true}"#;
+        let parsed = parse_defender_status_json(json);
+        assert!(parsed.present);
+        assert!(parsed.active);
+    }
+
+    #[test]
+    fn defender_status_handles_disabled_real_time() {
+        let json = r#"{"AntivirusEnabled":true,"RealTimeProtectionEnabled":false}"#;
+        let parsed = parse_defender_status_json(json);
+        assert!(parsed.present);
+        assert!(!parsed.active);
+    }
+
+    #[test]
+    fn defender_status_handles_missing_fields() {
+        let parsed = parse_defender_status_json("{}");
+        assert!(!parsed.present);
+        assert!(!parsed.active);
+    }
+
+    #[test]
+    fn defender_status_falls_back_when_input_is_empty() {
+        let parsed = parse_defender_status_json("");
+        assert!(!parsed.present);
+        assert!(!parsed.active);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn parse_windows_version_json_basic_shape() {
+        let json = r#"{"Major":10,"Minor":0,"Build":19045}"#;
+        assert_eq!(parse_powershell_version_json(json), Some((10, 0, 19045)));
+    }
 }

--- a/crates/soldr-cli/src/optimize_detect.rs
+++ b/crates/soldr-cli/src/optimize_detect.rs
@@ -1,0 +1,20 @@
+//! Scaffolding for `soldr optimize` detection. RED commit — real
+//! implementation lands with the GREEN feat commit.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Platform {
+    Windows10,
+    Windows11Pre22H2,
+    Windows11Post22H2,
+    MacOS,
+    Linux,
+    Other,
+}
+
+pub(crate) fn parse_windows_build(_major: u32, _minor: u32, _build: u32) -> Platform {
+    Platform::Other
+}
+
+pub(crate) fn detect_ci() -> Option<&'static str> {
+    None
+}

--- a/crates/soldr-cli/src/optimize_tests.rs
+++ b/crates/soldr-cli/src/optimize_tests.rs
@@ -1,0 +1,354 @@
+//! Unit tests for the `soldr optimize` subcommand. See `optimize.rs`,
+//! `optimize_detect.rs`, and `optimize_windows.rs` for the implementation.
+
+use super::{
+    filter_undo_entries, plan_global_paths, plan_project_paths, resolve_project_target_dir,
+    ManagedExclusion, ManagedExclusionFile, OptimizeOutput, OptimizeScope,
+};
+use crate::optimize_detect::{detect_ci, parse_windows_build, Platform};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = &self.previous {
+            std::env::set_var(self.key, value);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+// -- CI detection ----------------------------------------------------------
+
+#[test]
+fn ci_detection_returns_none_when_no_env_set() {
+    let _lock = lock_env();
+    let _a = EnvVarGuard::remove("GITHUB_ACTIONS");
+    let _b = EnvVarGuard::remove("CI");
+    let _c = EnvVarGuard::remove("BUILDKITE");
+    let _d = EnvVarGuard::remove("CIRCLECI");
+    let _e = EnvVarGuard::remove("TRAVIS");
+    let _f = EnvVarGuard::remove("JENKINS_URL");
+    assert_eq!(detect_ci(), None);
+}
+
+#[test]
+fn ci_detection_prefers_github_actions() {
+    let _lock = lock_env();
+    let _a = EnvVarGuard::set("GITHUB_ACTIONS", "true");
+    let _b = EnvVarGuard::set("CI", "true");
+    let _c = EnvVarGuard::remove("BUILDKITE");
+    let _d = EnvVarGuard::remove("CIRCLECI");
+    let _e = EnvVarGuard::remove("TRAVIS");
+    let _f = EnvVarGuard::remove("JENKINS_URL");
+    assert_eq!(detect_ci(), Some("github_actions"));
+}
+
+#[test]
+fn ci_detection_picks_up_each_label() {
+    let _lock = lock_env();
+    // Generic CI
+    let _a = EnvVarGuard::remove("GITHUB_ACTIONS");
+    let _b = EnvVarGuard::set("CI", "true");
+    let _c = EnvVarGuard::remove("BUILDKITE");
+    let _d = EnvVarGuard::remove("CIRCLECI");
+    let _e = EnvVarGuard::remove("TRAVIS");
+    let _f = EnvVarGuard::remove("JENKINS_URL");
+    assert_eq!(detect_ci(), Some("ci"));
+}
+
+#[test]
+fn ci_detection_picks_up_buildkite() {
+    let _lock = lock_env();
+    let _a = EnvVarGuard::remove("GITHUB_ACTIONS");
+    let _b = EnvVarGuard::remove("CI");
+    let _c = EnvVarGuard::set("BUILDKITE", "true");
+    let _d = EnvVarGuard::remove("CIRCLECI");
+    let _e = EnvVarGuard::remove("TRAVIS");
+    let _f = EnvVarGuard::remove("JENKINS_URL");
+    assert_eq!(detect_ci(), Some("buildkite"));
+}
+
+#[test]
+fn ci_detection_picks_up_circleci() {
+    let _lock = lock_env();
+    let _a = EnvVarGuard::remove("GITHUB_ACTIONS");
+    let _b = EnvVarGuard::remove("CI");
+    let _c = EnvVarGuard::remove("BUILDKITE");
+    let _d = EnvVarGuard::set("CIRCLECI", "true");
+    let _e = EnvVarGuard::remove("TRAVIS");
+    let _f = EnvVarGuard::remove("JENKINS_URL");
+    assert_eq!(detect_ci(), Some("circleci"));
+}
+
+#[test]
+fn ci_detection_picks_up_travis() {
+    let _lock = lock_env();
+    let _a = EnvVarGuard::remove("GITHUB_ACTIONS");
+    let _b = EnvVarGuard::remove("CI");
+    let _c = EnvVarGuard::remove("BUILDKITE");
+    let _d = EnvVarGuard::remove("CIRCLECI");
+    let _e = EnvVarGuard::set("TRAVIS", "true");
+    let _f = EnvVarGuard::remove("JENKINS_URL");
+    assert_eq!(detect_ci(), Some("travis"));
+}
+
+#[test]
+fn ci_detection_picks_up_jenkins_via_non_empty_url() {
+    let _lock = lock_env();
+    let _a = EnvVarGuard::remove("GITHUB_ACTIONS");
+    let _b = EnvVarGuard::remove("CI");
+    let _c = EnvVarGuard::remove("BUILDKITE");
+    let _d = EnvVarGuard::remove("CIRCLECI");
+    let _e = EnvVarGuard::remove("TRAVIS");
+    let _f = EnvVarGuard::set("JENKINS_URL", "http://example.com/");
+    assert_eq!(detect_ci(), Some("jenkins"));
+}
+
+#[test]
+fn ci_detection_ignores_falsy_values() {
+    let _lock = lock_env();
+    let _a = EnvVarGuard::set("GITHUB_ACTIONS", "false");
+    let _b = EnvVarGuard::set("CI", "0");
+    let _c = EnvVarGuard::set("BUILDKITE", "");
+    let _d = EnvVarGuard::set("CIRCLECI", "no");
+    let _e = EnvVarGuard::set("TRAVIS", "off");
+    let _f = EnvVarGuard::remove("JENKINS_URL");
+    assert_eq!(detect_ci(), None);
+}
+
+// -- Platform detection (boundary build numbers) ---------------------------
+
+#[test]
+fn platform_boundary_windows_10_22h2() {
+    assert_eq!(
+        parse_windows_build(10, 0, 19045),
+        Platform::Windows10
+    );
+}
+
+#[test]
+fn platform_boundary_windows_11_initial_build() {
+    assert_eq!(
+        parse_windows_build(10, 0, 22000),
+        Platform::Windows11Pre22H2
+    );
+}
+
+#[test]
+fn platform_boundary_windows_11_22h2() {
+    assert_eq!(
+        parse_windows_build(10, 0, 22621),
+        Platform::Windows11Post22H2
+    );
+}
+
+#[test]
+fn platform_windows_10_early_build_is_still_windows_10() {
+    assert_eq!(
+        parse_windows_build(10, 0, 19041),
+        Platform::Windows10
+    );
+}
+
+#[test]
+fn platform_above_22h2_threshold_remains_post22h2() {
+    assert_eq!(
+        parse_windows_build(10, 0, 25000),
+        Platform::Windows11Post22H2
+    );
+}
+
+// -- Scope resolution ------------------------------------------------------
+
+#[test]
+fn project_scope_errors_when_no_cargo_toml() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let result = resolve_project_target_dir(dir.path(), None);
+    assert!(
+        result.is_err(),
+        "expected error when no Cargo.toml in ancestor tree"
+    );
+}
+
+#[test]
+fn project_scope_resolves_workspace_root_target() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let manifest = dir.path().join("Cargo.toml");
+    std::fs::write(&manifest, "[package]\nname=\"x\"\nversion=\"0.0.1\"\n").unwrap();
+
+    let target = resolve_project_target_dir(dir.path(), None).expect("resolution");
+    assert_eq!(target, dir.path().join("target"));
+}
+
+#[test]
+fn project_scope_walks_up_to_find_cargo_toml() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let manifest = dir.path().join("Cargo.toml");
+    std::fs::write(&manifest, "[package]\nname=\"x\"\nversion=\"0.0.1\"\n").unwrap();
+    let nested = dir.path().join("a").join("b").join("c");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let target = resolve_project_target_dir(&nested, None).expect("resolution");
+    assert_eq!(target, dir.path().join("target"));
+}
+
+#[test]
+fn project_scope_uses_explicit_manifest_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let manifest_root = dir.path().join("sub");
+    std::fs::create_dir_all(&manifest_root).unwrap();
+    let manifest = manifest_root.join("Cargo.toml");
+    std::fs::write(&manifest, "[package]\nname=\"x\"\nversion=\"0.0.1\"\n").unwrap();
+
+    let unrelated = dir.path().join("else");
+    std::fs::create_dir_all(&unrelated).unwrap();
+
+    let target = resolve_project_target_dir(&unrelated, Some(&manifest)).expect("resolution");
+    assert_eq!(target, manifest_root.join("target"));
+}
+
+#[test]
+fn global_paths_include_soldr_owned_roots() {
+    let cache_root = PathBuf::from("/fake/.soldr");
+    let zccache = cache_root.join("cache").join("zccache");
+    let paths = plan_global_paths(&cache_root, &zccache);
+    // Cache, bench, runtime, state.redb, and the zccache subdir.
+    assert!(paths.iter().any(|p: &PathBuf| p.ends_with("cache")));
+    assert!(paths.iter().any(|p: &PathBuf| p.ends_with("bench")));
+    assert!(paths.iter().any(|p: &PathBuf| p.ends_with("runtime")));
+    assert!(paths.iter().any(|p: &PathBuf| p.ends_with("state.redb")));
+    assert!(paths.iter().any(|p: &PathBuf| p == &zccache));
+}
+
+#[test]
+fn project_paths_use_workspace_target() {
+    let workspace = PathBuf::from("/fake/proj");
+    let paths = plan_project_paths(&workspace);
+    assert_eq!(paths, vec![workspace.join("target")]);
+}
+
+// -- Undo filtering --------------------------------------------------------
+
+#[test]
+fn undo_filter_only_returns_soldr_added_entries() {
+    let managed = ManagedExclusionFile {
+        schema_version: 1,
+        exclusions: vec![
+            ManagedExclusion {
+                path: "C:\\Users\\you\\.soldr\\cache".into(),
+                added_at_unix: 1_715_000_000,
+                scope: "global".into(),
+            },
+            ManagedExclusion {
+                path: "C:\\Users\\you\\dev\\proj\\target".into(),
+                added_at_unix: 1_715_001_000,
+                scope: "project".into(),
+            },
+        ],
+    };
+    // Defender currently has soldr-added entries PLUS a user-added one.
+    let current_defender = vec![
+        "C:\\Users\\you\\.soldr\\cache".to_string(),
+        "C:\\Users\\you\\dev\\proj\\target".to_string(),
+        "C:\\Users\\you\\Documents\\Personal".to_string(), // user-added
+    ];
+    let to_remove = filter_undo_entries(&managed, &current_defender, None);
+    assert_eq!(to_remove.len(), 2);
+    assert!(to_remove
+        .iter()
+        .all(|p: &String| p.contains(".soldr") || p.contains("target")));
+    assert!(!to_remove
+        .iter()
+        .any(|p: &String| p.contains("Documents\\Personal")));
+}
+
+#[test]
+fn undo_filter_scoped_to_global_only() {
+    let managed = ManagedExclusionFile {
+        schema_version: 1,
+        exclusions: vec![
+            ManagedExclusion {
+                path: "C:\\Users\\you\\.soldr\\cache".into(),
+                added_at_unix: 1_715_000_000,
+                scope: "global".into(),
+            },
+            ManagedExclusion {
+                path: "C:\\Users\\you\\dev\\proj\\target".into(),
+                added_at_unix: 1_715_001_000,
+                scope: "project".into(),
+            },
+        ],
+    };
+    let to_remove = filter_undo_entries(
+        &managed,
+        &["C:\\Users\\you\\.soldr\\cache".into()],
+        Some(OptimizeScope::Global),
+    );
+    assert_eq!(to_remove.len(), 1);
+    assert!(to_remove[0].contains(".soldr"));
+}
+
+#[test]
+fn undo_skips_entries_already_absent_from_defender() {
+    let managed = ManagedExclusionFile {
+        schema_version: 1,
+        exclusions: vec![ManagedExclusion {
+            path: "C:\\Users\\you\\.soldr\\cache".into(),
+            added_at_unix: 1_715_000_000,
+            scope: "global".into(),
+        }],
+    };
+    // User already removed this exclusion manually.
+    let current_defender: Vec<String> = Vec::new();
+    let to_remove = filter_undo_entries(&managed, &current_defender, None);
+    // Still want to attempt removal (or at least drop from the manifest);
+    // we expose the entries to caller; the action layer decides.
+    assert_eq!(to_remove.len(), 1);
+}
+
+// -- JSON schema stability -------------------------------------------------
+
+#[test]
+fn optimize_output_round_trips_through_json() {
+    let output = OptimizeOutput::sample();
+    let json = serde_json::to_string(&output).expect("serialize");
+    let back: OptimizeOutput = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(output, back);
+}
+
+#[test]
+fn optimize_output_advertises_schema_version() {
+    let output = OptimizeOutput::sample();
+    let json = serde_json::to_value(&output).expect("serialize");
+    assert_eq!(json["schema_version"], crate::JSON_SCHEMA_VERSION);
+    assert_eq!(json["command"], "optimize");
+}

--- a/crates/soldr-cli/src/optimize_tests.rs
+++ b/crates/soldr-cli/src/optimize_tests.rs
@@ -149,10 +149,7 @@ fn ci_detection_ignores_falsy_values() {
 
 #[test]
 fn platform_boundary_windows_10_22h2() {
-    assert_eq!(
-        parse_windows_build(10, 0, 19045),
-        Platform::Windows10
-    );
+    assert_eq!(parse_windows_build(10, 0, 19045), Platform::Windows10);
 }
 
 #[test]
@@ -173,10 +170,7 @@ fn platform_boundary_windows_11_22h2() {
 
 #[test]
 fn platform_windows_10_early_build_is_still_windows_10() {
-    assert_eq!(
-        parse_windows_build(10, 0, 19041),
-        Platform::Windows10
-    );
+    assert_eq!(parse_windows_build(10, 0, 19041), Platform::Windows10);
 }
 
 #[test]

--- a/crates/soldr-cli/src/optimize_windows.rs
+++ b/crates/soldr-cli/src/optimize_windows.rs
@@ -1,10 +1,279 @@
-//! Scaffolding for `soldr optimize` Windows action layer. RED commit
-//! — real implementation lands with the GREEN feat commit.
+//! Windows-specific Defender exclusion logic for `soldr optimize`. The
+//! Rust side handles detection, decision, and UAC self-relaunch; the
+//! actual `Add-MpPreference` / `Remove-MpPreference` calls are issued
+//! through PowerShell.
 
-#![allow(dead_code)]
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
-pub(crate) const ELEVATED_HELPER_FLAG: &str = "--as-elevated-helper";
+use super::optimize::{ActionStatus, ExclusionAction, PathAction};
+
+/// Environment variable injected by the parent soldr process when it
+/// re-launches itself elevated. The helper subprocess writes its JSON
+/// status to this path so the parent can read and report it.
 pub(crate) const SOLDR_OPTIMIZE_HELPER_OUTPUT_ENV: &str = "SOLDR_OPTIMIZE_HELPER_OUTPUT";
+
+/// Sentinel flag the parent passes to the elevated helper to make it
+/// skip its own UAC self-relaunch loop.
+pub(crate) const ELEVATED_HELPER_FLAG: &str = "--as-elevated-helper";
+
+/// Test seam: when set, the helper that would normally call
+/// `Add-MpPreference` / `Remove-MpPreference` is replaced with a
+/// no-op that records what it would have done into the file pointed
+/// to by this env var (one TSV line per call:
+/// `op\tpath\n`). Used by the integration tests.
 pub(crate) const SOLDR_TEST_DEFENDER_LOG_ENV: &str = "SOLDR_TEST_DEFENDER_LOG";
+
+/// Test seam: when set, treats the current process as if it is
+/// running with administrator privileges regardless of the real
+/// token. Bypasses the UAC self-relaunch path in tests.
 pub(crate) const SOLDR_TEST_ASSUME_ADMIN_ENV: &str = "SOLDR_TEST_ASSUME_ADMIN";
+
+/// Test seam: when set, returns the contents of this file as the
+/// "current Defender exclusion list" (one path per line) instead of
+/// running `Get-MpPreference`.
 pub(crate) const SOLDR_TEST_DEFENDER_EXISTING_ENV: &str = "SOLDR_TEST_DEFENDER_EXISTING";
+
+/// Check whether the current process holds an administrator token.
+/// On Windows we try a registry read of `HKLM\SECURITY` — only admin
+/// processes can open this key. A read failure means non-admin.
+#[cfg(target_os = "windows")]
+pub(crate) fn is_admin() -> bool {
+    if std::env::var_os(SOLDR_TEST_ASSUME_ADMIN_ENV).is_some() {
+        return true;
+    }
+    // `reg query HKLM\SECURITY` errors with access denied for non-admin.
+    Command::new("reg")
+        .args(["query", r"HKLM\SECURITY"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn is_admin() -> bool {
+    false
+}
+
+/// Apply the given exclusion plan via PowerShell. Returns the per-path
+/// outcomes for the JSON / human-readable output. The caller is
+/// responsible for deciding whether elevation is needed before this is
+/// invoked.
+pub(crate) fn apply_exclusions(
+    powershell: &Path,
+    plan: &[PathAction],
+    existing_exclusions: &[String],
+) -> Vec<PathAction> {
+    let test_log_path = std::env::var_os(SOLDR_TEST_DEFENDER_LOG_ENV).map(PathBuf::from);
+    plan.iter()
+        .map(|action| {
+            let mut out = action.clone();
+            let already_excluded = exclusion_list_contains(existing_exclusions, &action.path);
+            match action.action {
+                ExclusionAction::Add => {
+                    if already_excluded {
+                        out.status = ActionStatus::AlreadyApplied;
+                        out.detail = Some("already on Defender exclusion list".into());
+                        return out;
+                    }
+                    match run_defender_command(
+                        powershell,
+                        "Add-MpPreference",
+                        &action.path,
+                        test_log_path.as_deref(),
+                    ) {
+                        Ok(()) => {
+                            out.status = ActionStatus::Applied;
+                        }
+                        Err(err) => {
+                            out.status = ActionStatus::Failed;
+                            out.detail = Some(err);
+                        }
+                    }
+                }
+                ExclusionAction::Remove => {
+                    if !already_excluded {
+                        out.status = ActionStatus::Skipped;
+                        out.detail = Some("not present in Defender exclusion list".into());
+                        return out;
+                    }
+                    match run_defender_command(
+                        powershell,
+                        "Remove-MpPreference",
+                        &action.path,
+                        test_log_path.as_deref(),
+                    ) {
+                        Ok(()) => {
+                            out.status = ActionStatus::Applied;
+                        }
+                        Err(err) => {
+                            out.status = ActionStatus::Failed;
+                            out.detail = Some(err);
+                        }
+                    }
+                }
+            }
+            out
+        })
+        .collect()
+}
+
+fn exclusion_list_contains(list: &[String], path: &str) -> bool {
+    let needle = normalize_path(path);
+    list.iter().any(|p| normalize_path(p) == needle)
+}
+
+fn normalize_path(path: &str) -> String {
+    path.replace('/', "\\").to_ascii_lowercase()
+}
+
+fn run_defender_command(
+    powershell: &Path,
+    cmdlet: &str,
+    path: &str,
+    test_log: Option<&Path>,
+) -> Result<(), String> {
+    if let Some(log) = test_log {
+        let line = format!("{cmdlet}\t{path}\n");
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log)
+            .map_err(|e| format!("failed to open test log: {e}"))?
+            .write_all_str(&line)?;
+        return Ok(());
+    }
+    let escaped = path.replace('\'', "''");
+    let script = format!("{cmdlet} -ExclusionPath '{escaped}'");
+    let output = Command::new(powershell)
+        .args(["-NoProfile", "-Command", &script])
+        .output()
+        .map_err(|e| format!("failed to invoke PowerShell: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!(
+            "{cmdlet} exited with {}: {}",
+            output.status.code().unwrap_or(-1),
+            stderr.trim()
+        ))
+    }
+}
+
+trait WriteAllStr {
+    fn write_all_str(&mut self, s: &str) -> Result<(), String>;
+}
+
+impl WriteAllStr for std::fs::File {
+    fn write_all_str(&mut self, s: &str) -> Result<(), String> {
+        use std::io::Write;
+        self.write_all(s.as_bytes())
+            .map_err(|e| format!("failed to write defender test log: {e}"))
+    }
+}
+
+/// Read the current Defender exclusion list. Requires admin in production;
+/// tests can shim the result via `SOLDR_TEST_DEFENDER_EXISTING`.
+pub(crate) fn current_exclusion_list(powershell: &Path) -> Vec<String> {
+    if let Some(path) = std::env::var_os(SOLDR_TEST_DEFENDER_EXISTING_ENV) {
+        return std::fs::read_to_string(&path)
+            .map(|s| s.lines().map(str::to_string).collect())
+            .unwrap_or_default();
+    }
+    let output = Command::new(powershell)
+        .args([
+            "-NoProfile",
+            "-Command",
+            "(Get-MpPreference).ExclusionPath | ForEach-Object { $_ }",
+        ])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Relaunch the current soldr binary elevated via UAC. Returns the
+/// child's exit code if the relaunch succeeded, or an error explaining
+/// why elevation wasn't possible.
+#[cfg(target_os = "windows")]
+pub(crate) fn relaunch_elevated(
+    powershell: &Path,
+    args: &[String],
+    helper_output_path: &Path,
+) -> Result<i32, String> {
+    let current =
+        std::env::current_exe().map_err(|e| format!("failed to resolve current binary: {e}"))?;
+    let arg_list = build_powershell_arg_list(args);
+    // Use `-Wait` so the parent blocks until the elevated child exits,
+    // and `-PassThru` so we can capture the child's exit code.
+    let exe_quoted = ps_quote(&current.display().to_string());
+    let output_env_quoted = ps_quote(&helper_output_path.display().to_string());
+    let script = format!(
+        "$env:{env_name}={out_lit}; $p = Start-Process -FilePath {exe} -ArgumentList {args} -Verb RunAs -Wait -PassThru; exit $p.ExitCode",
+        env_name = SOLDR_OPTIMIZE_HELPER_OUTPUT_ENV,
+        out_lit = output_env_quoted,
+        exe = exe_quoted,
+        args = arg_list,
+    );
+    let status = Command::new(powershell)
+        .args(["-NoProfile", "-Command", &script])
+        .status()
+        .map_err(|e| format!("failed to relaunch elevated: {e}"))?;
+    Ok(status.code().unwrap_or(1))
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn relaunch_elevated(
+    _powershell: &Path,
+    _args: &[String],
+    _helper_output_path: &Path,
+) -> Result<i32, String> {
+    Err("UAC self-relaunch is only supported on Windows".into())
+}
+
+fn build_powershell_arg_list(args: &[String]) -> String {
+    if args.is_empty() {
+        // PowerShell rejects empty Start-Process ArgumentList; pass a
+        // single empty string so the elevated process gets argc == 1.
+        return "@(' ')".to_string();
+    }
+    let parts: Vec<String> = args.iter().map(|a| ps_quote(a)).collect();
+    format!("@({})", parts.join(","))
+}
+
+fn ps_quote(value: &str) -> String {
+    let escaped = value.replace('\'', "''");
+    format!("'{}'", escaped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusion_list_contains_normalizes_separators_and_case() {
+        let list = vec!["C:\\Users\\You\\.soldr\\Cache".to_string()];
+        assert!(exclusion_list_contains(&list, "c:/users/you/.soldr/cache"));
+    }
+
+    #[test]
+    fn ps_quote_doubles_single_quotes() {
+        assert_eq!(ps_quote("a'b"), "'a''b'");
+    }
+
+    #[test]
+    fn build_powershell_arg_list_emits_array_literal() {
+        let args = vec!["optimize".to_string(), "--scope".to_string()];
+        assert_eq!(build_powershell_arg_list(&args), "@('optimize','--scope')");
+    }
+}

--- a/crates/soldr-cli/src/optimize_windows.rs
+++ b/crates/soldr-cli/src/optimize_windows.rs
@@ -1,0 +1,10 @@
+//! Scaffolding for `soldr optimize` Windows action layer. RED commit
+//! — real implementation lands with the GREEN feat commit.
+
+#![allow(dead_code)]
+
+pub(crate) const ELEVATED_HELPER_FLAG: &str = "--as-elevated-helper";
+pub(crate) const SOLDR_OPTIMIZE_HELPER_OUTPUT_ENV: &str = "SOLDR_OPTIMIZE_HELPER_OUTPUT";
+pub(crate) const SOLDR_TEST_DEFENDER_LOG_ENV: &str = "SOLDR_TEST_DEFENDER_LOG";
+pub(crate) const SOLDR_TEST_ASSUME_ADMIN_ENV: &str = "SOLDR_TEST_ASSUME_ADMIN";
+pub(crate) const SOLDR_TEST_DEFENDER_EXISTING_ENV: &str = "SOLDR_TEST_DEFENDER_EXISTING";

--- a/crates/soldr-cli/tests/cli_optimize.rs
+++ b/crates/soldr-cli/tests/cli_optimize.rs
@@ -1,0 +1,293 @@
+//! End-to-end tests for `soldr optimize`. Covers the CI auto-skip
+//! path, dry-run JSON output, scope resolution errors, and (on
+//! Windows) the stubbed PowerShell flow that verifies the right
+//! cmdlets are invoked without actually elevating.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use serde_json::Value;
+use std::process::Command;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+fn isolated_soldr_home() -> PathBuf {
+    unique_temp_dir("soldr-optimize-home")
+}
+
+#[test]
+fn optimize_dry_run_json_runs_end_to_end_on_current_platform() {
+    let soldr_home = isolated_soldr_home();
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["optimize", "--dry-run", "--json"])
+        .current_dir(&soldr_home)
+        .env("SOLDR_CACHE_DIR", &soldr_home)
+        // Make sure we never trip CI detection accidentally.
+        .env_remove("GITHUB_ACTIONS")
+        .env_remove("CI")
+        .env_remove("BUILDKITE")
+        .env_remove("CIRCLECI")
+        .env_remove("TRAVIS")
+        .env_remove("JENKINS_URL")
+        .output()
+        .expect("failed to run soldr optimize --dry-run --json");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // On Windows we expect a planned action set (no project Cargo.toml
+    // is present in the isolated home, so the project scope errors —
+    // but dry-run global still works when invoked with --scope global).
+    // To keep the test cross-platform, exit code 0 + parseable JSON is
+    // the contract.
+    if !output.status.success() {
+        // Project scope error path: not a Rust project. Verify the
+        // stderr explains it cleanly.
+        assert!(
+            stderr.contains("no Rust project detected"),
+            "unexpected failure mode\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        return;
+    }
+
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("optimize --json must produce JSON ({e}); stdout=\n{stdout}"));
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "optimize");
+    assert!(
+        json["platform"].as_str().is_some(),
+        "platform field missing"
+    );
+    assert_eq!(json["dry_run"], true);
+}
+
+#[test]
+fn optimize_ci_auto_skip_emits_skip_message() {
+    let soldr_home = isolated_soldr_home();
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["optimize", "--json"])
+        .current_dir(&soldr_home)
+        .env("SOLDR_CACHE_DIR", &soldr_home)
+        .env("GITHUB_ACTIONS", "true")
+        .output()
+        .expect("failed to run soldr optimize --json under GITHUB_ACTIONS");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "CI auto-skip must exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("optimize --json under CI must produce JSON");
+    assert_eq!(json["ci_label"], "github_actions");
+    let note = json["note"]
+        .as_str()
+        .expect("note field present in CI mode");
+    assert!(
+        note.contains("Skipping"),
+        "expected note to mention skipping, got: {note}"
+    );
+}
+
+#[test]
+fn optimize_project_scope_errors_when_no_cargo_toml() {
+    let workspace = unique_temp_dir("soldr-optimize-no-cargo");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["optimize", "--scope", "project", "--dry-run", "--json"])
+        .current_dir(&workspace)
+        .env_remove("GITHUB_ACTIONS")
+        .env_remove("CI")
+        .env_remove("BUILDKITE")
+        .env_remove("CIRCLECI")
+        .env_remove("TRAVIS")
+        .env_remove("JENKINS_URL")
+        .output()
+        .expect("failed to run soldr optimize --scope project");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "expected non-zero exit for project scope without Cargo.toml\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("no Rust project detected"),
+        "expected clear error about missing Rust project, got stderr:\n{stderr}"
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn optimize_invokes_add_mppreference_with_admin_seam() {
+    let soldr_home = unique_temp_dir("soldr-optimize-admin");
+    let defender_log = soldr_home.join("defender.log");
+    let existing_excl = soldr_home.join("existing.txt");
+    fs::write(&existing_excl, "").expect("write existing exclusion stub");
+
+    let workspace = soldr_home.join("ws");
+    fs::create_dir_all(&workspace).expect("workspace dir");
+    fs::write(
+        workspace.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.1\"\n",
+    )
+    .expect("Cargo.toml");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["optimize", "--scope", "all", "--json"])
+        .current_dir(&workspace)
+        .env("SOLDR_CACHE_DIR", &soldr_home)
+        .env("SOLDR_TEST_ASSUME_ADMIN", "1")
+        .env("SOLDR_TEST_DEFENDER_LOG", &defender_log)
+        .env("SOLDR_TEST_DEFENDER_EXISTING", &existing_excl)
+        .env_remove("GITHUB_ACTIONS")
+        .env_remove("CI")
+        .env_remove("BUILDKITE")
+        .env_remove("CIRCLECI")
+        .env_remove("TRAVIS")
+        .env_remove("JENKINS_URL")
+        .output()
+        .expect("failed to run soldr optimize under test seam");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "optimize must exit 0 under admin seam\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let log = fs::read_to_string(&defender_log).expect("defender log must be written");
+    assert!(
+        log.contains("Add-MpPreference"),
+        "expected Add-MpPreference invocations, got log:\n{log}"
+    );
+    // Each soldr-owned global path plus the project target must be
+    // recorded. SOLDR_CACHE_DIR overrides the root, so we look for the
+    // child basenames under the resolved root.
+    let soldr_root = soldr_home.display().to_string();
+    for expected in [
+        format!("{soldr_root}\\cache"),
+        format!("{soldr_root}\\bench"),
+        format!("{soldr_root}\\runtime"),
+        format!("{soldr_root}\\state.redb"),
+        format!("{soldr_root}\\cache\\zccache"),
+        format!("{soldr_root}\\ws\\target"),
+    ] {
+        assert!(
+            log.contains(&expected),
+            "missing {expected} in defender log:\n{log}"
+        );
+    }
+
+    // Managed file should record every applied path. JSON escapes
+    // backslashes, so normalize before comparing.
+    let managed = fs::read_to_string(soldr_home.join("managed-defender-exclusions.json"))
+        .expect("managed-defender-exclusions.json must be written");
+    let managed_normalized = managed.replace("\\\\", "\\");
+    assert!(
+        managed_normalized.contains(&soldr_root),
+        "managed file must list soldr-owned paths (normalized);\nraw:\n{managed}"
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn optimize_undo_only_removes_managed_paths() {
+    let soldr_home = unique_temp_dir("soldr-optimize-undo");
+    let workspace = soldr_home.join("ws");
+    fs::create_dir_all(&workspace).expect("workspace dir");
+    fs::write(
+        workspace.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.1\"\n",
+    )
+    .expect("Cargo.toml");
+
+    // Pre-seed a managed file that simulates a prior `optimize global` run.
+    let managed_path = soldr_home.join("managed-defender-exclusions.json");
+    fs::create_dir_all(&soldr_home).expect("soldr home");
+    let cache_path = soldr_home.join("cache");
+    let managed = serde_json::json!({
+        "schema_version": 1,
+        "exclusions": [
+            { "path": cache_path.display().to_string(), "added_at_unix": 1, "scope": "global" }
+        ]
+    });
+    fs::write(
+        &managed_path,
+        serde_json::to_string_pretty(&managed).unwrap(),
+    )
+    .expect("write managed file");
+
+    // Defender pretends it currently has both the soldr cache path AND
+    // a user-added entry. We must NEVER remove the user entry.
+    let existing_path = soldr_home.join("existing.txt");
+    let user_added = "C:\\Users\\you\\Documents\\Personal";
+    let existing_body = format!("{}\n{}\n", cache_path.display(), user_added);
+    fs::write(&existing_path, &existing_body).expect("existing list");
+
+    let defender_log = soldr_home.join("defender.log");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["optimize", "--undo", "--scope", "global", "--json"])
+        .current_dir(&workspace)
+        .env("SOLDR_CACHE_DIR", &soldr_home)
+        .env("SOLDR_TEST_ASSUME_ADMIN", "1")
+        .env("SOLDR_TEST_DEFENDER_LOG", &defender_log)
+        .env("SOLDR_TEST_DEFENDER_EXISTING", &existing_path)
+        .env_remove("GITHUB_ACTIONS")
+        .env_remove("CI")
+        .env_remove("BUILDKITE")
+        .env_remove("CIRCLECI")
+        .env_remove("TRAVIS")
+        .env_remove("JENKINS_URL")
+        .output()
+        .expect("failed to run soldr optimize --undo");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "undo must exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let log = fs::read_to_string(&defender_log).expect("defender log written");
+    assert!(
+        log.contains("Remove-MpPreference"),
+        "expected Remove-MpPreference, got:\n{log}"
+    );
+    // User-added entry must not be touched.
+    assert!(
+        !log.contains("Documents\\Personal"),
+        "undo must never touch user-added Defender entries; log:\n{log}"
+    );
+    // soldr-tracked entry must be in the removal log.
+    let cache_str = cache_path.display().to_string();
+    assert!(
+        log.contains(&cache_str),
+        "expected {cache_str} in removal log:\n{log}"
+    );
+}
+
+#[test]
+fn optimize_help_lists_scope_values() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["optimize", "--help"])
+        .output()
+        .expect("failed to run soldr optimize --help");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in ["global", "project", "all", "--undo", "--dry-run", "--json"] {
+        assert!(
+            stdout.contains(expected),
+            "help output missing `{expected}`:\n{stdout}"
+        );
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -335,6 +335,112 @@ Component installed-state matching is target-qualified: rustup's
 installed entry that either equals `clippy` exactly or starts with
 `clippy-`.
 
+### `soldr optimize`
+
+Apply platform-specific hot-cache optimizations to remove
+build-time penalties caused by antivirus / real-time scanners. On
+Windows this adds soldr-owned cache paths (and optionally the current
+project's `target/`) to Windows Defender's exclusion list. On macOS
+and Linux it is a no-op with a clear message — soldr's workloads do
+not require exclusions there.
+
+```bash
+soldr optimize                                # default scope: all
+soldr optimize --scope global                 # only ~/.soldr/* paths
+soldr optimize --scope project                # only <workspace>/target
+soldr optimize --scope all                    # both
+soldr optimize --dry-run --json               # plan-only output
+soldr optimize --undo --scope global          # reverse soldr-added exclusions
+```
+
+Flags:
+
+- `--scope {global|project|all}` — what to optimize. Defaults to
+  `all`.
+- `--undo` — reverse exclusions previously added by soldr. Only
+  paths tracked in `~/.soldr/managed-defender-exclusions.json` are
+  removed; entries the user added by hand are never touched.
+- `--dry-run` — print the plan and exit without invoking PowerShell.
+- `--json` — emit the stable machine-facing JSON form.
+- `--manifest-path <PATH>` — explicit `Cargo.toml` for the `project`
+  scope. When unset, soldr walks up from the current directory.
+
+Platform behavior:
+
+| Platform | Behavior |
+|---|---|
+| Windows 10 | Add Defender exclusions. UAC self-relaunch when not admin. |
+| Windows 11 pre-22H2 | Same as Windows 10, plus an info note about Dev Drive in 22H2. |
+| Windows 11 22H2+ | Same as Windows 10, plus a Dev Drive suggestion when `fsutil devdrv` is supported. |
+| Windows + Defender disabled | Prints "Defender not active; no exclusions needed." Exits 0. |
+| Windows + no PowerShell on PATH | Hard error; exits non-zero. |
+| macOS / Linux | No-op; exits 0 with a message. |
+
+The global scope covers:
+
+- `~/.soldr/cache`
+- `~/.soldr/bench`
+- `~/.soldr/runtime`
+- `~/.soldr/state.redb`
+- The resolved zccache cache directory (`~/.soldr/cache/zccache`).
+  When `ZCCACHE_CACHE_DIR` is set outside soldr's default, the
+  resolved path is excluded explicitly and a warning suggests
+  unsetting the override.
+
+The project scope covers `<workspace_root>/target/`, where
+`<workspace_root>` is the nearest ancestor of the current directory
+containing a `Cargo.toml`. Without `--manifest-path` and without a
+matching ancestor, the command exits with `no Rust project detected`.
+
+UAC self-relaunch:
+
+When the current process is not elevated, soldr re-launches itself
+via `Start-Process powershell -Verb RunAs --as-elevated-helper`. The
+elevated child writes its JSON status to a temp file referenced by
+the `SOLDR_OPTIMIZE_HELPER_OUTPUT` env var; the parent reads,
+prints, and deletes it. The same exit code is propagated. If UAC is
+denied or unavailable, soldr prints instructions for running the
+helper from an elevated PowerShell and exits non-zero — soldr will
+never silently elevate via tokens or scheduled tasks.
+
+CI auto-skip:
+
+`soldr optimize` detects CI via `GITHUB_ACTIONS`, `CI`, `BUILDKITE`,
+`CIRCLECI`, `TRAVIS` (truthy values), or a non-empty `JENKINS_URL`,
+and exits 0 with a clear message. Ephemeral runners discard
+Defender state at job end, so adding exclusions is a no-op there.
+
+Example JSON output (`schema_version: 1`):
+
+```json
+{
+  "schema_version": 1,
+  "command": "optimize",
+  "platform": "Windows10",
+  "scope": "all",
+  "undo": false,
+  "dry_run": true,
+  "defender_present": true,
+  "defender_active": true,
+  "actions": [
+    {
+      "path": "C:\\Users\\you\\.soldr\\cache",
+      "action": "add",
+      "scope": "global",
+      "status": "planned"
+    }
+  ],
+  "note": "dry-run: would add 6 paths to Defender exclusions"
+}
+```
+
+Suppressing the pre-build warning:
+
+When the cargo front door detects that the soldr cache directory is
+being scanned by Defender, it emits a one-line warning to stderr
+suggesting `soldr optimize global`. Set `SOLDR_QUIET_DEFENDER=1` to
+silence it. The warning is also suppressed automatically in CI.
+
 ### `soldr gc`
 
 Review reclaimable Cargo `target/` directories tracked in
@@ -587,6 +693,8 @@ Commands:
 | `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE` | Default-on: skip `rust-plan restore` when `target/` is already warm from a prior step in the same GitHub Actions job + attempt (issue #229). Set to a falsy value (`0` / `false` / `no` / `off`) to opt out. | unset (on) |
 | `SOLDR_TARGET_CACHE_TAR_THREADS` | Reader-thread count for the target-cache tar walk in zccache, AND for soldr's own thin-slice manifest walk (issue #272). `auto` lets each side pick a vCPU-bounded count (capped at 8). `1` disables parallelism (sequential walk). Any positive integer sets an explicit count, clamped to `[1, 8]` on the soldr side. soldr validates the value at the cargo front door and uses it when statting bundle files for the `manifest.v2.json` thin-slice manifest; the bulk multi-GB `target/` tar walk lives in zccache. | unset (`auto`) |
 | `SOLDR_LINKER` | Pick the linker injected for `soldr cargo ...` builds (issue #285). Accepted values: `default` (no injection — keep the rust-toolchain default), `ld` (system linker — also no injection on every supported platform), `mold` (Linux only; hard error elsewhere), `rust-lld` (cross-platform via rustup), `fast` (mold on Linux when present on `PATH`, otherwise rust-lld; rust-lld on macOS and Windows). The choice resolves to `CARGO_TARGET_<TRIPLE>_LINKER` and `CARGO_TARGET_<TRIPLE>_RUSTFLAGS` injected into the spawned cargo process; the active target is the same one Cargo would pick (`--target` flag, `CARGO_BUILD_TARGET`, or the host triple). A `linker = "..."` field in `~/.soldr/config.toml` is honored when the env var is unset. | unset |
+| `SOLDR_QUIET_DEFENDER` | Suppress the once-per-day pre-build warning emitted by the cargo front door when Defender is actively scanning the soldr cache directory (issue #358). Truthy values silence the warning; the warning is also automatically suppressed in CI environments. | unset |
+| `SOLDR_OPTIMIZE_HELPER_OUTPUT` | Internal: set by the parent soldr process when it re-launches itself elevated via `--as-elevated-helper`. The elevated child writes its JSON status to this path so the parent can read and propagate it. | unset |
 
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.


### PR DESCRIPTION
Closes #358.

## Summary

Ships `soldr optimize [--scope global|project|all] [--undo] [--dry-run] [--json]` as a first-class, platform-aware subcommand. On Windows it adds soldr-owned hot-cache paths (and the current project's `target/`) to Windows Defender's real-time scanning exclusion list. On macOS / Linux it is a clean no-op with a message. CI environments auto-skip.

## Platform matrix

| Platform | Behavior |
|---|---|
| Windows 10 | Add Defender exclusions via PowerShell `Add-MpPreference`. UAC self-relaunch when not admin. |
| Windows 11 pre-22H2 | Same as Windows 10, plus info note that Dev Drive becomes available in 22H2. |
| Windows 11 22H2+ | Same as Windows 10, plus a Dev Drive suggestion link when `fsutil devdrv` is supported. |
| Windows + AntivirusEnabled=false | "Defender not active; no exclusions needed." Exit 0. |
| Windows + no PowerShell on PATH | Hard error; exit non-zero. |
| macOS / Linux | "$OS does not need cache exclusions for soldr's workloads." Exit 0. |

## UAC self-relaunch flow

* Non-admin invocations: soldr relaunches itself via `Start-Process powershell -Verb RunAs <self> optimize <args> --as-elevated-helper --json`.
* The elevated child writes its `OptimizeOutput` JSON to a temp file referenced by `SOLDR_OPTIMIZE_HELPER_OUTPUT`. The parent waits, reads, prints to its own stdout/stderr, deletes the file, and exits with the same code as the child.
* If `Start-Process -Verb RunAs` fails or the user denies UAC, soldr prints clear instructions for running the helper from an elevated PowerShell and exits non-zero. Never silently elevates via tokens / scheduled tasks.

## `--undo` model

* Reads `~/.soldr/managed-defender-exclusions.json` (schema v1).
* Removes only entries that match the current `--scope`, calling `Remove-MpPreference` for each.
* Never touches user-added Defender exclusions — confirmed by an integration test that seeds `Documents\Personal` into the simulated exclusion list and verifies soldr leaves it alone.
* Successfully-removed entries are pruned from the managed file.

## Zccache cache-dir coverage (per the #358 Directive)

`--scope global` excludes:

* `~/.soldr/cache`
* `~/.soldr/bench`
* `~/.soldr/runtime`
* `~/.soldr/state.redb`
* The resolved `zccache_dir(SoldrPaths)` (currently `~/.soldr/cache/zccache`)

The resolved zccache path is added explicitly, not via the parent `~/.soldr/cache` exclusion, so a future change moving zccache to a sibling location under `~/.soldr/` is covered without users re-running optimize. When `ZCCACHE_CACHE_DIR` is set externally, the resolved path is still excluded and a warning suggests unsetting the override.

## CI auto-skip

`GITHUB_ACTIONS`, `CI`, `BUILDKITE`, `CIRCLECI`, `TRAVIS` (truthy), and non-empty `JENKINS_URL` trigger a one-line skip message and exit 0. Ephemeral runners discard Defender state at job end.

## Four gates (local)

* `cargo build -p soldr-cli` — green
* `cargo test --workspace` — 387 passed, 0 failed
* `cargo clippy --workspace --all-targets -- -D warnings` — green
* `cargo fmt --all -- --check` — green

## RED → GREEN

* RED commit (`accb243`): committed the unit tests with stub function bodies returning `Err("not yet implemented")`. The tests compiled but 19 of 24 behavior assertions failed as expected (the 5 that passed were the structural ones that work against stubs — e.g. JSON round-trip on an empty `OptimizeOutput`).
* GREEN commit (`177717b`): replaced the stubs with the real implementation; all 32 unit tests + 6 integration tests pass.
* Docs commit (`6d74297`): CLAUDE.md frozen-builtins list and `docs/API.md` reference + env var table.

## Notes

* No new crate dependencies. Implementation uses existing `clap`, `serde`, `serde_json`, `tempfile` (in tests), and shells out to `powershell` / `pwsh` / `fsutil` / `reg` for OS-level queries.
* New `optimize` is allowed as a frozen built-in — `grep` confirms no `cargo-optimize` exists in `known_tools.rs`, so there is no namespace collision risk.
* CI's existing setup-soldr action pin drift (pre-existing) is unrelated to this PR.
* `soldr optimize --dry-run --json` was verified end-to-end on this machine (Windows 10, build 19045) and produced a sensible plan covering all six paths.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>