### PR TITLE
fix(cli): prune orphan .rmeta after failed cargo build (soldr#410)

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door.rs
+++ b/crates/soldr-cli/src/cargo_front_door.rs
@@ -148,6 +148,15 @@ pub(crate) async fn run_cargo_front_door(
         if let Some(plan) = trampoline_plan.as_ref() {
             refresh_sidecar_after_cargo(plan);
         }
+    } else if let Some(plan) = plan_ctx.as_ref() {
+        // A non-zero cargo exit can leave orphan `.rmeta` files (rmeta
+        // emitted, then rustc aborted before the `.rlib` codegen pass)
+        // in `target/<triple>/<profile>/deps/`. Subsequent invocations
+        // then fail with `E0463: can't find crate` because cargo passes
+        // `--extern X=orphan.rmeta` to dependents and rustc cannot link
+        // an rmeta-only crate. Sweep them so the next build rebuilds
+        // cleanly. See soldr#410.
+        rust_plan::prune_orphan_rmetas_after_failed_build(plan);
     }
     if let Some(session) = session {
         finish_zccache_build(&session)?;

--- a/crates/soldr-cli/src/rust_plan.rs
+++ b/crates/soldr-cli/src/rust_plan.rs
@@ -448,6 +448,138 @@ pub(crate) fn write_warm_restore_sentinel(plan: &RustArtifactPlanContext) {
     }
 }
 
+/// Walk `deps_dir` shallowly and delete every `.rmeta` file whose filename
+/// stem has no matching `.rlib`, `.so`, `.dylib`, or `.dll` sibling.
+/// Returns the number of files deleted. See soldr#410: a half-completed
+/// rustc invocation (rmeta emitted before codegen finishes) leaves orphan
+/// rmetas that poison the next `cargo build` with
+/// `E0463: can't find crate`. Best-effort — IO errors are reported via
+/// stderr and skipped so the caller can still surface the original cargo
+/// failure.
+pub(crate) fn prune_orphan_rmetas_in_deps(deps_dir: &std::path::Path) -> usize {
+    let entries = match std::fs::read_dir(deps_dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+
+    let mut rmeta_paths: Vec<std::path::PathBuf> = Vec::new();
+    let mut companion_stems: std::collections::HashSet<std::ffi::OsString> =
+        std::collections::HashSet::new();
+
+    for entry in entries.flatten() {
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let Some(ext) = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|s| s.to_ascii_lowercase())
+        else {
+            continue;
+        };
+        let Some(stem) = path.file_stem() else {
+            continue;
+        };
+        match ext.as_str() {
+            "rmeta" => rmeta_paths.push(path.clone()),
+            "rlib" | "so" | "dylib" | "dll" => {
+                companion_stems.insert(stem.to_owned());
+            }
+            _ => {}
+        }
+    }
+
+    let mut deleted = 0;
+    for rmeta in rmeta_paths {
+        let Some(stem) = rmeta.file_stem() else {
+            continue;
+        };
+        if companion_stems.contains(stem) {
+            continue;
+        }
+        match std::fs::remove_file(&rmeta) {
+            Ok(()) => deleted += 1,
+            Err(e) => eprintln!(
+                "soldr warning: failed to prune orphan rmeta {}: {e}",
+                rmeta.display()
+            ),
+        }
+    }
+    deleted
+}
+
+/// Apply [`prune_orphan_rmetas_in_deps`] to the deps directory implied by
+/// the active artifact plan. `target_dir` from the plan is the workspace
+/// `target/` root (per `cargo metadata`); the actual deps live under
+/// `<target>/[<triple>/]<profile>/deps/`. We walk every directory named
+/// `deps` up to a small depth so we cover both the host-target layout
+/// (`target/<profile>/deps/`) and the explicit-target layout
+/// (`target/<triple>/<profile>/deps/`) without needing to thread the
+/// triple/profile through the call site.
+pub(crate) fn prune_orphan_rmetas_after_failed_build(plan: &RustArtifactPlanContext) {
+    let target_root = std::path::PathBuf::from(&plan.target_dir);
+    let mut total = 0usize;
+    for deps_dir in find_deps_dirs(&target_root, 3) {
+        total = total.saturating_add(prune_orphan_rmetas_in_deps(&deps_dir));
+    }
+    if total > 0 {
+        eprintln!(
+            "soldr: pruned {total} orphan .rmeta file(s) under {} after failed cargo build (soldr#410)",
+            target_root.display()
+        );
+    }
+}
+
+/// Locate `deps/` subdirectories under `root` up to `max_depth` levels
+/// deep (inclusive). Designed to find the cargo `target/[<triple>/]<profile>/deps/`
+/// trees without descending into unrelated directories like `incremental/`,
+/// `build/`, or `doc/`.
+fn find_deps_dirs(root: &std::path::Path, max_depth: usize) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    walk_for_deps_dirs(root, max_depth, &mut out);
+    out
+}
+
+#[cfg(test)]
+pub(crate) fn find_deps_dirs_for_test(
+    root: &std::path::Path,
+    max_depth: usize,
+) -> Vec<std::path::PathBuf> {
+    find_deps_dirs(root, max_depth)
+}
+
+fn walk_for_deps_dirs(
+    dir: &std::path::Path,
+    remaining_depth: usize,
+    out: &mut Vec<std::path::PathBuf>,
+) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        if !ft.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        if path.file_name().is_some_and(|n| n == "deps") {
+            out.push(path.clone());
+            // Do not descend further: cargo never nests another `deps/`
+            // inside a `deps/`, and we want to keep the walk shallow.
+            continue;
+        }
+        if remaining_depth > 0 {
+            walk_for_deps_dirs(&path, remaining_depth - 1, out);
+        }
+    }
+}
+
 fn rust_artifact_cache_mode_from_env() -> Result<Option<String>, SoldrError> {
     let raw = std::env::var(TARGET_CACHE_MODE_ENV_VAR).unwrap_or_default();
     let mode = raw.trim().to_ascii_lowercase();

--- a/crates/soldr-cli/src/rust_plan_tests/mod.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/mod.rs
@@ -5,6 +5,7 @@
 
 mod bundle_walk;
 mod manifest;
+mod orphan_rmeta;
 mod plan_build;
 mod warm_restore;
 mod wire_compat;

--- a/crates/soldr-cli/src/rust_plan_tests/orphan_rmeta.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/orphan_rmeta.rs
@@ -1,0 +1,350 @@
+//! Tests for the orphan-`.rmeta` pruner that defends against
+//! soldr#410: when `cargo build` aborts mid-build after rustc has
+//! emitted a crate's `.rmeta` but before the `.rlib` codegen pass
+//! completes, the orphan `.rmeta` survives in
+//! `target/<triple>/<profile>/deps/`. Subsequent builds then fail
+//! with `E0463: can't find crate for X` because cargo passes
+//! `--extern X=orphan.rmeta` and rustc cannot link an rmeta-only
+//! crate.
+//!
+//! Pruner contract under test:
+//!
+//! 1. An `.rmeta` whose stem has a matching `.rlib`, `.so`,
+//!    `.dylib`, or `.dll` sibling stays.
+//! 2. An `.rmeta` with no matching companion is deleted.
+//! 3. Non-`.rmeta` files are never touched.
+//! 4. Files in subdirectories of `deps/` (e.g.,
+//!    `deps/<somedir>/whatever.rmeta`) are never touched.
+//! 5. A missing `deps/` directory is a no-op (returns 0).
+//! 6. The walker reports the count of deleted files.
+//!
+//! The adversarial cases below pin down each leaf of the contract
+//! plus interactions: per-crate-type companions (lib/cdylib/proc-
+//! macro), hash-collision twins (two builds of the same crate at
+//! different fingerprints), and subdir isolation.
+
+use crate::rust_plan::{find_deps_dirs_for_test, prune_orphan_rmetas_in_deps};
+use std::fs;
+use std::path::Path;
+
+/// Create an empty file at `dir/name`. Panics on IO failure — tests
+/// run in an empty `tempdir()` so this is a programmer-error path.
+fn touch(dir: &Path, name: &str) {
+    fs::write(dir.join(name), b"").expect("touch");
+}
+
+fn exists(dir: &Path, name: &str) -> bool {
+    dir.join(name).exists()
+}
+
+#[test]
+fn missing_deps_dir_is_a_no_op() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("nonexistent-deps");
+    assert_eq!(prune_orphan_rmetas_in_deps(&missing), 0);
+}
+
+#[test]
+fn empty_deps_dir_is_a_no_op() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert_eq!(prune_orphan_rmetas_in_deps(tmp.path()), 0);
+}
+
+#[test]
+fn paired_rmeta_and_rlib_are_kept() {
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    touch(deps, "libserde-2d377630294144c0.rmeta");
+    touch(deps, "libserde-2d377630294144c0.rlib");
+    touch(deps, "libserde-2d377630294144c0.d");
+
+    assert_eq!(prune_orphan_rmetas_in_deps(deps), 0);
+    assert!(exists(deps, "libserde-2d377630294144c0.rmeta"));
+    assert!(exists(deps, "libserde-2d377630294144c0.rlib"));
+    assert!(exists(deps, "libserde-2d377630294144c0.d"));
+}
+
+#[test]
+fn orphan_rmeta_with_no_companion_is_deleted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    touch(deps, "libsoldr_core-bc09ee1008e7e294.rmeta");
+    touch(deps, "libsoldr_core-bc09ee1008e7e294.d");
+
+    assert_eq!(prune_orphan_rmetas_in_deps(deps), 1);
+    assert!(!exists(deps, "libsoldr_core-bc09ee1008e7e294.rmeta"));
+    // `.d` files are unrelated to the linking failure and must not be
+    // touched: they're cargo dep-info bookkeeping, not artifacts.
+    assert!(exists(deps, "libsoldr_core-bc09ee1008e7e294.d"));
+}
+
+#[test]
+fn proc_macro_dll_on_windows_keeps_rmeta() {
+    // Proc-macro crate types on Windows emit a `.dll` instead of an
+    // `.rlib`. The rmeta-with-dll pair is a legitimate "built and
+    // linkable" state and must not be pruned.
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    touch(deps, "serde_derive-abc123.rmeta");
+    touch(deps, "serde_derive-abc123.dll");
+
+    assert_eq!(prune_orphan_rmetas_in_deps(deps), 0);
+    assert!(exists(deps, "serde_derive-abc123.rmeta"));
+    assert!(exists(deps, "serde_derive-abc123.dll"));
+}
+
+#[test]
+fn proc_macro_so_on_linux_keeps_rmeta() {
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    touch(deps, "libserde_derive-abc123.rmeta");
+    touch(deps, "libserde_derive-abc123.so");
+
+    assert_eq!(prune_orphan_rmetas_in_deps(deps), 0);
+    assert!(exists(deps, "libserde_derive-abc123.rmeta"));
+    assert!(exists(deps, "libserde_derive-abc123.so"));
+}
+
+#[test]
+fn cdylib_dylib_on_macos_keeps_rmeta() {
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    touch(deps, "libfoo-abc123.rmeta");
+    touch(deps, "libfoo-abc123.dylib");
+
+    assert_eq!(prune_orphan_rmetas_in_deps(deps), 0);
+    assert!(exists(deps, "libfoo-abc123.rmeta"));
+    assert!(exists(deps, "libfoo-abc123.dylib"));
+}
+
+#[test]
+fn rlib_without_rmeta_is_untouched() {
+    // The reverse of an orphan rmeta. A bare rlib with no rmeta is a
+    // legitimate state for some crate types (and is harmless even when
+    // it isn't). Pruner must never touch non-`.rmeta` files.
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    touch(deps, "libfoo-abc123.rlib");
+
+    assert_eq!(prune_orphan_rmetas_in_deps(deps), 0);
+    assert!(exists(deps, "libfoo-abc123.rlib"));
+}
+
+#[test]
+fn mixed_dir_prunes_only_orphans() {
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+
+    // Paired (keep).
+    touch(deps, "libserde-2d37763.rmeta");
+    touch(deps, "libserde-2d37763.rlib");
+    // Orphan (delete).
+    touch(deps, "libsoldr_core-bc09ee.rmeta");
+    // Proc-macro pair (keep).
+    touch(deps, "serde_derive-abc123.rmeta");
+    touch(deps, "serde_derive-abc123.dll");
+    // Another orphan (delete).
+    touch(deps, "libtoml-deadbeef.rmeta");
+    // Bare rlib (keep — untouched, not even considered).
+    touch(deps, "libonly_rlib-cafef00d.rlib");
+    // Bare .d (untouched).
+    touch(deps, "stray-12345.d");
+
+    let deleted = prune_orphan_rmetas_in_deps(deps);
+    assert_eq!(deleted, 2, "exactly two orphan rmetas should be deleted");
+
+    assert!(exists(deps, "libserde-2d37763.rmeta"));
+    assert!(exists(deps, "libserde-2d37763.rlib"));
+    assert!(!exists(deps, "libsoldr_core-bc09ee.rmeta"));
+    assert!(exists(deps, "serde_derive-abc123.rmeta"));
+    assert!(exists(deps, "serde_derive-abc123.dll"));
+    assert!(!exists(deps, "libtoml-deadbeef.rmeta"));
+    assert!(exists(deps, "libonly_rlib-cafef00d.rlib"));
+    assert!(exists(deps, "stray-12345.d"));
+}
+
+#[test]
+fn hash_collision_twins_evaluated_independently() {
+    // The exact failure shape from soldr#410: cargo invalidates the
+    // existing crate fingerprint between two builds and a new hash
+    // gets recompiled. The previous (paired) artifact stays; the
+    // newer (failed) build leaves an orphan rmeta. Pruning must keep
+    // the paired set and remove only the orphan twin.
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    touch(deps, "libsoldr_core-b246b1f7b60ba827.rmeta");
+    touch(deps, "libsoldr_core-b246b1f7b60ba827.rlib");
+    touch(deps, "libsoldr_core-bc09ee1008e7e294.rmeta"); // orphan twin
+
+    assert_eq!(prune_orphan_rmetas_in_deps(deps), 1);
+    assert!(exists(deps, "libsoldr_core-b246b1f7b60ba827.rmeta"));
+    assert!(exists(deps, "libsoldr_core-b246b1f7b60ba827.rlib"));
+    assert!(!exists(deps, "libsoldr_core-bc09ee1008e7e294.rmeta"));
+}
+
+#[test]
+fn files_in_subdirectories_are_ignored() {
+    // `target/<profile>/deps/` does not normally contain
+    // subdirectories, but cargo and zccache occasionally drop nested
+    // structures (e.g., `incremental/`). The pruner walks deps/
+    // shallow and must not descend into subdirs — a stray orphan
+    // rmeta inside an incremental cache or a side-by-side build
+    // directory has different semantics and is not our concern.
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    let nested = deps.join("nested");
+    fs::create_dir_all(&nested).unwrap();
+    touch(&nested, "libfoo-deadbeef.rmeta");
+    // Sibling orphan at the top level — must still be pruned.
+    touch(deps, "libbar-cafef00d.rmeta");
+
+    assert_eq!(prune_orphan_rmetas_in_deps(deps), 1);
+    assert!(exists(&nested, "libfoo-deadbeef.rmeta"));
+    assert!(!exists(deps, "libbar-cafef00d.rmeta"));
+}
+
+#[test]
+fn non_rmeta_files_are_never_touched() {
+    // The pruner must not act on any extension other than `.rmeta`.
+    // Crate-author convention emits `.d` dep-info files, `.rlib`,
+    // `.so`/`.dll`/`.dylib`, and `.exe` outputs, none of which we own.
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    touch(deps, "libfoo-1.d");
+    touch(deps, "libfoo-1.rlib");
+    touch(deps, "libfoo-1.so");
+    touch(deps, "libfoo-1.dll");
+    touch(deps, "libfoo-1.dylib");
+    touch(deps, "main-2.exe");
+    touch(deps, "extension-less-file");
+
+    assert_eq!(prune_orphan_rmetas_in_deps(deps), 0);
+    for name in [
+        "libfoo-1.d",
+        "libfoo-1.rlib",
+        "libfoo-1.so",
+        "libfoo-1.dll",
+        "libfoo-1.dylib",
+        "main-2.exe",
+        "extension-less-file",
+    ] {
+        assert!(exists(deps, name), "{name} must not have been touched");
+    }
+}
+
+#[test]
+fn file_path_not_a_directory_is_a_no_op() {
+    // Defensive: if the caller hands the pruner a path that happens
+    // to be a file (because they passed the wrong arg, or a deps/
+    // path was clobbered by a `touch` on Windows AV), do not crash —
+    // just return 0 and leave it alone.
+    let tmp = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("not-a-dir");
+    fs::write(&f, b"hi").unwrap();
+    assert_eq!(prune_orphan_rmetas_in_deps(&f), 0);
+    assert!(f.exists(), "the bogus file must not be deleted");
+}
+
+#[test]
+fn find_deps_dirs_covers_host_target_layout() {
+    // `target/debug/deps/` (no triple) and `target/release/deps/`
+    // (host-target builds) sit two levels under the target root.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("debug").join("deps")).unwrap();
+    fs::create_dir_all(root.join("release").join("deps")).unwrap();
+
+    let mut found = find_deps_dirs_for_test(root, 3);
+    found.sort();
+    assert_eq!(found.len(), 2);
+    assert!(found[0].ends_with("debug/deps") || found[0].ends_with("debug\\deps"));
+    assert!(found[1].ends_with("release/deps") || found[1].ends_with("release\\deps"));
+}
+
+#[test]
+fn find_deps_dirs_covers_explicit_target_layout() {
+    // `target/<triple>/<profile>/deps/` — the soldr-injected layout
+    // sits THREE levels under target/, which is why the default
+    // search depth must be at least 3.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(
+        root.join("x86_64-pc-windows-msvc")
+            .join("debug")
+            .join("deps"),
+    )
+    .unwrap();
+    fs::create_dir_all(
+        root.join("x86_64-pc-windows-msvc")
+            .join("release")
+            .join("deps"),
+    )
+    .unwrap();
+
+    let found = find_deps_dirs_for_test(root, 3);
+    assert_eq!(found.len(), 2);
+    for p in &found {
+        assert!(
+            p.ends_with("deps"),
+            "every returned path must end with deps: {p:?}"
+        );
+    }
+}
+
+#[test]
+fn find_deps_dirs_does_not_descend_into_deps_subtree() {
+    // The walker stops descending once it finds a `deps/`. A nested
+    // `deps/deps/` (cargo never makes one, but we should be safe
+    // against pathological repo state) is reported once, not twice.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("debug").join("deps").join("deps")).unwrap();
+
+    let found = find_deps_dirs_for_test(root, 5);
+    assert_eq!(found.len(), 1);
+    assert!(found[0].ends_with("debug/deps") || found[0].ends_with("debug\\deps"));
+}
+
+#[test]
+fn find_deps_dirs_ignores_non_deps_siblings() {
+    // `target/<profile>/{build,incremental,examples}/...` must not be
+    // misclassified as a deps directory. Only the literal name `deps`
+    // matches.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    for sibling in ["build", "incremental", "examples", "doc"] {
+        fs::create_dir_all(root.join("debug").join(sibling)).unwrap();
+    }
+    fs::create_dir_all(root.join("debug").join("deps")).unwrap();
+
+    let found = find_deps_dirs_for_test(root, 3);
+    assert_eq!(found.len(), 1);
+    assert!(found[0].ends_with("debug/deps") || found[0].ends_with("debug\\deps"));
+}
+
+#[test]
+fn find_deps_dirs_missing_root_returns_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("never-created-target");
+    assert!(find_deps_dirs_for_test(&missing, 3).is_empty());
+}
+
+#[test]
+fn case_insensitive_rmeta_extension_is_recognized() {
+    // Windows filesystems are case-insensitive by default and rustc's
+    // output is always lowercase, but a user-supplied symlink or a
+    // restored backup could conceivably land an `.RMETA` (or `.RLib`)
+    // in deps/. Match extensions case-insensitively so the pruner
+    // remains predictable.
+    let tmp = tempfile::tempdir().unwrap();
+    let deps = tmp.path();
+    touch(deps, "libfoo-1.RMETA"); // orphan, but uppercase
+    touch(deps, "libbar-2.Rmeta");
+    touch(deps, "libbar-2.RLIB"); // companion in upper case
+
+    let deleted = prune_orphan_rmetas_in_deps(deps);
+    assert_eq!(deleted, 1, "only the bare uppercase rmeta should be pruned");
+    assert!(!exists(deps, "libfoo-1.RMETA"));
+    assert!(exists(deps, "libbar-2.Rmeta"));
+    assert!(exists(deps, "libbar-2.RLIB"));
+}


