### PR TITLE
ci: clean up stale crate references after monocrate collapse

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -32,9 +32,10 @@ on:
         type: string
         default: ''
       run_fetch_test:
-        # The crates.io fetch integration test (soldr-fetch) is
-        # heavy and not platform-conditional. Disable when a caller
-        # only wants the unit-test sweep.
+        # The crates.io fetch integration test (tests/fetch_crgx.rs in
+        # the monocrate soldr-cli) is heavy and not platform-
+        # conditional. Disable when a caller only wants the unit-test
+        # sweep.
         required: false
         type: boolean
         default: true
@@ -97,4 +98,4 @@ jobs:
 
       - name: Run fetch integration test
         if: inputs.run_fetch_test == true
-        run: cargo test -p soldr-fetch --test fetch_crgx --locked --target ${{ inputs.target }}
+        run: cargo test -p soldr-cli --test fetch_crgx --locked --target ${{ inputs.target }}

--- a/.github/workflows/_cache-benchmark-build.yml
+++ b/.github/workflows/_cache-benchmark-build.yml
@@ -106,7 +106,11 @@ jobs:
               printf '\n// cache benchmark mutation: soldr-cli\n' >> crates/soldr-cli/src/main.rs
               ;;
             soldr-core)
-              printf '\n// cache benchmark mutation: soldr-core\n' >> crates/soldr-core/src/lib.rs
+              # Post-monocrate (PR #415): soldr-core became
+              # `crates/soldr-cli/src/core.rs`. The mutation still
+              # touches the same logical module so cache-hit
+              # expectations are preserved.
+              printf '\n// cache benchmark mutation: soldr-core\n' >> crates/soldr-cli/src/core.rs
               ;;
             *)
               echo "unsupported benchmark mutation: ${{ inputs.mutation }}" >&2

--- a/.github/workflows/parent-cache-bench.yml
+++ b/.github/workflows/parent-cache-bench.yml
@@ -25,7 +25,7 @@ on:
     branches:
       - main
     paths:
-      - "crates/soldr-cache/src/lib.rs"
+      - "crates/soldr-cli/src/cache_lib/**"
       - "crates/soldr-cli/src/zccache.rs"
       - ".github/workflows/parent-cache-bench.yml"
       - "bench/parent_cache_bench.py"

--- a/.github/workflows/thin-v2-verify.yml
+++ b/.github/workflows/thin-v2-verify.yml
@@ -32,14 +32,16 @@ on:
     branches: [main]
     paths:
       - "crates/soldr-cli/src/main.rs"
-      - "crates/soldr-cache/**"
+      - "crates/soldr-cli/src/cache_lib/**"
+      - "crates/soldr-cli/src/rust_plan.rs"
       - ".github/scripts/assert_thin_noop.py"
       - ".github/scripts/assert_thin_manifest.py"
       - ".github/workflows/thin-v2-verify.yml"
   pull_request:
     paths:
       - "crates/soldr-cli/src/main.rs"
-      - "crates/soldr-cache/**"
+      - "crates/soldr-cli/src/cache_lib/**"
+      - "crates/soldr-cli/src/rust_plan.rs"
       - ".github/scripts/assert_thin_noop.py"
       - ".github/scripts/assert_thin_manifest.py"
       - ".github/workflows/thin-v2-verify.yml"

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -105,10 +105,14 @@ kind = "lint"
 
 [[mutations]]
 id = "soldr-cli"
-label = "Top-crate edit"
+label = "Top-of-tree edit"
 path = "crates/soldr-cli/src/main.rs"
 
 [[mutations]]
 id = "soldr-core"
-label = "Lower-crate edit"
-path = "crates/soldr-core/src/lib.rs"
+# Pre-monocrate this was `crates/soldr-core/src/lib.rs` (its own
+# crate). After PR #415 the file moved to
+# `crates/soldr-cli/src/core.rs`. The mutation `id` stays as
+# "soldr-core" so historic benchmark records remain comparable.
+label = "Lower-module edit"
+path = "crates/soldr-cli/src/core.rs"


### PR DESCRIPTION
## Summary

Follow-up to the monocrate collapse (PR #415). Five workflow files (and `benchmark.toml`) still pointed at the dead `soldr-core` / `soldr-fetch` / `soldr-cache` crate paths after the collapse — one was an outright build error, four were silent decay (path filters that now never match).

| File | Was | Now |
|---|---|---|
| `.github/workflows/_build-and-test.yml:100` | `cargo test -p soldr-fetch --test fetch_crgx` | `cargo test -p soldr-cli --test fetch_crgx` |
| `.github/workflows/parent-cache-bench.yml:28` | paths filter `crates/soldr-cache/src/lib.rs` | paths filter `crates/soldr-cli/src/cache_lib/**` |
| `.github/workflows/thin-v2-verify.yml:35,42` | paths filter `crates/soldr-cache/**` | paths filter `crates/soldr-cli/src/cache_lib/**` (plus `crates/soldr-cli/src/rust_plan.rs`, which is where the thin-v2 plan logic lives) |
| `.github/workflows/_cache-benchmark-build.yml:109` | `crates/soldr-core/src/lib.rs` mutation target | `crates/soldr-cli/src/core.rs` |
| `benchmark.toml` | `[[mutations]] path = "crates/soldr-core/src/lib.rs"` | `path = "crates/soldr-cli/src/core.rs"` |

## What stayed

The `soldr-core` and `soldr-cli` mutation **ids** are preserved as stable benchmark labels — only the underlying file paths moved. That keeps historic benchmark records comparable across the collapse rename.

## Why this was missed in #415

The collapse PR exercised `cargo test --workspace` and `cargo fmt --all -- --check` locally, but workflow YAML doesn't appear in either. The `Run fetch integration test` step in `_build-and-test.yml` would have caught it on the first post-merge CI run — but the Lint job (`cargo fmt`) failed first (fixed in #417), short-circuiting before fetch could fail. Once Lint went green on the next CI cycle, fetch would have errored on `package soldr-fetch not found`.

## Out of scope

Not addressed here:
- soldr#418 — pre-existing `target/debug/soldr.exe` vs `target/<triple>/debug/soldr.exe` mismatch in `.github/scripts/windows-msys-default-msvc.sh`. Different root cause, predates the collapse.
- `Perf Matrix` cold-tar-untar-warm soft-perf-gate regressions. Predates the collapse, unrelated to any crate path.

## Test plan

- [x] `cargo test -p soldr-cli --test monocrate_guard` — green.
- [x] `grep -r "soldr-core\|soldr-fetch\|soldr-cache"` across `.github/` + `benchmark.toml` — only intentional history-preserving label references left.
- [ ] CI run confirms `Run fetch integration test` step passes against the post-collapse layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)