### PR TITLE
ci(perf-cluster): list each platform in the dispatch dropdown

### DIFF
--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -49,21 +49,21 @@ on:
           - all
           - medium
           - sqlite-link
-      scenario_cold:
-        description: Run scenario "cold-tar-untar-warm"
-        type: boolean
+      scenarios:
+        # Single-select dropdown to match the platforms / fixtures
+        # shape. Arbitrary subsets (e.g. "cold + worktree but not
+        # touch") aren't expressible here today — pick `all` or one
+        # specific scenario. If subsets become a regular need, swap
+        # back to per-scenario booleans.
+        description: Scenario subset
+        type: choice
         required: true
-        default: true
-      scenario_worktree:
-        description: Run scenario "worktree-share"
-        type: boolean
-        required: true
-        default: true
-      scenario_touch:
-        description: Run scenario "touch-no-change"
-        type: boolean
-        required: true
-        default: true
+        default: all
+        options:
+          - all
+          - cold-tar-untar-warm
+          - worktree-share
+          - touch-no-change
       debug:
         description: Verbose tracing + retain raw RSS CSVs
         type: boolean
@@ -195,15 +195,11 @@ jobs:
       - name: Gate cell against dispatch inputs
         id: gate
         env:
-          REQ_PLATFORMS:     ${{ inputs.platforms || 'linux' }}
-          REQ_FIXTURES:      ${{ inputs.fixtures  || 'all' }}
-          # Per-scenario booleans. Empty (push event) => enabled,
-          # 'true' => enabled, 'false' => disabled.
-          SCENARIO_COLD:     ${{ inputs.scenario_cold }}
-          SCENARIO_WORKTREE: ${{ inputs.scenario_worktree }}
-          SCENARIO_TOUCH:    ${{ inputs.scenario_touch }}
-          M_PLATFORM:        ${{ matrix.platform }}
-          M_FIXTURE:         ${{ matrix.fixture }}
+          REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
+          REQ_FIXTURES:  ${{ inputs.fixtures  || 'all' }}
+          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
+          M_PLATFORM:    ${{ matrix.platform }}
+          M_FIXTURE:     ${{ matrix.fixture }}
         run: |
           in_subset() {
             local req="$1" val="$2"
@@ -216,11 +212,13 @@ jobs:
           # are not selected are filtered out of the per-cell loop
           # below, so a cell with zero selected scenarios still skips
           # the rest of the steps but does not consume bench-time.
+          ALL_SCENARIOS="cold-tar-untar-warm worktree-share touch-no-change"
           selected_scenarios=""
-          [[ "${SCENARIO_COLD:-true}"     != "false" ]] && selected_scenarios+=" cold-tar-untar-warm"
-          [[ "${SCENARIO_WORKTREE:-true}" != "false" ]] && selected_scenarios+=" worktree-share"
-          [[ "${SCENARIO_TOUCH:-true}"    != "false" ]] && selected_scenarios+=" touch-no-change"
-          selected_scenarios="${selected_scenarios# }"
+          for s in ${ALL_SCENARIOS}; do
+            if in_subset "${REQ_SCENARIOS}" "${s}"; then
+              selected_scenarios="${selected_scenarios:+${selected_scenarios} }${s}"
+            fi
+          done
 
           if in_subset "${REQ_PLATFORMS}" "${M_PLATFORM}" \
              && in_subset "${REQ_FIXTURES}" "${M_FIXTURE}" \
@@ -393,23 +391,18 @@ jobs:
       - name: Evaluate scenarios for ${{ matrix.fixture }}
         if: steps.gate.outputs.selected == 'true'
         env:
-          MIN_SPEEDUP:       ${{ matrix.min_speedup }}
-          # Mirror bench's per-scenario booleans; empty = enabled.
-          SCENARIO_COLD:     ${{ inputs.scenario_cold }}
-          SCENARIO_WORKTREE: ${{ inputs.scenario_worktree }}
-          SCENARIO_TOUCH:    ${{ inputs.scenario_touch }}
-          M_PLATFORM:        ${{ matrix.platform }}
-          M_FIXTURE:         ${{ matrix.fixture }}
+          MIN_SPEEDUP:   ${{ matrix.min_speedup }}
+          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
+          M_PLATFORM:    ${{ matrix.platform }}
+          M_FIXTURE:     ${{ matrix.fixture }}
         run: |
           set -uo pipefail
 
-          enabled_for() {
-            case "$1" in
-              cold-tar-untar-warm) [[ "${SCENARIO_COLD:-true}"     != "false" ]] ;;
-              worktree-share)      [[ "${SCENARIO_WORKTREE:-true}" != "false" ]] ;;
-              touch-no-change)     [[ "${SCENARIO_TOUCH:-true}"    != "false" ]] ;;
-              *) return 1 ;;
-            esac
+          in_subset() {
+            local req="$1" val="$2"
+            [[ "${req}" == "all" ]] && return 0
+            [[ ",${req}," == *",${val},"* ]] && return 0
+            return 1
           }
 
           # scenario -> "fail" or "warn". cold-tar-untar-warm is the
