### PR TITLE
ci: SHA-pin actions in perf-cluster.yml

### DIFF
--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -34,7 +34,7 @@ jobs:
       soldr_version: ${{ steps.version.outputs.soldr_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
         run: |
@@ -59,7 +59,7 @@ jobs:
           echo "soldr_version=${v}" >> "$GITHUB_OUTPUT"
 
       - name: Upload soldr binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: soldr-bin-linux
           path: soldr-artifact/
@@ -92,7 +92,7 @@ jobs:
 
       - name: Checkout
         if: steps.gate.outputs.selected == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
         if: steps.gate.outputs.selected == 'true'
@@ -103,7 +103,7 @@ jobs:
 
       - name: Download soldr binary
         if: steps.gate.outputs.selected == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: soldr-bin-linux
           path: soldr-bin
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload raw results
         if: steps.gate.outputs.selected == 'true' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: perf-results-${{ matrix.scenario }}-linux
           path: |


### PR DESCRIPTION
Follow-up to #385.

#385 squash-merged before my SHA-pinning follow-up commit (\`571b34b\` on the merged branch) landed, so \`perf-cluster.yml\` on main currently has unpinned \`@v4\` tags. The repo policy rejects unpinned actions — the next \`workflow_dispatch\` of *Soldr Perf Cluster* would fail at \`Set up job\` the same way \`parent-cache-bench.yml\` did before #386.

SHAs match the convention used everywhere else in \`.github/workflows/\`:
- \`actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\`
- \`actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4\`
- \`actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)