### PR TITLE
test(cook): add opt-in speedup benchmark for soldr cook

### DIFF
--- a/crates/soldr-cli/tests/cli_cook.rs
+++ b/crates/soldr-cli/tests/cli_cook.rs
@@ -7,6 +7,7 @@
 mod common;
 
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 #[test]
 fn help_advertises_cook_subcommand() {
@@ -149,4 +150,179 @@ fn cook_prepare_only_against_example_project_runs_end_to_end() {
     }
     assert!(output.status.success());
     assert!(recipe.is_file(), "cargo chef prepare must write the recipe");
+}
+
+/// Soldr CLI argv that disables zccache so the only thing speeding up the
+/// post-cook build is the dependency artifacts cargo-chef left behind in
+/// `target/`. Without `--no-cache` zccache would also serve hits on the
+/// cold side and muddy the comparison.
+const NO_CACHE: &[&str] = &["--no-cache"];
+
+/// End-to-end speedup benchmark for `soldr cook`. Demonstrates the
+/// cargo-chef value prop: once `cook` has populated `target/` with the
+/// transitive dep artifacts, a subsequent `cargo build` only has to
+/// compile the user's own crate — so it is dramatically faster than a
+/// from-scratch build that has to compile the whole dep graph too.
+///
+/// Network + heavy: pulls `serde_json` + its transitive deps from
+/// crates.io, downloads the pinned `cargo-chef` release, and runs three
+/// full cargo builds. Opt in explicitly:
+///
+/// ```text
+/// SOLDR_TEST_COOK_BENCH=1 \
+///   cargo test --test cli_cook -- --ignored cook_post_build_is_significantly_faster
+/// ```
+///
+/// The assertion is intentionally loose (post-cook build must be at
+/// least 2× faster than the cold from-scratch build). Real speedups on
+/// developer hardware are typically 5–10× — the 2× floor exists so the
+/// test survives slow shared CI workers and Windows Defender overhead.
+#[test]
+#[ignore = "perf+network; opt in with SOLDR_TEST_COOK_BENCH=1 cargo test --test cli_cook -- --ignored cook_post_build_is_significantly_faster"]
+fn cook_post_build_is_significantly_faster() {
+    if std::env::var_os("SOLDR_TEST_COOK_BENCH").is_none() {
+        eprintln!("skipping: SOLDR_TEST_COOK_BENCH not set");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path();
+
+    // A minimal but non-trivial project: serde_json pulls in serde +
+    // serde_derive (proc-macro, slow to compile) + itoa + ryu + memchr
+    // + serde_core, so the dep compile dominates a from-scratch build.
+    // That's exactly where cook's pre-populated `target/` pays off.
+    std::fs::write(
+        project.join("Cargo.toml"),
+        r#"[package]
+name = "soldr_cook_bench_demo"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+serde_json = "1"
+"#,
+    )
+    .unwrap();
+    let src = project.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("main.rs"),
+        r#"fn main() {
+    let v: serde_json::Value = serde_json::json!({ "hello": "cold" });
+    println!("{}", v);
+}
+"#,
+    )
+    .unwrap();
+
+    // Materialise Cargo.lock once up front so neither side pays the
+    // resolver cost during the timed build.
+    let lock_status = Command::new("cargo")
+        .args(["generate-lockfile"])
+        .current_dir(project)
+        .status()
+        .expect("cargo generate-lockfile must succeed");
+    assert!(lock_status.success(), "generate-lockfile failed");
+
+    // Pre-fetch dep sources so the timed builds don't include network
+    // download time — we're measuring compile, not curl.
+    let fetch_status = Command::new("cargo")
+        .args(["fetch"])
+        .current_dir(project)
+        .status()
+        .expect("cargo fetch must succeed");
+    assert!(fetch_status.success(), "cargo fetch failed");
+
+    // === Scenario A: cold build from scratch (no cook) =================
+    wipe_target(project);
+    let (t_cold, cold_status) = time_soldr(project, NO_CACHE, "cargo build --release");
+    assert!(
+        cold_status,
+        "cold `soldr --no-cache cargo build --release` failed"
+    );
+
+    // === Scenario B: cook, then build =================================
+    wipe_target(project);
+    let (t_cook, cook_status) = time_soldr(project, NO_CACHE, "cook --release");
+    assert!(cook_status, "`soldr --no-cache cook --release` failed");
+
+    // Touch main.rs to invalidate the prior `cargo build` artefact even
+    // though we wiped `target/` — defensive against cook accidentally
+    // leaving a binary behind. The dep .rlibs cargo-chef wrote stay put.
+    std::fs::write(
+        src.join("main.rs"),
+        r#"fn main() {
+    let v: serde_json::Value = serde_json::json!({ "hello": "post-cook" });
+    println!("{}", v);
+}
+"#,
+    )
+    .unwrap();
+
+    let (t_post_cook, post_cook_status) = time_soldr(project, NO_CACHE, "cargo build --release");
+    assert!(
+        post_cook_status,
+        "post-cook `soldr --no-cache cargo build --release` failed"
+    );
+
+    let ratio = t_post_cook.as_secs_f64() / t_cold.as_secs_f64().max(f64::EPSILON);
+    eprintln!(
+        "\nsoldr cook speedup summary\n\
+         --------------------------\n\
+           T_cold      (cargo build, target/ empty)         = {:?}\n\
+           T_cook      (soldr cook, target/ empty)          = {:?}\n\
+           T_post_cook (cargo build, target/ pre-populated) = {:?}\n\
+           ratio       (T_post_cook / T_cold)               = {:.3}\n\
+           speedup                                          = {:.2}×\n",
+        t_cold,
+        t_cook,
+        t_post_cook,
+        ratio,
+        1.0 / ratio,
+    );
+
+    // Pre-cooked target/ must make the second build at least 2× faster
+    // than a cold from-scratch build. This is the soldr cook value
+    // prop: in CI / Docker layered caching, you pay `T_cook` once and
+    // amortise it across every subsequent source-only change.
+    assert!(
+        ratio < 0.5,
+        "soldr cook did not deliver a significant speedup: \
+         T_post_cook = {:?}, T_cold = {:?}, ratio = {:.3} (want < 0.5, i.e. ≥ 2× faster)",
+        t_post_cook,
+        t_cold,
+        ratio,
+    );
+}
+
+fn wipe_target(project: &std::path::Path) {
+    let target = project.join("target");
+    if target.exists() {
+        std::fs::remove_dir_all(&target).expect("failed to wipe target dir");
+    }
+}
+
+/// Run the soldr CLI with the given pre-subcommand flags + a single
+/// space-separated tail (`cargo build --release`, `cook --release`,
+/// etc.) and return `(wallclock, success)`. The split is just so the
+/// caller reads naturally; clap doesn't care about quoting at this
+/// level since none of our tokens contain spaces.
+fn time_soldr(project: &std::path::Path, leading: &[&str], tail: &str) -> (Duration, bool) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_soldr"));
+    cmd.args(leading);
+    cmd.args(tail.split_whitespace());
+    cmd.current_dir(project);
+
+    let started = Instant::now();
+    let output = cmd.output().expect("failed to spawn soldr");
+    let elapsed = started.elapsed();
+
+    if !output.status.success() {
+        eprintln!("soldr {} {}", leading.join(" "), tail);
+        eprintln!("  exit: {:?}", output.status);
+        eprintln!("  stdout:\n{}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("  stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+    }
+    (elapsed, output.status.success())
 }


