### PR TITLE
feat(#412): 'did you mean?' suggestions on unknown verbs / cargo subcommands

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door.rs
+++ b/crates/soldr-cli/src/cargo_front_door.rs
@@ -1458,6 +1458,17 @@ async fn ensure_known_subcommand_tool(
         return Ok(Vec::new());
     };
     let Some(spec) = crate::fetch::lookup_by_cargo_subcommand(sub) else {
+        // Issue #412: when the typed subcommand isn't in
+        // `known_tools` but LOOKS like a typo of one that IS, drop a
+        // "did you mean?" hint on stderr. We still return Ok(empty)
+        // so the underlying cargo invocation continues as today —
+        // the suggestion is advisory and cargo's own external-command
+        // dispatch may still find the tool on PATH.
+        let known = crate::fetch::known_cargo_subcommands();
+        if let Some(suggestion) = crate::fuzzy_match::suggest_close_match(sub, &known) {
+            eprintln!("soldr: '{sub}' is not a cargo subcommand soldr ships a prebuilt for.");
+            eprintln!("soldr: did you mean: cargo {suggestion}?");
+        }
         return Ok(Vec::new());
     };
 

--- a/crates/soldr-cli/src/fetch/known_tools.rs
+++ b/crates/soldr-cli/src/fetch/known_tools.rs
@@ -200,6 +200,19 @@ pub fn lookup_by_cargo_subcommand(sub: &str) -> Option<&'static ToolSpec> {
     KNOWN_TOOLS.iter().find(|t| t.cargo_subcommand == Some(sub))
 }
 
+/// Every cargo subcommand soldr knows how to fetch a prebuilt binary
+/// for, as a flat list of `&'static str` for use in the fuzzy-match
+/// suggestion path (issue #412). Order matches `KNOWN_TOOLS`
+/// declaration — which is also the tie-break order
+/// `fuzzy_match::suggest_close_match` uses, so the deterministic
+/// pick on equal-distance candidates stays predictable.
+pub fn known_cargo_subcommands() -> Vec<&'static str> {
+    KNOWN_TOOLS
+        .iter()
+        .filter_map(|t| t.cargo_subcommand)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -7,7 +7,8 @@
 pub mod known_tools;
 
 pub use known_tools::{
-    lookup_by_cargo_subcommand, lookup_by_crate, ToolSpec, CARGO_CHEF_PINNED_VERSION, KNOWN_TOOLS,
+    known_cargo_subcommands, lookup_by_cargo_subcommand, lookup_by_crate, ToolSpec,
+    CARGO_CHEF_PINNED_VERSION, KNOWN_TOOLS,
 };
 
 pub mod trust;

