### PR TITLE
ci(windows): drop setup-soldr from all Windows-running jobs

### DIFF
--- a/.github/workflows/_bootstrap-e2e-windows.yml
+++ b/.github/workflows/_bootstrap-e2e-windows.yml
@@ -1,0 +1,167 @@
+name: _Bootstrap E2E (Windows)
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      target:
+        required: true
+        type: string
+      binary_name:
+        required: true
+        type: string
+      save_cache:
+        required: false
+        type: boolean
+        default: false
+      source_ref:
+        required: true
+        type: string
+      third_party_repo:
+        required: false
+        type: string
+        default: "zackees/soldr"
+      third_party_ref:
+        required: false
+        type: string
+        default: "0c8daefe4a4ac526b491fade590b32636340dce1"
+      third_party_path:
+        required: false
+        type: string
+        default: "third_party/bootstrap-fixture"
+      third_party_build_dir:
+        required: false
+        type: string
+        default: "crates/soldr-cli/tests/fixtures/windows-msvc-default"
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap-e2e:
+    name: Build soldr and bootstrap third-party app (${{ inputs.target }})
+    runs-on: ${{ inputs.runner }}
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          path: soldr
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: ${{ inputs.third_party_repo }}
+          ref: ${{ inputs.third_party_ref }}
+          path: ${{ inputs.third_party_path }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.1
+          targets: ${{ inputs.target }}
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: soldr -> target
+          key: bootstrap-${{ inputs.target }}
+          shared-key: bootstrap-${{ inputs.target }}
+
+      - name: Build soldr-cli
+        shell: pwsh
+        working-directory: soldr
+        run: |
+          cargo build --package soldr-cli --locked --target "${{ inputs.target }}"
+
+      - name: Resolve third-party toolchain
+        id: third_party_toolchain
+        shell: pwsh
+        run: |
+          $checkoutRoot = Join-Path $env:GITHUB_WORKSPACE "${{ inputs.third_party_path }}"
+          $candidateFiles = @(
+            (Join-Path $checkoutRoot "${{ inputs.third_party_build_dir }}/rust-toolchain.toml"),
+            (Join-Path $checkoutRoot "rust-toolchain.toml")
+          )
+
+          $toolchainFile = $candidateFiles | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $toolchainFile) {
+            "channel=repo-default" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            exit 0
+          }
+
+          $channelLine = Select-String -Path $toolchainFile -Pattern '^channel = "(.*)"$' | Select-Object -First 1
+          if (-not $channelLine) {
+            throw "failed to resolve third-party Rust toolchain from $toolchainFile"
+          }
+
+          $channel = $channelLine.Matches[0].Groups[1].Value
+          rustup toolchain install $channel --profile minimal
+          rustup target add --toolchain $channel "${{ inputs.target }}"
+          "channel=$channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Resolve soldr binary path
+        id: soldr_binary
+        shell: pwsh
+        run: |
+          $soldrPath = Join-Path $env:GITHUB_WORKSPACE "soldr/target/${{ inputs.target }}/debug/${{ inputs.binary_name }}"
+          "path=$soldrPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Show soldr version
+        shell: pwsh
+        run: |
+          & "${{ steps.soldr_binary.outputs.path }}" --version
+
+      - name: Build third-party app through soldr
+        shell: pwsh
+        working-directory: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}/target-${{ inputs.target }}
+        run: |
+          & "${{ steps.soldr_binary.outputs.path }}" cargo build --locked --target "${{ inputs.target }}"
+
+      - name: Show shared soldr cache status
+        if: ${{ always() }}
+        continue-on-error: true
+        shell: pwsh
+        working-directory: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}
+        run: |
+          $soldrPath = "${{ steps.soldr_binary.outputs.path }}"
+          if ([string]::IsNullOrWhiteSpace($soldrPath) -or -not (Test-Path -LiteralPath $soldrPath)) {
+            Write-Host "Soldr binary is unavailable; skipping shared cache status."
+            exit 0
+          }
+          & $soldrPath cache
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: soldr-${{ inputs.target }}
+          path: ${{ steps.soldr_binary.outputs.path }}
+
+      - name: Stop managed zccache
+        if: ${{ always() }}
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $exeName = "zccache.exe"
+          $zccache = $null
+          if (-not [string]::IsNullOrWhiteSpace($env:SOLDR_CACHE_DIR)) {
+            $soldrBin = Join-Path -Path $env:SOLDR_CACHE_DIR -ChildPath "bin"
+            if (Test-Path -LiteralPath $soldrBin) {
+              $zccache = Get-ChildItem -LiteralPath $soldrBin -Recurse -Filter $exeName -File -ErrorAction SilentlyContinue |
+                Select-Object -First 1 -ExpandProperty FullName
+            }
+          }
+          if ([string]::IsNullOrWhiteSpace($zccache)) {
+            $command = Get-Command zccache -ErrorAction SilentlyContinue
+            if ($command) {
+              $zccache = $command.Source
+            }
+          }
+          if ([string]::IsNullOrWhiteSpace($zccache)) {
+            Write-Host "zccache binary is unavailable; nothing to stop."
+            exit 0
+          }
+          & $zccache stop

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -10,11 +10,36 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
 jobs:
   build:
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: windows-11-arm
-      target: aarch64-pc-windows-msvc
-      binary_name: soldr.exe
-      source_ref: ${{ github.sha }}
+    name: Build Windows ARM64
+    runs-on: windows-11-arm
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.1
+          targets: aarch64-pc-windows-msvc
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: build-windows-arm64
+          shared-key: windows-aarch64-msvc
+
+      - name: Build workspace
+        run: cargo build --workspace --locked --target aarch64-pc-windows-msvc
+
+      - name: Run library tests
+        run: cargo test --workspace --lib --locked --target aarch64-pc-windows-msvc
+
+      - name: Run CLI smoke tests
+        run: cargo test -p soldr-cli --tests --locked --target aarch64-pc-windows-msvc

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -10,11 +10,36 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
 jobs:
   build:
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: windows-2025
-      target: x86_64-pc-windows-msvc
-      binary_name: soldr.exe
-      source_ref: ${{ github.sha }}
+    name: Build Windows x64
+    runs-on: windows-2025
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.1
+          targets: x86_64-pc-windows-msvc
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: build-windows-x64
+          shared-key: windows-x86_64-msvc
+
+      - name: Build workspace
+        run: cargo build --workspace --locked --target x86_64-pc-windows-msvc
+
+      - name: Run library tests
+        run: cargo test --workspace --lib --locked --target x86_64-pc-windows-msvc
+
+      - name: Run CLI smoke tests
+        run: cargo test -p soldr-cli --tests --locked --target x86_64-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,28 +141,27 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Verify setup-soldr pin matches v0
-        shell: bash
-        run: |
-          set -euo pipefail
-          if command -v python3 >/dev/null 2>&1; then
-            python3 .github/scripts/verify_setup_soldr_pin.py
-          else
-            python .github/scripts/verify_setup_soldr_pin.py
-          fi
-
-      - uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          linker: platform-default
+          toolchain: 1.94.1
+          targets: x86_64-pc-windows-msvc
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ci-windows-x64
+          shared-key: windows-x86_64-msvc
 
       - name: Build workspace