@@ -447,7 +440,7 @@ jobs:
 
           status=0
           for scenario in cold-tar-untar-warm worktree-share touch-no-change; do
-            if ! enabled_for "${scenario}"; then
+            if ! in_subset "${REQ_SCENARIOS}" "${scenario}"; then
               echo "scenario ${scenario} not selected by dispatch input; skipping"
               continue
             fi

--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -347,14 +347,15 @@ jobs:
           retention-days: 14
 
   evaluate:
-    # Per-fixture gate: pull each scenario's result.json and check the
-    # warm-vs-cold speedup against MIN_SPEEDUP. cold-tar-untar-warm is
-    # the hard gate (fails the workflow); worktree-share and
-    # touch-no-change are soft today (::warning::) — they'll be
-    # promoted to hard once their baselines are trusted. Matrix has
-    # one row per fixture so each fixture's "Evaluate" cell shows up
-    # as its own check in the GHA UI.
-    name: Evaluate ${{ matrix.fixture }}
+    # Per-platform gate: pull every fixture's artifact for this
+    # platform via `pattern: perf-results-<platform>-*` and iterate
+    # (fixture x scenario) internally. One Evaluate check per
+    # platform (max 3 when win and mac-arm matrix rows land alongside
+    # linux). cold-tar-untar-warm is the hard gate (fails the
+    # workflow); worktree-share and touch-no-change are soft today
+    # (::warning::) — they'll be promoted to hard once their
+    # baselines are trusted.
+    name: Evaluate ${{ matrix.platform }}
     needs: bench
     strategy:
       fail-fast: false
@@ -362,11 +363,6 @@ jobs:
         include:
           - platform: linux
             runs_on: ubuntu-24.04
-            fixture: medium
-            min_speedup: "3.0"
-          - platform: linux
-            runs_on: ubuntu-24.04
-            fixture: sqlite-link
             min_speedup: "3.0"
     runs-on: ${{ matrix.runs_on }}
     steps:
@@ -374,11 +370,48 @@ jobs:
         id: gate
         env:
           REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
