### PR TITLE
feat(cache): soldr cache flush + cache shutdown waits for daemon exit (#383)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cache"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "blake3",
  "filetime",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "blake3",
  "clap",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-core"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "serde",
  "tempfile",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-fetch"
-version = "0.7.26"
+version = "0.7.27"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.26"
+version = "0.7.27"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -675,9 +675,33 @@ struct CacheShutdownOutput {
     /// Whether a graceful `zccache stop` ran. False when the daemon was
     /// already stopped or no zccache binary has ever been fetched.
     daemon_stopped: bool,
+    /// Whether the daemon process was observed to have actually exited
+    /// after `zccache stop` (per soldr#383, `zccache stop` returns
+    /// before the daemon process has exited, so soldr polls
+    /// `zccache status` until the daemon stops responding).
+    /// `false` when the daemon was never running, when polling was
+    /// disabled with `--no-wait`, or when polling timed out.
+    daemon_exited: bool,
     /// Where session logs were archived to, if `--archive-logs` was
     /// supplied.
     archive_dir: Option<String>,
+    /// Diagnostic notes for the human-facing print path.
+    notes: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct CacheFlushOutput {
+    schema_version: u32,
+    command: &'static str,
+    cache_dir: String,
+    /// True after `zccache flush` returned 0. False when zccache does
+    /// not yet support the `flush` subcommand or when the daemon was
+    /// never running.
+    flushed: bool,
+    /// Parsed contents of `zccache flush --json` stdout when zccache
+    /// emits it. `null` when zccache only prints a text summary or
+    /// when flush was not run.
+    stats: Option<serde_json::Value>,
     /// Diagnostic notes for the human-facing print path.
     notes: Vec<String>,
 }
@@ -904,6 +928,7 @@ pub(crate) async fn run_cache_shutdown_command(
     archive_logs: Option<std::path::PathBuf>,
     no_depgraph_save: bool,
     shutdown_timeout_seconds: u64,
+    wait: bool,
     json: bool,
 ) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
@@ -917,6 +942,7 @@ pub(crate) async fn run_cache_shutdown_command(
         cache_dir: zccache_dir.display().to_string(),
         session_id: None,
         daemon_stopped: false,
+        daemon_exited: false,
         archive_dir: None,
         notes: Vec::new(),
     };
@@ -1016,13 +1042,52 @@ pub(crate) async fn run_cache_shutdown_command(
         notes.push("managed zccache binary not yet fetched; nothing to stop".into());
     }
 
-    // shutdown_timeout_seconds is reserved for future polling once
-    // `zccache stop` exposes an async surface. Today the command blocks
-    // until the daemon exits, so the timeout is informational; record
-    // it in the output for observability.
-    let _ = shutdown_timeout_seconds;
+    // Step 4 (soldr#383): block until the daemon process has actually
+    // exited. `zccache stop` returns before the OS has reaped the
+    // daemon, so without this poll the caller (setup-soldr's post step)
+    // races the daemon's still-in-flight depgraph save with its
+    // `tar | zstd` of the cache directory. The result reproduced in
+    // soldr#383's evidence: zero warm-run cache hits because the
+    // depgraph file was never durable on disk by the time the tar
+    // started.
+    //
+    // Poll `zccache status` (the same surface the user runs by hand)
+    // every 100ms until it reports the daemon is gone, or until the
+    // shutdown deadline elapses. We deliberately use the existing
+    // `daemon not running` heuristic so the polling code does not need
+    // to know zccache's IPC layout.
+    let mut polled_for_exit = false;
+    if wait && output.daemon_stopped {
+        if let Some(fetch) = fetch.as_ref() {
+            polled_for_exit = true;
+            match poll_zccache_daemon_exit(
+                &fetch.binary_path,
+                &zccache_dir,
+                std::time::Duration::from_secs(shutdown_timeout_seconds),
+            ) {
+                DaemonExitPollResult::Exited => {
+                    output.daemon_exited = true;
+                }
+                DaemonExitPollResult::TimedOut => {
+                    notes.push(format!(
+                        "daemon did not exit within {shutdown_timeout_seconds}s after `zccache stop`; depgraph state may not be durable on disk"
+                    ));
+                }
+                DaemonExitPollResult::PollFailed(err) => {
+                    notes.push(format!(
+                        "could not confirm daemon exit (polling `zccache status` failed): {err}"
+                    ));
+                }
+            }
+        }
+    }
+    if !wait {
+        notes.push("polling disabled via --no-wait; daemon exit not confirmed".into());
+    }
 
     output.notes = notes;
+
+    let timed_out = polled_for_exit && !output.daemon_exited;
 
     if json {
         let line = serde_json::to_string(&output)
@@ -1038,12 +1103,198 @@ pub(crate) async fn run_cache_shutdown_command(
         }
         println!(
             "  daemon: {}",
-            if output.daemon_stopped {
-                "stopped"
+            if output.daemon_exited {
+                "exited"
+            } else if output.daemon_stopped {
+                "signalled (exit not confirmed)"
             } else {
                 "no-op"
             }
         );
+        for note in &output.notes {
+            println!("  note: {note}");
+        }
+    }
+
+    if timed_out {
+        // soldr#383: surface a non-zero exit when the daemon outlives
+        // the polling deadline so the caller (CI) can fail loud
+        // instead of racing the depgraph flush with a `tar`. The
+        // human-readable note above already explains what happened.
+        return Err(SoldrError::Other(format!(
+            "cache shutdown: daemon process did not exit within {shutdown_timeout_seconds}s"
+        )));
+    }
+    Ok(())
+}
+
+/// Result of polling `zccache status` after a `zccache stop`. Used by
+/// `run_cache_shutdown_command` to determine whether the daemon's
+/// depgraph snapshot is durable on disk.
+enum DaemonExitPollResult {
+    /// `zccache status` reported the daemon is no longer running.
+    Exited,
+    /// Deadline elapsed before the daemon stopped responding.
+    TimedOut,
+    /// `zccache status` itself failed in an unexpected way (e.g. the
+    /// binary became unreadable). The shutdown is treated as
+    /// indeterminate.
+    PollFailed(String),
+}
+
+fn poll_zccache_daemon_exit(
+    binary: &std::path::Path,
+    zccache_dir: &std::path::Path,
+    timeout: std::time::Duration,
+) -> DaemonExitPollResult {
+    let deadline = std::time::Instant::now() + timeout;
+    let poll_interval = std::time::Duration::from_millis(100);
+    loop {
+        match run_zccache_command_raw_in_cache_dir(binary, &["status"], zccache_dir) {
+            Ok(output) => {
+                // If `zccache status` errored out with a
+                // daemon-not-running phrase, the daemon is gone and
+                // the on-disk state from `stop` is durable.
+                if !output.status.success() && zccache_daemon_already_stopped(&output) {
+                    return DaemonExitPollResult::Exited;
+                }
+                // Some zccache builds may print the daemon-stopped
+                // marker on stdout while still exiting 0 (e.g. a
+                // future "status --json" with state="stopped"). Cover
+                // that path too without committing to a JSON schema.
+                let combined = format!(
+                    "{}\n{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                )
+                .to_ascii_lowercase();
+                if combined.contains("daemon not running")
+                    || combined.contains("no daemon")
+                    || combined.contains("connection refused")
+                {
+                    return DaemonExitPollResult::Exited;
+                }
+            }
+            Err(err) => {
+                // Spawning zccache itself failed — surface the cause,
+                // do not retry.
+                return DaemonExitPollResult::PollFailed(err.to_string());
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return DaemonExitPollResult::TimedOut;
+        }
+        std::thread::sleep(poll_interval);
+    }
+}
+
+pub(crate) async fn run_cache_flush_command(json: bool) -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let zccache_dir = managed_zccache_cache_dir(&paths)?;
+    let fetch = cached_managed_zccache(&paths)?;
+
+    let mut output = CacheFlushOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "cache flush",
+        cache_dir: zccache_dir.display().to_string(),
+        flushed: false,
+        stats: None,
+        notes: Vec::new(),
+    };
+
+    if let Some(fetch) = fetch.as_ref() {
+        // soldr#383 contract: ask zccache to fsync its in-memory
+        // depgraph (and any other state) to disk and return only once
+        // the bytes are durable. Prefer the JSON form so we can
+        // re-emit the upstream stats verbatim; fall back to plain
+        // `zccache flush` when the build does not yet support
+        // `--json`.
+        let result = run_zccache_command_raw_in_cache_dir(
+            &fetch.binary_path,
+            &["flush", "--json"],
+            &zccache_dir,
+        )?;
+        if result.status.success() {
+            output.flushed = true;
+            let stdout = String::from_utf8_lossy(&result.stdout);
+            let trimmed = stdout.trim();
+            if !trimmed.is_empty() {
+                output.stats = serde_json::from_str(trimmed).ok();
+                if output.stats.is_none() {
+                    output.notes.push(format!(
+                        "zccache flush --json stdout was not valid JSON: {}",
+                        zccache_output_snippet(trimmed.as_bytes())
+                            .unwrap_or_else(|| "<empty>".into())
+                    ));
+                }
+            }
+        } else if zccache_flag_unsupported(&result, "--json") {
+            // zccache does not yet implement `flush --json`. Retry the
+            // bare form so we still get a durable on-disk snapshot.
+            let retry =
+                run_zccache_command_raw_in_cache_dir(&fetch.binary_path, &["flush"], &zccache_dir)?;
+            if retry.status.success() {
+                output.flushed = true;
+                output.notes.push(format!(
+                    "zccache flush --json not supported by managed zccache {}; ran `zccache flush` instead",
+                    soldr_fetch::MANAGED_ZCCACHE_VERSION
+                ));
+            } else if zccache_subcommand_unsupported(&retry, "flush") {
+                output.notes.push(format!(
+                    "managed zccache {} does not yet implement the `flush` subcommand; upgrade for soldr#383 CI checkpointing",
+                    soldr_fetch::MANAGED_ZCCACHE_VERSION
+                ));
+            } else if zccache_daemon_already_stopped(&retry) {
+                output.notes.push(
+                    "daemon was not running; nothing to flush (state on disk is already durable)"
+                        .into(),
+                );
+            } else {
+                return Err(SoldrError::Other(format!(
+                    "zccache flush failed: {}",
+                    command_stderr(&retry)
+                )));
+            }
+        } else if zccache_subcommand_unsupported(&result, "flush") {
+            output.notes.push(format!(
+                "managed zccache {} does not yet implement the `flush` subcommand; upgrade for soldr#383 CI checkpointing",
+                soldr_fetch::MANAGED_ZCCACHE_VERSION
+            ));
+        } else if zccache_daemon_already_stopped(&result) {
+            output.notes.push(
+                "daemon was not running; nothing to flush (state on disk is already durable)"
+                    .into(),
+            );
+        } else {
+            return Err(SoldrError::Other(format!(
+                "zccache flush --json failed: {}",
+                command_stderr(&result)
+            )));
+        }
+    } else {
+        output
+            .notes
+            .push("managed zccache binary not yet fetched; nothing to flush".into());
+    }
+
+    if json {
+        let line = serde_json::to_string(&output)
+            .map_err(|e| SoldrError::Other(format!("failed to serialize cache flush: {e}")))?;
+        println!("{line}");
+    } else {
+        println!("soldr cache flush");
+        println!(
+            "  status: {}",
+            if output.flushed { "flushed" } else { "no-op" }
+        );
+        if let Some(stats) = &output.stats {
+            if let Some(bytes) = stats.get("bytes_written").and_then(|v| v.as_u64()) {
+                println!("  bytes_written: {bytes}");
+            }
+            if let Some(secs) = stats.get("duration_ms").and_then(|v| v.as_u64()) {
+                println!("  duration_ms: {secs}");
+            }
+        }
         for note in &output.notes {
             println!("  note: {note}");
         }
@@ -1211,5 +1462,23 @@ mod tests {
         assert!(note.contains("rollups: zccache analyze exited with status Some(1)"));
         assert!(note.contains("stderr: expected compile journal JSONL"));
         assert!(note.contains(r#"stdout: {"status":"error","error":"bad input"}"#));
+    }
+
+    /// soldr#383: the shutdown poll uses a real zccache binary as its
+    /// daemon-alive oracle. With a missing binary path, the poll must
+    /// terminate quickly with `PollFailed`, never silently loop until
+    /// the deadline expires (which would mask the underlying error).
+    #[test]
+    fn poll_zccache_daemon_exit_surfaces_spawn_failure() {
+        use super::{poll_zccache_daemon_exit, DaemonExitPollResult};
+        use std::time::Duration;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bogus = tmp.path().join("definitely-not-zccache");
+        let result = poll_zccache_daemon_exit(&bogus, tmp.path(), Duration::from_millis(50));
+        assert!(
+            matches!(result, DaemonExitPollResult::PollFailed(_)),
+            "expected PollFailed when zccache binary cannot be spawned"
+        );
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -465,6 +465,27 @@ enum CacheSubcommand {
         /// before returning a non-zero status.
         #[arg(long, value_name = "SECONDS", default_value_t = 30)]
         shutdown_timeout_seconds: u64,
+        /// Skip the post-signal poll that confirms the daemon process
+        /// has actually exited. By default `shutdown` blocks until
+        /// `zccache status` reports the daemon is gone (or the
+        /// `--shutdown-timeout-seconds` deadline elapses); pass
+        /// `--no-wait` only when you genuinely do not care
+        /// (interactive shells). See soldr#383.
+        #[arg(long)]
+        no_wait: bool,
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Synchronously serialize the in-memory depgraph (and any other
+    /// in-memory zccache state) to disk without stopping the daemon.
+    ///
+    /// Returns 0 only after the bytes are durable (zccache fsync'd the
+    /// snapshot). Pair with `cache shutdown` in CI post steps to
+    /// guarantee the tar snapshot captures the freshest depgraph even
+    /// when the daemon is later killed by an external signal. See
+    /// soldr#383.
+    Flush {
         /// Emit the stable machine-facing JSON form for this command.
         #[arg(long)]
         json: bool,
@@ -661,15 +682,20 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 archive_logs,
                 no_depgraph_save,
                 shutdown_timeout_seconds,
+                no_wait,
                 json: shutdown_json,
             }) => {
                 cache::run_cache_shutdown_command(
                     archive_logs,
                     no_depgraph_save,
                     shutdown_timeout_seconds,
+                    !no_wait,
                     shutdown_json || json,
                 )
                 .await?;
+            }
+            Some(CacheSubcommand::Flush { json: flush_json }) => {
+                cache::run_cache_flush_command(flush_json || json).await?;
             }
             Some(CacheSubcommand::PruneTarget {
                 path,

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -536,3 +536,259 @@ fn clean_rejects_json_flag() {
         "expected clap to reject clean --json: {stderr}"
     );
 }
+
+/// soldr#383 (part 1): `cache flush` synchronously persists the
+/// depgraph + in-memory state without stopping the daemon. We assert
+/// the JSON output shape so CI consumers (setup-soldr) can rely on it.
+#[test]
+fn cache_flush_emits_zccache_stats_on_success() {
+    let cache_root = unique_temp_dir("cache-flush-ok");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "flush", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache flush --json");
+
+    assert!(
+        output.status.success(),
+        "cache flush --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("cache flush --json must produce parseable JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "cache flush");
+    assert_eq!(json["flushed"], true);
+    assert_eq!(json["stats"]["status"], "ok");
+    assert_eq!(json["stats"]["bytes_written"], 4096);
+
+    let log = fs::read_to_string(&log_path).expect("read tool log");
+    assert!(
+        log.contains("zccache flush args="),
+        "flush must shell out to `zccache flush`: {log}"
+    );
+}
+
+/// soldr#383 (part 1): when the running zccache predates the `flush`
+/// subcommand, `cache flush` returns 0 with a note so CI does not
+/// fail the post step on older daemons.
+#[test]
+fn cache_flush_handles_unsupported_zccache_gracefully() {
+    let cache_root = unique_temp_dir("cache-flush-unsupported");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "flush", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_TEST_ZCCACHE_FLUSH_UNSUPPORTED", "1")
+        .output()
+        .expect("failed to run soldr cache flush --json");
+
+    assert!(
+        output.status.success(),
+        "cache flush should succeed-with-note when zccache lacks flush\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("cache flush --json must produce parseable JSON");
+    assert_eq!(json["flushed"], false);
+    let notes = json["notes"].as_array().expect("notes array");
+    assert!(
+        notes
+            .iter()
+            .any(|n| n.as_str().unwrap_or("").contains("does not yet implement")),
+        "expected upgrade-hint note, got: {notes:?}"
+    );
+}
+
+/// soldr#383 (part 1): older zccache builds that have `flush` but not
+/// `flush --json` should still produce a durable on-disk snapshot.
+/// soldr retries with the bare form and surfaces a note explaining
+/// the JSON form was unavailable.
+#[test]
+fn cache_flush_falls_back_when_json_flag_is_unsupported() {
+    let cache_root = unique_temp_dir("cache-flush-no-json");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "flush", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_TEST_ZCCACHE_FLUSH_NO_JSON", "1")
+        .output()
+        .expect("failed to run soldr cache flush --json");
+
+    assert!(
+        output.status.success(),
+        "cache flush should retry without --json\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("cache flush --json must produce parseable JSON");
+    assert_eq!(json["flushed"], true);
+    assert!(
+        json["stats"].is_null(),
+        "no upstream JSON should mean stats is null"
+    );
+    let notes = json["notes"].as_array().expect("notes array");
+    assert!(
+        notes.iter().any(|n| {
+            let s = n.as_str().unwrap_or("");
+            s.contains("flush --json not supported")
+        }),
+        "expected fallback note, got: {notes:?}"
+    );
+}
+
+/// soldr#383 (part 2): `cache shutdown` must block until the daemon
+/// process has actually exited. The fake zccache here marks the
+/// daemon as "stopped" only after `zccache stop` runs, so the poll
+/// proves we are checking status *after* the signal.
+#[test]
+fn cache_shutdown_waits_for_daemon_to_exit() {
+    let cache_root = unique_temp_dir("cache-shutdown-wait");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+    let down_marker = cache_root.join("daemon.down");
+    // Sanity: the marker must not exist before stop runs.
+    assert!(!down_marker.exists());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "shutdown", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER", &down_marker)
+        .output()
+        .expect("failed to run soldr cache shutdown --json");
+
+    assert!(
+        output.status.success(),
+        "cache shutdown --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("cache shutdown --json must produce parseable JSON");
+    assert_eq!(json["daemon_stopped"], true);
+    assert_eq!(
+        json["daemon_exited"], true,
+        "shutdown must confirm daemon exit before returning"
+    );
+
+    // The fake script logs every zccache invocation. After stop we
+    // should see at least one status probe (the polling loop's
+    // confirmation that the daemon is gone).
+    let log = fs::read_to_string(&log_path).expect("read tool log");
+    let stop_idx = log
+        .find("zccache stop")
+        .expect("zccache stop must have run");
+    let after_stop = &log[stop_idx..];
+    // status writes to stderr/stdout but not to the tool log; the
+    // log on its own only confirms stop ran. The daemon_exited flag
+    // above proves the polling loop observed the down-marker.
+    let _ = after_stop;
+}
+
+/// soldr#383 (part 2): when the daemon outlives the shutdown timeout
+/// (the prod-bug case from the issue), soldr must exit non-zero so CI
+/// fails loud instead of racing the depgraph flush with a tarball.
+#[test]
+fn cache_shutdown_times_out_when_daemon_does_not_exit() {
+    let cache_root = unique_temp_dir("cache-shutdown-timeout");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+
+    // Deliberately omit SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER, so the
+    // fake `status` always reports the daemon as up. The shutdown
+    // poll then has to give up after the deadline.
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "cache",
+            "shutdown",
+            "--shutdown-timeout-seconds",
+            "1",
+            "--json",
+        ])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache shutdown --shutdown-timeout-seconds 1");
+
+    assert!(
+        !output.status.success(),
+        "cache shutdown must fail when daemon outlives the timeout\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("did not exit within"),
+        "stderr should explain the timeout: {stderr}"
+    );
+}
+
+/// soldr#383 (part 2): `--no-wait` opts out of the polling loop and
+/// returns immediately so interactive shells are not blocked. The
+/// JSON output must still note that exit was not confirmed.
+#[test]
+fn cache_shutdown_no_wait_skips_polling() {
+    let cache_root = unique_temp_dir("cache-shutdown-no-wait");
+    let log_path = cache_root.join("tool.log");
+    let (_, _, zccache) = install_fake_toolchain(&log_path);
+
+    // Daemon never goes down — without the poll this would hang.
+    let start = std::time::Instant::now();
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "cache",
+            "shutdown",
+            "--no-wait",
+            "--shutdown-timeout-seconds",
+            "60",
+            "--json",
+        ])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .output()
+        .expect("failed to run soldr cache shutdown --no-wait");
+
+    let elapsed = start.elapsed();
+    assert!(
+        output.status.success(),
+        "--no-wait must succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "--no-wait must return fast, took {elapsed:?}"
+    );
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("cache shutdown --json must produce parseable JSON");
+    assert_eq!(json["daemon_stopped"], true);
+    assert_eq!(
+        json["daemon_exited"], false,
+        "no-wait should leave daemon_exited=false"
+    );
+    let notes = json["notes"].as_array().expect("notes array");
+    assert!(
+        notes
+            .iter()
+            .any(|n| n.as_str().unwrap_or("").contains("--no-wait")),
+        "expected --no-wait note, got: {notes:?}"
+    );
+}

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -410,6 +410,7 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
              if \"%~1\"==\"stop\" (\n\
                echo zccache stop cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                if defined SOLDR_TEST_ZCCACHE_STALE_START_ONCE type nul > \"%SOLDR_TEST_ZCCACHE_STALE_START_ONCE%.stopped\"\n\
+               if defined SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER type nul > \"%SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER%\"\n\
                exit /b 0\n\
              )\n\
               if \"%~1\"==\"session-start\" (\n\
@@ -438,9 +439,16 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
                exit /b 0\n\
              )\n\
              if \"%~1\"==\"status\" (\n\
+               if defined SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER (\n\
+                 if exist \"%SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER%\" (\n\
+                   echo daemon not running 1>&2\n\
+                   exit /b 1\n\
+                 )\n\
+               )\n\
                echo hits=7\n\
                exit /b 0\n\
              )\n\
+             if \"%~1\"==\"flush\" goto soldr_zccache_flush\n\
              if \"%~1\"==\"clear\" (\n\
                echo zccache clear cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
                exit /b 0\n\
@@ -460,7 +468,23 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
                exit /b 1\n\
              )\n\
              echo zccache start retried before stop 1>&2\n\
-             exit /b 66\n",
+             exit /b 66\n\
+             :soldr_zccache_flush\n\
+             echo zccache flush args=%* cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+             if defined SOLDR_TEST_ZCCACHE_FLUSH_UNSUPPORTED goto soldr_zccache_flush_unsupported\n\
+             if not \"%~2\"==\"--json\" goto soldr_zccache_flush_plain\n\
+             if defined SOLDR_TEST_ZCCACHE_FLUSH_NO_JSON goto soldr_zccache_flush_no_json\n\
+             echo {{\"status\":\"ok\",\"bytes_written\":4096,\"duration_ms\":12}}\n\
+             exit /b 0\n\
+             :soldr_zccache_flush_plain\n\
+             echo flushed\n\
+             exit /b 0\n\
+             :soldr_zccache_flush_unsupported\n\
+             echo error: unrecognized subcommand 'flush' 1>&2\n\
+             exit /b 2\n\
+             :soldr_zccache_flush_no_json\n\
+             echo error: unexpected argument '--json' found 1>&2\n\
+             exit /b 2\n",
             log_path.display()
         )
     }
@@ -488,6 +512,9 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
                  echo \"zccache stop cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  if [ -n \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE:-}}\" ]; then\n\
                    : > \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE}}.stopped\"\n\
+                 fi\n\
+                 if [ -n \"${{SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER:-}}\" ]; then\n\
+                   : > \"${{SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER}}\"\n\
                  fi\n\
                  exit 0\n\
                  ;;\n\
@@ -517,9 +544,30 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
                 exit 0\n\
                 ;;\n\
               status)\n\
+                if [ -n \"${{SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER:-}}\" ] && [ -e \"${{SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER}}\" ]; then\n\
+                  echo 'daemon not running' >&2\n\
+                  exit 1\n\
+                fi\n\
                 echo 'hits=7'\n\
                 exit 0\n\
-                 ;;\n\
+                ;;\n\
+              flush)\n\
+                echo \"zccache flush args=$* cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+                if [ -n \"${{SOLDR_TEST_ZCCACHE_FLUSH_UNSUPPORTED:-}}\" ]; then\n\
+                  echo \"error: unrecognized subcommand 'flush'\" >&2\n\
+                  exit 2\n\
+                fi\n\
+                if [ \"${{2:-}}\" = \"--json\" ]; then\n\
+                  if [ -n \"${{SOLDR_TEST_ZCCACHE_FLUSH_NO_JSON:-}}\" ]; then\n\
+                    echo \"error: unexpected argument '--json' found\" >&2\n\
+                    exit 2\n\
+                  fi\n\
+                  printf '{{\"status\":\"ok\",\"bytes_written\":4096,\"duration_ms\":12}}\\n'\n\
+                else\n\
+                  echo 'flushed'\n\
+                fi\n\
+                exit 0\n\
+                ;;\n\
                clear)\n\
                  echo \"zccache clear cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
                  exit 0\n\

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Closes #383.

## Summary

`soldr cache shutdown` (added in #381) returned before the zccache daemon process had actually exited, so setup-soldr's post step raced the daemon's in-flight depgraph save against its `tar | zstd` of the cache directory. The symptom reproduced in the issue: 0% warm-run hit rate even when the build-cache layer restored the prior tarball cleanly.

Two coupled changes, shipped together because they target the same contract:

### 1. `soldr cache shutdown` now waits for daemon exit

- After `zccache stop`, polls `zccache status` every 100ms until the daemon stops responding or `--shutdown-timeout-seconds` elapses (default 30s).
- Times out with a non-zero exit code so CI fails loud instead of silently shipping a corrupted depgraph snapshot.
- New `--no-wait` opts out (interactive shells, etc).
- Output JSON gains `daemon_exited` alongside the existing `daemon_stopped`.

### 2. New `soldr cache flush [--json]`

- Synchronously persists the in-memory depgraph without stopping the daemon.
- Designed for CI checkpointing: post steps can flush, then optionally shutdown, guaranteeing the tar snapshot is durable even if the daemon is later killed by an external signal (OOM, runner timeout, user cancel).
- Forwards to `zccache flush --json`, falls back to bare `zccache flush` when the daemon predates the `--json` flag, and reports a graceful no-op + upgrade hint when running against a zccache that does not yet implement `flush` at all (preserves CI green on older daemons).

### Versions

| Package | From | To |
|---|---|---|
| soldr (Cargo.toml) | 0.7.26 | 0.7.27 |
| soldr (package.json) | 0.7.26 | 0.7.27 |

## Test plan

- [x] `soldr cargo test -p soldr-cli --bin soldr cache::tests` — 20 passed (1 new: `poll_zccache_daemon_exit_surfaces_spawn_failure`)
- [x] `soldr cargo test -p soldr-cli --test cli_cache` — 18 passed (6 new: `cache_flush_emits_zccache_stats_on_success`, `cache_flush_handles_unsupported_zccache_gracefully`, `cache_flush_falls_back_when_json_flag_is_unsupported`, `cache_shutdown_waits_for_daemon_to_exit`, `cache_shutdown_times_out_when_daemon_does_not_exit`, `cache_shutdown_no_wait_skips_polling`)
- [x] `soldr cargo clippy --workspace --no-deps --tests -- -D warnings` — clean
- [ ] setup-soldr#129 (consumer post-step) picks up `cache flush` once 0.7.27 ships

## Related

- #383 — this PR's tracking issue
- #381 — initial `cache shutdown` CLI (this PR enforces the synchronous-exit contract that was already stated there)
- zackees/zccache#262 — depgraph persistence (without `flush`/`wait` working, the consumer side was dropping the output of this work)
- zackees/setup-soldr#129 — downstream consumer rewrite, will pick up `cache flush` automatically once 0.7.27 ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)