### PR TITLE
chore(release): soldr 0.7.28 + managed zccache 1.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.27"
+version = "0.7.28"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.27"
+version = "0.7.28"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -68,7 +68,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.8.1";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.8.2";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.8.1");
+    assert_eq!(json["managed_zccache_version"], "1.8.2");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.8.1");
+    assert_eq!(json["managed_zccache_version"], "1.8.2");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.8.1");
+    assert_eq!(json["managed_zccache_version"], "1.8.2");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -106,7 +106,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.8.1");
+    assert_eq!(status_json["managed_version"], "1.8.2");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -150,7 +150,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.8.1");
+    assert_eq!(json["managed_version"], "1.8.2");
 }
 
 #[test]

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -35,16 +35,39 @@ fn seed_source_dir(root: &Path) -> PathBuf {
     src
 }
 
+/// Per-test isolated home directory used to anchor the pinned-zccache
+/// install (issue #426 — `paths.pinned_bin` lives under `$HOME/.soldr/bin/`
+/// regardless of `SOLDR_CACHE_DIR`). Without this, every test in this
+/// binary would write into the same `$HOME/.soldr/bin/zccache-pinned/`
+/// at the same time when cargo runs them in parallel — Linux CI surfaces
+/// the race as "Directory not empty (os error 39)" during `remove_dir_all`
+/// + `create_dir_all` in `install_zccache_from_source`.
+fn unique_home_dir(label: &str) -> PathBuf {
+    let home = unique_temp_dir(&format!("{label}-home"));
+    // pre-create .soldr/bin to match what `SoldrPaths::ensure_dirs()` would
+    // do on a fresh production install; keeps test setup mirroring reality.
+    fs::create_dir_all(home.join(".soldr").join("bin")).expect("seed home/.soldr/bin");
+    home
+}
+
+/// Path the pin lands at under the per-test isolated home dir.
+fn pinned_dir_in(home_root: &Path) -> PathBuf {
+    home_root.join(".soldr").join("bin").join("zccache-pinned")
+}
+
 #[test]
 fn install_zccache_from_directory_writes_sidecar() {
     let tmp = unique_temp_dir("install-zccache-dir");
     let cache_root = tmp.join("soldr-root");
+    let home_root = unique_home_dir("install-zccache-dir");
     let src = seed_source_dir(&tmp);
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["install-zccache"])
         .arg(&src)
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("failed to run install-zccache");
@@ -56,7 +79,8 @@ fn install_zccache_from_directory_writes_sidecar() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let pinned = cache_root.join("bin").join("zccache-pinned");
+    // The pin is home-anchored (issue #426), not under SOLDR_CACHE_DIR.
+    let pinned = pinned_dir_in(&home_root);
     assert!(pinned.join(bin_name("zccache")).exists());
     assert!(pinned.join(bin_name("zccache-daemon")).exists());
     assert!(pinned.join(bin_name("zccache-fp")).exists());
