### PR TITLE
feat(release): bundle crgx into the combined soldr release archive

### DIFF
--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -15,12 +15,14 @@ from pathlib import Path
 
 # Soldr releases ship a single .tar.zst archive per target since the
 # combined-bundle refactor (#XXX). The archive contains soldr +
-# zccache + zccache-daemon + zccache-fp + manifest.json at its root.
-# The setup-soldr action extracts all four binaries into the install
-# dir and exports SOLDR_ZCCACHE_LOCAL_DIR so soldr's runtime resolution
-# wires up the bundled zccache without a managed-download round trip.
+# zccache + zccache-daemon + zccache-fp + crgx + manifest.json at its
+# root. The setup-soldr action extracts every binary into the install
+# dir and exports SOLDR_ZCCACHE_LOCAL_DIR + SOLDR_CRGX_LOCAL_DIR so
+# soldr's runtime resolution wires up the bundled tools without a
+# managed-download round trip.
 ARCHIVE_EXT = "tar.zst"
 ZCCACHE_BUNDLED_BINARIES = ("zccache", "zccache-daemon", "zccache-fp")
+CRGX_BUNDLED_BINARY = "crgx"
 
 
 def _normalize_version(value: str) -> str:
@@ -184,6 +186,26 @@ def main() -> None:
                     zccache_dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
                 )
 
+        # Stage the bundled crgx next to soldr so the install dir
+        # also doubles as SOLDR_CRGX_LOCAL_DIR for `soldr crgx ...`.
+        # Archives shipped before the crgx-bundling landed won't
+        # include crgx — treat that as a best-effort skip rather than
+        # a hard failure (the runtime fetch path still works).
+        crgx_file_name = f"{CRGX_BUNDLED_BINARY}{zccache_ext}"
+        crgx_present = False
+        try:
+            crgx_src = _locate_binary(extract_dir, crgx_file_name)
+        except RuntimeError:
+            crgx_src = None
+        if crgx_src is not None:
+            crgx_dst = install_dir / crgx_file_name
+            shutil.copy2(crgx_src, crgx_dst)
+            if os.name != "nt":
+                crgx_dst.chmod(
+                    crgx_dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+                )
+            crgx_present = True
+
         # Optional: surface manifest.json next to the binaries.
         manifest_src = extract_dir.rglob("manifest.json")
         for candidate in manifest_src:
@@ -191,13 +213,21 @@ def main() -> None:
                 shutil.copy2(candidate, install_dir / "manifest.json")
                 break
 
-    # Export SOLDR_ZCCACHE_LOCAL_DIR to GITHUB_ENV so subsequent steps
-    # see the bundled zccache without a managed-fetch round trip. Don't
-    # clobber an explicit caller setting if it's already in the env.
+    # Export SOLDR_ZCCACHE_LOCAL_DIR + SOLDR_CRGX_LOCAL_DIR to
+    # GITHUB_ENV so subsequent steps see the bundled tools without a
+    # managed-fetch round trip. Don't clobber an explicit caller
+    # setting if it's already in the env.
     github_env = os.environ.get("GITHUB_ENV")
     if github_env and not os.environ.get("SOLDR_ZCCACHE_LOCAL_DIR"):
         with open(github_env, "a", encoding="utf-8") as fh:
             fh.write(f"SOLDR_ZCCACHE_LOCAL_DIR={install_dir}\n")
+    if (
+        github_env
+        and crgx_present
+        and not os.environ.get("SOLDR_CRGX_LOCAL_DIR")
+    ):
+        with open(github_env, "a", encoding="utf-8") as fh:
+            fh.write(f"SOLDR_CRGX_LOCAL_DIR={install_dir}\n")
 
     output = os.environ.get("GITHUB_OUTPUT")
     if output:

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -365,6 +365,69 @@ jobs:
           chmod +x "dist/package/${{ matrix.binary }}" 2>/dev/null || true
           ls -la dist/package/
 
