### PR TITLE
chore(ci): bump checkout/upload-artifact/download-artifact off Node 20

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -45,12 +45,12 @@ jobs:
     runs-on: ${{ inputs.runner }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.source_ref }}
           path: soldr
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ inputs.third_party_repo }}
           ref: ${{ inputs.third_party_ref }}
@@ -166,7 +166,7 @@ jobs:
           }
           & $soldrPath cache
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: soldr-${{ inputs.target }}
           path: ${{ steps.soldr_binary.outputs.path }}

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/_cache-benchmark-build.yml
+++ b/.github/workflows/_cache-benchmark-build.yml
@@ -62,7 +62,7 @@ jobs:
       cache_hit_detail: ${{ steps.cache_hit.outputs.detail }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
 
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload cargo timing artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ inputs.upload_name != '' && inputs.upload_name || format('cache-benchmark-{0}-{1}-{2}-timings', inputs.cache_backend, inputs.mutation, inputs.save_cache && 'seed' || (inputs.cache_backend == 'none' && 'cold' || 'warm')) }}
           path: target/cargo-timings

--- a/.github/workflows/cache-benchmark-child-branch.yml
+++ b/.github/workflows/cache-benchmark-child-branch.yml
@@ -49,7 +49,7 @@ jobs:
       seconds: ${{ steps.measure.outputs.seconds }}
       result: ${{ steps.measure.outputs.result }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.child_branch != '' && inputs.child_branch || github.ref }}
 
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload cold timing artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: child-branch-probe-cold
           path: |
@@ -123,7 +123,7 @@ jobs:
       soldr_version: ${{ steps.setup.outputs.soldr-version }}
       toolchain: ${{ steps.setup.outputs.toolchain }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.child_branch != '' && inputs.child_branch || github.ref }}
 
@@ -206,7 +206,7 @@ jobs:
 
       - name: Upload warm timing artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: child-branch-probe-warm
           path: |
@@ -223,7 +223,7 @@ jobs:
       - warm-soldr
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build report
         id: report
@@ -245,7 +245,7 @@ jobs:
           python3 .github/scripts/cache_benchmark_child_branch_report.py
 
       - name: Upload report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: child-branch-probe-report
           path: parent-child-zccache-report.md

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -74,7 +74,7 @@ jobs:
             arch: aarch64
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
@@ -375,7 +375,7 @@ jobs:
 
       - name: Upload native SQLite benchmark artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: native-sqlite-benchmark-${{ matrix.target }}
           path: benchmark-summary/native-sqlite-${{ matrix.target }}.json
@@ -394,7 +394,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Resolve benchmark config
         id: config
@@ -610,7 +610,7 @@ jobs:
           PY
 
       - name: Download native SQLite benchmark artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: native-sqlite-benchmark-*
           path: benchmark-summary/native-sqlite
@@ -697,7 +697,7 @@ jobs:
 
       - name: Upload raw benchmark artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cache-benchmark-raw
           path: benchmark-summary/cache-benchmark-results.json
@@ -705,7 +705,7 @@ jobs:
 
       - name: Upload benchmark summary artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cache-benchmark-summary
           path: benchmark-summary/cache-benchmark-summary.json
@@ -713,7 +713,7 @@ jobs:
 
       - name: Upload benchmark www artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cache-benchmark-www
           path: benchmark-summary/site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/parent-cache-bench.yml