--- a/crates/soldr-cli/src/fuzzy_match.rs
+++ b/crates/soldr-cli/src/fuzzy_match.rs
@@ -1,0 +1,275 @@
+//! "Did you mean?" suggestion engine for the external-subcommand
+//! fallthrough path (issue #412).
+//!
+//! When clap doesn't recognize a soldr verb, the dispatch falls
+//! through to `Commands::External` which fetches `<verb>` from
+//! crates.io / GitHub Releases as an arbitrary tool. The same
+//! happens inside the cargo front door: when the cargo subcommand
+//! the user typed isn't in `known_tools`, soldr quietly skips the
+//! prebuilt-binary path. Either way, an ordinary typo or a verb
+//! rename that didn't ship a clap alias surfaces as either a
+//! network error ("tool not found") or a cargo external-command
+//! error ("no such subcommand: cago"). Neither names the actual
+//! cause.
+//!
+//! This module wraps a tiny Levenshtein distance calculation and a
+//! single user-facing call:
+//!
+//! ```ignore
+//! let candidates = ["install-zccache", "update-zccache", "doctor"];
+//! suggest_close_match("update-zccacheee", &candidates);
+//! // => Some("update-zccache")
+//! ```
+//!
+//! Threshold per issue #412 (acceptance criteria):
+//!
+//!   max(2, ceil(0.3 × len(query)))
+//!
+//! That gives `ntest` → `nextest` (dist 2, threshold 2) and
+//! `update-zccacheee` → `update-zccache` (dist 3, threshold 5) while
+//! rejecting `completely-made-up-name` (no neighbour within 10).
+//!
+//! The matcher is intentionally caller-agnostic. The two callsites
+//! that consume it are:
+//!
+//! - `main.rs Commands::External` → matches against the soldr
+//!   built-in verb list (including clap aliases).
+//! - `cargo_front_door::ensure_known_subcommand_tool` → matches
+//!   against the `cargo_subcommand` field of `KNOWN_TOOLS`.
+//!
+//! Both add an `eprintln!` hint and then continue with the fetch —
+//! the suggestion is purely advisory.
+//!
+//! Cost: Levenshtein over a ~20-entry list at startup is
+//! sub-microsecond on any host soldr runs on. No measurable
+//! invocation overhead added (#412 acceptance criterion).
+
+/// Compute the Levenshtein edit distance between two ASCII-ish
+/// strings. Operates byte-by-byte, which is correct for the
+/// command-name strings we feed it (kebab-case ASCII) and avoids
+/// pulling in a unicode-aware crate just for this.
+///
+/// O(|a| × |b|) time and O(min(|a|, |b|)) space via the standard
+/// rolling-row trick.
+pub(crate) fn levenshtein(a: &str, b: &str) -> usize {
+    // Cheap shortcuts.
+    if a == b {
+        return 0;
+    }
+    if a.is_empty() {
+        return b.chars().count();
+    }
+    if b.is_empty() {
+        return a.chars().count();
+    }
+
+    // Work on byte length — exact for the ASCII command names we use.
+    // Falls back to a still-correct (just slightly looser) bound for
+    // any incidental non-ASCII input.
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    let (shorter, longer) = if a_bytes.len() <= b_bytes.len() {
+        (a_bytes, b_bytes)
+    } else {
+        (b_bytes, a_bytes)
+    };
+
+    // Rolling-row DP: previous row + current row indexed by `shorter`.
+    let mut prev: Vec<usize> = (0..=shorter.len()).collect();
+    let mut curr: Vec<usize> = vec![0; shorter.len() + 1];
+
+    for (i, &lb) in longer.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &sb) in shorter.iter().enumerate() {
+            let cost = if lb == sb { 0 } else { 1 };
+            curr[j + 1] = (prev[j] + cost)
+                .min(prev[j + 1] + 1) // deletion from `longer`
+                .min(curr[j] + 1); //   insertion into `longer`
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[shorter.len()]
+}
+
+/// Threshold for "close enough to suggest" per issue #412:
+/// `max(2, ceil(0.3 × len(query)))`. Always returns at least 2 so
+/// 1-3 character queries don't reject typos. Capped above 2 by 30%
+/// of the query length for longer strings.
+fn distance_threshold(query: &str) -> usize {
+    let len = query.chars().count();
+    // ceil(0.3 × len) without floating-point: (len * 3 + 9) / 10
+    // gives the same value as `(len as f64 * 0.3).ceil() as usize`
+    // for non-negative integer len up to usize::MAX / 4.
+    let scaled = (len * 3 + 9) / 10;
+    scaled.max(2)
+}
+
+/// Return the candidate from `candidates` with the smallest edit
+/// distance to `query`, provided that distance is within the threshold
+/// AND `query` is not an exact match for any candidate.
+///
+/// Returns `None` when:
+/// - `query` exactly matches a candidate (no suggestion needed — the
+///   caller's normal dispatch path will handle it).
+/// - No candidate sits within the threshold (no false suggestions).
+/// - `candidates` is empty.
+///
+/// Tie-breaking: ascending distance, then candidate order in the input
+/// list. That's deterministic for tests; the input order in production
+/// is the clap declaration order, which is fine.
+pub(crate) fn suggest_close_match<'a>(query: &str, candidates: &'a [&'a str]) -> Option<&'a str> {
+    if query.is_empty() || candidates.is_empty() {
+        return None;
+    }
+    // Exact match → no suggestion (the regular dispatch handles it).
+    if candidates.iter().any(|c| *c == query) {
+        return None;
+    }
+
+    let threshold = distance_threshold(query);
+    let mut best: Option<(usize, &'a str)> = None;
+    for &candidate in candidates {
+        let d = levenshtein(query, candidate);
+        if d > threshold {
+            continue;
+        }
+        match best {
+            None => best = Some((d, candidate)),
+            Some((bd, _)) if d < bd => best = Some((d, candidate)),
+            _ => {} // keep first occurrence on tie
+        }
+    }
+    best.map(|(_, c)| c)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn levenshtein_handles_trivial_cases() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("a", ""), 1);
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+    }
+
+    #[test]
+    fn levenshtein_known_distances() {
+        // Classic kitten→sitting: 3 (k→s, e→i, +g).
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        // Verb rename in soldr's own history. `update-` ↔ `install-`
+        // differs in 6 of 7 characters; one trailing `h` adds 1
+        // length difference. Net edit distance = 6.
+        assert_eq!(levenshtein("update-zccache", "install-zccache"), 6);
+        // Typical typo distance (one missing char).
+        assert_eq!(levenshtein("installzccache", "install-zccache"), 1);
+        // Common short typo.
+        assert_eq!(levenshtein("ntest", "nextest"), 2);
+    }
+
+    #[test]
+    fn distance_threshold_floor_is_two() {
+        // ceil(0.3 × 1) = 1 → floor to 2 so 1-char queries still
+        // tolerate a single edit.
+        assert_eq!(distance_threshold("a"), 2);
+        assert_eq!(distance_threshold("ab"), 2);
+        assert_eq!(distance_threshold("ntest"), 2);
+    }
+
+    #[test]
+    fn distance_threshold_scales_with_length() {
+        // 0.3 × 10 = 3 (ceil).
+        assert_eq!(distance_threshold("0123456789"), 3);
+        // 0.3 × 14 = 4.2 → ceil to 5.
+        assert_eq!(distance_threshold("installzccache"), 5);
+        // 0.3 × 16 = 4.8 → ceil to 5.
+        assert_eq!(distance_threshold("update-zccacheee"), 5);
+    }
+
+    #[test]
+    fn suggest_returns_none_on_exact_match() {
+        // No suggestion when the verb actually exists. The caller's
+        // normal dispatch handles it.
+        let cands = ["install-zccache", "update-zccache", "doctor"];
+        assert_eq!(suggest_close_match("install-zccache", &cands), None);
+        assert_eq!(suggest_close_match("doctor", &cands), None);
+    }
+
+    #[test]
+    fn suggest_recognizes_the_update_zccacheee_typo_from_issue_412() {
+        // Acceptance criterion: `soldr update-zccacheee` prints a hint
+        // pointing at install-zccache (or its update-zccache alias).
+        let cands = ["install-zccache", "update-zccache", "doctor"];
+        let suggestion = suggest_close_match("update-zccacheee", &cands);
+        // Either branch of the OR is acceptable per #412; both are
+        // within the threshold and lead the user to the right place.
+        assert!(
+            matches!(suggestion, Some("update-zccache" | "install-zccache")),
+            "expected install-zccache or update-zccache, got {suggestion:?}",
+        );
+    }
+
+    #[test]
+    fn suggest_handles_unhyphenated_typo() {
+        // `soldr installzccache` (missing the dash) is one edit away
+        // from the canonical `install-zccache`.
+        let cands = ["install-zccache", "update-zccache", "doctor"];
+        assert_eq!(
+            suggest_close_match("installzccache", &cands),
+            Some("install-zccache"),
+        );
+    }
+
+    #[test]
+    fn suggest_recognizes_cargo_ntest_typo_from_issue_412() {
+        // Acceptance criterion: `soldr cargo ntest` prints a hint
+        // pointing at nextest. Threshold is 2 for a 5-char query;
+        // `ntest`→`nextest` is exactly distance 2.
+        let cargo_subs = ["nextest", "deny", "audit", "llvm-cov"];
+        assert_eq!(suggest_close_match("ntest", &cargo_subs), Some("nextest"),);
+    }
+
+    #[test]
+    fn suggest_returns_none_for_far_from_everything() {
+        // Acceptance criterion: `soldr completely-made-up-name` must
+        // NOT produce a false suggestion. The query is far enough from
+        // every soldr verb that the threshold is never reached.
+        let cands = ["install-zccache", "doctor", "cargo", "cook"];
+        assert_eq!(suggest_close_match("completely-made-up-name", &cands), None,);
+    }
+
+    #[test]
+    fn suggest_returns_none_on_empty_inputs() {
+        assert_eq!(suggest_close_match("", &["doctor"]), None);
+        assert_eq!(suggest_close_match("doctor", &[]), None);
+    }
+
+    #[test]
+    fn suggest_picks_closest_when_multiple_candidates_within_threshold() {
+        // `cago` is within threshold of both `cargo` (dist 1) and
+        // `cago-` (hypothetical, dist 1) — but `cargo` should win on
+        // first-occurrence tie-break since we always prefer earlier
+        // entries on equal distance.
+        let cands = ["cargo", "carbo", "cook"];
+        assert_eq!(suggest_close_match("cago", &cands), Some("cargo"));
+    }
+
+    #[test]
+    fn suggest_handles_typo_that_drops_a_character() {
+        // `cago build` was the example from #412's body — must
+        // suggest `cargo`.
+        let cands = ["cargo", "clean", "cook"];
+        assert_eq!(suggest_close_match("cago", &cands), Some("cargo"));
+    }
+
+    #[test]
+    fn suggest_rejects_very_short_substring_of_long_verb() {
+        // A 4-char query against a 15-char verb: threshold is 2 for
+        // the query side. Distance |a|-|b| = 11, way over → no false
+        // match.
+        let cands = ["install-zccache"];
+        assert_eq!(suggest_close_match("inst", &cands), None);
+    }
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -10,6 +10,7 @@ mod cook;
 mod core;
 mod doctor;
 mod fetch;
+mod fuzzy_match;
 mod gc;
 mod linker;
 mod optimize;
@@ -126,6 +127,48 @@ pub(crate) enum ZccacheSourceArg {
     /// Use the `zccache` binary already installed on PATH.
     System,
 }
+
+/// Flat list of every built-in soldr verb that clap recognizes,
+/// PLUS aliases (e.g. `update-zccache` for `install-zccache`,
+/// `purge-targets` for `gc`). Used by the fuzzy-match suggestion
+/// path in `Commands::External` (issue #412) to detect typos /
+/// pre-rename verbs that fell through to the external-tool fetch.
+///
+/// Must stay in sync with the `Commands` enum + `#[command(alias = ...)]`
+/// attributes below. A unit test in `main_tests.rs` walks the const
+/// against clap's discovered subcommands and fails when they drift,
+/// so adding a new verb here without updating the enum (or vice
+/// versa) trips the build.
+const SOLDR_BUILTIN_VERBS: &[&str] = &[
+    "cargo",
+    "cook",
+    "rustc",
+    "rustfmt",
+    "clippy-driver",
+    "rustdoc",
+    "rust-gdb",
+    "rust-lldb",
+    "rust-analyzer",
+    "status",
+    "clean",
+    "purge",
+    "config",
+    "cache",
+    "version",
+    "gc",
+    "purge-targets", // alias of `gc`
+    "rustup",
+    "toolchain",
+    "bootstrap",
+    "doctor",
+    "optimize",
+    "session-start",
+    "session-end",
+    "install-zccache",
+    "update-zccache", // alias of `install-zccache`
+    "save",
+    "load",
+];
 
 #[derive(Subcommand)]
 enum Commands {
@@ -928,6 +971,18 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
 
             let (crate_name, version) = parse_tool_spec(&args[0]);
             let tool_args = &args[1..];
+
+            // Issue #412: when the user typed a verb that LOOKS like
+            // a typo or a renamed built-in (e.g. `update-zccacheee`,
+            // `installzccache`), emit a "did you mean?" hint before
+            // we fire the network fetch. The fetch still runs — the
+            // suggestion is advisory.
+            if let Some(suggestion) =
+                fuzzy_match::suggest_close_match(&crate_name, &SOLDR_BUILTIN_VERBS)
+            {
+                eprintln!("soldr: '{crate_name}' is not a known built-in soldr verb.");
+                eprintln!("soldr: did you mean: {suggestion}?");
+            }
 
             eprintln!("soldr: fetching {crate_name}...");
             let result = crate::fetch::fetch_tool(&crate_name, &version).await?;

--- a/crates/soldr-cli/src/main_tests.rs
+++ b/crates/soldr-cli/src/main_tests.rs
@@ -246,3 +246,72 @@ fn should_trampoline_matches_current_version_as_no_op() {
     )));
     assert!(should_trampoline("0.0.0-not-this-version"));
 }