+      - name: Build crgx from pinned source
+        # Source-build crgx instead of fetching an upstream release asset:
+        # crgx upstream (yfedoseev/crgx) currently doesn't ship
+        # aarch64-unknown-linux-musl or aarch64-pc-windows-msvc binaries,
+        # and building from a pinned tag gives soldr full control over
+        # provenance — the combined archive's manifest.json carries the
+        # crgx source commit + per-target sha256 so downstream consumers
+        # can verify exactly what shipped.
+        #
+        # The toolchain installed at the top of the job
+        # (dtolnay/rust-toolchain @ 1.94.1 with the target added) and,
+        # for musl rows, musl-tools already on PATH, are sufficient — no
+        # extra docker / cross step needed. Crgx requires edition 2024
+        # which 1.94.1 supports.
+        shell: bash
+        run: |
+          set -euo pipefail
+          crgx_version=$(sed -n 's/.*MANAGED_CRGX_VERSION: &str = "\(.*\)";/\1/p' \
+            crates/soldr-cli/src/fetch/mod.rs | head -n1)
+          if [ -z "$crgx_version" ]; then
+            echo "could not read MANAGED_CRGX_VERSION from crates/soldr-cli/src/fetch/mod.rs" >&2
+            exit 1
+          fi
+          echo "crgx_version=$crgx_version"
+
+          work_dir="${RUNNER_TEMP}/crgx-build"
+          rm -rf "$work_dir"
+          # Pin to the exact tag — depth 1 keeps the clone small. The
+          # tag → commit sha lookup is recorded in manifest.json below
+          # so a re-build is exactly reproducible from the manifest.
+          git clone --depth 1 --branch "v${crgx_version}" \
+            https://github.com/yfedoseev/crgx.git "$work_dir"
+          crgx_commit=$(git -C "$work_dir" rev-parse HEAD)
+          echo "crgx_commit=$crgx_commit"
+          echo "CRGX_SOURCE_COMMIT=$crgx_commit" >> "$GITHUB_ENV"
+
+          # `--locked` honors crgx's Cargo.lock so the build is
+          # byte-for-byte reproducible across release runs. Use the
+          # same target the soldr binary was just built for — the
+          # cargo toolchain is shared with the soldr build step above,
+          # so no extra setup-uv / install-musl / install-rust is
+          # needed here.
+          cargo build \
+            --release \
+            --manifest-path "$work_dir/Cargo.toml" \
+            --target "${{ matrix.target }}" \
+            --locked
+
+          suffix=""
+          case "${{ matrix.target }}" in *-pc-windows-msvc) suffix=".exe" ;; esac
+
+          built="$work_dir/target/${{ matrix.target }}/release/crgx${suffix}"
+          if [ ! -f "$built" ]; then
+            echo "crgx not built at expected path: $built" >&2
+            ls -la "$work_dir/target/${{ matrix.target }}/release/" >&2 || true
+            exit 1
+          fi
+          file "$built" || true
+
+          cp "$built" "dist/package/crgx${suffix}"
+          chmod +x "dist/package/crgx${suffix}" 2>/dev/null || true
+          ls -la dist/package/
+
       - name: Write manifest.json
         # Drop a small JSON descriptor into the archive root so downstream
         # consumers (setup-soldr, npm install wrapper, ad-hoc tooling)
@@ -380,6 +443,9 @@ jobs:
           soldr_target="${{ matrix.target }}"
           zccache_version=$(sed -n 's/.*MANAGED_ZCCACHE_VERSION: &str = "\(.*\)";/\1/p' \
             crates/soldr-cli/src/fetch/mod.rs | head -n1)
+          crgx_version=$(sed -n 's/.*MANAGED_CRGX_VERSION: &str = "\(.*\)";/\1/p' \
+            crates/soldr-cli/src/fetch/mod.rs | head -n1)
+          crgx_commit="${CRGX_SOURCE_COMMIT:-unknown}"
           case "$soldr_target" in
             x86_64-unknown-linux-*)  zccache_target=x86_64-unknown-linux-musl ;;
             aarch64-unknown-linux-*) zccache_target=aarch64-unknown-linux-musl ;;
