### PR TITLE
ci(perf-cluster): trigger routing + hybrid input UI (follow-up to #395)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,13 @@ name: CI
 
 on:
   push:
-    branches:
-      - '**'
+    # Skip perf-iteration branches — they only need perf-cluster.yml,
+    # not the full Lint/build/e2e sweep. (`branches` and
+    # `branches-ignore` are mutually exclusive, so this replaces the
+    # previous `branches: ['**']` catch-all.)
+    branches-ignore:
+      - 'perf/**'
+      - 'evaluate/**'
     tags-ignore:
       - '*'
     paths-ignore:

--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -41,6 +41,7 @@ on:
         default: false
   push:
     branches:
+      - main
       - 'perf/**'
       - 'evaluate/**'
     paths:

--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -10,30 +10,52 @@ name: Soldr Perf Cluster
 # clean per-scenario workdir + cache root so isolation is preserved.
 #
 # Triggered by `workflow_dispatch` (manual button) and by pushes to
-# `perf/**` / `evaluate/**` branches — the AI perf-iteration loop.
-# ci.yml has a matching `branches-ignore` so perf branches only run
-# this workflow. Push events don't supply workflow_dispatch inputs,
-# so each `inputs.X` consumer falls back to the dispatch default via
-# `inputs.X || '<default>'`.
+# `main` / `perf/**` / `evaluate/**`. ci.yml has a matching
+# `branches-ignore` so perf branches only run this workflow.
+#
+# Input UI: GHA does not support multi-select. Platforms and fixtures
+# are `choice` dropdowns (their enums are tiny; `all` is the only
+# multi-value case). Scenarios are three booleans so arbitrary
+# subsets like "cold-tar-untar-warm + worktree-share" are
+# expressible. Push events leave every `inputs.X` empty — gate steps
+# treat empty as the dispatch default (`linux` / `all` / scenario
+# enabled) via `inputs.X || '<default>'` and `:-true` bash fallbacks.
 
 on:
   workflow_dispatch:
     inputs:
       platforms:
-        description: Platform subset, or "all" (currently ships linux only)
-        type: string
+        description: Platform subset
+        type: choice
         required: true
         default: linux
+        options:
+          - all
+          - linux
       fixtures:
-        description: Fixture subset, or "all"
-        type: string
+        description: Fixture subset
+        type: choice
         required: true
         default: all
-      scenarios:
-        description: Scenario subset, or "all"
-        type: string
+        options:
+          - all
+          - medium
+          - sqlite-link
+      scenario_cold:
+        description: Run scenario "cold-tar-untar-warm"
+        type: boolean
         required: true
-        default: all
+        default: true
+      scenario_worktree:
+        description: Run scenario "worktree-share"
+        type: boolean
+        required: true
+        default: true
+      scenario_touch:
+        description: Run scenario "touch-no-change"
+        type: boolean
+        required: true
+        default: true
       debug:
         description: Verbose tracing + retain raw RSS CSVs
         type: boolean
@@ -165,11 +187,15 @@ jobs:
       - name: Gate cell against dispatch inputs
         id: gate
         env:
-          REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
-          REQ_FIXTURES:  ${{ inputs.fixtures  || 'all' }}
-          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
-          M_PLATFORM:    ${{ matrix.platform }}
-          M_FIXTURE:     ${{ matrix.fixture }}
+          REQ_PLATFORMS:     ${{ inputs.platforms || 'linux' }}
+          REQ_FIXTURES:      ${{ inputs.fixtures  || 'all' }}
+          # Per-scenario booleans. Empty (push event) => enabled,
+          # 'true' => enabled, 'false' => disabled.
+          SCENARIO_COLD:     ${{ inputs.scenario_cold }}
+          SCENARIO_WORKTREE: ${{ inputs.scenario_worktree }}
+          SCENARIO_TOUCH:    ${{ inputs.scenario_touch }}
+          M_PLATFORM:        ${{ matrix.platform }}
+          M_FIXTURE:         ${{ matrix.fixture }}
         run: |
           in_subset() {
             local req="$1" val="$2"
@@ -182,13 +208,11 @@ jobs:
           # are not selected are filtered out of the per-cell loop
           # below, so a cell with zero selected scenarios still skips
           # the rest of the steps but does not consume bench-time.
-          ALL_SCENARIOS="cold-tar-untar-warm worktree-share touch-no-change"
           selected_scenarios=""
-          for s in ${ALL_SCENARIOS}; do
-            if in_subset "${REQ_SCENARIOS}" "${s}"; then
-              selected_scenarios="${selected_scenarios:+${selected_scenarios} }${s}"
-            fi
-          done
+          [[ "${SCENARIO_COLD:-true}"     != "false" ]] && selected_scenarios+=" cold-tar-untar-warm"
+          [[ "${SCENARIO_WORKTREE:-true}" != "false" ]] && selected_scenarios+=" worktree-share"
+          [[ "${SCENARIO_TOUCH:-true}"    != "false" ]] && selected_scenarios+=" touch-no-change"
+          selected_scenarios="${selected_scenarios# }"
 
           if in_subset "${REQ_PLATFORMS}" "${M_PLATFORM}" \
              && in_subset "${REQ_FIXTURES}" "${M_FIXTURE}" \
@@ -361,18 +385,23 @@ jobs:
       - name: Evaluate scenarios for ${{ matrix.fixture }}
         if: steps.gate.outputs.selected == 'true'
         env:
-          MIN_SPEEDUP:   ${{ matrix.min_speedup }}
-          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
-          M_PLATFORM:    ${{ matrix.platform }}
-          M_FIXTURE:     ${{ matrix.fixture }}
+          MIN_SPEEDUP:       ${{ matrix.min_speedup }}
+          # Mirror bench's per-scenario booleans; empty = enabled.
+          SCENARIO_COLD:     ${{ inputs.scenario_cold }}
+          SCENARIO_WORKTREE: ${{ inputs.scenario_worktree }}
+          SCENARIO_TOUCH:    ${{ inputs.scenario_touch }}
+          M_PLATFORM:        ${{ matrix.platform }}
+          M_FIXTURE:         ${{ matrix.fixture }}
         run: |
           set -uo pipefail
 
-          in_subset() {
-            local req="$1" val="$2"
-            [[ "${req}" == "all" ]] && return 0
-            [[ ",${req}," == *",${val},"* ]] && return 0
-            return 1
+          enabled_for() {
+            case "$1" in
+              cold-tar-untar-warm) [[ "${SCENARIO_COLD:-true}"     != "false" ]] ;;
+              worktree-share)      [[ "${SCENARIO_WORKTREE:-true}" != "false" ]] ;;
+              touch-no-change)     [[ "${SCENARIO_TOUCH:-true}"    != "false" ]] ;;
+              *) return 1 ;;
+            esac
           }
 
           # scenario -> "fail" or "warn". cold-tar-untar-warm is the
