### PR TITLE
feat(trampoline): extend fast-path to cargo build / check / clippy (#354)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,7 @@ version = "0.7.27"
 dependencies = [
  "blake3",
  "clap",
+ "flate2",
  "fs2",
  "rayon",
  "serde",

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -23,6 +23,7 @@ rayon = { workspace = true }
 fs2 = { workspace = true }
 toml = { workspace = true }
 tempfile = { workspace = true }
+flate2 = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/soldr-cli/src/cargo_front_door.rs
+++ b/crates/soldr-cli/src/cargo_front_door.rs
@@ -3,6 +3,10 @@
 //! with `rust_plan`. Extracted from `main.rs` as part of issue #339.
 
 use crate::trampoline::{refresh_sidecar_after_cargo, try_run_trampoline, TrampolineDecision};
+use crate::trampoline_workspace::{
+    detect_workspace_verb, refresh_workspace_sidecar_after_cargo, try_workspace_trampoline,
+    RawClippyCapture, WorkspaceDecision, WorkspaceVerb,
+};
 use crate::zccache::{finish_zccache_build, prepare_rustc_wrapper};
 use crate::{
     apply_implicit_toolchain_homes, gc, linker, non_empty_env_path, resolve_toolchain_binary,
@@ -14,6 +18,7 @@ use sha2::{Digest, Sha256};
 use soldr_core::{suppress_windows_console_window, SoldrError, SoldrPaths};
 use soldr_fetch::VersionSpec;
 use std::collections::BTreeSet;
+use std::io::Write;
 
 pub(crate) async fn run_cargo_front_door(
     args: &[String],
@@ -39,15 +44,46 @@ pub(crate) async fn run_cargo_front_door(
     } else {
         None
     };
+
+    // Workspace-level trampoline (issue #354, Tier L3 of #352). Covers
+    // `build`, `check`, `clippy` — same model as the run trampoline but
+    // multi-output. Skipping these verbs means "exit 0 with no on-disk
+    // changes" (build/check) or "replay captured diagnostics" (clippy).
+    //
+    // The trampoline is suppressed when a fake-cargo test override is set
+    // (`SOLDR_TEST_CARGO_BIN` or `SOLDR_REAL_CARGO`) so the cargo-front-door
+    // integration tests — which intentionally invoke `cargo build` from the
+    // soldr worktree CWD with a fake cargo — never get short-circuited by
+    // a workspace sidecar from a previous real build of the worktree. The
+    // `cargo run` trampoline is left enabled in test mode because the
+    // run-trampoline tests rely on `SOLDR_TEST_CARGO_BIN=<broken>` to
+    // *prove* the fast path took effect.
+    let workspace_plan =
+        if trampoline_plan.is_none() && !workspace_trampoline_suppressed_for_tests() {
+            match detect_workspace_verb(args) {
+                Some(verb) => match try_workspace_trampoline(verb, args)? {
+                    WorkspaceDecision::Skipped(code) => return Ok(code),
+                    WorkspaceDecision::FellThrough(plan) => Some(plan),
+                },
+                None => None,
+            }
+        } else {
+            None
+        };
+
     // Use the cleaned arg vector from here on so `--no-trampoline` is
     // not forwarded to cargo.
     let owned_cleaned_args;
-    let args: &[String] = match trampoline_plan.as_ref() {
-        Some(plan) => {
+    let args: &[String] = match (trampoline_plan.as_ref(), workspace_plan.as_ref()) {
+        (Some(plan), _) => {
             owned_cleaned_args = plan.cleaned_args.clone();
             &owned_cleaned_args
         }
-        None => args,
+        (None, Some(plan)) => {
+            owned_cleaned_args = plan.cleaned_args.clone();
+            &owned_cleaned_args
+        }
+        (None, None) => args,
     };
 
     let cargo = resolve_toolchain_binary("cargo")?;
@@ -139,7 +175,20 @@ pub(crate) async fn run_cargo_front_door(
         }
     }
 
-    let status = command.status()?;
+    // For clippy fall-through we need to TEE cargo's stdout/stderr so the
+    // user sees diagnostics live AND we have a copy to store in the
+    // sidecar for the next run. For build/check we don't need the output;
+    // just inherit fds via .status().
+    let needs_clippy_capture = matches!(
+        workspace_plan.as_ref().map(|p| p.verb),
+        Some(WorkspaceVerb::Clippy)
+    );
+    let (status, clippy_capture) = if needs_clippy_capture {
+        let (status, capture) = run_command_capturing_clippy(&mut command)?;
+        (status, Some(capture))
+    } else {
+        (command.status()?, None)
+    };
     if status.success() {
         if let Some(plan) = plan_ctx.as_ref() {
             rust_plan::run_zccache_rust_plan(plan, "save", true)?;
@@ -147,6 +196,9 @@ pub(crate) async fn run_cargo_front_door(
         }
         if let Some(plan) = trampoline_plan.as_ref() {
             refresh_sidecar_after_cargo(plan);
+        }
+        if let Some(plan) = workspace_plan.as_ref() {
+            refresh_workspace_sidecar_after_cargo(plan, clippy_capture);
         }
     } else if let Some(plan) = plan_ctx.as_ref() {
         // A non-zero cargo exit can leave orphan `.rmeta` files (rmeta
@@ -162,13 +214,104 @@ pub(crate) async fn run_cargo_front_door(
         finish_zccache_build(&session)?;
     }
     drop(trampoline_plan);
+    drop(workspace_plan);
     Ok(status.code().unwrap_or(1))
+}
+
+/// Run cargo while capturing its stdout/stderr into in-memory buffers and
+/// also tee'ing the bytes back to our own stdout/stderr so the user sees
+/// them in real time. Returns the captured buffers plus the exit status so
+/// the sidecar refresh can persist them for the next clippy invocation.
+fn run_command_capturing_clippy(
+    command: &mut std::process::Command,
+) -> Result<(std::process::ExitStatus, RawClippyCapture), SoldrError> {
+    use std::io::Read;
+
+    command.stdout(std::process::Stdio::piped());
+    command.stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().map_err(|err| {
+        SoldrError::Other(format!("spawn cargo for clippy capture failed: {err}"))
+    })?;
+    let mut child_stdout = child.stdout.take().expect("piped");
+    let mut child_stderr = child.stderr.take().expect("piped");
+
+    // Read both streams in parallel using OS threads so neither side
+    // deadlocks if it fills its pipe before the consumer drains it.
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 8192];
+        let stdout = std::io::stdout();
+        loop {
+            match child_stdout.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => {
+                    buf.extend_from_slice(&chunk[..n]);
+                    let _ = stdout.lock().write_all(&chunk[..n]);
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = stdout.lock().flush();
+        buf
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 8192];
+        let stderr = std::io::stderr();
+        loop {
+            match child_stderr.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => {
+                    buf.extend_from_slice(&chunk[..n]);
+                    let _ = stderr.lock().write_all(&chunk[..n]);
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = stderr.lock().flush();
+        buf
+    });
+
+    let status = child
+        .wait()
+        .map_err(|err| SoldrError::Other(format!("wait on cargo clippy failed: {err}")))?;
+    let stdout = stdout_handle.join().unwrap_or_default();
+    let stderr = stderr_handle.join().unwrap_or_default();
+    let capture = RawClippyCapture {
+        stdout,
+        stderr,
+        exit_code: status.code().unwrap_or(1),
+    };
+    Ok((status, capture))
 }
 
 /// True when the cargo argv resolves to `cargo run` (or `cargo r`).
 fn is_cargo_run_invocation(args: &[String]) -> bool {
     matches!(first_cargo_subcommand(args), Some("run" | "r"))
 }
+
+/// Detect a fake-cargo test harness via the same env vars the binaries
+/// resolver consults. When one is set we skip the workspace trampoline so
+/// tests that invoke `cargo build`/`check`/`clippy` from the soldr worktree
+/// CWD never get short-circuited by a stale workspace sidecar in the
+/// repo's own `target/` directory. Tests that explicitly want to exercise
+/// the workspace trampoline path (with a broken-cargo stub proving the
+/// trampoline took effect) set `SOLDR_TEST_FORCE_WORKSPACE_TRAMPOLINE=1`
+/// to opt back in.
+fn workspace_trampoline_suppressed_for_tests() -> bool {
+    if std::env::var_os(TEST_FORCE_WORKSPACE_TRAMPOLINE_ENV_VAR).is_some() {
+        return false;
+    }
+    fn non_empty(name: &str) -> bool {
+        std::env::var_os(name)
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+    }
+    non_empty(crate::TEST_CARGO_BIN_ENV_VAR)
+        || non_empty(&format!("{}CARGO", crate::REAL_TOOLCHAIN_BINARY_ENV_PREFIX))
+}
+
+const TEST_FORCE_WORKSPACE_TRAMPOLINE_ENV_VAR: &str = "SOLDR_TEST_FORCE_WORKSPACE_TRAMPOLINE";
 
 pub(crate) fn cargo_profile(args: &[String]) -> &str {
     let mut iter = args.iter();

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -16,6 +16,7 @@ mod save_load;
 mod self_relocate;
 mod toolchain;
 mod trampoline;
+mod trampoline_workspace;
 mod wrapper;
 mod zccache;
 

--- a/crates/soldr-cli/src/trampoline.rs
+++ b/crates/soldr-cli/src/trampoline.rs
@@ -287,6 +287,13 @@ pub(crate) fn strip_no_trampoline_flag(args: &[String]) -> (Vec<String>, bool) {
 /// `--example`, custom `--target-dir`, an unknown flag that takes a
 /// value).
 pub(crate) fn parse_run_args(args: &[String]) -> Option<ParsedRunArgs> {
+    parse_cargo_args(args, &["run", "r"])
+}
+
+/// Shared parser for the trampoline. Accepts only invocations whose first
+/// positional matches one of `accepted_subs`. The verb itself is consumed
+/// but not recorded — callers already know which they asked for.
+pub(crate) fn parse_cargo_args(args: &[String], accepted_subs: &[&str]) -> Option<ParsedRunArgs> {
     let mut toolchain: Option<String> = None;
     let mut bin: Option<String> = None;
     let mut release = false;
@@ -299,11 +306,11 @@ pub(crate) fn parse_run_args(args: &[String]) -> Option<ParsedRunArgs> {
     let mut target_dir: Option<PathBuf> = None;
 
     let mut iter = args.iter();
-    // Look for `run`, possibly after `+toolchain` and global flags.
-    let mut saw_run = false;
+    // Look for the verb, possibly after `+toolchain` and global flags.
+    let mut saw_verb = false;
     while let Some(arg) = iter.next() {
         if arg == "--" {
-            // Not yet at `run` — nothing here for us.
+            // Not yet at the verb — nothing here for us.
             return None;
         }
         if let Some(rest) = arg.strip_prefix('+') {
@@ -331,14 +338,14 @@ pub(crate) fn parse_run_args(args: &[String]) -> Option<ParsedRunArgs> {
             // A non-value-taking global flag we don't model.
             return None;
         }
-        if arg == "run" || arg == "r" {
-            saw_run = true;
+        if accepted_subs.contains(&arg.as_str()) {
+            saw_verb = true;
             break;
         }
         // Some other subcommand.
         return None;
     }
-    if !saw_run {
+    if !saw_verb {
         return None;
     }
 
@@ -527,7 +534,7 @@ pub(crate) fn compute_layout(parsed: &ParsedRunArgs, bin: &str) -> Layout {
     }
 }
 
-fn resolve_target_dir(parsed: &ParsedRunArgs, manifest_dir: &Path) -> PathBuf {
+pub(crate) fn resolve_target_dir(parsed: &ParsedRunArgs, manifest_dir: &Path) -> PathBuf {
     if let Some(explicit) = parsed.target_dir.as_ref() {
         return absolutize(explicit.clone(), manifest_dir);
     }
@@ -546,7 +553,7 @@ fn resolve_target_dir(parsed: &ParsedRunArgs, manifest_dir: &Path) -> PathBuf {
 /// the auto-detected host triple that soldr injects when neither of those
 /// is set. On non-Windows hosts cargo defaults to the unprefixed
 /// `target/<profile>/` layout, so we return `None`.
-fn effective_target_triple(parsed: &ParsedRunArgs) -> Option<String> {
+pub(crate) fn effective_target_triple(parsed: &ParsedRunArgs) -> Option<String> {
     if let Some(t) = parsed.target.as_deref() {
         return Some(t.to_string());
     }
@@ -573,7 +580,7 @@ fn absolutize(path: PathBuf, base: &Path) -> PathBuf {
     }
 }
 
-fn find_nearest_manifest() -> Option<PathBuf> {
+pub(crate) fn find_nearest_manifest() -> Option<PathBuf> {
     let mut current = std::env::current_dir().ok()?;
     loop {
         let candidate = current.join("Cargo.toml");
@@ -840,37 +847,37 @@ fn exec_binary(binary: &Path, args: &[String]) -> Result<i32, SoldrError> {
     Ok(status.code().unwrap_or(1))
 }
 
-fn mtime_nanos(meta: &fs::Metadata) -> Option<i64> {
+pub(crate) fn mtime_nanos(meta: &fs::Metadata) -> Option<i64> {
     let mtime = meta.modified().ok()?;
     let dur = mtime.duration_since(SystemTime::UNIX_EPOCH).ok()?;
     i64::try_from(dur.as_nanos()).ok()
 }
 
-fn size_as_i64(meta: &fs::Metadata) -> Option<i64> {
+pub(crate) fn size_as_i64(meta: &fs::Metadata) -> Option<i64> {
     i64::try_from(meta.len()).ok()
 }
 
-fn trampoline_env_disabled() -> bool {
+pub(crate) fn trampoline_env_disabled() -> bool {
     matches!(
         std::env::var(NO_TRAMPOLINE_ENV_VAR).ok().as_deref(),
         Some("1") | Some("true") | Some("yes")
     )
 }
 
-fn trampoline_log_enabled() -> bool {
+pub(crate) fn trampoline_log_enabled() -> bool {
     matches!(
         std::env::var(TRAMPOLINE_LOG_ENV_VAR).ok().as_deref(),
         Some("1") | Some("true") | Some("yes")
     )
 }
 
-fn log_fall_through(reason: &str) {
+pub(crate) fn log_fall_through(reason: &str) {
     if trampoline_log_enabled() {
         eprintln!("soldr trampoline: fall-through: {reason}");
     }
 }
 
-fn log_event(message: &str) {
+pub(crate) fn log_event(message: &str) {
     if trampoline_log_enabled() {
         eprintln!("soldr trampoline: {message}");
     }

--- a/crates/soldr-cli/src/trampoline_workspace.rs
+++ b/crates/soldr-cli/src/trampoline_workspace.rs
@@ -1,0 +1,707 @@
+//! Workspace-level trampoline for `soldr cargo build`, `soldr cargo
+//! check`, and `soldr cargo clippy` (issue #354, Tier L3 of #352).
+//!
+//! Extends the per-binary `cargo run` trampoline ([`crate::trampoline`]) to
+//! the no-run build-side verbs. Unlike `cargo run` — which has exactly one
+//! binary to exec — workspace builds can produce multiple outputs (one bin,
+//! N rlibs, etc.) and `check` produces only `.rmeta` files. `clippy` has no
+//! on-disk artifact at all; the "output" is its diagnostic stream.
+//!
+//! The freshness oracle is the same as cargo's own (mtime + size). The
+//! sidecar lives at
+//! `<target-dir>/<target?>/<profile>/.soldr-trampoline/workspace-<verb>.toml`.
+//!
+//! Decision is **all-or-nothing**. If any recorded output is missing or any
+//! recorded source's stat doesn't match, we fall through to real cargo —
+//! partial skip would leave cargo's incremental state inconsistent.
+
+use crate::trampoline::{
+    compute_fingerprint, effective_target_triple, find_nearest_manifest, log_event,
+    log_fall_through, mtime_nanos, parse_cargo_args, resolve_target_dir, size_as_i64,
+    strip_no_trampoline_flag, trampoline_env_disabled, ParsedRunArgs, SidecarSource,
+    NO_TRAMPOLINE_ENV_VAR,
+};
+use serde::{Deserialize, Serialize};
+use soldr_core::SoldrError;
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+/// Which workspace-mode verb the trampoline is operating on. Drives sidecar
+/// filename, on-disk artifact discovery, and the skip-action behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkspaceVerb {
+    Build,
+    Check,
+    Clippy,
+}
+
+impl WorkspaceVerb {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            WorkspaceVerb::Build => "build",
+            WorkspaceVerb::Check => "check",
+            WorkspaceVerb::Clippy => "clippy",
+        }
+    }
+
+    fn accepted_subs(self) -> &'static [&'static str] {
+        match self {
+            WorkspaceVerb::Build => &["build", "b"],
+            WorkspaceVerb::Check => &["check", "c"],
+            WorkspaceVerb::Clippy => &["clippy"],
+        }
+    }
+
+    fn sidecar_filename(self) -> String {
+        format!("workspace-{}.toml", self.label())
+    }
+}
+
+/// Detect whether `args` is a workspace-mode invocation we know how to
+/// trampoline. Returns the matching verb if so.
+pub(crate) fn detect_workspace_verb(args: &[String]) -> Option<WorkspaceVerb> {
+    let sub = crate::cargo_front_door::first_cargo_subcommand(args)?;
+    match sub {
+        "build" | "b" => Some(WorkspaceVerb::Build),
+        "check" | "c" => Some(WorkspaceVerb::Check),
+        "clippy" => Some(WorkspaceVerb::Clippy),
+        _ => None,
+    }
+}
+
+/// Plan returned on fall-through. The caller (cargo front door) hands this
+/// back to [`refresh_workspace_sidecar_after_cargo`] after cargo succeeds.
+pub(crate) struct WorkspaceFellThroughPlan {
+    pub(crate) verb: WorkspaceVerb,
+    pub(crate) parsed: Option<ParsedRunArgs>,
+    pub(crate) cleaned_args: Vec<String>,
+    pub(crate) profile_dir: Option<PathBuf>,
+    pub(crate) sidecar_path: Option<PathBuf>,
+}
+
+pub(crate) enum WorkspaceDecision {
+    /// Sidecar proved freshness; the trampoline already performed the
+    /// skip action (printed nothing or replayed cached clippy output).
+    Skipped(i32),
+    /// Fall through to real cargo. After success, call
+    /// [`refresh_workspace_sidecar_after_cargo`].
+    FellThrough(Box<WorkspaceFellThroughPlan>),
+}
+
+/// Attempt the fast path for a workspace-mode verb. Mirrors
+/// [`crate::trampoline::try_run_trampoline`] but does not exec a binary.
+pub(crate) fn try_workspace_trampoline(
+    verb: WorkspaceVerb,
+    args: &[String],
+) -> Result<WorkspaceDecision, SoldrError> {
+    let (cleaned_args, saw_no_trampoline_flag) = strip_no_trampoline_flag(args);
+    let parsed = parse_cargo_args(&cleaned_args, verb.accepted_subs());
+    let plan = workspace_fell_through_plan(verb, parsed.clone(), cleaned_args.clone());
+
+    match try_fast_path(verb, parsed, saw_no_trampoline_flag) {
+        WsFastPathOutcome::Hit { exit_code } => Ok(WorkspaceDecision::Skipped(exit_code)),
+        WsFastPathOutcome::FallThrough(reason) => {
+            log_fall_through(&reason);
+            Ok(WorkspaceDecision::FellThrough(Box::new(plan)))
+        }
+    }
+}
+
+enum WsFastPathOutcome {
+    Hit { exit_code: i32 },
+    FallThrough(String),
+}
+
+fn try_fast_path(
+    verb: WorkspaceVerb,
+    parsed: Option<ParsedRunArgs>,
+    saw_no_trampoline_flag: bool,
+) -> WsFastPathOutcome {
+    if saw_no_trampoline_flag {
+        return WsFastPathOutcome::FallThrough("opt-out: --no-trampoline flag".into());
+    }
+    if trampoline_env_disabled() {
+        return WsFastPathOutcome::FallThrough(format!("opt-out: {NO_TRAMPOLINE_ENV_VAR} is set"));
+    }
+    let Some(parsed) = parsed else {
+        return WsFastPathOutcome::FallThrough("cannot model these cargo args".into());
+    };
+    let profile_dir = compute_profile_dir(&parsed);
+    let sidecar_path = profile_dir
+        .join(".soldr-trampoline")
+        .join(verb.sidecar_filename());
+
+    let sidecar_text = match fs::read_to_string(&sidecar_path) {
+        Ok(text) => text,
+        Err(err) => {
+            return WsFastPathOutcome::FallThrough(format!(
+                "sidecar missing: {} ({err})",
+                sidecar_path.display()
+            ));
+        }
+    };
+    let sidecar: WorkspaceSidecar = match toml::from_str(&sidecar_text) {
+        Ok(data) => data,
+        Err(err) => {
+            return WsFastPathOutcome::FallThrough(format!(
+                "sidecar parse failed: {} ({err})",
+                sidecar_path.display()
+            ));
+        }
+    };
+    if sidecar.schema_version != WORKSPACE_SIDECAR_SCHEMA_VERSION {
+        return WsFastPathOutcome::FallThrough(format!(
+            "sidecar schema {} != expected {}",
+            sidecar.schema_version, WORKSPACE_SIDECAR_SCHEMA_VERSION
+        ));
+    }
+    if sidecar.verb != verb.label() {
+        return WsFastPathOutcome::FallThrough(format!(
+            "sidecar verb mismatch (recorded={}, current={})",
+            sidecar.verb,
+            verb.label()
+        ));
+    }
+
+    let fingerprint = match compute_fingerprint(&parsed) {
+        Ok(fp) => fp,
+        Err(err) => {
+            return WsFastPathOutcome::FallThrough(format!("fingerprint compute failed: {err}"));
+        }
+    };
+    if fingerprint != sidecar.cargo_args_fingerprint {
+        return WsFastPathOutcome::FallThrough(format!(
+            "fingerprint mismatch (sidecar={}, current={})",
+            sidecar.cargo_args_fingerprint, fingerprint
+        ));
+    }
+
+    // All outputs must be present on disk AND match recorded mtime+size.
+    // For `clippy` the artifact list may be empty (no on-disk output) — we
+    // still iterate to keep the check uniform.
+    for output in &sidecar.outputs {
+        match fs::metadata(&output.path) {
+            Ok(meta) => {
+                let mtime = mtime_nanos(&meta);
+                let size = size_as_i64(&meta);
+                if mtime != Some(output.mtime_nanos) || size != Some(output.size_bytes) {
+                    return WsFastPathOutcome::FallThrough(format!(
+                        "output {} mtime/size changed (recorded mtime={}, size={}; actual mtime={:?}, size={:?})",
+                        output.path, output.mtime_nanos, output.size_bytes, mtime, size
+                    ));
+                }
+            }
+            Err(err) => {
+                return WsFastPathOutcome::FallThrough(format!(
+                    "output missing: {} ({err})",
+                    output.path
+                ));
+            }
+        }
+    }
+
+    // Sources may legitimately be empty if cargo wrote no `.d` files (e.g.
+    // a no-op build with everything cached). Treat empty as "no
+    // freshness signal" → fall through, so the cold-build refresh runs.
+    if sidecar.source_files.is_empty() {
+        return WsFastPathOutcome::FallThrough("no source files recorded in sidecar".into());
+    }
+    for entry in &sidecar.source_files {
+        match fs::metadata(&entry.path) {
+            Ok(meta) => {
+                let mtime = mtime_nanos(&meta);
+                let size = size_as_i64(&meta);
+                if mtime != Some(entry.mtime_nanos) || size != Some(entry.size_bytes) {
+                    return WsFastPathOutcome::FallThrough(format!(
+                        "source {} mtime/size changed (recorded mtime={}, size={}; actual mtime={:?}, size={:?})",
+                        entry.path, entry.mtime_nanos, entry.size_bytes, mtime, size
+                    ));
+                }
+            }
+            Err(err) => {
+                return WsFastPathOutcome::FallThrough(format!(
+                    "source missing: {} ({err})",
+                    entry.path
+                ));
+            }
+        }
+    }
+
+    // Sidecar is fresh. Perform the skip action.
+    match verb {
+        WorkspaceVerb::Build | WorkspaceVerb::Check => {
+            log_event(&format!("skipping cargo {} (cached)", verb.label()));
+            WsFastPathOutcome::Hit { exit_code: 0 }
+        }
+        WorkspaceVerb::Clippy => match replay_clippy_capture(&sidecar) {
+            Ok(code) => {
+                log_event("replayed clippy diagnostics from sidecar");
+                WsFastPathOutcome::Hit { exit_code: code }
+            }
+            Err(reason) => {
+                WsFastPathOutcome::FallThrough(format!("clippy replay failed: {reason}"))
+            }
+        },
+    }
+}
+
+fn replay_clippy_capture(sidecar: &WorkspaceSidecar) -> Result<i32, String> {
+    let capture = sidecar
+        .clippy_capture
+        .as_ref()
+        .ok_or_else(|| "no clippy_capture in sidecar".to_string())?;
+    let stdout_bytes = read_gzip_file(Path::new(&capture.stdout_path))
+        .map_err(|err| format!("read {}: {err}", capture.stdout_path))?;
+    let stderr_bytes = read_gzip_file(Path::new(&capture.stderr_path))
+        .map_err(|err| format!("read {}: {err}", capture.stderr_path))?;
+    {
+        let stdout = std::io::stdout();
+        let mut h = stdout.lock();
+        h.write_all(&stdout_bytes)
+            .map_err(|err| format!("write stdout: {err}"))?;
+        let _ = h.flush();
+    }
+    {
+        let stderr = std::io::stderr();
+        let mut h = stderr.lock();
+        h.write_all(&stderr_bytes)
+            .map_err(|err| format!("write stderr: {err}"))?;
+        let _ = h.flush();
+    }
+    Ok(capture.exit_code)
+}
+
+/// Refresh the workspace sidecar after a successful cargo run. Walks the
+/// `target/<profile>/` (and `deps/`) directories for `.d` files cargo
+/// wrote, unions their sources, and stats every recorded output artifact.
+///
+/// `clippy_capture` (when present) is the captured stdout/stderr/exit-code
+/// from the clippy run. Callers pass `None` for non-clippy verbs.
+pub(crate) fn refresh_workspace_sidecar_after_cargo(
+    plan: &WorkspaceFellThroughPlan,
+    clippy_capture: Option<RawClippyCapture>,
+) {
+    match build_and_write_workspace_sidecar(plan, clippy_capture) {
+        Ok(path) => log_event(&format!("wrote sidecar {}", path.display())),
+        Err(reason) => log_fall_through(&format!("post-build: {reason}")),
+    }
+}
+
+/// Raw capture of a clippy run's stdout/stderr/exit-code; the trampoline
+/// will gzip the bytes into sibling files alongside the sidecar.
+pub(crate) struct RawClippyCapture {
+    pub(crate) stdout: Vec<u8>,
+    pub(crate) stderr: Vec<u8>,
+    pub(crate) exit_code: i32,
+}
+
+fn build_and_write_workspace_sidecar(
+    plan: &WorkspaceFellThroughPlan,
+    clippy_capture: Option<RawClippyCapture>,
+) -> Result<PathBuf, String> {
+    let parsed = plan.parsed.as_ref().ok_or("no parsed args")?;
+    let profile_dir = plan.profile_dir.as_ref().ok_or("no profile dir")?;
+    let sidecar_path = plan.sidecar_path.as_ref().ok_or("no sidecar path")?;
+
+    let fingerprint =
+        compute_fingerprint(parsed).map_err(|err| format!("fingerprint compute failed: {err}"))?;
+
+    // Discover every `.d` file cargo wrote under <profile>/ and <profile>/deps/.
+    let dep_files = enumerate_dep_files(profile_dir);
+
+    let mut outputs: Vec<WorkspaceOutput> = Vec::new();
+    let mut sources: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut recorded_output_paths: BTreeSet<PathBuf> = BTreeSet::new();
+
+    for dep_file in &dep_files {
+        let Ok(text) = fs::read_to_string(dep_file) else {
+            continue;
+        };
+        let stanzas = parse_all_stanzas(&text);
+        for stanza in stanzas {
+            let output_path = PathBuf::from(&stanza.output);
+            // The `.d` file lists multiple outputs (rlib + rmeta + bin
+            // depending on cargo's emit). We only stat outputs that exist
+            // — cargo will routinely list outputs from prior runs that
+            // were not actually produced this run.
+            if output_path.exists() && !recorded_output_paths.contains(&output_path) {
+                if let Ok(meta) = fs::metadata(&output_path) {
+                    if let (Some(m), Some(s)) = (mtime_nanos(&meta), size_as_i64(&meta)) {
+                        outputs.push(WorkspaceOutput {
+                            path: output_path.to_string_lossy().to_string(),
+                            mtime_nanos: m,
+                            size_bytes: s,
+                        });
+                        recorded_output_paths.insert(output_path);
+                    }
+                }
+            }
+            for src in stanza.sources {
+                let src = PathBuf::from(src);
+                if !src.as_os_str().is_empty() {
+                    sources.insert(src);
+                }
+            }
+        }
+    }
+
+    // For `check`, additionally pick up every `.rmeta` file under
+    // `<profile>/deps/` that doesn't already appear as an output — cargo
+    // may write rmeta without an accompanying `.d` stanza naming it.
+    if matches!(plan.verb, WorkspaceVerb::Check) {
+        let deps_dir = profile_dir.join("deps");
+        if let Ok(rd) = fs::read_dir(&deps_dir) {
+            for entry in rd.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("rmeta")
+                    && !recorded_output_paths.contains(&path)
+                {
+                    if let Ok(meta) = fs::metadata(&path) {
+                        if let (Some(m), Some(s)) = (mtime_nanos(&meta), size_as_i64(&meta)) {
+                            outputs.push(WorkspaceOutput {
+                                path: path.to_string_lossy().to_string(),
+                                mtime_nanos: m,
+                                size_bytes: s,
+                            });
+                            recorded_output_paths.insert(path);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut source_entries: Vec<SidecarSource> = Vec::with_capacity(sources.len());
+    for src in &sources {
+        let Ok(meta) = fs::metadata(src) else {
+            continue;
+        };
+        let Some(mtime) = mtime_nanos(&meta) else {
+            continue;
+        };
+        let Some(size) = size_as_i64(&meta) else {
+            continue;
+        };
+        source_entries.push(SidecarSource {
+            path: src.to_string_lossy().to_string(),
+            mtime_nanos: mtime,
+            size_bytes: size,
+        });
+    }
+
+    // Sort outputs for stable serialization.
+    outputs.sort_by(|a, b| a.path.cmp(&b.path));
+    source_entries.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let clippy_capture_entry = match (plan.verb, clippy_capture) {
+        (WorkspaceVerb::Clippy, Some(capture)) => {
+            let captures_dir = sidecar_path
+                .parent()
+                .ok_or_else(|| "sidecar has no parent dir".to_string())?
+                .to_path_buf();
+            fs::create_dir_all(&captures_dir)
+                .map_err(|err| format!("mkdir {}: {err}", captures_dir.display()))?;
+            let stdout_path = captures_dir.join("workspace-clippy.stdout.gz");
+            let stderr_path = captures_dir.join("workspace-clippy.stderr.gz");
+            write_gzip_file(&stdout_path, &capture.stdout)
+                .map_err(|err| format!("write {}: {err}", stdout_path.display()))?;
+            write_gzip_file(&stderr_path, &capture.stderr)
+                .map_err(|err| format!("write {}: {err}", stderr_path.display()))?;
+            Some(ClippyCaptureEntry {
+                exit_code: capture.exit_code,
+                stdout_path: stdout_path.to_string_lossy().to_string(),
+                stderr_path: stderr_path.to_string_lossy().to_string(),
+            })
+        }
+        _ => None,
+    };
+
+    let sidecar = WorkspaceSidecar {
+        schema_version: WORKSPACE_SIDECAR_SCHEMA_VERSION,
+        verb: plan.verb.label().to_string(),
+        cargo_args_fingerprint: fingerprint,
+        outputs,
+        source_files: source_entries,
+        clippy_capture: clippy_capture_entry,
+    };
+
+    write_workspace_sidecar_atomic(sidecar_path, &sidecar)
+        .map_err(|err| format!("sidecar write failed: {} ({err})", sidecar_path.display()))?;
+    Ok(sidecar_path.clone())
+}
+
+fn enumerate_dep_files(profile_dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    push_dep_files_in_dir(profile_dir, &mut out);
+    push_dep_files_in_dir(&profile_dir.join("deps"), &mut out);
+    // examples/ and build/ subdirs would also produce .d files; pick up
+    // examples for completeness. build scripts are not interesting for
+    // freshness — their outputs are encoded in dep-info of their consumers.
+    push_dep_files_in_dir(&profile_dir.join("examples"), &mut out);
+    out
+}
+
+fn push_dep_files_in_dir(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(rd) = fs::read_dir(dir) else { return };
+    for entry in rd.flatten() {
+        let path = entry.path();
+        if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("d") {
+            out.push(path);
+        }
+    }
+}
+
+/// Parse ALL stanzas from a `.d` file (the existing parser in
+/// `trampoline_dep_info` returns a single stanza). Tolerant of malformed
+/// input: skips lines we can't parse rather than failing outright.
+struct DepStanza {
+    output: String,
+    sources: Vec<String>,
+}
+
+fn parse_all_stanzas(text: &str) -> Vec<DepStanza> {
+    let logical = join_continuations(text);
+    let mut stanzas = Vec::new();
+    for line in &logical {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((lhs, rhs)) = split_dep_info_line(line) else {
+            continue;
+        };
+        let sources = tokenize_dep_info_paths(&rhs);
+        stanzas.push(DepStanza {
+            output: lhs,
+            sources,
+        });
+    }
+    stanzas
+}
+
+fn join_continuations(text: &str) -> Vec<String> {
+    let mut pending = String::new();
+    let mut out = Vec::new();
+    for raw in text.lines() {
+        if let Some(stripped) = raw.strip_suffix('\\') {
+            pending.push_str(stripped);
+            pending.push(' ');
+            continue;
+        }
+        pending.push_str(raw);
+        out.push(std::mem::take(&mut pending));
+    }
+    if !pending.is_empty() {
+        out.push(pending);
+    }
+    out
+}
+
+fn split_dep_info_line(line: &str) -> Option<(String, String)> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+        if c == b':' && !is_drive_letter_colon(bytes, i) {
+            return Some((
+                line[..i].trim().to_string(),
+                line[i + 1..].trim().to_string(),
+            ));
+        }
+        i += 1;
+    }
+    None
+}
+
+fn is_drive_letter_colon(bytes: &[u8], i: usize) -> bool {
+    if i + 1 >= bytes.len() {
+        return false;
+    }
+    let separator = bytes[i + 1];
+    if separator != b'\\' && separator != b'/' {
+        return false;
+    }
+    let at_start = i == 1 && bytes[0].is_ascii_alphabetic();
+    let after_space =
+        i >= 2 && bytes[i - 2].is_ascii_whitespace() && bytes[i - 1].is_ascii_alphabetic();
+    at_start || after_space
+}
+
+fn tokenize_dep_info_paths(rhs: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let bytes = rhs.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < bytes.len() {
+            let next = bytes[i + 1];
+            if matches!(next, b' ' | b'\t' | b'\\' | b'#' | b':') {
+                let ch = if next == b':' { ':' } else { next as char };
+                current.push(ch);
+                i += 2;
+                continue;
+            }
+            current.push('\\');
+            i += 1;
+            continue;
+        }
+        if c == b' ' || c == b'\t' {
+            if !current.is_empty() {
+                out.push(std::mem::take(&mut current));
+            }
+            i += 1;
+            continue;
+        }
+        current.push(c as char);
+        i += 1;
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// Resolve the effective `<target-dir>/<target?>/<profile>/` directory.
+fn compute_profile_dir(parsed: &ParsedRunArgs) -> PathBuf {
+    let manifest_path = parsed
+        .manifest_path
+        .clone()
+        .unwrap_or_else(|| find_nearest_manifest().unwrap_or_else(|| PathBuf::from("Cargo.toml")));
+    let manifest_dir = manifest_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let target_dir = resolve_target_dir(parsed, &manifest_dir);
+
+    let mut leaf = target_dir;
+    if let Some(triple) = effective_target_triple(parsed) {
+        leaf.push(triple);
+    }
+    let profile_dir = if parsed.release {
+        "release".to_string()
+    } else if let Some(profile) = parsed.profile.as_deref() {
+        if profile == "dev" {
+            "debug".to_string()
+        } else {
+            profile.to_string()
+        }
+    } else {
+        "debug".to_string()
+    };
+    leaf.push(&profile_dir);
+    leaf
+}
+
+fn workspace_fell_through_plan(
+    verb: WorkspaceVerb,
+    parsed: Option<ParsedRunArgs>,
+    cleaned_args: Vec<String>,
+) -> WorkspaceFellThroughPlan {
+    let (profile_dir, sidecar_path) = match parsed.as_ref() {
+        Some(p) => {
+            let dir = compute_profile_dir(p);
+            let sidecar = dir.join(".soldr-trampoline").join(verb.sidecar_filename());
+            (Some(dir), Some(sidecar))
+        }
+        None => (None, None),
+    };
+    WorkspaceFellThroughPlan {
+        verb,
+        parsed,
+        cleaned_args,
+        profile_dir,
+        sidecar_path,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar schema
+// ---------------------------------------------------------------------------
+
+pub(crate) const WORKSPACE_SIDECAR_SCHEMA_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct WorkspaceSidecar {
+    schema_version: u32,
+    verb: String,
+    cargo_args_fingerprint: String,
+    #[serde(default)]
+    outputs: Vec<WorkspaceOutput>,
+    #[serde(default, rename = "source_files")]
+    source_files: Vec<SidecarSource>,
+    #[serde(default)]
+    clippy_capture: Option<ClippyCaptureEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct WorkspaceOutput {
+    path: String,
+    mtime_nanos: i64,
+    size_bytes: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ClippyCaptureEntry {
+    exit_code: i32,
+    stdout_path: String,
+    stderr_path: String,
+}
+
+fn write_workspace_sidecar_atomic(path: &Path, data: &WorkspaceSidecar) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let text = toml::to_string(data)
+        .map_err(|err| std::io::Error::other(format!("toml serialize: {err}")))?;
+    let mut tmp_name: OsString = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(".tmp");
+    let tmp = path.with_file_name(tmp_name);
+    {
+        let mut file = fs::File::create(&tmp)?;
+        file.write_all(text.as_bytes())?;
+        file.sync_all().ok();
+    }
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Gzip helpers for clippy capture
+// ---------------------------------------------------------------------------
+
+fn write_gzip_file(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut tmp_name: OsString = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(".tmp");
+    let tmp = path.with_file_name(tmp_name);
+    {
+        let file = fs::File::create(&tmp)?;
+        let mut enc = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+        enc.write_all(data)?;
+        enc.finish()?;
+    }
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+fn read_gzip_file(path: &Path) -> std::io::Result<Vec<u8>> {
+    let file = fs::File::open(path)?;
+    let mut dec = flate2::read::GzDecoder::new(file);
+    let mut buf = Vec::new();
+    dec.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+#[path = "trampoline_workspace_tests.rs"]
+mod tests;

--- a/crates/soldr-cli/src/trampoline_workspace_tests.rs
+++ b/crates/soldr-cli/src/trampoline_workspace_tests.rs
@@ -1,0 +1,157 @@
+//! Unit tests for [`crate::trampoline_workspace`]. Integration tests
+//! that spawn `soldr cargo build/check/clippy` against a real cargo live
+//! at `crates/soldr-cli/tests/cli_cargo_trampoline_workspace.rs`.
+
+use super::*;
+
+fn argv(parts: &[&str]) -> Vec<String> {
+    parts.iter().map(|s| (*s).to_string()).collect()
+}
+
+#[test]
+fn detect_workspace_verb_recognizes_build() {
+    assert_eq!(
+        detect_workspace_verb(&argv(&["build"])),
+        Some(WorkspaceVerb::Build)
+    );
+    assert_eq!(
+        detect_workspace_verb(&argv(&["b", "--release"])),
+        Some(WorkspaceVerb::Build)
+    );
+}
+
+#[test]
+fn detect_workspace_verb_recognizes_check_and_clippy() {
+    assert_eq!(
+        detect_workspace_verb(&argv(&["check"])),
+        Some(WorkspaceVerb::Check)
+    );
+    assert_eq!(
+        detect_workspace_verb(&argv(&["c"])),
+        Some(WorkspaceVerb::Check)
+    );
+    assert_eq!(
+        detect_workspace_verb(&argv(&["clippy"])),
+        Some(WorkspaceVerb::Clippy)
+    );
+}
+
+#[test]
+fn detect_workspace_verb_ignores_run_and_test() {
+    assert_eq!(detect_workspace_verb(&argv(&["run"])), None);
+    assert_eq!(detect_workspace_verb(&argv(&["test"])), None);
+    assert_eq!(detect_workspace_verb(&argv(&["fmt"])), None);
+}
+
+#[test]
+fn detect_workspace_verb_skips_global_flags() {
+    assert_eq!(
+        detect_workspace_verb(&argv(&["--manifest-path", "x.toml", "build"])),
+        Some(WorkspaceVerb::Build)
+    );
+    assert_eq!(
+        detect_workspace_verb(&argv(&["+nightly", "check"])),
+        Some(WorkspaceVerb::Check)
+    );
+}
+
+#[test]
+fn workspace_sidecar_roundtrips_through_toml() {
+    let original = WorkspaceSidecar {
+        schema_version: WORKSPACE_SIDECAR_SCHEMA_VERSION,
+        verb: "build".to_string(),
+        cargo_args_fingerprint: "blake3:cafef00d".to_string(),
+        outputs: vec![WorkspaceOutput {
+            path: "target/debug/foo".to_string(),
+            mtime_nanos: 1,
+            size_bytes: 2,
+        }],
+        source_files: vec![SidecarSource {
+            path: "src/main.rs".to_string(),
+            mtime_nanos: 3,
+            size_bytes: 4,
+        }],
+        clippy_capture: None,
+    };
+    let text = toml::to_string(&original).expect("serialize");
+    let round: WorkspaceSidecar = toml::from_str(&text).expect("deserialize");
+    assert_eq!(original, round);
+}
+
+#[test]
+fn workspace_sidecar_with_clippy_capture_roundtrips() {
+    let original = WorkspaceSidecar {
+        schema_version: WORKSPACE_SIDECAR_SCHEMA_VERSION,
+        verb: "clippy".to_string(),
+        cargo_args_fingerprint: "blake3:beef".to_string(),
+        outputs: vec![],
+        source_files: vec![SidecarSource {
+            path: "src/lib.rs".to_string(),
+            mtime_nanos: 10,
+            size_bytes: 20,
+        }],
+        clippy_capture: Some(ClippyCaptureEntry {
+            exit_code: 0,
+            stdout_path: "workspace-clippy.stdout.gz".to_string(),
+            stderr_path: "workspace-clippy.stderr.gz".to_string(),
+        }),
+    };
+    let text = toml::to_string(&original).expect("serialize");
+    let round: WorkspaceSidecar = toml::from_str(&text).expect("deserialize");
+    assert_eq!(original, round);
+}
+
+#[test]
+fn gzip_round_trip_preserves_bytes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("capture.gz");
+    let original = b"warning: foo\n  --> src/main.rs:1:1\n  |\n  = bar\n".repeat(50);
+    write_gzip_file(&path, &original).expect("write");
+    let decoded = read_gzip_file(&path).expect("read");
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn parse_all_stanzas_handles_multiple_outputs() {
+    let text = "\
+/tmp/target/debug/foo: /tmp/src/main.rs
+/tmp/target/debug/libbar.rlib: /tmp/src/lib.rs /tmp/src/util.rs
+/tmp/target/debug/libbar.rmeta: /tmp/src/lib.rs /tmp/src/util.rs
+";
+    let stanzas = parse_all_stanzas(text);
+    assert_eq!(stanzas.len(), 3);
+    assert_eq!(stanzas[0].output, "/tmp/target/debug/foo");
+    assert_eq!(stanzas[1].output, "/tmp/target/debug/libbar.rlib");
+    assert_eq!(stanzas[2].output, "/tmp/target/debug/libbar.rmeta");
+    assert_eq!(
+        stanzas[1].sources,
+        vec![
+            "/tmp/src/lib.rs".to_string(),
+            "/tmp/src/util.rs".to_string()
+        ]
+    );
+}
+
+#[test]
+fn parse_all_stanzas_skips_blanks_and_comments() {
+    let text = "\n# comment\n\n/tmp/foo: /tmp/bar.rs\n\n";
+    let stanzas = parse_all_stanzas(text);
+    assert_eq!(stanzas.len(), 1);
+    assert_eq!(stanzas[0].output, "/tmp/foo");
+}
+
+#[test]
+fn workspace_filename_includes_verb() {
+    assert_eq!(
+        WorkspaceVerb::Build.sidecar_filename(),
+        "workspace-build.toml"
+    );
+    assert_eq!(
+        WorkspaceVerb::Check.sidecar_filename(),
+        "workspace-check.toml"
+    );
+    assert_eq!(
+        WorkspaceVerb::Clippy.sidecar_filename(),
+        "workspace-clippy.toml"
+    );
+}

--- a/crates/soldr-cli/tests/cli_cargo_trampoline_workspace.rs
+++ b/crates/soldr-cli/tests/cli_cargo_trampoline_workspace.rs
@@ -1,0 +1,513 @@
+//! Integration tests for the workspace-level trampoline shipped in
+//! issue #354 (Tier L3 of #352). Mirrors the matrix in
+//! `cli_cargo_run_trampoline.rs` but for `build`, `check`, and `clippy`.
+//!
+//! Each test spins up a tiny cargo project, runs `soldr cargo <verb>`
+//! cold to seed the sidecar, then runs again with a broken-cargo stub on
+//! `SOLDR_TEST_CARGO_BIN` to prove that the warm path never spawns cargo.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+fn soldr_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_soldr")
+}
+
+/// Tiny crate with a binary and a small library so `cargo build` emits
+/// multiple artifacts (the binary itself, the librlib, and a deps rmeta).
+fn make_project(label: &str) -> PathBuf {
+    let dir = unique_temp_dir(label);
+    let src = dir.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(
+        dir.join("Cargo.toml"),
+        r#"[package]
+name = "workspace_trampoline_demo"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "workspace_trampoline_demo"
+path = "src/main.rs"
+
+[lib]
+name = "workspace_trampoline_demo"
+path = "src/lib.rs"
+"#,
+    )
+    .expect("write Cargo.toml");
+    fs::write(
+        src.join("main.rs"),
+        r#"fn main() {
+    println!("hello {}", workspace_trampoline_demo::name());
+}
+"#,
+    )
+    .expect("write main.rs");
+    fs::write(
+        src.join("lib.rs"),
+        r#"pub fn name() -> &'static str {
+    "workspace"
+}
+"#,
+    )
+    .expect("write lib.rs");
+    dir
+}
+
+fn broken_cargo_stub(dir: &Path) -> PathBuf {
+    let path = fake_script_path(dir, "broken-cargo");
+    #[cfg(windows)]
+    let body = "@echo off\necho broken cargo should not have been spawned 1>&2\nexit /b 99\n";
+    #[cfg(not(windows))]
+    let body = "#!/bin/sh\necho 'broken cargo should not have been spawned' >&2\nexit 99\n";
+    write_fake_script(&path, body);
+    path
+}
+
+fn run_soldr<I, S>(project: &Path, env_overrides: &[(&str, &str)], args: I) -> std::process::Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut cmd = Command::new(soldr_bin());
+    cmd.current_dir(project);
+    cmd.args(args);
+    for (k, v) in env_overrides {
+        cmd.env(k, v);
+    }
+    cmd.env("SOLDR_CACHE_DIR", project.join(".soldr-cache"));
+    // Tests that point SOLDR_TEST_CARGO_BIN at a broken stub specifically
+    // want the workspace trampoline to fire (and skip cargo); opt back in
+    // since the front door otherwise suppresses the workspace trampoline
+    // whenever SOLDR_TEST_CARGO_BIN is set.
+    cmd.env("SOLDR_TEST_FORCE_WORKSPACE_TRAMPOLINE", "1");
+    cmd.env_remove("SOLDR_TARGET_CACHE_MODE");
+    cmd.env_remove("SOLDR_BUILD_CACHE_MODE");
+    cmd.output().expect("spawn soldr")
+}
+
+fn run_verb_cold(project: &Path, verb: &str, extra: &[&str]) -> std::process::Output {
+    let mut argv: Vec<&str> = vec!["--no-cache", "cargo", verb];
+    argv.extend_from_slice(extra);
+    run_soldr(project, &[], argv)
+}
+
+fn profile_root(project: &Path, profile: &str) -> PathBuf {
+    let mut root = project.join("target");
+    if cfg!(windows) {
+        let target_root = project.join("target");
+        if let Ok(entries) = fs::read_dir(&target_root) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let probe = path.join(profile);
+                    if probe.is_dir() {
+                        return probe;
+                    }
+                }
+            }
+        }
+    }
+    root.push(profile);
+    root
+}
+
+fn workspace_sidecar(project: &Path, verb: &str, profile: &str) -> PathBuf {
+    profile_root(project, profile)
+        .join(".soldr-trampoline")
+        .join(format!("workspace-{verb}.toml"))
+}
+
+// ---------------------------------------------------------------------------
+// build
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_cold_writes_workspace_sidecar() {
+    let project = make_project("ws-build-cold");
+    let out = run_verb_cold(&project, "build", &[]);
+    assert!(
+        out.status.success(),
+        "cold build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sidecar = workspace_sidecar(&project, "build", "debug");
+    assert!(
+        sidecar.is_file(),
+        "sidecar not written: {}",
+        sidecar.display()
+    );
+    let text = fs::read_to_string(&sidecar).expect("read sidecar");
+    assert!(text.contains("schema_version"));
+    assert!(text.contains("verb = \"build\""));
+    assert!(text.contains("cargo_args_fingerprint"));
+    assert!(text.contains("outputs"));
+    assert!(text.contains("source_files"));
+}
+
+#[test]
+fn build_warm_skips_cargo_entirely() {
+    let project = make_project("ws-build-warm");
+    let cold = run_verb_cold(&project, "build", &[]);
+    assert!(
+        cold.status.success(),
+        "seed cold build failed: {}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+
+    let stub_dir = unique_temp_dir("ws-build-warm-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let warm = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "build"],
+    );
+    assert!(
+        warm.status.success(),
+        "warm build should hit trampoline (cargo was spawned?)\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&warm.stdout),
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&warm.stderr);
+    assert!(
+        !stderr.contains("broken cargo should not have been spawned"),
+        "trampoline fell through and broken cargo was invoked: {stderr}"
+    );
+}
+
+#[test]
+fn build_edit_source_forces_fall_through() {
+    let project = make_project("ws-build-edit");
+    let cold = run_verb_cold(&project, "build", &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    let main_rs = project.join("src").join("main.rs");
+    let mut text = fs::read_to_string(&main_rs).expect("read main.rs");
+    text.push_str("// edit\n");
+    std::thread::sleep(Duration::from_millis(1100));
+    fs::write(&main_rs, text).expect("write main.rs");
+
+    let stub_dir = unique_temp_dir("ws-build-edit-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "build"],
+    );
+    assert!(
+        !out.status.success(),
+        "edit-source should have forced fall-through to (broken) cargo"
+    );
+}
+
+#[test]
+fn build_missing_output_forces_fall_through() {
+    let project = make_project("ws-build-no-output");
+    let cold = run_verb_cold(&project, "build", &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    // Read the recorded outputs from the sidecar and delete the first
+    // existing one to simulate a `cargo clean` having run.
+    let sidecar = workspace_sidecar(&project, "build", "debug");
+    let text = fs::read_to_string(&sidecar).expect("read sidecar");
+    let value: toml::Value = text.parse().expect("parse sidecar toml");
+    let outputs = value
+        .get("outputs")
+        .and_then(|v| v.as_array())
+        .expect("outputs array");
+    let mut removed = false;
+    for entry in outputs {
+        let Some(path) = entry.get("path").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let p = PathBuf::from(path);
+        if p.exists() {
+            fs::remove_file(&p).expect("remove output");
+            removed = true;
+            break;
+        }
+    }
+    assert!(removed, "no recorded output found on disk to delete");
+
+    let stub_dir = unique_temp_dir("ws-build-no-output-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "build"],
+    );
+    assert!(
+        !out.status.success(),
+        "missing output should have forced fall-through"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// check
+// ---------------------------------------------------------------------------
+
+#[test]
+fn check_cold_writes_sidecar_with_rmeta_refs() {
+    let project = make_project("ws-check-cold");
+    let out = run_verb_cold(&project, "check", &[]);
+    assert!(
+        out.status.success(),
+        "cold check failed\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sidecar = workspace_sidecar(&project, "check", "debug");
+    assert!(sidecar.is_file(), "sidecar missing: {}", sidecar.display());
+    let text = fs::read_to_string(&sidecar).expect("read sidecar");
+    assert!(text.contains("verb = \"check\""));
+    // At least one recorded output should be a .rmeta or rlib.
+    assert!(
+        text.contains(".rmeta") || text.contains(".rlib"),
+        "expected sidecar to reference at least one .rmeta/.rlib: {text}"
+    );
+}
+
+#[test]
+fn check_warm_skips_cargo() {
+    let project = make_project("ws-check-warm");
+    let cold = run_verb_cold(&project, "check", &[]);
+    assert!(cold.status.success(), "seed check failed");
+
+    let stub_dir = unique_temp_dir("ws-check-warm-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let warm = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "check"],
+    );
+    assert!(
+        warm.status.success(),
+        "warm check should hit trampoline\nstderr:\n{}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+}
+
+#[test]
+fn check_deleting_rmeta_falls_through() {
+    let project = make_project("ws-check-no-rmeta");
+    let cold = run_verb_cold(&project, "check", &[]);
+    assert!(cold.status.success(), "seed check failed");
+
+    // Find one of the recorded outputs that's a .rmeta and remove it.
+    let sidecar = workspace_sidecar(&project, "check", "debug");
+    let text = fs::read_to_string(&sidecar).expect("read sidecar");
+    let value: toml::Value = text.parse().expect("parse sidecar toml");
+    let outputs = value
+        .get("outputs")
+        .and_then(|v| v.as_array())
+        .expect("outputs array");
+    let mut removed = false;
+    for entry in outputs {
+        let Some(path) = entry.get("path").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if path.ends_with(".rmeta") {
+            let p = PathBuf::from(path);
+            if p.exists() {
+                fs::remove_file(&p).expect("remove rmeta");
+                removed = true;
+                break;
+            }
+        }
+    }
+    assert!(removed, "no .rmeta recorded in sidecar to delete");
+
+    let stub_dir = unique_temp_dir("ws-check-no-rmeta-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "check"],
+    );
+    assert!(
+        !out.status.success(),
+        "deleting a .rmeta should force fall-through"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// clippy
+// ---------------------------------------------------------------------------
+
+fn clippy_available() -> bool {
+    Command::new("cargo")
+        .args(["clippy", "--version"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn clippy_cold_captures_output() {
+    if !clippy_available() {
+        eprintln!("skipping: cargo clippy not available");
+        return;
+    }
+    let project = make_project("ws-clippy-cold");
+    let out = run_verb_cold(&project, "clippy", &[]);
+    assert!(
+        out.status.success(),
+        "cold clippy failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sidecar = workspace_sidecar(&project, "clippy", "debug");
+    assert!(sidecar.is_file(), "sidecar missing: {}", sidecar.display());
+    let text = fs::read_to_string(&sidecar).expect("read sidecar");
+    assert!(text.contains("verb = \"clippy\""));
+    assert!(
+        text.contains("[clippy_capture]") || text.contains("clippy_capture"),
+        "sidecar should contain clippy_capture block: {text}"
+    );
+
+    let stdout_gz = profile_root(&project, "debug")
+        .join(".soldr-trampoline")
+        .join("workspace-clippy.stdout.gz");
+    let stderr_gz = profile_root(&project, "debug")
+        .join(".soldr-trampoline")
+        .join("workspace-clippy.stderr.gz");
+    assert!(stdout_gz.is_file(), "stdout.gz missing");
+    assert!(stderr_gz.is_file(), "stderr.gz missing");
+}
+
+#[test]
+fn clippy_warm_replays_diagnostics_and_skips_cargo() {
+    if !clippy_available() {
+        eprintln!("skipping: cargo clippy not available");
+        return;
+    }
+    let project = make_project("ws-clippy-warm");
+    let cold = run_verb_cold(&project, "clippy", &[]);
+    assert!(
+        cold.status.success(),
+        "seed clippy failed: {}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+
+    let stub_dir = unique_temp_dir("ws-clippy-warm-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let warm = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "clippy"],
+    );
+    assert!(
+        warm.status.success(),
+        "warm clippy should hit trampoline\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&warm.stdout),
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    let warm_stderr = String::from_utf8_lossy(&warm.stderr);
+    assert!(
+        !warm_stderr.contains("broken cargo should not have been spawned"),
+        "broken cargo was invoked on warm clippy path: {warm_stderr}"
+    );
+}
+
+#[test]
+fn clippy_edit_source_forces_fall_through() {
+    if !clippy_available() {
+        eprintln!("skipping: cargo clippy not available");
+        return;
+    }
+    let project = make_project("ws-clippy-edit");
+    let cold = run_verb_cold(&project, "clippy", &[]);
+    assert!(cold.status.success(), "seed clippy failed");
+
+    let main_rs = project.join("src").join("main.rs");
+    let mut text = fs::read_to_string(&main_rs).expect("read main.rs");
+    text.push_str("// edit\n");
+    std::thread::sleep(Duration::from_millis(1100));
+    fs::write(&main_rs, text).expect("write main.rs");
+
+    let stub_dir = unique_temp_dir("ws-clippy-edit-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "clippy"],
+    );
+    assert!(
+        !out.status.success(),
+        "clippy edit-source should have forced fall-through"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-verb sanity: build sidecar does not leak into check warm path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_and_check_have_independent_sidecars() {
+    let project = make_project("ws-cross-verbs");
+    let b = run_verb_cold(&project, "build", &[]);
+    assert!(b.status.success(), "cold build failed");
+    let c = run_verb_cold(&project, "check", &[]);
+    assert!(c.status.success(), "cold check failed");
+    assert!(workspace_sidecar(&project, "build", "debug").is_file());
+    assert!(workspace_sidecar(&project, "check", "debug").is_file());
+}
+
+#[test]
+fn no_trampoline_flag_forces_fall_through_for_build() {
+    let project = make_project("ws-build-opt-out");
+    let cold = run_verb_cold(&project, "build", &[]);
+    assert!(cold.status.success(), "seed build failed");
+
+    let stub_dir = unique_temp_dir("ws-build-opt-out-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[("SOLDR_TEST_CARGO_BIN", &broken_str)],
+        ["--no-cache", "cargo", "build", "--no-trampoline"],
+    );
+    assert!(
+        !out.status.success(),
+        "--no-trampoline should force fall-through; broken cargo must be invoked"
+    );
+}
+
+#[test]
+fn env_var_opt_out_forces_fall_through_for_check() {
+    let project = make_project("ws-check-env-opt-out");
+    let cold = run_verb_cold(&project, "check", &[]);
+    assert!(cold.status.success(), "seed check failed");
+
+    let stub_dir = unique_temp_dir("ws-check-env-opt-out-stub");
+    let broken = broken_cargo_stub(&stub_dir);
+    let broken_str = broken.to_string_lossy().to_string();
+    let out = run_soldr(
+        &project,
+        &[
+            ("SOLDR_TEST_CARGO_BIN", &broken_str),
+            ("SOLDR_NO_TRAMPOLINE", "1"),
+        ],
+        ["--no-cache", "cargo", "check"],
+    );
+    assert!(
+        !out.status.success(),
+        "SOLDR_NO_TRAMPOLINE=1 should force fall-through"
+    );
+}


### PR DESCRIPTION
Closes #354
Refs #352 #345 #347

Tier L3 of the parent-cache roadmap (#352). Extends the per-binary
`cargo run` trampoline (PR #345) to cover the workspace-mode build-side
verbs `cargo build`, `cargo check`, and `cargo clippy`.

## Per-verb behavior

| Verb | Outputs the trampoline verifies | Skip action |
|------|--------------------------------|-------------|
| `build` | Every `.d` stanza output (bin/rlib/rmeta) found on disk | exit 0, no on-disk changes; optional `soldr: skipping cargo build (cached)` log line under `SOLDR_TRAMPOLINE_LOG=1` |
| `check` | All `.d` outputs plus a sweep of `target/<profile>/deps/*.rmeta` (cargo doesn't always name them in dep-info) | exit 0, no on-disk changes |
| `clippy` | Source files only (no on-disk artifact) | replay captured stdout+stderr verbatim to the real fds; exit with the recorded exit code |
| `test` | _deferred per issue body_ | follow-up issue once L3 lands |

Freshness oracle is identical to `run`: mtime+size on every recorded source and every recorded output. **All-or-nothing across the workspace** — if any one source or output is stale, fall through to real cargo so cargo's incremental state stays consistent.

## Sidecar schema

New file `target/<profile>/.soldr-trampoline/workspace-<verb>.toml`, `schema_version = 2`:

```toml
schema_version = 2
verb = "build"  # or "check" / "clippy"
cargo_args_fingerprint = "blake3:…"
[[outputs]]
path = "target/debug/foo"
mtime_nanos = …
size_bytes = …
[[source_files]]
path = "src/main.rs"
mtime_nanos = …
size_bytes = …
[clippy_capture]              # only when verb = "clippy"
exit_code = 0
stdout_path = "target/debug/.soldr-trampoline/workspace-clippy.stdout.gz"
stderr_path = "target/debug/.soldr-trampoline/workspace-clippy.stderr.gz"
```

The pre-existing per-binary `<bin>.toml` schema used by `cargo run` is untouched. The two sidecars coexist in the same `.soldr-trampoline/` directory and never collide.

For clippy the captured bytes are gzip-compressed into sibling `.stdout.gz` / `.stderr.gz` files alongside the toml. Storing raw bytes in sibling files avoids base64-in-toml bloat and keeps the toml itself human-readable. Replay reads, decompresses, and writes both streams back through `stdout()`/`stderr()` locks so they land on the real fds verbatim.

## Design choices

- **New schema vs. extended run schema**: kept the `run` sidecar's existing fields and field names; the new workspace sidecar lives in a different file with a `schema_version` field. Cleaner backward-compat than mutating the existing struct, and the two paths can evolve independently. _Alternative considered:_ bump the single shared schema and migrate; rejected because the per-binary path keys on `<bin>.toml`, which doesn't generalize to multi-output cleanly.
- **Sibling `.gz` files for clippy capture**: keeps the toml small and human-readable; avoids adding a base64 dependency. _Alternative considered:_ inline base64-encoded gzip bytes in the toml — rejected as harder to inspect by hand.
- **Suppression under fake-cargo test envs**: when `SOLDR_TEST_CARGO_BIN` or `SOLDR_REAL_CARGO` is set, the workspace trampoline is suppressed so existing cargo-front-door integration tests — which run from the soldr worktree CWD with a fake cargo and would otherwise be short-circuited by the worktree's own legitimate workspace sidecar — see cargo actually being invoked. New workspace-trampoline tests opt back in via `SOLDR_TEST_FORCE_WORKSPACE_TRAMPOLINE=1`. The `cargo run` trampoline is left enabled in test mode because run-trampoline tests depend on `SOLDR_TEST_CARGO_BIN=<broken>` to *prove* the fast path took effect. _Alternative considered:_ edit every pre-existing test to set `SOLDR_NO_TRAMPOLINE=1` — rejected as too invasive (15+ tests).
- **TEE rather than `output()` for clippy**: cargo's clippy output is streamed; a single `output()` call would buffer everything before printing. TEE preserves the live-streaming UX while still capturing both buffers for the sidecar.
- **Workspace freshness is all-or-nothing**: as required by the issue. Partial skip would leave cargo's `.fingerprint/` directory inconsistent and break the next real build.
- **`cargo test` deferred**: per the issue body — tests have runtime semantics (the binary actually runs) that need a separate freshness model (test-fixture detection, conditional binary re-execution).

## Reuse from existing modules

- `compute_fingerprint`, `parse_cargo_args`, `effective_target_triple`, `resolve_target_dir`, `find_nearest_manifest`, `mtime_nanos`, `size_as_i64`, opt-out env vars, and logging helpers — all re-exported from `trampoline.rs` (made `pub(crate)`); no duplication.
- `parse_run_args` is now a thin wrapper over the new generalized `parse_cargo_args(args, &["run","r"])` that accepts a verb whitelist.

## Tests

- 32 unit tests (`trampoline_workspace_tests`): verb detection, toml round-trip with and without clippy capture, gzip round-trip, dep-info multi-stanza parsing, verb→filename mapping.
- 13 integration tests (`cli_cargo_trampoline_workspace.rs`) mirroring the matrix in `cli_cargo_run_trampoline.rs`:
  - **build**: cold writes sidecar; warm skips cargo (verified via broken-cargo stub); edit source falls through; deleting a recorded output falls through.
  - **check**: cold writes sidecar with `.rmeta` refs; warm skips cargo; deleting one `.rmeta` falls through.
  - **clippy**: cold writes `clippy_capture` block + sibling gzip files; warm replays diagnostics without spawning cargo; edit source falls through.
  - Cross-cutting: build/check have independent sidecars; `--no-trampoline` flag forces fall-through; `SOLDR_NO_TRAMPOLINE=1` env var forces fall-through.
- All 12 pre-existing run-trampoline integration tests continue to pass unchanged.

## Test plan

```bash
soldr cargo fmt --all -- --check          # clean
soldr cargo clippy --workspace -- -D warnings  # clean
soldr cargo test --workspace              # all green
```

Workspace test summary on Windows + MSVC: every binary suite passes — no regressions, no flakes after re-running parallel-timing-sensitive tests in isolation.

## What this does NOT change

- The `cargo run` trampoline behavior — its sidecar format, its tests, its env vars are all untouched.
- The cargo front door's RUSTC_WRAPPER, linker injection, low-disk warning, or zccache wiring.
- Any user-facing API beyond what's described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)