### PR TITLE
fix(#426): pin survives SOLDR_CACHE_DIR override

### DIFF
--- a/bench/docker/update-zccache-pin-honored/repro.sh
+++ b/bench/docker/update-zccache-pin-honored/repro.sh
@@ -25,8 +25,14 @@ fail() {
     soldr update-zccache --status --json 2>&1 | jq . >&2 || true
     printf '\n~/.soldr/bin layout:\n' >&2
     ls -la "$HOME/.soldr/bin"        2>&1 >&2 || true
-    printf '\ncargo build stderr (last 80 lines):\n' >&2
-    tail -n 80 /tmp/cargo-build.stderr 2>&1 >&2 || true
+    for log in /tmp/cargo-build.stderr /tmp/cargo-build-soldr-cache-dir.stderr; do
+        if [ -f "$log" ]; then
+            printf '\n%s (last 80 lines):\n' "$log" >&2
+            tail -n 80 "$log" >&2 || true
+        else
+            printf '\n%s: missing\n' "$log" >&2
+        fi
+    done
     exit 1
 }
 setup_fail() {
@@ -148,19 +154,62 @@ if [ -n "$MANAGED_DIRS" ]; then
     echo "$MANAGED_DIRS"
 fi
 
-# === Verdict ============================================================
-step 'Verdict'
+# === Default cache dir verdict ==========================================
+step 'Default cache dir verdict'
 case "$SOURCE_LINE" in
     "soldr: zccache source: pinned"*)
-        echo "PASS: pin honored — soldr resolved to the pinned dir as expected."
-        exit 0
+        echo "PASS (default cache dir): pin honored."
         ;;
     "soldr: zccache source: managed"*)
-        fail "BUG #424 REPRODUCED: pin was registered (source_kind=path, \
+        fail "BUG #424 REPRODUCED (default cache dir): pin registered (source_kind=path, \
 source_value=$PINNED_DIR) but soldr cargo build spawned the MANAGED \
 zccache anyway. Diagnostic line: $SOURCE_LINE"
         ;;
     *)
-        fail "unexpected zccache source classification — got: $SOURCE_LINE"
+        fail "unexpected zccache source classification (default cache dir) — got: $SOURCE_LINE"
+        ;;
+esac
+
+# === SOLDR_CACHE_DIR variant (#426) ====================================
+# Same setup, different cache root. Before #426's fix, the pin lookup
+# under a custom SOLDR_CACHE_DIR resolved against `<SOLDR_CACHE_DIR>/bin/`
+# (which is empty), so soldr silently bypassed the pin and downloaded
+# the managed v1.8.1. The fix anchors pinned_bin at $HOME/.soldr/bin/
+# so the pin survives any SOLDR_CACHE_DIR override.
+step 'Re-run with SOLDR_CACHE_DIR=/work-cache — pin must STILL be honored (#426)'
+mkdir -p /work-cache
+# Wipe target/ so cargo actually re-invokes the wrapper. The trampoline
+# fast-path (#346 / #354) skips the wrapper-prep step entirely when the
+# previous build's artifacts are still up-to-date — which means the
+# `soldr: zccache source:` diagnostic never fires, and we can't tell
+# whether the pin was honored or not. A fresh `target/` forces a real
+# compile.
+rm -rf target
+SOLDR_CACHE_DIR=/work-cache soldr cargo build 2>/tmp/cargo-build-soldr-cache-dir.stderr || true
+
+ls -la /work-cache/bin 2>/dev/null || echo "(no /work-cache/bin — expected when pin wins)"
+
+SOURCE_LINE_426=$(grep -m1 -E '^soldr: zccache source: (pinned|managed|local|system|unrecognized)' \
+                  /tmp/cargo-build-soldr-cache-dir.stderr || true)
+if [ -z "$SOURCE_LINE_426" ]; then
+    fail "#426 variant: soldr did not print the 'soldr: zccache source:' \
+diagnostic under SOLDR_CACHE_DIR=/work-cache — inspect \
+/tmp/cargo-build-soldr-cache-dir.stderr inside the container."
+fi
+echo "$SOURCE_LINE_426"
+
+step '#426 verdict'
+case "$SOURCE_LINE_426" in
+    "soldr: zccache source: pinned"*)
+        echo "PASS (#426): pin survives SOLDR_CACHE_DIR override."
+        exit 0
+        ;;
+    "soldr: zccache source: managed"*)
+        fail "BUG #426 REPRODUCED: pin registered against the default cache \
+root but \`SOLDR_CACHE_DIR=/work-cache soldr cargo build\` bypassed it \
+and spawned the managed zccache anyway. Diagnostic line: $SOURCE_LINE_426"
+        ;;
+    *)
+        fail "unexpected zccache source classification (#426 variant) — got: $SOURCE_LINE_426"
         ;;
 esac

