### PR TITLE
fix: SOLDR_ZCCACHE_LOCAL_DIR daemon resolution + MSVC underscore PDB discovery (#365)

### DIFF
--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -1463,10 +1463,7 @@ fn run_install_zccache_remove(json: bool) -> Result<(), SoldrError> {
         };
         print_json(&output)?;
     } else if removed {
-        println!(
-            "soldr install-zccache --remove: removed {}",
-            dir.display()
-        );
+        println!("soldr install-zccache --remove: removed {}", dir.display());
     } else {
         println!(
             "soldr install-zccache --remove: no pinned install at {} (nothing to do)",

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -137,6 +137,16 @@ async fn prepare_zccache_build(
         ZccacheSourceArg::System => soldr_fetch::resolve_system_zccache(paths)?,
     };
 
+    // When the resolved zccache CLI binary differs from the one a
+    // previous soldr invocation started the daemon with, the live
+    // daemon is stale relative to what we just resolved. This matters
+    // most for `SOLDR_ZCCACHE_LOCAL_DIR` debugging (issue #365): the
+    // user expects `cargo` invocations to actually run their freshly
+    // built daemon, but `zccache start` is a no-op when any daemon
+    // is already alive, so a managed daemon from a previous build
+    // would keep handling requests. Evict it explicitly here.
+    evict_zccache_daemon_if_binary_changed(&fetch.binary_path, &zccache_dir)?;
+
     start_zccache_with_recovery(&fetch.binary_path, &zccache_dir)?;
 
     let session_log_path = soldr_cache::session_log_path(&zccache_dir);
@@ -396,6 +406,69 @@ pub(crate) fn run_zccache_command_strings_in_cache_dir(
     })
 }
 
