### PR TITLE
fix(test): forward --target triple to inner cargo build for fake-zccache-265-stub

### DIFF
--- a/crates/soldr-cli/tests/cli_unknown_session_retry.rs
+++ b/crates/soldr-cli/tests/cli_unknown_session_retry.rs
@@ -44,10 +44,35 @@ use tempfile::TempDir;
 fn ensure_fake_zccache_stub() -> PathBuf {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
-    let output = Command::new(&cargo)
+
+    let soldr_bin = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let bin_dir = soldr_bin
+        .parent()
+        .expect("CARGO_BIN_EXE_soldr should have a parent dir");
+
+    // When the outer `cargo test` runs with `--target <triple>` (CI on
+    // Windows / macOS / Linux), `CARGO_BIN_EXE_soldr` resolves to
+    // `target/<triple>/debug/soldr[.exe]`. Without `--target` it is
+    // `target/debug/soldr[.exe]`. We need the inner `cargo build` to
+    // emit the stub into the *same* directory so the assertion below
+    // finds it — otherwise the inner build defaults to `target/debug`
+    // and the test fails with "expected stub at .../<triple>/debug/...".
+    let target_triple = bin_dir
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .filter(|name| *name != "target")
+        .map(str::to_owned);
+
+    let mut command = Command::new(&cargo);
+    command
         .args(["build", "--quiet", "--manifest-path"])
         .arg(format!("{manifest_dir}/Cargo.toml"))
-        .args(["--bin", "fake-zccache-265-stub", "--features", "test-stubs"])
+        .args(["--bin", "fake-zccache-265-stub", "--features", "test-stubs"]);
+    if let Some(triple) = target_triple.as_deref() {
+        command.args(["--target", triple]);
+    }
+    let output = command
         .output()
         .expect("failed to invoke cargo build for fake-zccache-265-stub");
     assert!(
@@ -57,10 +82,6 @@ fn ensure_fake_zccache_stub() -> PathBuf {
         String::from_utf8_lossy(&output.stderr),
     );
 
-    let soldr_bin = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
-    let bin_dir = soldr_bin
-        .parent()
-        .expect("CARGO_BIN_EXE_soldr should have a parent dir");
     let stub_name = if cfg!(windows) {
         "fake-zccache-265-stub.exe"
     } else {


### PR DESCRIPTION
## Summary

Fixes the persistent `Build Windows x64` red on main (5+ consecutive failures, going back to at least 2026-05-19).

When the outer `cargo test` runs with `--target x86_64-pc-windows-msvc` (which is exactly what `.github/workflows/build-windows-x64.yml` line 45 does), the runner places `CARGO_BIN_EXE_soldr` under `target/x86_64-pc-windows-msvc/debug/`. But the `cli_unknown_session_retry` test's `ensure_fake_zccache_stub` helper then shells out to `cargo build --bin fake-zccache-265-stub --features test-stubs` *without* forwarding `--target`, so cargo defaults to `target/debug/` — and the stub never appears at the path the test expects:

```
expected stub at D:\a\soldr\soldr\target\x86_64-pc-windows-msvc\debug\fake-zccache-265-stub.exe
  after cargo build
```

This PR derives the target triple from `CARGO_BIN_EXE_soldr`'s grandparent component (skipping when it is literally `target`, i.e. the no-triple default), and forwards `--target <triple>` to the inner build.

## Test plan

Verified locally on Windows against the same invocation CI runs:

- [x] `cargo test -p soldr-cli --test cli_unknown_session_retry --target x86_64-pc-windows-msvc` — 3 passed
- [x] `cargo test -p soldr-cli --test cli_unknown_session_retry` (no triple) — 3 passed (no regression)

Should turn `Build Windows x64` (and any other `--target`-passing job) green on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)