### PR TITLE
fix(cli): reorder trampoline_workspace.rs imports for rustfmt

### DIFF
--- a/crates/soldr-cli/src/trampoline_workspace.rs
+++ b/crates/soldr-cli/src/trampoline_workspace.rs
@@ -15,6 +15,7 @@
 //! recorded source's stat doesn't match, we fall through to real cargo —
 //! partial skip would leave cargo's incremental state inconsistent.
 
+use crate::core::SoldrError;
 use crate::trampoline::{
     compute_fingerprint, effective_target_triple, find_nearest_manifest, log_event,
     log_fall_through, mtime_nanos, parse_cargo_args, resolve_target_dir, size_as_i64,
@@ -22,7 +23,6 @@ use crate::trampoline::{
     NO_TRAMPOLINE_ENV_VAR,
 };
 use serde::{Deserialize, Serialize};
-use crate::core::SoldrError;
 use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::fs;


### PR DESCRIPTION
## Summary

One-line follow-up to the monocrate collapse (PR #415). The rebase-time fix that rewrote `use soldr_core::SoldrError;` → `use crate::core::SoldrError;` left the import in the original position. rustfmt expects all `use crate::*` imports in one sorted group, so the line needs to move above `use crate::trampoline::{...}`.

```diff
-use crate::trampoline::{
-    compute_fingerprint, ...,
-    NO_TRAMPOLINE_ENV_VAR,
-};
-use serde::{Deserialize, Serialize};
-use crate::core::SoldrError;
+use crate::core::SoldrError;
+use crate::trampoline::{
+    compute_fingerprint, ...,
+    NO_TRAMPOLINE_ENV_VAR,
+};
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
```

Caught by the CI Lint job on commit `f5ef30a` (post-#415 main). Verified `cargo fmt --all -- --check` is clean locally after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)