### PR TITLE
fix(trampoline): hash .cargo/config.toml content into fingerprint (#346)

### DIFF
--- a/crates/soldr-cli/src/trampoline.rs
+++ b/crates/soldr-cli/src/trampoline.rs
@@ -718,6 +718,12 @@ struct FingerprintInputs<'a> {
     manifest_path: String,
     rustflags: String,
     rustc_identity: String,
+    /// Digest of every `.cargo/config.toml` (+ legacy `.cargo/config`)
+    /// cargo would discover walking from the manifest dir up to the
+    /// filesystem root, plus `$CARGO_HOME/config.toml`. Added for #346:
+    /// the trampoline previously only hashed `RUSTFLAGS` from the env,
+    /// so a config-file edit silently fast-pathed the stale binary.
+    cargo_config_digest: String,
 }
 
 pub(crate) fn compute_fingerprint(parsed: &ParsedRunArgs) -> Result<String, SoldrError> {
@@ -739,6 +745,10 @@ pub(crate) fn compute_fingerprint(parsed: &ParsedRunArgs) -> Result<String, Sold
         .or_else(find_nearest_manifest)
         .ok_or_else(|| SoldrError::Other("Cargo.toml not found for fingerprint".into()))?;
     let canonical = fs::canonicalize(&manifest_path).unwrap_or(manifest_path);
+    let manifest_dir = canonical
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
     let manifest_string = canonical.to_string_lossy().to_string();
 
     let mut features: Vec<String> = parsed.features.clone();
@@ -747,6 +757,7 @@ pub(crate) fn compute_fingerprint(parsed: &ParsedRunArgs) -> Result<String, Sold
 
     let rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
     let rustc_identity = rustc_identity_cached()?;
+    let cargo_config_digest = cargo_config_digest(&manifest_dir);
 
     let effective_target = effective_target_triple(parsed);
     let inputs = FingerprintInputs {
@@ -758,6 +769,7 @@ pub(crate) fn compute_fingerprint(parsed: &ParsedRunArgs) -> Result<String, Sold
         manifest_path: manifest_string,
         rustflags,
         rustc_identity,
+        cargo_config_digest,
     };
 
     let bytes = serde_json::to_vec(&inputs)
@@ -795,6 +807,15 @@ fn rustc_identity_cached() -> Result<String, SoldrError> {
 #[path = "trampoline_dep_info.rs"]
 mod dep_info;
 pub(crate) use dep_info::parse_dep_info_for_output;
+
+// ---------------------------------------------------------------------------
+// `.cargo/config.toml` content digest (issue #346) — see [`config`] sibling
+// module.
+// ---------------------------------------------------------------------------
+
+#[path = "trampoline_config.rs"]
+mod config;
+pub(crate) use config::cargo_config_digest;
 
 // ---------------------------------------------------------------------------
 // Exec / stat / logging helpers

--- a/crates/soldr-cli/src/trampoline_config.rs
+++ b/crates/soldr-cli/src/trampoline_config.rs
@@ -1,0 +1,161 @@
+//! `.cargo/config.toml` walker + content digest for the trampoline
+//! fingerprint (issue #346).
+//!
+//! The trampoline previously hashed only `RUSTFLAGS` from the environment.
+//! Cargo also reads rustflags (and a pile of other build-affecting
+//! settings) from `.cargo/config.toml`. Editing the config file silently
+//! left the fingerprint untouched, so the trampoline kept fast-pathing
+//! the stale binary.
+//!
+//! Mirroring cargo's full config resolution (precedence, target tables,
+//! `--config` CLI overrides, etc.) is a non-trivial amount of code. The
+//! issue (#346) explicitly accepts a simpler tradeoff for slice 2 of
+//! #342: hash the raw bytes of every `.cargo/config.toml` cargo could
+//! see, mix the digest into the fingerprint, and accept that editing an
+//! unrelated section (`[net]`, `[registries]`, etc.) will also bust the
+//! fingerprint.
+//!
+//! Walk order matches cargo's documented hierarchical lookup:
+//!   1. From the manifest dir upward to filesystem root, checking
+//!      `.cargo/config.toml` and the legacy `.cargo/config` at each
+//!      level.
+//!   2. `$CARGO_HOME/config.toml` (and legacy `$CARGO_HOME/config`),
+//!      where `CARGO_HOME` defaults to `~/.cargo`.
+//!
+//! Files that don't exist contribute nothing — appearing or disappearing
+//! changes the digest exactly as if their bytes changed.
+//!
+//! The digest is intentionally cheap: blake3 over a sorted list of
+//! `(canonical-path, bytes)` pairs. No TOML parsing, no canonical
+//! re-serialization. We pay the cost of reading a handful of small
+//! config files on every trampoline check — small change compared to
+//! either spawning cargo or recompiling.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Compute the cargo-config digest mixed into the trampoline
+/// fingerprint. Returns `"blake3:<hex>"`. The digest covers every
+/// `.cargo/config.toml` (+ legacy `.cargo/config`) discovered by walking
+/// from `manifest_dir` up to the filesystem root, plus
+/// `$CARGO_HOME/config.toml` (default `~/.cargo/config.toml`).
+///
+/// Missing files contribute nothing; appearing or disappearing changes
+/// the digest exactly as if file content had been edited.
+pub(crate) fn cargo_config_digest(manifest_dir: &Path) -> String {
+    let files = discover_cargo_config_files(manifest_dir);
+    let mut hasher = blake3::Hasher::new();
+    // Domain-separate this digest so a future caller can never accidentally
+    // collide with another blake3 input mixed into the same fingerprint.
+    hasher.update(b"soldr-trampoline-cargo-config-v1\0");
+    for path in &files {
+        let path_str = path.to_string_lossy();
+        // Length-prefix the path so the boundary between path and bytes
+        // is unambiguous (otherwise "ab" + "cd" hashes the same as "abc"
+        // + "d").
+        let path_bytes = path_str.as_bytes();
+        hasher.update(&(path_bytes.len() as u64).to_le_bytes());
+        hasher.update(path_bytes);
+        match std::fs::read(path) {
+            Ok(bytes) => {
+                hasher.update(&(bytes.len() as u64).to_le_bytes());
+                hasher.update(&bytes);
+            }
+            Err(_) => {
+                // Race: file existed during discovery, gone now. Treat
+                // as zero-length; the next invocation will pick up the
+                // real state.
+                hasher.update(&0u64.to_le_bytes());
+            }
+        }
+    }
+    format!("blake3:{}", hasher.finalize().to_hex())
+}
+
+/// Walk from `manifest_dir` upward and collect every cargo config file
+/// cargo would consider, plus the per-user config under `$CARGO_HOME`.
+///
+/// Returned paths are canonicalized when possible and deduplicated. The
+/// order is ascending by canonical path string so the resulting digest
+/// is stable regardless of discovery order.
+pub(crate) fn discover_cargo_config_files(manifest_dir: &Path) -> Vec<PathBuf> {
+    // BTreeMap keeps the final list sorted by canonical path string and
+    // dedupes naturally — important on Windows where `\\?\` prefixes and
+    // case folding can produce duplicates.
+    let mut seen: BTreeMap<String, PathBuf> = BTreeMap::new();
+
+    // 1. Walk the manifest dir up to the filesystem root.
+    let mut cursor: Option<PathBuf> = Some(manifest_dir.to_path_buf());
+    while let Some(dir) = cursor {
+        for candidate in cargo_config_candidates_in(&dir) {
+            insert_if_present(&mut seen, &candidate);
+        }
+        cursor = dir.parent().map(Path::to_path_buf);
+    }
+
+    // 2. $CARGO_HOME/config.toml and the legacy $CARGO_HOME/config.
+    if let Some(home) = cargo_home_dir() {
+        for candidate in cargo_config_candidates_in(&home) {
+            insert_if_present(&mut seen, &candidate);
+        }
+    }
+
+    seen.into_values().collect()
+}
+
+/// Paths cargo will look for inside a given directory's `.cargo/`
+/// subdirectory. `config.toml` is the modern name; bare `config` is the
+/// legacy fallback cargo still honors. Order doesn't matter — the caller
+/// sorts.
+fn cargo_config_candidates_in(dir: &Path) -> [PathBuf; 2] {
+    let cargo_dir = dir.join(".cargo");
+    [cargo_dir.join("config.toml"), cargo_dir.join("config")]
+}
+
+/// $CARGO_HOME → directory holding cargo's per-user config. Default is
+/// `~/.cargo`. Returns `None` if neither env var nor home dir is
+/// resolvable, which means we just skip the per-user config (the walk
+/// of the manifest dir still contributes).
+fn cargo_home_dir() -> Option<PathBuf> {
+    if let Some(v) = std::env::var_os("CARGO_HOME") {
+        if !v.is_empty() {
+            return Some(PathBuf::from(v));
+        }
+    }
+    home_dir().map(|h| h.join(".cargo"))
+}
+
+/// Cross-platform `~`. We don't pull in `dirs` for this — only one
+/// caller, and `$HOME` / `$USERPROFILE` cover the practical cases.
+fn home_dir() -> Option<PathBuf> {
+    if let Some(v) = std::env::var_os("HOME") {
+        if !v.is_empty() {
+            return Some(PathBuf::from(v));
+        }
+    }
+    #[cfg(windows)]
+    {
+        if let Some(v) = std::env::var_os("USERPROFILE") {
+            if !v.is_empty() {
+                return Some(PathBuf::from(v));
+            }
+        }
+    }
+    None
+}
+
+/// Insert `candidate` into `seen` keyed by canonical path string if the
+/// file exists. Canonicalization is best-effort — if it fails we fall
+/// back to the raw path so we still record the file content.
+fn insert_if_present(seen: &mut BTreeMap<String, PathBuf>, candidate: &Path) {
+    if !candidate.is_file() {
+        return;
+    }
+    let canonical = std::fs::canonicalize(candidate).unwrap_or_else(|_| candidate.to_path_buf());
+    let key = canonical.to_string_lossy().to_string();
+    seen.entry(key).or_insert(canonical);
+}
+
+#[cfg(test)]
+#[path = "trampoline_config_tests.rs"]
+mod tests;

--- a/crates/soldr-cli/src/trampoline_config_tests.rs
+++ b/crates/soldr-cli/src/trampoline_config_tests.rs
@@ -1,0 +1,247 @@
+//! Unit tests for `trampoline_config`: the cargo-config walker and the
+//! content digest.
+
+use super::*;
+use std::fs;
+use std::sync::Mutex;
+
+/// Env vars (`CARGO_HOME`, `HOME`, `USERPROFILE`) are process-global, so
+/// tests that mutate them must serialize. cargo test runs unit tests in
+/// parallel by default and we want to keep that for everything else, so
+/// every env-touching test in this module grabs this lock first.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Build a tempdir-anchored test bed and return `(tempdir, manifest_dir,
+/// cargo_home)`. We override `CARGO_HOME` and `HOME` per test so the
+/// walker can't reach into the developer's real `~/.cargo`.
+fn temp_layout(label: &str) -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let _ = label;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manifest_dir = tmp.path().join("proj");
+    fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+    let cargo_home = tmp.path().join("cargo-home");
+    fs::create_dir_all(&cargo_home).expect("create cargo home");
+    (tmp, manifest_dir, cargo_home)
+}
+
+fn write_config(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
+    let cargo_dir = dir.join(".cargo");
+    fs::create_dir_all(&cargo_dir).expect("create .cargo");
+    let path = cargo_dir.join("config.toml");
+    fs::write(&path, body).expect("write config.toml");
+    path
+}
+
+/// Helper that scopes env-var mutations for the duration of one test.
+/// `std::env::set_var` is process-global; with `cargo test` running
+/// these tests serially within the binary, restoring on drop is enough.
+struct EnvGuard {
+    keys: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl EnvGuard {
+    fn new() -> Self {
+        Self { keys: Vec::new() }
+    }
+    fn set(&mut self, key: &'static str, value: &std::path::Path) {
+        let prev = std::env::var_os(key);
+        std::env::set_var(key, value);
+        self.keys.push((key, prev));
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, prev) in self.keys.drain(..) {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+#[test]
+fn discovers_configs_walking_up_three_levels() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (_tmp, manifest_dir, cargo_home) = temp_layout("walk-three-levels");
+    let mut env = EnvGuard::new();
+    env.set("CARGO_HOME", &cargo_home);
+    // Point HOME at the tempdir too so the walker can't escape.
+    env.set("HOME", _tmp.path());
+    #[cfg(windows)]
+    env.set("USERPROFILE", _tmp.path());
+
+    // Layout: tmp/a/b/c/proj/Cargo.toml — `proj` is the manifest dir.
+    // Place .cargo/config.toml at depths 1, 2, and 3 above it.
+    let deep_manifest = manifest_dir.join("a").join("b").join("c").join("proj");
+    fs::create_dir_all(&deep_manifest).expect("create deep manifest");
+    let depth_1 = write_config(deep_manifest.parent().unwrap(), "[build]\n");
+    let depth_2 = write_config(deep_manifest.parent().unwrap().parent().unwrap(), "[net]\n");
+    let depth_3 = write_config(
+        deep_manifest
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap(),
+        "[registries]\n",
+    );
+
+    let files = discover_cargo_config_files(&deep_manifest);
+    let strs: Vec<String> = files
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    let canon = |p: &std::path::Path| {
+        fs::canonicalize(p)
+            .unwrap_or_else(|_| p.to_path_buf())
+            .to_string_lossy()
+            .to_string()
+    };
+    assert!(strs.contains(&canon(&depth_1)), "missing depth 1: {strs:?}");
+    assert!(strs.contains(&canon(&depth_2)), "missing depth 2: {strs:?}");
+    assert!(strs.contains(&canon(&depth_3)), "missing depth 3: {strs:?}");
+
+    // Sorted by canonical path string — deterministic.
+    let mut sorted = strs.clone();
+    sorted.sort();
+    assert_eq!(strs, sorted, "discovered files should be sorted");
+}
+
+#[test]
+fn discovers_cargo_home_config() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (_tmp, manifest_dir, cargo_home) = temp_layout("cargo-home");
+    let mut env = EnvGuard::new();
+    env.set("CARGO_HOME", &cargo_home);
+    env.set("HOME", _tmp.path());
+    #[cfg(windows)]
+    env.set("USERPROFILE", _tmp.path());
+
+    let home_config = write_config(&cargo_home, "[build]\nrustflags = []\n");
+    let files = discover_cargo_config_files(&manifest_dir);
+    let canon_home = fs::canonicalize(&home_config)
+        .unwrap_or(home_config.clone())
+        .to_string_lossy()
+        .to_string();
+    let found: Vec<String> = files
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    assert!(
+        found.iter().any(|s| s == &canon_home),
+        "cargo home config not discovered: {found:?}"
+    );
+}
+
+#[test]
+fn discovers_legacy_config_file_without_extension() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (_tmp, manifest_dir, cargo_home) = temp_layout("legacy-name");
+    let mut env = EnvGuard::new();
+    env.set("CARGO_HOME", &cargo_home);
+    env.set("HOME", _tmp.path());
+    #[cfg(windows)]
+    env.set("USERPROFILE", _tmp.path());
+
+    // Use the legacy bare-`config` name.
+    let cargo_dir = manifest_dir.join(".cargo");
+    fs::create_dir_all(&cargo_dir).expect("create .cargo");
+    let legacy = cargo_dir.join("config");
+    fs::write(&legacy, "[build]\n").expect("write legacy config");
+
+    let files = discover_cargo_config_files(&manifest_dir);
+    let canon = fs::canonicalize(&legacy)
+        .unwrap_or(legacy.clone())
+        .to_string_lossy()
+        .to_string();
+    let found: Vec<String> = files
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    assert!(
+        found.iter().any(|s| s == &canon),
+        "legacy config not discovered: {found:?}"
+    );
+}
+
+#[test]
+fn digest_changes_when_config_content_changes() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (_tmp, manifest_dir, cargo_home) = temp_layout("content-change");
+    let mut env = EnvGuard::new();
+    env.set("CARGO_HOME", &cargo_home);
+    env.set("HOME", _tmp.path());
+    #[cfg(windows)]
+    env.set("USERPROFILE", _tmp.path());
+
+    let cfg_path = write_config(
+        &manifest_dir,
+        "[build]\nrustflags = [\"-C\", \"opt-level=0\"]\n",
+    );
+    let before = cargo_config_digest(&manifest_dir);
+
+    fs::write(
+        &cfg_path,
+        "[build]\nrustflags = [\"-C\", \"opt-level=0\", \"-C\", \"debug-assertions=on\"]\n",
+    )
+    .expect("rewrite config");
+    let after = cargo_config_digest(&manifest_dir);
+
+    assert_ne!(before, after, "digest must change when rustflags change");
+}
+
+#[test]
+fn digest_changes_when_config_appears() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (_tmp, manifest_dir, cargo_home) = temp_layout("appears");
+    let mut env = EnvGuard::new();
+    env.set("CARGO_HOME", &cargo_home);
+    env.set("HOME", _tmp.path());
+    #[cfg(windows)]
+    env.set("USERPROFILE", _tmp.path());
+
+    let before = cargo_config_digest(&manifest_dir);
+    write_config(&manifest_dir, "[build]\nrustflags = []\n");
+    let after = cargo_config_digest(&manifest_dir);
+    assert_ne!(before, after, "digest must change when a config appears");
+}
+
+#[test]
+fn digest_stable_for_unchanged_inputs() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (_tmp, manifest_dir, cargo_home) = temp_layout("stable");
+    let mut env = EnvGuard::new();
+    env.set("CARGO_HOME", &cargo_home);
+    env.set("HOME", _tmp.path());
+    #[cfg(windows)]
+    env.set("USERPROFILE", _tmp.path());
+
+    write_config(
+        &manifest_dir,
+        "[build]\nrustflags = [\"-C\", \"opt-level=3\"]\n",
+    );
+    let a = cargo_config_digest(&manifest_dir);
+    let b = cargo_config_digest(&manifest_dir);
+    assert_eq!(a, b, "digest must be deterministic");
+    assert!(a.starts_with("blake3:"), "digest format: {a}");
+}
+
+#[test]
+fn digest_with_no_configs_is_well_defined() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let (_tmp, manifest_dir, cargo_home) = temp_layout("no-configs");
+    let mut env = EnvGuard::new();
+    env.set("CARGO_HOME", &cargo_home);
+    env.set("HOME", _tmp.path());
+    #[cfg(windows)]
+    env.set("USERPROFILE", _tmp.path());
+
+    let d = cargo_config_digest(&manifest_dir);
+    assert!(d.starts_with("blake3:"));
+    // Empty input is still deterministic.
+    let d2 = cargo_config_digest(&manifest_dir);
+    assert_eq!(d, d2);
+}

