### PR TITLE
fix(zccache): source-aware diagnostic + audit all pin spawn paths

### DIFF
--- a/crates/soldr-cli/src/binaries.rs
+++ b/crates/soldr-cli/src/binaries.rs
@@ -256,7 +256,15 @@ pub(crate) fn current_soldr_binary() -> Result<std::path::PathBuf, SoldrError> {
     std::env::current_exe().map_err(SoldrError::from)
 }
 
-pub(crate) async fn fetch_managed_zccache(
+/// Resolve the active zccache binary, honoring the
+/// `SOLDR_ZCCACHE_LOCAL_DIR` -> pinned-install -> managed-cache ->
+/// managed-download precedence chain implemented by
+/// [`crate::fetch::fetch_zccache_with_paths`]. Despite the historical
+/// "managed" name on its callers (see issue #420), the resolution path
+/// already honors `soldr install-zccache` pins ahead of the managed
+/// download — this helper just adds the `SOLDR_TEST_ZCCACHE_BIN` test
+/// override on top.
+pub(crate) async fn fetch_active_zccache(
     paths: &SoldrPaths,
 ) -> Result<crate::fetch::FetchResult, SoldrError> {
     if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
@@ -270,7 +278,11 @@ pub(crate) async fn fetch_managed_zccache(
     crate::fetch::fetch_zccache_with_paths(paths).await
 }
 
-pub(crate) fn cached_managed_zccache(
+/// Same precedence chain as [`fetch_active_zccache`] but only reports
+/// what is already on disk — never triggers a managed download. Returns
+/// `Ok(None)` when nothing has been fetched yet AND no pin / local
+/// override is in effect.
+pub(crate) fn cached_active_zccache(
     paths: &SoldrPaths,
 ) -> Result<Option<crate::fetch::FetchResult>, SoldrError> {
     if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {

--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -6,7 +6,7 @@ use crate::zccache::{
     command_stderr, managed_zccache_cache_dir, run_zccache_command_in_cache_dir,
     run_zccache_command_raw_in_cache_dir, start_zccache_with_recovery,
 };
-use crate::{cached_managed_zccache, fetch_managed_zccache, JSON_SCHEMA_VERSION};
+use crate::{cached_active_zccache, fetch_active_zccache, JSON_SCHEMA_VERSION};
 use serde::Serialize;
 
 pub(crate) fn clear_zccache_cache() -> Result<(), SoldrError> {
@@ -14,7 +14,7 @@ pub(crate) fn clear_zccache_cache() -> Result<(), SoldrError> {
     let zccache_dir = managed_zccache_cache_dir(&paths)?;
     let mut cleared_anything = false;
 
-    if let Some(fetch) = cached_managed_zccache(&paths)? {
+    if let Some(fetch) = cached_active_zccache(&paths)? {
         let _ = run_zccache_command_in_cache_dir(&fetch.binary_path, &["clear"], &zccache_dir)?;
         println!("cleared zccache artifact cache");
         cleared_anything = true;
@@ -103,6 +103,11 @@ pub(crate) struct ZccacheStatusSnapshot {
     session_stats_path: String,
     session_stats_present: bool,
     binary_path: Option<String>,
+    /// Which precedence chain branch produced `binary_path`:
+    /// `"pinned"`, `"local"`, `"managed"`, or `"none"`. Surfaced so
+    /// `soldr cache` / `soldr status` consumers don't have to derive
+    /// it from the path (issue #420).
+    binary_source: &'static str,
     binary_fetched: bool,
     status_lines: Vec<String>,
     status_empty: bool,
@@ -204,7 +209,7 @@ fn collect_cache_report_output() -> Result<CacheReportOutput, SoldrError> {
     };
 
     let rollups = if journal_present {
-        match cached_managed_zccache(&paths)? {
+        match cached_active_zccache(&paths)? {
             Some(fetch) => {
                 let journal_arg = journal_path.display().to_string();
                 let result = run_zccache_command_raw_in_cache_dir(
@@ -524,12 +529,13 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
     let session_stats_path = crate::cache_lib::session_stats_path(&zccache_dir);
     let session_stats_present = session_stats_path.exists();
 
-    match cached_managed_zccache(paths)? {
+    match cached_active_zccache(paths)? {
         Some(fetch) => {
             let output =
                 run_zccache_command_in_cache_dir(&fetch.binary_path, &["status"], &zccache_dir)?;
             let stdout = output.stdout.trim();
             let status_lines = stdout.lines().map(str::to_owned).collect();
+            let source = crate::fetch::classify_zccache_source(paths, &fetch.binary_path);
             Ok(ZccacheStatusSnapshot {
                 cache_dir: zccache_dir.display().to_string(),
                 state_dir: zccache_dir.display().to_string(),
@@ -540,6 +546,7 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
                 session_stats_path: session_stats_path.display().to_string(),
                 session_stats_present,
                 binary_path: Some(fetch.binary_path.display().to_string()),
+                binary_source: source.as_str(),
                 binary_fetched: true,
                 status_lines,
                 status_empty: stdout.is_empty(),
@@ -555,6 +562,7 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
             session_stats_path: session_stats_path.display().to_string(),
             session_stats_present,
             binary_path: None,
+            binary_source: "none",
             binary_fetched: false,
             status_lines: Vec::new(),
             status_empty: false,
@@ -616,7 +624,10 @@ fn print_zccache_status_snapshot(snapshot: &ZccacheStatusSnapshot) {
     );
 
     if let Some(binary_path) = &snapshot.binary_path {
-        println!("zccache binary: {binary_path}");
+        println!(
+            "zccache binary: {binary_path} (source: {})",
+            snapshot.binary_source
+        );
         if snapshot.status_empty {
             println!("zccache status: no output");
         } else {
@@ -747,7 +758,7 @@ pub(crate) async fn run_session_start_command(
         }
     }
 
-    let fetch = fetch_managed_zccache(&paths).await?;
+    let fetch = fetch_active_zccache(&paths).await?;
     start_zccache_with_recovery(&fetch.binary_path, &zccache_dir)?;
 
     let log_arg = session_log_path.display().to_string();
@@ -828,7 +839,7 @@ pub(crate) fn run_session_end_command(
 
     let paths = SoldrPaths::new()?;
     let zccache_dir = managed_zccache_cache_dir(&paths)?;
-    let fetch = cached_managed_zccache(&paths)?.ok_or_else(|| {
+    let fetch = cached_active_zccache(&paths)?.ok_or_else(|| {
         SoldrError::Other(
             "managed zccache binary not yet fetched — run a cache-enabled build first".into(),
         )
@@ -936,7 +947,7 @@ pub(crate) async fn run_cache_shutdown_command(
     let zccache_dir = managed_zccache_cache_dir(&paths)?;
     let mut notes: Vec<String> = Vec::new();
 
-    let fetch = cached_managed_zccache(&paths)?;
+    let fetch = cached_active_zccache(&paths)?;
     let mut output = CacheShutdownOutput {
         schema_version: JSON_SCHEMA_VERSION,
         command: "cache shutdown",
@@ -1192,7 +1203,7 @@ fn poll_zccache_daemon_exit(
 pub(crate) async fn run_cache_flush_command(json: bool) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
     let zccache_dir = managed_zccache_cache_dir(&paths)?;
-    let fetch = cached_managed_zccache(&paths)?;
+    let fetch = cached_active_zccache(&paths)?;
 
     let mut output = CacheFlushOutput {
         schema_version: JSON_SCHEMA_VERSION,

--- a/crates/soldr-cli/src/doctor.rs
+++ b/crates/soldr-cli/src/doctor.rs
@@ -41,6 +41,11 @@ struct DoctorOutput {
     drift: bool,
     missing_components: Vec<String>,
     missing_targets: Vec<String>,
+    /// Which source `soldr cargo build` would actually invoke right
+    /// now: `"pinned"`, `"local"`, `"managed"`, or `"none"`. Added in
+    /// issue #420 so JSON consumers don't have to derive it by
+    /// inspecting `pinned_zccache_active`.
+    active_zccache_source: &'static str,
     /// Managed zccache state on disk. Always reports the managed-path
     /// view even when the active source is a pinned install; the
     /// pinned section below explains the override.
@@ -135,6 +140,7 @@ pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
                 drift: false,
                 missing_components: Vec::new(),
                 missing_targets: Vec::new(),
+                active_zccache_source: bundle.active.source.as_str(),
                 managed_zccache: DoctorManagedZccache::from_summary(&bundle.managed),
                 pinned_zccache: bundle.pinned_doctor.clone(),
                 pinned_zccache_active: bundle.pinned_active,
@@ -217,6 +223,7 @@ pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
             drift,
             missing_components,
             missing_targets,
+            active_zccache_source: bundle.active.source.as_str(),
             managed_zccache: DoctorManagedZccache::from_summary(&bundle.managed),
             pinned_zccache: bundle.pinned_doctor.clone(),
             pinned_zccache_active: bundle.pinned_active,
@@ -246,9 +253,9 @@ pub(crate) fn run_doctor(json: bool) -> Result<i32, SoldrError> {
 /// printer can surface both sections.
 struct ZccacheDoctorBundle {
     /// Active resolution (what `soldr cargo` would use right now).
-    /// Retained for diagnostic context even though every print path
-    /// derives its summary from `managed` / `pinned`.
-    #[allow(dead_code)]
+    /// Now surfaced as the leading "active zccache source:" diagnostic
+    /// line so users can see at a glance which source wins resolution
+    /// before reading the per-section detail (issue #420).
     active: ZccacheBinarySummary,
     /// Managed-path-only state for the "managed zccache:" section. Always
     /// reports the GitHub-Releases view, even when the pinned dir wins
@@ -314,6 +321,13 @@ fn collect_zccache_bundle() -> Result<ZccacheDoctorBundle, SoldrError> {
 }
 
 fn print_zccache_sections(bundle: &ZccacheDoctorBundle) {
+    // Issue #420: lead with a one-liner naming the source that
+    // `soldr cargo build` will actually invoke, so users debugging
+    // pin-related issues don't have to cross-reference the "pinned
+    // zccache:" and "managed zccache:" sections to figure out which
+    // one is live.
+    println!();
+    println!("active zccache source: {}", bundle.active.source.as_str());
     if let (Some(summary), Some(sidecar)) = (bundle.pinned.as_ref(), bundle.pinned_sidecar.as_ref())
     {
         print_pinned_zccache_human(summary, sidecar);

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -199,6 +199,49 @@ impl ZccacheSource {
     }
 }
 
+/// Classify which source produced a resolved zccache binary path.
+///
+/// Uses the same precedence rules as `fetch_zccache_with_paths`:
+/// `SOLDR_ZCCACHE_LOCAL_DIR` -> pinned-install -> managed cache. The
+/// classification is path-prefix-based, so callers that already have a
+/// `FetchResult` from the fetch path can ask "where did this binary
+/// come from" without re-running the resolution.
+///
+/// Returns [`ZccacheSource::None`] when the path matches none of the
+/// known source directories. Practical callers should treat that as
+/// "managed" since the unlabelled fallback comes from the managed
+/// download, but the explicit `None` lets diagnostics distinguish a
+/// path soldr cannot recognize (a test override binary, for example)
+/// from one it can.
+pub fn classify_zccache_source(paths: &SoldrPaths, binary_path: &Path) -> ZccacheSource {
+    let parent = match binary_path.parent() {
+        Some(p) => p,
+        None => return ZccacheSource::None,
+    };
+
+    // Local-build override: binaries land in a content-hashed
+    // `zccache-local-<sha>` subdir under `paths.bin`. Match the dir name
+    // pattern unconditionally so we still classify correctly if
+    // `SOLDR_ZCCACHE_LOCAL_DIR` is no longer set in the current env.
+    if let Some(name) = parent.file_name().and_then(|s| s.to_str()) {
+        if name.starts_with("zccache-local-") {
+            return ZccacheSource::Local;
+        }
+    }
+
+    let pinned_dir = install_zccache::pinned_zccache_dir(paths);
+    if parent == pinned_dir.as_path() {
+        return ZccacheSource::Pinned;
+    }
+
+    let managed_dir = paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"));
+    if parent == managed_dir.as_path() {
+        return ZccacheSource::Managed;
+    }
+
+    ZccacheSource::None
+}
+
 /// Discover the local zccache build that `SOLDR_ZCCACHE_LOCAL_DIR`
 /// points at, copy the binaries (and any debug-info sidecars) into
 /// the soldr-owned cache dir under a content-hashed version key, and
@@ -641,12 +684,16 @@ pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult,
     // Pinned install (`soldr install-zccache <SOURCE>`). Sits
     // between the env-var override and the managed download so users
     // who pinned once never go back to the GitHub-Releases path.
+    //
+    // We deliberately do NOT print a "using pinned zccache from ..."
+    // line here: the cargo front door now emits a source-aware
+    // `soldr: zccache source: pinned|local|managed (...)` line via
+    // `classify_zccache_source` so users see exactly which binary won
+    // resolution. See issue #420 — the old per-branch eprintln paired
+    // with prepare_zccache_build's hard-coded "soldr: using managed
+    // zccache 1.8.1" was the smoking gun that fooled the perf-cluster
+    // debugging session.
     if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
-        eprintln!(
-            "soldr: using pinned zccache from {} (version={})",
-            pinned.runtime_dir.display(),
-            pinned.version
-        );
         return Ok(FetchResult {
             binary_path: pinned.binary_path,
             version: pinned.version,

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -28,8 +28,8 @@ use crate::fetch::VersionSpec;
 
 #[allow(unused_imports)]
 pub(crate) use binaries::{
-    apply_implicit_toolchain_homes, cached_managed_zccache, current_soldr_binary,
-    fetch_managed_zccache, non_empty_env_path, parse_tool_spec, resolve_toolchain_binary,
+    apply_implicit_toolchain_homes, cached_active_zccache, current_soldr_binary,
+    fetch_active_zccache, non_empty_env_path, parse_tool_spec, resolve_toolchain_binary,
     rustup_binary, rustup_resolution_failure, zccache_binary_override,
 };
 

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -2,8 +2,9 @@
 //! Extracted from `main.rs` as part of issue #339.
 
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
+use crate::fetch::ZccacheSource;
 use crate::{
-    current_soldr_binary, fetch_managed_zccache, non_empty_env_path, ZccacheSourceArg,
+    current_soldr_binary, fetch_active_zccache, non_empty_env_path, ZccacheSourceArg,
     RUSTC_WRAPPER_OVERRIDE_ENV_VAR,
 };
 
@@ -119,23 +120,62 @@ async fn prepare_zccache_build(
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
     let fetch = match zccache_source {
-        ZccacheSourceArg::Managed => {
-            let fetched = fetch_managed_zccache(paths).await?;
-            if fetched.cached {
+        ZccacheSourceArg::Managed => fetch_active_zccache(paths).await?,
+        ZccacheSourceArg::System => crate::fetch::resolve_system_zccache(paths)?,
+    };
+
+    // Source-aware diagnostic (issue #420). The old "soldr: using
+    // managed zccache 1.8.1" line printed even when the pinned install
+    // won resolution, which sent three perf-cluster runs chasing the
+    // wrong binary. Print exactly one line that names the actual
+    // source, runtime dir, and version of the binary we just resolved.
+    let source = if matches!(zccache_source, ZccacheSourceArg::System) {
+        ZccacheSource::None // `--zccache=system` doesn't go through the precedence chain.
+    } else {
+        crate::fetch::classify_zccache_source(paths, &fetch.binary_path)
+    };
+    let runtime_dir = fetch
+        .binary_path
+        .parent()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<unknown>".into());
+    match source {
+        ZccacheSource::Pinned => eprintln!(
+            "soldr: zccache source: pinned ({runtime_dir}) version={}",
+            fetch.version
+        ),
+        ZccacheSource::Local => eprintln!(
+            "soldr: zccache source: local ({runtime_dir}) version={}",
+            fetch.version
+        ),
+        ZccacheSource::Managed => {
+            if fetch.cached {
                 eprintln!(
-                    "soldr: using managed zccache {}",
-                    crate::fetch::MANAGED_ZCCACHE_VERSION
+                    "soldr: zccache source: managed ({runtime_dir}) version={} (cached)",
+                    fetch.version
                 );
             } else {
                 eprintln!(
-                    "soldr: fetched managed zccache {}",
-                    crate::fetch::MANAGED_ZCCACHE_VERSION
+                    "soldr: zccache source: managed ({runtime_dir}) version={} (downloaded)",
+                    fetch.version
                 );
             }
-            fetched
         }
-        ZccacheSourceArg::System => crate::fetch::resolve_system_zccache(paths)?,
-    };
+        ZccacheSource::None => {
+            if matches!(zccache_source, ZccacheSourceArg::System) {
+                eprintln!(
+                    "soldr: zccache source: system ({runtime_dir}) version={}",
+                    fetch.version
+                );
+            } else {
+                eprintln!(
+                    "soldr: zccache source: unrecognized ({runtime_dir}) version={} \
+                     — likely SOLDR_TEST_ZCCACHE_BIN override",
+                    fetch.version
+                );
+            }
+        }
+    }
 
     // When the resolved zccache CLI binary differs from the one a
     // previous soldr invocation started the daemon with, the live

--- a/crates/soldr-cli/tests/cli_install_zccache_resolution.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache_resolution.rs
@@ -1,0 +1,382 @@
+//! Regression tests for issue #420 — `install-zccache` / `update-zccache`
+//! pin silently ignored by daemon spawn.
+//!
+//! The issue reporter (zackees) observed that after pinning a custom
+//! zccache build via `soldr install-zccache <path>`, subsequent
+//! `soldr cargo build` invocations spawned the managed v1.8.1 daemon
+//! instead of the pinned one — silently invalidating three perf-cluster
+//! runs in the zackees/zccache repo before being noticed.
+//!
+//! Code reading suggested the resolution chain in
+//! `fetch_zccache_with_paths` already places the pinned check ahead of
+//! the managed cache, so the pin SHOULD win. These tests pin that
+//! contract down so the bug can't silently regress:
+//!
+//! 1. `fetch_zccache_with_paths_returns_pinned_over_managed_cache` —
+//!    the most direct expression of the issue's hypothesis. Seeds both
+//!    the managed cache dir AND the pinned dir, then asserts the
+//!    resolver returns the pinned binary.
+//! 2. `cached_zccache_binary_returns_pinned_over_managed_cache` — same
+//!    invariant for the read-only path used by `soldr cache`, status,
+//!    session-end, shutdown.
+//! 3. `classify_zccache_source_tags_each_branch_correctly` — pure
+//!    classifier used by `soldr doctor` / cache status / the new
+//!    "soldr: zccache source: ..." diagnostic in prepare_zccache_build.
+//! 4. `eviction_sentinel_triggers_switch_from_managed_to_pinned` —
+//!    covers the "stale daemon was already alive" hypothesis from the
+//!    issue. Simulates the user's actual repro by seeding the sentinel
+//!    with a managed path, then asserting that resolution against the
+//!    pinned binary triggers an eviction.
+//! 5. `install_then_status_subprocess_reports_pinned_source` — the
+//!    CLI-surface check: pin via subprocess, then run `soldr doctor`
+//!    and `soldr cache --json`, assert both report `pinned` as the
+//!    active source.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::unique_temp_dir;
+use serde_json::Value;
+use soldr_cli::core::SoldrPaths;
+use soldr_cli::fetch::{
+    cached_zccache_binary, classify_zccache_source, fetch_zccache_with_paths,
+    install_zccache_from_source, FetchResult, InstallSource, ZccacheSource,
+    MANAGED_ZCCACHE_VERSION, PINNED_ZCCACHE_DIRNAME, ZCCACHE_LOCAL_DIR_ENV_VAR,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Tests in this file run blocking installs via `tokio::test`; pull in
+/// the runtime so `install_zccache_from_source` (which is `async`)
+/// works.
+fn bin_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+fn write_fake(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
+    fs::create_dir_all(dir).unwrap();
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    path
+}
+
+fn seed_pin_source(tmp_root: &Path) -> PathBuf {
+    let src = tmp_root.join("pin-source");
+    write_fake(&src, &bin_name("zccache"), b"PINNED_CLI_BYTES");
+    write_fake(&src, &bin_name("zccache-daemon"), b"PINNED_DAEMON_BYTES");
+    write_fake(&src, &bin_name("zccache-fp"), b"PINNED_FP_BYTES");
+    src
+}
+
+/// Pre-populate the managed cache dir as if a previous `soldr cargo`
+/// invocation had already fetched the managed v1.8.1 binaries. The
+/// resolver hits this dir via `check_cache` after the pinned check, so
+/// seeding it lets us verify the pinned check actually beats it.
+fn seed_managed_cache(paths: &SoldrPaths) -> PathBuf {
+    let managed_dir = paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"));
+    write_fake(&managed_dir, &bin_name("zccache"), b"MANAGED_CLI_BYTES");
+    write_fake(
+        &managed_dir,
+        &bin_name("zccache-daemon"),
+        b"MANAGED_DAEMON_BYTES",
+    );
+    write_fake(&managed_dir, &bin_name("zccache-fp"), b"MANAGED_FP_BYTES");
+    managed_dir
+}
+
+/// Reset env state that would otherwise leak across tests. Restored on
+/// drop. We unset the override vars so neither the local-dir override
+/// (`SOLDR_ZCCACHE_LOCAL_DIR`) nor the test override
+/// (`SOLDR_TEST_ZCCACHE_BIN`) shadows the pinned resolution path under
+/// test.
+struct EnvGuard {
+    saved: Vec<(String, Option<std::ffi::OsString>)>,
+}
+
+impl EnvGuard {
+    fn isolate(keys: &[&str]) -> Self {
+        let mut saved = Vec::with_capacity(keys.len());
+        for key in keys {
+            saved.push((key.to_string(), std::env::var_os(key)));
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, prior) in &self.saved {
+            unsafe {
+                match prior {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Scenario 1: fetch_zccache_with_paths
+// ---------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn fetch_zccache_with_paths_returns_pinned_over_managed_cache() {
+    let _guard = EnvGuard::isolate(&[ZCCACHE_LOCAL_DIR_ENV_VAR, "SOLDR_TEST_ZCCACHE_BIN"]);
+    let tmp = unique_temp_dir("pin-wins-fetch");
+    let paths = SoldrPaths::with_root(tmp.join("soldr-root"));
+
+    // 1. Seed the managed cache as if a previous build had already
+    //    fetched v1.8.1. This is what the issue reporter's environment
+    //    looked like — managed v1.8.1 already on disk from earlier runs.
+    let managed_dir = seed_managed_cache(&paths);
+    assert!(managed_dir.join(bin_name("zccache")).exists());
+
+    // 2. Install a pinned binary on top.
+    let pin_src = seed_pin_source(&tmp);
+    install_zccache_from_source(&InstallSource::Path(pin_src), &paths)
+        .await
+        .expect("install pin");
+
+    // 3. Resolve. The pinned dir must win over the managed cache.
+    let fetched = fetch_zccache_with_paths(&paths)
+        .await
+        .expect("fetch should resolve");
+    let resolved_parent = fetched.binary_path.parent().expect("parent");
+    let expected_parent = paths.bin.join(PINNED_ZCCACHE_DIRNAME);
+    assert_eq!(
+        resolved_parent,
+        expected_parent,
+        "issue #420: pinned binary must win resolution over the managed cache;\n  \
+         resolved = {}\n  pinned   = {}\n  managed  = {}",
+        resolved_parent.display(),
+        expected_parent.display(),
+        managed_dir.display()
+    );
+
+    // Sanity: the resolved bytes are the pinned ones, not the managed
+    // placeholder. If this fails the resolver returned the right path
+    // but pointed at the wrong file (would happen if pinned_dir was
+    // empty and we somehow returned the dir path).
+    let bytes = fs::read(&fetched.binary_path).expect("read resolved binary");
+    assert_eq!(
+        bytes,
+        b"PINNED_CLI_BYTES",
+        "resolved binary must be the pinned bytes; got {} bytes from {}",
+        bytes.len(),
+        fetched.binary_path.display()
+    );
+}
+
+// ---------------------------------------------------------------------
+// Scenario 2: cached_zccache_binary
+// ---------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn cached_zccache_binary_returns_pinned_over_managed_cache() {
+    let _guard = EnvGuard::isolate(&[ZCCACHE_LOCAL_DIR_ENV_VAR, "SOLDR_TEST_ZCCACHE_BIN"]);
+    let tmp = unique_temp_dir("pin-wins-cached");
+    let paths = SoldrPaths::with_root(tmp.join("soldr-root"));
+
+    seed_managed_cache(&paths);
+    let pin_src = seed_pin_source(&tmp);
+    install_zccache_from_source(&InstallSource::Path(pin_src), &paths)
+        .await
+        .expect("install pin");
+
+    let cached: Option<FetchResult> =
+        cached_zccache_binary(&paths).expect("cached lookup should succeed");
+    let cached = cached.expect("expected a cached pinned binary");
+    let parent = cached.binary_path.parent().expect("parent");
+    assert_eq!(
+        parent,
+        paths.bin.join(PINNED_ZCCACHE_DIRNAME),
+        "cached_zccache_binary must return the pinned binary, not the managed cache (issue #420)"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Scenario 3: classify_zccache_source
+// ---------------------------------------------------------------------
+
+#[test]
+fn classify_zccache_source_tags_each_branch_correctly() {
+    let _guard = EnvGuard::isolate(&[ZCCACHE_LOCAL_DIR_ENV_VAR]);
+    let tmp = unique_temp_dir("classify-source");
+    let paths = SoldrPaths::with_root(tmp.join("soldr-root"));
+    let ext = if cfg!(windows) { ".exe" } else { "" };
+
+    // Pinned: lives under <paths.bin>/zccache-pinned/.
+    let pinned = paths
+        .bin
+        .join(PINNED_ZCCACHE_DIRNAME)
+        .join(format!("zccache{ext}"));
+    assert_eq!(
+        classify_zccache_source(&paths, &pinned),
+        ZccacheSource::Pinned
+    );
+
+    // Managed: lives under <paths.bin>/zccache-<MANAGED_VERSION>/.
+    let managed = paths
+        .bin
+        .join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"))
+        .join(format!("zccache{ext}"));
+    assert_eq!(
+        classify_zccache_source(&paths, &managed),
+        ZccacheSource::Managed
+    );
+
+    // Local: parent dir name starts with `zccache-local-` regardless of
+    // whether SOLDR_ZCCACHE_LOCAL_DIR is currently set in the env.
+    let local = paths
+        .bin
+        .join("zccache-local-deadbeefcafe")
+        .join(format!("zccache{ext}"));
+    assert_eq!(
+        classify_zccache_source(&paths, &local),
+        ZccacheSource::Local
+    );
+
+    // Unknown: a path under neither — e.g. SOLDR_TEST_ZCCACHE_BIN
+    // override pointing at /tmp/some-test-binary.
+    let unknown = tmp.join("some-other-place").join(format!("zccache{ext}"));
+    assert_eq!(
+        classify_zccache_source(&paths, &unknown),
+        ZccacheSource::None
+    );
+}
+
+// ---------------------------------------------------------------------
+// Scenario 4: eviction sentinel
+//
+// `should_evict_zccache_daemon` and `evict_zccache_daemon_if_binary_changed`
+// live in the binary-tree `zccache` module (not the lib tree), so they
+// are exercised by the unit tests in
+// `crates/soldr-cli/src/zccache.rs#[cfg(test)] mod tests` instead of
+// here. Notably the `evict_decision_triggers_when_local_dir_overrides_managed`
+// case there asserts the managed -> pinned/local switch triggers
+// eviction, which is exactly the path issue #420's reporter took (pin
+// installed after a managed-daemon run).
+// ---------------------------------------------------------------------
+
+// ---------------------------------------------------------------------
+// Scenario 5: CLI surface — install + doctor + cache
+// ---------------------------------------------------------------------
+
+#[test]
+fn install_then_doctor_subprocess_reports_pinned_active_source() {
+    let tmp = unique_temp_dir("cli-install-doctor");
+    let cache_root = tmp.join("soldr-root");
+    let pin_src = seed_pin_source(&tmp);
+
+    // 1. Pin the staged binaries via the CLI.
+    let install = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["install-zccache", "--json"])
+        .arg(&pin_src)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .env_remove("SOLDR_TEST_ZCCACHE_BIN")
+        .output()
+        .expect("install-zccache subprocess");
+    assert!(
+        install.status.success(),
+        "install failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+
+    // 2. soldr doctor --json must report active_zccache_source = pinned.
+    let doctor = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["doctor", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .env_remove("SOLDR_TEST_ZCCACHE_BIN")
+        .output()
+        .expect("doctor subprocess");
+    assert!(
+        doctor.status.success(),
+        "doctor failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&doctor.stdout),
+        String::from_utf8_lossy(&doctor.stderr)
+    );
+    let doctor_json: Value =
+        serde_json::from_slice(&doctor.stdout).expect("doctor --json should emit valid JSON");
+    assert_eq!(
+        doctor_json["active_zccache_source"],
+        "pinned",
+        "doctor must report active source = pinned after install-zccache (issue #420):\n{}",
+        serde_json::to_string_pretty(&doctor_json).unwrap_or_default()
+    );
+    assert_eq!(
+        doctor_json["pinned_zccache_active"], true,
+        "doctor must report pinned_zccache_active = true after install"
+    );
+
+    // 3. The new "active zccache source:" diagnostic line appears in the
+    //    human output too.
+    let doctor_human = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["doctor"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .env_remove("SOLDR_TEST_ZCCACHE_BIN")
+        .output()
+        .expect("doctor human subprocess");
+    assert!(doctor_human.status.success(), "doctor human failed");
+    let stdout = String::from_utf8_lossy(&doctor_human.stdout);
+    assert!(
+        stdout.contains("active zccache source: pinned"),
+        "doctor human output should include the source banner:\n{stdout}"
+    );
+}
+
+#[test]
+fn install_then_cache_subprocess_reports_pinned_source() {
+    let tmp = unique_temp_dir("cli-install-cache");
+    let cache_root = tmp.join("soldr-root");
+    let pin_src = seed_pin_source(&tmp);
+
+    let install = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["install-zccache"])
+        .arg(&pin_src)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .env_remove("SOLDR_TEST_ZCCACHE_BIN")
+        .output()
+        .expect("install subprocess");
+    assert!(install.status.success(), "install failed");
+
+    // The pinned binaries we wrote with `seed_pin_source` are not real
+    // executables — `zccache status` will fail to run them. That's
+    // fine: `collect_zccache_status` handles the failure and the JSON
+    // still contains `binary_source` per the new schema.
+    let cache = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
+        .env_remove("SOLDR_TEST_ZCCACHE_BIN")
+        .output()
+        .expect("cache subprocess");
+    // We don't assert on exit status — `cache` may legitimately fail
+    // when the fake pinned binary can't run `status`. We just need the
+    // diagnostic field to flow through to JSON when it's emitted.
+    if cache.status.success() {
+        let value: Value =
+            serde_json::from_slice(&cache.stdout).expect("cache --json should emit valid JSON");
+        let source = value["zccache"]["binary_source"].as_str();
+        assert_eq!(
+            source,
+            Some("pinned"),
+            "cache --json must report binary_source = pinned (issue #420):\n{}",
+            serde_json::to_string_pretty(&value).unwrap_or_default()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #420.

`soldr install-zccache <path>` writes a pinned binary, but the issue
reporter observed `soldr cargo build` silently spawning the managed
v1.8.1 daemon instead — invalidating three zccache perf-cluster runs.

Code reading showed the resolution chain in `fetch_zccache_with_paths`
already places the pinned check ahead of the managed cache, and the
`fetch_managed_zccache` / `cached_managed_zccache` helpers (despite
the misleading "managed" name) delegate to it. New regression tests
seed both dirs and assert the pin wins — they pass on `main` today.

What actually fooled the user during perf-cluster debugging was the
unconditional `soldr: using managed zccache 1.8.1` line in
`prepare_zccache_build`, which prints even when the pin won
resolution. This PR replaces it with a source-aware diagnostic and
hardens every adjacent spawn path so the bug cannot quietly come
back.

## What changed

* **Source-aware diagnostic** in `prepare_zccache_build` — prints
  exactly one of:
  ```
  soldr: zccache source: pinned  (<dir>) version=<v>
  soldr: zccache source: local   (<dir>) version=<v>
  soldr: zccache source: managed (<dir>) version=<v> (cached|downloaded)
  ```
* **Rename** `fetch_managed_zccache` → `fetch_active_zccache` and
  `cached_managed_zccache` → `cached_active_zccache` so future readers
  don't repeat the user's hypothesis that the "managed" helpers
  shadowed the pin. Updated 8 call sites.
* **New public helper** `classify_zccache_source(paths, &binary_path)`
  tags a resolved path as `pinned` / `local` / `managed` / `none`,
  reused by the front-door diagnostic and `soldr cache` /
  `soldr status` snapshots.
* **`soldr doctor`** gains an `active zccache source:` line (human)
  and `active_zccache_source` JSON field.
* **`soldr cache` / `soldr status`** snapshots add `binary_source` to
  JSON and a `(source: …)` suffix to the human `zccache binary:` line.
* **New regression test file** `cli_install_zccache_resolution.rs` —
  5 tests covering the pin-wins-over-managed contract, the
  classifier, and the doctor / cache CLI surface.

## Test plan

- [x] `soldr cargo test --test cli_install_zccache_resolution` — all 5
  new tests pass.
- [x] `soldr cargo test --workspace` — every test passes except the
  pre-existing `cli_doctor::doctor_reports_missing_target` flake,
  which also fails on `main` (verified by stashing changes + re-running).
- [x] `soldr cargo fmt --all -- --check` — clean.
- [x] `soldr cargo clippy --workspace --tests -- -D warnings` — only
  pre-existing dead-code errors from the monocrate collapse, none
  introduced by this PR (verified by stashing changes + re-running).

## What this PR deliberately does NOT do

* Change the zccache daemon-spawn fallback inside zccache itself — the
  CLI binary's `zccache start` already picks `zccache-daemon` next to
  itself, which the pinned binaries satisfy. If perf-cluster ever sees
  the wrong daemon spawn AFTER this PR, file a follow-up against
  zackees/zccache and link it from #420.
* Rename `MANAGED_ZCCACHE_VERSION` or `managed_only_zccache_summary` —
  those are correctly named (they refer specifically to the managed
  source, not the active resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)