### PR TITLE
chore: bump managed-zccache 1.7.2 → 1.8.0 (+ soldr 0.7.25)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "blake3",
  "redb",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "blake3",
  "clap",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "serde",
  "tempfile",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.24"
+version = "0.7.25"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.24"
+version = "0.7.25"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -64,7 +64,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.7.2");
+    assert_eq!(json["managed_zccache_version"], "1.8.0");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -221,7 +221,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.7.2");
+    assert_eq!(json["managed_zccache_version"], "1.8.0");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -273,7 +273,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.7.2");
+    assert_eq!(json["managed_zccache_version"], "1.8.0");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -47,7 +47,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.7.2";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.8.0";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),


### PR DESCRIPTION
## Summary
- zccache 1.8.0 shipped today (https://github.com/zackees/zccache/releases/tag/1.8.0). It contains the macOS RUSTC_WRAPPER spawn fix — soldr's prior trampoline-build workaround can be retired once this lands.
- Bump `MANAGED_ZCCACHE_VERSION` in \`soldr-fetch\` from \`1.7.2\` → \`1.8.0\` so the managed resolver pulls the fixed binary.
- Three \`cli_cache.rs\` assertions retargeted at \`1.8.0\`.
- Workspace version bump 0.7.24 → 0.7.25 (patch — managed-zccache is a vendored dep, soldr's API surface is unchanged).

## Test plan
- [x] \`soldr cargo check --workspace --all-targets\` clean
- [ ] CI: full test matrix