@@ -74,6 +98,7 @@ fn install_zccache_from_directory_writes_sidecar() {
 fn install_zccache_json_round_trip() {
     let tmp = unique_temp_dir("install-zccache-json");
     let cache_root = tmp.join("soldr-root");
+    let home_root = unique_home_dir("install-zccache-json");
     let src = seed_source_dir(&tmp);
 
     // install --json
@@ -81,6 +106,8 @@ fn install_zccache_json_round_trip() {
         .args(["install-zccache", "--json"])
         .arg(&src)
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("install-zccache --json");
@@ -98,6 +125,8 @@ fn install_zccache_json_round_trip() {
     let status = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["install-zccache", "--status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("install-zccache --status --json");
@@ -116,6 +145,8 @@ fn install_zccache_json_round_trip() {
     let remove = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["install-zccache", "--remove", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("install-zccache --remove --json");
@@ -127,6 +158,8 @@ fn install_zccache_json_round_trip() {
     let remove2 = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["install-zccache", "--remove", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("install-zccache --remove --json (second)");
@@ -140,10 +173,13 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     let tmp = unique_temp_dir("install-zccache-status-empty");
     let cache_root = tmp.join("soldr-root");
     fs::create_dir_all(&cache_root).unwrap();
+    let home_root = unique_home_dir("install-zccache-status-empty");
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["install-zccache", "--status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("status with no install");
@@ -157,10 +193,13 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
 fn install_zccache_no_source_no_flags_errors() {
     let tmp = unique_temp_dir("install-zccache-empty-args");
     let cache_root = tmp.join("soldr-root");
+    let home_root = unique_home_dir("install-zccache-empty-args");
 
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["install-zccache"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("install-zccache (no args)");
@@ -176,11 +215,14 @@ fn install_zccache_no_source_no_flags_errors() {
 fn install_zccache_mutually_exclusive_flags_rejected() {
     let tmp = unique_temp_dir("install-zccache-mutex");
     let cache_root = tmp.join("soldr-root");
+    let home_root = unique_home_dir("install-zccache-mutex");
 
     // clap should reject `--remove` + `--status` outright.
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["install-zccache", "--remove", "--status"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("install-zccache --remove --status");
@@ -193,6 +235,8 @@ fn install_zccache_mutually_exclusive_flags_rejected() {
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["install-zccache", "system", "--remove"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("install-zccache SOURCE --remove");
@@ -206,6 +250,7 @@ fn install_zccache_mutually_exclusive_flags_rejected() {
 fn install_zccache_unknown_extension_errors() {
     let tmp = unique_temp_dir("install-zccache-unknown-ext");
     let cache_root = tmp.join("soldr-root");
+    let home_root = unique_home_dir("install-zccache-unknown-ext");
     let bogus = tmp.join("zccache.7z");
     fs::write(&bogus, b"junk").unwrap();
 
@@ -213,6 +258,8 @@ fn install_zccache_unknown_extension_errors() {
         .args(["install-zccache"])
         .arg(&bogus)
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .output()
         .expect("install-zccache with bogus archive");

--- a/crates/soldr-cli/tests/cli_install_zccache_resolution.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache_resolution.rs
@@ -276,6 +276,11 @@ fn classify_zccache_source_tags_each_branch_correctly() {
 fn install_then_doctor_subprocess_reports_pinned_active_source() {
     let tmp = unique_temp_dir("cli-install-doctor");
     let cache_root = tmp.join("soldr-root");
+    // Issue #426: the pin lives under $HOME/.soldr/bin/ now, so every
+    // subprocess that installs MUST get its own HOME — otherwise parallel
+    // test cases race on a shared pin dir.
+    let home_root = unique_temp_dir("cli-install-doctor-home");
+    fs::create_dir_all(home_root.join(".soldr").join("bin")).expect("seed home/.soldr/bin");
     let pin_src = seed_pin_source(&tmp);
 
     // 1. Pin the staged binaries via the CLI.
@@ -283,6 +288,8 @@ fn install_then_doctor_subprocess_reports_pinned_active_source() {
         .args(["install-zccache", "--json"])
         .arg(&pin_src)
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .env_remove("SOLDR_TEST_ZCCACHE_BIN")
         .output()
@@ -298,6 +305,8 @@ fn install_then_doctor_subprocess_reports_pinned_active_source() {
     let doctor = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["doctor", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .env_remove("SOLDR_TEST_ZCCACHE_BIN")
         .output()
@@ -326,6 +335,8 @@ fn install_then_doctor_subprocess_reports_pinned_active_source() {
     let doctor_human = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["doctor"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .env_remove("SOLDR_TEST_ZCCACHE_BIN")
         .output()
@@ -342,12 +353,18 @@ fn install_then_doctor_subprocess_reports_pinned_active_source() {
 fn install_then_cache_subprocess_reports_pinned_source() {
     let tmp = unique_temp_dir("cli-install-cache");
     let cache_root = tmp.join("soldr-root");
+    // Issue #426: see the matching comment in
+    // `install_then_doctor_subprocess_reports_pinned_active_source`.
+    let home_root = unique_temp_dir("cli-install-cache-home");
+    fs::create_dir_all(home_root.join(".soldr").join("bin")).expect("seed home/.soldr/bin");
     let pin_src = seed_pin_source(&tmp);
 
     let install = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["install-zccache"])
         .arg(&pin_src)
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .env_remove("SOLDR_TEST_ZCCACHE_BIN")
         .output()
@@ -361,6 +378,8 @@ fn install_then_cache_subprocess_reports_pinned_source() {
     let cache = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["cache", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("HOME", &home_root)
+        .env("USERPROFILE", &home_root)
         .env_remove("SOLDR_ZCCACHE_LOCAL_DIR")
         .env_remove("SOLDR_TEST_ZCCACHE_BIN")
         .output()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.27",
+  "version": "0.7.28",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Release PR that bumps the managed zccache pin from **1.8.1 → 1.8.2** (latest upstream — published 2026-05-22) and the soldr workspace version from **0.7.27 → 0.7.28**. Merging this triggers the Autonomous Release workflow per `CLAUDE.md`'s release rules.

This release also carries the freshly-merged fix for #426 (pin survives `SOLDR_CACHE_DIR` override — see #427).

## Pre-merge checklist (from `CLAUDE.md`)

- [x] `[workspace.package].version` bumped in `Cargo.toml` (`0.7.27 → 0.7.28`).
- [x] Matching `"version"` bumped in `package.json` (`0.7.27 → 0.7.28`).
- [x] `Cargo.lock` regenerated to match.
- [x] `0.7.28` is not yet published — verified against:
  - git tags: `v0.7.27` is the most recent, no `v0.7.28`.
  - PyPI `soldr`: latest is `0.7.27`.
  - npm `@zackees/soldr`: latest is `0.7.27`.

## What changed

| File | Change |
|------|--------|
| `crates/soldr-cli/src/fetch/mod.rs` | `MANAGED_ZCCACHE_VERSION: "1.8.1" → "1.8.2"` |
| `Cargo.toml` | `[workspace.package].version` `0.7.27 → 0.7.28` |
| `Cargo.lock` | regenerated |
| `package.json` | `"version"` `0.7.27 → 0.7.28` |
| `crates/soldr-cli/tests/cli_cache.rs` | three `managed_zccache_version` assertions updated |
| `crates/soldr-cli/tests/cli_install_zccache.rs` | two `managed_version` assertions updated |

Test data references to `zccache-v1.8.1/` inside `tests/lib_install_zccache.rs` are intentionally **not** touched — those exercise nested-dir archive extraction logic, not version tracking.

## Upstream zccache 1.8.2

- Tag: `1.8.2` (no `v` prefix, matching soldr's existing fetch logic).
- Published: 2026-05-22T14:29:38Z by github-actions[bot].
- All target archives present: `aarch64-apple-darwin`, `aarch64-pc-windows-msvc`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, `x86_64-pc-windows-msvc`, `x86_64-unknown-linux-musl`.

## Test plan

- [x] `cargo build -p soldr-cli` clean.
- [x] `cargo test --workspace` — every binary passes except for two pre-existing host-specific failures (`auto_bootstrap_reports_opted_out_when_env_var_set`, `doctor_reports_missing_target`) that also fail against `main` HEAD without this change.
- [x] `cargo fmt --check` clean.
- [ ] CI green on all platforms (this PR).
- [ ] On merge, Autonomous Release workflow:
  - prepares the release (detects unpublished `0.7.28` version)
  - creates `v0.7.28` git tag + GitHub release
  - publishes to PyPI / npm

Refs: #426, #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)