### PR TITLE
test(repro): docker harness for #424 update-zccache pin regression

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Keep the docker build context small. soldr docker harnesses live
+# under `bench/docker/<name>/` and only need Cargo.{toml,lock},
+# rust-toolchain.toml, and crates/ — see e.g.
+# bench/docker/update-zccache-pin-honored/Dockerfile.
+
+# Rust build output (multi-GB on a warm cache)
+target/
+**/target/
+
+# VCS / IDE / Python build caches that have no business in the image
+.git/
+.github/
+.venv/
+.vscode/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+__pycache__/
+
+# Local secrets, env files
+.env
+.env.*
+
+# Top-level non-code that bloats the context without helping any build
+*.md
+docs/
+benchmarks/
+
+# But keep the harness's own README + scripts copyable
+!bench/docker/**
+
+# Top-level test/working dirs that occasionally accumulate
+.claude/

--- a/bench/docker/update-zccache-pin-honored/Dockerfile
+++ b/bench/docker/update-zccache-pin-honored/Dockerfile
@@ -1,0 +1,55 @@
+# Self-contained reproduction harness for zackees/soldr#424:
+#
+#   `soldr update-zccache <path>` reports a successful path-pin, but a
+#   subsequent `soldr cargo build` spawns the MANAGED v1.8.1 daemon
+#   anyway — i.e. the pin is silently ignored.
+#
+# The container builds soldr from the local checkout (the build context
+# must be the soldr repo root), stages three fake zccache binaries under
+# /pinned-bin/, pins them with `soldr update-zccache`, runs a tiny
+# `soldr cargo build`, and inspects the `soldr: zccache source: ...`
+# diagnostic that PR #421 promised would name the actual source. If
+# that line says `managed` instead of `pinned`, the harness exits
+# non-zero with a verbose dump.
+#
+# Build (from the soldr repo root):
+#   docker build -t soldr-pin-repro -f bench/docker/update-zccache-pin-honored/Dockerfile .
+# Run:
+#   docker run --rm soldr-pin-repro
+#
+# The companion `run.sh` does both in one shot.
+
+# Single-stage on purpose: the repro needs cargo at runtime because the
+# bug only triggers during `soldr cargo build`. Multi-stage with a
+# slim runtime would force us to also install a rust toolchain there.
+FROM rust:1.94.1-alpine
+
+# bash + jq for the repro script; coreutils so `comm` / `sort` / `sha256sum`
+# behave like GNU coreutils (busybox versions differ in some flags); git
+# because cargo emits a deprecation warning without it on some setups.
+RUN apk add --no-cache musl-dev bash jq coreutils git
+
+WORKDIR /soldr
+
+# Copy only what's needed to build soldr-cli. The root `.dockerignore`
+# already excludes target/, .git/, .venv/, etc., so a blanket COPY is
+# acceptable, but being explicit keeps the build layer-cacheable across
+# unrelated file changes (e.g. README edits don't bust the cargo layer).
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates ./crates
+
+# Build the soldr binary against the Alpine musl toolchain. The
+# resulting binary is statically linked and lands at
+# /soldr/target/release/soldr.
+RUN cargo build --release -p soldr-cli \
+ && install -m 0755 target/release/soldr /usr/local/bin/soldr \
+ && cargo clean
+
+COPY bench/docker/update-zccache-pin-honored/repro.sh /repro.sh
+RUN chmod +x /repro.sh
+
+# Run in /work because soldr cargo build needs a writable Cargo project
+# dir; /soldr is left in case anyone wants to inspect the source.
+WORKDIR /work
+
+ENTRYPOINT ["/repro.sh"]

--- a/bench/docker/update-zccache-pin-honored/README.md
+++ b/bench/docker/update-zccache-pin-honored/README.md
@@ -1,0 +1,95 @@
+# `soldr update-zccache` pin-honored Docker repro
+
+Self-contained Docker harness for [zackees/soldr#424][issue]:
+`soldr update-zccache <path>` registers a successful path-pin, but a
+subsequent `soldr cargo build` spawns the managed v1.8.1 daemon anyway —
+the pin is silently ignored.
+
+This harness builds soldr from the local checkout, stages three fake
+zccache binaries under `/pinned-bin/`, pins them, runs a tiny
+`soldr cargo build`, and inspects the **`soldr: zccache source: ...`**
+diagnostic that [PR #421][pr-421] added precisely to make the
+pin-vs-managed routing observable.
+
+If the diagnostic says `managed` instead of `pinned`, the bug from
+#424 reproduces and the harness exits non-zero with a dump of the pin
+status JSON, the contents of `~/.soldr/bin/`, and the last 80 lines of
+`cargo build` stderr.
+
+## Run it
+
+From the soldr repo root:
+
+```bash
+bash bench/docker/update-zccache-pin-honored/run.sh
+```
+
+Or by hand:
+
+```bash
+docker build -t soldr-pin-repro \
+  -f bench/docker/update-zccache-pin-honored/Dockerfile .
+docker run --rm soldr-pin-repro
+```
+
+Interactive debug (drops into a shell inside the built image, skipping
+the repro):
+
+```bash
+bash bench/docker/update-zccache-pin-honored/run.sh -- -it --entrypoint /bin/bash
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | Pin honored. `soldr: zccache source: pinned (...)` was emitted. |
+| 1    | **Bug reproduced.** Pin was registered but `soldr cargo build` resolved to `managed (...)`. |
+| 2    | Setup failure — `update-zccache` itself errored, or the pin status JSON didn't reflect the requested path pin. |
+
+## Current status
+
+Building this harness against soldr `main` HEAD (post-#421) **passes** —
+the diagnostic emits `soldr: zccache source: pinned (...)` as it
+should. So either:
+
+1. **#421 actually fixed the routing bug** for this exact code path, and
+   the residual failures the issue reports come from somewhere else
+   (real zccache binary behavior, fingerprinting, pre-existing managed
+   installs the harness doesn't simulate, etc.), **or**
+2. **the bug only triggers under conditions this synthetic repro
+   doesn't reach** — e.g. with real signed v1.8.1 binaries, with a
+   pre-existing `~/.soldr/bin/zccache-1.8.1/` install, or with a
+   particular `RUSTC_WRAPPER` / `--zccache` flag combination.
+
+Either way, this harness now serves as a **regression test**: if a
+future change re-breaks the path-pin spawn path, the diagnostic flips
+to `managed (...)` and this exits 1 with a full diagnostic dump. Add
+or extend variants here when you discover the conditions that surface
+the live bug.
+
+## What's inside
+
+| File | Role |
+|------|------|
+| `Dockerfile` | Single-stage `rust:1.94.1-alpine` image. Copies `Cargo.toml`/`Cargo.lock`/`rust-toolchain.toml` + `crates/` from the build context (the repo root), builds `soldr-cli --release`, installs the binary to `/usr/local/bin/soldr`, and `cargo clean`s to shrink the image. |
+| `repro.sh` | In-container script. Stages fake binaries, registers the pin, asserts pin status, runs `soldr cargo build`, grep's stderr for the source diagnostic, and prints a verdict. |
+| `run.sh` | Host-side convenience wrapper — `docker build` + `docker run` in one step. Forwards anything after `--` to `docker run`. |
+| `README.md` | This file. |
+
+## Why this can't be a pure Rust integration test
+
+The bug only manifests when soldr resolves zccache at runtime against a
+real `$HOME/.soldr/bin/` layout. A unit test would have to mock the
+entire fetch + pin + spawn pipeline, at which point you're not testing
+the bug anymore. Docker gives us a clean `$HOME` and a writable
+`~/.soldr/` per run, with zero pollution of the host's soldr cache.
+
+The harness deliberately does **not** ship with the rest of the test
+suite — it requires Docker, takes a couple of minutes for the cargo
+build inside the container, and is a regression repro, not a
+day-to-day smoke test. Run it locally when investigating #424 or any
+follow-up to #420 / #421.
+
+[issue]: https://github.com/zackees/soldr/issues/424
+[pr-421]: https://github.com/zackees/soldr/pull/421

--- a/bench/docker/update-zccache-pin-honored/repro.sh
+++ b/bench/docker/update-zccache-pin-honored/repro.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Reproduction script for zackees/soldr#424. Runs inside the harness
+# container (see Dockerfile in this directory). Exits 0 if soldr honored
+# the path pin, 1 if the bug from #424 reproduces, 2 on setup failure.
+#
+# The diagnostic this script grep's for was added by PR #421 specifically
+# to make the pin-vs-managed routing observable:
+#
+#   soldr: zccache source: pinned (<dir>) version=...
+#   soldr: zccache source: managed (<dir>) version=... (downloaded|cached)
+#
+# If a pin is registered but the routing logic ignores it (the bug),
+# we'll see `managed` instead of `pinned`.
+
+set -euo pipefail
+
+PINNED_DIR="/pinned-bin"
+MARKER="this-is-the-pinned-binary-$(cat /proc/sys/kernel/random/uuid)"
+
+step() { printf '\n=== %s ===\n' "$*"; }
+fail() {
+    printf '\n!!! REPRO FAILED: %s\n' "$*" >&2
+    printf '\n--- diagnostic dump ---\n' >&2
+    printf 'pin status:\n'           >&2
+    soldr update-zccache --status --json 2>&1 | jq . >&2 || true
+    printf '\n~/.soldr/bin layout:\n' >&2
+    ls -la "$HOME/.soldr/bin"        2>&1 >&2 || true
+    printf '\ncargo build stderr (last 80 lines):\n' >&2
+    tail -n 80 /tmp/cargo-build.stderr 2>&1 >&2 || true
+    exit 1
+}
+setup_fail() {
+    printf '\n!!! SETUP FAILED: %s\n' "$*" >&2
+    exit 2
+}
+
+step 'Stage fake zccache binaries at /pinned-bin'
+mkdir -p "$PINNED_DIR"
+# Three shell-script stubs that each carry the marker (so the SHA256
+# soldr records is unique to this run and traceable in --status output).
+# They speak enough of the zccache protocol that `update-zccache` and a
+# subsequent build attempt won't immediately bail. The fake daemon
+# doesn't actually compile anything — that's fine, we only care about
+# which binary soldr decided to spawn, and that's emitted to stderr
+# before any compile work.
+for name in zccache zccache-daemon zccache-fp; do
+    cat > "$PINNED_DIR/$name" <<EOF
+#!/bin/sh
+# marker: $MARKER
+case "\$1" in
+    --version) echo "zccache 1.8.1 (PINNED-FAKE)"; exit 0;;
+    start|stop|clear) exit 0;;
+    status) echo "hits=0"; exit 0;;
+    session-start)
+        # update-zccache and prepare_zccache_build both invoke this. The
+        # 4th and 6th args are status/stats file paths that soldr expects
+        # to exist (see fake_zccache_script in crates/soldr-cli/tests/common/mod.rs).
+        [ -n "\${4:-}" ] && : > "\$4"
+        [ -n "\${6:-}" ] && : > "\$6"
+        echo '{"session_id":"pinned-fake-session"}'
+        exit 0
+        ;;
+    session-end)
+        echo '{"status":"ok","session_id":"pinned-fake-session","duration_ms":0,"compilations":0,"hits":0,"misses":0,"non_cacheable":0,"errors":0,"time_saved_ms":0,"unique_sources":0,"bytes_read":0,"bytes_written":0,"hit_rate":0}'
+        exit 0
+        ;;
+    rust-plan)
+        echo '{"operation":"'"\$2"'","compatibility":{"status":"ok","errors":[]}}'
+        exit 0
+        ;;
+    flush)
+        if [ "\${2:-}" = "--json" ]; then
+            echo '{"status":"ok","bytes_written":0,"duration_ms":0}'
+        else
+            echo "flushed"
+        fi
+        exit 0
+        ;;
+esac
+# When invoked as RUSTC_WRAPPER, argv is "<rustc> <rustc-args...>". Just
+# delegate to rustc so the compile produces something on disk; the
+# session stats we'd return are still fine because we already lied
+# about them above.
+"\$@"
+EOF
+    chmod +x "$PINNED_DIR/$name"
+done
+
+ls -la "$PINNED_DIR"
+
+step 'soldr update-zccache /pinned-bin --json'
+PIN_REGISTER_JSON=$(soldr update-zccache "$PINNED_DIR" --json 2>&1) \
+    || setup_fail "update-zccache failed:\n$PIN_REGISTER_JSON"
+echo "$PIN_REGISTER_JSON" | jq . || echo "$PIN_REGISTER_JSON"
+
+step 'soldr update-zccache --status --json'
+STATUS_JSON=$(soldr update-zccache --status --json) \
+    || setup_fail "update-zccache --status failed"
+echo "$STATUS_JSON" | jq .
+
+source_kind=$(echo "$STATUS_JSON" | jq -r '.pinned.source_kind // empty')
+source_value=$(echo "$STATUS_JSON" | jq -r '.pinned.source_value // empty')
+if [ "$source_kind" != "path" ] || [ "$source_value" != "$PINNED_DIR" ]; then
+    setup_fail "pin status did not register a path pin: source_kind='$source_kind' source_value='$source_value'"
+fi
+echo "pin registered: source_kind=$source_kind source_value=$source_value"
+
+step 'Set up minimal Cargo project at /work'
+mkdir -p src
+cat > Cargo.toml <<'EOF'
+[package]
+name = "pin-repro"
+version = "0.0.0"
+edition = "2021"
+EOF
+echo 'fn main() {}' > src/main.rs
+
+step 'soldr cargo build (captures the source-diagnostic line)'
+# We don't care whether the build succeeds. The diagnostic is printed
+# BEFORE any compile work, so the bug is observable even if the fake
+# daemon later fails. `|| true` keeps the script alive past a non-zero
+# build exit.
+soldr cargo build 2>/tmp/cargo-build.stderr || true
+
+step '~/.soldr/bin layout after the build'
+# Always dump this — it's the cheapest way to see whether soldr
+# downloaded a managed binary alongside the pinned one (the smoking
+# gun pattern called out in #424's debugging notes).
+ls -la "$HOME/.soldr/bin" 2>/dev/null || echo "(no $HOME/.soldr/bin)"
+
+step 'Inspect soldr stderr for the zccache source diagnostic'
+SOURCE_LINE=$(grep -m1 -E '^soldr: zccache source: (pinned|managed|local|system|unrecognized)' \
+              /tmp/cargo-build.stderr || true)
+if [ -z "$SOURCE_LINE" ]; then
+    fail "soldr did not print the 'soldr: zccache source:' diagnostic — \
+the build either failed before reaching the wrapper-prep step or the \
+diagnostic was removed. Inspect /tmp/cargo-build.stderr inside the container."
+fi
+echo "$SOURCE_LINE"
+
+# Cross-check: even when the diagnostic claims `pinned`, a `zccache-<ver>/`
+# sibling dir means soldr ALSO downloaded a managed binary — which is
+# benign (the pin still wins resolution) but worth flagging because it's
+# the artifact pattern #424's debugging notes asked to look for.
+MANAGED_DIRS=$(ls -d "$HOME/.soldr/bin"/zccache-[0-9]* 2>/dev/null || true)
+if [ -n "$MANAGED_DIRS" ]; then
+    printf '\nnote: a managed zccache install also exists alongside the pin:\n'
+    echo "$MANAGED_DIRS"
+fi
+
+# === Verdict ============================================================
+step 'Verdict'
+case "$SOURCE_LINE" in
+    "soldr: zccache source: pinned"*)
+        echo "PASS: pin honored — soldr resolved to the pinned dir as expected."
+        exit 0
+        ;;
+    "soldr: zccache source: managed"*)
+        fail "BUG #424 REPRODUCED: pin was registered (source_kind=path, \
+source_value=$PINNED_DIR) but soldr cargo build spawned the MANAGED \
+zccache anyway. Diagnostic line: $SOURCE_LINE"
+        ;;
+    *)
+        fail "unexpected zccache source classification — got: $SOURCE_LINE"
+        ;;
+esac

--- a/bench/docker/update-zccache-pin-honored/run.sh
+++ b/bench/docker/update-zccache-pin-honored/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Convenience wrapper for the zackees/soldr#424 reproduction harness:
+# builds the image and runs the container in one shot.
+#
+# Run from the soldr repo root:
+#   bash bench/docker/update-zccache-pin-honored/run.sh
+#
+# Pass-through flags after `--` go to `docker run`. Useful for
+# interactive debugging: `bash run.sh -- -it --entrypoint /bin/bash`.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+IMAGE_TAG="${SOLDR_PIN_REPRO_IMAGE_TAG:-soldr-pin-repro:local}"
+DOCKERFILE="$REPO_ROOT/bench/docker/update-zccache-pin-honored/Dockerfile"
+
+extra_run_args=()
+seen_dash_dash=0
+for arg in "$@"; do
+    if [ "$seen_dash_dash" -eq 1 ]; then
+        extra_run_args+=("$arg")
+    elif [ "$arg" = "--" ]; then
+        seen_dash_dash=1
+    fi
+done
+
+echo "==> building $IMAGE_TAG"
+docker build -t "$IMAGE_TAG" -f "$DOCKERFILE" "$REPO_ROOT"
+
+echo "==> running $IMAGE_TAG"
+docker run --rm "${extra_run_args[@]}" "$IMAGE_TAG"


### PR DESCRIPTION
## Summary

Self-contained Docker reproduction harness for #424 ("`update-zccache` pin still ignored on main HEAD"). Lives at `bench/docker/update-zccache-pin-honored/`.

- **Dockerfile** — builds soldr from the local checkout inside `rust:1.94.1-alpine` (no external soldr download; tests whatever the PR is checking out).
- **repro.sh** — stages three fake zccache binaries under `/pinned-bin/`, runs `soldr update-zccache /pinned-bin --json`, asserts the status JSON reports a path pin, runs a tiny `soldr cargo build`, and inspects the `soldr: zccache source: ...` diagnostic that PR #421 introduced specifically to make the routing observable.
- **run.sh** — convenience wrapper that does `docker build` + `docker run` in one step.
- **README.md** — explains exit semantics, why it can't be a pure Rust integration test, and where to extend it.
- **.dockerignore** at the repo root — keeps the build context small (excludes `target/`, `.git/`, `.venv/`, etc.) so future docker harnesses don't have to fight a multi-GB context.

## Exit semantics

| Code | Meaning |
|------|---------|
| 0    | Pin honored. `soldr: zccache source: pinned (...)` emitted. |
| 1    | **Bug reproduced.** Pin registered but `soldr cargo build` resolved to `managed (...)`. Script dumps pin-status JSON, `~/.soldr/bin` layout, and the last 80 lines of cargo stderr. |
| 2    | Setup failure (`update-zccache` itself errored or didn't register the path pin). |

## Current behavior

Against main HEAD (`e928da6`) the harness **passes** — the diagnostic reports `pinned (/root/.soldr/bin/zccache-pinned)` and no managed `zccache-<ver>/` dir gets created alongside the pin. That means either #421 actually fixed the routing bug for this exact code path, or #424's live repro needs conditions this synthetic harness doesn't yet simulate (real signed v1.8.1 binaries, a pre-existing `~/.soldr/bin/zccache-1.8.1/` install, or a specific `--zccache` flag combo). The README spells this out.

Either way, the harness now serves as a **regression gate**: if any future change re-breaks the path-pin spawn path, the diagnostic flips to `managed` and this exits 1 with a complete dump.

## Test plan

- [x] `docker build` against the repo root succeeds (~5 min cold; <1 s after a script-only edit thanks to layer caching on the cargo build step).
- [x] `docker run --rm soldr-pin-repro:local` exits 0, prints `PASS: pin honored`, and shows only `zccache-pinned/` under `~/.soldr/bin/`.
- [x] `bash -n` clean on both shell scripts.

## How to run

From the repo root:

```bash
bash bench/docker/update-zccache-pin-honored/run.sh
```

Interactive debug:

```bash
bash bench/docker/update-zccache-pin-honored/run.sh -- -it --entrypoint /bin/bash
```

Refs: #420, #421, #424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)