+          M_PLATFORM:    ${{ matrix.platform }}
+        run: |
+          in_subset() {
+            local req="$1" val="$2"
+            [[ "${req}" == "all" ]] && return 0
+            [[ ",${req}," == *",${val},"* ]] && return 0
+            return 1
+          }
+
+          # Fixture/scenario subsetting + branch-aware narrowing
+          # happens inside the evaluate step. The cell-level gate
+          # only decides whether this whole platform's evaluator
+          # should run at all.
+          if in_subset "${REQ_PLATFORMS}" "${M_PLATFORM}"; then
+            echo "selected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "selected=false" >> "$GITHUB_OUTPUT"
+            echo "Evaluate (${M_PLATFORM}) not selected by dispatch inputs; skipping." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Download all perf results for ${{ matrix.platform }}
+        if: steps.gate.outputs.selected == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          # Glob across every fixture bench cell ran for this
+          # platform. v4's `pattern:` keeps each artifact's
+          # subdirectory under `perf-results/` so the scenario
+          # lookup below stays unambiguous.
+          pattern: perf-results-${{ matrix.platform }}-*
+          path: perf-results
+
+      - name: Evaluate scenarios for ${{ matrix.platform }}
+        if: steps.gate.outputs.selected == 'true'
+        env:
+          MIN_SPEEDUP:   ${{ matrix.min_speedup }}
           REQ_FIXTURES:  ${{ inputs.fixtures  || 'all' }}
+          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
           REF_NAME:      ${{ github.ref_name }}
           M_PLATFORM:    ${{ matrix.platform }}
-          M_FIXTURE:     ${{ matrix.fixture }}
         run: |