@@ -402,11 +468,16 @@ jobs:
           zccache_sha=$(sha256_of "dist/package/zccache${suffix}")
           zccache_daemon_sha=$(sha256_of "dist/package/zccache-daemon${suffix}")
           zccache_fp_sha=$(sha256_of "dist/package/zccache-fp${suffix}")
+          crgx_sha=$(sha256_of "dist/package/crgx${suffix}")
           built_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+          # schema_version 2 adds the `crgx` block. Consumers that
+          # only understand v1 still get a usable v2 manifest because
+          # the existing fields are unchanged; the new block is
+          # additive. Bump again on any field rename or removal.
           cat > dist/package/manifest.json <<EOF
           {
-            "schema_version": 1,
+            "schema_version": 2,
             "soldr": {
               "version": "${version}",
               "target": "${soldr_target}",
@@ -422,6 +493,13 @@ jobs:
                 { "name": "zccache-daemon${suffix}", "sha256": "${zccache_daemon_sha}" },
                 { "name": "zccache-fp${suffix}",     "sha256": "${zccache_fp_sha}" }
               ]
+            },
+            "crgx": {
+              "version": "${crgx_version}",
+              "target": "${soldr_target}",
+              "binary": "crgx${suffix}",
+              "sha256": "${crgx_sha}",
+              "source_commit": "${crgx_commit}"
             },
             "archive": {
               "format": "tar.zst",
@@ -579,9 +657,10 @@ jobs:
           echo "--- extracted layout ---"
           ls -la "$extract"
 
-          # Every archive must ship the 4 expected binaries (soldr,
-          # zccache, zccache-daemon, zccache-fp) with their platform
-          # extension, plus a manifest.json describing the bundle.
+          # Every archive must ship the 5 expected binaries (soldr,
+          # zccache, zccache-daemon, zccache-fp, crgx) with their
+          # platform extension, plus a manifest.json describing the
+          # bundle.
           suffix=""
           case "${{ matrix.target }}" in *-pc-windows-msvc) suffix=".exe" ;; esac
           for required in \
@@ -589,6 +668,7 @@ jobs:
             "zccache${suffix}" \
             "zccache-daemon${suffix}" \
             "zccache-fp${suffix}" \
+            "crgx${suffix}" \
             "manifest.json"; do
             test -f "$extract/$required" \
               || { echo "missing $required in $archive" >&2; exit 1; }
@@ -604,6 +684,11 @@ jobs:
           case "$runner_arch:${{ matrix.target }}" in
             x86_64:x86_64-*|aarch64:aarch64-*|arm64:aarch64-*)
               "$extract/${{ matrix.binary }}" --version
+              # Smoke the bundled crgx too — same arch gate. crgx is
+              # self-contained (no daemon, no sidecars), so --version
+              # is enough to prove the binary loads and the static
+              # linkage works on the host.
+              "$extract/crgx${suffix}" --version
               ;;
             *)
               echo "skipping --version (runner $runner_arch vs target ${{ matrix.target }})"