+
+#[test]
+fn soldr_builtin_verbs_match_clap_subcommands_and_aliases() {
+    // Issue #412: the SOLDR_BUILTIN_VERBS const drives the fuzzy
+    // suggestion engine. If it drifts from the actual `Commands`
+    // enum (someone adds a verb but forgets to update the list, or
+    // renames one without updating the alias entry), users get
+    // either bogus "did you mean?" hints or NO hint when one would
+    // have helped. This test walks clap's discovered subcommands +
+    // their `#[command(alias = ...)]` annotations and asserts every
+    // discovered name is in the const, and vice versa.
+    use clap::CommandFactory;
+
+    let cmd = Cli::command();
+    let mut discovered: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for sub in cmd.get_subcommands() {
+        discovered.insert(sub.get_name().to_string());
+        for alias in sub.get_all_aliases() {
+            discovered.insert(alias.to_string());
+        }
+    }
+    let declared: std::collections::BTreeSet<String> =
+        SOLDR_BUILTIN_VERBS.iter().map(|s| s.to_string()).collect();
+
+    let missing_from_const: Vec<_> = discovered.difference(&declared).collect();
+    let extra_in_const: Vec<_> = declared.difference(&discovered).collect();
+    assert!(
+        missing_from_const.is_empty() && extra_in_const.is_empty(),
+        "SOLDR_BUILTIN_VERBS is out of sync with the Commands enum.\n  \
+         missing from const (clap knows, fuzzy-match doesn't): {missing_from_const:?}\n  \
+         extra in const   (fuzzy-match knows, clap doesn't): {extra_in_const:?}\n\
+         Update SOLDR_BUILTIN_VERBS in `main.rs` to match.",
+    );
+}
+
+#[test]
+fn fuzzy_match_with_soldr_verbs_recognizes_issue_412_examples() {
+    // Black-box sanity check that the in-tree const list + the
+    // shared fuzzy engine actually produce the suggestions the issue
+    // documents as acceptance criteria. Cheap to keep alongside the
+    // pure-logic tests in fuzzy_match.rs because it locks in the
+    // const → suggestion contract end-to-end.
+    use crate::fuzzy_match::suggest_close_match;
+
+    let typo = "update-zccacheee";
+    let suggestion = suggest_close_match(typo, SOLDR_BUILTIN_VERBS);
+    assert!(
+        matches!(suggestion, Some("update-zccache" | "install-zccache")),
+        "expected install-zccache (or alias) for {typo:?}; got {suggestion:?}",
+    );
+
+    let typo = "installzccache";
+    assert_eq!(
+        suggest_close_match(typo, SOLDR_BUILTIN_VERBS),
+        Some("install-zccache"),
+    );
+
+    // Acceptance criterion: completely-different verb produces no
+    // hint (no false suggestion).
+    assert_eq!(
+        suggest_close_match("completely-made-up-name", SOLDR_BUILTIN_VERBS),
+        None,
+    );
+
+    // Acceptance criterion: a verb that IS a known built-in must
+    // NOT produce a hint — the regular dispatch handles it. Tested
+    // by suggest_close_match returning None on exact match.
+    assert_eq!(suggest_close_match("doctor", SOLDR_BUILTIN_VERBS), None);
+}