--- a/crates/soldr-cli/tests/cli_cargo_run_trampoline.rs
+++ b/crates/soldr-cli/tests/cli_cargo_run_trampoline.rs
@@ -325,6 +325,47 @@ fn rustflags_change_forces_fall_through() {
 }
 
 #[test]
+fn cargo_config_rustflags_edit_forces_fall_through() {
+    // Regression test for issue #346: editing `.cargo/config.toml`
+    // [build] rustflags must bust the trampoline fingerprint even when
+    // the env var `RUSTFLAGS` is unchanged.
+    let project = make_project("trampoline-cargo-config-rustflags");
+    // Seed: cold build with no .cargo/config.toml — sidecar records a
+    // fingerprint that includes the empty-config digest.
+    let cold = run_cold(&project, &[]);
+    assert!(
+        cold.status.success(),
+        "seed cold build failed:\n{}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+
+    // Add `.cargo/config.toml` declaring new rustflags. After this edit
+    // the trampoline must not fast-path the stale binary; if it does,
+    // the broken-cargo stub never runs and the assertion below fails.
+    let cargo_dir = project.join(".cargo");
+    fs::create_dir_all(&cargo_dir).expect("create .cargo");
+    fs::write(
+        cargo_dir.join("config.toml"),
+        "[build]\nrustflags = [\"-C\", \"opt-level=0\"]\n",
+    )
+    .expect("write .cargo/config.toml");
+
+    let stub_dir = unique_temp_dir("trampoline-cargo-config-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "run"],
+    );
+    assert!(
+        !out.status.success(),
+        ".cargo/config.toml [build] rustflags edit should force trampoline fall-through; broken cargo must be invoked\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
 fn release_profile_has_distinct_sidecar() {
     let project = make_project("trampoline-release");
     // Cold debug build.


### PR DESCRIPTION
Closes #346.

## Problem

`crates/soldr-cli/src/trampoline.rs` computed `cargo_args_fingerprint` over `RUSTFLAGS` from the process env only. Cargo also reads rustflags (and other build-affecting settings) from `.cargo/config.toml` — walked up from the manifest dir to the filesystem root, plus `\$CARGO_HOME/config.toml`. Editing the config file left the fingerprint untouched, so the trampoline kept fast-pathing the stale binary. The bug is silent for users who only ever invoke `soldr cargo run` (no other cargo invocation arrives to force a rebuild), which is exactly the workflow the trampoline targets.

## Fix

Per the issue's preferred slice-2 tradeoff: hash the raw bytes of every `.cargo/config.toml` cargo could see, mix the digest into the trampoline fingerprint. No TOML parsing, no cargo invocation.

New `trampoline_config` module exposes `cargo_config_digest(manifest_dir)`:

- Walks from the manifest dir upward; at each level checks `.cargo/config.toml` then the legacy `.cargo/config`.
- Also includes `\$CARGO_HOME/config.toml` (and legacy bare name), where `CARGO_HOME` defaults to `~/.cargo` (`\$HOME` / `\$USERPROFILE`).
- Canonicalizes each discovered path, deduplicates via `BTreeMap` keyed by canonical path string (sorted ascending — deterministic).
- Hashes a length-prefixed `(path, bytes)` stream with blake3 (domain-separated by a fixed prefix string) and returns `\"blake3:<hex>\"`.

The digest is added as a new field on `FingerprintInputs` and serialized into the existing blake3-over-JSON fingerprint, so existing sidecars naturally mismatch on the first invocation after upgrade and get refreshed.

### Walk order / sources hashed

1. `<manifest_dir>/.cargo/config.toml` and `<manifest_dir>/.cargo/config`
2. `<manifest_dir>/../.cargo/config.toml` and `<manifest_dir>/../.cargo/config`
3. ... up to filesystem root
4. `\$CARGO_HOME/config.toml` and `\$CARGO_HOME/config`

Missing files contribute nothing; appearing or disappearing changes the digest exactly as if file content had been edited.

### Implementation decision: raw bytes vs canonical TOML

Followed the explicit guidance in the issue / agent prompt: hash raw file bytes. Parsing + re-serializing would be more robust to whitespace-only edits but adds dependency on a TOML emitter giving a stable canonical form, and isn't worth the complexity for slice 2.

## Documented caveat (false rebuild)

Editing an unrelated section of `.cargo/config.toml` (e.g. `[net]`, `[registries]`, `[http]`) will also bust the trampoline fingerprint and force a fall-through to real cargo. This is the agreed tradeoff in #346 — cargo will no-op the build anyway, and avoiding it requires replicating cargo's full config-resolution rules (target tables, host config, CLI overrides, etc.) which is much larger than this slice.

## Test plan

Added one unit-test file (`trampoline_config_tests.rs`) with 7 tests:

- Walker discovers configs at depths 1, 2, 3 above the manifest dir and returns them sorted.
- Walker discovers `\$CARGO_HOME/config.toml`.
- Walker honors the legacy bare-`config` name.
- Digest changes when rustflags inside `.cargo/config.toml` change.
- Digest changes when a config file appears.
- Digest is deterministic for unchanged inputs and starts with `\"blake3:\"`.
- Digest with no configs is still well-defined / deterministic.

Tests serialize on a `Mutex<()>` because they mutate process-global env vars (`CARGO_HOME`, `HOME`, `USERPROFILE`) and cargo test runs unit tests in parallel.

Added one integration test in `cli_cargo_run_trampoline.rs`:

- `cargo_config_rustflags_edit_forces_fall_through`: cold build → drop a `.cargo/config.toml` with `[build] rustflags` → assert the trampoline falls through to the broken-cargo stub (i.e. did NOT fast-path the stale binary).

Commands run locally (all green, x86_64-pc-windows-msvc):

\`\`\`
soldr cargo fmt --all -- --check
soldr cargo clippy --workspace --all-targets -- -D warnings
soldr cargo test -p soldr-cli --bin soldr trampoline             # 29 unit tests
soldr cargo test -p soldr-cli --bin soldr                         # 194 unit tests
soldr cargo test -p soldr-cli --test cli_cargo_run_trampoline    # 13 integration tests
\`\`\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>