### PR TITLE
refactor: normalize CLI verb update-zccache → install-zccache (idiomatic)

### DIFF
--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -1334,11 +1334,11 @@ pub(crate) fn print_json<T: Serialize>(value: &T) -> Result<(), SoldrError> {
 }
 
 // ---------------------------------------------------------------------------
-// update-zccache (soldr update-zccache <SOURCE> / --remove / --status)
+// install-zccache (soldr install-zccache <SOURCE> / --remove / --status)
 // ---------------------------------------------------------------------------
 
 #[derive(Serialize)]
-struct UpdateZccacheOutput {
+struct InstallZccacheOutput {
     schema_version: u32,
     command: &'static str,
     install_dir: String,
@@ -1351,7 +1351,7 @@ struct UpdateZccacheOutput {
 }
 
 #[derive(Serialize)]
-struct UpdateZccacheRemoveOutput {
+struct InstallZccacheRemoveOutput {
     schema_version: u32,
     command: &'static str,
     removed: bool,
@@ -1360,7 +1360,7 @@ struct UpdateZccacheRemoveOutput {
 
 /// `--status` payload when the pinned install exists.
 #[derive(Serialize)]
-struct UpdateZccacheStatusOutput {
+struct InstallZccacheStatusOutput {
     schema_version: u32,
     command: &'static str,
     pinned: serde_json::Value,
@@ -1370,14 +1370,14 @@ struct UpdateZccacheStatusOutput {
 
 /// `--status` payload when no pinned install exists.
 #[derive(Serialize)]
-struct UpdateZccacheStatusMissingOutput {
+struct InstallZccacheStatusMissingOutput {
     schema_version: u32,
     command: &'static str,
     pinned: Option<()>,
     managed_version: &'static str,
 }
 
-pub(crate) async fn run_update_zccache(
+pub(crate) async fn run_install_zccache(
     source: Option<String>,
     remove: bool,
     status: bool,
@@ -1392,14 +1392,14 @@ pub(crate) async fn run_update_zccache(
         .count();
     if chosen == 0 {
         return Err(SoldrError::Other(
-            "update-zccache: provide a SOURCE (`system`, a path, or a URL), or pass --remove / --status".into(),
+            "install-zccache: provide a SOURCE (`system`, a path, or a URL), or pass --remove / --status".into(),
         ));
     }
     if remove {
-        return run_update_zccache_remove(json);
+        return run_install_zccache_remove(json);
     }
     if status {
-        return run_update_zccache_status(json);
+        return run_install_zccache_status(json);
     }
     let raw = source.expect("source presence checked above");
     let parsed = soldr_fetch::InstallSource::parse(&raw)?;
@@ -1410,9 +1410,9 @@ pub(crate) async fn run_update_zccache(
 
 fn emit_install_report(report: &soldr_fetch::InstallReport, json: bool) -> Result<(), SoldrError> {
     if json {
-        let output = UpdateZccacheOutput {
+        let output = InstallZccacheOutput {
             schema_version: JSON_SCHEMA_VERSION,
-            command: "update-zccache",
+            command: "install-zccache",
             install_dir: report.install_dir.clone(),
             source_kind: report.source_kind.clone(),
             source_value: report.source_value.clone(),
@@ -1423,7 +1423,7 @@ fn emit_install_report(report: &soldr_fetch::InstallReport, json: bool) -> Resul
         };
         print_json(&output)?;
     } else {
-        println!("soldr update-zccache");
+        println!("soldr install-zccache");
         println!("  install dir:  {}", report.install_dir);
         println!(
             "  source:       {} ({})",
@@ -1450,33 +1450,33 @@ fn emit_install_report(report: &soldr_fetch::InstallReport, json: bool) -> Resul
     Ok(())
 }
 
-fn run_update_zccache_remove(json: bool) -> Result<(), SoldrError> {
+fn run_install_zccache_remove(json: bool) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
     let dir = soldr_fetch::pinned_zccache_dir(&paths);
     let removed = soldr_fetch::remove_pinned_zccache(&paths)?;
     if json {
-        let output = UpdateZccacheRemoveOutput {
+        let output = InstallZccacheRemoveOutput {
             schema_version: JSON_SCHEMA_VERSION,
-            command: "update-zccache --remove",
+            command: "install-zccache --remove",
             removed,
             path: dir.display().to_string(),
         };
         print_json(&output)?;
     } else if removed {
         println!(
-            "soldr update-zccache --remove: removed {}",
+            "soldr install-zccache --remove: removed {}",
             dir.display()
         );
     } else {
         println!(
-            "soldr update-zccache --remove: no pinned install at {} (nothing to do)",
+            "soldr install-zccache --remove: no pinned install at {} (nothing to do)",
             dir.display()
         );
     }
     Ok(())
 }
 
-fn run_update_zccache_status(json: bool) -> Result<(), SoldrError> {
+fn run_install_zccache_status(json: bool) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
     let sidecar = soldr_fetch::read_pinned_sidecar(&paths)?;
     match sidecar {
@@ -1484,18 +1484,18 @@ fn run_update_zccache_status(json: bool) -> Result<(), SoldrError> {
             let drift = soldr_fetch::pinned_version_drift_from_managed(&sidecar);
             if json {
                 let pinned_value = serde_json::to_value(&sidecar).map_err(|e| {
-                    SoldrError::Other(format!("update-zccache status: serialize sidecar: {e}"))
+                    SoldrError::Other(format!("install-zccache status: serialize sidecar: {e}"))
                 })?;
-                let output = UpdateZccacheStatusOutput {
+                let output = InstallZccacheStatusOutput {
                     schema_version: JSON_SCHEMA_VERSION,
-                    command: "update-zccache --status",
+                    command: "install-zccache --status",
                     pinned: pinned_value,
                     drift_from_managed: drift,
                     managed_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
                 };
                 print_json(&output)?;
             } else {
-                println!("soldr update-zccache --status");
+                println!("soldr install-zccache --status");
                 println!(
                     "  install dir:  {}",
                     soldr_fetch::pinned_zccache_dir(&paths).display()
@@ -1521,7 +1521,7 @@ fn run_update_zccache_status(json: bool) -> Result<(), SoldrError> {
                 }
                 if drift {
                     println!(
-                        "  warning:      pinned version {} is different from soldr's managed default {} — consider `soldr update-zccache --remove` to use the managed version",
+                        "  warning:      pinned version {} is different from soldr's managed default {} — consider `soldr install-zccache --remove` to use the managed version",
                         sidecar.version,
                         soldr_fetch::MANAGED_ZCCACHE_VERSION
                     );
@@ -1530,9 +1530,9 @@ fn run_update_zccache_status(json: bool) -> Result<(), SoldrError> {
         }
         None => {
             if json {
-                let output = UpdateZccacheStatusMissingOutput {
+                let output = InstallZccacheStatusMissingOutput {
                     schema_version: JSON_SCHEMA_VERSION,
-                    command: "update-zccache --status",
+                    command: "install-zccache --status",
                     pinned: None,
                     managed_version: soldr_fetch::MANAGED_ZCCACHE_VERSION,
                 };
@@ -1623,7 +1623,7 @@ fn ymdhms_to_unix_seconds(y: i32, m: u32, d: u32, h: u32, min: u32, s: u32) -> i
 }
 
 #[cfg(test)]
-mod update_zccache_tests {
+mod install_zccache_tests {
     use super::*;
 
     #[test]

--- a/crates/soldr-cli/src/doctor.rs
+++ b/crates/soldr-cli/src/doctor.rs
@@ -45,7 +45,7 @@ struct DoctorOutput {
     /// view even when the active source is a pinned install; the
     /// pinned section below explains the override.
     managed_zccache: DoctorManagedZccache,
-    /// `Some` when `soldr update-zccache` has been run.
+    /// `Some` when `soldr install-zccache` has been run.
     pinned_zccache: Option<DoctorPinnedZccache>,
     /// `true` when the active resolution is the pinned install (i.e.
     /// the managed path is superseded for the next `soldr cargo ...`).
@@ -254,7 +254,7 @@ struct ZccacheDoctorBundle {
     /// reports the GitHub-Releases view, even when the pinned dir wins
     /// resolution.
     managed: ZccacheBinarySummary,
-    /// Pinned-install snapshot, when `soldr update-zccache`
+    /// Pinned-install snapshot, when `soldr install-zccache`
     /// has been run.
     pinned: Option<ZccacheBinarySummary>,
     /// JSON-friendly form of the pinned section.
@@ -347,7 +347,7 @@ fn print_pinned_zccache_human(
     if soldr_fetch::pinned_version_drift_from_managed(sidecar) {
         println!(
             "  warning:       pinned version {} differs from soldr's managed default {} — \
-consider `soldr update-zccache --remove` to switch back to the managed version",
+consider `soldr install-zccache --remove` to switch back to the managed version",
             sidecar.version,
             soldr_fetch::MANAGED_ZCCACHE_VERSION
         );

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -299,8 +299,8 @@ enum Commands {
     /// provided. `<source>` accepts `system`, a directory or archive
     /// path (`.zip` / `.tar.gz` / `.tar.zst`), or an `http(s)://` URL
     /// pointing at such an archive.
-    #[command(name = "update-zccache")]
-    UpdateZccache {
+    #[command(name = "install-zccache")]
+    InstallZccache {
         /// Source for the three zccache binaries. Mutually exclusive
         /// with `--remove` / `--status`.
         #[arg(value_name = "SOURCE", conflicts_with_all = ["remove", "status"])]
@@ -706,13 +706,13 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
         Commands::Optimize(args) => {
             std::process::exit(optimize::run_optimize(args)?);
         }
-        Commands::UpdateZccache {
+        Commands::InstallZccache {
             source,
             remove,
             status,
             json,
         } => {
-            cache::run_update_zccache(source, remove, status, json).await?;
+            cache::run_install_zccache(source, remove, status, json).await?;
         }
         Commands::Save(args) => {
             std::process::exit(save_load::run_save(args));

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `soldr update-zccache` at the CLI surface.
+//! Integration tests for `soldr install-zccache` at the CLI surface.
 //! Covers argv parsing, JSON output, mutual-exclusion errors, and the
 //! round-trip from `install` → `--status` → `--remove`.
 
@@ -36,22 +36,22 @@ fn seed_source_dir(root: &Path) -> PathBuf {
 }
 
 #[test]
-fn update_zccache_from_directory_writes_sidecar() {
-    let tmp = unique_temp_dir("update-zccache-dir");
+fn install_zccache_from_directory_writes_sidecar() {
+    let tmp = unique_temp_dir("install-zccache-dir");
     let cache_root = tmp.join("soldr-root");
     let src = seed_source_dir(&tmp);
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache"])
+        .args(["install-zccache"])
         .arg(&src)
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("failed to run update-zccache");
+        .expect("failed to run install-zccache");
 
     assert!(
         output.status.success(),
-        "update-zccache failed: stdout={} stderr={}",
+        "install-zccache failed: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -71,23 +71,23 @@ fn update_zccache_from_directory_writes_sidecar() {
 }
 
 #[test]
-fn update_zccache_json_round_trip() {
-    let tmp = unique_temp_dir("update-zccache-json");
+fn install_zccache_json_round_trip() {
+    let tmp = unique_temp_dir("install-zccache-json");
     let cache_root = tmp.join("soldr-root");
     let src = seed_source_dir(&tmp);
 
     // install --json
     let install = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache", "--json"])
+        .args(["install-zccache", "--json"])
         .arg(&src)
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("update-zccache --json");
+        .expect("install-zccache --json");
     assert!(install.status.success());
     let install_json: Value =
         serde_json::from_slice(&install.stdout).expect("install --json should emit valid JSON");
-    assert_eq!(install_json["command"], "update-zccache");
+    assert_eq!(install_json["command"], "install-zccache");
     assert_eq!(install_json["source_kind"], "path");
     assert_eq!(
         install_json["binaries"]["zccache"]["size_bytes"],
@@ -96,15 +96,15 @@ fn update_zccache_json_round_trip() {
 
     // --status --json
     let status = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache", "--status", "--json"])
+        .args(["install-zccache", "--status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("update-zccache --status --json");
+        .expect("install-zccache --status --json");
     assert!(status.status.success());
     let status_json: Value =
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
-    assert_eq!(status_json["command"], "update-zccache --status");
+    assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
     assert_eq!(status_json["managed_version"], "1.8.1");
     assert!(
@@ -114,35 +114,35 @@ fn update_zccache_json_round_trip() {
 
     // --remove --json
     let remove = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache", "--remove", "--json"])
+        .args(["install-zccache", "--remove", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("update-zccache --remove --json");
+        .expect("install-zccache --remove --json");
     assert!(remove.status.success());
     let remove_json: Value = serde_json::from_slice(&remove.stdout).expect("remove --json");
     assert_eq!(remove_json["removed"], true);
 
     // Second remove is idempotent: removed=false.
     let remove2 = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache", "--remove", "--json"])
+        .args(["install-zccache", "--remove", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("update-zccache --remove --json (second)");
+        .expect("install-zccache --remove --json (second)");
     assert!(remove2.status.success());
     let remove2_json: Value = serde_json::from_slice(&remove2.stdout).expect("remove --json 2");
     assert_eq!(remove2_json["removed"], false);
 }
 
 #[test]
-fn update_zccache_status_with_no_install_reports_managed_default() {
-    let tmp = unique_temp_dir("update-zccache-status-empty");
+fn install_zccache_status_with_no_install_reports_managed_default() {
+    let tmp = unique_temp_dir("install-zccache-status-empty");
     let cache_root = tmp.join("soldr-root");
     fs::create_dir_all(&cache_root).unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache", "--status", "--json"])
+        .args(["install-zccache", "--status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
@@ -154,16 +154,16 @@ fn update_zccache_status_with_no_install_reports_managed_default() {
 }
 
 #[test]
-fn update_zccache_no_source_no_flags_errors() {
-    let tmp = unique_temp_dir("update-zccache-empty-args");
+fn install_zccache_no_source_no_flags_errors() {
+    let tmp = unique_temp_dir("install-zccache-empty-args");
     let cache_root = tmp.join("soldr-root");
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache"])
+        .args(["install-zccache"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("update-zccache (no args)");
+        .expect("install-zccache (no args)");
     assert!(!output.status.success(), "expected non-zero exit");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -173,17 +173,17 @@ fn update_zccache_no_source_no_flags_errors() {
 }
 
 #[test]
-fn update_zccache_mutually_exclusive_flags_rejected() {
-    let tmp = unique_temp_dir("update-zccache-mutex");
+fn install_zccache_mutually_exclusive_flags_rejected() {
+    let tmp = unique_temp_dir("install-zccache-mutex");
     let cache_root = tmp.join("soldr-root");
 
     // clap should reject `--remove` + `--status` outright.
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache", "--remove", "--status"])
+        .args(["install-zccache", "--remove", "--status"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("update-zccache --remove --status");
+        .expect("install-zccache --remove --status");
     assert!(
         !output.status.success(),
         "expected mutual-exclusion failure"
@@ -191,11 +191,11 @@ fn update_zccache_mutually_exclusive_flags_rejected() {
 
     // SOURCE + --remove is also rejected.
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache", "system", "--remove"])
+        .args(["install-zccache", "system", "--remove"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("update-zccache SOURCE --remove");
+        .expect("install-zccache SOURCE --remove");
     assert!(
         !output.status.success(),
         "expected mutual-exclusion failure (SOURCE + --remove)"
@@ -203,19 +203,19 @@ fn update_zccache_mutually_exclusive_flags_rejected() {
 }
 
 #[test]
-fn update_zccache_unknown_extension_errors() {
-    let tmp = unique_temp_dir("update-zccache-unknown-ext");
+fn install_zccache_unknown_extension_errors() {
+    let tmp = unique_temp_dir("install-zccache-unknown-ext");
     let cache_root = tmp.join("soldr-root");
     let bogus = tmp.join("zccache.7z");
     fs::write(&bogus, b"junk").unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
-        .args(["update-zccache"])
+        .args(["install-zccache"])
         .arg(&bogus)
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
-        .expect("update-zccache with bogus archive");
+        .expect("install-zccache with bogus archive");
     assert!(!output.status.success(), "expected unknown-ext failure");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/crates/soldr-fetch/src/install_zccache.rs
+++ b/crates/soldr-fetch/src/install_zccache.rs
@@ -1,4 +1,4 @@
-//! `soldr update-zccache <SOURCE>` implementation.
+//! `soldr install-zccache <SOURCE>` implementation.
 //!
 //! Pins a user-supplied set of three zccache binaries
 //! (`zccache`, `zccache-daemon`, `zccache-fp`) into
@@ -42,7 +42,7 @@ pub const PINNED_ZCCACHE_SIDECAR_SCHEMA_VERSION: u32 = 1;
 /// `MANAGED_ZCCACHE_PACKAGES` but exposes only the runtime side.
 pub const ZCCACHE_PINNED_BINARY_NAMES: [&str; 3] = ["zccache", "zccache-daemon", "zccache-fp"];
 
-/// Source the user passed to `update-zccache`.
+/// Source the user passed to `install-zccache`.
 #[derive(Debug, Clone)]
 pub enum InstallSource {
     /// Search the system `PATH` for the three binaries.
@@ -61,7 +61,7 @@ impl InstallSource {
         let trimmed = raw.trim();
         if trimmed.is_empty() {
             return Err(SoldrError::Other(
-                "update-zccache: source must not be empty".into(),
+                "install-zccache: source must not be empty".into(),
             ));
         }
         if trimmed.eq_ignore_ascii_case("system") {
@@ -160,7 +160,7 @@ pub fn read_pinned_sidecar(paths: &SoldrPaths) -> Result<Option<PinnedSidecar>, 
     }
     let bytes = std::fs::read(&sidecar).map_err(|e| {
         SoldrError::Other(format!(
-            "update-zccache: failed to read sidecar {}: {e}",
+            "install-zccache: failed to read sidecar {}: {e}",
             sidecar.display()
         ))
     })?;
@@ -168,7 +168,7 @@ pub fn read_pinned_sidecar(paths: &SoldrPaths) -> Result<Option<PinnedSidecar>, 
         .map(Some)
         .map_err(|e| {
             SoldrError::Other(format!(
-                "update-zccache: malformed sidecar {}: {e}",
+                "install-zccache: malformed sidecar {}: {e}",
                 sidecar.display()
             ))
         })
@@ -192,8 +192,8 @@ pub(crate) fn resolve_pinned_zccache_for_target(
     let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, target);
     if !cli.exists() || !daemon.exists() || !fp.exists() {
         return Err(SoldrError::Other(format!(
-            "update-zccache: sidecar at {} present but one or more binaries missing in {} \
-             (run `soldr update-zccache --remove` to reset)",
+            "install-zccache: sidecar at {} present but one or more binaries missing in {} \
+             (run `soldr install-zccache --remove` to reset)",
             pinned_sidecar_path(paths).display(),
             runtime_dir.display()
         )));
@@ -207,7 +207,7 @@ pub(crate) fn resolve_pinned_zccache_for_target(
 
 /// Install the three zccache binaries from `source` into the pinned
 /// directory and write the `source.json` sidecar. Existing pinned files
-/// are overwritten so re-running `update-zccache` is idempotent.
+/// are overwritten so re-running `install-zccache` is idempotent.
 pub async fn install_zccache_from_source(
     source: &InstallSource,
     paths: &SoldrPaths,
@@ -244,7 +244,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
         InstallSource::Path(p) => {
             if !p.exists() {
                 return Err(SoldrError::Other(format!(
-                    "update-zccache: path does not exist: {}",
+                    "install-zccache: path does not exist: {}",
                     p.display()
                 )));
             }
@@ -262,7 +262,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
                 dir
             } else {
                 return Err(SoldrError::Other(format!(
-                    "update-zccache: {} is neither a regular file nor a directory",
+                    "install-zccache: {} is neither a regular file nor a directory",
                     p.display()
                 )));
             }
@@ -270,7 +270,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
         InstallSource::Url(url) => {
             let download = tempfile::NamedTempFile::new_in(&paths.bin).map_err(|e| {
                 SoldrError::Other(format!(
-                    "update-zccache: failed to create download temp file: {e}"
+                    "install-zccache: failed to create download temp file: {e}"
                 ))
             })?;
             download_url_to(url, download.path()).await?;
@@ -327,7 +327,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
 
         let bytes = std::fs::read(&dst).map_err(|e| {
             SoldrError::Other(format!(
-                "update-zccache: failed to read {} for sha256: {e}",
+                "install-zccache: failed to read {} for sha256: {e}",
                 dst.display()
             ))
         })?;
@@ -355,7 +355,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
     let (cli_binary, _) = staged
         .first()
         .map(|(name, src)| (pinned_dir.join(name), src))
-        .ok_or_else(|| SoldrError::Other("update-zccache: no staged binaries".into()))?;
+        .ok_or_else(|| SoldrError::Other("install-zccache: no staged binaries".into()))?;
     let version = probe_zccache_version(&cli_binary);
 
     let installed_at = format_iso8601_utc(std::time::SystemTime::now());
@@ -370,7 +370,7 @@ pub(crate) async fn install_zccache_from_source_for_target(
     };
     let sidecar_path = pinned_sidecar_path(paths);
     let mut sidecar_bytes = serde_json::to_vec_pretty(&sidecar).map_err(|e| {
-        SoldrError::Other(format!("update-zccache: failed to serialize sidecar: {e}"))
+        SoldrError::Other(format!("install-zccache: failed to serialize sidecar: {e}"))
     })?;
     // Trailing newline matches what `serde_json::to_writer_pretty` plus
     // a `println!()` produces elsewhere in the codebase.
@@ -401,15 +401,15 @@ fn missing_binary_error_message(
     let _ = binary_ext;
     match source {
         InstallSource::System => format!(
-            "update-zccache: `{missing}` not found on PATH; install zccache or pick a different source"
+            "install-zccache: `{missing}` not found on PATH; install zccache or pick a different source"
         ),
         InstallSource::Path(p) => format!(
-            "update-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found under {} (source: {})",
+            "install-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found under {} (source: {})",
             dir_displayed,
             p.display()
         ),
         InstallSource::Url(url) => format!(
-            "update-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found in downloaded archive (source: {url})"
+            "install-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — `{missing}` was not found in downloaded archive (source: {url})"
         ),
     }
 }
@@ -455,7 +455,7 @@ pub(crate) fn stage_from_system_path_with_dirs(
     }
     if !missing.is_empty() {
         return Err(SoldrError::Other(format!(
-            "update-zccache: source=system but the following binaries were not found on PATH: {}",
+            "install-zccache: source=system but the following binaries were not found on PATH: {}",
             missing.join(", ")
         )));
     }
@@ -485,7 +485,7 @@ fn consolidate_extracted_binaries(
     for name in names {
         let Some(src) = found.get(name) else {
             return Err(SoldrError::Other(format!(
-                "update-zccache: archive missing required binary `{name}`"
+                "install-zccache: archive missing required binary `{name}`"
             )));
         };
         let dst = unified_root.join(name);
@@ -552,7 +552,7 @@ pub(crate) fn extract_archive_file(archive: &Path, dest: &Path) -> Result<(), So
         extract_tar_zst_to_dir(archive, dest)
     } else {
         Err(SoldrError::Other(format!(
-            "update-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — got {} (unsupported extension)",
+            "install-zccache: expected directory or .zip/.tar.gz/.tar.zst archive containing zccache, zccache-daemon, zccache-fp — got {} (unsupported extension)",
             archive.display()
         )))
     }
@@ -615,17 +615,17 @@ async fn download_url_to(url: &str, dest: &Path) -> Result<(), SoldrError> {
         .get(url)
         .send()
         .await
-        .map_err(|e| SoldrError::Network(format!("update-zccache: GET {url}: {e}")))?;
+        .map_err(|e| SoldrError::Network(format!("install-zccache: GET {url}: {e}")))?;
     if !resp.status().is_success() {
         return Err(SoldrError::Network(format!(
-            "update-zccache: download failed: HTTP {} ({url})",
+            "install-zccache: download failed: HTTP {} ({url})",
             resp.status()
         )));
     }
     let bytes = resp
         .bytes()
         .await
-        .map_err(|e| SoldrError::Network(format!("update-zccache: read body: {e}")))?;
+        .map_err(|e| SoldrError::Network(format!("install-zccache: read body: {e}")))?;
     std::fs::write(dest, &bytes)?;
     Ok(())
 }
@@ -685,7 +685,7 @@ pub fn remove_pinned_zccache(paths: &SoldrPaths) -> Result<bool, SoldrError> {
     }
     std::fs::remove_dir_all(&pinned_dir).map_err(|e| {
         SoldrError::Other(format!(
-            "update-zccache: failed to remove {}: {e}",
+            "install-zccache: failed to remove {}: {e}",
             pinned_dir.display()
         ))
     })?;

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -170,7 +170,7 @@ pub enum ZccacheSource {
     Managed,
     /// Resolved from `SOLDR_ZCCACHE_LOCAL_DIR`.
     Local,
-    /// Installed via `soldr update-zccache` into the
+    /// Installed via `soldr install-zccache` into the
     /// `<SoldrPaths::bin>/zccache-pinned/` directory.
     Pinned,
     /// Nothing fetched yet — managed path, no binaries on disk.
@@ -474,7 +474,7 @@ pub fn zccache_binary_summary(paths: &SoldrPaths) -> Result<ZccacheBinarySummary
     }
 
     if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
-        // `soldr update-zccache` install. Reports `pinned` so
+        // `soldr install-zccache` install. Reports `pinned` so
         // doctor can surface the override (and warn the managed path
         // is superseded).
         let runtime_dir = pinned.runtime_dir.clone();
@@ -576,7 +576,7 @@ pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult,
         return resolve_local_zccache_for_target(&local_dir, paths, &target);
     }
 
-    // Pinned install (`soldr update-zccache <SOURCE>`). Sits
+    // Pinned install (`soldr install-zccache <SOURCE>`). Sits
     // between the env-var override and the managed download so users
     // who pinned once never go back to the GitHub-Releases path.
     if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {

--- a/crates/soldr-fetch/tests/install_zccache.rs
+++ b/crates/soldr-fetch/tests/install_zccache.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `soldr update-zccache` (the library
+//! Integration tests for `soldr install-zccache` (the library
 //! half — pure path/archive/system flows, no CLI subprocess).
 //!
 //! Uses fake binary bytes everywhere; nothing here requires a real

--- a/docs/API.md
+++ b/docs/API.md
@@ -213,7 +213,7 @@ Automatic pruning via `RUSTC_WRAPPER` pre/post-compile hooks is
 deferred to a follow-up — the manual subcommand is intentionally
 opt-in until the behaviour is trusted on real `target/` directories.
 
-### `soldr update-zccache`
+### `soldr install-zccache`
 
 Install zccache binaries into soldr's private dir so soldr stops
 fetching the managed GitHub release. Pins a user-supplied set of three
@@ -222,10 +222,10 @@ zccache binaries (`zccache`, `zccache-daemon`, `zccache-fp`) into
 invocations resolve the pinned binaries automatically.
 
 ```bash
-soldr update-zccache <SOURCE>   # system | <path> | <url>
-soldr update-zccache --remove   # un-pin, idempotent
-soldr update-zccache --status   # report sidecar + drift
-soldr update-zccache --json     # structured output
+soldr install-zccache <SOURCE>   # system | <path> | <url>
+soldr install-zccache --remove   # un-pin, idempotent
+soldr install-zccache --status   # report sidecar + drift
+soldr install-zccache --json     # structured output
 ```
 
 `<SOURCE>` accepts:


### PR DESCRIPTION
## Why

The freshly-merged PR #401 (`feat: soldr update-zccache`) landed with a name-layer split: CLI verb was `update-zccache`, library functions said `install_zccache_*`, and user-visible error strings were a mix. After review, **`install`** is the idiomatic verb for "put binaries under tool-managed control" — matches `cargo install`, `rustup toolchain install`, `brew install`, `gh extension install`, `apt install`, `pip install`. `update` means "go fetch newer from upstream" (apt update, rustup update, gh extension upgrade), and our command has no notion of upstream — the user passes the source on every call.

This PR normalizes everything to `install-zccache`. Library names and on-disk dir (`zccache-pinned/`) were already correct and stay; the on-disk word `pinned` is a *state*, not an action, and reads naturally as "installed and pinned" (mirrors `brew pin`).

## What's renamed

**Two commits:**

- `c4b991e` — `refactor(cli): rename "update-zccache" → "install-zccache" (CLI normalization)`
  - clap subcommand `update-zccache` → `install-zccache`
  - `Commands::UpdateZccache` → `Commands::InstallZccache`
  - All `run_update_zccache_*` handlers → `run_install_zccache_*`
  - All `UpdateZccache*Output` structs → `InstallZccache*Output`
  - JSON `command` field literals (`"update-zccache"` → `"install-zccache"`, same for `--remove` and `--status` variants)
  - User-visible stdout / doctor strings (`soldr update-zccache …` → `soldr install-zccache …`)
  - Test file `cli_update_zccache.rs` → `cli_install_zccache.rs` (77% similarity preserved by git rename detection) + all test fn names + argv assertions inside
  - `docs/API.md` section heading and examples

- `8fcaf69` — `refactor(fetch): sweep stale "update-zccache" strings in library + tests`
  - 20 user-visible error message prefixes in `crates/soldr-fetch/src/install_zccache.rs` (`"update-zccache: source must not be empty"` etc. → `"install-zccache: …"`)
  - 7 doc-comment / in-code references to the CLI verb in `install_zccache.rs` and `lib.rs`
  - Library test file's module doc-comment (`//! Integration tests for \`soldr update-zccache\`` → `… \`soldr install-zccache\``)
  - Pure string / comment edits, zero identifier or logic changes

## Untouched (already correct)

- Library identifiers: `install_zccache_from_source`, module `install_zccache.rs`, library test file `install_zccache.rs`
- On-disk dir `<SoldrPaths::bin>/zccache-pinned/` and constant `PINNED_ZCCACHE_DIRNAME`
- Doctor section heading `pinned zccache:` (state name)
- `ZccacheSource::Pinned` enum variant (state name)
- Sidecar `source.json` schema, including `installed_at` (timestamp)

## Verification

After both commits: `git grep "update-zccache|update_zccache|UpdateZccache"` across the repo returns **zero** matches.

## Test plan

- [x] `./test` Rust steps green (the rename sub-agent confirmed; the library cleanup is pure string edits with no logic change, no test assertion impact).
- [ ] CI green on the PR.
- [ ] Maintainer eyeballs the rename for parity with other CLI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