### PR DESCRIPTION
## Summary

Closes #412. When clap doesn't recognize a verb (or `known_tools` doesn't recognize a cargo subcommand), soldr now fuzzy-matches against its built-in list and prints a `did you mean: <closest>?` hint before continuing with the existing fallthrough behavior. The suggestion is advisory — the network fetch / cargo dispatch still fires.

## Output

```
$ soldr update-zccacheee
soldr: 'update-zccacheee' is not a known built-in soldr verb.
soldr: did you mean: update-zccache?
soldr: fetching update-zccacheee...
soldr: tool not found: ...
```

```
$ soldr cargo ntest --workspace
soldr: 'ntest' is not a cargo subcommand soldr ships a prebuilt for.
soldr: did you mean: cargo nextest?
<cargo runs ntest and reports its own external-command error>
```

## Threshold

Per the issue's spec: `max(2, ceil(0.3 × len(query)))`. Gives:

| Query | Closest | Distance | Threshold | Match? |
|---|---|---:|---:|:---:|
| `ntest` | `nextest` | 2 | 2 | ✓ |
| `update-zccacheee` | `update-zccache` | 2 | 5 | ✓ |
| `installzccache` | `install-zccache` | 1 | 5 | ✓ |
| `cago` | `cargo` | 1 | 2 | ✓ |
| `completely-made-up-name` | (none within 10) | — | 10 | ✗ |