--- a/bin/soldr.js
+++ b/bin/soldr.js
@@ -28,15 +28,28 @@ if (!fs.existsSync(binaryPath)) {
 // binaries into the active zccache automatically — no manual env
 // setup, no managed fetch over the network. Users who explicitly set
 // the env var themselves keep their override.
-const zccacheExt = process.platform === "win32" ? ".exe" : "";
+const exeExt = process.platform === "win32" ? ".exe" : "";
 const childEnv = { ...process.env };
 if (
   !childEnv.SOLDR_ZCCACHE_LOCAL_DIR &&
-  fs.existsSync(path.join(nativeDir, `zccache${zccacheExt}`)) &&
-  fs.existsSync(path.join(nativeDir, `zccache-daemon${zccacheExt}`)) &&
-  fs.existsSync(path.join(nativeDir, `zccache-fp${zccacheExt}`))
+  fs.existsSync(path.join(nativeDir, `zccache${exeExt}`)) &&
+  fs.existsSync(path.join(nativeDir, `zccache-daemon${exeExt}`)) &&
+  fs.existsSync(path.join(nativeDir, `zccache-fp${exeExt}`))
 ) {
   childEnv.SOLDR_ZCCACHE_LOCAL_DIR = nativeDir;
+}
+
+// Same wiring for the bundled crgx binary (shipped alongside soldr
+// since the crgx-bundling follow-up to the combined-archive release
+// format). soldr's `fetch_tool_with_paths` honors
+// SOLDR_CRGX_LOCAL_DIR ahead of the GitHub Releases / crates.io
+// fetch chain, so `soldr crgx ...` runs the bundled binary with no
+// network round trip. Caller-set overrides win.
+if (
+  !childEnv.SOLDR_CRGX_LOCAL_DIR &&
+  fs.existsSync(path.join(nativeDir, `crgx${exeExt}`))
+) {
+  childEnv.SOLDR_CRGX_LOCAL_DIR = nativeDir;
 }
 
 const child = childProcess.spawn(binaryPath, process.argv.slice(2), {

--- a/crates/soldr-cli/src/fetch/known_tools.rs
+++ b/crates/soldr-cli/src/fetch/known_tools.rs
@@ -169,6 +169,22 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
         tag_prefix: None,
         pinned_version: None,
     },
+    // `crgx` is bundled into the combined soldr release archive
+    // (release-auto.yml source-builds it from a pinned crgx tag), so
+    // first-use needs no network round trip. The registry entry is the
+    // fallback path when the bundle is unavailable (sideloaded soldr
+    // binary, custom install, etc.) — it pins to the same upstream
+    // version the bundle ships so `soldr crgx ...` is reproducible
+    // across both paths. See SOLDR_CRGX_LOCAL_DIR for the runtime
+    // override used by the npm shim and setup-soldr action.
+    ToolSpec {
+        crate_name: "crgx",
+        cargo_subcommand: None,
+        binary_name: "crgx",
+        repo: Some(("yfedoseev", "crgx")),
+        tag_prefix: None,
+        pinned_version: Some(super::MANAGED_CRGX_VERSION),
+    },
 ];
 
 /// Pinned `cargo-chef` release that `soldr cook` resolves by default. See the
@@ -256,6 +272,27 @@ mod tests {
             lookup_by_cargo_subcommand("chef").map(|s| s.crate_name),
             Some("cargo-chef")
         );
+    }
+
+    #[test]
+    fn crgx_is_registered_and_pinned_to_managed_version() {
+        // soldr bundles crgx into the combined release archive (see
+        // release-auto.yml's `Build crgx from pinned source` step).
+        // The registry entry MUST pin to `MANAGED_CRGX_VERSION` so the
+        // fallback fetch path resolves to the same version the bundle
+        // ships. If these drift apart, `soldr crgx` from a sideloaded
+        // binary lands on a different version than the bundled one —
+        // exactly the cross-source inconsistency the pin is meant to
+        // prevent.
+        let spec = lookup_by_crate("crgx").expect("crgx must be registered");
+        assert_eq!(spec.cargo_subcommand, None);
+        assert_eq!(spec.binary_name, "crgx");
+        assert_eq!(spec.repo, Some(("yfedoseev", "crgx")));
+        assert_eq!(
+            spec.pinned_version,
+            Some(super::super::MANAGED_CRGX_VERSION)
+        );
+        assert_eq!(super::super::MANAGED_CRGX_VERSION, "0.1.0");
     }
 
     #[test]

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -81,6 +81,22 @@ const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
 /// `resolve_local_zccache` for the resolution contract.
 pub const ZCCACHE_LOCAL_DIR_ENV_VAR: &str = "SOLDR_ZCCACHE_LOCAL_DIR";
 