+/// Name of the marker file inside the zccache cache dir that records
+/// which CLI binary path soldr last started a daemon with. When the
+/// resolved binary path changes between runs (e.g. user toggled
+/// `SOLDR_ZCCACHE_LOCAL_DIR`, bumped `MANAGED_ZCCACHE_VERSION`, or
+/// rebuilt zccache locally so its content-hashed dir name changed),
+/// soldr evicts the live daemon before starting so the next
+/// `zccache start` actually spawns the new binary. Issue #365.
+pub(crate) const ZCCACHE_LAST_CLI_BINARY_SENTINEL: &str = "soldr-last-cli-binary";
+
+/// Pure decision: should soldr evict the running zccache daemon
+/// before starting a fresh one?
+///
+/// `current` is the absolute path of the CLI binary the current
+/// invocation just resolved. `previous` is the contents of the
+/// sentinel file from the last invocation (already trimmed), or
+/// `None` if the sentinel is absent or unreadable.
+///
+/// First run (no sentinel) returns `false` — nothing to evict.
+/// Path change returns `true`. Same path returns `false`.
+pub(crate) fn should_evict_zccache_daemon(current: &str, previous: Option<&str>) -> bool {
+    match previous {
+        None => false,
+        Some(prev) if prev == current => false,
+        Some(_) => true,
+    }
+}
+
+/// If a previous invocation recorded a different CLI binary path,
+/// run `zccache stop` to evict the stale daemon. Best-effort: any
+/// I/O failure is logged but not propagated, because the start path
+/// below has its own stale-daemon recovery.
+pub(crate) fn evict_zccache_daemon_if_binary_changed(
+    binary: &std::path::Path,
+    cache_dir: &std::path::Path,
+) -> Result<(), SoldrError> {
+    let sentinel = cache_dir.join(ZCCACHE_LAST_CLI_BINARY_SENTINEL);
+    let resolved = binary.display().to_string();
+    let prev = std::fs::read_to_string(&sentinel)
+        .ok()
+        .map(|s| s.trim().to_string());
+
+    if should_evict_zccache_daemon(&resolved, prev.as_deref()) {
+        eprintln!(
+            "soldr: zccache CLI binary changed since last build; stopping stale daemon to force a fresh spawn (issue #365)",
+        );
+        if let Err(err) = run_zccache_command_raw_in_cache_dir(binary, &["stop"], cache_dir) {
+            // Stop failures shouldn't block the build — the start
+            // path below has its own stale-daemon recovery.
+            eprintln!("soldr: zccache stop reported {err}; continuing");
+        }
+    }
+
+    // Record the current resolution so future invocations can detect
+    // the next change. Best-effort write — failure here is non-fatal.
+    if let Err(err) = std::fs::write(&sentinel, &resolved) {
+        eprintln!(
+            "soldr: failed to record current zccache CLI binary at {}: {err}",
+            sentinel.display()
+        );
+    }
+    Ok(())
+}
+
 pub(crate) fn start_zccache_with_recovery(
     binary: &std::path::Path,
     cache_dir: &std::path::Path,
@@ -637,5 +710,53 @@ mod tests {
         // in the inherited environment.
         assert_eq!(resolve_path_remap_env(Some("auto"), None), None);
         assert_eq!(resolve_path_remap_env(Some("auto"), Some("off")), None);
+    }
+
+    // ---------------------------------------------------------------
+    // Stale-daemon eviction when the resolved CLI binary changes
+    // between soldr invocations (issue #365).
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn evict_decision_skips_first_run_with_no_sentinel() {
+        // Nothing recorded yet — no daemon to evict.
+        assert!(!should_evict_zccache_daemon(
+            "/path/zccache-1.8.1/zccache.exe",
+            None
+        ));
+    }
+
+    #[test]
+    fn evict_decision_skips_when_path_unchanged() {
+        let current = "/path/zccache-1.8.1/zccache.exe";
+        assert!(!should_evict_zccache_daemon(current, Some(current)));
+    }
+
+    #[test]
+    fn evict_decision_triggers_when_local_dir_overrides_managed() {
+        // The user just exported SOLDR_ZCCACHE_LOCAL_DIR but a stale
+        // managed daemon is still alive. Issue #365 acceptance: the
+        // next soldr invocation must evict.
+        let previous = "/home/u/.soldr/bin/zccache-1.8.1/zccache.exe";
+        let current = "/home/u/.soldr/bin/zccache-local-219d33e77197/zccache.exe";
+        assert!(should_evict_zccache_daemon(current, Some(previous)));
+    }
+
+    #[test]
+    fn evict_decision_triggers_when_local_dir_rebuilt() {
+        // User rebuilt zccache; content hash changed; the resolved
+        // CLI path is a different `zccache-local-<hash>` directory.
+        let previous = "/home/u/.soldr/bin/zccache-local-aaaaaaaaaaaa/zccache.exe";
+        let current = "/home/u/.soldr/bin/zccache-local-bbbbbbbbbbbb/zccache.exe";
+        assert!(should_evict_zccache_daemon(current, Some(previous)));
+    }
+
+    #[test]
+    fn evict_decision_triggers_when_local_dir_reverts_to_managed() {
+        // User unset SOLDR_ZCCACHE_LOCAL_DIR — switching back to the
+        // managed path must also evict the stale local daemon.
+        let previous = "/home/u/.soldr/bin/zccache-local-219d33e77197/zccache.exe";
+        let current = "/home/u/.soldr/bin/zccache-1.8.1/zccache.exe";
+        assert!(should_evict_zccache_daemon(current, Some(previous)));
     }
 }

--- a/crates/soldr-cli/tests/cli_doctor.rs
+++ b/crates/soldr-cli/tests/cli_doctor.rs
@@ -353,6 +353,32 @@ fn doctor_surfaces_local_zccache_override_when_env_var_set() {
             .and_then(|s| s.to_str()),
         Some("local-build")
     );
+
+    // Issue #365 — every binary soldr resolves (cli, daemon, fp) must
+    // live under the override dir. The previous coverage only asserted
+    // the runtime_dir hash; this confirms the per-binary paths the
+    // child process actually executes are all under it. This is the
+    // path soldr propagates to cargo via SOLDR_ZCCACHE_BIN and the
+    // path the zccache CLI uses for its sibling-daemon lookup.
+    let cli_path = json["managed_zccache"]["cli_path"]
+        .as_str()
+        .expect("cli_path present");
+    let daemon_path = json["managed_zccache"]["daemon_path"]
+        .as_str()
+        .expect("daemon_path present");
+    let fp_path = json["managed_zccache"]["fp_path"]
+        .as_str()
+        .expect("fp_path present");
+    for (label, value) in [("cli", cli_path), ("daemon", daemon_path), ("fp", fp_path)] {
+        assert!(
+            value.starts_with(runtime_dir),
+            "{label}_path must live under runtime_dir; runtime_dir={runtime_dir} {label}_path={value}"
+        );
+        assert!(
+            value.contains("zccache-local-"),
+            "{label}_path must resolve under the SOLDR_ZCCACHE_LOCAL_DIR-derived dir: {value}"
+        );
+    }
 }
 
 #[test]

