### PR TITLE
feat(release): ship soldr musl binaries for Linux x86_64 + aarch64

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -181,6 +181,23 @@ jobs:
             target: aarch64-unknown-linux-gnu
             archive: tar.gz
             binary: soldr
+          # musl variants ship statically-linked Linux binaries that run on
+          # alpine and other libc-less distros. CI already exercises these
+          # via `_bootstrap-e2e.yml`'s `e2e-linux-*-musl` jobs, so the
+          # toolchain + linker story is known-good. See `bench/docker/`
+          # and zackees/zccache's perf harness, both of which rebuild
+          # soldr-cli for musl from source per run because no pre-built
+          # binary existed before this matrix expansion.
+          - name: Linux x64 (musl)
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            archive: tar.gz
+            binary: soldr
+          - name: Linux ARM64 (musl)
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            archive: tar.gz
+            binary: soldr
           - name: macOS x64
             runner: macos-15-intel
             target: x86_64-apple-darwin
@@ -213,6 +230,36 @@ jobs:
           toolchain: 1.94.1
           targets: ${{ matrix.target }}
 
+      # Mirrors `_bootstrap-e2e.yml`'s musl-tools install: retried apt
+      # update + install, --no-install-recommends to narrow the input
+      # surface (#41), and an installed-version log line so the workflow
+      # run is auditable.
+      - name: Install musl tools
+        if: contains(matrix.target, 'musl')
+        shell: bash
+        run: |
+          set -euo pipefail
+          attempts=0
+          max_attempts=3
+          until sudo apt-get update; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get update failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+          attempts=0
+          until sudo apt-get install -y --no-install-recommends musl-tools; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get install musl-tools failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+          dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
+
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -243,11 +290,20 @@ jobs:
           Compress-Archive -Path "dist\package\${{ matrix.binary }}" -DestinationPath "dist\$name.zip" -Force
 
       - name: Install uv
+        # PyPI wheel build is gnu-only for now. musllinux wheels need a
+        # docker-based smoke test (the smoke step below cannot install a
+        # musllinux wheel on the glibc-based release runner), and that
+        # plumbing is out of scope for the initial musl-binary ship.
+        # Users on alpine still get pip install via the source dist or
+        # the GitHub Releases tarball; the npm wrapper picks up the musl
+        # tarball directly via libc detection.
+        if: ${{ !contains(matrix.target, 'musl') }}
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:
           enable-cache: false
 
       - name: Build hardened wheel from shared target directory