+/// Pinned crgx version that soldr's release pipeline source-builds and
+/// bundles into the combined `.tar.zst` archive (see PR follow-up to
+/// #434 — combined archive now ships zccache + crgx). Also surfaced
+/// via `lookup_by_crate("crgx").pinned_version` so the
+/// `fetch_repo_binary` fallback resolves the same version when the
+/// bundled binary is not available.
+pub const MANAGED_CRGX_VERSION: &str = "0.1.0";
+
+/// Override the runtime crgx resolution: when set, soldr uses the
+/// `crgx` (or `crgx.exe`) binary in this directory ahead of any
+/// GitHub-Releases / crates.io fetch. The npm shim (`bin/soldr.js`)
+/// and the setup-soldr action point this at the directory containing
+/// the bundled binary so the first `soldr crgx ...` call needs no
+/// network round trip. Mirrors `SOLDR_ZCCACHE_LOCAL_DIR`.
+pub const CRGX_LOCAL_DIR_ENV_VAR: &str = "SOLDR_CRGX_LOCAL_DIR";
+
 /// Retry budget for the GitHub-Releases + crates.io fetch chain inside
 /// `fetch_repo_binary_with_paths`. Transient errors
 /// (`SoldrError::Network`, `SoldrError::ToolNotFound`) retry up to
