### PR TITLE
fix(lint): gate windows-only optimize_windows items + wrapper import

### DIFF
--- a/crates/soldr-cli/src/optimize.rs
+++ b/crates/soldr-cli/src/optimize.rs
@@ -17,13 +17,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::cache::print_json;
 use crate::JSON_SCHEMA_VERSION;
 
+#[cfg(not(target_os = "windows"))]
+use crate::optimize_windows::{apply_exclusions, current_exclusion_list, is_admin};
 #[cfg(target_os = "windows")]
 use crate::optimize_windows::{
     apply_exclusions, current_exclusion_list, is_admin, relaunch_elevated, ELEVATED_HELPER_FLAG,
-};
-#[cfg(not(target_os = "windows"))]
-use crate::optimize_windows::{
-    apply_exclusions, current_exclusion_list, is_admin, ELEVATED_HELPER_FLAG,
 };
 
 use crate::optimize_detect::{detect_ci, detect_platform, detect_tools, find_powershell, Platform};

--- a/crates/soldr-cli/src/optimize_windows.rs
+++ b/crates/soldr-cli/src/optimize_windows.rs
@@ -11,10 +11,12 @@ use super::optimize::{ActionStatus, ExclusionAction, PathAction};
 /// Environment variable injected by the parent soldr process when it
 /// re-launches itself elevated. The helper subprocess writes its JSON
 /// status to this path so the parent can read and report it.
+#[cfg(target_os = "windows")]
 pub(crate) const SOLDR_OPTIMIZE_HELPER_OUTPUT_ENV: &str = "SOLDR_OPTIMIZE_HELPER_OUTPUT";
 
 /// Sentinel flag the parent passes to the elevated helper to make it
 /// skip its own UAC self-relaunch loop.
+#[cfg(target_os = "windows")]
 pub(crate) const ELEVATED_HELPER_FLAG: &str = "--as-elevated-helper";
 
 /// Test seam: when set, the helper that would normally call
@@ -27,6 +29,7 @@ pub(crate) const SOLDR_TEST_DEFENDER_LOG_ENV: &str = "SOLDR_TEST_DEFENDER_LOG";
 /// Test seam: when set, treats the current process as if it is
 /// running with administrator privileges regardless of the real
 /// token. Bypasses the UAC self-relaunch path in tests.
+#[cfg(target_os = "windows")]
 pub(crate) const SOLDR_TEST_ASSUME_ADMIN_ENV: &str = "SOLDR_TEST_ASSUME_ADMIN";
 
 /// Test seam: when set, returns the contents of this file as the
@@ -232,15 +235,7 @@ pub(crate) fn relaunch_elevated(
     Ok(status.code().unwrap_or(1))
 }
 
-#[cfg(not(target_os = "windows"))]
-pub(crate) fn relaunch_elevated(
-    _powershell: &Path,
-    _args: &[String],
-    _helper_output_path: &Path,
-) -> Result<i32, String> {
-    Err("UAC self-relaunch is only supported on Windows".into())
-}
-
+#[cfg(target_os = "windows")]
 fn build_powershell_arg_list(args: &[String]) -> String {
     if args.is_empty() {
         // PowerShell rejects empty Start-Process ArgumentList; pass a
@@ -251,6 +246,7 @@ fn build_powershell_arg_list(args: &[String]) -> String {
     format!("@({})", parts.join(","))
 }
 
+#[cfg(target_os = "windows")]
 fn ps_quote(value: &str) -> String {
     let escaped = value.replace('\'', "''");
     format!("'{}'", escaped)
@@ -266,11 +262,13 @@ mod tests {
         assert!(exclusion_list_contains(&list, "c:/users/you/.soldr/cache"));
     }
 
+    #[cfg(target_os = "windows")]
     #[test]
     fn ps_quote_doubles_single_quotes() {
         assert_eq!(ps_quote("a'b"), "'a''b'");
     }
 
+    #[cfg(target_os = "windows")]
     #[test]
     fn build_powershell_arg_list_emits_array_literal() {
         let args = vec!["optimize".to_string(), "--scope".to_string()];

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -3,6 +3,7 @@
 //! from "unknown session" errors on Windows. Extracted from `main.rs` as
 //! part of issue #339.
 
+#[cfg(not(unix))]
 use crate::zccache::run_zccache_command_in_cache_dir;
 use crate::{apply_implicit_toolchain_homes, resolve_toolchain_binary, zccache_binary_override};
 use soldr_core::{suppress_windows_console_window, SoldrError, SoldrPaths};


### PR DESCRIPTION
## Summary

Fixes the Lint job on main ([run 26098144954](https://github.com/zackees/soldr/actions/runs/26098144954/job/76741361218)) — 8 errors under `soldr cargo clippy --workspace --all-targets --locked -- -D warnings`. All of them are items only consumed inside Windows-cfg-gated code paths but not themselves cfg-gated, so the Linux build sees them as dead.

## Changes

### `crates/soldr-cli/src/wrapper.rs`
- Gate `use crate::zccache::run_zccache_command_in_cache_dir;` with `#[cfg(not(unix))]`. Its sole caller, `allocate_replacement_session`, is already `#[cfg(not(unix))]`.

### `crates/soldr-cli/src/optimize.rs`
- Drop `ELEVATED_HELPER_FLAG` from the non-Windows `use` of `optimize_windows`. It is only referenced inside `#[cfg(target_os = "windows")] fn rebuild_argv_for_helper`.
- Reorder the two `use` blocks so rustfmt is happy (cfg(not) before cfg).

### `crates/soldr-cli/src/optimize_windows.rs`
- `#[cfg(target_os = "windows")]` on `SOLDR_OPTIMIZE_HELPER_OUTPUT_ENV`, `ELEVATED_HELPER_FLAG`, and `SOLDR_TEST_ASSUME_ADMIN_ENV` (only consumed inside Windows code).
- Delete the non-Windows `relaunch_elevated` stub. No caller exists on non-Windows (`elevate_or_explain`'s call site is `#[cfg(target_os = "windows")]`), so the stub was unreachable.
- `#[cfg(target_os = "windows")]` on `build_powershell_arg_list` and `ps_quote`.
- Their unit tests `ps_quote_doubles_single_quotes` and `build_powershell_arg_list_emits_array_literal` get the same cfg gate. `exclusion_list_contains_normalizes_separators_and_case` stays unconditional (its target isn't cfg-gated).

## Validation

- `soldr cargo clippy --workspace --all-targets --locked -- -D warnings` — clean on Windows (the failing run was Linux, but the failures were Linux-only dead-code triggered by Windows-only callers; the gates make Linux match Windows's view).
- `soldr cargo fmt --all -- --check` — clean.
- `soldr cargo build --workspace --all-targets --locked` — clean.

## Test plan

- [ ] CI `Lint` job goes green on this branch.
- [ ] Downstream `Build *` jobs (which had `needs: lint`) unblock.

Refs [run 26098144954](https://github.com/zackees/soldr/actions/runs/26098144954/job/76741361218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)