### PR TITLE
fix(cli): keep `update-zccache` as a clap alias of `install-zccache`

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -299,7 +299,7 @@ enum Commands {
     /// provided. `<source>` accepts `system`, a directory or archive
     /// path (`.zip` / `.tar.gz` / `.tar.zst`), or an `http(s)://` URL
     /// pointing at such an archive.
-    #[command(name = "install-zccache")]
+    #[command(name = "install-zccache", alias = "update-zccache")]
     InstallZccache {
         /// Source for the three zccache binaries. Mutually exclusive
         /// with `--remove` / `--status`.


### PR DESCRIPTION
## Summary

PR #403 renamed the CLI verb `update-zccache` → `install-zccache` without keeping the old name as an alias. clap stopped matching the old name, so soldr now falls through to the external-subcommand fetch path and fails with `tool not found: update-zccache: not found on crates.io`.

This breaks external CI callers that pin to an older invocation, in particular the [zccache repo's perf workflow](https://github.com/zackees/zccache/actions/runs/26253458842/job/77270870766):

```
soldr update-zccache "$(pwd)/staged/zccache" --json
→ soldr: fetching update-zccache...
→ soldr: tool not found: update-zccache: not found on crates.io
```

One-line fix: add `alias = "update-zccache"` to the `InstallZccache` clap attribute. The canonical name stays `install-zccache` in help output and docs; the old name keeps working for existing callers.

```diff
-    #[command(name = "install-zccache")]
+    #[command(name = "install-zccache", alias = "update-zccache")]
     InstallZccache { ... }
```

## Audit — is this the only renamed verb that lost an alias?

Yes. I scanned the full history of `crates/soldr-cli/src/main.rs` for prior `#[command(name = ...)]` changes:

```
-    #[command(name = "update-zccache")]
+    #[command(name = "install-zccache")]
+    #[command(name = "update-zccache")]    ← original add in #401
+    #[command(name = "session-start")]
+    #[command(name = "session-end")]
+    #[command(name = "prune-target")]
+    #[command(name = "clippy-driver")]
+    #[command(name = "rust-gdb")]
+    #[command(name = "rust-lldb")]
+    #[command(name = "rust-analyzer")]
```

Only one verb has ever been renamed: `update-zccache` → `install-zccache`. Every other entry is an introduction of a new command under its current name. There's already one alias precedent (`#[command(alias = "purge-targets")]` on `Gc`, `crates/soldr-cli/src/main.rs:199`), so this matches an existing pattern.

## Verification

Built locally (rustup 1.94.1-x86_64-pc-windows-msvc) and ran both names against the same binary:

```
$ ./target/debug/soldr.exe update-zccache --status --json | head
{
  "schema_version": 1,
  "command": "install-zccache --status",
  ...

$ ./target/debug/soldr.exe install-zccache --status --json | head
{
  "schema_version": 1,
  "command": "install-zccache --status",
  ...
```

Identical output. The alias dispatches to the same handler.

## Test plan

- [x] `soldr update-zccache --status --json` produces the expected JSON instead of falling through to external-tool fetch.
- [x] `soldr install-zccache --status --json` still produces the same output.
- [ ] Re-run the failing zccache CI step against a soldr build that includes this PR (will exercise `soldr update-zccache "<path>" --json` end-to-end, not just `--status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)