+++ b/.github/workflows/parent-cache-bench.yml
@@ -41,7 +41,7 @@ jobs:
       TARGET: ${{ inputs.target || 'self' }}
       THRESHOLD: ${{ inputs.threshold_ratio || '5' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/perf-cold-warm.yml
+++ b/.github/workflows/perf-cold-warm.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         run: |
@@ -113,7 +113,7 @@ jobs:
           soldr-artifact/soldr version --json | tee soldr-artifact/version.json
 
       - name: Upload soldr binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-cold-warm-soldr-bin-linux
           path: soldr-artifact/
@@ -190,7 +190,7 @@ jobs:
       SOLDR_DEBUG: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         run: |
@@ -202,7 +202,7 @@ jobs:
           which gcc || sudo apt-get install -y gcc
 
       - name: Download soldr binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: perf-cold-warm-soldr-bin-linux
           path: soldr-bin
@@ -269,7 +269,7 @@ jobs:
 
       - name: Upload cold artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-cold-warm-cold-${{ inputs.fixture }}
           path: |
@@ -296,7 +296,7 @@ jobs:
       SOLDR_DEBUG: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         run: |
@@ -308,7 +308,7 @@ jobs:
           which gcc || sudo apt-get install -y gcc
 
       - name: Download soldr binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: perf-cold-warm-soldr-bin-linux
           path: soldr-bin
@@ -389,7 +389,7 @@ jobs:
 
       - name: Upload warm artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-cold-warm-warm-${{ inputs.fixture }}
           path: |

--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Checkout
         if: steps.gate.outputs.selected == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         if: steps.gate.outputs.selected == 'true'
@@ -268,7 +268,7 @@ jobs:
 
       - name: Upload soldr binary
         if: steps.gate.outputs.selected == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: soldr-bin-${{ matrix.platform }}
           path: soldr-artifact/
@@ -327,7 +327,7 @@ jobs:
 
       - name: Checkout
         if: steps.gate.outputs.selected == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         if: steps.gate.outputs.selected == 'true'
@@ -347,7 +347,7 @@ jobs:
 
       - name: Download soldr binary
         if: steps.gate.outputs.selected == 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: soldr-bin-${{ matrix.platform }}
           path: soldr-bin
@@ -419,7 +419,7 @@ jobs:
 
       - name: Upload raw results
         if: steps.gate.outputs.selected == 'true' && always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-results-${{ matrix.platform }}-${{ matrix.fixture }}
           path: |
@@ -478,7 +478,7 @@ jobs:
 
       - name: Download all perf results for ${{ matrix.platform }}
         if: steps.gate.outputs.selected == 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           # Glob across every fixture bench cell ran for this
           # platform. v4's `pattern:` keeps each artifact's

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -44,7 +44,7 @@ jobs:
       commit_sha: ${{ steps.validate.outputs.commit_sha }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -220,7 +220,7 @@ jobs:
             binary: soldr.exe
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.prepare.outputs.commit_sha }}
 
@@ -398,7 +398,7 @@ jobs:
           file "$binary" || true
           "./$binary" --version
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-soldr-${{ matrix.target }}
           path: |
@@ -406,7 +406,7 @@ jobs:
             dist/soldr-*.zip
 
       - if: ${{ !contains(matrix.target, 'musl') }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pypi-soldr-${{ matrix.target }}
           path: dist/*.whl
@@ -420,7 +420,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
           pattern: release-soldr-*
@@ -469,7 +469,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
           pattern: pypi-soldr-*
@@ -500,7 +500,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.prepare.outputs.commit_sha }}
 

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -49,7 +49,7 @@ jobs:
             runner: macos-15
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Verify setup-soldr pin matches v0
         shell: bash

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -154,6 +154,16 @@ jobs:
         shell: pwsh
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
+          # Network-touching tests (e.g. `fetch_crgx_and_run`) hit the
+          # GitHub Releases API. Without a token the rate limit is
+          # 60/hr per runner IP and gets exhausted quickly when several
+          # workflows run on the same shared macOS / Linux pool.
+          # Authenticating bumps the limit to 5000/hr and turns the
+          # flake into a non-issue. Pair the env var with the inner
+          # retry budget in fetch_repo_binary_with_paths (#432) — the
+          # token covers rate-limit class failures, the retry covers
+          # transient release-propagation 404s.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           Remove-Item Env:ZCCACHE_CACHE_DIR -ErrorAction SilentlyContinue
           $timer = [Diagnostics.Stopwatch]::StartNew()

--- a/.github/workflows/thin-v2-verify.yml
+++ b/.github/workflows/thin-v2-verify.yml
@@ -66,7 +66,7 @@ jobs:
       CARGO_TERM_COLOR: never
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build soldr CLI
         run: cargo build -p soldr-cli --locked
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload build logs
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: thin-v2-verify-logs-${{ matrix.target }}
           path: |

--- a/crates/soldr-cli/src/core.rs
+++ b/crates/soldr-cli/src/core.rs
@@ -1349,16 +1349,26 @@ min_age_secs = 7200
 
     #[test]
     fn suppress_windows_console_window_preserves_piped_output() {
+        // Use absolute paths so this test does NOT race with the
+        // PATH-mutating tests elsewhere in this module (the
+        // `resolve_runtime_rustc_*` family temporarily sets PATH to a
+        // synthetic tool dir; if their `EnvVarGuard` hasn't dropped by
+        // the time this test runs in parallel, `Command::new("sh")`
+        // fails with `NotFound` because the shell isn't on the
+        // synthetic PATH). Surfaced as an intermittent Linux CI
+        // failure on PR #431.
         #[cfg(windows)]
         let mut command = {
-            let mut command = Command::new("cmd");
+            let comspec = std::env::var_os("ComSpec")
+                .unwrap_or_else(|| std::ffi::OsString::from(r"C:\Windows\System32\cmd.exe"));
+            let mut command = Command::new(comspec);
             command.args(["/C", "echo soldr-no-window"]);
             command
         };
 
         #[cfg(not(windows))]
         let mut command = {
-            let mut command = Command::new("sh");
+            let mut command = Command::new("/bin/sh");
             command.args(["-c", "printf soldr-no-window"]);
             command
         };


### PR DESCRIPTION
## Summary

CI on PR #429 surfaced this warning across all 7 build platforms:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5`, `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

Bumps the three Node-20-bound actions across every workflow file to their latest stable majors. The SHAs are resolved off each action's release tag so the pin survives a tag-retag.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 (`34e1148`) | v6.0.2 (`de0fac2`) |
| `actions/upload-artifact` | v4 (`ea165f8`) | v7.0.1 (`043fb46`) |
| `actions/download-artifact` | v4 (`d3f86a1`) | v8.0.1 (`3e5f45b`) |

12 files touched, 45 line replacements, no semantic changes — just version bumps.

## Why all three together

`download-artifact@v8` still consumes `upload-artifact@v4+` output formats, so the pair would technically work split across PRs. But keeping the bumps in one commit means a partial revert can't strand the two halves on incompatible majors.

## What's NOT in this PR

- **`actions/cache@v4.2.4`** — GitHub's warning did not flag it as Node-20-bound. Its v5 has behavior changes around key matching / restore semantics that would need to be vetted against the perf-matrix and cache-benchmark workflows specifically. Out of scope here.
- **`actions/setup-node@v6`** — already current (v6).

## Test plan

- [x] `for f in .github/workflows/*.yml; do python -c "import yaml; yaml.safe_load(open('$f'))"; done` — every file parses clean.
- [x] `git grep "actions/checkout@34e\|actions/upload-artifact@ea1\|actions/download-artifact@d3f" .github/workflows/` returns empty (no stale pins).
- [ ] CI green on this PR. The new pins are tested by the workflows themselves on this run.