### PR DESCRIPTION
## Summary

- New `cook_post_build_is_significantly_faster` integration test in `crates/soldr-cli/tests/cli_cook.rs` that proves the cargo-chef value prop end-to-end: a `cargo build` against a `target/` pre-populated by `soldr cook` is significantly faster than the same build from scratch.
- Double-gated as **optional perf work** so default test runs (`cargo test`, `soldr cargo test`, `./test`) skip it entirely:
  1. `#[ignore = "..."]` keeps it out of the default test set.
  2. An inner `SOLDR_TEST_COOK_BENCH` env-var check makes the test exit early even under `--ignored`, unless explicitly opted in.
- Pure-cook signal: both timed builds pass `--no-cache` so zccache can't muddy the comparison — the only variable between the two scenarios is whether `target/` was pre-populated by cook.

## Methodology

1. Synthesize a temp project with `serde_json = "1"` as the dep (pulls in `serde_derive` proc-macro + several transitive crates so dep compilation dominates a cold build).
2. `cargo generate-lockfile` + `cargo fetch` once up front so the timed builds don't pay resolver / download cost.
3. **T_cold** — wipe `target/`, then `soldr --no-cache cargo build --release`.
4. **T_cook** — wipe `target/`, then `soldr --no-cache cook --release`.
5. **T_post_cook** — touch `main.rs`, then `soldr --no-cache cargo build --release` (deps already in `target/`).
6. Assert `T_post_cook / T_cold < 0.5` (≥ 2× faster).

## Local result

```
T_cold      (cargo build, target/ empty)         = 10.633853s
T_cook      (soldr cook, target/ empty)          = 12.151129s
T_post_cook (cargo build, target/ pre-populated) =  1.698832s
ratio       (T_post_cook / T_cold)               =  0.160
speedup                                          =  6.26×
```

The 2× floor in the assertion is intentionally loose so the test survives slow shared CI workers and Windows Defender overhead; real hardware typically sees 5–10×.

## Test plan

- [x] `cargo test -p soldr-cli --test cli_cook` (default) — 5 pass, 2 ignored (including the new one).
- [x] `SOLDR_TEST_COOK_BENCH=1 soldr cargo test -p soldr-cli --test cli_cook -- --ignored cook_post_build_is_significantly_faster` — pass, 6.26× speedup reported.
- [x] `cargo fmt --check` clean.
- [x] No new clippy warnings against `cli_cook.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)