### PR TITLE
ci(perf-cluster): hierarchical branch-scope resolution + PERF.md

### DIFF
--- a/.github/workflows/perf-cluster.yml
+++ b/.github/workflows/perf-cluster.yml
@@ -1,25 +1,18 @@
 name: Soldr Perf Cluster
 
-# See perf/README.md for the design and what each cell is supposed
-# to prove. Workers receive a soldr binary built once (and cached!)
-# by the master job and exercise every selected scenario for one
-# (platform, fixture) cell in a single runner. Grouping by
-# (platform, fixture) instead of per-scenario amortises runner
-# startup, toolchain install, soldr download, and apt-get over all
-# selected scenarios for that fixture; each scenario still gets a
-# clean per-scenario workdir + cache root so isolation is preserved.
+# See PERF.md (root of repo) for the user-facing branch-naming
+# convention and the full per-branch scope table. perf/README.md
+# explains the per-scenario design rationale.
 #
 # Triggered by `workflow_dispatch` (manual button) and by pushes to
 # `main` / `perf/**` / `evaluate/**`. ci.yml has a matching
 # `branches-ignore` so perf branches only run this workflow.
 #
-# Input UI: GHA does not support multi-select. Platforms and fixtures
-# are `choice` dropdowns (their enums are tiny; `all` is the only
-# multi-value case). Scenarios are three booleans so arbitrary
-# subsets like "cold-tar-untar-warm + worktree-share" are
-# expressible. Push events leave every `inputs.X` empty — gate steps
-# treat empty as the dispatch default (`linux` / `all` / scenario
-# enabled) via `inputs.X || '<default>'` and `:-true` bash fallbacks.
+# Effective scope is computed by the `setup` job from the branch
+# name (hierarchical `perf/<plat>-<fix>-<scen>`) on push events, or
+# from the dispatch inputs on workflow_dispatch events. Downstream
+# build-soldr / bench / evaluate gates consult
+# `needs.setup.outputs.{platforms,fixtures,scenarios}`.
 
 on:
   workflow_dispatch:
@@ -93,7 +86,111 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  setup:
+    # Resolve the effective (platforms, fixtures, scenarios) scope
+    # once and pipe the result to every downstream gate via job
+    # outputs. Two sources:
+    #
+    # 1. `workflow_dispatch` -> use the dispatch inputs verbatim.
+    # 2. `push` -> parse the branch name. `main` and `perf/all` are
+    #    full-sweep aliases. `perf/<P>-<F>-<S>` narrows on the named
+    #    axis tokens (see PERF.md for the full table). Unknown
+    #    perf/* branches fall back to a full sweep with an
+    #    `::notice::` so the dev still gets useful data while
+    #    iterating on a feature branch.
+    name: setup
+    runs-on: ubuntu-24.04
+    outputs:
+      platforms: ${{ steps.parse.outputs.platforms }}
+      fixtures:  ${{ steps.parse.outputs.fixtures }}
+      scenarios: ${{ steps.parse.outputs.scenarios }}
+      source:    ${{ steps.parse.outputs.source }}
+    steps:
+      - name: Parse scope
+        id: parse
+        env:
+          EVENT:    ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          IN_PLAT:  ${{ inputs.platforms }}
+          IN_FIX:   ${{ inputs.fixtures }}
+          IN_SCEN:  ${{ inputs.scenarios }}
+        run: |
+          set -euo pipefail
+
+          PLAT="all"; FIX="all"; SCEN="all"; SOURCE="default"
+
+          if [[ "${EVENT}" == "workflow_dispatch" ]]; then
+            PLAT="${IN_PLAT:-linux}"
+            FIX="${IN_FIX:-all}"
+            SCEN="${IN_SCEN:-all}"
+            SOURCE="dispatch"
+          else
+            case "${REF_NAME}" in
+              main|perf/all)
+                SOURCE="alias:${REF_NAME}"
+                ;;
+              perf/*)
+                triple="${REF_NAME#perf/}"
+                # Strict 3-token split. Branches with fewer or more
+                # tokens fall through to the unknown-branch arm.
+                IFS='-' read -r tp tf ts rest <<<"${triple}"
+                bad=0
+                # Platform token
+                case "${tp}" in
+                  all|linux|win) plat="${tp}" ;;
+                  mac)           plat="mac-arm" ;;
+                  *)             bad=1 ;;
+                esac
+                # Fixture token
+                case "${tf}" in
+                  all|medium) fix="${tf}" ;;
+                  sqlite)     fix="sqlite-link" ;;
+                  *)          bad=1 ;;
+                esac
+                # Scenario token
+                case "${ts}" in
+                  all)      scen="all" ;;
+                  cold)     scen="cold-tar-untar-warm" ;;
+                  worktree) scen="worktree-share" ;;
+                  touch)    scen="touch-no-change" ;;
+                  *)        bad=1 ;;
+                esac
+                if [[ -n "${rest}" || "${bad}" == "1" ]]; then
+                  echo "::notice::Branch '${REF_NAME}' does not match perf/<plat>-<fix>-<scen>; running full sweep. See PERF.md."
+                  SOURCE="unknown-perf:${REF_NAME}"
+                else
+                  PLAT="${plat}"; FIX="${fix}"; SCEN="${scen}"
+                  SOURCE="branch:${REF_NAME}"
+                fi
+                ;;
+              *)
+                # evaluate/** and anything else covered by the push
+                # filter that isn't main/perf — run full.
+                SOURCE="non-perf:${REF_NAME}"
+                ;;
+            esac
+          fi
+
+          {
+            echo "## Scope"
+            echo ""
+            echo "| axis | value |"
+            echo "| --- | --- |"
+            echo "| event | ${EVENT} |"
+            echo "| ref | ${REF_NAME} |"
+            echo "| source | ${SOURCE} |"
+            echo "| platforms | ${PLAT} |"
+            echo "| fixtures | ${FIX} |"
+            echo "| scenarios | ${SCEN} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "platforms=${PLAT}" >> "$GITHUB_OUTPUT"
+          echo "fixtures=${FIX}"   >> "$GITHUB_OUTPUT"
+          echo "scenarios=${SCEN}" >> "$GITHUB_OUTPUT"
+          echo "source=${SOURCE}"  >> "$GITHUB_OUTPUT"
+
   build-soldr:
+    needs: setup
     name: build-soldr (${{ matrix.platform }})
     strategy:
       fail-fast: false
@@ -113,10 +210,10 @@ jobs:
       # same context is available at `runs-on:` and inside step
       # `if:` blocks. Mirrors the gate-step pattern used by the
       # bench job below.
-      - name: Gate cell against dispatch inputs
+      - name: Gate cell against resolved scope
         id: gate
         env:
-          REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
+          REQ_PLATFORMS: ${{ needs.setup.outputs.platforms }}
           M_PLATFORM:    ${{ matrix.platform }}
         run: |
           if [[ "${REQ_PLATFORMS}" == "all" ]] \
@@ -124,7 +221,7 @@ jobs:
             echo "selected=true" >> "$GITHUB_OUTPUT"
           else
             echo "selected=false" >> "$GITHUB_OUTPUT"
-            echo "Platform ${M_PLATFORM} not selected by dispatch input '${REQ_PLATFORMS}'; skipping build." >> "$GITHUB_STEP_SUMMARY"
+            echo "Platform ${M_PLATFORM} not in scope '${REQ_PLATFORMS}'; skipping build." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Checkout
@@ -181,7 +278,7 @@ jobs:
 
   bench:
     name: bench (${{ matrix.platform }} / ${{ matrix.fixture }})
-    needs: build-soldr
+    needs: [setup, build-soldr]
     strategy:
       fail-fast: false
       matrix:
@@ -192,13 +289,12 @@ jobs:
             runs_on: ubuntu-24.04
     runs-on: ${{ matrix.runs_on }}
     steps:
-      - name: Gate cell against dispatch inputs
+      - name: Gate cell against resolved scope
         id: gate
         env:
-          REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
-          REQ_FIXTURES:  ${{ inputs.fixtures  || 'all' }}
-          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
-          REF_NAME:      ${{ github.ref_name }}
+          REQ_PLATFORMS: ${{ needs.setup.outputs.platforms }}
+          REQ_FIXTURES:  ${{ needs.setup.outputs.fixtures }}
+          REQ_SCENARIOS: ${{ needs.setup.outputs.scenarios }}
           M_PLATFORM:    ${{ matrix.platform }}
           M_FIXTURE:     ${{ matrix.fixture }}
         run: |
@@ -208,20 +304,6 @@ jobs:
             [[ ",${req}," == *",${val},"* ]] && return 0
             return 1
           }
-
-          # Branch-aware narrowing: `perf/<axis-value>/**` (or
-          # `perf/<axis-value>-**`) forces the corresponding axis to
-          # that value, overriding the dispatch input. Push events
-          # get this for free; dispatching `fixtures=all` from a
-          # perf/sqlite/foo branch still runs sqlite-link only.
-          # Extend this case for new fixtures/scenarios as needed.
-          if   [[ "${REF_NAME}" =~ ^perf/sqlite(/|-) ]]; then
-            echo "Branch ${REF_NAME} narrows fixtures -> sqlite-link"
-            REQ_FIXTURES="sqlite-link"
-          elif [[ "${REF_NAME}" =~ ^perf/medium(/|-) ]]; then
-            echo "Branch ${REF_NAME} narrows fixtures -> medium"
-            REQ_FIXTURES="medium"
-          fi
 
           # Cell is gated on (platform, fixture) only. Scenarios that
           # are not selected are filtered out of the per-cell loop
@@ -356,7 +438,7 @@ jobs:
     # (::warning::) — they'll be promoted to hard once their
     # baselines are trusted.
     name: Evaluate ${{ matrix.platform }}
-    needs: bench
+    needs: [setup, bench]
     strategy:
       fail-fast: false
       matrix:
@@ -366,10 +448,10 @@ jobs:
             min_speedup: "3.0"
     runs-on: ${{ matrix.runs_on }}
     steps:
-      - name: Gate cell against dispatch inputs
+      - name: Gate cell against resolved scope
         id: gate
         env:
-          REQ_PLATFORMS: ${{ inputs.platforms || 'linux' }}
+          REQ_PLATFORMS: ${{ needs.setup.outputs.platforms }}
           M_PLATFORM:    ${{ matrix.platform }}
         run: |
           in_subset() {
@@ -379,10 +461,9 @@ jobs:
             return 1
           }
 
-          # Fixture/scenario subsetting + branch-aware narrowing
-          # happens inside the evaluate step. The cell-level gate
-          # only decides whether this whole platform's evaluator
-          # should run at all.
+          # Fixture/scenario subsetting is done inside the evaluate
+          # step (via needs.setup.outputs). The cell-level gate only
+          # decides whether this whole platform's evaluator runs.
           if in_subset "${REQ_PLATFORMS}" "${M_PLATFORM}"; then
             echo "selected=true" >> "$GITHUB_OUTPUT"
           else
@@ -405,9 +486,8 @@ jobs:
         if: steps.gate.outputs.selected == 'true'
         env:
           MIN_SPEEDUP:   ${{ matrix.min_speedup }}
-          REQ_FIXTURES:  ${{ inputs.fixtures  || 'all' }}
-          REQ_SCENARIOS: ${{ inputs.scenarios || 'all' }}
-          REF_NAME:      ${{ github.ref_name }}
+          REQ_FIXTURES:  ${{ needs.setup.outputs.fixtures }}
+          REQ_SCENARIOS: ${{ needs.setup.outputs.scenarios }}
           M_PLATFORM:    ${{ matrix.platform }}
         run: |
           set -uo pipefail
@@ -418,13 +498,6 @@ jobs:
             [[ ",${req}," == *",${val},"* ]] && return 0
             return 1
           }
-
-          # Branch-aware fixture narrowing — must match bench gate.
-          if   [[ "${REF_NAME}" =~ ^perf/sqlite(/|-) ]]; then
-            REQ_FIXTURES="sqlite-link"
-          elif [[ "${REF_NAME}" =~ ^perf/medium(/|-) ]]; then
-            REQ_FIXTURES="medium"
-          fi
 
           # scenario -> "fail" or "warn". cold-tar-untar-warm is the
           # only gate today; the others are soft until their baselines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+> [!IMPORTANT]
+> ## ⚡ Performance work → read [PERF.md](PERF.md) FIRST ⚡
+>
+> **The perf-cluster GitHub Action is the MOST important workflow in this repo.**
+> If you are testing, measuring, optimizing, or regressing soldr's performance
+> — read **[PERF.md](PERF.md)** before doing anything else.
+>
+> Branch naming (`perf/<plat>-<fix>-<scen>`) controls exactly which cells run.
+> Pushing to a wrong branch name silently runs the full sweep — costly and slow.
+> **Do not guess.** PERF.md has the complete 48-pattern scope table.
+
 ## What is soldr
 
 A single Rust binary with two jobs:
@@ -115,12 +126,11 @@ Anything not registered falls through the generic External subcommand, which res
 
 ## Reference Docs
 
+- **`PERF.md` — Performance testing. Read this BEFORE running any perf work. See callout at the top of this file.**
 - `DESIGN.md` — Authoritative implementation guide, architecture decisions, phase roadmap
 - `docs/API.md` — Full CLI specification, environment variables, cache layout
 - `docs/TRUST_BOUNDARIES.md` — Runtime fetch policy, what integrity is enforced, what remains follow-up
 - `README.md` — User-facing motivation and prior art comparison
-
-If you are looking to test performance of soldr, then please see [PERF.md](PERF.md).
 
 ## Dogfooding
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,8 @@ Anything not registered falls through the generic External subcommand, which res
 - `docs/TRUST_BOUNDARIES.md` — Runtime fetch policy, what integrity is enforced, what remains follow-up
 - `README.md` — User-facing motivation and prior art comparison
 
+If you are looking to test performance of soldr, then please see [PERF.md](PERF.md).
+
 ## Dogfooding
 
 The repo builds itself through soldr so every contributor populates and hits the same cache.

--- a/PERF.md
+++ b/PERF.md
@@ -1,0 +1,157 @@
+# PERF.md — testing soldr performance
+
+soldr has one performance workflow: **`.github/workflows/perf-cluster.yml`** (the "Soldr Perf Cluster"). Push to a branch with a recognized name and the matrix runs the right cells automatically — no manual `workflow_dispatch` needed.
+
+For the per-scenario design rationale (what each cell proves), see [`perf/README.md`](perf/README.md).
+
+## How it triggers
+
+The workflow fires on:
+
+1. **`workflow_dispatch`** — the "Run workflow" button in the Actions UI. Dispatch inputs are used verbatim and the branch name is ignored.
+2. **`push`** to `main`, `perf/**`, or `evaluate/**`. The branch name is parsed into an effective `(platforms, fixtures, scenarios)` scope (see below). The dispatch inputs are not consulted.
+3. **Manual `gh workflow run` CLI** — same as the dispatch button.
+
+The full matrix is always loaded; cells that fall outside the resolved scope skip themselves at the gate step. `main` always runs the full sweep.
+
+## Branch-name convention
+
+Branch syntax: **`perf/<plat>-<fix>-<scen>`** with one short token per axis. `all` is the wildcard at any axis.
+
+### Token mapping
+
+| Axis | Branch token | Real value |
+|---|---|---|
+| Platform | `linux` | `linux` |
+| Platform | `win` | `win` |
+| Platform | `mac` | `mac-arm` |
+| Fixture | `medium` | `medium` |
+| Fixture | `sqlite` | `sqlite-link` |
+| Scenario | `cold` | `cold-tar-untar-warm` |
+| Scenario | `worktree` | `worktree-share` |
+| Scenario | `touch` | `touch-no-change` |
+| any axis | `all` | wildcard — run every value on this axis |
+
+Short tokens keep the branch name unambiguous (the real names contain hyphens that would collide with the axis separator).
+
+### Full scope table
+
+48 hierarchical patterns plus two full-sweep aliases. Anything not in this table (e.g., a developer iteration branch like `perf/cluster-hierarchical-skip`) falls back to a full sweep and emits a `::notice::` so the run is still useful.
+
+#### Aliases — full ride
+
+| Branch | Scope |
+|---|---|
+| `main` | every platform × fixture × scenario |
+| `perf/all` | same as `perf/all-all-all` |
+
+#### Platform = `all` (12)
+
+| Branch | Scope |
+|---|---|
+| `perf/all-all-all` | full sweep |
+| `perf/all-all-cold` | every platform, every fixture, **cold** only |
+| `perf/all-all-worktree` | every platform, every fixture, **worktree-share** only |
+| `perf/all-all-touch` | every platform, every fixture, **touch-no-change** only |
+| `perf/all-medium-all` | every platform, **medium** fixture, every scenario |
+| `perf/all-medium-cold` | every platform, **medium**, cold only |
+| `perf/all-medium-worktree` | every platform, **medium**, worktree only |
+| `perf/all-medium-touch` | every platform, **medium**, touch only |
+| `perf/all-sqlite-all` | every platform, **sqlite-link**, every scenario |
+| `perf/all-sqlite-cold` | every platform, **sqlite-link**, cold only |
+| `perf/all-sqlite-worktree` | every platform, **sqlite-link**, worktree only |
+| `perf/all-sqlite-touch` | every platform, **sqlite-link**, touch only |
+
+#### Platform = `linux` (12)
+
+| Branch | Scope |
+|---|---|
+| `perf/linux-all-all` | **linux** only, every fixture × scenario |
+| `perf/linux-all-cold` | linux, every fixture, cold only |
+| `perf/linux-all-worktree` | linux, every fixture, worktree only |
+| `perf/linux-all-touch` | linux, every fixture, touch only |
+| `perf/linux-medium-all` | linux + medium, every scenario |
+| `perf/linux-medium-cold` | **single cell**: linux × medium × cold |
+| `perf/linux-medium-worktree` | **single cell**: linux × medium × worktree |
+| `perf/linux-medium-touch` | **single cell**: linux × medium × touch |
+| `perf/linux-sqlite-all` | linux + sqlite-link, every scenario |
+| `perf/linux-sqlite-cold` | **single cell**: linux × sqlite-link × cold |
+| `perf/linux-sqlite-worktree` | **single cell**: linux × sqlite-link × worktree |
+| `perf/linux-sqlite-touch` | **single cell**: linux × sqlite-link × touch |
+
+#### Platform = `win` (12)
+
+| Branch | Scope |
+|---|---|
+| `perf/win-all-all` | **win** only, every fixture × scenario |
+| `perf/win-all-cold` | win, every fixture, cold only |
+| `perf/win-all-worktree` | win, every fixture, worktree only |
+| `perf/win-all-touch` | win, every fixture, touch only |
+| `perf/win-medium-all` | win + medium, every scenario |
+| `perf/win-medium-cold` | **single cell**: win × medium × cold |
+| `perf/win-medium-worktree` | **single cell**: win × medium × worktree |
+| `perf/win-medium-touch` | **single cell**: win × medium × touch |
+| `perf/win-sqlite-all` | win + sqlite-link, every scenario |
+| `perf/win-sqlite-cold` | **single cell**: win × sqlite-link × cold |
+| `perf/win-sqlite-worktree` | **single cell**: win × sqlite-link × worktree |
+| `perf/win-sqlite-touch` | **single cell**: win × sqlite-link × touch |
+
+#### Platform = `mac` (mac-arm) (12)
+
+| Branch | Scope |
+|---|---|
+| `perf/mac-all-all` | **mac-arm** only, every fixture × scenario |
+| `perf/mac-all-cold` | mac, every fixture, cold only |
+| `perf/mac-all-worktree` | mac, every fixture, worktree only |
+| `perf/mac-all-touch` | mac, every fixture, touch only |
+| `perf/mac-medium-all` | mac + medium, every scenario |
+| `perf/mac-medium-cold` | **single cell**: mac × medium × cold |
+| `perf/mac-medium-worktree` | **single cell**: mac × medium × worktree |
+| `perf/mac-medium-touch` | **single cell**: mac × medium × touch |
+| `perf/mac-sqlite-all` | mac + sqlite-link, every scenario |
+| `perf/mac-sqlite-cold` | **single cell**: mac × sqlite-link × cold |
+| `perf/mac-sqlite-worktree` | **single cell**: mac × sqlite-link × worktree |
+| `perf/mac-sqlite-touch` | **single cell**: mac × sqlite-link × touch |
+
+> Today, only `linux` has a matrix row in `build-soldr` / `bench`. `win` and `mac` branches resolve correctly via setup but their cells gate out until cross-platform runner rows land. The branch names stay stable.
+
+## Picking a branch for the work you're doing
+
+- **Iterating on cache hit-rate fixes that only affect sqlite builds** → `perf/linux-sqlite-cold` (fastest signal: one cell, the hard gate scenario).
+- **Tuning archive fidelity** → `perf/all-all-cold` (sweep cold-tar-untar-warm across everything; fixture variation matters).
+- **Worktree path-remap change** → `perf/linux-all-worktree` (every fixture on linux, worktree scenario only).
+- **Just experimenting / unsure** → `perf/all` or `main` — full sweep; the workflow handles the volume.
+- **Personal feature branch like `perf/wip/foo`** → falls through to full sweep with an `::notice::`. Fine for one-off runs; rename to a canonical pattern when you know what axis you're working on.
+
+## Gate semantics
+
+- **`cold-tar-untar-warm` < 3x** (cold/warm ratio in the Evaluate step) → **fails the workflow**. Hard gate.
+- **`worktree-share` < 3x** → emits `::warning::`, doesn't fail. Soft gate today; promotes to hard once the baseline stabilizes.
+- **`touch-no-change` < 3x** → same as worktree-share, soft today.
+
+Threshold lives on the `evaluate` matrix row (`min_speedup: "3.0"`).
+
+## Reading the run
+
+Every cell appends to `$GITHUB_STEP_SUMMARY`. From the run page:
+
+1. **Scope** table at the top (`setup` job) — confirms the resolved `(platforms, fixtures, scenarios)` and the source (`branch:<ref>`, `alias:main`, `dispatch`, `unknown-perf:<ref>`, etc.).
+2. **bench** cells emit a per-fixture table with `cold/A ms | warm/B ms | speedup | hits/misses | hit rate | peak daemon RSS`.
+3. **Evaluate** cell emits a single per-platform table covering every (fixture, scenario) it could find, with `cold | warm | speedup | threshold | mode | result`.
+4. Failed runs annotate the failing rows with `::error::` lines (visible in the "Annotations" sidebar).
+
+Raw `result.json`, `*-shutdown.json`, and `rss-*.csv` are uploaded as `perf-results-<platform>-<fixture>` artifacts (14-day retention).
+
+## Local dry-runs
+
+You can run any single scenario locally without GHA:
+
+```bash
+# Set up the fixture
+bash perf/lib/extract.sh medium /tmp/perf-medium
+
+# Run one scenario (writes result.json to stdout)
+bash perf/scenarios/cold-tar-untar-warm/run.sh /tmp/perf-medium/medium
+```
+
+The scripts are POSIX bash and do not require any GHA-only env vars; `measure::append_summary_md` is a no-op when `$GITHUB_STEP_SUMMARY` is unset.


### PR DESCRIPTION
## Summary
- New `setup` job parses the branch name into an effective `(platforms, fixtures, scenarios)` scope and pipes it through `needs.setup.outputs` to every downstream gate. Replaces the ad-hoc `perf/sqlite/**` / `perf/medium/**` narrowing.
- Branch convention: `perf/<plat>-<fix>-<scen>` with short tokens (`linux`, `win`, `mac`, `medium`, `sqlite`, `cold`, `worktree`, `touch`, `all`). `main` and `perf/all` are full-sweep aliases. Unrecognized `perf/**` branches fall back to full sweep with a `::notice::` so feature/iteration branches still get useful data.
- `PERF.md` (new at repo root) documents the convention, the 48-pattern scope table, gate semantics, and a local dry-run recipe.
- `CLAUDE.md` gains a one-line pointer to `PERF.md`.
- `workflow_dispatch` behavior is unchanged — dispatch inputs flow through setup verbatim.

## Test plan
- [ ] This branch is itself `perf/cluster-hierarchical-skip` — its push should fire perf-cluster with source `unknown-perf:...` and run the full sweep (matches the fall-back arm).
- [ ] Open a follow-up branch named `perf/linux-medium-cold` and confirm only the linux × medium × cold-tar-untar-warm cell runs in bench, and the evaluate table shows only that row.
- [ ] Dispatch from the Actions UI with `platforms=all fixtures=sqlite-link scenarios=cold-tar-untar-warm` and confirm the setup table shows `source: dispatch` and the resolved scope matches.
- [ ] Verify `setup` writes a Scope table to `\$GITHUB_STEP_SUMMARY` showing event, ref, source, platforms, fixtures, scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)