+        if: ${{ !contains(matrix.target, 'musl') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -262,6 +318,7 @@ jobs:
             --out dist
 
       - name: Verify wheel ships the bin script at the spec path
+        if: ${{ !contains(matrix.target, 'musl') }}
         shell: python
         run: |
           import zipfile
@@ -319,11 +376,27 @@ jobs:
           )
 
       - name: Smoke test wheel
+        if: ${{ !contains(matrix.target, 'musl') }}
         shell: bash
         run: |
           uv venv .venv
           uv pip install --python .venv dist/*.whl
           .venv/bin/soldr --version || .venv/Scripts/soldr.exe --version
+
+      - name: Smoke test standalone musl binary
+        # The wheel smoke test above is unreachable for musl rows (the
+        # release runner is glibc, can't install a musllinux wheel). The
+        # standalone musl binary is statically linked so it CAN run on
+        # glibc — verify that the build actually produced a working
+        # executable, otherwise we'd ship an untested artifact.
+        if: contains(matrix.target, 'musl')
+        shell: bash
+        run: |
+          set -euo pipefail
+          binary="target/${{ matrix.target }}/release/${{ matrix.binary }}"
+          test -x "$binary" || { echo "missing release binary: $binary" >&2; exit 1; }
+          file "$binary" || true
+          "./$binary" --version
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -332,7 +405,8 @@ jobs:
             dist/soldr-*.tar.gz
             dist/soldr-*.zip
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - if: ${{ !contains(matrix.target, 'musl') }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pypi-soldr-${{ matrix.target }}
           path: dist/*.whl

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -13,13 +13,23 @@ const PACKAGE_ROOT = path.resolve(__dirname, "..");
 const PACKAGE_JSON = require(path.join(PACKAGE_ROOT, "package.json"));
 
 const TARGETS = {
-  "linux-x64": {
+  "linux-x64-gnu": {
     triple: "x86_64-unknown-linux-gnu",
     archive: "tar.gz",
     binary: "soldr",
   },
-  "linux-arm64": {
+  "linux-x64-musl": {
+    triple: "x86_64-unknown-linux-musl",
+    archive: "tar.gz",
+    binary: "soldr",
+  },
+  "linux-arm64-gnu": {
     triple: "aarch64-unknown-linux-gnu",
+    archive: "tar.gz",
+    binary: "soldr",
+  },
+  "linux-arm64-musl": {
+    triple: "aarch64-unknown-linux-musl",
     archive: "tar.gz",
     binary: "soldr",
   },
@@ -45,10 +55,53 @@ const TARGETS = {
   },
 };
 
-function platformTarget(platform = process.platform, arch = process.arch) {
-  const target = TARGETS[`${platform}-${arch}`];
+// Detect whether the running Linux uses musl or glibc. Three layered probes:
+//   1. process.report.header.glibcVersionRuntime is the documented Node
+//      surface for runtime glibc version — present on glibc, absent /
+//      empty on musl. Same approach used by @swc/core, @napi-rs/*, etc.
+//   2. Filesystem check for `/lib/ld-musl-*.so.1` covers cases where the
+//      Node binary itself is glibc (e.g. someone running glibc Node on
+//      alpine via apk add nodejs-current) but the system is musl — the
+//      soldr binary we download must match the SYSTEM libc, not Node's.
+//   3. Final fallback: assume glibc. The mismatch will surface
+//      immediately at runtime as "soldr: not found" or
+//      "soldr: error while loading shared libraries", which is louder
+//      than silently downloading the wrong tarball.
+function detectLibc(platform = process.platform) {
+  if (platform !== "linux") {
+    return null;
+  }
+  try {
+    const header = process.report && process.report.getReport && process.report.getReport().header;
+    if (header && typeof header.glibcVersionRuntime === "string" && header.glibcVersionRuntime.length > 0) {
+      return "gnu";
+    }
+    if (header && Object.prototype.hasOwnProperty.call(header, "glibcVersionRuntime")) {
+      // Field present but empty / null → Node was built against musl.
+      return "musl";
+    }
+  } catch (err) {
+    // process.report can throw on locked-down environments; fall through.
+  }
+  try {
+    const entries = fs.readdirSync("/lib");
+    if (entries.some((name) => /^ld-musl-.+\.so\.1$/.test(name))) {
+      return "musl";
+    }
+  } catch (err) {
+    // /lib may not be readable in heavily sandboxed containers; fall through.
+  }
+  return "gnu";
+}
+
+function platformTarget(platform = process.platform, arch = process.arch, libc = detectLibc(platform)) {
+  const key =
+    platform === "linux"
+      ? `${platform}-${arch}-${libc || "gnu"}`
+      : `${platform}-${arch}`;
+  const target = TARGETS[key];
   if (!target) {
-    throw new Error(`unsupported platform for soldr npm package: ${platform}-${arch}`);
+    throw new Error(`unsupported platform for soldr npm package: ${key}`);
   }
   return target;
 }
@@ -235,6 +288,7 @@ if (require.main === module) {
 
 module.exports = {
   checksumFor,
+  detectLibc,
   platformTarget,
   releaseBaseUrl,
 };

--- a/scripts/test-npm-package.js
+++ b/scripts/test-npm-package.js
@@ -75,13 +75,41 @@ assert.deepStrictEqual(pkg.files, [
 const bin = fs.readFileSync(path.join(root, pkg.bin.soldr), "utf8");
 assert(bin.startsWith("#!/usr/bin/env node"), "bin/soldr.js must have a node shebang");
 
-assert.strictEqual(install.platformTarget("linux", "x64").triple, "x86_64-unknown-linux-gnu");
-assert.strictEqual(install.platformTarget("linux", "arm64").triple, "aarch64-unknown-linux-gnu");
+// Linux: triple selection branches on libc. `platformTarget` accepts an
+// explicit `libc` arg so tests don't depend on the runtime detector.
+assert.strictEqual(
+  install.platformTarget("linux", "x64", "gnu").triple,
+  "x86_64-unknown-linux-gnu",
+);
+assert.strictEqual(
+  install.platformTarget("linux", "x64", "musl").triple,
+  "x86_64-unknown-linux-musl",
+);
+assert.strictEqual(
+  install.platformTarget("linux", "arm64", "gnu").triple,
+  "aarch64-unknown-linux-gnu",
+);
+assert.strictEqual(
+  install.platformTarget("linux", "arm64", "musl").triple,
+  "aarch64-unknown-linux-musl",
+);
+// Default (no libc arg) falls back to detectLibc; on most CI hosts that's
+// gnu. We don't assert the triple here — just that the call resolves.
+assert.ok(install.platformTarget("linux", "x64").triple.startsWith("x86_64-unknown-linux-"));
 assert.strictEqual(install.platformTarget("darwin", "x64").triple, "x86_64-apple-darwin");
 assert.strictEqual(install.platformTarget("darwin", "arm64").triple, "aarch64-apple-darwin");
 assert.strictEqual(install.platformTarget("win32", "x64").triple, "x86_64-pc-windows-msvc");
 assert.strictEqual(install.platformTarget("win32", "arm64").triple, "aarch64-pc-windows-msvc");
 assert.throws(() => install.platformTarget("freebsd", "x64"), /unsupported platform/);
+
+// detectLibc must return null on non-Linux platforms so the platform key
+// stays `<platform>-<arch>` rather than `<platform>-<arch>-gnu`.
+assert.strictEqual(install.detectLibc("darwin"), null);
+assert.strictEqual(install.detectLibc("win32"), null);
+// On Linux it must always resolve to one of the two known families so
+// `platformTarget` can build a well-formed key.
+const linuxLibc = install.detectLibc("linux");
+assert.ok(linuxLibc === "gnu" || linuxLibc === "musl", `unexpected libc: ${linuxLibc}`);
 
 assert.strictEqual(
   install.checksumFor("abc123  soldr-v0.7.5-x86_64-unknown-linux-gnu.tar.gz\n", "soldr-v0.7.5-x86_64-unknown-linux-gnu.tar.gz"),


### PR DESCRIPTION
## Summary

Adds `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to the Autonomous Release matrix in `.github/workflows/release-auto.yml`. The musl variants ship statically-linked binaries that run on alpine and other libc-less distros.

**Why now:** both our own `bench/docker/update-zccache-pin-honored/` harness (introduced in #425) and zackees/zccache's perf harness ([PR #341 there](https://github.com/zackees/zccache/pull/341)) currently rebuild `soldr-cli` for musl from source every CI run because no pre-built binary exists. Each rebuild is ~4 minutes — wasted work that goes away once the next release ships the tarballs.

CI already validates the musl build path via `_bootstrap-e2e.yml`'s `e2e-linux-x64-musl` and `e2e-linux-arm64-musl` jobs, so the toolchain + linker story is known-good. This PR just packages what CI already builds.

## What changed

### `.github/workflows/release-auto.yml`

- Matrix gains two musl rows (lines 191-200).
- New `Install musl tools` step gated on `contains(matrix.target, 'musl')` — mirrors `_bootstrap-e2e.yml`'s retried-apt pattern with `--no-install-recommends` and an audit-log version line.
- New `Smoke test standalone musl binary` step (also gated) — runs `<binary> --version` on the built artifact. Statically-linked musl binaries run fine on the glibc release runner, so cross-libc verification works.
- PyPI wheel build steps (`Install uv`, `Build hardened wheel`, `Verify wheel`, `Smoke test wheel`, `pypi-soldr-*` upload) are now gated `!contains(matrix.target, 'musl')`. Reason: the existing `Smoke test wheel` step installs the wheel on the runner, which fails for musllinux wheels on a glibc runner. Adding a docker-based smoke test for musllinux is its own bundle of work and out of scope here.

### `scripts/install.js`

- TARGETS table gains four Linux variants keyed on `linux-<arch>-<libc>` (gnu and musl, x64 and arm64). macOS / Windows entries unchanged.
- New `detectLibc(platform)` with three layered probes:
  1. `process.report.getReport().header.glibcVersionRuntime` — the documented Node surface, used by `@swc/core` / `@napi-rs/*` and friends.
  2. Filesystem check for `/lib/ld-musl-*.so.1` — covers cases where Node itself is glibc but the system is musl.
  3. Final `gnu` fallback.
  Non-Linux platforms return `null` so the platform key stays `<platform>-<arch>`.
- `platformTarget(platform, arch, libc)` now takes an optional `libc` arg (defaults to `detectLibc(platform)`) so tests don't have to mock the host env.

### `scripts/test-npm-package.js`

- Asserts all four Linux libc / arch combinations resolve to the right triple.
- Asserts `detectLibc("darwin")` and `detectLibc("win32")` return `null`.
- Asserts `detectLibc("linux")` returns one of `"gnu"` or `"musl"` on whatever host runs CI.

## Intentional scope limits

- **No version bump.** Per `CLAUDE.md`'s release rules, only a `Cargo.toml` + `package.json` version bump triggers the release workflow. This PR is workflow-only — the next release PR picks up the musl rows automatically.
- **No musllinux PyPI wheels yet.** Alpine users can use the GitHub Releases tarball directly or `npm install @zackees/soldr` (which now picks the right tarball via libc detection). A follow-up can add docker-based musllinux smoke tests and turn on the PyPI path.
- **gnu Linux unchanged.** Existing rows + steps unmodified; the diff is additive.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release-auto.yml'))"` — yaml well-formed.
- [x] `node scripts/test-npm-package.js` — passes locally, exercises both libc branches.
- [x] Manual sanity:
  ```
  $ node -e "const i = require('./scripts/install.js'); console.log(i.platformTarget('linux', 'x64', 'musl').triple)"
  x86_64-unknown-linux-musl
  ```
- [ ] CI green on this PR.
- [ ] Next release after merge produces `soldr-vX.Y.Z-{x86_64,aarch64}-unknown-linux-musl.tar.gz` artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)