+          set -uo pipefail
+
           in_subset() {
             local req="$1" val="$2"
             [[ "${req}" == "all" ]] && return 0
@@ -392,41 +425,6 @@ jobs:
           elif [[ "${REF_NAME}" =~ ^perf/medium(/|-) ]]; then
             REQ_FIXTURES="medium"
           fi
-
-          # Scenario subset is evaluated per-scenario inside the
-          # assertion step (each scenario emits its own JSON), so the
-          # cell-level gate only checks platform + fixture.
-          if in_subset "${REQ_PLATFORMS}" "${M_PLATFORM}" \
-             && in_subset "${REQ_FIXTURES}"  "${M_FIXTURE}"; then
-            echo "selected=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "selected=false" >> "$GITHUB_OUTPUT"
-            echo "Evaluate (${M_PLATFORM}, ${M_FIXTURE}) not selected by dispatch inputs; skipping." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Download perf results for ${{ matrix.fixture }}
-        if: steps.gate.outputs.selected == 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: perf-results-${{ matrix.platform }}-${{ matrix.fixture }}
-          path: perf-results
-
-      - name: Evaluate scenarios for ${{ matrix.fixture }}
-        if: steps.gate.outputs.selected == 'true'
-        env:
-          MIN_SPEEDUP:   ${{ matrix.min_speedup }}
-          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
-          M_PLATFORM:    ${{ matrix.platform }}
-          M_FIXTURE:     ${{ matrix.fixture }}
-        run: |
-          set -uo pipefail
-
-          in_subset() {
-            local req="$1" val="$2"
-            [[ "${req}" == "all" ]] && return 0
-            [[ ",${req}," == *",${val},"* ]] && return 0
-            return 1
-          }
 
           # scenario -> "fail" or "warn". cold-tar-untar-warm is the
           # only gate today; the others are soft until their baselines
@@ -455,77 +453,92 @@ jobs:
           }
 
           {
-            echo "## Evaluate ${M_PLATFORM} / ${M_FIXTURE}"
+            echo "## Evaluate ${M_PLATFORM}"
             echo
-            echo "| scenario | cold ms | warm ms | speedup | threshold | mode | result |"
-            echo "| --- | --- | --- | --- | --- | --- | --- |"
+            echo "| fixture | scenario | cold ms | warm ms | speedup | threshold | mode | result |"
+            echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           status=0
-          for scenario in cold-tar-untar-warm worktree-share touch-no-change; do
-            if ! in_subset "${REQ_SCENARIOS}" "${scenario}"; then
-              echo "scenario ${scenario} not selected by dispatch input; skipping"
+          for fixture in medium sqlite-link; do
+            if ! in_subset "${REQ_FIXTURES}" "${fixture}"; then
+              echo "fixture ${fixture} not selected by dispatch input / branch narrowing; skipping"
               continue
             fi
 
-            mode="$(mode_for "${scenario}")"
-            cold_key="$(cold_key_for "${scenario}")"
-            warm_key="$(warm_key_for "${scenario}")"
-
-            result_json="$(find perf-results -type f -path "*/${scenario}/result.json" | head -n1)"
-            if [[ -z "${result_json}" ]]; then
-              echo "| ${scenario} | - | - | - | >= ${MIN_SPEEDUP}x | ${mode} | MISSING |" >> "$GITHUB_STEP_SUMMARY"
-              if [[ "${mode}" == "fail" ]]; then
-                echo "::error::${scenario}/result.json not found in ${M_FIXTURE} artifact"
-                status=1
-              else
-                echo "::warning::${scenario}/result.json not found in ${M_FIXTURE} artifact"
-              fi
+            # download-artifact@v4 with `pattern:` lays each artifact
+            # under its own subdir: perf-results/perf-results-<plat>-<fixt>/.
+            fixture_root="perf-results/perf-results-${M_PLATFORM}-${fixture}"
+            if [[ ! -d "${fixture_root}" ]]; then
+              echo "::warning::no artifact for fixture ${fixture} on ${M_PLATFORM} — bench cell likely skipped"
               continue
             fi
 
-            cold_ms="$(jq -r --arg k "${cold_key}" '.[$k] // empty' "${result_json}")"
-            warm_ms="$(jq -r --arg k "${warm_key}" '.[$k] // empty' "${result_json}")"
-
-            if [[ -z "${cold_ms}" || -z "${warm_ms}" ]]; then
-              echo "| ${scenario} | ${cold_ms:--} | ${warm_ms:--} | - | >= ${MIN_SPEEDUP}x | ${mode} | BAD-JSON |" >> "$GITHUB_STEP_SUMMARY"
-              if [[ "${mode}" == "fail" ]]; then
-                echo "::error::${scenario} result.json missing ${cold_key}/${warm_key}"
-                status=1
-              else
-                echo "::warning::${scenario} result.json missing ${cold_key}/${warm_key}"
+            for scenario in cold-tar-untar-warm worktree-share touch-no-change; do
+              if ! in_subset "${REQ_SCENARIOS}" "${scenario}"; then
+                echo "scenario ${scenario} not selected by dispatch input; skipping"
+                continue
               fi
-              continue
-            fi
 
-            # Treat a 0ms warm build as a measurement bug, not a win.
-            if (( warm_ms <= 0 )); then
-              echo "| ${scenario} | ${cold_ms} | ${warm_ms} | - | >= ${MIN_SPEEDUP}x | ${mode} | BAD-WARM |" >> "$GITHUB_STEP_SUMMARY"
-              if [[ "${mode}" == "fail" ]]; then
-                echo "::error::${scenario} ${warm_key}=${warm_ms} is non-positive"
-                status=1
-              else
-                echo "::warning::${scenario} ${warm_key}=${warm_ms} is non-positive"
+              mode="$(mode_for "${scenario}")"
+              cold_key="$(cold_key_for "${scenario}")"
+              warm_key="$(warm_key_for "${scenario}")"
+
+              result_json="$(find "${fixture_root}" -type f -path "*/${scenario}/result.json" | head -n1)"
+              if [[ -z "${result_json}" ]]; then
+                echo "| ${fixture} | ${scenario} | - | - | - | >= ${MIN_SPEEDUP}x | ${mode} | MISSING |" >> "$GITHUB_STEP_SUMMARY"
+                if [[ "${mode}" == "fail" ]]; then
+                  echo "::error::${scenario}/result.json not found in ${fixture} artifact"
+                  status=1
+                else
+                  echo "::warning::${scenario}/result.json not found in ${fixture} artifact"
+                fi
+                continue
               fi
-              continue
-            fi
 
-            speedup="$(awk -v c="${cold_ms}" -v w="${warm_ms}" 'BEGIN { printf "%.2f", c / w }')"
-            pass="$(awk -v s="${speedup}" -v t="${MIN_SPEEDUP}" 'BEGIN { print (s >= t) ? "1" : "0" }')"
+              cold_ms="$(jq -r --arg k "${cold_key}" '.[$k] // empty' "${result_json}")"
+              warm_ms="$(jq -r --arg k "${warm_key}" '.[$k] // empty' "${result_json}")"
 
-            if [[ "${pass}" == "1" ]]; then
-              echo "| ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | >= ${MIN_SPEEDUP}x | ${mode} | PASS |" >> "$GITHUB_STEP_SUMMARY"
-              echo "${scenario}: ${speedup}x >= ${MIN_SPEEDUP}x — PASS"
-            else
-              if [[ "${mode}" == "fail" ]]; then
-                echo "| ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | >= ${MIN_SPEEDUP}x | fail | FAIL |" >> "$GITHUB_STEP_SUMMARY"
-                echo "::error::${scenario} (${M_FIXTURE}) only ${speedup}x faster (need >= ${MIN_SPEEDUP}x)"
-                status=1
-              else
-                echo "| ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | >= ${MIN_SPEEDUP}x | warn | WARN |" >> "$GITHUB_STEP_SUMMARY"
-                echo "::warning::${scenario} (${M_FIXTURE}) only ${speedup}x faster (need >= ${MIN_SPEEDUP}x); soft gate — not failing today"
+              if [[ -z "${cold_ms}" || -z "${warm_ms}" ]]; then
+                echo "| ${fixture} | ${scenario} | ${cold_ms:--} | ${warm_ms:--} | - | >= ${MIN_SPEEDUP}x | ${mode} | BAD-JSON |" >> "$GITHUB_STEP_SUMMARY"
+                if [[ "${mode}" == "fail" ]]; then
+                  echo "::error::${fixture}/${scenario} result.json missing ${cold_key}/${warm_key}"
+                  status=1
+                else
+                  echo "::warning::${fixture}/${scenario} result.json missing ${cold_key}/${warm_key}"
+                fi
+                continue
               fi
-            fi
+
+              # Treat a 0ms warm build as a measurement bug, not a win.
+              if (( warm_ms <= 0 )); then
+                echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | - | >= ${MIN_SPEEDUP}x | ${mode} | BAD-WARM |" >> "$GITHUB_STEP_SUMMARY"
+                if [[ "${mode}" == "fail" ]]; then
+                  echo "::error::${fixture}/${scenario} ${warm_key}=${warm_ms} is non-positive"
+                  status=1
+                else
+                  echo "::warning::${fixture}/${scenario} ${warm_key}=${warm_ms} is non-positive"
+                fi
+                continue
+              fi
+
+              speedup="$(awk -v c="${cold_ms}" -v w="${warm_ms}" 'BEGIN { printf "%.2f", c / w }')"
+              pass="$(awk -v s="${speedup}" -v t="${MIN_SPEEDUP}" 'BEGIN { print (s >= t) ? "1" : "0" }')"
+
+              if [[ "${pass}" == "1" ]]; then
+                echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | >= ${MIN_SPEEDUP}x | ${mode} | PASS |" >> "$GITHUB_STEP_SUMMARY"
+                echo "${fixture}/${scenario}: ${speedup}x >= ${MIN_SPEEDUP}x — PASS"
+              else
+                if [[ "${mode}" == "fail" ]]; then
+                  echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | >= ${MIN_SPEEDUP}x | fail | FAIL |" >> "$GITHUB_STEP_SUMMARY"
+                  echo "::error::${fixture}/${scenario} only ${speedup}x faster (need >= ${MIN_SPEEDUP}x)"
+                  status=1
+                else
+                  echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | >= ${MIN_SPEEDUP}x | warn | WARN |" >> "$GITHUB_STEP_SUMMARY"
+                  echo "::warning::${fixture}/${scenario} only ${speedup}x faster (need >= ${MIN_SPEEDUP}x); soft gate — not failing today"
+                fi
+              fi
+            done
           done
 
           exit "${status}"

--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -198,6 +198,7 @@ jobs:
           REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
           REQ_FIXTURES:  ${{ inputs.fixtures  || 'all' }}
           REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
+          REF_NAME:      ${{ github.ref_name }}
           M_PLATFORM:    ${{ matrix.platform }}
           M_FIXTURE:     ${{ matrix.fixture }}
         run: |
@@ -207,6 +208,20 @@ jobs:
             [[ ",${req}," == *",${val},"* ]] && return 0
             return 1
           }
