### PR TITLE
ci: pin astral-sh/setup-uv@v4 to commit SHA

### DIFF
--- a/.github/workflows/parent-cache-bench.yml
+++ b/.github/workflows/parent-cache-bench.yml
@@ -54,7 +54,7 @@ jobs:
           shared-key: parent-cache-bench
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Build soldr-cli
         run: cargo build --package soldr-cli --release --locked


### PR DESCRIPTION
The `Parent Cache Bench` workflow ([run](https://github.com/zackees/soldr/actions/runs/26177449119/job/77011175898)) fails at `Set up job` because the repo enforces SHA-pinned actions:

> The action astral-sh/setup-uv@v4 is not allowed in zackees/soldr because all actions must be pinned to a full-length commit SHA.

Resolved `v4` → annotated tag `e4db8464…` → commit `38f3f104447c67c051c4a08e39b64a148898af3a`. Pinned to that SHA with a `# v4` trailing comment, matching the convention every other action in this repo follows (`actions/checkout@34e114…  # v4`, `Swatinem/rust-cache@e18b4977…  # v2`, etc.).

Only one offender on `main` — `parent-cache-bench.yml` line 57. No other floating tags in `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)