@@ -410,7 +439,7 @@ jobs:
 
           status=0
           for scenario in cold-tar-untar-warm worktree-share touch-no-change; do
-            if ! in_subset "${REQ_SCENARIOS}" "${scenario}"; then
+            if ! enabled_for "${scenario}"; then
               echo "scenario ${scenario} not selected by dispatch input; skipping"
               continue
             fi

--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -1,14 +1,20 @@
 name: Soldr Perf Cluster
 
-# Manual-only — see perf/README.md for the design and what each cell
-# is supposed to prove. Workers receive a soldr binary built once
-# (and cached!) by the master job and exercise every selected
-# scenario for one (platform, fixture) cell in a single runner.
-# Grouping by (platform, fixture) instead of per-scenario amortises
-# runner startup, toolchain install, soldr download, and apt-get over
-# all selected scenarios for that fixture; each scenario still gets
-# a clean per-scenario workdir + cache root so isolation is
-# preserved.
+# See perf/README.md for the design and what each cell is supposed
+# to prove. Workers receive a soldr binary built once (and cached!)
+# by the master job and exercise every selected scenario for one
+# (platform, fixture) cell in a single runner. Grouping by
+# (platform, fixture) instead of per-scenario amortises runner
+# startup, toolchain install, soldr download, and apt-get over all
+# selected scenarios for that fixture; each scenario still gets a
+# clean per-scenario workdir + cache root so isolation is preserved.
+#
+# Triggered by `workflow_dispatch` (manual button) and by pushes to
+# `perf/**` / `evaluate/**` branches — the AI perf-iteration loop.
+# ci.yml has a matching `branches-ignore` so perf branches only run
+# this workflow. Push events don't supply workflow_dispatch inputs,
+# so each `inputs.X` consumer falls back to the dispatch default via
+# `inputs.X || '<default>'`.
 
 on:
   workflow_dispatch:
@@ -33,13 +39,28 @@ on:
         type: boolean
         required: true
         default: false
+  push:
+    branches:
+      - 'perf/**'
+      - 'evaluate/**'
+    paths:
+      - '.github/workflows/perf-cluster.yml'
+      - 'perf/**'
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
 
 permissions:
   contents: read
 
 concurrency:
+  # Push-driven iteration: cancel the stale run when a new push lands
+  # so the loop doesn't pile up runners. Manual dispatches share the
+  # same group; if you want a dispatch to survive a follow-up push,
+  # dispatch against a different ref.
   group: perf-cluster-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build-soldr:
@@ -65,7 +86,7 @@ jobs:
       - name: Gate cell against dispatch inputs
         id: gate
         env:
-          REQ_PLATFORMS: ${{ inputs.platforms }}
+          REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
           M_PLATFORM:    ${{ matrix.platform }}
         run: |
           if [[ "${REQ_PLATFORMS}" == "all" ]] \
@@ -144,9 +165,9 @@ jobs:
       - name: Gate cell against dispatch inputs
         id: gate
         env:
-          REQ_PLATFORMS: ${{ inputs.platforms }}
-          REQ_FIXTURES:  ${{ inputs.fixtures }}
-          REQ_SCENARIOS: ${{ inputs.scenarios }}
+          REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
+          REQ_FIXTURES:  ${{ inputs.fixtures  || 'all' }}
+          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
           M_PLATFORM:    ${{ matrix.platform }}
           M_FIXTURE:     ${{ matrix.fixture }}
         run: |
@@ -307,8 +328,8 @@ jobs:
       - name: Gate cell against dispatch inputs
         id: gate
         env:
-          REQ_PLATFORMS: ${{ inputs.platforms }}
-          REQ_FIXTURES:  ${{ inputs.fixtures }}
+          REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
+          REQ_FIXTURES:  ${{ inputs.fixtures  || 'all' }}
           M_PLATFORM:    ${{ matrix.platform }}
           M_FIXTURE:     ${{ matrix.fixture }}
         run: |
@@ -341,7 +362,7 @@ jobs:
         if: steps.gate.outputs.selected == 'true'
         env:
           MIN_SPEEDUP:   ${{ matrix.min_speedup }}
-          REQ_SCENARIOS: ${{ inputs.scenarios }}
+          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
           M_PLATFORM:    ${{ matrix.platform }}
           M_FIXTURE:     ${{ matrix.fixture }}
         run: |

--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -55,12 +55,11 @@ permissions:
   contents: read
 
 concurrency:
-  # Push-driven iteration: cancel the stale run when a new push lands
-  # so the loop doesn't pile up runners. Manual dispatches share the
-  # same group; if you want a dispatch to survive a follow-up push,
-  # dispatch against a different ref.
+  # Never cancel a perf run in flight — every measurement is a data
+  # point we want to keep, even if a follow-up push lands before this
+  # one finishes. Runs queue per-ref instead of superseding.
   group: perf-cluster-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build-soldr:


### PR DESCRIPTION
## Summary
Follow-up to #395, which merged before these commits landed. Four commits, all in the same area:

- **Trigger routing**: `ci.yml` gets `branches-ignore: ['perf/**', 'evaluate/**']` so perf-iteration branches don't burn Lint/build/e2e minutes; `perf-cluster.yml` adds `push: branches: ['main', 'perf/**', 'evaluate/**']` with a `paths:` filter so pushes auto-run the cluster.
- **Hybrid dispatch UI**: `platforms` and `fixtures` become `choice` dropdowns; `scenarios` becomes three `boolean` checkboxes (`scenario_cold`, `scenario_worktree`, `scenario_touch`) so arbitrary subsets are expressible (GHA has no native multi-select). Push events inherit defaults via `inputs.X || '<default>'` and `:-true` bash fallbacks.
- **`cancel-in-progress: false`** — every perf measurement is a data point we keep.

## Test plan
- [ ] On merge, the `main` push fires `Soldr Perf Cluster` (new `branches: [main]` rule) and **not** `CI` (matched by `branches-ignore: ['perf/**']` only — main still runs CI normally).
- [ ] A push to any `perf/**` branch fires only `Soldr Perf Cluster`, not `CI`.
- [ ] The manual dispatch button shows two dropdowns + three scenario checkboxes + a debug checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)