+
+          # Branch-aware narrowing: `perf/<axis-value>/**` (or
+          # `perf/<axis-value>-**`) forces the corresponding axis to
+          # that value, overriding the dispatch input. Push events
+          # get this for free; dispatching `fixtures=all` from a
+          # perf/sqlite/foo branch still runs sqlite-link only.
+          # Extend this case for new fixtures/scenarios as needed.
+          if   [[ "${REF_NAME}" =~ ^perf/sqlite(/|-) ]]; then
+            echo "Branch ${REF_NAME} narrows fixtures -> sqlite-link"
+            REQ_FIXTURES="sqlite-link"
+          elif [[ "${REF_NAME}" =~ ^perf/medium(/|-) ]]; then
+            echo "Branch ${REF_NAME} narrows fixtures -> medium"
+            REQ_FIXTURES="medium"
+          fi
 
           # Cell is gated on (platform, fixture) only. Scenarios that
           # are not selected are filtered out of the per-cell loop
@@ -360,6 +375,7 @@ jobs:
         env:
           REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
           REQ_FIXTURES:  ${{ inputs.fixtures  || 'all' }}
+          REF_NAME:      ${{ github.ref_name }}
           M_PLATFORM:    ${{ matrix.platform }}
           M_FIXTURE:     ${{ matrix.fixture }}
         run: |