--- a/crates/soldr-fetch/src/lib.rs
+++ b/crates/soldr-fetch/src/lib.rs
@@ -322,18 +322,26 @@ pub(crate) fn copy_debug_info_sidecars(
     // Windows: <binary>.pdb (sibling file).
     // Linux: <binary>.dwp (sibling file).
     // macOS: <binary>.dSYM (sibling directory).
+    //
+    // Rust + MSVC emits PDBs whose stem is the crate name with hyphens
+    // replaced by underscores (e.g. `zccache-daemon.exe` ships
+    // `zccache_daemon.pdb`). Search both naming variants so we never
+    // silently miss an MSVC sidecar (issue #365).
     for sidecar_ext in ["pdb", "dwp"] {
-        if let Some(src) = adjacent_with_extension(src_binary, sidecar_ext) {
+        for src in adjacent_sidecar_candidates(src_binary, sidecar_ext) {
             if src.is_file() {
-                if let Some(dst) = adjacent_with_extension(dst_binary, sidecar_ext) {
+                // Mirror the source basename into the destination so
+                // the copied PDB lines up with the debug record cdb
+                // reads out of the binary header.
+                if let Some(dst) = sidecar_dst_matching_src(&src, dst_binary, sidecar_ext) {
                     copy_if_changed(&src, &dst)?;
                 }
             }
         }
     }
-    if let Some(src) = adjacent_with_extension(src_binary, "dSYM") {
+    for src in adjacent_sidecar_candidates(src_binary, "dSYM") {
         if src.is_dir() {
-            if let Some(dst) = adjacent_with_extension(dst_binary, "dSYM") {
+            if let Some(dst) = sidecar_dst_matching_src(&src, dst_binary, "dSYM") {
                 copy_dir_recursive(&src, &dst)?;
             }
         }
@@ -348,6 +356,44 @@ pub(crate) fn adjacent_with_extension(binary: &Path, ext: &str) -> Option<PathBu
     name.push(".");
     name.push(ext);
     Some(parent.join(name))
+}
+
+/// Sidecar lookup candidates for `binary`, trying first the literal
+/// stem and then the hyphen-to-underscore variant (Rust+MSVC PDB
+/// naming). Issue #365.
+pub(crate) fn adjacent_sidecar_candidates(binary: &Path, ext: &str) -> Vec<PathBuf> {
+    let mut out = Vec::with_capacity(2);
+    if let Some(primary) = adjacent_with_extension(binary, ext) {
+        out.push(primary);
+    }
+    if let (Some(stem), Some(parent)) =
+        (binary.file_stem().and_then(|s| s.to_str()), binary.parent())
+    {
+        if stem.contains('-') {
+            let underscored = stem.replace('-', "_");
+            out.push(parent.join(format!("{underscored}.{ext}")));
+        }
+    }
+    out
+}
+
+/// Pick the destination filename when copying a discovered sidecar
+/// next to `dst_binary`. If `src` already uses the underscored MSVC
+/// variant (e.g. `zccache_daemon.pdb`), preserve that name so the
+/// debug-info record embedded in the binary continues to match.
+fn sidecar_dst_matching_src(src: &Path, dst_binary: &Path, ext: &str) -> Option<PathBuf> {
+    let src_name = src.file_name()?;
+    let dst_parent = dst_binary.parent()?;
+    let primary = adjacent_with_extension(dst_binary, ext);
+    let primary_matches = primary
+        .as_ref()
+        .and_then(|p| p.file_name())
+        .is_some_and(|name| name == src_name);
+    if primary_matches {
+        primary
+    } else {
+        Some(dst_parent.join(src_name))
+    }
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), SoldrError> {
@@ -542,18 +588,23 @@ fn count_debug_info_sidecars(binaries: &[&Path]) -> (usize, usize) {
             continue;
         }
         let mut sidecar_found = false;
-        for ext in ["pdb", "dwp"] {
-            if let Some(sidecar) = adjacent_with_extension(binary, ext) {
+        // Try `pdb` and `dwp` against both the literal binary stem and
+        // the hyphen-to-underscore variant — Rust+MSVC writes PDBs as
+        // `<crate_name>.pdb` even when the binary is `<crate-name>.exe`
+        // (issue #365).
+        'file_exts: for ext in ["pdb", "dwp"] {
+            for sidecar in adjacent_sidecar_candidates(binary, ext) {
                 if sidecar.is_file() {
                     sidecar_found = true;
-                    break;
+                    break 'file_exts;
                 }
             }
         }
         if !sidecar_found {
-            if let Some(sidecar) = adjacent_with_extension(binary, "dSYM") {
+            for sidecar in adjacent_sidecar_candidates(binary, "dSYM") {
                 if sidecar.is_dir() {
                     sidecar_found = true;
+                    break;
                 }
             }
         }
@@ -1819,6 +1870,96 @@ mod tests {
             !dst_dir.join("zccache-fp.pdb").exists(),
             "fp.pdb wasn't in the source, so it shouldn't appear in the destination"
         );
+    }
+
+    #[test]
+    fn local_zccache_copies_msvc_underscored_pdb_sidecars() {
+        // Rust + MSVC writes PDBs as `<crate_name>.pdb`, replacing
+        // hyphens with underscores. The hyphen-only matcher in
+        // `adjacent_with_extension` missed these so a fresh MSVC
+        // release build of zccache reported `pdbs found: 1/3`
+        // (issue #365).
+        let tmp = tempfile::tempdir().unwrap();
+        let local_dir = tmp.path().join("local-build");
+        write_fake_binary(&local_dir, "zccache.exe", b"cli-bytes");
+        write_fake_binary(&local_dir, "zccache-daemon.exe", b"daemon-bytes");
+        write_fake_binary(&local_dir, "zccache-fp.exe", b"fp-bytes");
+        // All three PDBs in MSVC naming.
+        write_fake_binary(&local_dir, "zccache.pdb", b"cli-pdb");
+        write_fake_binary(&local_dir, "zccache_daemon.pdb", b"daemon-pdb");
+        write_fake_binary(&local_dir, "zccache_fp.pdb", b"fp-pdb");
+
+        let soldr_root = tmp.path().join("soldr");
+        let paths = SoldrPaths::with_root(soldr_root);
+
+        let result =
+            resolve_local_zccache_for_target(&local_dir, &paths, &windows_target()).unwrap();
+        let dst_dir = result.binary_path.parent().unwrap();
+        // PDBs land at the destination under their MSVC names so the
+        // CodeView debug record embedded in the binary continues to
+        // match (cdb compares by GUID, but only after locating the file
+        // by basename — keep the same basename).
+        assert!(
+            dst_dir.join("zccache.pdb").exists(),
+            "cli PDB should be copied: {dst_dir:?}",
+        );
+        assert!(
+            dst_dir.join("zccache_daemon.pdb").exists(),
+            "underscored daemon PDB should be copied: {dst_dir:?}",
+        );
+        assert!(
+            dst_dir.join("zccache_fp.pdb").exists(),
+            "underscored fp PDB should be copied: {dst_dir:?}",
+        );
+
+        // Doctor's debug-info counter must agree — issue #365 acceptance
+        // criterion says a fresh MSVC build should report `3/3`.
+        let (found, expected) = count_debug_info_sidecars(&[
+            dst_dir.join("zccache.exe").as_path(),
+            dst_dir.join("zccache-daemon.exe").as_path(),
+            dst_dir.join("zccache-fp.exe").as_path(),
+        ]);
+        assert_eq!(expected, 3);
+        assert_eq!(found, 3, "all three PDBs must be discovered");
+    }
+
+    #[test]
+    fn count_debug_info_sidecars_finds_underscored_pdb_variants() {
+        // Direct unit test for the doctor counter — exercised without
+        // going through resolve_local_zccache_for_target. Plants a
+        // synthetic tree with MSVC-style underscored PDBs and confirms
+        // all three are counted.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("zccache.exe"), b"cli").unwrap();
+        std::fs::write(dir.join("zccache-daemon.exe"), b"daemon").unwrap();
+        std::fs::write(dir.join("zccache-fp.exe"), b"fp").unwrap();
+        std::fs::write(dir.join("zccache.pdb"), b"cli-pdb").unwrap();
+        std::fs::write(dir.join("zccache_daemon.pdb"), b"daemon-pdb").unwrap();
+        std::fs::write(dir.join("zccache_fp.pdb"), b"fp-pdb").unwrap();
+
+        let (found, expected) = count_debug_info_sidecars(&[
+            dir.join("zccache.exe").as_path(),
+            dir.join("zccache-daemon.exe").as_path(),
+            dir.join("zccache-fp.exe").as_path(),
+        ]);
+        assert_eq!(expected, 3);
+        assert_eq!(found, 3, "all three PDBs should be discovered");
+    }
+
+    #[test]
+    fn count_debug_info_sidecars_still_finds_hyphenated_pdbs() {
+        // Some toolchains (or hand-renamed assets) emit hyphenated
+        // PDBs. Keep them working alongside the underscored variant.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("zccache-daemon.exe"), b"daemon").unwrap();
+        std::fs::write(dir.join("zccache-daemon.pdb"), b"daemon-pdb").unwrap();
+
+        let (found, expected) =
+            count_debug_info_sidecars(&[dir.join("zccache-daemon.exe").as_path()]);
+        assert_eq!(expected, 1);
+        assert_eq!(found, 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #365

## Where the leak was and how it's fixed

After tracing every place soldr writes a zccache binary path into the env or a config file, the only daemon-side leak surface is `start_zccache_with_recovery` → `zccache start`. zccache itself looks up its daemon binary via `find_daemon_binary` (sibling-of-cli + PATH fallback) and relocates it to `<global_cache_dir>/runtime-binaries/zccache-daemon.<rand>.<ext>` before spawning — soldr only ever propagates the CLI path (`SOLDR_ZCCACHE_BIN`), never a daemon path. The runtime-binaries entry the issue calls out is therefore the *output* of zccache's `prepare_daemon_exe`, not a soldr-leaked managed path.

The actual symptom — "daemon is the managed-released binary" — comes from `zccache start` being a no-op while any daemon is alive. After the user flips `SOLDR_ZCCACHE_LOCAL_DIR` on (or rebuilds zccache so its content-hashed runtime dir flips), the freshly resolved local-build CLI talks to the *previous* build's still-running daemon, and PR #363's symbol-path workflow can't help: the loaded module is the prior managed binary. The fix records the resolved CLI binary path in a sentinel inside the zccache cache dir; when the next invocation resolves a different path, soldr runs `zccache stop` before `zccache start` so the daemon respawns from the new binary. Stop failures are non-fatal — the existing start-recovery path handles them.

## PDB naming fix

PR #363 only matched `<binary-name>.pdb`, but Rust+MSVC writes PDBs whose stem replaces hyphens with underscores in the crate name (`zccache-daemon.exe` ships `zccache_daemon.pdb`). On a fresh MSVC release build `soldr doctor` therefore reported `pdbs found: 1/3` instead of `3/3`. The sidecar discovery helpers now try both `<binary-name>.pdb` and the underscore variant, the copier preserves the source basename so the CodeView debug record embedded in the binary continues to resolve, and `count_debug_info_sidecars` agrees with the copier on both naming conventions.

## Test plan

All commands routed through `soldr cargo` as required by CLAUDE.md / `.claude/hooks/tool_guard.py`:

- `soldr cargo fmt --all -- --check` — clean (also includes one unrelated rustfmt fix in `cache.rs` that was already broken on main).
- `soldr cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `soldr cargo test -p soldr-fetch --lib` — 49/49 (3 new tests: `local_zccache_copies_msvc_underscored_pdb_sidecars`, `count_debug_info_sidecars_finds_underscored_pdb_variants`, `count_debug_info_sidecars_still_finds_hyphenated_pdbs`).
- `soldr cargo test -p soldr-cli --bin soldr` — 192/192 (5 new tests covering `should_evict_zccache_daemon` for first-run, unchanged, local-overrides-managed, local-dir rebuild, and local-reverts-to-managed cases).
- `soldr cargo test -p soldr-cli --test cli_doctor` — 5/5 (the existing `doctor_surfaces_local_zccache_override_when_env_var_set` integration test now asserts `cli_path`, `daemon_path`, and `fp_path` all live under the override-derived `runtime_dir`).
- `soldr cargo test -p soldr-cli --test cli_cargo_wrappers` — 14/14 (no regression in the cargo-front-door flow that calls `prepare_zccache_build`).
- `soldr cargo test -p soldr-cli --test cli_unknown_session_retry` — 3/3 (no regression in `start_zccache_with_recovery`).
- `soldr cargo test -p soldr-cli --test cli_install_zccache` — 6/6.
- `soldr cargo test -p soldr-fetch --test install_zccache` — 12/12 (install_zccache shares the sidecar-copy code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)