### PR TITLE
ci: bump setup-soldr pin 37ab11d -> 4ed67cf to match current @v0

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
+        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
           linker: platform-default

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -436,7 +436,7 @@ jobs:
       - id: setup-soldr
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335
+        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11
         with:
           linker: platform-default
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
+      - uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
         with:
           linker: platform-default
           # Formatting does not benefit from a restored target directory, but
@@ -77,7 +77,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
+      - uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
         with:
           linker: platform-default
 
@@ -114,7 +114,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
+      - uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
         with:
           linker: platform-default
 
@@ -151,7 +151,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
+      - uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
         with:
           linker: platform-default
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -218,7 +218,7 @@ jobs:
           fi
 
       - name: Setup Soldr toolchain
-        uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335 # @v0
+        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
         with:
           linker: platform-default
           cache: false

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -66,7 +66,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@37ab11d8638b8ba9c7d4d0d9efac81bece533335
+        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11
         with:
           cache: true
           linker: platform-default


### PR DESCRIPTION
## Summary

`zackees/setup-soldr@v0` moved forward to [`4ed67cf`](https://github.com/zackees/setup-soldr/commit/4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11) (setup-soldr#108 / #109 — `fix(linker): defer default fast linker when user preset CARGO_TARGET_<T>_LINKER`). The pin verifier (`.github/scripts/verify_setup_soldr_pin.py`) now fails every job that runs it, reporting:

> `zackees/setup-soldr pin 37ab11d8638b8ba9c7d4d0d9efac81bece533335 does not match current @v0 4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11`

## Change

Update every executable `uses: zackees/setup-soldr@<SHA>` in `.github/workflows/` to the current `@v0` SHA. This is the same edit the verifier's `SETUP_SOLDR_PIN_AUTOFIX` path produces automatically; doing it by hand because the verifier fires before the autofix step on most jobs.

8 lines across 6 files:
- `.github/workflows/_bootstrap-e2e.yml`
- `.github/workflows/cache-benchmark.yml`
- `.github/workflows/ci.yml` (4 lines)
- `.github/workflows/release-auto.yml`
- `.github/workflows/setup-soldr-action.yml`

(`parent-cache-bench.yml` was already on the new SHA.)

## Validation

```
$ python .github/scripts/verify_setup_soldr_pin.py
zackees/setup-soldr workflow pins match @v0: 4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11
```

## Test plan

- [x] Local pin verifier reports match.
- [ ] CI: every workflow that runs `verify_setup_soldr_pin.py` is now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)