@@ -369,6 +385,13 @@ jobs:
             [[ ",${req}," == *",${val},"* ]] && return 0
             return 1
           }
+
+          # Branch-aware fixture narrowing — must match bench gate.
+          if   [[ "${REF_NAME}" =~ ^perf/sqlite(/|-) ]]; then
+            REQ_FIXTURES="sqlite-link"
+          elif [[ "${REF_NAME}" =~ ^perf/medium(/|-) ]]; then
+            REQ_FIXTURES="medium"
+          fi
 
           # Scenario subset is evaluated per-scenario inside the
           # assertion step (each scenario emits its own JSON), so the

--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -25,6 +25,12 @@ on:
   workflow_dispatch:
     inputs:
       platforms:
+        # mac-x86 is intentionally not listed (Intel macs are EOL on
+        # GHA's roadmap). Until a matrix row exists for a given
+        # platform its cells gate themselves out via the
+        # bench/build-soldr gate steps, so the dispatch UI stays
+        # stable as cross-platform RSS pollers land in
+        # perf/lib/common.sh.
         description: Platform subset
         type: choice
         required: true
@@ -32,6 +38,8 @@ on:
         options:
           - all
           - linux
+          - mac-arm
+          - win
       fixtures:
         description: Fixture subset
         type: choice


### PR DESCRIPTION
## Summary
- Adds `mac-arm` and `win` to the platforms `choice` alongside `all` + `linux`.
- `mac-x86` deliberately omitted (Intel macs are EOL on GHA's roadmap).
- Names mirror `perf/README.md`. Cells for not-yet-shipped platforms gate themselves out via the existing bench/build-soldr gate steps, so selecting one today is a no-op — the dispatch UI just stays stable as cross-platform RSS pollers land in `perf/lib/common.sh`.

## Test plan
- [ ] Visit the workflow's "Run workflow" button and confirm the Platforms dropdown shows `all / linux / mac-arm / win` with `linux` as default.
- [ ] Dispatch with `platforms=mac-arm` and confirm the workflow finishes green with every cell skipped via the gate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)