### PR TITLE
chore: rename perf-cluster.yml -> perf-matrix.yml + always-on debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    # Skip perf-iteration branches — they only need perf-cluster.yml,
+    # Skip perf-iteration branches — they only need perf-matrix.yml,
     # not the full Lint/build/e2e sweep. (`branches` and
     # `branches-ignore` are mutually exclusive, so this replaces the
     # previous `branches: ['**']` catch-all.)

--- a/.github/workflows/perf-cold-warm.yml
+++ b/.github/workflows/perf-cold-warm.yml
@@ -10,7 +10,7 @@ name: Soldr Cold/Warm Bench
 # 1. `build-soldr` — master, builds soldr once and uploads it as an
 #    artifact. Layered actions/cache + Swatinem/rust-cache so the
 #    second dispatch on the same soldr commit is nearly free. The
-#    perf cluster has to keep working when soldr itself is broken
+#    perf matrix has to keep working when soldr itself is broken
 #    or absent on a new platform, so this step uses bare cargo (not
 #    `soldr cargo`).
 # 2. `purge-demo-caches` — only fires when run_mode is the "Purge

--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -1,4 +1,4 @@
-name: Soldr Perf Cluster
+name: Perf Matrix
 
 # See PERF.md (root of repo) for the user-facing branch-naming
 # convention and the full per-branch scope table. perf/README.md
@@ -57,18 +57,16 @@ on:
           - cold-tar-untar-warm
           - worktree-share
           - touch-no-change
-      debug:
-        description: Verbose tracing + retain raw RSS CSVs
-        type: boolean
-        required: true
-        default: false
+      # The `debug` input was removed: verbose tracing + raw RSS CSV
+      # retention is now always on. The downstream consumer sets
+      # SOLDR_DEBUG=1 unconditionally.
   push:
     branches:
       - main
       - 'perf/**'
       - 'evaluate/**'
     paths:
-      - '.github/workflows/perf-cluster.yml'
+      - '.github/workflows/perf-matrix.yml'
       - 'perf/**'
       - 'crates/**'
       - 'Cargo.toml'
@@ -82,7 +80,7 @@ concurrency:
   # Never cancel a perf run in flight — every measurement is a data
   # point we want to keep, even if a follow-up push lands before this
   # one finishes. Runs queue per-ref instead of superseding.
-  group: perf-cluster-${{ github.ref }}
+  group: perf-matrix-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -372,7 +370,10 @@ jobs:
         if: steps.gate.outputs.selected == 'true'
         id: run
         env:
-          SOLDR_DEBUG: ${{ inputs.debug == true && '1' || '' }}
+          # Verbose tracing + raw RSS CSV retention always on — no
+          # dispatch toggle. Saves the cost of a missed debug flag
+          # the next time something breaks.
+          SOLDR_DEBUG: "1"
           SELECTED_SCENARIOS: ${{ steps.gate.outputs.scenarios }}
           M_PLATFORM: ${{ matrix.platform }}
           M_FIXTURE: ${{ matrix.fixture }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 > [!IMPORTANT]
 > ## ⚡ Performance work → read [PERF.md](PERF.md) FIRST ⚡
 >
-> **The perf-cluster GitHub Action is the MOST important workflow in this repo.**
+> **The Perf Matrix GitHub Action is the MOST important workflow in this repo.**
 > If you are testing, measuring, optimizing, or regressing soldr's performance
 > — read **[PERF.md](PERF.md)** before doing anything else.
 >

--- a/LOOP.md
+++ b/LOOP.md
@@ -1,6 +1,6 @@
-# Perf Cluster Optimization Loop
+# Perf Matrix Optimization Loop
 
-You are a ralph-loop agent driving `.github/workflows/perf-cluster.yml`
+You are a ralph-loop agent driving `.github/workflows/perf-matrix.yml`
 down from **~17 minutes** to **≤ 9 minutes** of total wall time, with
 the stronger invariant that **every warm build is ≤ ½ of its cold
 parent**. You will iterate: change code, push a commit to one
@@ -15,7 +15,7 @@ iteration.
 ## Stop condition (read this twice)
 
 You are done when **all** of the following are true on the most
-recent perf-cluster run on your branch:
+recent perf-matrix run on your branch:
 
 1. The whole workflow run (max of `bench (linux / medium)` and
    `bench (linux / sqlite-link)`, plus `build-soldr`) finishes in
@@ -153,10 +153,10 @@ cache sharing — don't.
 
 Each iteration:
 
-1. **Read the latest perf-cluster run** for your branch:
+1. **Read the latest perf-matrix run** for your branch:
 
    ```bash
-   gh run list -R zackees/soldr --workflow=perf-cluster.yml --branch <your-branch> --limit 3
+   gh run list -R zackees/soldr --workflow=perf-matrix.yml --branch <your-branch> --limit 3
    gh run view <run-id> -R zackees/soldr
    gh run view --job <medium-job-id> -R zackees/soldr --log \
      | grep -E "scenario:|Compiling|Installing|hits:|compilations:|^\\{\"scenario\""
@@ -176,7 +176,7 @@ Each iteration:
    ```bash
    git add -A && git commit -m "perf: <what changed and why, ≤80 chars>"
    git push
-   gh workflow run perf-cluster.yml -R zackees/soldr --ref <your-branch>
+   gh workflow run perf-matrix.yml -R zackees/soldr --ref <your-branch>
    ```
 
 5. **Wait for the run.** `gh run watch <run-id>` blocks until done.
@@ -220,7 +220,7 @@ Each iteration:
 
 - **Do not edit `LOOP.md` itself.** It's your spec. Edit it only if
   the user explicitly tells you to.
-- **Do not change perf-cluster.yml's structure (jobs, matrix axes,
+- **Do not change perf-matrix.yml's structure (jobs, matrix axes,
   triggers).** Optimize within the existing shape. The user has
   spent multiple PRs nailing this shape down; don't churn it.
 - **Do not delete scenarios or fixtures.** They each pin a specific
@@ -248,9 +248,9 @@ Each iteration:
 - `CLAUDE.md` — repo invariants, especially the
   "Local zccache for debugging" section about
   `SOLDR_ZCCACHE_LOCAL_DIR`
-- `.github/workflows/perf-cluster.yml` — the workflow itself
+- `.github/workflows/perf-matrix.yml` — the workflow itself
 
-Run `cat .github/workflows/perf-cluster.yml` and
+Run `cat .github/workflows/perf-matrix.yml` and
 `cat perf/scenarios/cold-tar-untar-warm/run.sh` before iteration 1
 so you have the full surface in head.
 

--- a/PERF.md
+++ b/PERF.md
@@ -1,6 +1,6 @@
 # PERF.md — testing soldr performance
 
-soldr has one performance workflow: **`.github/workflows/perf-cluster.yml`** (the "Soldr Perf Cluster"). Push to a branch with a recognized name and the matrix runs the right cells automatically — no manual `workflow_dispatch` needed.
+soldr has one performance workflow: **`.github/workflows/perf-matrix.yml`** (the "Perf Matrix"). Push to a branch with a recognized name and the matrix runs the right cells automatically — no manual `workflow_dispatch` needed.
 
 For the per-scenario design rationale (what each cell proves), see [`perf/README.md`](perf/README.md).
 

--- a/perf/README.md
+++ b/perf/README.md
@@ -60,7 +60,7 @@ the second dispatch on the same soldr commit is essentially free:
    cache miss, so the rare rebuild is incremental.
 
 Soldr itself is deliberately **not** used to build soldr in this
-workflow. The perf cluster has to keep working when soldr is broken
+workflow. The perf matrix has to keep working when soldr is broken
 or absent on a new platform, so the bootstrap path stays on bare
 cargo + stock GHA caches.
 
@@ -100,7 +100,7 @@ perf/
    fixture's working directory as its first positional argument and
    writes a single JSON line to stdout.
 2. Add the scenario name to the matrix in
-   `.github/workflows/perf-cluster.yml`.
+   `.github/workflows/perf-matrix.yml`.
 
 ## Running locally
 

--- a/perf/fixtures/medium/Cargo.toml
+++ b/perf/fixtures/medium/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 # Standalone workspace so cargo never tries to fold this into the
-# parent soldr workspace at crates/. The perf cluster builds this
+# parent soldr workspace at crates/. The perf matrix builds this
 # fixture in isolation under $RUNNER_TEMP, but checking in
 # `[workspace]` here makes ad-hoc local builds work too.
 [workspace]

--- a/perf/fixtures/medium/src/main.rs
+++ b/perf/fixtures/medium/src/main.rs
@@ -1,5 +1,5 @@
 // A deliberately ordinary Rust binary used as the medium-sized
-// performance fixture for the soldr perf cluster.
+// performance fixture for the soldr perf matrix.
 //
 // Every dep declared in Cargo.toml is exercised by name from main so
 // dead-code elimination cannot prune the compile units we want to

--- a/perf/lib/common.sh
+++ b/perf/lib/common.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-# Common helpers for perf cluster workers. Source this file with
+# Common helpers for perf matrix workers. Source this file with
 # `. "${LIB_DIR}/common.sh"` from a scenario script.
 #
 # Conventions


### PR DESCRIPTION
## Summary
- Rename `.github/workflows/perf-cluster.yml` to `perf-matrix.yml`, and the workflow name from **"Soldr Perf Cluster"** to **"Perf Matrix"**. Concurrency group + self-referencing `paths:` filter updated to match.
- Drop the \`debug\` workflow_dispatch input. \`SOLDR_DEBUG=1\` is now hardcoded so verbose tracing + raw RSS CSV retention is always on.
- Sweep all incidental references: \`CLAUDE.md\`, \`PERF.md\`, \`LOOP.md\`, \`perf/README.md\`, \`perf/lib/common.sh\`, the medium fixture, \`ci.yml\`, \`perf-cold-warm.yml\`.

The local-only \`.clud/loop/\` directory was not staged.

## Test plan
- [ ] After merge, the Actions tab shows "Perf Matrix" (not "Soldr Perf Cluster"). The old name disappears.
- [ ] The post-merge push to \`main\` fires the renamed workflow (its push trigger matches the new filename's \`paths:\` entry).
- [ ] Manual dispatch UI shows only \`platforms\` / \`fixtures\` / \`scenarios\` (no debug checkbox); a dispatch run has \`SOLDR_DEBUG=1\` in the env block of the "Run selected scenarios" step.
- [ ] \`gh workflow run perf-matrix.yml\` works; \`gh workflow run perf-cluster.yml\` 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)