### PR DESCRIPTION
## Summary

Fixes #410. When `cargo build` aborts mid-build, rustc may have emitted a crate's `.rmeta` (pipelined-metadata pass) but not the matching `.rlib` (codegen pass). The orphan `.rmeta` survives in `target/<triple>/<profile>/deps/`, and every subsequent build then fails with `E0463: can't find crate for X` because cargo passes `--extern X=orphan.rmeta` to dependent rustc invocations and rustc cannot link against an rmeta-only crate.

This is the exact bug #410 documents — `cargo check` works (no link), `cargo build` doesn't, the user sees what looks like a fetch failure even though every artifact they need is right there.

The acceptance criterion from #410:

> After any failing `soldr cargo build`, the next `soldr cargo build` either succeeds (if the input that caused the failure is gone) or fails with the same root-cause error — not with a stale `E0463: can't find crate` caused by orphan rmetas from the prior run.

## Fix

In `crates/soldr-cli/src/cargo_front_door.rs`, on a non-zero cargo exit, sweep the deps directory implied by the active artifact plan and delete any `.rmeta` whose stem has no companion `.rlib` / `.so` / `.dylib` / `.dll`. The next invocation rebuilds the affected crates cleanly.

```rust
let status = command.status()?;
if status.success() {
    // ... save + sentinel ...
} else if let Some(plan) = plan_ctx.as_ref() {
    // soldr#410: rmeta-but-no-rlib orphans poison cargo's dep graph.
    rust_plan::prune_orphan_rmetas_after_failed_build(plan);
}
```