--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -531,10 +531,34 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
 
     match cached_active_zccache(paths)? {
         Some(fetch) => {
-            let output =
-                run_zccache_command_in_cache_dir(&fetch.binary_path, &["status"], &zccache_dir)?;
-            let stdout = output.stdout.trim();
-            let status_lines = stdout.lines().map(str::to_owned).collect();
+            // Use the raw helper so a non-zero exit with a "daemon not
+            // running" stderr surfaces as success-with-empty-status rather
+            // than a hard error — issue #426 made this case reachable in
+            // tests by exposing a host-side pin under custom SOLDR_CACHE_DIR
+            // contexts whose daemon hasn't been spawned yet. Mirrors the
+            // tolerance already in place for `zccache stop` polling.
+            let raw = run_zccache_command_raw_in_cache_dir(
+                &fetch.binary_path,
+                &["status"],
+                &zccache_dir,
+            )?;
+            let (status_lines, status_empty) = if raw.status.success() {
+                let stdout = String::from_utf8_lossy(&raw.stdout);
+                let trimmed = stdout.trim();
+                (
+                    trimmed.lines().map(str::to_owned).collect(),
+                    trimmed.is_empty(),
+                )
+            } else if zccache_daemon_already_stopped(&raw) {
+                (Vec::new(), false)
+            } else {
+                let stderr = String::from_utf8_lossy(&raw.stderr);
+                return Err(SoldrError::Other(format!(
+                    "zccache status exited with {:?}: {}",
+                    raw.status.code(),
+                    stderr.trim()
+                )));
+            };
             let source = crate::fetch::classify_zccache_source(paths, &fetch.binary_path);
             Ok(ZccacheStatusSnapshot {
                 cache_dir: zccache_dir.display().to_string(),
@@ -549,7 +573,7 @@ fn collect_zccache_status(paths: &SoldrPaths) -> Result<ZccacheStatusSnapshot, S
                 binary_source: source.as_str(),
                 binary_fetched: true,
                 status_lines,
-                status_empty: stdout.is_empty(),
+                status_empty,
             })
         }
         None => Ok(ZccacheStatusSnapshot {

--- a/crates/soldr-cli/src/core.rs
+++ b/crates/soldr-cli/src/core.rs
@@ -605,6 +605,13 @@ pub const SOLDR_CACHE_DIR_ENV_VAR: &str = "SOLDR_CACHE_DIR";
 pub struct SoldrPaths {
     pub root: PathBuf,
     pub bin: PathBuf,
+    /// Directory holding the pinned-zccache install (issue #426). Lives at
+    /// the user's home-anchored `~/.soldr/bin/` independent of
+    /// `SOLDR_CACHE_DIR`, so a pin registered against the default cache dir
+    /// remains visible to builds that re-root with `SOLDR_CACHE_DIR=/x`.
+    /// For synthetic-root construction (`SoldrPaths::with_root`, used by
+    /// tests) this collapses into `bin` so test isolation is preserved.
+    pub pinned_bin: PathBuf,
     pub cache: PathBuf,
     pub config_file: PathBuf,
 }
@@ -615,14 +622,53 @@ impl SoldrPaths {
     }
 
     fn from_root_env_value(value: Option<&OsStr>) -> Result<Self, SoldrError> {
-        let root = soldr_root_from_env_var(value)
-            .unwrap_or_else(|| home_dir().map(|home| home.join(".soldr")))?;
-        Ok(Self::with_root(root))
+        let env_root = soldr_root_from_env_var(value).transpose()?;
+        Self::from_env_root_and_home(env_root, home_dir().map(|h| h.join(".soldr")))
+    }
+
+    /// Inner constructor split out so tests can inject explicit `env_root`
+    /// + `home_root` values without mutating the process env. Other tests
+    /// in this binary read HOME / USERPROFILE too, so global env mutation
+    /// in a unit test races with parallel cases.
+    fn from_env_root_and_home(
+        env_root: Option<PathBuf>,
+        home_root: Result<PathBuf, SoldrError>,
+    ) -> Result<Self, SoldrError> {
+        let root = match (&env_root, &home_root) {
+            (Some(env), _) => env.clone(),
+            (None, Ok(home)) => home.clone(),
+            (None, Err(_)) => return Err(SoldrError::NoHomeDir),
+        };
+        // The pin must NOT move when SOLDR_CACHE_DIR overrides the rest of
+        // the install root (issue #426 — pinned binaries are a machine-level
+        // user preference, not per-cache-dir state). When no $HOME / no
+        // USERPROFILE is available — e.g. a headless CI sandbox that relies
+        // entirely on SOLDR_CACHE_DIR — fall back to the env-rooted bin/ so
+        // the pin lives somewhere accessible; that env does lose the
+        // cross-SOLDR_CACHE_DIR survival property, but it matches today's
+        // behavior so nothing regresses.
+        let pinned_bin = match &home_root {
+            Ok(home) => home.join("bin"),
+            Err(_) => root.join("bin"),
+        };
+        Ok(Self {
+            bin: root.join("bin"),
+            pinned_bin,
+            cache: root.join("cache"),
+            config_file: root.join("config.toml"),
+            root,
+        })
     }
 
     pub fn with_root(root: PathBuf) -> Self {
+        let bin = root.join("bin");
         Self {
-            bin: root.join("bin"),
+            bin: bin.clone(),
+            // Tests use synthetic roots and rely on the pin landing inside
+            // the test workspace. Collapse pinned_bin into bin so isolation
+            // works; production goes through `from_root_env_value` which
+            // anchors pinned_bin at the user's home.
+            pinned_bin: bin,
             cache: root.join("cache"),
             config_file: root.join("config.toml"),
             root,
@@ -631,6 +677,7 @@ impl SoldrPaths {
 
     pub fn ensure_dirs(&self) -> Result<(), SoldrError> {
         std::fs::create_dir_all(&self.bin)?;
+        std::fs::create_dir_all(&self.pinned_bin)?;
         std::fs::create_dir_all(&self.cache)?;
         Ok(())
     }
@@ -1020,6 +1067,76 @@ mod tests {
         assert!(paths.root.ends_with(".soldr"));
         assert!(paths.bin.ends_with("bin"));
         assert!(paths.cache.ends_with("cache"));
+    }
+
+    #[test]
+    fn pinned_bin_survives_soldr_cache_dir_override() {
+        // Issue #426: SOLDR_CACHE_DIR overrides the install root (and bin/
+        // and cache/ along with it), but the pin must keep living at the
+        // home-anchored ~/.soldr/bin/ so a pin registered against the
+        // default cache dir stays visible to builds that re-root the cache.
+        //
+        // We exercise `from_env_root_and_home` directly so the test
+        // doesn't have to mutate HOME / USERPROFILE — that would race with
+        // every other case in this binary that reads them.
+        let home_root = PathBuf::from("/synthetic-home/.soldr");
+        let env_root = PathBuf::from("/synthetic-cache-dir");
+        let paths =
+            SoldrPaths::from_env_root_and_home(Some(env_root.clone()), Ok(home_root.clone()))
+                .unwrap();
+
+        assert_eq!(paths.root, env_root, "root follows SOLDR_CACHE_DIR");
+        assert_eq!(
+            paths.bin,
+            env_root.join("bin"),
+            "bin/ follows SOLDR_CACHE_DIR (managed binaries stay per-cache-dir)"
+        );
+        assert_eq!(
+            paths.pinned_bin,
+            home_root.join("bin"),
+            "pinned_bin stays at $HOME/.soldr/bin/ regardless of SOLDR_CACHE_DIR"
+        );
+        assert_ne!(
+            paths.bin, paths.pinned_bin,
+            "the whole point of the fix: bin and pinned_bin diverge under env override"
+        );
+    }
+
+    #[test]
+    fn pinned_bin_equals_bin_when_no_cache_dir_override() {
+        // No SOLDR_CACHE_DIR → root falls back to home → bin == pinned_bin.
+        // No behavior change in the dominant case.
+        let home_root = PathBuf::from("/synthetic-home/.soldr");
+        let paths = SoldrPaths::from_env_root_and_home(None, Ok(home_root.clone())).unwrap();
+        assert_eq!(paths.root, home_root);
+        assert_eq!(paths.bin, home_root.join("bin"));
+        assert_eq!(paths.pinned_bin, paths.bin);
+    }
+
+    #[test]
+    fn pinned_bin_falls_back_to_env_root_when_no_home_available() {
+        // Headless sandbox case: SOLDR_CACHE_DIR set but no $HOME /
+        // USERPROFILE. pinned_bin must NOT panic — it falls back to the
+        // env-rooted bin/ (loses cross-SOLDR_CACHE_DIR survival, but
+        // matches today's behavior so nothing regresses).
+        let env_root = PathBuf::from("/sandbox/.soldr");
+        let paths =
+            SoldrPaths::from_env_root_and_home(Some(env_root.clone()), Err(SoldrError::NoHomeDir))
+                .unwrap();
+        assert_eq!(paths.pinned_bin, env_root.join("bin"));
+        assert_eq!(paths.pinned_bin, paths.bin);
+    }
+
+    #[test]
+    fn pinned_bin_collapses_into_bin_with_synthetic_root() {
+        // `SoldrPaths::with_root` is the test-construction path used by
+        // integration tests. The pin dir must live inside the synthetic
+        // root so test workspaces can register pins without escaping to
+        // the host's home dir.
+        let root = PathBuf::from("/tmp/synthetic-soldr-root");
+        let paths = SoldrPaths::with_root(root.clone());
+        assert_eq!(paths.bin, root.join("bin"));
+        assert_eq!(paths.pinned_bin, paths.bin);
     }
 
     #[test]

--- a/crates/soldr-cli/src/fetch/install_zccache.rs
+++ b/crates/soldr-cli/src/fetch/install_zccache.rs
@@ -141,8 +141,13 @@ pub struct PinnedResolution {
 
 /// Path to the pinned install dir for a given soldr root. The dir may
 /// not exist yet; callers must check.
+///
+/// Sources from `paths.pinned_bin` (NOT `paths.bin`) so that a pin
+/// registered against the default cache root remains visible when a
+/// build re-roots with `SOLDR_CACHE_DIR=/x`. See issue #426 for the
+/// failure that motivated the split.
 pub fn pinned_zccache_dir(paths: &SoldrPaths) -> PathBuf {
-    paths.bin.join(PINNED_ZCCACHE_DIRNAME)
+    paths.pinned_bin.join(PINNED_ZCCACHE_DIRNAME)
 }
 
 fn pinned_sidecar_path(paths: &SoldrPaths) -> PathBuf {

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -15,9 +15,17 @@ use std::{
 #[test]
 fn status_reports_cache_control_defaults() {
     let cache_root = unique_temp_dir("status");
+    // Redirect HOME / USERPROFILE so the test doesn't see the developer's
+    // host-side pin under `~/.soldr/bin/zccache-pinned/`. After issue #426
+    // the pin is home-anchored and survives SOLDR_CACHE_DIR overrides — so
+    // a stale host pin would otherwise leak into the test as a fetched
+    // binary and break the "not fetched yet" assertion below.
+    let home_root = unique_temp_dir("status-home");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .arg("status")
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .output()
         .expect("failed to run soldr status");
 
@@ -49,9 +57,15 @@ fn status_reports_cache_control_defaults() {
 #[test]
 fn status_json_reports_stable_machine_fields() {
     let cache_root = unique_temp_dir("status-json");
+    // See sibling `status_reports_cache_control_defaults`: redirect home
+    // discovery so the developer's host-side pin (issue #426) can't leak
+    // into the test as a "binary already fetched" signal.
+    let home_root = unique_temp_dir("status-json-home");
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .output()
         .expect("failed to run soldr status --json");
 


### PR DESCRIPTION
## Summary

Closes #426. Pinned-zccache binaries now live at `\$HOME/.soldr/bin/zccache-pinned/` independent of the active `SOLDR_CACHE_DIR`. Before this change, the env var re-rooted *every* `SoldrPaths` field — including `bin/` — so a pin registered against the default cache root was invisible to any `SOLDR_CACHE_DIR=/x soldr cargo build` invocation, and soldr silently fell through to a managed download.

## Root cause (verified)

`SoldrPaths::with_root` was deriving `bin`, `cache`, and `config_file` all from one `root`. When `SOLDR_CACHE_DIR=/x` was set, `paths.bin = /x/bin/`, so `pinned_zccache_dir(paths) = /x/bin/zccache-pinned/` — never the home-anchored location where `update-zccache` had written the install. Reproduced inside the existing docker harness in #425 (output captured in the issue).

## Fix

- `SoldrPaths` gains a new `pinned_bin: PathBuf` field. In production it resolves to `\$HOME/.soldr/bin/` regardless of `SOLDR_CACHE_DIR`; for the synthetic `SoldrPaths::with_root` constructor (used by integration tests) it collapses into `bin` so test isolation is preserved.
- `pinned_zccache_dir(paths)` reads from `paths.pinned_bin` instead of `paths.bin`. Install + resolve symmetrically go through this helper.
- `ensure_dirs()` now creates `pinned_bin` too.
- `collect_zccache_status` becomes tolerant of "daemon not running" — surfaced as a hard failure once the pin newly resolves under a custom `SOLDR_CACHE_DIR` whose daemon socket hasn't been spawned yet. Mirrors the tolerance already present elsewhere (see `zccache_daemon_already_stopped`).
- A `_pinned_bin` fallback path keeps headless sandboxes (no `\$HOME`/`\$USERPROFILE`, `SOLDR_CACHE_DIR` set) at the env-rooted bin — same behavior as today; that env loses cross-cache-dir survival, but nothing regresses.

## Test coverage

**Unit (`core.rs`)** — four new cases, all driven through a new `from_env_root_and_home` constructor so no test mutates process env:

- `pinned_bin_survives_soldr_cache_dir_override` — the core #426 assertion.
- `pinned_bin_equals_bin_when_no_cache_dir_override` — default case unchanged.
- `pinned_bin_falls_back_to_env_root_when_no_home_available` — headless sandbox.
- `pinned_bin_collapses_into_bin_with_synthetic_root` — `with_root` test path.

**Integration (`tests/cli_cache.rs`)** — two existing tests now `.env("HOME", &home_root).env("USERPROFILE", &home_root)` so the developer's host-side pin can't leak into the "no binary fetched" assertion (the test was coupled to host state once the pin became home-anchored).

**Docker harness** — `bench/docker/update-zccache-pin-honored/repro.sh` picks up a second verdict block:

1. Default cache dir → `soldr: zccache source: pinned (...)` (passed before this PR too).
2. `rm -rf target` (bypass the trampoline fast-path), then `SOLDR_CACHE_DIR=/work-cache soldr cargo build` → must still say `pinned (...)`.

Output on this PR (both pass):

```
=== Default cache dir verdict ===
PASS (default cache dir): pin honored.

=== Re-run with SOLDR_CACHE_DIR=/work-cache — pin must STILL be honored (#426) ===
soldr: zccache source: pinned (/root/.soldr/bin/zccache-pinned) version=unknown

=== #426 verdict ===
PASS (#426): pin survives SOLDR_CACHE_DIR override.
```

The new variant would fail (`managed (...)`) on un-patched soldr.

## Subtle: why the harness needs `rm -rf target`

`soldr cargo build` short-circuits the `prepare_zccache_build` wrapper-prep step (and therefore the `soldr: zccache source:` diagnostic) via the trampoline fast-path (#346 / #354) when `target/` is up-to-date. Without the wipe between runs, the second invocation produces empty stderr and the harness can't tell which binary won resolution. Documented inline.

## Compatibility

- Default-cache-dir users: zero behavior change. `root == home`, so `bin == pinned_bin`.
- Users who'd already pinned and never set `SOLDR_CACHE_DIR`: pin keeps working.
- Users who set `SOLDR_CACHE_DIR` *and* haven't pinned: zero behavior change.
- Users who set `SOLDR_CACHE_DIR` *and* pinned: **fixed** — pin now survives.
- `soldr cache clean` under `SOLDR_CACHE_DIR=/x`: now leaves the pin at `\$HOME/.soldr/bin/` alone (only clears `/x/`). To remove the pin specifically, use `soldr update-zccache --remove`.

## Test plan

- [x] `cargo test --workspace` — all suites that pass on `main` still pass; the two pre-existing host-specific failures (`auto_bootstrap_reports_opted_out_when_env_var_set`, `doctor_reports_missing_target`) reproduce against `main` HEAD too and are not related to this change.
- [x] `cargo fmt --check` clean.
- [x] Docker harness — `bash bench/docker/update-zccache-pin-honored/run.sh` — both verdicts pass.

Refs: #420, #421, #424, #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)