### PR TITLE
feat(cli): add --zccache=system to use the zccache already on PATH

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door.rs
+++ b/crates/soldr-cli/src/cargo_front_door.rs
@@ -6,8 +6,8 @@ use crate::trampoline::{refresh_sidecar_after_cargo, try_run_trampoline, Trampol
 use crate::zccache::{finish_zccache_build, prepare_rustc_wrapper};
 use crate::{
     apply_implicit_toolchain_homes, gc, linker, non_empty_env_path, resolve_toolchain_binary,
-    rust_plan, CARGO_PROFILE_DEV_DEBUG_ENV_VAR, CARGO_PROFILE_TEST_DEBUG_ENV_VAR, LINKER_ENV_VAR,
-    LOW_DISK_WARNING_THRESHOLD_BYTES, TEST_FREE_DISK_BYTES_ENV_VAR,
+    rust_plan, ZccacheSourceArg, CARGO_PROFILE_DEV_DEBUG_ENV_VAR, CARGO_PROFILE_TEST_DEBUG_ENV_VAR,
+    LINKER_ENV_VAR, LOW_DISK_WARNING_THRESHOLD_BYTES, TEST_FREE_DISK_BYTES_ENV_VAR,
 };
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -18,6 +18,7 @@ use std::collections::BTreeSet;
 pub(crate) async fn run_cargo_front_door(
     args: &[String],
     cache_enabled: bool,
+    zccache_source: ZccacheSourceArg,
 ) -> Result<i32, SoldrError> {
     if cargo_args_use_reserved_no_cache(args) {
         return Err(SoldrError::Other(
@@ -107,7 +108,7 @@ pub(crate) async fn run_cargo_front_door(
     apply_linker_override(&mut command, args, explicit_target.as_deref(), &paths)?;
 
     let session = if cache_enabled_for_cargo {
-        prepare_rustc_wrapper(&mut command, &paths).await?
+        prepare_rustc_wrapper(&mut command, &paths, zccache_source).await?
     } else {
         None
     };

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -98,8 +98,24 @@ struct Cli {
     /// Disable soldr's compilation cache for this invocation
     #[arg(long)]
     no_cache: bool,
+    /// Pick the zccache binary backing the compilation cache.
+    ///
+    /// `managed` (default) fetches the pinned zccache release into
+    /// `~/.soldr/`. `system` uses the `zccache` already on PATH
+    /// (must have `zccache-daemon` and `zccache-fp` as siblings).
+    #[arg(long, value_enum, default_value_t = ZccacheSourceArg::Managed, value_name = "SOURCE")]
+    zccache: ZccacheSourceArg,
     #[command(subcommand)]
     command: Commands,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum ZccacheSourceArg {
+    /// Use the soldr-managed zccache release (default).
+    #[default]
+    Managed,
+    /// Use the `zccache` binary already installed on PATH.
+    System,
 }
 
 #[derive(Subcommand)]
@@ -482,10 +498,14 @@ async fn run_with_args(prog: &str, args: &[String]) -> Result<i32, SoldrError> {
 
 async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
     let cache_enabled = !cli.no_cache;
+    let zccache_source = cli.zccache;
 
     match cli.command {
         Commands::Cargo { args } => {
-            std::process::exit(cargo_front_door::run_cargo_front_door(&args, cache_enabled).await?);
+            std::process::exit(
+                cargo_front_door::run_cargo_front_door(&args, cache_enabled, zccache_source)
+                    .await?,
+            );
         }
         Commands::Rustc { args } => {
             std::process::exit(toolchain::run_toolchain_passthrough("rustc", &args)?);
@@ -686,6 +706,12 @@ fn should_self_relocate_for_invocation(raw_args: &[String]) -> bool {
             "--no-cache" => {
                 cache_enabled = false;
                 idx += 1;
+            }
+            "--zccache" => {
+                // Value lives in the next token; skip both so the
+                // subcommand check below lands on `cargo` instead of
+                // the value.
+                idx += 2;
             }
             "--" => return false,
             arg if arg.starts_with('-') => idx += 1,

--- a/crates/soldr-cli/src/main_tests.rs
+++ b/crates/soldr-cli/src/main_tests.rs
@@ -105,6 +105,22 @@ fn self_relocate_gate_targets_managed_cacheable_cargo_builds() {
         "cargo".into(),
         "test".into(),
     ]));
+    // --zccache <value> in either form is a value-taking flag; the
+    // self-relocate parser must not stop at the value as if it were the
+    // subcommand.
+    assert!(should_self_relocate_for_invocation(&[
+        "soldr".into(),
+        "--zccache".into(),
+        "system".into(),
+        "cargo".into(),
+        "build".into(),
+    ]));
+    assert!(should_self_relocate_for_invocation(&[
+        "soldr".into(),
+        "--zccache=system".into(),
+        "cargo".into(),
+        "build".into(),
+    ]));
     assert!(!should_self_relocate_for_invocation(&[
         "soldr".into(),
         "cargo".into(),
@@ -127,6 +143,22 @@ fn self_relocate_gate_targets_managed_cacheable_cargo_builds() {
         "cargo".into(),
         "build".into(),
     ]));
+}
+
+#[test]
+fn cli_parses_zccache_flag_values() {
+    let default = Cli::try_parse_from(["soldr", "cargo", "build"]).unwrap();
+    assert_eq!(default.zccache, ZccacheSourceArg::Managed);
+
+    let system = Cli::try_parse_from(["soldr", "--zccache=system", "cargo", "build"]).unwrap();
+    assert_eq!(system.zccache, ZccacheSourceArg::System);
+
+    let managed =
+        Cli::try_parse_from(["soldr", "--zccache", "managed", "cargo", "build"]).unwrap();
+    assert_eq!(managed.zccache, ZccacheSourceArg::Managed);
+
+    let invalid = Cli::try_parse_from(["soldr", "--zccache=bogus", "cargo", "build"]);
+    assert!(invalid.is_err(), "unknown zccache source must fail clap");
 }
 
 #[test]

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -2,7 +2,8 @@
 //! Extracted from `main.rs` as part of issue #339.
 
 use crate::{
-    current_soldr_binary, fetch_managed_zccache, non_empty_env_path, RUSTC_WRAPPER_OVERRIDE_ENV_VAR,
+    current_soldr_binary, fetch_managed_zccache, non_empty_env_path, ZccacheSourceArg,
+    RUSTC_WRAPPER_OVERRIDE_ENV_VAR,
 };
 use soldr_core::{suppress_windows_console_window, SoldrError, SoldrPaths};
 
@@ -74,9 +75,12 @@ pub(crate) fn resolve_path_remap_env(
 pub(crate) async fn prepare_rustc_wrapper(
     cargo: &mut std::process::Command,
     paths: &SoldrPaths,
+    zccache_source: ZccacheSourceArg,
 ) -> Result<Option<ZccacheBuildSession>, SoldrError> {
     match rustc_wrapper_mode() {
-        RustcWrapperMode::ManagedZccache => prepare_zccache_build(cargo, paths).await.map(Some),
+        RustcWrapperMode::ManagedZccache => prepare_zccache_build(cargo, paths, zccache_source)
+            .await
+            .map(Some),
         RustcWrapperMode::Custom(wrapper) => {
             if is_sccache_wrapper(&wrapper) && std::env::var_os("SCCACHE_DIR").is_none() {
                 let sccache_dir = soldr_cache::sccache_dir(paths);
@@ -109,22 +113,29 @@ pub(crate) fn is_sccache_wrapper(wrapper: &std::ffi::OsStr) -> bool {
 async fn prepare_zccache_build(
     cargo: &mut std::process::Command,
     paths: &SoldrPaths,
+    zccache_source: ZccacheSourceArg,
 ) -> Result<ZccacheBuildSession, SoldrError> {
     let zccache_dir = managed_zccache_cache_dir(paths)?;
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
-    let fetch = fetch_managed_zccache(paths).await?;
-    if fetch.cached {
-        eprintln!(
-            "soldr: using managed zccache {}",
-            soldr_fetch::MANAGED_ZCCACHE_VERSION
-        );
-    } else {
-        eprintln!(
-            "soldr: fetched managed zccache {}",
-            soldr_fetch::MANAGED_ZCCACHE_VERSION
-        );
-    }
+    let fetch = match zccache_source {
+        ZccacheSourceArg::Managed => {
+            let fetched = fetch_managed_zccache(paths).await?;
+            if fetched.cached {
+                eprintln!(
+                    "soldr: using managed zccache {}",
+                    soldr_fetch::MANAGED_ZCCACHE_VERSION
+                );
+            } else {
+                eprintln!(
+                    "soldr: fetched managed zccache {}",
+                    soldr_fetch::MANAGED_ZCCACHE_VERSION
+                );
+            }
+            fetched
+        }
+        ZccacheSourceArg::System => soldr_fetch::resolve_system_zccache(paths)?,
+    };
 
     start_zccache_with_recovery(&fetch.binary_path, &zccache_dir)?;
 

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -559,6 +559,77 @@ pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, 
     )
 }
 
+/// Locate `zccache` on the system `PATH` and use it directly instead
+/// of the managed-fetch path. Requires the daemon/fingerprint sibling
+/// binaries to live next to `zccache` in the same directory, which is
+/// how every supported zccache installer lays them out.
+///
+/// Driven by the top-level `--zccache=system` CLI flag.
+pub fn resolve_system_zccache(_paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
+    let target = TargetTriple::detect()?;
+    resolve_system_zccache_for_target(&target)
+}
+
+pub(crate) fn resolve_system_zccache_for_target(
+    target: &TargetTriple,
+) -> Result<FetchResult, SoldrError> {
+    let path_dirs: Vec<PathBuf> = std::env::var_os("PATH")
+        .map(|value| std::env::split_paths(&value).collect())
+        .unwrap_or_default();
+    resolve_system_zccache_with_path_dirs(target, &path_dirs)
+}
+
+pub(crate) fn resolve_system_zccache_with_path_dirs(
+    target: &TargetTriple,
+    path_dirs: &[PathBuf],
+) -> Result<FetchResult, SoldrError> {
+    let binary_ext = target.binary_ext();
+    let zccache_name = format!("zccache{binary_ext}");
+    let zccache_path = find_in_dirs(path_dirs, &zccache_name).ok_or_else(|| {
+        SoldrError::Other(format!(
+            "`--zccache=system` requested but `{zccache_name}` was not found on PATH; install zccache or drop the flag to use the managed download"
+        ))
+    })?;
+
+    let dir = zccache_path.parent().ok_or_else(|| {
+        SoldrError::Other(format!(
+            "system zccache at {} has no parent directory",
+            zccache_path.display()
+        ))
+    })?;
+
+    for sibling in ["zccache-daemon", "zccache-fp"] {
+        let sibling_path = dir.join(format!("{sibling}{binary_ext}"));
+        if !sibling_path.is_file() {
+            return Err(SoldrError::Other(format!(
+                "`--zccache=system`: expected {} next to {}",
+                sibling_path.display(),
+                zccache_path.display()
+            )));
+        }
+    }
+
+    eprintln!(
+        "soldr: using system zccache at {}",
+        zccache_path.display()
+    );
+    Ok(FetchResult {
+        binary_path: zccache_path,
+        version: "system".to_string(),
+        cached: false,
+    })
+}
+
+fn find_in_dirs(dirs: &[PathBuf], file_name: &str) -> Option<PathBuf> {
+    for dir in dirs {
+        let candidate = dir.join(file_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 fn managed_zccache_repo() -> RepoInfo {
     RepoInfo {
         owner: "zackees".to_string(),
@@ -1688,5 +1759,73 @@ mod tests {
         // rename is a breaking change for users who exported it. Keep
         // it pinned.
         assert_eq!(ZCCACHE_LOCAL_DIR_ENV_VAR, "SOLDR_ZCCACHE_LOCAL_DIR");
+    }
+
+    // ---------------------------------------------------------------
+    // --zccache=system resolver
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn system_zccache_resolves_when_all_three_binaries_on_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        write_fake_binary(&bin_dir, "zccache.exe", b"cli-bytes");
+        write_fake_binary(&bin_dir, "zccache-daemon.exe", b"daemon-bytes");
+        write_fake_binary(&bin_dir, "zccache-fp.exe", b"fp-bytes");
+
+        let dirs = vec![bin_dir.clone()];
+        let result = resolve_system_zccache_with_path_dirs(&windows_target(), &dirs).unwrap();
+        assert_eq!(result.version, "system");
+        assert_eq!(result.binary_path, bin_dir.join("zccache.exe"));
+    }
+
+    #[test]
+    fn system_zccache_errors_when_zccache_not_on_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        let dirs = vec![bin_dir];
+        let err = resolve_system_zccache_with_path_dirs(&windows_target(), &dirs)
+            .expect_err("missing zccache on PATH must fail");
+        let message = err.to_string();
+        assert!(
+            message.contains("--zccache=system"),
+            "error must reference the flag: {message}"
+        );
+        assert!(
+            message.contains("PATH"),
+            "error must reference PATH: {message}"
+        );
+    }
+
+    #[test]
+    fn system_zccache_errors_when_daemon_sibling_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        write_fake_binary(&bin_dir, "zccache.exe", b"cli-bytes");
+        write_fake_binary(&bin_dir, "zccache-fp.exe", b"fp-bytes");
+
+        let dirs = vec![bin_dir];
+        let err = resolve_system_zccache_with_path_dirs(&windows_target(), &dirs)
+            .expect_err("missing daemon sibling must fail");
+        let message = err.to_string();
+        assert!(
+            message.contains("zccache-daemon.exe"),
+            "error must name the missing sibling: {message}"
+        );
+    }
+
+    #[test]
+    fn system_zccache_unix_uses_bare_binary_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        write_fake_binary(&bin_dir, "zccache", b"cli-bytes");
+        write_fake_binary(&bin_dir, "zccache-daemon", b"daemon-bytes");
+        write_fake_binary(&bin_dir, "zccache-fp", b"fp-bytes");
+
+        let dirs = vec![bin_dir.clone()];
+        let result = resolve_system_zccache_with_path_dirs(&linux_target(), &dirs).unwrap();
+        assert!(result.binary_path.ends_with("zccache"));
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -57,6 +57,7 @@ Current cache-control behavior:
 - caching is enabled by default for `soldr cargo ...`
 - `soldr --no-cache cargo ...` disables soldr's compilation-cache path for that invocation
 - `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
+- `soldr --zccache=system cargo ...` uses the `zccache` already on PATH instead of fetching the pinned managed release. The `zccache-daemon` and `zccache-fp` sibling binaries must live in the same directory as `zccache`. `--zccache=managed` (the default) restores the managed-fetch behavior.
 - zccache integration currently targets Rust builds through the cargo front door
 - managed zccache artifacts and daemon state live under Soldr's cache root through `ZCCACHE_CACHE_DIR`
 - toolchain binaries (`rustc`, `rustfmt`, `clippy-driver`, etc.) are resolved directly from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` before any `rustup` call; `rustup which` is only used as a fallback when the direct probe fails. The sole exception is when `RUSTUP_TOOLCHAIN` is explicitly set to a non-empty value — in that case soldr skips the direct probe and asks `rustup` for the matching toolchain binary so the pinned channel always wins


### PR DESCRIPTION
## Summary

- Adds top-level `--zccache <SOURCE>` flag (values `managed` default | `system`). `--zccache=system` skips the managed-release fetch and uses the `zccache` already on PATH (with `zccache-daemon` / `zccache-fp` siblings in the same dir).
- New `soldr_fetch::resolve_system_zccache` walks PATH, verifies sibling binaries, and surfaces actionable errors (`\`--zccache=system\` requested but \`zccache.exe\` was not found on PATH...`).
- Threaded `ZccacheSourceArg` through `run_cargo_front_door` → `prepare_rustc_wrapper` → `prepare_zccache_build`. The self-relocate gate skips the value token so `soldr --zccache system cargo build` still trampolines.
- Documented in `docs/API.md` alongside `--no-cache`.

## Test plan

- [x] `soldr cargo clippy -p soldr-fetch -p soldr-cli --all-targets -- -D warnings` (clean)
- [x] `soldr cargo test -p soldr-fetch -p soldr-cli` — 174 CLI unit + 37 fetch unit + every integration suite green
- [x] 4 new fetch unit tests (success / missing binary / missing sibling / unix bare names)
- [x] New CLI parse test + extended self-relocate test for `--zccache <v>` and `--zccache=<v>`
- [x] Smoke test: with no zccache on PATH the cargo front door errors with the actionable message; with zccache on PATH it logs `soldr: using system zccache at <path>` and proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)