## Files

- **`crates/soldr-cli/src/fuzzy_match.rs`** (new) — pure-logic Levenshtein + `suggest_close_match` + 13 unit tests.
- **`crates/soldr-cli/src/main.rs`** — `SOLDR_BUILTIN_VERBS` const enumerating every clap verb + aliases (`update-zccache` ↔ `install-zccache`, `purge-targets` ↔ `gc`). Hooked into `Commands::External`.
- **`crates/soldr-cli/src/main_tests.rs`** — regression guard that walks clap's discovered subcommands + their aliases via `Cli::command().get_subcommands()` and asserts the const stays in sync. Adding a verb in either place without updating the other trips the next `cargo test`.
- **`crates/soldr-cli/src/fetch/known_tools.rs`** — `known_cargo_subcommands()` helper exposing the cargo-subcommand list from KNOWN_TOOLS.
- **`crates/soldr-cli/src/cargo_front_door.rs`** — hooked into `ensure_known_subcommand_tool`. The hint fires when the typed subcommand misses KNOWN_TOOLS; the underlying cargo invocation still runs.

## Acceptance criteria (from #412)

- [x] `soldr update-zccache --help` (the alias) dispatches normally with no spurious hint.
- [x] `soldr update-zccacheee` prints `did you mean: update-zccache` (or `install-zccache`, whichever's closer).
- [x] `soldr cargo ntest` prints `did you mean: cargo nextest`.
- [x] `soldr completely-made-up-name` produces unchanged output (no false match).
- [x] No measurable startup latency added — Levenshtein over a ~25-entry const list is sub-microsecond and only runs on the already-uncommon "verb missed clap dispatch" path.

## Test plan

- [x] `cargo build -p soldr-cli` clean.
- [x] `cargo test -p soldr-cli --bins -- fuzzy soldr_builtin` — 15 / 15 passing (13 fuzzy_match + 2 main_tests integration).
- [x] `cargo test --workspace` — every binary passes except the pre-existing host-specific `doctor_reports_missing_target` failure (also fails against `main` without this change).
- [x] `cargo fmt --check` clean.

Closes #412.