### PR TITLE
chore(deps): bump managed zccache 1.5.0 -> 1.6.0 (daemon stdio fix)

### DIFF
--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -64,7 +64,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.5.0");
+    assert_eq!(json["managed_zccache_version"], "1.6.0");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -221,7 +221,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.5.0");
+    assert_eq!(json["managed_zccache_version"], "1.6.0");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -273,7 +273,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.5.0");
+    assert_eq!(json["managed_zccache_version"], "1.6.0");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -47,7 +47,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.5.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.6.0";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),


### PR DESCRIPTION
zccache 1.6.0 (released 2026-05-19) carries the fix for [zackees/zccache#276](https://github.com/zackees/zccache/issues/276) — the daemon now detaches inherited stdio handles before entering its main loop, so pipe-using wrappers no longer hang indefinitely after their build finishes.

## Why this matters

Filed yesterday from an empirical investigation: the parent-cache bench (#352) was hanging 60+ minutes per stage on Windows. We initially attributed it to Windows Defender. Live process inspection showed it wasn't Defender at all — the orphaned `zccache-daemon` was holding the inherited stdout pipe open, preventing Python's `proc.stdout` iteration from ever observing EOF. cargo and soldr had exited promptly; the daemon was just sitting on a 1300-handle, 0% CPU wait.

zccache 1.6.0 closes inherited handles before the daemon enters its main loop. Pipe-using wrappers (the bench script, any CI integration using `subprocess.Popen(stdout=PIPE)`, IDE integrations, etc.) now see EOF immediately after the build child exits.

## Diff

- `crates/soldr-fetch/src/lib.rs:50` — `MANAGED_ZCCACHE_VERSION` pin: `1.5.0` → `1.6.0`.
- `crates/soldr-cli/tests/cli_cache.rs` (×3) — `managed_zccache_version` assertions follow the pin.

The compatibility comment in `crates/soldr-cli/src/cache.rs:227` referencing \`1.5.0+\` as the minimum for the \`analyze\` subcommand is unchanged — 1.5.0 is still the floor for that feature.

## Validation

- \`cargo build -p soldr-cli\` — clean
- \`cargo test --workspace --no-fail-fast\` — all green
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- \`cargo fmt --all -- --check\` — clean

CI's \`Verify setup-soldr pin\` step is failing on main from pre-existing v0 tag drift; unrelated.

Refs zackees/zccache#276, #352

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>