### PR TITLE
chore(release): v0.7.23 — managed zccache 1.7.1, setup-soldr @v0 d66c6fc

### DIFF
--- a/.github/workflows/_bootstrap-e2e-windows.yml
+++ b/.github/workflows/_bootstrap-e2e-windows.yml
@@ -57,14 +57,14 @@ jobs:
           path: ${{ inputs.third_party_path }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.94.1
           targets: ${{ inputs.target }}
           components: rustfmt, clippy
 
       - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: soldr -> target
           key: bootstrap-${{ inputs.target }}

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Setup Soldr cache and toolchain
-        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
+        uses: zackees/setup-soldr@d66c6fc50c7dc6fd483f64bacd05526b21bfdcd6 # @v0
         with:
           toolchain-file: soldr/rust-toolchain.toml
           linker: platform-default

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -23,14 +23,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.94.1
           targets: aarch64-pc-windows-msvc
           components: rustfmt, clippy
 
       - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: build-windows-arm64
           shared-key: windows-aarch64-msvc

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -23,14 +23,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.94.1
           targets: x86_64-pc-windows-msvc
           components: rustfmt, clippy
 
       - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: build-windows-x64
           shared-key: windows-x86_64-msvc

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -436,7 +436,7 @@ jobs:
       - id: setup-soldr
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11
+        uses: zackees/setup-soldr@d66c6fc50c7dc6fd483f64bacd05526b21bfdcd6
         with:
           linker: platform-default
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
+      - uses: zackees/setup-soldr@d66c6fc50c7dc6fd483f64bacd05526b21bfdcd6 # @v0
         with:
           linker: platform-default
           # Formatting does not benefit from a restored target directory, but
@@ -77,7 +77,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
+      - uses: zackees/setup-soldr@d66c6fc50c7dc6fd483f64bacd05526b21bfdcd6 # @v0
         with:
           linker: platform-default
 
@@ -114,7 +114,7 @@ jobs:
             python .github/scripts/verify_setup_soldr_pin.py
           fi
 
-      - uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
+      - uses: zackees/setup-soldr@d66c6fc50c7dc6fd483f64bacd05526b21bfdcd6 # @v0
         with:
           linker: platform-default
 
@@ -142,14 +142,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.94.1
           targets: x86_64-pc-windows-msvc
           components: rustfmt, clippy
 
       - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-windows-x64
           shared-key: windows-x86_64-msvc

--- a/.github/workflows/parent-cache-bench.yml
+++ b/.github/workflows/parent-cache-bench.yml
@@ -49,7 +49,7 @@ jobs:
       # Pinned to the current @v0 expected by
       # .github/scripts/verify_setup_soldr_pin.py.
       - name: Set up soldr
-        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
+        uses: zackees/setup-soldr@d66c6fc50c7dc6fd483f64bacd05526b21bfdcd6 # @v0
 
       - name: Run parent-cache benchmark
         shell: bash

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Setup Soldr toolchain
         if: ${{ !contains(matrix.target, 'pc-windows-msvc') }}
-        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11 # @v0
+        uses: zackees/setup-soldr@d66c6fc50c7dc6fd483f64bacd05526b21bfdcd6 # @v0
         with:
           linker: platform-default
           cache: false
@@ -231,7 +231,7 @@ jobs:
 
       - name: Install Rust toolchain (Windows)
         if: ${{ contains(matrix.target, 'pc-windows-msvc') }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.94.1
           targets: ${{ matrix.target }}
@@ -239,7 +239,7 @@ jobs:
 
       - name: Cache cargo registry and target (Windows)
         if: ${{ contains(matrix.target, 'pc-windows-msvc') }}
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-${{ matrix.target }}
           shared-key: release-${{ matrix.target }}

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -64,7 +64,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@4ed67cf493c07fee9f7f6c2bc8dc94b8c2140f11
+        uses: zackees/setup-soldr@d66c6fc50c7dc6fd483f64bacd05526b21bfdcd6
         with:
           cache: true
           linker: platform-default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.22"
+version = "0.7.23"
 dependencies = [
  "blake3",
  "redb",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.22"
+version = "0.7.23"
 dependencies = [
  "blake3",
  "clap",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.22"
+version = "0.7.23"
 dependencies = [
  "serde",
  "tempfile",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.22"
+version = "0.7.23"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.22"
+version = "0.7.23"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -64,7 +64,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.7.0");
+    assert_eq!(json["managed_zccache_version"], "1.7.1");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -221,7 +221,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.7.0");
+    assert_eq!(json["managed_zccache_version"], "1.7.1");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -273,7 +273,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.7.0");
+    assert_eq!(json["managed_zccache_version"], "1.7.1");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -47,7 +47,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.7.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.7.1";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Release bump bundling three drift fixes so a single merge to main triggers a clean `release-auto` run.

- **`MANAGED_ZCCACHE_VERSION` 1.7.0 → 1.7.1** in `crates/soldr-fetch/src/lib.rs`. zccache 1.7.1 (released 2026-05-19) ships:
  - `feat(core): ZCCACHE_COLOCATE env var for cross-volume cache placement` ([zccache#298](https://github.com/zackees/zccache/pull/298))
  - `perf(daemon): hardlink-persist compiler outputs in multi-compile miss path` ([zccache#302](https://github.com/zackees/zccache/pull/302))
  - `feat(ipc): opt-in per-recv timeout to bound client request/response` ([zccache#306](https://github.com/zackees/zccache/pull/306))
  - `fix(dylint): migrate zccache-ci home_dir + allowlist legacy clap surface` ([zccache#301](https://github.com/zackees/zccache/pull/301))
- **soldr `0.7.22` → `0.7.23`** in both `Cargo.toml` (`[workspace.package].version`) and `package.json` (`"version"`). Lockfile regenerated.
- **`zackees/setup-soldr@v0` pin** bumped `4ed67cf` → `d66c6fc` across 8 lines in 7 workflows. `@v0` moved forward again and the pin verifier was failing CI; this resyncs every executable `uses:` to match.
- Test assertions in `crates/soldr-cli/tests/cli_cache.rs` updated to expect `"1.7.1"` (3 spots).

## Release state checks (per `CLAUDE.md`)

- `git ls-remote --tags origin v0.7.23` — not present ✅
- PyPI `soldr` latest — `0.7.22`; `0.7.23` not in releases ✅
- npm `@zackees/soldr` latest — `0.7.22`; `0.7.23` not in versions ✅

## Validation

- `soldr cargo build --workspace --locked` — clean (Cargo.lock refreshed).
- `soldr cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `soldr cargo fmt --all -- --check` — clean.
- `soldr cargo test -p soldr-cli --test cli_cache --locked` — 12/12 pass.
- `python .github/scripts/verify_setup_soldr_pin.py` →
  `zackees/setup-soldr workflow pins match @v0: d66c6fc50c7dc6fd483f64bacd05526b21bfdcd6`

## Test plan

- [ ] CI `Lint` and all `Build *` jobs go green on this branch.
- [ ] On merge: `release-auto` `prepare` sets `should_release=true` (Cargo.toml ≠ latest published) and creates tag `v0.7.23`.
- [ ] Published assets land on GitHub Releases, PyPI, and npm.

## Note on PR #368

Per request, PR #368 (zccache 1.7.0 + force-kill orphan daemon hack) is kept open separately. This release PR does **not** include the force-kill hack — that change is on #368's branch and will need to be rebased/conflict-resolved after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)