### PR TITLE
feat(cli): soldr update-zccache (system | path | url) + --remove / --status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "tokio",
  "toml",
  "zip",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -1333,6 +1333,324 @@ pub(crate) fn print_json<T: Serialize>(value: &T) -> Result<(), SoldrError> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// install-zccache (soldr cache install-zccache <SOURCE> / --remove / --status)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct InstallZccacheOutput {
+    schema_version: u32,
+    command: &'static str,
+    install_dir: String,
+    source_kind: String,
+    source_value: String,
+    version: String,
+    binaries: std::collections::BTreeMap<String, soldr_fetch::PinnedBinaryRecord>,
+    installed_at: String,
+    soldr_version: String,
+}
+
+#[derive(Serialize)]
+struct InstallZccacheRemoveOutput {
+    schema_version: u32,
+    command: &'static str,
+    removed: bool,
+    path: String,
+}
+
+/// `--status` payload when the pinned install exists.
+#[derive(Serialize)]
+struct InstallZccacheStatusOutput {
+    schema_version: u32,
+    command: &'static str,
+    pinned: serde_json::Value,
+    drift_from_managed: bool,
+    managed_version: &'static str,
+}
+
+/// `--status` payload when no pinned install exists.
+#[derive(Serialize)]
+struct InstallZccacheStatusMissingOutput {
+    schema_version: u32,
+    command: &'static str,
+    pinned: Option<()>,
+    managed_version: &'static str,
+}
+
+pub(crate) async fn run_cache_install_zccache(
+    source: Option<String>,
+    remove: bool,
+    status: bool,
+    json: bool,
+) -> Result<(), SoldrError> {
+    // Mutual-exclusion: clap already rejects multiple flags being set
+    // simultaneously, but it lets all three be omitted; reject that case
+    // explicitly so the user gets a clear, actionable error.
+    let chosen = [source.is_some(), remove, status]
+        .iter()
+        .filter(|x| **x)
+        .count();
+    if chosen == 0 {
+        return Err(SoldrError::Other(
+            "install-zccache: provide a SOURCE (`system`, a path, or a URL), or pass --remove / --status".into(),
+        ));
+    }
+    if remove {
+        return run_install_zccache_remove(json);
+    }
+    if status {
+        return run_install_zccache_status(json);
+    }
+    let raw = source.expect("source presence checked above");
+    let parsed = soldr_fetch::InstallSource::parse(&raw)?;
+    let paths = SoldrPaths::new()?;
+    let report = soldr_fetch::install_zccache_from_source(&parsed, &paths).await?;
+    emit_install_report(&report, json)
+}
+
+fn emit_install_report(report: &soldr_fetch::InstallReport, json: bool) -> Result<(), SoldrError> {
+    if json {
+        let output = InstallZccacheOutput {
+            schema_version: JSON_SCHEMA_VERSION,
+            command: "cache install-zccache",
+            install_dir: report.install_dir.clone(),
+            source_kind: report.source_kind.clone(),
+            source_value: report.source_value.clone(),
+            version: report.version.clone(),
+            binaries: report.binaries.clone(),
+            installed_at: report.installed_at.clone(),
+            soldr_version: report.soldr_version.clone(),
+        };
+        print_json(&output)?;
+    } else {
+        println!("soldr cache install-zccache");
+        println!("  install dir:  {}", report.install_dir);
+        println!(
+            "  source:       {} ({})",
+            report.source_kind, report.source_value
+        );
+        println!("  version:      {}", report.version);
+        println!("  installed at: {}", report.installed_at);
+        println!("  binaries:");
+        for (name, record) in &report.binaries {
+            let short = sha256_short_str(&record.sha256);
+            println!(
+                "    {name:<14}  sha256={short}  size={} bytes",
+                record.size_bytes
+            );
+        }
+        if report.version != "unknown" && report.version != soldr_fetch::MANAGED_ZCCACHE_VERSION {
+            println!(
+                "  note:         pinned version {} differs from managed default {}",
+                report.version,
+                soldr_fetch::MANAGED_ZCCACHE_VERSION
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_install_zccache_remove(json: bool) -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let dir = soldr_fetch::pinned_zccache_dir(&paths);
+    let removed = soldr_fetch::remove_pinned_zccache(&paths)?;
+    if json {
+        let output = InstallZccacheRemoveOutput {
+            schema_version: JSON_SCHEMA_VERSION,
+            command: "cache install-zccache --remove",
+            removed,
+            path: dir.display().to_string(),
+        };
+        print_json(&output)?;
+    } else if removed {
+        println!(
+            "soldr cache install-zccache --remove: removed {}",
+            dir.display()
+        );
+    } else {
+        println!(
+            "soldr cache install-zccache --remove: no pinned install at {} (nothing to do)",
+            dir.display()
+        );
+    }
+    Ok(())
+}
+
+fn run_install_zccache_status(json: bool) -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let sidecar = soldr_fetch::read_pinned_sidecar(&paths)?;
+    match sidecar {
+        Some(sidecar) => {
+            let drift = soldr_fetch::pinned_version_drift_from_managed(&sidecar);
+            if json {
+                let pinned_value = serde_json::to_value(&sidecar).map_err(|e| {
+                    SoldrError::Other(format!("install-zccache status: serialize sidecar: {e}"))
+                })?;
+                let output = InstallZccacheStatusOutput {
+                    schema_version: JSON_SCHEMA_VERSION,
+                    command: "cache install-zccache --status",
+                    pinned: pinned_value,
+                    drift_from_managed: drift,
+                    managed_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+                };
+                print_json(&output)?;
+            } else {
+                println!("soldr cache install-zccache --status");
+                println!(
+                    "  install dir:  {}",
+                    soldr_fetch::pinned_zccache_dir(&paths).display()
+                );
+                println!(
+                    "  source:       {} ({})",
+                    sidecar.source_kind, sidecar.source_value
+                );
+                println!("  version:      {}", sidecar.version);
+                println!(
+                    "  installed at: {}{}",
+                    sidecar.installed_at,
+                    install_age_note(&sidecar.installed_at)
+                );
+                println!("  soldr version: {}", sidecar.soldr_version);
+                println!("  binaries:");
+                for (name, record) in &sidecar.binaries {
+                    let short = sha256_short_str(&record.sha256);
+                    println!(
+                        "    {name:<14}  sha256={short}  size={} bytes",
+                        record.size_bytes
+                    );
+                }
+                if drift {
+                    println!(
+                        "  warning:      pinned version {} is different from soldr's managed default {} — consider `soldr cache install-zccache --remove` to use the managed version",
+                        sidecar.version,
+                        soldr_fetch::MANAGED_ZCCACHE_VERSION
+                    );
+                }
+            }
+        }
+        None => {
+            if json {
+                let output = InstallZccacheStatusMissingOutput {
+                    schema_version: JSON_SCHEMA_VERSION,
+                    command: "cache install-zccache --status",
+                    pinned: None,
+                    managed_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+                };
+                print_json(&output)?;
+            } else {
+                println!(
+                    "no pinned zccache installed; using managed default {}",
+                    soldr_fetch::MANAGED_ZCCACHE_VERSION
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn sha256_short_str(full: &str) -> String {
+    full.chars().take(12).collect()
+}
+
+/// Best-effort "installed N days ago" hint from an RFC3339 UTC string.
+/// Parses just enough of the timestamp to compute a delta in days;
+/// returns an empty string on parse failure so the human output never
+/// breaks.
+fn install_age_note(installed_at: &str) -> String {
+    let Some(parsed_secs) = parse_iso8601_utc_seconds(installed_at) else {
+        return String::new();
+    };
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let delta = now_secs - parsed_secs;
+    if delta < 60 {
+        " (just now)".to_string()
+    } else if delta < 3600 {
+        format!(
+            " ({} minute{} ago)",
+            delta / 60,
+            if delta / 60 == 1 { "" } else { "s" }
+        )
+    } else if delta < 86_400 {
+        format!(
+            " ({} hour{} ago)",
+            delta / 3600,
+            if delta / 3600 == 1 { "" } else { "s" }
+        )
+    } else {
+        format!(
+            " ({} day{} ago)",
+            delta / 86_400,
+            if delta / 86_400 == 1 { "" } else { "s" }
+        )
+    }
+}
+
+fn parse_iso8601_utc_seconds(s: &str) -> Option<i64> {
+    // Minimal "YYYY-MM-DDTHH:MM:SSZ" parser matching what
+    // soldr-fetch::install_zccache::format_iso8601_utc emits. Returns
+    // None on anything unexpected — the caller treats that as "no age
+    // hint".
+    let s = s.trim();
+    if s.len() < 20 {
+        return None;
+    }
+    let year: i32 = s.get(0..4)?.parse().ok()?;
+    let month: u32 = s.get(5..7)?.parse().ok()?;
+    let day: u32 = s.get(8..10)?.parse().ok()?;
+    let hour: u32 = s.get(11..13)?.parse().ok()?;
+    let minute: u32 = s.get(14..16)?.parse().ok()?;
+    let second: u32 = s.get(17..19)?.parse().ok()?;
+    Some(ymdhms_to_unix_seconds(
+        year, month, day, hour, minute, second,
+    ))
+}
+
+fn ymdhms_to_unix_seconds(y: i32, m: u32, d: u32, h: u32, min: u32, s: u32) -> i64 {
+    // Inverse of unix_seconds_to_ymdhms in install_zccache; civil_to_days
+    // by Howard Hinnant (public domain).
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = y.div_euclid(400);
+    let yoe = y.rem_euclid(400) as i64;
+    let m_i = m as i64;
+    let d_i = d as i64;
+    let doy = (153 * (if m_i > 2 { m_i - 3 } else { m_i + 9 }) + 2) / 5 + d_i - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era as i64 * 146_097 + doe - 719_468;
+    days * 86_400 + (h as i64) * 3600 + (min as i64) * 60 + (s as i64)
+}
+
+#[cfg(test)]
+mod install_zccache_tests {
+    use super::*;
+
+    #[test]
+    fn sha256_short_truncates_to_12() {
+        let s = sha256_short_str("0123456789abcdef0123456789");
+        assert_eq!(s, "0123456789ab");
+        assert_eq!(s.len(), 12);
+    }
+
+    #[test]
+    fn parse_iso8601_handles_known_timestamps() {
+        // Sanity-check the parser against hand-computed values.
+        assert_eq!(parse_iso8601_utc_seconds("1970-01-01T00:00:00Z"), Some(0));
+        assert_eq!(
+            parse_iso8601_utc_seconds("2023-11-14T22:13:20Z"),
+            Some(1_700_000_000)
+        );
+    }
+
+    #[test]
+    fn parse_iso8601_rejects_short_strings() {
+        assert_eq!(parse_iso8601_utc_seconds(""), None);
+        assert_eq!(parse_iso8601_utc_seconds("not-a-date"), None);
+        assert_eq!(parse_iso8601_utc_seconds("2026-05-2"), None);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -1334,11 +1334,11 @@ pub(crate) fn print_json<T: Serialize>(value: &T) -> Result<(), SoldrError> {
 }
 
 // ---------------------------------------------------------------------------
-// install-zccache (soldr cache install-zccache <SOURCE> / --remove / --status)
+// update-zccache (soldr update-zccache <SOURCE> / --remove / --status)
 // ---------------------------------------------------------------------------
 
 #[derive(Serialize)]
-struct InstallZccacheOutput {
+struct UpdateZccacheOutput {
     schema_version: u32,
     command: &'static str,
     install_dir: String,
@@ -1351,7 +1351,7 @@ struct InstallZccacheOutput {
 }
 
 #[derive(Serialize)]
-struct InstallZccacheRemoveOutput {
+struct UpdateZccacheRemoveOutput {
     schema_version: u32,
     command: &'static str,
     removed: bool,
@@ -1360,7 +1360,7 @@ struct InstallZccacheRemoveOutput {
 
 /// `--status` payload when the pinned install exists.
 #[derive(Serialize)]
-struct InstallZccacheStatusOutput {
+struct UpdateZccacheStatusOutput {
     schema_version: u32,
     command: &'static str,
     pinned: serde_json::Value,
@@ -1370,14 +1370,14 @@ struct InstallZccacheStatusOutput {
 
 /// `--status` payload when no pinned install exists.
 #[derive(Serialize)]
-struct InstallZccacheStatusMissingOutput {
+struct UpdateZccacheStatusMissingOutput {
     schema_version: u32,
     command: &'static str,
     pinned: Option<()>,
     managed_version: &'static str,
 }
 
-pub(crate) async fn run_cache_install_zccache(
+pub(crate) async fn run_update_zccache(
     source: Option<String>,
     remove: bool,
     status: bool,
@@ -1392,14 +1392,14 @@ pub(crate) async fn run_cache_install_zccache(
         .count();
     if chosen == 0 {
         return Err(SoldrError::Other(
-            "install-zccache: provide a SOURCE (`system`, a path, or a URL), or pass --remove / --status".into(),
+            "update-zccache: provide a SOURCE (`system`, a path, or a URL), or pass --remove / --status".into(),
         ));
     }
     if remove {
-        return run_install_zccache_remove(json);
+        return run_update_zccache_remove(json);
     }
     if status {
-        return run_install_zccache_status(json);
+        return run_update_zccache_status(json);
     }
     let raw = source.expect("source presence checked above");
     let parsed = soldr_fetch::InstallSource::parse(&raw)?;
@@ -1410,9 +1410,9 @@ pub(crate) async fn run_cache_install_zccache(
 
 fn emit_install_report(report: &soldr_fetch::InstallReport, json: bool) -> Result<(), SoldrError> {
     if json {
-        let output = InstallZccacheOutput {
+        let output = UpdateZccacheOutput {
             schema_version: JSON_SCHEMA_VERSION,
-            command: "cache install-zccache",
+            command: "update-zccache",
             install_dir: report.install_dir.clone(),
             source_kind: report.source_kind.clone(),
             source_value: report.source_value.clone(),
@@ -1423,7 +1423,7 @@ fn emit_install_report(report: &soldr_fetch::InstallReport, json: bool) -> Resul
         };
         print_json(&output)?;
     } else {
-        println!("soldr cache install-zccache");
+        println!("soldr update-zccache");
         println!("  install dir:  {}", report.install_dir);
         println!(
             "  source:       {} ({})",
@@ -1450,33 +1450,33 @@ fn emit_install_report(report: &soldr_fetch::InstallReport, json: bool) -> Resul
     Ok(())
 }
 
-fn run_install_zccache_remove(json: bool) -> Result<(), SoldrError> {
+fn run_update_zccache_remove(json: bool) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
     let dir = soldr_fetch::pinned_zccache_dir(&paths);
     let removed = soldr_fetch::remove_pinned_zccache(&paths)?;
     if json {
-        let output = InstallZccacheRemoveOutput {
+        let output = UpdateZccacheRemoveOutput {
             schema_version: JSON_SCHEMA_VERSION,
-            command: "cache install-zccache --remove",
+            command: "update-zccache --remove",
             removed,
             path: dir.display().to_string(),
         };
         print_json(&output)?;
     } else if removed {
         println!(
-            "soldr cache install-zccache --remove: removed {}",
+            "soldr update-zccache --remove: removed {}",
             dir.display()
         );
     } else {
         println!(
-            "soldr cache install-zccache --remove: no pinned install at {} (nothing to do)",
+            "soldr update-zccache --remove: no pinned install at {} (nothing to do)",
             dir.display()
         );
     }
     Ok(())
 }
 
-fn run_install_zccache_status(json: bool) -> Result<(), SoldrError> {
+fn run_update_zccache_status(json: bool) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
     let sidecar = soldr_fetch::read_pinned_sidecar(&paths)?;
     match sidecar {
@@ -1484,18 +1484,18 @@ fn run_install_zccache_status(json: bool) -> Result<(), SoldrError> {
             let drift = soldr_fetch::pinned_version_drift_from_managed(&sidecar);
             if json {
                 let pinned_value = serde_json::to_value(&sidecar).map_err(|e| {
-                    SoldrError::Other(format!("install-zccache status: serialize sidecar: {e}"))
+                    SoldrError::Other(format!("update-zccache status: serialize sidecar: {e}"))
                 })?;
-                let output = InstallZccacheStatusOutput {
+                let output = UpdateZccacheStatusOutput {
                     schema_version: JSON_SCHEMA_VERSION,
-                    command: "cache install-zccache --status",
+                    command: "update-zccache --status",
                     pinned: pinned_value,
                     drift_from_managed: drift,
                     managed_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
                 };
                 print_json(&output)?;
             } else {
-                println!("soldr cache install-zccache --status");
+                println!("soldr update-zccache --status");
                 println!(
                     "  install dir:  {}",
                     soldr_fetch::pinned_zccache_dir(&paths).display()
@@ -1521,7 +1521,7 @@ fn run_install_zccache_status(json: bool) -> Result<(), SoldrError> {
                 }
                 if drift {
                     println!(
-                        "  warning:      pinned version {} is different from soldr's managed default {} — consider `soldr cache install-zccache --remove` to use the managed version",
+                        "  warning:      pinned version {} is different from soldr's managed default {} — consider `soldr update-zccache --remove` to use the managed version",
                         sidecar.version,
                         soldr_fetch::MANAGED_ZCCACHE_VERSION
                     );
@@ -1530,9 +1530,9 @@ fn run_install_zccache_status(json: bool) -> Result<(), SoldrError> {
         }
         None => {
             if json {
-                let output = InstallZccacheStatusMissingOutput {
+                let output = UpdateZccacheStatusMissingOutput {
                     schema_version: JSON_SCHEMA_VERSION,
-                    command: "cache install-zccache --status",
+                    command: "update-zccache --status",
                     pinned: None,
                     managed_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
                 };
@@ -1623,7 +1623,7 @@ fn ymdhms_to_unix_seconds(y: i32, m: u32, d: u32, h: u32, min: u32, s: u32) -> i
 }
 
 #[cfg(test)]
-mod install_zccache_tests {
+mod update_zccache_tests {
     use super::*;
 
     #[test]

--- a/crates/soldr-cli/src/doctor.rs
+++ b/crates/soldr-cli/src/doctor.rs
@@ -45,7 +45,7 @@ struct DoctorOutput {
     /// view even when the active source is a pinned install; the
     /// pinned section below explains the override.
     managed_zccache: DoctorManagedZccache,
-    /// `Some` when `soldr cache install-zccache` has been run.
+    /// `Some` when `soldr update-zccache` has been run.
     pinned_zccache: Option<DoctorPinnedZccache>,
     /// `true` when the active resolution is the pinned install (i.e.
     /// the managed path is superseded for the next `soldr cargo ...`).
@@ -254,7 +254,7 @@ struct ZccacheDoctorBundle {
     /// reports the GitHub-Releases view, even when the pinned dir wins
     /// resolution.
     managed: ZccacheBinarySummary,
-    /// Pinned-install snapshot, when `soldr cache install-zccache`
+    /// Pinned-install snapshot, when `soldr update-zccache`
     /// has been run.
     pinned: Option<ZccacheBinarySummary>,
     /// JSON-friendly form of the pinned section.
@@ -347,7 +347,7 @@ fn print_pinned_zccache_human(
     if soldr_fetch::pinned_version_drift_from_managed(sidecar) {
         println!(
             "  warning:       pinned version {} differs from soldr's managed default {} — \
-consider `soldr cache install-zccache --remove` to switch back to the managed version",
+consider `soldr update-zccache --remove` to switch back to the managed version",
             sidecar.version,
             soldr_fetch::MANAGED_ZCCACHE_VERSION
         );

--- a/crates/soldr-cli/src/doctor.rs
+++ b/crates/soldr-cli/src/doctor.rs
@@ -41,10 +41,15 @@ struct DoctorOutput {
     drift: bool,
     missing_components: Vec<String>,
     missing_targets: Vec<String>,
-    /// Managed zccache resolution: where the binaries live, whether
-    /// the `SOLDR_ZCCACHE_LOCAL_DIR` override is active, and where to
-    /// point a debugger for symbol resolution.
+    /// Managed zccache state on disk. Always reports the managed-path
+    /// view even when the active source is a pinned install; the
+    /// pinned section below explains the override.
     managed_zccache: DoctorManagedZccache,
+    /// `Some` when `soldr cache install-zccache` has been run.
+    pinned_zccache: Option<DoctorPinnedZccache>,
+    /// `true` when the active resolution is the pinned install (i.e.
+    /// the managed path is superseded for the next `soldr cargo ...`).
+    pinned_zccache_active: bool,
 }
 
 #[derive(Serialize)]
@@ -93,6 +98,22 @@ impl DoctorManagedZccache {
     }
 }
 
+#[derive(Serialize, Clone)]
+struct DoctorPinnedZccache {
+    install_dir: String,
+    source_kind: String,
+    source_value: String,
+    version: String,
+    cli_path: Option<String>,
+    daemon_path: Option<String>,
+    fp_path: Option<String>,
+    debug_info_found: usize,
+    debug_info_expected: usize,
+    symbol_path: String,
+    drift_from_managed: bool,
+    managed_version: &'static str,
+}
+
 /// Implementation of `soldr doctor`. Read-only — never invokes
 /// `rustup component add` / `target add` / `toolchain install`.
 pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
@@ -100,7 +121,7 @@ pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
     let manifest_path = workspace_root.join("rust-toolchain.toml");
     let manifest = soldr_core::read_rust_toolchain_manifest(&workspace_root)?;
     let manifest_present = manifest_path.exists();
-    let zccache_summary = collect_zccache_summary()?;
+    let bundle = collect_zccache_bundle()?;
 
     let Some(channel) = manifest.channel.as_deref() else {
         if json {
@@ -114,7 +135,9 @@ pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
                 drift: false,
                 missing_components: Vec::new(),
                 missing_targets: Vec::new(),
-                managed_zccache: DoctorManagedZccache::from_summary(&zccache_summary),
+                managed_zccache: DoctorManagedZccache::from_summary(&bundle.managed),
+                pinned_zccache: bundle.pinned_doctor.clone(),
+                pinned_zccache_active: bundle.pinned_active,
             };
             print_json(&output)?;
         } else if manifest_present {
@@ -122,14 +145,14 @@ pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
                 "manifest: {} (present but no [toolchain] channel declared)",
                 manifest_path.display()
             );
-            print_managed_zccache_human(&zccache_summary);
+            print_zccache_sections(&bundle);
             println!("result: no manifest fields to compare; nothing to do");
         } else {
             println!(
                 "no rust-toolchain.toml found in {}",
                 workspace_root.display()
             );
-            print_managed_zccache_human(&zccache_summary);
+            print_zccache_sections(&bundle);
             println!("result: no manifest found; nothing to compare");
         }
         return Ok(0);
@@ -194,7 +217,9 @@ pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
             drift,
             missing_components,
             missing_targets,
-            managed_zccache: DoctorManagedZccache::from_summary(&zccache_summary),
+            managed_zccache: DoctorManagedZccache::from_summary(&bundle.managed),
+            pinned_zccache: bundle.pinned_doctor.clone(),
+            pinned_zccache_active: bundle.pinned_active,
         };
         print_json(&output)?;
     } else {
@@ -207,7 +232,7 @@ pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
             &missing_components,
             &missing_targets,
             drift,
-            &zccache_summary,
+            &bundle,
         );
     }
 
@@ -216,19 +241,131 @@ pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
 
 /// Collect zccache binary resolution info for doctor output. Read-only:
 /// honors `SOLDR_ZCCACHE_LOCAL_DIR` but doesn't trigger a managed
-/// fetch.
-fn collect_zccache_summary() -> Result<ZccacheBinarySummary, SoldrError> {
-    let paths = SoldrPaths::new()?;
-    soldr_fetch::zccache_binary_summary(&paths)
+/// fetch. The bundle includes the managed-only view (independent of
+/// resolution priority) plus an optional pinned snapshot so the human
+/// printer can surface both sections.
+struct ZccacheDoctorBundle {
+    /// Active resolution (what `soldr cargo` would use right now).
+    /// Retained for diagnostic context even though every print path
+    /// derives its summary from `managed` / `pinned`.
+    #[allow(dead_code)]
+    active: ZccacheBinarySummary,
+    /// Managed-path-only state for the "managed zccache:" section. Always
+    /// reports the GitHub-Releases view, even when the pinned dir wins
+    /// resolution.
+    managed: ZccacheBinarySummary,
+    /// Pinned-install snapshot, when `soldr cache install-zccache`
+    /// has been run.
+    pinned: Option<ZccacheBinarySummary>,
+    /// JSON-friendly form of the pinned section.
+    pinned_doctor: Option<DoctorPinnedZccache>,
+    /// True when the active source is the pinned install.
+    pinned_active: bool,
+    /// Pinned sidecar (when present). Used to render source-kind / source-value.
+    pinned_sidecar: Option<soldr_fetch::PinnedSidecar>,
 }
 
-fn print_managed_zccache_human(summary: &ZccacheBinarySummary) {
+fn collect_zccache_bundle() -> Result<ZccacheDoctorBundle, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let active = soldr_fetch::zccache_binary_summary(&paths)?;
+    // `managed` shows whichever source the next `soldr cargo` would
+    // actually use. When the pinned install is the active source the
+    // human/JSON output annotates it with "(superseded by pinned)" so
+    // users understand the precedence; the dedicated pinned section
+    // surfaces the install dir / drift warning.
+    let managed = if matches!(active.source, ZccacheSource::Pinned) {
+        soldr_fetch::managed_only_zccache_summary(&paths)?
+    } else {
+        active.clone()
+    };
+    let pinned = soldr_fetch::pinned_zccache_summary(&paths)?;
+    let pinned_sidecar = soldr_fetch::read_pinned_sidecar(&paths)?;
+    let pinned_active = matches!(active.source, ZccacheSource::Pinned);
+    let pinned_doctor = match (pinned.as_ref(), pinned_sidecar.as_ref()) {
+        (Some(summary), Some(sidecar)) => Some(DoctorPinnedZccache {
+            install_dir: soldr_fetch::pinned_zccache_dir(&paths)
+                .display()
+                .to_string(),
+            source_kind: sidecar.source_kind.clone(),
+            source_value: sidecar.source_value.clone(),
+            version: summary.version.clone(),
+            cli_path: summary.cli_path.as_ref().map(|p| p.display().to_string()),
+            daemon_path: summary
+                .daemon_path
+                .as_ref()
+                .map(|p| p.display().to_string()),
+            fp_path: summary.fp_path.as_ref().map(|p| p.display().to_string()),
+            debug_info_found: summary.debug_info_found,
+            debug_info_expected: summary.debug_info_expected,
+            symbol_path: summary.symbol_path.display().to_string(),
+            drift_from_managed: soldr_fetch::pinned_version_drift_from_managed(sidecar),
+            managed_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
+        }),
+        _ => None,
+    };
+    Ok(ZccacheDoctorBundle {
+        active,
+        managed,
+        pinned,
+        pinned_doctor,
+        pinned_active,
+        pinned_sidecar,
+    })
+}
+
+fn print_zccache_sections(bundle: &ZccacheDoctorBundle) {
+    if let (Some(summary), Some(sidecar)) = (bundle.pinned.as_ref(), bundle.pinned_sidecar.as_ref())
+    {
+        print_pinned_zccache_human(summary, sidecar);
+    }
+    print_managed_zccache_human(&bundle.managed, bundle.pinned_active);
+}
+
+fn print_pinned_zccache_human(
+    summary: &ZccacheBinarySummary,
+    sidecar: &soldr_fetch::PinnedSidecar,
+) {
+    println!();
+    println!("pinned zccache:");
+    println!("  install dir:   {}", summary.runtime_dir.display());
+    println!("  source kind:   {}", sidecar.source_kind);
+    println!("  source value:  {}", sidecar.source_value);
+    println!("  version:       {}", summary.version);
+    match &summary.cli_path {
+        Some(p) => println!("  active cli:    {}", p.display()),
+        None => println!("  active cli:    <not present>"),
+    }
+    match &summary.daemon_path {
+        Some(p) => println!("  active daemon: {}", p.display()),
+        None => println!("  active daemon: <not present>"),
+    }
+    match &summary.fp_path {
+        Some(p) => println!("  active fp:     {}", p.display()),
+        None => println!("  active fp:     <not present>"),
+    }
+    println!("  symbol path:   {}", summary.symbol_path.display());
+    if soldr_fetch::pinned_version_drift_from_managed(sidecar) {
+        println!(
+            "  warning:       pinned version {} differs from soldr's managed default {} — \
+consider `soldr cache install-zccache --remove` to switch back to the managed version",
+            sidecar.version,
+            soldr_fetch::MANAGED_ZCCACHE_VERSION
+        );
+    }
+}
+
+fn print_managed_zccache_human(summary: &ZccacheBinarySummary, superseded_by_pinned: bool) {
     println!();
     println!("managed zccache:");
+    let suffix = if superseded_by_pinned {
+        " (superseded by pinned)"
+    } else {
+        ""
+    };
     match summary.source {
         ZccacheSource::Local => {
             println!(
-                "  source:        local ({})",
+                "  source:        local ({}){suffix}",
                 soldr_fetch::ZCCACHE_LOCAL_DIR_ENV_VAR
             );
             if let Some(dir) = &summary.source_dir {
@@ -238,15 +375,27 @@ fn print_managed_zccache_human(summary: &ZccacheBinarySummary) {
                 println!("  version:       {}", summary.version);
             }
         }
+        ZccacheSource::Pinned => {
+            // Shouldn't happen for the managed-only summary, but cover
+            // it so the match is exhaustive and the rendering is sane
+            // if the surface evolves.
+            println!(
+                "  source:        pinned ({}){suffix}",
+                soldr_fetch::PINNED_ZCCACHE_DIRNAME
+            );
+            if !summary.version.is_empty() {
+                println!("  version:       {}", summary.version);
+            }
+        }
         ZccacheSource::Managed => {
             println!(
-                "  source:        managed ({})",
+                "  source:        managed ({}){suffix}",
                 soldr_fetch::MANAGED_ZCCACHE_VERSION
             );
         }
         ZccacheSource::None => {
             println!(
-                "  source:        managed ({}, not fetched yet)",
+                "  source:        managed ({}, not fetched yet){suffix}",
                 soldr_fetch::MANAGED_ZCCACHE_VERSION
             );
         }
@@ -299,7 +448,7 @@ fn print_doctor_human(
     missing_components: &[String],
     missing_targets: &[String],
     drift: bool,
-    zccache_summary: &ZccacheBinarySummary,
+    bundle: &ZccacheDoctorBundle,
 ) {
     println!("manifest: {}", manifest_path.display());
     println!("toolchain: {channel}");
@@ -356,7 +505,7 @@ fn print_doctor_human(
         }
     }
 
-    print_managed_zccache_human(zccache_summary);
+    print_zccache_sections(bundle);
 
     println!();
     if drift {

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -289,6 +289,34 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Install zccache binaries into soldr's private dir so soldr stops
+    /// fetching the managed GitHub release. Pins a user-supplied set of
+    /// three zccache binaries (zccache, zccache-daemon, zccache-fp) into
+    /// `<SoldrPaths::bin>/zccache-pinned/`. Subsequent `soldr cargo ...`
+    /// invocations resolve the pinned binaries automatically.
+    ///
+    /// Exactly one of `<source>`, `--remove`, or `--status` must be
+    /// provided. `<source>` accepts `system`, a directory or archive
+    /// path (`.zip` / `.tar.gz` / `.tar.zst`), or an `http(s)://` URL
+    /// pointing at such an archive.
+    #[command(name = "update-zccache")]
+    UpdateZccache {
+        /// Source for the three zccache binaries. Mutually exclusive
+        /// with `--remove` / `--status`.
+        #[arg(value_name = "SOURCE", conflicts_with_all = ["remove", "status"])]
+        source: Option<String>,
+        /// Delete the pinned install and fall back to the managed
+        /// fetch on next run. Idempotent.
+        #[arg(long, conflicts_with_all = ["source", "status"])]
+        remove: bool,
+        /// Print the install dir, source, version, and per-binary
+        /// sha256s of the pinned install (if any).
+        #[arg(long, conflicts_with_all = ["source", "remove"])]
+        status: bool,
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
     /// Bundle a build-cache directory plus a content-verified
     /// snapshot of source-file mtimes into a single `.tar.zst`
     /// archive. The output is consumed by `soldr load` to restore
@@ -517,33 +545,6 @@ enum CacheSubcommand {
         #[arg(long)]
         json: bool,
     },
-    /// Pin a specific zccache build (system PATH, local path, or
-    /// archive URL) so soldr stops fetching the managed GitHub release.
-    /// Subsequent `soldr cargo ...` invocations resolve the pinned
-    /// binaries from `<SoldrPaths::bin>/zccache-pinned/` automatically.
-    ///
-    /// Exactly one of `<source>`, `--remove`, or `--status` must be
-    /// provided. `<source>` accepts `system`, a directory or archive
-    /// path (`.zip` / `.tar.gz` / `.tar.zst`), or an `http(s)://` URL
-    /// pointing at such an archive.
-    #[command(name = "install-zccache")]
-    InstallZccache {
-        /// Source for the three zccache binaries. Mutually exclusive
-        /// with `--remove` / `--status`.
-        #[arg(value_name = "SOURCE", conflicts_with_all = ["remove", "status"])]
-        source: Option<String>,
-        /// Delete the pinned install and fall back to the managed
-        /// fetch on next run. Idempotent.
-        #[arg(long, conflicts_with_all = ["source", "status"])]
-        remove: bool,
-        /// Print the install dir, source, version, and per-binary
-        /// sha256s of the pinned install (if any).
-        #[arg(long, conflicts_with_all = ["source", "remove"])]
-        status: bool,
-        /// Emit the stable machine-facing JSON form for this command.
-        #[arg(long)]
-        json: bool,
-    },
     /// Prune stale per-prefix build artifacts from a cargo `target/`
     /// directory, keeping only the newest entry per
     /// `(parent_dir, prefix)` bucket inside
@@ -705,6 +706,14 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
         Commands::Optimize(args) => {
             std::process::exit(optimize::run_optimize(args)?);
         }
+        Commands::UpdateZccache {
+            source,
+            remove,
+            status,
+            json,
+        } => {
+            cache::run_update_zccache(source, remove, status, json).await?;
+        }
         Commands::Save(args) => {
             std::process::exit(save_load::run_save(args));
         }
@@ -750,15 +759,6 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             }
             Some(CacheSubcommand::Flush { json: flush_json }) => {
                 cache::run_cache_flush_command(flush_json || json).await?;
-            }
-            Some(CacheSubcommand::InstallZccache {
-                source,
-                remove,
-                status,
-                json: install_json,
-            }) => {
-                cache::run_cache_install_zccache(source, remove, status, install_json || json)
-                    .await?;
             }
             Some(CacheSubcommand::PruneTarget {
                 path,

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -517,6 +517,33 @@ enum CacheSubcommand {
         #[arg(long)]
         json: bool,
     },
+    /// Pin a specific zccache build (system PATH, local path, or
+    /// archive URL) so soldr stops fetching the managed GitHub release.
+    /// Subsequent `soldr cargo ...` invocations resolve the pinned
+    /// binaries from `<SoldrPaths::bin>/zccache-pinned/` automatically.
+    ///
+    /// Exactly one of `<source>`, `--remove`, or `--status` must be
+    /// provided. `<source>` accepts `system`, a directory or archive
+    /// path (`.zip` / `.tar.gz` / `.tar.zst`), or an `http(s)://` URL
+    /// pointing at such an archive.
+    #[command(name = "install-zccache")]
+    InstallZccache {
+        /// Source for the three zccache binaries. Mutually exclusive
+        /// with `--remove` / `--status`.
+        #[arg(value_name = "SOURCE", conflicts_with_all = ["remove", "status"])]
+        source: Option<String>,
+        /// Delete the pinned install and fall back to the managed
+        /// fetch on next run. Idempotent.
+        #[arg(long, conflicts_with_all = ["source", "status"])]
+        remove: bool,
+        /// Print the install dir, source, version, and per-binary
+        /// sha256s of the pinned install (if any).
+        #[arg(long, conflicts_with_all = ["source", "remove"])]
+        status: bool,
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
     /// Prune stale per-prefix build artifacts from a cargo `target/`
     /// directory, keeping only the newest entry per
     /// `(parent_dir, prefix)` bucket inside
@@ -723,6 +750,15 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             }
             Some(CacheSubcommand::Flush { json: flush_json }) => {
                 cache::run_cache_flush_command(flush_json || json).await?;
+            }
+            Some(CacheSubcommand::InstallZccache {
+                source,
+                remove,
+                status,
+                json: install_json,
+            }) => {
+                cache::run_cache_install_zccache(source, remove, status, install_json || json)
+                    .await?;
             }
             Some(CacheSubcommand::PruneTarget {
                 path,

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -1,0 +1,225 @@
+//! Integration tests for `soldr cache install-zccache` at the CLI
+//! surface. Covers argv parsing, JSON output, mutual-exclusion errors,
+//! and the round-trip from `install` → `--status` → `--remove`.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::unique_temp_dir;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn bin_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+fn write_fake_binary(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
+    fs::create_dir_all(dir).unwrap();
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    path
+}
+
+fn seed_source_dir(root: &Path) -> PathBuf {
+    let src = root.join("zccache-src");
+    write_fake_binary(&src, &bin_name("zccache"), b"cli-bytes");
+    write_fake_binary(&src, &bin_name("zccache-daemon"), b"daemon-bytes");
+    write_fake_binary(&src, &bin_name("zccache-fp"), b"fp-bytes");
+    src
+}
+
+#[test]
+fn cache_install_zccache_from_directory_writes_sidecar() {
+    let tmp = unique_temp_dir("install-zccache-dir");
+    let cache_root = tmp.join("soldr-root");
+    let src = seed_source_dir(&tmp);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache"])
+        .arg(&src)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("failed to run install-zccache");
+
+    assert!(
+        output.status.success(),
+        "install-zccache failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let pinned = cache_root.join("bin").join("zccache-pinned");
+    assert!(pinned.join(bin_name("zccache")).exists());
+    assert!(pinned.join(bin_name("zccache-daemon")).exists());
+    assert!(pinned.join(bin_name("zccache-fp")).exists());
+    assert!(pinned.join("source.json").exists());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("install dir:"),
+        "expected human output: {stdout}"
+    );
+    assert!(stdout.contains("source:"), "expected source line: {stdout}");
+}
+
+#[test]
+fn cache_install_zccache_json_round_trip() {
+    let tmp = unique_temp_dir("install-zccache-json");
+    let cache_root = tmp.join("soldr-root");
+    let src = seed_source_dir(&tmp);
+
+    // install --json
+    let install = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache", "--json"])
+        .arg(&src)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("install-zccache --json");
+    assert!(install.status.success());
+    let install_json: Value =
+        serde_json::from_slice(&install.stdout).expect("install --json should emit valid JSON");
+    assert_eq!(install_json["command"], "cache install-zccache");
+    assert_eq!(install_json["source_kind"], "path");
+    assert_eq!(
+        install_json["binaries"]["zccache"]["size_bytes"],
+        b"cli-bytes".len()
+    );
+
+    // --status --json
+    let status = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache", "--status", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("install-zccache --status --json");
+    assert!(status.status.success());
+    let status_json: Value =
+        serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
+    assert_eq!(status_json["command"], "cache install-zccache --status");
+    assert_eq!(status_json["pinned"]["source_kind"], "path");
+    assert_eq!(status_json["managed_version"], "1.8.1");
+    assert!(
+        status_json["drift_from_managed"].is_boolean(),
+        "drift_from_managed must be a bool"
+    );
+
+    // --remove --json
+    let remove = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache", "--remove", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("install-zccache --remove --json");
+    assert!(remove.status.success());
+    let remove_json: Value = serde_json::from_slice(&remove.stdout).expect("remove --json");
+    assert_eq!(remove_json["removed"], true);
+
+    // Second remove is idempotent: removed=false.
+    let remove2 = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache", "--remove", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("install-zccache --remove --json (second)");
+    assert!(remove2.status.success());
+    let remove2_json: Value = serde_json::from_slice(&remove2.stdout).expect("remove --json 2");
+    assert_eq!(remove2_json["removed"], false);
+}
+
+#[test]
+fn cache_install_zccache_status_with_no_install_reports_managed_default() {
+    let tmp = unique_temp_dir("install-zccache-status-empty");
+    let cache_root = tmp.join("soldr-root");
+    fs::create_dir_all(&cache_root).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache", "--status", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("status with no install");
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
+    assert!(json["pinned"].is_null(), "pinned should be null: {json}");
+    assert_eq!(json["managed_version"], "1.8.1");
+}
+
+#[test]
+fn cache_install_zccache_no_source_no_flags_errors() {
+    let tmp = unique_temp_dir("install-zccache-empty-args");
+    let cache_root = tmp.join("soldr-root");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("install-zccache (no args)");
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("SOURCE") || stderr.contains("--remove") || stderr.contains("--status"),
+        "stderr should describe the missing input: {stderr}"
+    );
+}
+
+#[test]
+fn cache_install_zccache_mutually_exclusive_flags_rejected() {
+    let tmp = unique_temp_dir("install-zccache-mutex");
+    let cache_root = tmp.join("soldr-root");
+
+    // clap should reject `--remove` + `--status` outright.
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache", "--remove", "--status"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("install-zccache --remove --status");
+    assert!(
+        !output.status.success(),
+        "expected mutual-exclusion failure"
+    );
+
+    // SOURCE + --remove is also rejected.
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache", "system", "--remove"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("install-zccache SOURCE --remove");
+    assert!(
+        !output.status.success(),
+        "expected mutual-exclusion failure (SOURCE + --remove)"
+    );
+}
+
+#[test]
+fn cache_install_zccache_unknown_extension_errors() {
+    let tmp = unique_temp_dir("install-zccache-unknown-ext");
+    let cache_root = tmp.join("soldr-root");
+    let bogus = tmp.join("zccache.7z");
+    fs::write(&bogus, b"junk").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "install-zccache"])
+        .arg(&bogus)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .output()
+        .expect("install-zccache with bogus archive");
+    assert!(!output.status.success(), "expected unknown-ext failure");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(".zip") && stderr.contains(".tar.gz") && stderr.contains(".tar.zst"),
+        "stderr should list supported extensions: {stderr}"
+    );
+}

--- a/crates/soldr-cli/tests/cli_update_zccache.rs
+++ b/crates/soldr-cli/tests/cli_update_zccache.rs
@@ -1,6 +1,6 @@
-//! Integration tests for `soldr cache install-zccache` at the CLI
-//! surface. Covers argv parsing, JSON output, mutual-exclusion errors,
-//! and the round-trip from `install` → `--status` → `--remove`.
+//! Integration tests for `soldr update-zccache` at the CLI surface.
+//! Covers argv parsing, JSON output, mutual-exclusion errors, and the
+//! round-trip from `install` → `--status` → `--remove`.
 
 #![allow(unused_imports)]
 
@@ -36,22 +36,22 @@ fn seed_source_dir(root: &Path) -> PathBuf {
 }
 
 #[test]
-fn cache_install_zccache_from_directory_writes_sidecar() {
-    let tmp = unique_temp_dir("install-zccache-dir");
+fn update_zccache_from_directory_writes_sidecar() {
+    let tmp = unique_temp_dir("update-zccache-dir");
     let cache_root = tmp.join("soldr-root");
     let src = seed_source_dir(&tmp);
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache"])
+        .args(["update-zccache"])
         .arg(&src)
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("failed to run install-zccache");
+        .expect("failed to run update-zccache");
 
     assert!(
         output.status.success(),
-        "install-zccache failed: stdout={} stderr={}",
+        "update-zccache failed: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -71,23 +71,23 @@ fn cache_install_zccache_from_directory_writes_sidecar() {
 }
 
 #[test]
-fn cache_install_zccache_json_round_trip() {
-    let tmp = unique_temp_dir("install-zccache-json");
+fn update_zccache_json_round_trip() {
+    let tmp = unique_temp_dir("update-zccache-json");
     let cache_root = tmp.join("soldr-root");
     let src = seed_source_dir(&tmp);
 
     // install --json
     let install = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache", "--json"])
+        .args(["update-zccache", "--json"])
         .arg(&src)
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("install-zccache --json");
+        .expect("update-zccache --json");
     assert!(install.status.success());
     let install_json: Value =
         serde_json::from_slice(&install.stdout).expect("install --json should emit valid JSON");
-    assert_eq!(install_json["command"], "cache install-zccache");
+    assert_eq!(install_json["command"], "update-zccache");
     assert_eq!(install_json["source_kind"], "path");
     assert_eq!(
         install_json["binaries"]["zccache"]["size_bytes"],
@@ -96,15 +96,15 @@ fn cache_install_zccache_json_round_trip() {
 
     // --status --json
     let status = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache", "--status", "--json"])
+        .args(["update-zccache", "--status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("install-zccache --status --json");
+        .expect("update-zccache --status --json");
     assert!(status.status.success());
     let status_json: Value =
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
-    assert_eq!(status_json["command"], "cache install-zccache --status");
+    assert_eq!(status_json["command"], "update-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
     assert_eq!(status_json["managed_version"], "1.8.1");
     assert!(
@@ -114,35 +114,35 @@ fn cache_install_zccache_json_round_trip() {
 
     // --remove --json
     let remove = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache", "--remove", "--json"])
+        .args(["update-zccache", "--remove", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("install-zccache --remove --json");
+        .expect("update-zccache --remove --json");
     assert!(remove.status.success());
     let remove_json: Value = serde_json::from_slice(&remove.stdout).expect("remove --json");
     assert_eq!(remove_json["removed"], true);
 
     // Second remove is idempotent: removed=false.
     let remove2 = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache", "--remove", "--json"])
+        .args(["update-zccache", "--remove", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("install-zccache --remove --json (second)");
+        .expect("update-zccache --remove --json (second)");
     assert!(remove2.status.success());
     let remove2_json: Value = serde_json::from_slice(&remove2.stdout).expect("remove --json 2");
     assert_eq!(remove2_json["removed"], false);
 }
 
 #[test]
-fn cache_install_zccache_status_with_no_install_reports_managed_default() {
-    let tmp = unique_temp_dir("install-zccache-status-empty");
+fn update_zccache_status_with_no_install_reports_managed_default() {
+    let tmp = unique_temp_dir("update-zccache-status-empty");
     let cache_root = tmp.join("soldr-root");
     fs::create_dir_all(&cache_root).unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache", "--status", "--json"])
+        .args(["update-zccache", "--status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
@@ -154,16 +154,16 @@ fn cache_install_zccache_status_with_no_install_reports_managed_default() {
 }
 
 #[test]
-fn cache_install_zccache_no_source_no_flags_errors() {
-    let tmp = unique_temp_dir("install-zccache-empty-args");
+fn update_zccache_no_source_no_flags_errors() {
+    let tmp = unique_temp_dir("update-zccache-empty-args");
     let cache_root = tmp.join("soldr-root");
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache"])
+        .args(["update-zccache"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("install-zccache (no args)");
+        .expect("update-zccache (no args)");
     assert!(!output.status.success(), "expected non-zero exit");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -173,17 +173,17 @@ fn cache_install_zccache_no_source_no_flags_errors() {
 }
 
 #[test]
-fn cache_install_zccache_mutually_exclusive_flags_rejected() {
-    let tmp = unique_temp_dir("install-zccache-mutex");
+fn update_zccache_mutually_exclusive_flags_rejected() {
+    let tmp = unique_temp_dir("update-zccache-mutex");
     let cache_root = tmp.join("soldr-root");
 
     // clap should reject `--remove` + `--status` outright.
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache", "--remove", "--status"])
+        .args(["update-zccache", "--remove", "--status"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("install-zccache --remove --status");
+        .expect("update-zccache --remove --status");
     assert!(
         !output.status.success(),
         "expected mutual-exclusion failure"
@@ -191,11 +191,11 @@ fn cache_install_zccache_mutually_exclusive_flags_rejected() {
 
     // SOURCE + --remove is also rejected.
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache", "system", "--remove"])
+        .args(["update-zccache", "system", "--remove"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("install-zccache SOURCE --remove");
+        .expect("update-zccache SOURCE --remove");
     assert!(
         !output.status.success(),
         "expected mutual-exclusion failure (SOURCE + --remove)"
@@ -203,19 +203,19 @@ fn cache_install_zccache_mutually_exclusive_flags_rejected() {
 }
 
 #[test]
-fn cache_install_zccache_unknown_extension_errors() {
-    let tmp = unique_temp_dir("install-zccache-unknown-ext");
+fn update_zccache_unknown_extension_errors() {
+    let tmp = unique_temp_dir("update-zccache-unknown-ext");
     let cache_root = tmp.join("soldr-root");
     let bogus = tmp.join("zccache.7z");
     fs::write(&bogus, b"junk").unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["cache", "install-zccache"])
+        .args(["update-zccache"])
         .arg(&bogus)
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("install-zccache with bogus archive");
+        .expect("update-zccache with bogus archive");
     assert!(!output.status.success(), "expected unknown-ext failure");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/crates/soldr-fetch/Cargo.toml
+++ b/crates/soldr-fetch/Cargo.toml
@@ -20,6 +20,7 @@ tar = { workspace = true }
 toml = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+zstd = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/soldr-fetch/src/install_zccache.rs
+++ b/crates/soldr-fetch/src/install_zccache.rs
@@ -1,0 +1,828 @@
+//! `soldr cache install-zccache <SOURCE>` implementation.
+//!
+//! Pins a user-supplied set of three zccache binaries
+//! (`zccache`, `zccache-daemon`, `zccache-fp`) into
+//! `<SoldrPaths::bin>/zccache-pinned/` together with a `source.json`
+//! sidecar. Once pinned, `fetch_zccache_with_paths` resolves the pinned
+//! binaries ahead of the managed GitHub-Releases fetch so users no
+//! longer have to pass `--zccache=system` on every invocation.
+//!
+//! Source forms:
+//!   * `system` — search PATH for the three binaries
+//!   * `<path>` — a directory or a `.zip` / `.tar.gz` / `.tgz` /
+//!     `.tar.zst` archive containing the three binaries (any depth —
+//!     release tarballs sometimes nest under a `zccache-vX.Y.Z/`
+//!     directory)
+//!   * `<url>` — `http://` or `https://` URL pointing at an archive
+//!     that satisfies the path rules above
+//!
+//! Debug-info sidecars (`.pdb`, `.dwp`, `.dSYM`) are copied next to
+//! every binary, mirroring the `SOLDR_ZCCACHE_LOCAL_DIR` behaviour.
+
+use crate::{
+    canonical_zccache_paths, copy_debug_info_sidecars, copy_if_changed, desired_binary_names,
+    find_in_dirs, http_client, suppress_windows_console_window, MANAGED_ZCCACHE_VERSION,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use soldr_core::{SoldrError, SoldrPaths, TargetTriple};
+use std::path::{Path, PathBuf};
+
+/// Directory name (under `SoldrPaths::bin`) where the pinned zccache
+/// binaries live.
+pub const PINNED_ZCCACHE_DIRNAME: &str = "zccache-pinned";
+
+/// File name (under the pinned dir) holding install provenance.
+pub const PINNED_ZCCACHE_SIDECAR_FILENAME: &str = "source.json";
+
+/// Schema version recorded in `source.json`. Bump on any breaking change.
+pub const PINNED_ZCCACHE_SIDECAR_SCHEMA_VERSION: u32 = 1;
+
+/// Canonical binary names (without platform extension). Mirrors
+/// `MANAGED_ZCCACHE_PACKAGES` but exposes only the runtime side.
+pub const ZCCACHE_PINNED_BINARY_NAMES: [&str; 3] = ["zccache", "zccache-daemon", "zccache-fp"];
+
+/// Source the user passed to `cache install-zccache`.
+#[derive(Debug, Clone)]
+pub enum InstallSource {
+    /// Search the system `PATH` for the three binaries.
+    System,
+    /// Local directory or archive file on disk.
+    Path(PathBuf),
+    /// HTTP / HTTPS URL pointing at an archive.
+    Url(String),
+}
+
+impl InstallSource {
+    /// Best-effort parse of the raw CLI string into a source variant.
+    /// `system` → `System`; `http(s)://...` → `Url`; everything else
+    /// is treated as a path. Empty input is rejected.
+    pub fn parse(raw: &str) -> Result<Self, SoldrError> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(SoldrError::Other(
+                "install-zccache: source must not be empty".into(),
+            ));
+        }
+        if trimmed.eq_ignore_ascii_case("system") {
+            return Ok(InstallSource::System);
+        }
+        if let Some(scheme_end) = trimmed.find("://") {
+            let scheme = &trimmed[..scheme_end].to_ascii_lowercase();
+            if scheme == "http" || scheme == "https" {
+                return Ok(InstallSource::Url(trimmed.to_string()));
+            }
+        }
+        Ok(InstallSource::Path(PathBuf::from(trimmed)))
+    }
+
+    /// Original string the user passed (e.g. `"system"`, `"/abs/path"`,
+    /// `"https://..."`). Used to roundtrip into `source.json`.
+    pub fn raw_value(&self) -> String {
+        match self {
+            InstallSource::System => "system".to_string(),
+            InstallSource::Path(p) => p.display().to_string(),
+            InstallSource::Url(u) => u.clone(),
+        }
+    }
+
+    /// Stable label for the `source_kind` JSON field.
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            InstallSource::System => "system",
+            InstallSource::Path(_) => "path",
+            InstallSource::Url(_) => "url",
+        }
+    }
+}
+
+/// Per-binary integrity record persisted in `source.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PinnedBinaryRecord {
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+/// Verbatim contents of `<pinned dir>/source.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PinnedSidecar {
+    pub schema_version: u32,
+    pub source_kind: String,
+    pub source_value: String,
+    /// `zccache --version` output, parsed. `"unknown"` when the probe
+    /// fails (still a valid install — surfaces in `--status`).
+    pub version: String,
+    pub binaries: std::collections::BTreeMap<String, PinnedBinaryRecord>,
+    pub installed_at: String,
+    pub soldr_version: String,
+}
+
+/// Pretty result of a successful install, returned to the CLI for
+/// json/text rendering.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallReport {
+    pub install_dir: String,
+    pub source_kind: String,
+    pub source_value: String,
+    pub version: String,
+    pub binaries: std::collections::BTreeMap<String, PinnedBinaryRecord>,
+    pub installed_at: String,
+    pub soldr_version: String,
+}
+
+/// Resolved pinned-zccache binaries for `fetch_zccache_with_paths` and
+/// `zccache_binary_summary`.
+#[derive(Debug, Clone)]
+pub struct PinnedResolution {
+    pub binary_path: PathBuf,
+    pub runtime_dir: PathBuf,
+    pub version: String,
+}
+
+/// Path to the pinned install dir for a given soldr root. The dir may
+/// not exist yet; callers must check.
+pub fn pinned_zccache_dir(paths: &SoldrPaths) -> PathBuf {
+    paths.bin.join(PINNED_ZCCACHE_DIRNAME)
+}
+
+fn pinned_sidecar_path(paths: &SoldrPaths) -> PathBuf {
+    pinned_zccache_dir(paths).join(PINNED_ZCCACHE_SIDECAR_FILENAME)
+}
+
+/// Read the pinned sidecar JSON. Returns `Ok(None)` when the pinned
+/// dir doesn't exist or the sidecar is missing. A malformed sidecar is
+/// a hard error so misconfigured installs don't silently fall back to
+/// the managed fetch.
+pub fn read_pinned_sidecar(paths: &SoldrPaths) -> Result<Option<PinnedSidecar>, SoldrError> {
+    let sidecar = pinned_sidecar_path(paths);
+    if !sidecar.exists() {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&sidecar).map_err(|e| {
+        SoldrError::Other(format!(
+            "install-zccache: failed to read sidecar {}: {e}",
+            sidecar.display()
+        ))
+    })?;
+    serde_json::from_slice::<PinnedSidecar>(&bytes)
+        .map(Some)
+        .map_err(|e| {
+            SoldrError::Other(format!(
+                "install-zccache: malformed sidecar {}: {e}",
+                sidecar.display()
+            ))
+        })
+}
+
+/// Look up the pinned install (if any) and verify the three binaries
+/// are present. Returns `Ok(None)` when no pinned install exists.
+pub fn resolve_pinned_zccache(paths: &SoldrPaths) -> Result<Option<PinnedResolution>, SoldrError> {
+    let target = TargetTriple::detect()?;
+    resolve_pinned_zccache_for_target(paths, &target)
+}
+
+pub(crate) fn resolve_pinned_zccache_for_target(
+    paths: &SoldrPaths,
+    target: &TargetTriple,
+) -> Result<Option<PinnedResolution>, SoldrError> {
+    let Some(sidecar) = read_pinned_sidecar(paths)? else {
+        return Ok(None);
+    };
+    let runtime_dir = pinned_zccache_dir(paths);
+    let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, target);
+    if !cli.exists() || !daemon.exists() || !fp.exists() {
+        return Err(SoldrError::Other(format!(
+            "install-zccache: sidecar at {} present but one or more binaries missing in {} \
+             (run `soldr cache install-zccache --remove` to reset)",
+            pinned_sidecar_path(paths).display(),
+            runtime_dir.display()
+        )));
+    }
+    Ok(Some(PinnedResolution {
+        binary_path: cli,
+        runtime_dir,
+        version: sidecar.version,
+    }))
+}
+
+/// Install the three zccache binaries from `source` into the pinned
+/// directory and write the `source.json` sidecar. Existing pinned files
+/// are overwritten so re-running `install-zccache` is idempotent.
+pub async fn install_zccache_from_source(
+    source: &InstallSource,
+    paths: &SoldrPaths,
+) -> Result<InstallReport, SoldrError> {
+    let target = TargetTriple::detect()?;
+    install_zccache_from_source_for_target(source, paths, &target).await
+}
+
+pub(crate) async fn install_zccache_from_source_for_target(
+    source: &InstallSource,
+    paths: &SoldrPaths,
+    target: &TargetTriple,
+) -> Result<InstallReport, SoldrError> {
+    paths.ensure_dirs()?;
+    let binary_ext = target.binary_ext();
+    let names = desired_binary_names(&ZCCACHE_PINNED_BINARY_NAMES, target);
+
+    // Resolve a staging directory whose layout has the three binaries
+    // sitting next to each other (with their `.pdb` / `.dwp` / `.dSYM`
+    // sidecars). For `system` PATH lookups each binary may live in a
+    // different directory; we copy them into a unified staging dir so
+    // downstream logic only sees one path per binary. The
+    // `staging_holder` keeps the tempdir alive until the install
+    // copy completes; tempfile::TempDir's Drop unlinks on exit
+    // (success or error).
+    let staging_holder: Option<tempfile::TempDir>;
+    let staging_root: PathBuf = match source {
+        InstallSource::System => {
+            let holder = tempfile::tempdir_in(&paths.bin)?;
+            let dir = stage_from_system_path(holder.path(), target)?;
+            staging_holder = Some(holder);
+            dir
+        }
+        InstallSource::Path(p) => {
+            if !p.exists() {
+                return Err(SoldrError::Other(format!(
+                    "install-zccache: path does not exist: {}",
+                    p.display()
+                )));
+            }
+            if p.is_dir() {
+                staging_holder = None;
+                p.clone()
+            } else if p.is_file() {
+                let extract_dir = tempfile::tempdir_in(&paths.bin)?;
+                extract_archive_file(p, extract_dir.path())?;
+                let unified = tempfile::tempdir_in(&paths.bin)?;
+                consolidate_extracted_binaries(extract_dir.path(), unified.path(), &names)?;
+                drop(extract_dir);
+                let dir = unified.path().to_path_buf();
+                staging_holder = Some(unified);
+                dir
+            } else {
+                return Err(SoldrError::Other(format!(
+                    "install-zccache: {} is neither a regular file nor a directory",
+                    p.display()
+                )));
+            }
+        }
+        InstallSource::Url(url) => {
+            let download = tempfile::NamedTempFile::new_in(&paths.bin).map_err(|e| {
+                SoldrError::Other(format!(
+                    "install-zccache: failed to create download temp file: {e}"
+                ))
+            })?;
+            download_url_to(url, download.path()).await?;
+            let extract_dir = tempfile::tempdir_in(&paths.bin)?;
+            extract_archive_file(download.path(), extract_dir.path())?;
+            let unified = tempfile::tempdir_in(&paths.bin)?;
+            consolidate_extracted_binaries(extract_dir.path(), unified.path(), &names)?;
+            drop(extract_dir);
+            drop(download);
+            let dir = unified.path().to_path_buf();
+            staging_holder = Some(unified);
+            dir
+        }
+    };
+
+    // Verify every binary is present in the staging dir.
+    let mut staged: Vec<(String, PathBuf)> = Vec::with_capacity(names.len());
+    for name in &names {
+        let candidate = staging_root.join(name);
+        if !candidate.is_file() {
+            return Err(SoldrError::Other(missing_binary_error_message(
+                source,
+                p_str(&staging_root),
+                name,
+                binary_ext,
+            )));
+        }
+        staged.push((name.clone(), candidate));
+    }
+
+    // Copy into the pinned dir.
+    let pinned_dir = pinned_zccache_dir(paths);
+    // Wipe any stale install first so leftover sidecars from a previous
+    // schema can't cause a malformed-sidecar error on the next read.
+    if pinned_dir.exists() {
+        std::fs::remove_dir_all(&pinned_dir)?;
+    }
+    std::fs::create_dir_all(&pinned_dir)?;
+
+    let mut binaries: std::collections::BTreeMap<String, PinnedBinaryRecord> =
+        std::collections::BTreeMap::new();
+    for (file_name, src) in &staged {
+        let dst = pinned_dir.join(file_name);
+        copy_if_changed(src, &dst)?;
+        copy_debug_info_sidecars(src, &dst)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&dst)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&dst, perms)?;
+        }
+
+        let bytes = std::fs::read(&dst).map_err(|e| {
+            SoldrError::Other(format!(
+                "install-zccache: failed to read {} for sha256: {e}",
+                dst.display()
+            ))
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let digest = hex::encode(hasher.finalize());
+
+        // Strip platform extension when keying the sidecar so the JSON
+        // is portable across operating systems (a Windows install's
+        // sidecar can be diffed against a Linux one).
+        let key = strip_platform_ext(file_name);
+        binaries.insert(
+            key,
+            PinnedBinaryRecord {
+                sha256: digest,
+                size_bytes: bytes.len() as u64,
+            },
+        );
+    }
+
+    // Probe the version. Best-effort: a binary that refuses to run
+    // (corrupted, ABI mismatch) still yields a valid install — the
+    // sidecar simply records `"unknown"` and the user finds out at
+    // first cargo invocation.
+    let (cli_binary, _) = staged
+        .first()
+        .map(|(name, src)| (pinned_dir.join(name), src))
+        .ok_or_else(|| SoldrError::Other("install-zccache: no staged binaries".into()))?;
+    let version = probe_zccache_version(&cli_binary);
+
+    let installed_at = format_iso8601_utc(std::time::SystemTime::now());
+    let sidecar = PinnedSidecar {
+        schema_version: PINNED_ZCCACHE_SIDECAR_SCHEMA_VERSION,
+        source_kind: source.kind_str().to_string(),
+        source_value: source.raw_value(),
+        version: version.clone(),
+        binaries: binaries.clone(),
+        installed_at: installed_at.clone(),
+        soldr_version: soldr_core::version().to_string(),
+    };
+    let sidecar_path = pinned_sidecar_path(paths);
+    let mut sidecar_bytes = serde_json::to_vec_pretty(&sidecar).map_err(|e| {
+        SoldrError::Other(format!("install-zccache: failed to serialize sidecar: {e}"))
+    })?;
+    // Trailing newline matches what `serde_json::to_writer_pretty` plus
+    // a `println!()` produces elsewhere in the codebase.
+    sidecar_bytes.push(b'\n');
+    std::fs::write(&sidecar_path, &sidecar_bytes)?;
+
+    // Keep the staging dir alive until everything that reads from it
+    // has finished; Drop unlinks the temp tree.
+    drop(staging_holder);
+
+    Ok(InstallReport {
+        install_dir: pinned_dir.display().to_string(),
+        source_kind: sidecar.source_kind,
+        source_value: sidecar.source_value,
+        version,
+        binaries,
+        installed_at,
+        soldr_version: sidecar.soldr_version,
+    })
+}
+
+fn missing_binary_error_message(
+    source: &InstallSource,
+    dir_displayed: String,
+    missing: &str,
+    binary_ext: &str,
+) -> String {
+    let _ = binary_ext;
+    match source {
+        InstallSource::System => format!(
+            "install-zccache: `{missing}` not found on PATH; install zccache or pick a different source"
+        ),
+        InstallSource::Path(p) => format!(
+            "install-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found under {} (source: {})",
+            dir_displayed,
+            p.display()
+        ),
+        InstallSource::Url(url) => format!(
+            "install-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found in downloaded archive (source: {url})"
+        ),
+    }
+}
+
+fn p_str(p: &Path) -> String {
+    p.display().to_string()
+}
+
+fn strip_platform_ext(file_name: &str) -> String {
+    // Cheap, deterministic: drop a trailing `.exe` only.
+    if let Some(stripped) = file_name.strip_suffix(".exe") {
+        return stripped.to_string();
+    }
+    file_name.to_string()
+}
+
+/// Search `PATH` for the three required zccache binaries and copy them
+/// (with sidecars) into `staging_dir`. Returns the staging dir on
+/// success.
+fn stage_from_system_path(
+    staging_dir: &Path,
+    target: &TargetTriple,
+) -> Result<PathBuf, SoldrError> {
+    let names = desired_binary_names(&ZCCACHE_PINNED_BINARY_NAMES, target);
+    let path_dirs: Vec<PathBuf> = std::env::var_os("PATH")
+        .map(|value| std::env::split_paths(&value).collect())
+        .unwrap_or_default();
+    stage_from_system_path_with_dirs(staging_dir, &names, &path_dirs)
+}
+
+pub(crate) fn stage_from_system_path_with_dirs(
+    staging_dir: &Path,
+    names: &[String],
+    path_dirs: &[PathBuf],
+) -> Result<PathBuf, SoldrError> {
+    let mut missing: Vec<String> = Vec::new();
+    let mut found: Vec<(String, PathBuf)> = Vec::with_capacity(names.len());
+    for name in names {
+        match find_in_dirs(path_dirs, name) {
+            Some(p) => found.push((name.clone(), p)),
+            None => missing.push(name.clone()),
+        }
+    }
+    if !missing.is_empty() {
+        return Err(SoldrError::Other(format!(
+            "install-zccache: source=system but the following binaries were not found on PATH: {}",
+            missing.join(", ")
+        )));
+    }
+    std::fs::create_dir_all(staging_dir)?;
+    for (name, src) in &found {
+        let dst = staging_dir.join(name);
+        copy_if_changed(src, &dst)?;
+        copy_debug_info_sidecars(src, &dst)?;
+    }
+    Ok(staging_dir.to_path_buf())
+}
+
+/// Pull every desired binary (and adjacent debug-info sidecars) out of
+/// `extracted_root` (the messy result of `extract_archive_file`) into a
+/// single flat `unified_root` directory. The original release tarball
+/// layout often nests under a `zccache-vX.Y.Z/` directory and may
+/// contain README / LICENSE files we don't care about; this consolidation
+/// step normalizes everything before the install-into-pinned-dir copy.
+fn consolidate_extracted_binaries(
+    extracted_root: &Path,
+    unified_root: &Path,
+    names: &[String],
+) -> Result<(), SoldrError> {
+    std::fs::create_dir_all(unified_root)?;
+    let mut found: std::collections::BTreeMap<String, PathBuf> = std::collections::BTreeMap::new();
+    walk_collect_named_files(extracted_root, names, &mut found)?;
+    for name in names {
+        let Some(src) = found.get(name) else {
+            return Err(SoldrError::Other(format!(
+                "install-zccache: archive missing required binary `{name}`"
+            )));
+        };
+        let dst = unified_root.join(name);
+        copy_if_changed(src, &dst)?;
+        copy_debug_info_sidecars(src, &dst)?;
+    }
+    Ok(())
+}
+
+fn walk_collect_named_files(
+    root: &Path,
+    names: &[String],
+    out: &mut std::collections::BTreeMap<String, PathBuf>,
+) -> Result<(), SoldrError> {
+    // Simple recursive walk; archives are small enough that depth-first
+    // without parallelism is fine.
+    let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(it) => it,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            // First match wins so a shallower copy beats a deeper duplicate.
+            for name in names {
+                if file_name == name && !out.contains_key(name) {
+                    out.insert(name.clone(), path.clone());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Dispatch the right archive extractor for the given file path.
+/// Rejects unknown extensions with the canonical error message.
+pub(crate) fn extract_archive_file(archive: &Path, dest: &Path) -> Result<(), SoldrError> {
+    let lower_name = archive
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    std::fs::create_dir_all(dest)?;
+    if lower_name.ends_with(".zip") {
+        extract_zip_to_dir(archive, dest)
+    } else if lower_name.ends_with(".tar.gz") || lower_name.ends_with(".tgz") {
+        extract_tar_gz_to_dir(archive, dest)
+    } else if lower_name.ends_with(".tar.zst") {
+        extract_tar_zst_to_dir(archive, dest)
+    } else {
+        Err(SoldrError::Other(format!(
+            "install-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — got {} (unsupported extension)",
+            archive.display()
+        )))
+    }
+}
+
+fn extract_zip_to_dir(archive: &Path, dest: &Path) -> Result<(), SoldrError> {
+    let file = std::fs::File::open(archive)?;
+    let mut zip = zip::ZipArchive::new(file).map_err(|e| SoldrError::Archive(e.to_string()))?;
+    for i in 0..zip.len() {
+        let mut entry = zip
+            .by_index(i)
+            .map_err(|e| SoldrError::Archive(e.to_string()))?;
+        let Some(rel) = entry.enclosed_name() else {
+            continue;
+        };
+        let out_path = dest.join(rel);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out_path)?;
+            continue;
+        }
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut out = std::fs::File::create(&out_path)?;
+        std::io::copy(&mut entry, &mut out)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Some(mode) = entry.unix_mode() {
+                std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(mode))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn extract_tar_gz_to_dir(archive: &Path, dest: &Path) -> Result<(), SoldrError> {
+    let file = std::fs::File::open(archive)?;
+    let gz = flate2::read::GzDecoder::new(file);
+    let mut tar = tar::Archive::new(gz);
+    tar.unpack(dest)
+        .map_err(|e| SoldrError::Archive(e.to_string()))?;
+    Ok(())
+}
+
+fn extract_tar_zst_to_dir(archive: &Path, dest: &Path) -> Result<(), SoldrError> {
+    let file = std::fs::File::open(archive)?;
+    let decoder = zstd::stream::read::Decoder::new(file)
+        .map_err(|e| SoldrError::Archive(format!("zstd init failed: {e}")))?;
+    let mut tar = tar::Archive::new(decoder);
+    tar.unpack(dest)
+        .map_err(|e| SoldrError::Archive(e.to_string()))?;
+    Ok(())
+}
+
+async fn download_url_to(url: &str, dest: &Path) -> Result<(), SoldrError> {
+    let client = http_client()?;
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(format!("install-zccache: GET {url}: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(SoldrError::Network(format!(
+            "install-zccache: download failed: HTTP {} ({url})",
+            resp.status()
+        )));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| SoldrError::Network(format!("install-zccache: read body: {e}")))?;
+    std::fs::write(dest, &bytes)?;
+    Ok(())
+}
+
+fn probe_zccache_version(binary: &Path) -> String {
+    let mut command = std::process::Command::new(binary);
+    command.arg("--version");
+    suppress_windows_console_window(&mut command);
+    let Ok(output) = command.output() else {
+        return "unknown".to_string();
+    };
+    if !output.status.success() {
+        return "unknown".to_string();
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    parse_zccache_version(&stdout).unwrap_or_else(|| "unknown".to_string())
+}
+
+fn parse_zccache_version(text: &str) -> Option<String> {
+    // Accept both `1.8.1` and `zccache 1.8.1` (clap's default --version
+    // output). Take the last whitespace-separated token if it looks
+    // like a semver-ish triplet.
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let last = trimmed.split_whitespace().last().unwrap_or("");
+        if last.split('.').count() >= 2
+            && last
+                .chars()
+                .next()
+                .map(|c| c.is_ascii_digit())
+                .unwrap_or(false)
+        {
+            return Some(last.to_string());
+        }
+        if trimmed
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+        {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}
+
+/// Remove the pinned install directory. Returns `Ok(true)` if a
+/// directory was actually deleted, `Ok(false)` when the pinned dir
+/// didn't exist (so callers can report "no-op"). Idempotent.
+pub fn remove_pinned_zccache(paths: &SoldrPaths) -> Result<bool, SoldrError> {
+    let pinned_dir = pinned_zccache_dir(paths);
+    if !pinned_dir.exists() {
+        return Ok(false);
+    }
+    std::fs::remove_dir_all(&pinned_dir).map_err(|e| {
+        SoldrError::Other(format!(
+            "install-zccache: failed to remove {}: {e}",
+            pinned_dir.display()
+        ))
+    })?;
+    Ok(true)
+}
+
+/// True when the pinned sidecar's recorded version differs from the
+/// managed default. Used by `--status` to print a "consider --remove"
+/// hint and by doctor to flag drift. An `unknown` version never counts
+/// as drift (we can't compare what we don't know).
+pub fn pinned_version_drift_from_managed(sidecar: &PinnedSidecar) -> bool {
+    sidecar.version != "unknown" && sidecar.version != MANAGED_ZCCACHE_VERSION
+}
+
+/// Compact ISO-8601 / RFC3339 timestamp (UTC, second precision). Rolls
+/// its own formatter so we don't have to take a chrono / time dep just
+/// for one timestamp.
+pub(crate) fn format_iso8601_utc(now: std::time::SystemTime) -> String {
+    let secs = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let (year, month, day, hour, minute, second) = unix_seconds_to_ymdhms(secs);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+fn unix_seconds_to_ymdhms(secs: i64) -> (i32, u32, u32, u32, u32, u32) {
+    // Civil-from-days algorithm by Howard Hinnant (public domain).
+    // Splits a unix timestamp into UTC Y/M/D/h/m/s with no leap-second
+    // handling — good enough for filesystem provenance.
+    let days = secs.div_euclid(86_400);
+    let secs_of_day = secs.rem_euclid(86_400) as u32;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let second = secs_of_day % 60;
+
+    let z = days + 719_468; // shift epoch to 0000-03-01
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097); // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let y = (y + if m <= 2 { 1 } else { 0 }) as i32;
+    (y, m, d, hour, minute, second)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_system_source() {
+        let s = InstallSource::parse("system").unwrap();
+        assert!(matches!(s, InstallSource::System));
+        let s = InstallSource::parse(" SYSTEM ").unwrap();
+        assert!(matches!(s, InstallSource::System));
+    }
+
+    #[test]
+    fn parse_url_source() {
+        let s = InstallSource::parse("https://example.com/pkg.tar.gz").unwrap();
+        assert!(matches!(s, InstallSource::Url(_)));
+        let s = InstallSource::parse("HTTP://example.com/pkg.zip").unwrap();
+        assert!(matches!(s, InstallSource::Url(_)));
+    }
+
+    #[test]
+    fn parse_path_source() {
+        let s = InstallSource::parse("/opt/zccache/bin").unwrap();
+        assert!(matches!(s, InstallSource::Path(_)));
+        let s = InstallSource::parse("./relative").unwrap();
+        assert!(matches!(s, InstallSource::Path(_)));
+    }
+
+    #[test]
+    fn parse_rejects_empty() {
+        assert!(InstallSource::parse("").is_err());
+        assert!(InstallSource::parse("   ").is_err());
+    }
+
+    #[test]
+    fn parse_zccache_version_accepts_clap_default() {
+        assert_eq!(parse_zccache_version("zccache 1.8.1"), Some("1.8.1".into()));
+        assert_eq!(parse_zccache_version("1.8.1"), Some("1.8.1".into()));
+        assert_eq!(
+            parse_zccache_version("zccache 1.8.1\nbuild: abc"),
+            Some("1.8.1".into())
+        );
+    }
+
+    #[test]
+    fn parse_zccache_version_rejects_garbage() {
+        assert_eq!(parse_zccache_version(""), None);
+        assert_eq!(parse_zccache_version("hello world"), None);
+    }
+
+    #[test]
+    fn strip_extension_only_drops_exe() {
+        assert_eq!(strip_platform_ext("zccache"), "zccache");
+        assert_eq!(strip_platform_ext("zccache.exe"), "zccache");
+        assert_eq!(strip_platform_ext("zccache-daemon"), "zccache-daemon");
+    }
+
+    #[test]
+    fn drift_helper_treats_unknown_as_no_drift() {
+        let mut sidecar = sample_sidecar("unknown");
+        assert!(!pinned_version_drift_from_managed(&sidecar));
+        sidecar.version = MANAGED_ZCCACHE_VERSION.to_string();
+        assert!(!pinned_version_drift_from_managed(&sidecar));
+        sidecar.version = "0.0.1".to_string();
+        assert!(pinned_version_drift_from_managed(&sidecar));
+    }
+
+    fn sample_sidecar(version: &str) -> PinnedSidecar {
+        PinnedSidecar {
+            schema_version: PINNED_ZCCACHE_SIDECAR_SCHEMA_VERSION,
+            source_kind: "system".into(),
+            source_value: "system".into(),
+            version: version.into(),
+            binaries: std::collections::BTreeMap::new(),
+            installed_at: "2026-05-21T00:00:00Z".into(),
+            soldr_version: "0.0.0".into(),
+        }
+    }
+
+    #[test]
+    fn iso8601_formatter_matches_known_timestamps() {
+        // 1970-01-01T00:00:00Z
+        let s = format_iso8601_utc(std::time::UNIX_EPOCH);
+        assert_eq!(s, "1970-01-01T00:00:00Z");
+        // A few well-known dates.
+        let later = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        let s = format_iso8601_utc(later);
+        // 1_700_000_000 == 2023-11-14T22:13:20Z
+        assert_eq!(s, "2023-11-14T22:13:20Z");
+    }
+}

--- a/crates/soldr-fetch/src/install_zccache.rs
+++ b/crates/soldr-fetch/src/install_zccache.rs
@@ -1,4 +1,4 @@
-//! `soldr cache install-zccache <SOURCE>` implementation.
+//! `soldr update-zccache <SOURCE>` implementation.
 //!
 //! Pins a user-supplied set of three zccache binaries
 //! (`zccache`, `zccache-daemon`, `zccache-fp`) into
@@ -42,7 +42,7 @@ pub const PINNED_ZCCACHE_SIDECAR_SCHEMA_VERSION: u32 = 1;
 /// `MANAGED_ZCCACHE_PACKAGES` but exposes only the runtime side.
 pub const ZCCACHE_PINNED_BINARY_NAMES: [&str; 3] = ["zccache", "zccache-daemon", "zccache-fp"];
 
-/// Source the user passed to `cache install-zccache`.
+/// Source the user passed to `update-zccache`.
 #[derive(Debug, Clone)]
 pub enum InstallSource {
     /// Search the system `PATH` for the three binaries.
@@ -61,7 +61,7 @@ impl InstallSource {
         let trimmed = raw.trim();
         if trimmed.is_empty() {
             return Err(SoldrError::Other(
-                "install-zccache: source must not be empty".into(),
+                "update-zccache: source must not be empty".into(),
             ));
         }
         if trimmed.eq_ignore_ascii_case("system") {
@@ -160,7 +160,7 @@ pub fn read_pinned_sidecar(paths: &SoldrPaths) -> Result<Option<PinnedSidecar>, 
     }
     let bytes = std::fs::read(&sidecar).map_err(|e| {
         SoldrError::Other(format!(
-            "install-zccache: failed to read sidecar {}: {e}",
+            "update-zccache: failed to read sidecar {}: {e}",
             sidecar.display()
         ))
     })?;
@@ -168,7 +168,7 @@ pub fn read_pinned_sidecar(paths: &SoldrPaths) -> Result<Option<PinnedSidecar>, 
         .map(Some)
         .map_err(|e| {
             SoldrError::Other(format!(
-                "install-zccache: malformed sidecar {}: {e}",
+                "update-zccache: malformed sidecar {}: {e}",
                 sidecar.display()
             ))
         })
@@ -192,8 +192,8 @@ pub(crate) fn resolve_pinned_zccache_for_target(
     let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, target);
     if !cli.exists() || !daemon.exists() || !fp.exists() {
         return Err(SoldrError::Other(format!(
-            "install-zccache: sidecar at {} present but one or more binaries missing in {} \
-             (run `soldr cache install-zccache --remove` to reset)",
+            "update-zccache: sidecar at {} present but one or more binaries missing in {} \
+             (run `soldr update-zccache --remove` to reset)",
             pinned_sidecar_path(paths).display(),
             runtime_dir.display()
         )));
@@ -207,7 +207,7 @@ pub(crate) fn resolve_pinned_zccache_for_target(
 
 /// Install the three zccache binaries from `source` into the pinned
 /// directory and write the `source.json` sidecar. Existing pinned files
-/// are overwritten so re-running `install-zccache` is idempotent.
+/// are overwritten so re-running `update-zccache` is idempotent.
 pub async fn install_zccache_from_source(
     source: &InstallSource,
     paths: &SoldrPaths,
@@ -244,7 +244,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
         InstallSource::Path(p) => {
             if !p.exists() {
                 return Err(SoldrError::Other(format!(
-                    "install-zccache: path does not exist: {}",
+                    "update-zccache: path does not exist: {}",
                     p.display()
                 )));
             }
@@ -262,7 +262,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
                 dir
             } else {
                 return Err(SoldrError::Other(format!(
-                    "install-zccache: {} is neither a regular file nor a directory",
+                    "update-zccache: {} is neither a regular file nor a directory",
                     p.display()
                 )));
             }
@@ -270,7 +270,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
         InstallSource::Url(url) => {
             let download = tempfile::NamedTempFile::new_in(&paths.bin).map_err(|e| {
                 SoldrError::Other(format!(
-                    "install-zccache: failed to create download temp file: {e}"
+                    "update-zccache: failed to create download temp file: {e}"
                 ))
             })?;
             download_url_to(url, download.path()).await?;
@@ -327,7 +327,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
 
         let bytes = std::fs::read(&dst).map_err(|e| {
             SoldrError::Other(format!(
-                "install-zccache: failed to read {} for sha256: {e}",
+                "update-zccache: failed to read {} for sha256: {e}",
                 dst.display()
             ))
         })?;
@@ -355,7 +355,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
     let (cli_binary, _) = staged
         .first()
         .map(|(name, src)| (pinned_dir.join(name), src))
-        .ok_or_else(|| SoldrError::Other("install-zccache: no staged binaries".into()))?;
+        .ok_or_else(|| SoldrError::Other("update-zccache: no staged binaries".into()))?;
     let version = probe_zccache_version(&cli_binary);
 
     let installed_at = format_iso8601_utc(std::time::SystemTime::now());
@@ -370,7 +370,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
     };
     let sidecar_path = pinned_sidecar_path(paths);
     let mut sidecar_bytes = serde_json::to_vec_pretty(&sidecar).map_err(|e| {
-        SoldrError::Other(format!("install-zccache: failed to serialize sidecar: {e}"))
+        SoldrError::Other(format!("update-zccache: failed to serialize sidecar: {e}"))
     })?;
     // Trailing newline matches what `serde_json::to_writer_pretty` plus
     // a `println!()` produces elsewhere in the codebase.
@@ -401,15 +401,15 @@ fn missing_binary_error_message(
     let _ = binary_ext;
     match source {
         InstallSource::System => format!(
-            "install-zccache: `{missing}` not found on PATH; install zccache or pick a different source"
+            "update-zccache: `{missing}` not found on PATH; install zccache or pick a different source"
         ),
         InstallSource::Path(p) => format!(
-            "install-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found under {} (source: {})",
+            "update-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found under {} (source: {})",
             dir_displayed,
             p.display()
         ),
         InstallSource::Url(url) => format!(
-            "install-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found in downloaded archive (source: {url})"
+            "update-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found in downloaded archive (source: {url})"
         ),
     }
 }
@@ -455,7 +455,7 @@ pub(crate) fn stage_from_system_path_with_dirs(
     }
     if !missing.is_empty() {
         return Err(SoldrError::Other(format!(
-            "install-zccache: source=system but the following binaries were not found on PATH: {}",
+            "update-zccache: source=system but the following binaries were not found on PATH: {}",
             missing.join(", ")
         )));
     }
@@ -485,7 +485,7 @@ fn consolidate_extracted_binaries(
     for name in names {
         let Some(src) = found.get(name) else {
             return Err(SoldrError::Other(format!(
-                "install-zccache: archive missing required binary `{name}`"
+                "update-zccache: archive missing required binary `{name}`"
             )));
         };
         let dst = unified_root.join(name);
@@ -552,7 +552,7 @@ pub(crate) fn extract_archive_file(archive: &Path, dest: &Path) -> Result<(), So
         extract_tar_zst_to_dir(archive, dest)
     } else {
         Err(SoldrError::Other(format!(
-            "install-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — got {} (unsupported extension)",
+            "update-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — got {} (unsupported extension)",
             archive.display()
         )))
     }
@@ -615,17 +615,17 @@ async fn download_url_to(url: &str, dest: &Path) -> Result<(), SoldrError> {
         .get(url)
         .send()
         .await
-        .map_err(|e| SoldrError::Network(format!("install-zccache: GET {url}: {e}")))?;
+        .map_err(|e| SoldrError::Network(format!("update-zccache: GET {url}: {e}")))?;
     if !resp.status().is_success() {
         return Err(SoldrError::Network(format!(
-            "install-zccache: download failed: HTTP {} ({url})",
+            "update-zccache: download failed: HTTP {} ({url})",
             resp.status()
         )));
     }
     let bytes = resp
         .bytes()
         .await
-        .map_err(|e| SoldrError::Network(format!("install-zccache: read body: {e}")))?;
+        .map_err(|e| SoldrError::Network(format!("update-zccache: read body: {e}")))?;
     std::fs::write(dest, &bytes)?;
     Ok(())
 }
@@ -685,7 +685,7 @@ pub fn remove_pinned_zccache(paths: &SoldrPaths) -> Result<bool, SoldrError> {
     }
     std::fs::remove_dir_all(&pinned_dir).map_err(|e| {
         SoldrError::Other(format!(
-            "install-zccache: failed to remove {}: {e}",
+            "update-zccache: failed to remove {}: {e}",
             pinned_dir.display()
         ))
     })?;

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -170,7 +170,7 @@ pub enum ZccacheSource {
     Managed,
     /// Resolved from `SOLDR_ZCCACHE_LOCAL_DIR`.
     Local,
-    /// Installed via `soldr cache install-zccache` into the
+    /// Installed via `soldr update-zccache` into the
     /// `<SoldrPaths::bin>/zccache-pinned/` directory.
     Pinned,
     /// Nothing fetched yet — managed path, no binaries on disk.
@@ -474,7 +474,7 @@ pub fn zccache_binary_summary(paths: &SoldrPaths) -> Result<ZccacheBinarySummary
     }
 
     if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
-        // `soldr cache install-zccache` install. Reports `pinned` so
+        // `soldr update-zccache` install. Reports `pinned` so
         // doctor can surface the override (and warn the managed path
         // is superseded).
         let runtime_dir = pinned.runtime_dir.clone();
@@ -576,7 +576,7 @@ pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult,
         return resolve_local_zccache_for_target(&local_dir, paths, &target);
     }
 
-    // Pinned install (`soldr cache install-zccache <SOURCE>`). Sits
+    // Pinned install (`soldr update-zccache <SOURCE>`). Sits
     // between the env-var override and the managed download so users
     // who pinned once never go back to the GitHub-Releases path.
     if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -15,6 +15,16 @@ pub use trust::{
     CHECKSUMS_FILE_ENV_VAR, TRUST_MODE_ENV_VAR,
 };
 
+pub mod install_zccache;
+
+pub use install_zccache::{
+    install_zccache_from_source, pinned_version_drift_from_managed, pinned_zccache_dir,
+    read_pinned_sidecar, remove_pinned_zccache, resolve_pinned_zccache, InstallReport,
+    InstallSource, PinnedBinaryRecord, PinnedResolution, PinnedSidecar, PINNED_ZCCACHE_DIRNAME,
+    PINNED_ZCCACHE_SIDECAR_FILENAME, PINNED_ZCCACHE_SIDECAR_SCHEMA_VERSION,
+    ZCCACHE_PINNED_BINARY_NAMES,
+};
+
 use soldr_core::{
     suppress_windows_console_window, Arch, Env, Os, SoldrError, SoldrPaths, TargetTriple,
 };
@@ -160,6 +170,9 @@ pub enum ZccacheSource {
     Managed,
     /// Resolved from `SOLDR_ZCCACHE_LOCAL_DIR`.
     Local,
+    /// Installed via `soldr cache install-zccache` into the
+    /// `<SoldrPaths::bin>/zccache-pinned/` directory.
+    Pinned,
     /// Nothing fetched yet — managed path, no binaries on disk.
     None,
 }
@@ -169,6 +182,7 @@ impl ZccacheSource {
         match self {
             ZccacheSource::Managed => "managed",
             ZccacheSource::Local => "local",
+            ZccacheSource::Pinned => "pinned",
             ZccacheSource::None => "none",
         }
     }
@@ -279,7 +293,7 @@ fn local_zccache_version_label(binary: &Path) -> String {
     }
 }
 
-fn sha256_short(bytes: &[u8]) -> String {
+pub(crate) fn sha256_short(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(bytes);
@@ -288,7 +302,7 @@ fn sha256_short(bytes: &[u8]) -> String {
     hex_digest[..12].to_string()
 }
 
-fn copy_if_changed(src: &Path, dst: &Path) -> Result<(), SoldrError> {
+pub(crate) fn copy_if_changed(src: &Path, dst: &Path) -> Result<(), SoldrError> {
     // Cheap no-op when sizes match — content hash already pins the
     // destination dir name, so a byte-for-byte difference at the
     // same size is impossible under our naming scheme.
@@ -301,7 +315,10 @@ fn copy_if_changed(src: &Path, dst: &Path) -> Result<(), SoldrError> {
     Ok(())
 }
 
-fn copy_debug_info_sidecars(src_binary: &Path, dst_binary: &Path) -> Result<(), SoldrError> {
+pub(crate) fn copy_debug_info_sidecars(
+    src_binary: &Path,
+    dst_binary: &Path,
+) -> Result<(), SoldrError> {
     // Windows: <binary>.pdb (sibling file).
     // Linux: <binary>.dwp (sibling file).
     // macOS: <binary>.dSYM (sibling directory).
@@ -324,7 +341,7 @@ fn copy_debug_info_sidecars(src_binary: &Path, dst_binary: &Path) -> Result<(), 
     Ok(())
 }
 
-fn adjacent_with_extension(binary: &Path, ext: &str) -> Option<PathBuf> {
+pub(crate) fn adjacent_with_extension(binary: &Path, ext: &str) -> Option<PathBuf> {
     let stem = binary.file_stem()?.to_owned();
     let parent = binary.parent()?;
     let mut name = stem;
@@ -361,6 +378,72 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), SoldrError> {
 /// doctor's reported `cli_path` / `daemon_path` / PDB count reflect
 /// the actually-resolvable state, not a prediction. This matches what
 /// the next `soldr cargo ...` invocation will produce.
+/// Snapshot of the managed (GitHub-Releases) zccache state on disk.
+/// Always reports what the managed path *would* produce on next fetch,
+/// even when the pinned-install path is currently winning resolution.
+/// Used by `soldr doctor` to differentiate the two paths and annotate
+/// "(superseded by pinned)" on the managed section when appropriate.
+pub fn managed_only_zccache_summary(
+    paths: &SoldrPaths,
+) -> Result<ZccacheBinarySummary, SoldrError> {
+    let target = TargetTriple::detect()?;
+    let runtime_dir = paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"));
+    let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
+    let any_present = cli.exists() || daemon.exists() || fp.exists();
+    let (debug_found, debug_expected) =
+        count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
+    Ok(ZccacheBinarySummary {
+        source: if any_present {
+            ZccacheSource::Managed
+        } else {
+            ZccacheSource::None
+        },
+        version: if any_present {
+            MANAGED_ZCCACHE_VERSION.to_string()
+        } else {
+            String::new()
+        },
+        symbol_path: runtime_dir.clone(),
+        runtime_dir,
+        source_dir: None,
+        cli_path: cli.exists().then_some(cli),
+        daemon_path: daemon.exists().then_some(daemon),
+        fp_path: fp.exists().then_some(fp),
+        debug_info_found: debug_found,
+        debug_info_expected: debug_expected,
+    })
+}
+
+/// Snapshot of the pinned-install state independent of resolution
+/// priority. Returns `Ok(None)` when no `source.json` exists. Used by
+/// `soldr doctor` so the pinned section can render even when something
+/// further up the resolution chain (e.g. `SOLDR_ZCCACHE_LOCAL_DIR`)
+/// wins.
+pub fn pinned_zccache_summary(
+    paths: &SoldrPaths,
+) -> Result<Option<ZccacheBinarySummary>, SoldrError> {
+    let target = TargetTriple::detect()?;
+    let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? else {
+        return Ok(None);
+    };
+    let runtime_dir = pinned.runtime_dir.clone();
+    let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
+    let (debug_found, debug_expected) =
+        count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
+    Ok(Some(ZccacheBinarySummary {
+        source: ZccacheSource::Pinned,
+        version: pinned.version,
+        symbol_path: runtime_dir.clone(),
+        runtime_dir,
+        source_dir: None,
+        cli_path: cli.exists().then_some(cli),
+        daemon_path: daemon.exists().then_some(daemon),
+        fp_path: fp.exists().then_some(fp),
+        debug_info_found: debug_found,
+        debug_info_expected: debug_expected,
+    }))
+}
+
 pub fn zccache_binary_summary(paths: &SoldrPaths) -> Result<ZccacheBinarySummary, SoldrError> {
     let target = TargetTriple::detect()?;
 
@@ -382,6 +465,28 @@ pub fn zccache_binary_summary(paths: &SoldrPaths) -> Result<ZccacheBinarySummary
             symbol_path: runtime_dir.clone(),
             runtime_dir,
             source_dir: Some(source_dir),
+            cli_path: cli.exists().then_some(cli),
+            daemon_path: daemon.exists().then_some(daemon),
+            fp_path: fp.exists().then_some(fp),
+            debug_info_found: debug_found,
+            debug_info_expected: debug_expected,
+        });
+    }
+
+    if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
+        // `soldr cache install-zccache` install. Reports `pinned` so
+        // doctor can surface the override (and warn the managed path
+        // is superseded).
+        let runtime_dir = pinned.runtime_dir.clone();
+        let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
+        let (debug_found, debug_expected) =
+            count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
+        return Ok(ZccacheBinarySummary {
+            source: ZccacheSource::Pinned,
+            version: pinned.version,
+            symbol_path: runtime_dir.clone(),
+            runtime_dir,
+            source_dir: None,
             cli_path: cli.exists().then_some(cli),
             daemon_path: daemon.exists().then_some(daemon),
             fp_path: fp.exists().then_some(fp),
@@ -418,7 +523,7 @@ pub fn zccache_binary_summary(paths: &SoldrPaths) -> Result<ZccacheBinarySummary
     })
 }
 
-fn canonical_zccache_paths(
+pub(crate) fn canonical_zccache_paths(
     runtime_dir: &Path,
     target: &TargetTriple,
 ) -> (PathBuf, PathBuf, PathBuf) {
@@ -469,6 +574,22 @@ pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult,
     // WinDbg can resolve symbols when attaching to the daemon.
     if let Some(local_dir) = non_empty_env_path(ZCCACHE_LOCAL_DIR_ENV_VAR) {
         return resolve_local_zccache_for_target(&local_dir, paths, &target);
+    }
+
+    // Pinned install (`soldr cache install-zccache <SOURCE>`). Sits
+    // between the env-var override and the managed download so users
+    // who pinned once never go back to the GitHub-Releases path.
+    if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
+        eprintln!(
+            "soldr: using pinned zccache from {} (version={})",
+            pinned.runtime_dir.display(),
+            pinned.version
+        );
+        return Ok(FetchResult {
+            binary_path: pinned.binary_path,
+            version: pinned.version,
+            cached: true,
+        });
     }
 
     let binary_names = ["zccache", "zccache-daemon", "zccache-fp"];
@@ -550,6 +671,14 @@ pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, 
         return resolve_local_zccache_for_target(&local_dir, paths, &target).map(Some);
     }
 
+    if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
+        return Ok(Some(FetchResult {
+            binary_path: pinned.binary_path,
+            version: pinned.version,
+            cached: true,
+        }));
+    }
+
     check_cache(
         paths,
         "zccache",
@@ -609,10 +738,7 @@ pub(crate) fn resolve_system_zccache_with_path_dirs(
         }
     }
 
-    eprintln!(
-        "soldr: using system zccache at {}",
-        zccache_path.display()
-    );
+    eprintln!("soldr: using system zccache at {}", zccache_path.display());
     Ok(FetchResult {
         binary_path: zccache_path,
         version: "system".to_string(),
@@ -620,7 +746,7 @@ pub(crate) fn resolve_system_zccache_with_path_dirs(
     })
 }
 
-fn find_in_dirs(dirs: &[PathBuf], file_name: &str) -> Option<PathBuf> {
+pub(crate) fn find_in_dirs(dirs: &[PathBuf], file_name: &str) -> Option<PathBuf> {
     for dir in dirs {
         let candidate = dir.join(file_name);
         if candidate.is_file() {
@@ -854,7 +980,7 @@ struct AssetInfo {
     download_url: String,
 }
 
-fn http_client() -> Result<reqwest::Client, SoldrError> {
+pub(crate) fn http_client() -> Result<reqwest::Client, SoldrError> {
     reqwest::Client::builder()
         .user_agent(format!("soldr/{}", soldr_core::version()))
         .build()
@@ -1324,7 +1450,7 @@ async fn download_and_extract(
     Ok(binary_path)
 }
 
-fn desired_binary_names(binary_names: &[&str], target: &TargetTriple) -> Vec<String> {
+pub(crate) fn desired_binary_names(binary_names: &[&str], target: &TargetTriple) -> Vec<String> {
     binary_names
         .iter()
         .map(|binary_name| format!("{binary_name}{}", target.binary_ext()))

--- a/crates/soldr-fetch/tests/install_zccache.rs
+++ b/crates/soldr-fetch/tests/install_zccache.rs
@@ -1,0 +1,469 @@
+//! Integration tests for `soldr cache install-zccache` (the library
+//! half — pure path/archive/system flows, no CLI subprocess).
+//!
+//! Uses fake binary bytes everywhere; nothing here requires a real
+//! zccache. Tests that touch the network are guarded by `#[ignore]`.
+
+use soldr_core::SoldrPaths;
+use soldr_fetch::{
+    install_zccache_from_source, pinned_version_drift_from_managed, pinned_zccache_dir,
+    read_pinned_sidecar, remove_pinned_zccache, resolve_pinned_zccache, InstallSource,
+    MANAGED_ZCCACHE_VERSION,
+};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Tests need to invoke install_zccache_from_source with a TargetTriple
+/// matching the host so the .exe suffix lines up with the fake binaries
+/// we lay down. We use the public surface (which detects the host) and
+/// drop `.exe` on Unix / keep `.exe` on Windows.
+fn bin_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+fn write_fake(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
+    fs::create_dir_all(dir).unwrap();
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    path
+}
+
+fn isolate_local_dir_env() -> EnvGuard {
+    EnvGuard::unset("SOLDR_ZCCACHE_LOCAL_DIR")
+}
+
+/// RAII wrapper that restores an env var on drop. Tests must use this
+/// instead of touching env vars directly so failures don't leak state
+/// into sibling tests.
+struct EnvGuard {
+    key: String,
+    prior: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn unset(key: &str) -> Self {
+        let prior = std::env::var_os(key);
+        // SAFETY: tests run with `cargo test` which permits env
+        // mutation; the harness assumes single-threaded teardown
+        // within each test process.
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self {
+            key: key.to_string(),
+            prior,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: same scope as set in `unset`.
+        unsafe {
+            match self.prior.take() {
+                Some(v) => std::env::set_var(&self.key, v),
+                None => std::env::remove_var(&self.key),
+            }
+        }
+    }
+}
+
+fn seed_dir_source(root: &Path) -> PathBuf {
+    let src = root.join("bin-dir");
+    write_fake(&src, &bin_name("zccache"), b"cli-bytes-v1");
+    write_fake(&src, &bin_name("zccache-daemon"), b"daemon-bytes-v1");
+    write_fake(&src, &bin_name("zccache-fp"), b"fp-bytes-v1");
+    src
+}
+
+#[tokio::test]
+async fn path_directory_install_records_sidecar_and_copies_all_three() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root.clone());
+
+    let src = seed_dir_source(tmp.path());
+    let report = install_zccache_from_source(&InstallSource::Path(src.clone()), &paths)
+        .await
+        .expect("install from directory");
+
+    // Layout: every binary copied + sidecar exists.
+    let pinned = pinned_zccache_dir(&paths);
+    assert!(pinned.join(bin_name("zccache")).exists());
+    assert!(pinned.join(bin_name("zccache-daemon")).exists());
+    assert!(pinned.join(bin_name("zccache-fp")).exists());
+    assert!(pinned.join("source.json").exists());
+
+    // Report sanity.
+    assert_eq!(report.source_kind, "path");
+    assert_eq!(report.source_value, src.display().to_string());
+    assert_eq!(report.binaries.len(), 3);
+    let cli_record = &report.binaries["zccache"];
+    assert_eq!(cli_record.size_bytes, b"cli-bytes-v1".len() as u64);
+    assert_eq!(cli_record.sha256.len(), 64);
+
+    // Sidecar roundtrip matches the report.
+    let sidecar = read_pinned_sidecar(&paths).unwrap().unwrap();
+    assert_eq!(sidecar.source_kind, "path");
+    assert_eq!(sidecar.binaries.len(), 3);
+    assert_eq!(sidecar.binaries["zccache"].sha256, cli_record.sha256);
+
+    // Resolution chain: pinned wins.
+    let resolved = resolve_pinned_zccache(&paths).unwrap().unwrap();
+    assert!(resolved.binary_path.ends_with(bin_name("zccache")));
+}
+
+#[tokio::test]
+async fn path_tar_gz_install_extracts_nested_layout() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    let archive = build_tar_gz_with_nested_dir(tmp.path(), "zccache-v1.8.1");
+    let report = install_zccache_from_source(&InstallSource::Path(archive.clone()), &paths)
+        .await
+        .expect("install from .tar.gz");
+
+    assert_eq!(report.source_kind, "path");
+    let pinned = pinned_zccache_dir(&paths);
+    assert!(pinned.join(bin_name("zccache")).exists());
+    assert!(pinned.join(bin_name("zccache-daemon")).exists());
+    assert!(pinned.join(bin_name("zccache-fp")).exists());
+    let sidecar = read_pinned_sidecar(&paths).unwrap().unwrap();
+    assert_eq!(sidecar.binaries.len(), 3);
+}
+
+#[tokio::test]
+async fn path_tar_zst_install_extracts_archive() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    let archive = build_tar_zst_with_nested_dir(tmp.path(), "zccache-v1.8.1");
+    let report = install_zccache_from_source(&InstallSource::Path(archive), &paths)
+        .await
+        .expect("install from .tar.zst");
+
+    assert_eq!(report.source_kind, "path");
+    let pinned = pinned_zccache_dir(&paths);
+    assert!(pinned.join(bin_name("zccache")).exists());
+}
+
+#[tokio::test]
+async fn path_zip_install_extracts_archive() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    let archive = build_zip_with_nested_dir(tmp.path(), "zccache-v1.8.1");
+    let report = install_zccache_from_source(&InstallSource::Path(archive), &paths)
+        .await
+        .expect("install from .zip");
+
+    assert_eq!(report.source_kind, "path");
+    let pinned = pinned_zccache_dir(&paths);
+    assert!(pinned.join(bin_name("zccache")).exists());
+}
+
+#[tokio::test]
+async fn path_archive_missing_one_binary_errors() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    // Build an archive that contains only two of the three binaries.
+    let staging = tmp.path().join("staging");
+    let inner = staging.join("zccache-v1.8.1");
+    write_fake(&inner, &bin_name("zccache"), b"cli");
+    write_fake(&inner, &bin_name("zccache-daemon"), b"daemon");
+    let archive = tmp.path().join("incomplete.tar.gz");
+    write_tar_gz(&archive, &staging).unwrap();
+
+    let err = install_zccache_from_source(&InstallSource::Path(archive), &paths)
+        .await
+        .expect_err("missing binary should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("zccache-fp") || msg.contains("missing required binary"),
+        "error message should name the missing binary: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn path_unknown_extension_errors() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    // A single random file with an unrecognized extension.
+    let single = tmp.path().join("zccache-bundle.7z");
+    fs::write(&single, b"not actually 7z").unwrap();
+
+    let err = install_zccache_from_source(&InstallSource::Path(single), &paths)
+        .await
+        .expect_err("unknown ext should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains(".zip") && msg.contains(".tar.gz") && msg.contains(".tar.zst"),
+        "error must list supported extensions: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn system_source_uses_path_lookup_via_real_path_env() {
+    // Uses the public install_zccache_from_source surface, which reads
+    // $PATH at runtime. Build a fresh PATH containing only a directory
+    // we control (so we don't accidentally resolve a real zccache on
+    // the developer's machine).
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    let bin_dir = tmp.path().join("fake-system-bin");
+    write_fake(&bin_dir, &bin_name("zccache"), b"system-cli");
+    write_fake(&bin_dir, &bin_name("zccache-daemon"), b"system-daemon");
+    write_fake(&bin_dir, &bin_name("zccache-fp"), b"system-fp");
+
+    let _path_guard = PathGuard::set_only(&bin_dir);
+    let report = install_zccache_from_source(&InstallSource::System, &paths)
+        .await
+        .expect("system install");
+    assert_eq!(report.source_kind, "system");
+    assert_eq!(report.source_value, "system");
+    let pinned = pinned_zccache_dir(&paths);
+    assert!(pinned.join(bin_name("zccache")).exists());
+}
+
+#[tokio::test]
+async fn system_source_missing_binary_reports_which_one() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    let bin_dir = tmp.path().join("fake-system-bin");
+    write_fake(&bin_dir, &bin_name("zccache"), b"system-cli");
+    // intentionally skip zccache-daemon
+    write_fake(&bin_dir, &bin_name("zccache-fp"), b"system-fp");
+
+    let _path_guard = PathGuard::set_only(&bin_dir);
+    let err = install_zccache_from_source(&InstallSource::System, &paths)
+        .await
+        .expect_err("missing daemon should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("zccache-daemon"),
+        "error must name the missing binary: {msg}"
+    );
+    assert!(msg.contains("PATH"));
+}
+
+#[test]
+fn remove_is_idempotent() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    // First removal on a fresh root is a no-op.
+    assert!(!remove_pinned_zccache(&paths).unwrap());
+
+    // Seed a pinned dir manually and verify removal returns true then
+    // false on a second call.
+    let pinned = pinned_zccache_dir(&paths);
+    fs::create_dir_all(&pinned).unwrap();
+    fs::write(pinned.join("dummy"), b"hello").unwrap();
+    assert!(remove_pinned_zccache(&paths).unwrap());
+    assert!(!remove_pinned_zccache(&paths).unwrap());
+}
+
+#[test]
+fn status_with_no_install_returns_none() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    assert!(read_pinned_sidecar(&paths).unwrap().is_none());
+    assert!(resolve_pinned_zccache(&paths).unwrap().is_none());
+}
+
+#[tokio::test]
+async fn status_with_install_reports_drift_when_version_differs() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    let src = seed_dir_source(tmp.path());
+    install_zccache_from_source(&InstallSource::Path(src), &paths)
+        .await
+        .expect("install");
+
+    let mut sidecar = read_pinned_sidecar(&paths).unwrap().unwrap();
+    // Fake binaries can't be probed for version, so version is "unknown"
+    // — no drift.
+    assert_eq!(sidecar.version, "unknown");
+    assert!(!pinned_version_drift_from_managed(&sidecar));
+
+    // Force a drift scenario.
+    sidecar.version = "0.0.1".to_string();
+    assert!(pinned_version_drift_from_managed(&sidecar));
+
+    // The managed default never drifts against itself.
+    sidecar.version = MANAGED_ZCCACHE_VERSION.to_string();
+    assert!(!pinned_version_drift_from_managed(&sidecar));
+}
+
+#[tokio::test]
+async fn resolution_chain_pinned_overrides_managed_default() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root.clone());
+
+    let src = seed_dir_source(tmp.path());
+    install_zccache_from_source(&InstallSource::Path(src), &paths)
+        .await
+        .expect("install");
+
+    // cached_zccache_binary picks pinned over managed.
+    let cached = soldr_fetch::cached_zccache_binary(&paths)
+        .unwrap()
+        .expect("pinned must be reported as cached");
+    let pinned_dir = pinned_zccache_dir(&paths);
+    assert!(
+        cached.binary_path.starts_with(&pinned_dir),
+        "expected cached path under {} but got {}",
+        pinned_dir.display(),
+        cached.binary_path.display()
+    );
+}
+
+// ---------------------------------------------------------------------
+// PathGuard — RAII wrapper that sets PATH for the duration of a test
+// and restores it on drop. Tests that touch PATH MUST hold the global
+// mutex first; otherwise parallel tests race on the env var and the
+// install lookup sees an inconsistent PATH.
+// ---------------------------------------------------------------------
+
+fn path_mutex() -> &'static std::sync::Mutex<()> {
+    static MUTEX: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    MUTEX.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+struct PathGuard {
+    prior: Option<std::ffi::OsString>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl PathGuard {
+    fn set_only(dir: &Path) -> Self {
+        // Acquire the mutex first; a poisoned lock just means a prior
+        // test panicked while holding it. Recover the guard and carry
+        // on so a single failure doesn't cascade.
+        let lock = path_mutex().lock().unwrap_or_else(|p| p.into_inner());
+        let prior = std::env::var_os("PATH");
+        // SAFETY: tests run with `cargo test` which permits env mutation.
+        unsafe {
+            std::env::set_var("PATH", dir);
+        }
+        Self { prior, _lock: lock }
+    }
+}
+
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        // SAFETY: same scope as set_only.
+        unsafe {
+            match self.prior.take() {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Archive builders
+// ---------------------------------------------------------------------
+
+fn build_tar_gz_with_nested_dir(root: &Path, inner_dirname: &str) -> PathBuf {
+    let staging = root.join(format!("staging-{inner_dirname}-tar-gz"));
+    let inner = staging.join(inner_dirname);
+    write_fake(&inner, &bin_name("zccache"), b"tar-gz-cli");
+    write_fake(&inner, &bin_name("zccache-daemon"), b"tar-gz-daemon");
+    write_fake(&inner, &bin_name("zccache-fp"), b"tar-gz-fp");
+    let archive = root.join("bundle.tar.gz");
+    write_tar_gz(&archive, &staging).unwrap();
+    archive
+}
+
+fn build_tar_zst_with_nested_dir(root: &Path, inner_dirname: &str) -> PathBuf {
+    let staging = root.join(format!("staging-{inner_dirname}-tar-zst"));
+    let inner = staging.join(inner_dirname);
+    write_fake(&inner, &bin_name("zccache"), b"tar-zst-cli");
+    write_fake(&inner, &bin_name("zccache-daemon"), b"tar-zst-daemon");
+    write_fake(&inner, &bin_name("zccache-fp"), b"tar-zst-fp");
+    let archive = root.join("bundle.tar.zst");
+    write_tar_zst(&archive, &staging).unwrap();
+    archive
+}
+
+fn build_zip_with_nested_dir(root: &Path, inner_dirname: &str) -> PathBuf {
+    let staging = root.join(format!("staging-{inner_dirname}-zip"));
+    let inner = staging.join(inner_dirname);
+    write_fake(&inner, &bin_name("zccache"), b"zip-cli");
+    write_fake(&inner, &bin_name("zccache-daemon"), b"zip-daemon");
+    write_fake(&inner, &bin_name("zccache-fp"), b"zip-fp");
+    let archive = root.join("bundle.zip");
+    write_zip(&archive, &staging, inner_dirname).unwrap();
+    archive
+}
+
+fn write_tar_gz(out: &Path, staging: &Path) -> std::io::Result<()> {
+    let file = fs::File::create(out)?;
+    let gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    let mut builder = tar::Builder::new(gz);
+    builder.append_dir_all(".", staging)?;
+    builder.into_inner()?.finish()?;
+    Ok(())
+}
+
+fn write_tar_zst(out: &Path, staging: &Path) -> std::io::Result<()> {
+    let file = fs::File::create(out)?;
+    let encoder = zstd::stream::write::Encoder::new(file, 3).map_err(std::io::Error::other)?;
+    let mut builder = tar::Builder::new(encoder.auto_finish());
+    builder.append_dir_all(".", staging)?;
+    builder.finish()?;
+    Ok(())
+}
+
+fn write_zip(out: &Path, staging: &Path, inner_dirname: &str) -> std::io::Result<()> {
+    let file = fs::File::create(out)?;
+    let mut writer = zip::ZipWriter::new(file);
+    let opts: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+    for name in ["zccache", "zccache-daemon", "zccache-fp"] {
+        let file_name = bin_name(name);
+        let bytes = fs::read(staging.join(inner_dirname).join(&file_name))?;
+        let path_in_zip = format!("{inner_dirname}/{file_name}");
+        writer
+            .start_file(&path_in_zip, opts)
+            .map_err(std::io::Error::other)?;
+        writer.write_all(&bytes)?;
+    }
+    writer.finish().map_err(std::io::Error::other)?;
+    Ok(())
+}

--- a/crates/soldr-fetch/tests/install_zccache.rs
+++ b/crates/soldr-fetch/tests/install_zccache.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `soldr cache install-zccache` (the library
+//! Integration tests for `soldr update-zccache` (the library
 //! half — pure path/archive/system flows, no CLI subprocess).
 //!
 //! Uses fake binary bytes everywhere; nothing here requires a real

--- a/docs/API.md
+++ b/docs/API.md
@@ -213,6 +213,39 @@ Automatic pruning via `RUSTC_WRAPPER` pre/post-compile hooks is
 deferred to a follow-up — the manual subcommand is intentionally
 opt-in until the behaviour is trusted on real `target/` directories.
 
+### `soldr update-zccache`
+
+Install zccache binaries into soldr's private dir so soldr stops
+fetching the managed GitHub release. Pins a user-supplied set of three
+zccache binaries (`zccache`, `zccache-daemon`, `zccache-fp`) into
+`<SoldrPaths::bin>/zccache-pinned/`. Subsequent `soldr cargo ...`
+invocations resolve the pinned binaries automatically.
+
+```bash
+soldr update-zccache <SOURCE>   # system | <path> | <url>
+soldr update-zccache --remove   # un-pin, idempotent
+soldr update-zccache --status   # report sidecar + drift
+soldr update-zccache --json     # structured output
+```
+
+`<SOURCE>` accepts:
+
+- `system` — copy the `zccache`, `zccache-daemon`, `zccache-fp`
+  binaries already on `PATH`.
+- A directory path containing the three binaries.
+- An archive file (`.zip` / `.tar.gz` / `.tgz` / `.tar.zst`) — recursive
+  search for binaries handles nested release layouts like
+  `zccache-vX.Y.Z/`.
+- An `http(s)://` URL pointing at such an archive.
+
+Resolution chain becomes:
+
+1. `SOLDR_ZCCACHE_LOCAL_DIR` env var (unchanged, highest priority).
+2. Pinned install at `<SoldrPaths::bin>/zccache-pinned/` (this command).
+3. Managed GitHub Releases fetch (unchanged, default).
+
+Exactly one of `<SOURCE>`, `--remove`, or `--status` must be provided.
+
 ### `soldr version`
 
 Print soldr version.

--- a/test
+++ b/test
@@ -20,6 +20,7 @@ run_step "Build workspace" "${CARGO[@]}" build --workspace --locked
 run_step "Run library tests" "${CARGO[@]}" test --workspace --lib --locked
 run_step "Run CLI smoke tests" "${CARGO[@]}" test -p soldr-cli --tests --locked
 run_step "Run fetch integration test" "${CARGO[@]}" test -p soldr-fetch --test fetch_crgx --locked
+run_step "Run install-zccache integration test" "${CARGO[@]}" test -p soldr-fetch --test install_zccache --locked
 run_step "Run Python wrapper tests" uv run pytest -n auto tests -v --durations=0
 
 printf '\nPipeline complete.\n'


### PR DESCRIPTION
## Summary

Adds `soldr update-zccache <SOURCE>` — a **top-level discrete command** that pins a user-supplied set of zccache binaries into soldr's private dir, so users don't have to pass `--zccache=system` on every invocation. Source can be `system` (copy from PATH), a filesystem path (directory or archive), or an `http(s)://` URL. Side-effect-free: no global PATH writes, no system installs — everything lives under `<SoldrPaths::bin>/zccache-pinned/`.

## Two commits

- `c34255b` — `feat(cli): soldr cache install-zccache (system | path | url) + --remove / --status` — full feature implementation. *(Original commit was scoped under `cache install-zccache`.)*
- `d0088ca` — `refactor(cli): rename "cache install-zccache" → top-level "update-zccache"` — moves it out of the `cache` subcommand group to its own top-level command, since installing pinned binaries is its own discrete step (not a cache-state operation).

## CLI surface

```
soldr update-zccache <SOURCE>     # SOURCE = "system" | <path> | <url>
soldr update-zccache --remove     # un-pin; idempotent
soldr update-zccache --status     # report sidecar + drift vs MANAGED_ZCCACHE_VERSION
soldr update-zccache --json       # apply to install / remove / status
```

`<path>` accepts a **directory** containing the three binaries, OR an archive (`.zip`, `.tar.gz`, `.tgz`, `.tar.zst`) — the installer recursively finds the binaries inside, so nested release layouts like `zccache-vX.Y.Z/` work out of the box.

`<url>` downloads to a temp file then runs the archive path. The temp file is cleaned up on success and failure.

## Resolution chain change

`fetch_zccache` in `crates/soldr-fetch/src/lib.rs` now goes:

1. `SOLDR_ZCCACHE_LOCAL_DIR` env var (unchanged, highest — dev override)
2. **NEW**: `<SoldrPaths::bin>/zccache-pinned/` if `source.json` parses cleanly
3. Managed GitHub Releases fetch (unchanged, default for users who never pin)

New `ZccacheSource::Pinned` variant; all match sites updated exhaustively.

## What's recorded — `source.json` sidecar

```json
{
  "schema_version": 1,
  "source_kind": "system" | "path" | "url",
  "source_value": "<original input>",
  "version": "1.8.1",
  "binaries": {
    "zccache":         {"sha256": "...", "size_bytes": ...},
    "zccache-daemon":  {"sha256": "...", "size_bytes": ...},
    "zccache-fp":      {"sha256": "...", "size_bytes": ...}
  },
  "installed_at":  "2026-05-21T17:32:09Z",
  "soldr_version": "0.7.27"
}
```

Debug-symbol sidecars (`.pdb` on Windows, `.dwp` on Linux, `.dSYM/` on macOS) are copied alongside each binary using the same helpers as the existing `SOLDR_ZCCACHE_LOCAL_DIR` debug path — no copy-paste, helpers widened to `pub(crate)`.

## `soldr doctor` integration

When a pinned install exists, a new `pinned zccache:` section renders above the `managed zccache:` section showing install dir, source kind/value, version, sha256s, and a drift warning when `pinned_version != MANAGED_ZCCACHE_VERSION`. When pinned is the *active* resolution, the managed section is annotated `(superseded by pinned)`. Existing doctor tests preserved (backwards-compatible JSON field semantics).

## Test coverage

18 integration tests:

- `crates/soldr-fetch/tests/install_zccache.rs` — 12 tests: directory, `.tar.gz`, `.tar.zst`, `.zip`, missing-binary, unknown-extension, system PATH lookup, remove idempotency, status-when-empty, drift detection, pinned-overrides-managed resolution.
- `crates/soldr-cli/tests/cli_update_zccache.rs` (renamed from `cli_install_zccache.rs`) — 6 tests: argv parsing, `--json` round-trip, mutual-exclusion errors, unknown-extension errors, status with no install, idempotent `--remove`.

URL download path is implemented and exercised at runtime; per the brief, no localhost-server unit test was added since path+archive tests cover the post-download logic.

## Naming notes (for review)

- Command verb is **`update`** (per the user's explicit ask) even though the library function and on-disk directory still say "install" / "pinned". The user's framing: this is an update of soldr's pinned-binary state, not necessarily a first-time install.
- On-disk directory `<SoldrPaths::bin>/zccache-pinned/` and sidecar schema are unchanged from the original commit, so anyone who ran the pre-rename build will be picked up by the new command automatically.

## Constraints honored

- Side-effect-free for other zccache users — nothing written outside `~/.soldr/`, no PATH mutation.
- All three managed binaries handled: `zccache`, `zccache-daemon`, `zccache-fp`. Missing-binary errors name which one is absent.
- Did NOT break `SOLDR_ZCCACHE_LOCAL_DIR`, `SOLDR_ZCCACHE_BIN` test override, or the runtime `--zccache=system` flag — all keep current behaviour and priority.

## Test plan

- [x] `./test` — every Rust step green (workspace build, 139 library tests, 333 CLI smoke tests, fetch crate integration tests including the 12 install_zccache tests + 6 renamed CLI tests). 6 Python failures are pre-existing on `main` (confirmed by stash-and-reset diff, unrelated to this change).
- [ ] CI green on PR — `setup-soldr-action` verify step is now non-blocking via merged #402, so the stale pin warns but doesn't fail.
- [ ] Manual smoke: `soldr update-zccache system && soldr doctor` shows the pinned section; `soldr cargo build` in any repo uses the pinned binaries; `soldr update-zccache --remove` reverts to managed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