@@ -113,6 +129,19 @@ pub async fn fetch_tool_with_paths(
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
 
+    // Bundled-crgx escape hatch: when the npm shim or setup-soldr
+    // action ships a bundled crgx (see release-auto.yml's "Build crgx
+    // from pinned source" step) they export SOLDR_CRGX_LOCAL_DIR
+    // pointing at the directory holding the binary. Honor it ahead of
+    // every other resolution path so first-use carries no network
+    // round trip. Mirrors the SOLDR_ZCCACHE_LOCAL_DIR contract used by
+    // the bundled zccache trio (#434).
+    if crate_name == "crgx" {
+        if let Some(local_dir) = non_empty_env_path(CRGX_LOCAL_DIR_ENV_VAR) {
+            return resolve_local_crgx(&local_dir);
+        }
+    }
+
     if let Some(spec) = lookup_by_crate(crate_name) {
         let repo = match spec.repo {
             Some((owner, name)) => RepoInfo {
@@ -121,11 +150,21 @@ pub async fn fetch_tool_with_paths(
             },
             None => resolve_repo(crate_name).await?,
         };
+        // Honor `spec.pinned_version` when the caller didn't pass an
+        // explicit `@version` — mirrors the cargo-front-door's
+        // existing pin substitution so `soldr crgx` and
+        // `soldr cargo chef` resolve the same way from both entry
+        // points. Lets the `External` dispatch in main.rs go through
+        // the registry pin without each call site re-implementing it.
+        let effective_version = match (version, spec.pinned_version) {
+            (VersionSpec::Latest, Some(pin)) => VersionSpec::Exact(pin.to_string()),
+            _ => version.clone(),
+        };
         return fetch_repo_binary_with_paths(
             spec.crate_name,
             &[spec.binary_name],
             &repo,
-            version,
+            &effective_version,
             spec.tag_prefix,
             paths,
         )
@@ -134,6 +173,36 @@ pub async fn fetch_tool_with_paths(
 
     let repo = resolve_repo(crate_name).await?;
     fetch_repo_binary_with_paths(crate_name, &[crate_name], &repo, version, None, paths).await
+}
+
+/// Resolve crgx to the binary in `local_dir` set via
+/// `SOLDR_CRGX_LOCAL_DIR`. Returns the path verbatim — no copy, no
+/// content hashing — because crgx is a single binary with no
+/// daemon/sidecar siblings (contrast with `resolve_local_zccache`
+/// which normalizes a trio plus debug-info sidecars).
+fn resolve_local_crgx(local_dir: &Path) -> Result<FetchResult, SoldrError> {
+    if !local_dir.is_dir() {
+        return Err(SoldrError::Other(format!(
+            "{}={} is not a directory",
+            CRGX_LOCAL_DIR_ENV_VAR,
+            local_dir.display(),
+        )));
+    }
+    let binary_name = if cfg!(windows) { "crgx.exe" } else { "crgx" };
+    let binary = local_dir.join(binary_name);
+    if !binary.is_file() {
+        return Err(SoldrError::Other(format!(
+            "{}={} but {} is missing",
+            CRGX_LOCAL_DIR_ENV_VAR,
+            local_dir.display(),
+            binary.display(),
+        )));
+    }
+    Ok(FetchResult {
+        binary_path: binary,
+        version: format!("local-{MANAGED_CRGX_VERSION}"),
+        cached: true,
+    })
 }
 
 pub async fn fetch_zccache() -> Result<FetchResult, SoldrError> {
@@ -2205,5 +2274,70 @@ mod tests {
         let dirs = vec![bin_dir.clone()];
         let result = resolve_system_zccache_with_path_dirs(&linux_target(), &dirs).unwrap();
         assert!(result.binary_path.ends_with("zccache"));
+    }
+
+    // ── Bundled crgx (SOLDR_CRGX_LOCAL_DIR) ─────────────────────────
+    // Locks the contract used by the npm shim and setup-soldr action:
+    // when the env var points at a directory containing `crgx`
+    // (`crgx.exe` on Windows), `resolve_local_crgx` returns that path
+    // verbatim with `cached: true` and a `local-<version>` label.
+
+    fn crgx_binary_name() -> &'static str {
+        if cfg!(windows) {
+            "crgx.exe"
+        } else {
+            "crgx"
+        }
+    }
+
+    #[test]
+    fn resolve_local_crgx_returns_binary_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stub = tmp.path().join(crgx_binary_name());
+        std::fs::write(&stub, b"stub").unwrap();
+
+        let result = resolve_local_crgx(tmp.path()).expect("should resolve");
+        assert_eq!(result.binary_path, stub);
+        assert!(result.cached, "bundled path must report cached=true");
+        assert!(
+            result.version.starts_with("local-"),
+            "version should be `local-<ver>`, got: {}",
+            result.version
+        );
+        assert!(
+            result.version.contains(MANAGED_CRGX_VERSION),
+            "version should embed MANAGED_CRGX_VERSION, got: {}",
+            result.version
+        );
+    }
+
+    #[test]
+    fn resolve_local_crgx_errors_when_dir_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nonexistent = tmp.path().join("not-a-dir");
+
+        let err = resolve_local_crgx(&nonexistent).expect_err("missing dir should error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not a directory"),
+            "error must explain the dir is missing, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_local_crgx_errors_when_binary_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Empty directory — no crgx binary inside.
+
+        let err = resolve_local_crgx(tmp.path()).expect_err("missing binary should error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("is missing"),
+            "error must explain the binary is missing, got: {msg}"
+        );
+        assert!(
+            msg.contains(crgx_binary_name()),
+            "error should name the expected binary, got: {msg}"
+        );
     }
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -14,9 +14,10 @@ const PACKAGE_JSON = require(path.join(PACKAGE_ROOT, "package.json"));
 
 // Every release ships a single .tar.zst per target that bundles soldr
 // alongside its matching-target zccache trio (zccache, zccache-daemon,
-// zccache-fp). One fetch installs both, and `bin/soldr.js` wires
-// SOLDR_ZCCACHE_LOCAL_DIR to the install dir so soldr finds the
-// sibling binaries without going through the managed-download path.
+// zccache-fp) and a same-target crgx. One fetch installs everything,
+// and `bin/soldr.js` wires SOLDR_ZCCACHE_LOCAL_DIR + SOLDR_CRGX_LOCAL_DIR
+// to the install dir so soldr finds the sibling binaries without going
+// through the managed-download path.
 const ARCHIVE_EXT = "tar.zst";
 
 const TARGETS = {
@@ -32,10 +33,17 @@ const TARGETS = {
 
 // Files we expect to find at the root of every extracted release
 // archive. Names line up with what `release-auto.yml`'s
-// `Fetch matched zccache release` step + `Stage soldr binary` step
-// drop into `dist/package/` before the tar.zst is built. `.exe` suffix
-// is appended at install time based on `target.binary`.
-const BUNDLED_BINARIES = ["soldr", "zccache", "zccache-daemon", "zccache-fp"];
+// `Fetch matched zccache release`, `Stage soldr binary`, and
+// `Build crgx from pinned source` steps drop into `dist/package/`
+// before the tar.zst is built. `.exe` suffix is appended at install
+// time based on `target.binary`.
+const BUNDLED_BINARIES = [
+  "soldr",
+  "zccache",
+  "zccache-daemon",
+  "zccache-fp",
+  "crgx",
+];
 
 // Detect whether the running Linux uses musl or glibc. Three layered probes:
 //   1. process.report.header.glibcVersionRuntime is the documented Node
@@ -246,9 +254,10 @@ async function install() {
     fs.mkdirSync(nativeDir, { recursive: true });
 
     // Copy every bundled binary so soldr can find its sibling zccache
-    // via SOLDR_ZCCACHE_LOCAL_DIR (wired up by `bin/soldr.js` before
-    // exec). The archive layout is flat — all four binaries live at the
-    // archive root.
+    // via SOLDR_ZCCACHE_LOCAL_DIR and its sibling crgx via
+    // SOLDR_CRGX_LOCAL_DIR (both wired up by `bin/soldr.js` before
+    // exec). The archive layout is flat — all five binaries live at
+    // the archive root.
     const binaryExt = target.binary.endsWith(".exe") ? ".exe" : "";
     for (const baseName of BUNDLED_BINARIES) {
       const fileName = `${baseName}${binaryExt}`;
@@ -274,7 +283,7 @@ async function install() {
     }
 
     console.log(
-      `soldr: installed ${target.triple} (soldr + zccache trio) into ${nativeDir}`,
+      `soldr: installed ${target.triple} (soldr + zccache trio + crgx) into ${nativeDir}`,
     );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });

--- a/scripts/test-npm-package.js
+++ b/scripts/test-npm-package.js
@@ -138,4 +138,24 @@ for (const [key, target] of Object.entries(install.TARGETS || {})) {
   );
 }
 
+// BUNDLED_BINARIES must include soldr, the zccache trio, and crgx.
+// Locks the per-archive layout contract so a future bundling
+// refactor can't quietly drop a binary.
+assert.ok(
+  Array.isArray(install.BUNDLED_BINARIES),
+  "install.BUNDLED_BINARIES must be exported as an array",
+);
+for (const required of [
+  "soldr",
+  "zccache",
+  "zccache-daemon",
+  "zccache-fp",
+  "crgx",
+]) {
+  assert.ok(
+    install.BUNDLED_BINARIES.includes(required),
+    `BUNDLED_BINARIES must include "${required}" (got ${JSON.stringify(install.BUNDLED_BINARIES)})`,
+  );
+}
+
 console.log("npm package and PyPI version checks passed");


### PR DESCRIPTION
## Summary

Extends the combined `soldr+zccache.tar.zst` archive (#434) with a matching-target **crgx** binary. The release matrix source-builds crgx from a pinned tag of `yfedoseev/crgx`, stages it alongside soldr + zccache + zccache-daemon + zccache-fp in `dist/package/`, and the existing tar.zst step packages the whole set. One fetch from GitHub Releases now gives consumers soldr, zccache, **and** crgx with verified provenance — no separate runtime fetch for any of them.

## Why source-build instead of fetching upstream

`yfedoseev/crgx` v0.1.0 ships `linux-x86_64`, `linux-x86_64-musl`, `linux-aarch64`, `macos-x86_64`, `macos-aarch64`, `windows-x86_64`. soldr's release matrix needs `aarch64-unknown-linux-musl` and `aarch64-pc-windows-msvc` too — both missing upstream.

Docker verification (`messense/rust-musl-cross:{x86_64,aarch64}-musl`) confirms crgx builds cleanly from source on both musl targets, producing statically-linked 4-5 MB binaries:

| target | host image | build time | binary | static |
|---|---|---|---|---|
| `x86_64-unknown-linux-musl` | `messense/rust-musl-cross:x86_64-musl` | 2m 53s | 4.5 MB | ✅ static-pie |
| `aarch64-unknown-linux-musl` | `messense/rust-musl-cross:aarch64-musl` | 1m 45s | 4.3 MB | ✅ |

Source-building also gives soldr full control over provenance — the manifest's `source_commit` makes a re-build exactly reproducible from the manifest alone.

## Archive format (`manifest.json` bumped 1 → 2)

```json
{
  "schema_version": 2,
  "soldr":   { "version", "target", "binary", "sha256", "commit_sha" },
  "zccache": { "version", "target", "binaries": [...] },
  "crgx":    { "version", "target", "binary", "sha256", "source_commit" },
  "archive": { "format": "tar.zst", "compression_level": 19 },
  "built_at": "<ISO8601>"
}
```

Schema bump is additive: v1 consumers still get usable fields, only the new `crgx` block is new. Bump again on any field rename or removal.

## Files touched

- **`release-auto.yml`** — new `Build crgx from pinned source` step (uses the host's `cargo` and the dtolnay-installed musl target — no docker or `cross`); manifest writer reads `MANAGED_CRGX_VERSION` and adds the `crgx` block; smoke step now requires `crgx[.exe]` and runs `--version` on native-arch runs.
- **`crates/soldr-cli/src/fetch/mod.rs`** — `MANAGED_CRGX_VERSION = "0.1.0"`, `CRGX_LOCAL_DIR_ENV_VAR = "SOLDR_CRGX_LOCAL_DIR"`, new `resolve_local_crgx`, `fetch_tool_with_paths` honors the env var ahead of every other path and substitutes `spec.pinned_version` when the caller passed `VersionSpec::Latest` (parallels the cargo-front-door's existing pin logic).
- **`crates/soldr-cli/src/fetch/known_tools.rs`** — new crgx registry entry: `repo: ("yfedoseev", "crgx"), pinned_version: Some(MANAGED_CRGX_VERSION)`.
- **`bin/soldr.js`** — exports `SOLDR_CRGX_LOCAL_DIR` from `bin/native/` when the bundled crgx is present. Caller-set overrides win.
- **`scripts/install.js`** — adds `crgx` to `BUNDLED_BINARIES` so the npm install stages it into `bin/native/`.
- **`scripts/test-npm-package.js`** — locks BUNDLED_BINARIES with all five names.
- **`.github/actions/setup-soldr/ensure_soldr.py`** — stages bundled crgx into `SOLDR_INSTALL_DIR`, writes `SOLDR_CRGX_LOCAL_DIR` to `$GITHUB_ENV`. Best-effort: archives predating the crgx bundling silently skip the crgx stage (runtime fetch path still works).

## Tests

- [x] 4 new Rust unit tests (`resolve_local_crgx_*`, `crgx_is_registered_and_pinned_to_managed_version`)
- [x] All 159 library tests pass
- [x] All 409+ CLI integration tests pass (1 pre-existing failure on main: `cli_doctor::doctor_reports_missing_target` — unrelated)
- [x] `node scripts/test-npm-package.js` passes (new BUNDLED_BINARIES assertion)
- [x] `python -m py_compile .github/actions/setup-soldr/ensure_soldr.py` clean
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release-auto.yml'))"` clean
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo clippy -p soldr-cli --lib --tests` — no new warnings
- [ ] CI green on this PR (the `release-auto.yml` matrix is workflow_dispatch + push-on-main; PR exercises dogfood + bootstrap-e2e but not the release matrix itself — that runs on the next release-trigger merge)

## Scope intentionally limited

- **No PyPI wheel change.** Wheels still ship soldr-only via Maturin.
- **No version bump.** Workflow + runtime shim change. The next release PR picks up the new format automatically.
- **No new tools beyond crgx.** sccache, mdbook, cargo-chef etc. stay on the runtime-fetch path. They can follow this same template later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)