### PR TITLE
chore(deps): bump managed zccache 1.6.0 -> 1.7.0 (daemon-stdio fix + shipped PDBs)

### DIFF
--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -64,7 +64,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.6.0");
+    assert_eq!(json["managed_zccache_version"], "1.7.0");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -221,7 +221,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.6.0");
+    assert_eq!(json["managed_zccache_version"], "1.7.0");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -273,7 +273,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.6.0");
+    assert_eq!(json["managed_zccache_version"], "1.7.0");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -47,7 +47,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.6.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.7.0";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),


### PR DESCRIPTION
zccache 1.7.0 (released 2026-05-19T12:18:48Z) carries:

1. The Windows daemon-stdio fix per [zackees/zccache#289](https://github.com/zackees/zccache/issues/289) -- the root-cause analysis we filed showing that 1.6.0's daemon-side \`detach_stdio\` missed the orphaned inheritable handles leaking from a pipe-redirected ancestor. The 1.7.0 fix moves the closure to the spawn boundary (PROC_THREAD_ATTRIBUTE_HANDLE_LIST), so the Python pipe never crosses into the daemon.

2. PDB sidecars shipped in the release zip for MSVC binaries. The locally-built workflow we set up in #363 was a stop-gap; with PDBs in the release artifact, attaching cdb with symbols just works against the managed binary.

## Effect on this repo

Pipe-using soldr wrappers -- the parent-cache bench (\`bench/parent_cache_bench.py\`), Python \`subprocess.Popen\` flows that redirect stdout, IDE language-server hosts, CI runners -- should stop hanging after cargo's \`Finished\` line on Windows. The 60-min Stage-A/B/C tax in PR #353's bench should disappear, and the actual L1.x parent-cache speedup signal can finally be measured.

The \`SOLDR_ZCCACHE_LOCAL_DIR\` override from #363 stays in place as a debugging aid. With symbols now in the managed binary, it's no longer the *recommended* workflow.

## Diff

- \`crates/soldr-fetch/src/lib.rs:50\` -- \`MANAGED_ZCCACHE_VERSION\` 1.6.0 -> 1.7.0
- \`crates/soldr-cli/tests/cli_cache.rs\` (x3) -- \`managed_zccache_version\` assertions

## Validation (Windows MSVC, soldr cargo wrapper)

- \`soldr cargo build -p soldr-cli\` -- clean
- \`soldr cargo test --workspace --no-fail-fast\` -- all green
- \`soldr cargo clippy --workspace --all-targets -- -D warnings\` -- clean
- \`soldr cargo fmt --all -- --check\` -- clean

Refs [zackees/zccache#276](https://github.com/zackees/zccache/issues/276), [zackees/zccache#289](https://github.com/zackees/zccache/issues/289), #352, #363

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>