-        run: soldr cargo build --workspace --locked
+        run: cargo build --workspace --locked --target x86_64-pc-windows-msvc
 
       - name: Run library tests
-        run: soldr cargo test --workspace --lib --locked
+        run: cargo test --workspace --lib --locked --target x86_64-pc-windows-msvc
 
       - name: Run CLI smoke tests
-        run: soldr cargo test -p soldr-cli --tests --locked
+        run: cargo test -p soldr-cli --tests --locked --target x86_64-pc-windows-msvc
 
       - name: Verify Windows defaults to MSVC under Git Bash
         if: runner.os == 'Windows'
@@ -170,7 +169,7 @@ jobs:
         run: bash .github/scripts/windows-msys-default-msvc.sh
 
       - name: Run fetch integration test
-        run: soldr cargo test -p soldr-fetch --test fetch_crgx --locked
+        run: cargo test -p soldr-fetch --test fetch_crgx --locked --target x86_64-pc-windows-msvc
 
   e2e-linux-x64:
     name: build
@@ -235,7 +234,7 @@ jobs:
 
   e2e-windows-x64:
     name: build
-    uses: ./.github/workflows/_bootstrap-e2e.yml
+    uses: ./.github/workflows/_bootstrap-e2e-windows.yml
     with:
       runner: windows-2025
       target: x86_64-pc-windows-msvc
@@ -245,7 +244,7 @@ jobs:
 
   e2e-windows-arm64:
     name: build
-    uses: ./.github/workflows/_bootstrap-e2e.yml
+    uses: ./.github/workflows/_bootstrap-e2e-windows.yml
     with:
       runner: windows-11-arm
       target: aarch64-pc-windows-msvc

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -208,6 +208,7 @@ jobs:
           ref: ${{ needs.prepare.outputs.commit_sha }}
 
       - name: Verify setup-soldr pin matches v0
