### PR TITLE
fix(ci): point windows-msys-default-msvc.sh at --target artifact path

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -94,6 +94,12 @@ jobs:
       - name: Verify Windows defaults to MSVC under Git Bash
         if: inputs.verify_windows_msys_default_msvc == true && runner.os == 'Windows'
         shell: bash
+        env:
+          # The build step above passes `--target ${{ inputs.target }}`, so cargo
+          # writes the binary to `target/<triple>/debug/`, not `target/debug/`.
+          # The script defaults to the no-target path; point it at the
+          # matrix-aware location explicitly. See issue #418.
+          SOLDR_EXE: ${{ github.workspace }}\target\${{ inputs.target }}\debug\soldr.exe
         run: bash .github/scripts/windows-msys-default-msvc.sh
 
       - name: Run fetch integration test


### PR DESCRIPTION
## Summary

The Windows x64 and Windows ARM64 jobs in `_build-and-test.yml` have been failing on every push to `main` for at least 5 consecutive commits with:

```
.github/scripts/windows-msys-default-msvc.sh: line 33: /d/a/soldr/soldr/target/debug/soldr.exe: No such file or directory
##[error]Process completed with exit code 127.
```

Root cause: the build step uses `cargo build --target ${{ inputs.target }}`, so cargo writes the binary to `target/<triple>/debug/soldr.exe`. The verification script defaults to `target/debug/soldr.exe` (the no-target path) — that path doesn't exist on these jobs, so the script exits 127.

## Fix

Adopt option (2) from the issue write-up: set `SOLDR_EXE` on the workflow step so the script (which already honors the override on line 9) resolves the matrix-aware path. The script stays triple-agnostic — the workflow owns the platform-specific path knowledge it already had via `${{ inputs.target }}`.

```yaml
env:
  SOLDR_EXE: ${{ github.workspace }}\target\${{ inputs.target }}\debug\soldr.exe
```

Six added lines, zero touched lines, no script changes.

Closes #418

## Test plan

- [ ] Windows x64 caller (`ci.yml` `windows-x86_64-msvc`) reaches the `Verify Windows defaults to MSVC under Git Bash` step and passes
- [ ] `bash -n .github/scripts/windows-msys-default-msvc.sh` clean (verified locally)
- [ ] `python -c "import yaml; yaml.safe_load(open('.github/workflows/_build-and-test.yml'))"` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)