### PR TITLE
chore(hook): block env-prefixed bare Rust tools + add rustup/rustdoc/etc

### DIFF
--- a/.claude/hooks/test_tool_guard.py
+++ b/.claude/hooks/test_tool_guard.py
@@ -122,6 +122,65 @@ class ToolGuardTests(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result[0], "cargo")
 
+    def test_blocks_bare_rustup(self):
+        result = check_command("rustup target add x86_64-pc-windows-msvc")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "rustup")
+
+    def test_blocks_bare_rustdoc(self):
+        result = check_command("rustdoc --output target/doc src/lib.rs")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "rustdoc")
+
+    def test_blocks_bare_rust_gdb_lldb_analyzer(self):
+        for tool in ("rust-gdb", "rust-lldb", "rust-analyzer"):
+            with self.subTest(tool=tool):
+                result = check_command(f"{tool} --version")
+                self.assertIsNotNone(result)
+                self.assertEqual(result[0], tool)
+
+    def test_allows_soldr_rustup_rustdoc(self):
+        self.assertIsNone(check_command("soldr rustup target add x86_64-pc-windows-msvc"))
+        self.assertIsNone(check_command("soldr rustdoc --output target/doc src/lib.rs"))
+        self.assertIsNone(check_command("uv run soldr rustup show"))
+
+    def test_blocks_env_prefixed_bare_cargo(self):
+        # Leading env-var assignments are not a backdoor around the policy.
+        cases = (
+            "RUSTUP_TOOLCHAIN=1.94.1 cargo build",
+            "FOO=bar BAZ=qux cargo test",
+            "CARGO_PROFILE_RELEASE_DEBUG=2 CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=packed cargo build",
+            "CARGO_TARGET_DIR=/tmp/foo cargo check",
+        )
+        for command in cases:
+            with self.subTest(command=command):
+                result = check_command(command)
+                self.assertIsNotNone(result)
+                self.assertEqual(result[0], "cargo")
+
+    def test_blocks_env_prefixed_bare_rustup(self):
+        result = check_command("RUSTUP_HOME=/tmp/h rustup show")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "rustup")
+
+    def test_allows_env_prefixed_soldr_invocation(self):
+        # Env-var assignments before soldr are fine -- the policy is about
+        # routing the *tool*, not forbidding env overrides.
+        self.assertIsNone(check_command("SOLDR_TRUST_MODE=strict soldr cargo build"))
+        self.assertIsNone(check_command("CARGO_BUILD_JOBS=4 soldr cargo test --release"))
+        self.assertIsNone(check_command("FOO=bar uv run soldr cargo check"))
+
+    def test_blocks_env_prefixed_bare_python(self):
+        result = check_command("PYTHONPATH=/foo python ci/script.py")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "python")
+
+    def test_blocks_env_prefixed_in_compound(self):
+        # Env-prefixed bare cargo on the right side of && must still trip.
+        result = check_command("git status && RUSTUP_TOOLCHAIN=foo cargo build")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "cargo")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tool_guard.py
+++ b/.claude/hooks/tool_guard.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env -S uv run --script
 """PreToolUse hook: blocks bare Rust commands and bare python/pip.
 
-All cargo/rustc/rustfmt must go through soldr (ensures correct toolchain).
+All Rust toolchain commands (cargo, rustup, rustc, rustfmt, clippy-driver,
+cargo-clippy, cargo-fmt, rustdoc, rust-gdb, rust-lldb, rust-analyzer) must
+go through soldr. soldr resolves the project-pinned toolchain via rustup
+and ensures every per-unit compile is routed through the soldr-managed
+zccache.
+
 All python must go through uv (ensures correct environment).
+
+Leading env-var assignments (`FOO=bar baz=qux cargo build`) are stripped
+before evaluation so they cannot be used as a backdoor around the policy.
 
 Exit codes:
   0 - Allow (outputs JSON hookSpecificOutput to deny if needed)
@@ -13,7 +21,22 @@ import re
 import sys
 
 
-RUST_TOOLS = {"cargo", "rustc", "rustfmt", "clippy-driver", "cargo-clippy", "cargo-fmt"}
+# Anything in this set, invoked bare, is denied. The user is expected to
+# route through `soldr <tool> ...` (or `uv run soldr <tool> ...`).
+RUST_TOOLS = {
+    "cargo",
+    "cargo-clippy",
+    "cargo-fmt",
+    "clippy-driver",
+    "rustc",
+    "rustdoc",
+    "rustfmt",
+    "rustup",
+    "rust-gdb",
+    "rust-lldb",
+    "rust-analyzer",
+}
+
 PYTHON_TOOLS = {"python", "python3", "pip", "pip3"}
 
 SOLDR_PREFIXES = ("soldr ", "uv run soldr ")
@@ -40,9 +63,26 @@ UV_RUN_FLAGS_WITH_VALUES = {
     "-p",
 }
 
+# Matches `IDENT=`, with optional digits/underscores after the first letter.
+# Used to strip leading shell env-var assignments before evaluating the real
+# command, so `RUSTUP_TOOLCHAIN=foo cargo build` is recognized as `cargo build`.
+ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def strip_env_prefix(tokens):
+    """Return tokens with leading shell env-var assignments removed."""
+    i = 0
+    while i < len(tokens) and ENV_ASSIGN_RE.match(tokens[i]):
+        i += 1
+    return tokens[i:]
+
 
 def uv_run_target(parts):
-    """Return the uv-run command target after leading uv options."""
+    """Return the uv-run command target after leading uv options.
+
+    `parts` is the token list AFTER any env-var prefix has been stripped,
+    starting with `uv run ...`.
+    """
     index = 2
     while index < len(parts):
         token = parts[index]
@@ -75,26 +115,35 @@ def check_command(command):
         if not seg:
             continue
 
+        # Strip leading env-var assignments so they can't be used as a
+        # backdoor: `RUSTUP_TOOLCHAIN=foo cargo build` is the same policy
+        # violation as `cargo build`.
+        tokens = strip_env_prefix(seg.split())
+        if not tokens:
+            continue
+
+        # Reconstruct the cleaned command for prefix checks.
+        stripped = " ".join(tokens)
+
         # Skip if Rust tooling is explicitly routed through soldr.
-        if any(seg.startswith(p) for p in SOLDR_PREFIXES):
+        if any(stripped.startswith(p) for p in SOLDR_PREFIXES):
             continue
 
-        if seg.startswith(UV_PIP_PREFIX):
+        if stripped.startswith(UV_PIP_PREFIX):
             continue
 
-        first_word = seg.split()[0] if seg.split() else ""
+        first_word = tokens[0]
 
-        if seg.startswith(UV_RUN_PREFIX):
-            parts = seg.split()
+        if stripped.startswith(UV_RUN_PREFIX):
             # `uv run soldr ...` was handled above. Block the old `uv run cargo`
             # console-script shim path so Rust tooling has one canonical entry.
-            run_target = uv_run_target(parts)
+            run_target = uv_run_target(tokens)
             if run_target in RUST_TOOLS:
                 return (
                     run_target,
                     f"Use `uv run soldr {run_target} ...` instead of "
-                    f"`uv run {run_target} ...`. soldr resolves the checked-in "
-                    f"Rust toolchain directly via rustup.",
+                    f"`uv run {run_target} ...`. soldr resolves the project-pinned "
+                    f"Rust toolchain via rustup.",
                 )
             continue
 
@@ -103,13 +152,20 @@ def check_command(command):
                 first_word,
                 f"Use `soldr {first_word} ...` or "
                 f"`uv run soldr {first_word} ...` instead of bare "
-                f"`{first_word}`. soldr resolves the checked-in Rust toolchain "
-                f"directly via rustup.",
+                f"`{first_word}`. All Rust toolchain commands (cargo, rustup, "
+                f"rustc, rustfmt, clippy-driver, cargo-clippy, cargo-fmt, "
+                f"rustdoc, rust-gdb, rust-lldb, rust-analyzer) must go through "
+                f"soldr -- including invocations with leading env-var "
+                f"assignments like `FOO=bar {first_word} ...`.",
             )
 
         if first_word in PYTHON_TOOLS:
             if first_word.startswith("pip"):
-                suggestion = f"uv pip {' '.join(seg.split()[1:])}" if len(seg.split()) > 1 else "uv pip ..."
+                suggestion = (
+                    f"uv pip {' '.join(tokens[1:])}"
+                    if len(tokens) > 1
+                    else "uv pip ..."
+                )
                 return (
                     first_word,
                     f"Use `{suggestion}` instead of bare `{first_word}`. "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Anything not registered falls through the generic External subcommand, which res
 - **Parent-cache sharing is default-on**: For managed-zccache builds soldr seeds `ZCCACHE_PATH_REMAP=auto` on the child cargo (issue #352, Tier L1.x). zccache then normalizes absolute source paths inside compiled artifacts so two git worktrees of the same repo serve each other's cache hits via hardlinks. Escape hatch: `SOLDR_PATH_REMAP=off` suppresses the injection; setting `ZCCACHE_PATH_REMAP` yourself wins. Requires a real `.git/` checkout — tarball/zip checkouts silently fall back to no remap.
 - **Integrity is default**: every fetch records sha256. Pins are opt-in via `SOLDR_CHECKSUMS_FILE`; `SOLDR_TRUST_MODE=strict` refuses unpinned fetches.
 - **Version independence**: Users install once and forget. CI should pin: `pip install soldr==X.Y.Z`.
+- **All Rust toolchain commands go through soldr**: `cargo`, `rustup`, `rustc`, `rustfmt`, `clippy-driver`, `cargo-clippy`, `cargo-fmt`, `rustdoc`, `rust-gdb`, `rust-lldb`, and `rust-analyzer` must be invoked as `soldr <tool> ...` (or `uv run soldr <tool> ...`). This includes invocations with leading env-var assignments — `RUSTUP_TOOLCHAIN=... cargo build` is the same policy violation as `cargo build`. The hook at `.claude/hooks/tool_guard.py` enforces this in Claude Code shell tools; the helper script `bench/build_local_zccache.sh` and any documented workflow must follow the same rule. Env-vars prefixed before `soldr` are fine — the policy is about routing the tool, not forbidding env overrides.
 
 ## Agent Completion Rules
 


### PR DESCRIPTION
## What

The PreToolUse \`tool_guard\` hook had two gaps that let policy-violating commands through. I tripped over both today while trying to bypass the soldr-routing policy without realizing it.

1. **Leading env-var assignments were not stripped before evaluation.** \`RUSTUP_TOOLCHAIN=1.94.1-x86_64-pc-windows-msvc cargo build --release\` reached \`split()[0]\` as \`RUSTUP_TOOLCHAIN=...\`, which is not in \`RUST_TOOLS\`, so the hook allowed it. \`CARGO_PROFILE_RELEASE_DEBUG=2 cargo build\`, \`CARGO_TARGET_DIR=/tmp cargo check\`, etc., were equally invisible to the guard.
2. **\`rustup\`, \`rustdoc\`, \`rust-gdb\`, \`rust-lldb\`, \`rust-analyzer\` were not in the blocklist at all.** Even though CLAUDE.md already treats them as soldr-managed surface area (the soldr binary has a \`rustup\` subcommand that injects \`--toolchain <channel>\` per \`rust-toolchain.toml\`), bare invocations weren't blocked.

## Fix

- New \`strip_env_prefix\` helper that walks past leading shell env-var assignments before any rust-tool / python check fires.
- \`RUST_TOOLS\` extended to include \`rustup\`, \`rustdoc\`, \`rust-gdb\`, \`rust-lldb\`, \`rust-analyzer\`.
- The \`SOLDR_PREFIXES\` and \`UV_PIP_PREFIX\` checks now run against the *stripped* command so authorized env overrides like \`SOLDR_TRUST_MODE=strict soldr cargo build\` still pass.

## Tests

\`.claude/hooks/test_tool_guard.py\` grew from 18 to 27 tests. New cases:
- bare \`rustup\` / \`rustdoc\` / \`rust-gdb\` / \`rust-lldb\` / \`rust-analyzer\` blocked
- \`soldr rustup ...\` / \`soldr rustdoc ...\` / \`uv run soldr rustup ...\` allowed
- \`RUSTUP_TOOLCHAIN=... cargo build\`, \`CARGO_PROFILE_RELEASE_DEBUG=2 ... cargo build\`, \`PYTHONPATH=/foo python ...\`, \`RUSTUP_HOME=/tmp rustup show\` all blocked
- \`SOLDR_TRUST_MODE=strict soldr cargo build\`, \`CARGO_BUILD_JOBS=4 soldr cargo test\`, \`FOO=bar uv run soldr cargo check\` all allowed (the policy is about routing the tool, not forbidding env overrides)
- env-prefixed bare cargo on the right side of \`&&\` (\`git status && RUSTUP_TOOLCHAIN=foo cargo build\`) also blocked

Smoke-tested by piping the exact bypass command I used earlier into the hook -- it correctly returns the deny JSON.

## Docs

New Key Design Rule in CLAUDE.md spelling out the policy so reviewers and contributors see it as a project-level invariant, not just a hook implementation detail. Quote:

> All Rust toolchain commands go through soldr: cargo, rustup, rustc, rustfmt, clippy-driver, cargo-clippy, cargo-fmt, rustdoc, rust-gdb, rust-lldb, and rust-analyzer must be invoked as \`soldr <tool> ...\` (or \`uv run soldr <tool> ...\`). This includes invocations with leading env-var assignments -- \`RUSTUP_TOOLCHAIN=... cargo build\` is the same policy violation as \`cargo build\`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>