+        if: ${{ !contains(matrix.target, 'pc-windows-msvc') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -218,6 +219,7 @@ jobs:
           fi
 
       - name: Setup Soldr toolchain
+        if: ${{ !contains(matrix.target, 'pc-windows-msvc') }}
         uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
         with:
           linker: platform-default
@@ -227,13 +229,34 @@ jobs:
           cargo-registry-cache: false
           cache-key-suffix: release-${{ matrix.target }}
 
+      - name: Install Rust toolchain (Windows)
+        if: ${{ contains(matrix.target, 'pc-windows-msvc') }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.1
+          targets: ${{ matrix.target }}
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and target (Windows)
+        if: ${{ contains(matrix.target, 'pc-windows-msvc') }}
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+          shared-key: release-${{ matrix.target }}
+
       - name: Install target toolchain support
+        if: ${{ !contains(matrix.target, 'pc-windows-msvc') }}
         shell: pwsh
         run: |
           rustup target add "${{ matrix.target }}"
 
       - name: Build release binary
+        if: ${{ !contains(matrix.target, 'pc-windows-msvc') }}
         run: soldr --no-cache cargo build --package soldr-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Build release binary (Windows)
+        if: ${{ contains(matrix.target, 'pc-windows-msvc') }}
+        run: cargo build --package soldr-cli --release --locked --target ${{ matrix.target }}
 
       - name: Package tarball
         if: matrix.archive == 'tar.gz'

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -47,8 +47,6 @@ jobs:
             runner: ubuntu-24.04
           - name: macOS
             runner: macos-15
-          - name: Windows
-            runner: windows-2025
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Replace `zackees/setup-soldr` with `dtolnay/rust-toolchain` + `Swatinem/rust-cache` on every Windows-running GH Actions job.
- `build-windows-x64.yml` and `build-windows-arm64.yml`: self-contained jobs, no more call to `_bootstrap-e2e.yml`; build the workspace and run lib + CLI smoke tests with plain `cargo`.
- `ci.yml`:
  - `Windows x64` job swapped to dtolnay + rust-cache + plain `cargo`.
  - `e2e-windows-x64` / `e2e-windows-arm64` rewired to a new `_bootstrap-e2e-windows.yml` that builds soldr-cli via dtolnay + rust-cache and still runs the third-party fixture build through the freshly-built `soldr` binary (so the e2e signal is preserved; only the cache layer changed).
- `release-auto.yml`: per-step `if:` guards leave the Linux/macOS release path on setup-soldr while Windows targets use dtolnay + rust-cache + plain `cargo build` for the release binary. Downstream artifact naming, attestation, and PyPI/npm publish jobs are untouched.
- `setup-soldr-action.yml`: Windows entry removed from the smoke matrix (the workflow exists to exercise setup-soldr, so per the request, Windows coverage is dropped rather than meaningless).
- `cache-benchmark.yml` needs no change: its native-sqlite Windows entries already use `dtolnay/rust-toolchain`, and the only setup-soldr usage (the `benchmark` job) runs only on `ubuntu-24.04`.

Trade-offs / notes:
- `dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2` are pinned to tag refs, not SHAs (the existing convention in this repo is SHA-pinning). Happy to switch to SHA pins.
- `_bootstrap-e2e-windows.yml` duplicates a fair chunk of `_bootstrap-e2e.yml`. An alternative would have been adding OS-conditional steps inside the shared workflow, but that bloats every non-Windows run and is harder to reason about.
- The original Windows `build-*.yml` workflows used the e2e bootstrap (build soldr + build a third-party app through it). The new self-contained versions only build/test the soldr workspace; the third-party bootstrap coverage now lives exclusively in ci.yml's e2e-windows-* jobs.

## Test plan
- [ ] CI runs on this branch: confirm `Windows x64` lint/build job is green using dtolnay + rust-cache.
- [ ] `build-windows-x64.yml` and `build-windows-arm64.yml` workflows pass on push to a branch (they only run on `main` today — may need a manual dispatch to verify).
- [ ] `e2e-windows-x64` and `e2e-windows-arm64` reach the "Build third-party app through soldr" step and pass.
- [ ] Confirm cache hits land on a second run of the same workflow (look at the `Swatinem/rust-cache` summary line).
- [ ] Dry-run `release-auto.yml` on a non-publish path (or wait for the next real release bump) and confirm the Windows targets still produce `release-soldr-*` and `pypi-soldr-*` artifacts.
- [ ] `setup-soldr-action.yml` matrix now has only Linux + macOS — confirm both still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)