### PR TITLE
fix(test): strip inherited SOLDR_RELOCATED_EXE in windows-self-relocate test

### DIFF
--- a/crates/soldr-cli/tests/cli_cargo_basic.rs
+++ b/crates/soldr-cli/tests/cli_cargo_basic.rs
@@ -279,6 +279,15 @@ fn windows_worktree_copy_relocates_wrapper_and_original_dir_can_be_removed() {
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
         .env_remove("SOLDR_TARGET_CACHE_MODE")
         .env_remove("SOLDR_BUILD_CACHE_MODE")
+        // Strip any relocation guard the parent process might be carrying
+        // (it inherits these when the test suite itself is run via
+        // `soldr cargo test`, because the outer soldr self-relocates and
+        // exports SOLDR_RELOCATED_EXE / SOLDR_ORIGINAL_EXE in its env).
+        // Leaving them set short-circuits relocation_guard_active() inside
+        // the copied soldr, so RUSTC_WRAPPER would point at the worktree
+        // copy instead of the runtime/soldr-self copy this test asserts.
+        .env_remove("SOLDR_RELOCATED_EXE")
+        .env_remove("SOLDR_ORIGINAL_EXE")
         .output()
         .expect("failed to run copied soldr exe");
 


### PR DESCRIPTION
## Summary

Fixes `windows_worktree_copy_relocates_wrapper_and_original_dir_can_be_removed` (crates/soldr-cli/tests/cli_cargo_basic.rs), which fails on Windows whenever the test suite is launched through `soldr cargo test`.

## Root cause

When the outer `soldr cargo test` runs:

1. The outer `soldr` self-relocates and re-execs the runtime copy with `SOLDR_RELOCATED_EXE=1` / `SOLDR_ORIGINAL_EXE=<path>` set.
2. `cargo test` inherits both env vars from the relocated soldr.
3. The test binary inherits them from cargo.
4. The test spawns `copied_soldr` via `Command::env()` (additive — not `env_clear`/`env_remove`), so the copied soldr sees `SOLDR_RELOCATED_EXE` already set.
5. Inside the copied soldr, `self_relocate::maybe_reexec_from_runtime` sees `relocation_guard_active() == true` and returns early.
6. `RUSTC_WRAPPER` is then set to the worktree copy (`<worktree>/target/debug/soldr.exe`) instead of `<cache>/runtime/soldr-self/...`, and the test's assertion fires.

## Fix

Add two `.env_remove()` calls to the test's `Command` builder:

```rust
.env_remove("SOLDR_RELOCATED_EXE")
.env_remove("SOLDR_ORIGINAL_EXE")
```

This makes the test robust regardless of how the suite is launched (`cargo test` directly, `soldr cargo test`, or under any other parent that may have these env vars set). A comment explains the inheritance chain.

## Validation

- Before: `soldr cargo test -p soldr-cli --test cli_cargo_basic` fails this single test.
- After: all 9 tests in `cli_cargo_basic` pass.
- `soldr cargo clippy --workspace --all-targets -- -D warnings` clean.
- `soldr cargo fmt --all -- --check` clean.

## Test plan

- [x] `soldr cargo test -p soldr-cli --test cli_cargo_basic` — all 9 pass locally.
- [ ] CI: Windows x64 / ARM64 bootstrap workflows complete without regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)