### PR TITLE
test(#430): lock in last_session passthrough so unknown zccache fields survive

### DIFF
--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -164,7 +164,14 @@ struct CacheReportOutput {
     /// Whether the journal file exists on disk.
     journal_present: bool,
     /// Verbatim contents of `last-session-stats.json`, parsed into a JSON
-    /// value. `null` if the file is missing or unparseable.
+    /// value. `null` if the file is missing or unparseable. Kept as a raw
+    /// `Value` (not a typed struct) on purpose: zccache evolves its
+    /// `SessionStats` shape across protocol versions, and downstream
+    /// consumers (perf-rust-cluster, `ci/perf_local.py`) rely on new
+    /// fields like `phase_profile` (zccache PROTOCOL_VERSION 9) reaching
+    /// them without a soldr release. See soldr#430 — the
+    /// `cache_report_json_passes_through_unknown_session_stat_fields`
+    /// integration test locks this contract in.
     last_session: Option<serde_json::Value>,
     /// Output of `zccache analyze --json` over the per-session journal,
     /// when the managed zccache supports it. `null` otherwise.

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -343,6 +343,51 @@ fn cache_report_json_surfaces_persisted_session_stats() {
     assert_eq!(json["last_session"]["hit_rate"].as_f64(), Some(0.7));
 }
 
+/// Regression for soldr#430. `last_session` must be a verbatim passthrough
+/// of `last-session-stats.json` so new zccache schema additions (e.g.
+/// PROTOCOL_VERSION 9's `phase_profile`) reach downstream consumers
+/// without a soldr-side change. If someone "cleans up" `last_session`
+/// into a typed struct, this test fails.
+#[test]
+fn cache_report_json_passes_through_unknown_session_stat_fields() {
+    let cache_root = unique_temp_dir("cache-report-forward-compat");
+    let zccache_dir = cache_root.join("cache").join("zccache");
+    let stats_path = zccache_dir.join("logs").join("last-session-stats.json");
+    fs::create_dir_all(stats_path.parent().expect("stats parent missing"))
+        .expect("failed to create logs dir");
+    fs::write(
+        &stats_path,
+        r#"{
+            "status":"ok",
+            "hits":11,
+            "phase_profile":{"hit_count":103,"miss_count":4,"buckets":[1,2,3]},
+            "future_field":"please don't drop me"
+        }"#,
+    )
+    .expect("failed to seed session stats");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "report", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr cache report --json");
+
+    assert!(
+        output.status.success(),
+        "cache report --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("cache report --json must produce JSON");
+    assert_eq!(json["last_session"]["hits"], 11);
+    assert_eq!(json["last_session"]["phase_profile"]["hit_count"], 103);
+    assert_eq!(json["last_session"]["phase_profile"]["miss_count"], 4);
+    assert_eq!(json["last_session"]["phase_profile"]["buckets"][2], 3);
+    assert_eq!(json["last_session"]["future_field"], "please don't drop me");
+}
+
 #[test]
 fn clean_clears_managed_zccache_and_state_dir() {
     let cache_root = unique_temp_dir("clean-command");


### PR DESCRIPTION
## Summary

Closes #430.

After investigating, the issue's premise — that `soldr cache report` "lifts a fixed allowlist of keys into the report's `last_session` block" and drops unknown ones — does not match the current code (or v0.7.28). `last_session` is already typed as `Option<serde_json::Value>` and populated by `serde_json::from_str::<Value>(...)` of `last-session-stats.json`, i.e. the issue's "Option 1: Passthrough" is already implemented. A `phase_profile` field present in the on-disk JSON already appears in `soldr cache report --json` as `last_session.phase_profile`.

The actual gap was **no regression test**: a future refactor toward a typed struct would silently re-introduce the bug. This PR locks the contract in.

- Adds `cache_report_json_passes_through_unknown_session_stat_fields` in `crates/soldr-cli/tests/cli_cache.rs` that seeds `last-session-stats.json` with a `phase_profile` block plus a `future_field` and asserts both round-trip through `cache report --json` verbatim.
- Sharpens the doc-comment on `CacheReportOutput.last_session` in `crates/soldr-cli/src/cache.rs` to document the passthrough as load-bearing for zccache schema evolution and to name the test that guards it. No production logic change.

## Verification

```bash
soldr cargo test -p soldr-cli --test cli_cache cache_report
# 3 passed; 0 failed
soldr cargo fmt --all -- --check    # clean
soldr cargo clippy -p soldr-cli --tests  # only pre-existing warnings
```

The issue's repro is also exercised by the new test, which uses the real built `soldr` binary via `CARGO_BIN_EXE_soldr`.

## Test plan

- [x] New test passes (`cache_report_json_passes_through_unknown_session_stat_fields`)
- [x] Existing `cache_report_*` tests still pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` introduces no new warnings
- [ ] Reviewer confirms the issue can be closed once this lands (or, if the reporter still observes the documented repro on a clean checkout, asks them to attach the actual stdout of `soldr cache report --json` against a real `last-session-stats.json` so we can identify a different code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)