The walker handles both cargo layouts:
- host-target: `target/<profile>/deps/`
- explicit-target (soldr's default on Windows): `target/<triple>/<profile>/deps/`

Best-effort: any IO failure during pruning is reported to stderr and skipped so the original cargo exit code remains the user's signal.

## TDD — RED → GREEN

Built up the contract one adversarial leaf at a time before writing a line of impl. 19 unit tests, all in a new `crates/soldr-cli/src/rust_plan_tests/orphan_rmeta.rs` module.

**Pruner contract (`prune_orphan_rmetas_in_deps`)**

- `paired_rmeta_and_rlib_are_kept` — the only common case.
- `orphan_rmeta_with_no_companion_is_deleted` — the bug from #410.
- `proc_macro_dll_on_windows_keeps_rmeta` — proc-macros on Windows emit a `.dll`, not an `.rlib`. rmeta + dll is a legitimate pair.
- `proc_macro_so_on_linux_keeps_rmeta` — same for Linux `.so`.
- `cdylib_dylib_on_macos_keeps_rmeta` — same for macOS `.dylib`.
- `rlib_without_rmeta_is_untouched` — pruner is rmeta-only; we don't own bare rlibs.
- `non_rmeta_files_are_never_touched` — `.d`, `.exe`, extension-less files all stay put.
- `mixed_dir_prunes_only_orphans` — combination of the above in one dir.
- `hash_collision_twins_evaluated_independently` — the exact #410 shape: cargo invalidated a fingerprint, two builds left two `libsoldr_core-<hash>` stems, the paired one stays and the orphan twin is removed.
- `files_in_subdirectories_are_ignored` — pruner walks `deps/` shallow, never recurses into anything cargo might park inside it.
- `case_insensitive_rmeta_extension_is_recognized` — Windows-friendly: `.RMETA` matches `.rmeta`.
- `empty_deps_dir_is_a_no_op`, `missing_deps_dir_is_a_no_op` — degenerate inputs.
- `file_path_not_a_directory_is_a_no_op` — caller hands us a bogus path; we return 0 and never delete the file.

**Directory-walk contract (`find_deps_dirs`)**

- `find_deps_dirs_covers_host_target_layout` — `target/debug/deps/` and `target/release/deps/` (depth 2) are both found.
- `find_deps_dirs_covers_explicit_target_layout` — `target/<triple>/<profile>/deps/` (depth 3, soldr's default on Windows MSVC) is found.
- `find_deps_dirs_does_not_descend_into_deps_subtree` — pathological `deps/deps/` reports the outer once.
- `find_deps_dirs_ignores_non_deps_siblings` — `build/`, `incremental/`, `examples/`, `doc/` are never matched.
- `find_deps_dirs_missing_root_returns_empty` — missing target root is benign.

## Verification

```
$ cargo test -p soldr-cli --bin soldr orphan_rmeta
... 19 passed; 0 failed; 0 ignored; 0 measured; 187 filtered out

$ cargo test --workspace
... 65 passed
... 206 passed   <- includes the new 19
... 18 passed
... [many more] ...
test result: ok across the workspace.
```

No regressions in the 380-test suite.

## Scope notes / what this does NOT fix yet

This is the defensive fallback the #410 acceptance criteria explicitly call out. It does not address the deeper "why does cargo abort mid-build in the first place" question — that's the [follow-up comment on #410](https://github.com/zackees/soldr/issues/410#issuecomment-4513099966) covering plan-rollback semantics and the warm-restore sentinel short-circuit. Those changes are higher-risk and worth landing separately.

Specifically NOT in this PR (deferred to follow-ups on #410):
- Plan-file rollback on cargo failure.
- Warm-restore sentinel verifying the artifacts it expects on disk before short-circuiting `restore`.
- Pinned-zccache binary sha256 re-verification.

After this PR, the user-visible symptom is gone even if the underlying mid-build abort still happens occasionally.

## Test plan

- [x] `cargo test -p soldr-cli --bin soldr orphan_rmeta` — 19/19 green.
- [x] `cargo test --workspace` — full suite green, no regressions.
- [ ] On a Windows MSVC checkout that currently exhibits the bug, run `soldr cargo build` once (expected: fails with E0463). Confirm the new stderr line `soldr: pruned N orphan .rmeta file(s) ...` appears, then re-run `soldr cargo build` (expected: succeeds, no more E0463).

🤖 Generated with [Claude Code](https://claude.com/claude-code)