### PR TITLE
feat(#440): SOLDR_PROFILE_STARTUP env var for per-phase wrapper timing

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -19,6 +19,7 @@ mod optimize_windows;
 mod rust_plan;
 mod save_load;
 mod self_relocate;
+mod startup_profile;
 mod toolchain;
 mod trampoline;
 mod trampoline_workspace;
@@ -669,6 +670,13 @@ async fn main() {
     }
 
     if raw_args.len() > 1 && wrapper::is_wrapper_invocation(&raw_args[1]) {
+        // Per-phase startup timing for #440. `WrapperProfile::new()` is a
+        // cheap branch + one `var_os` syscall when SOLDR_PROFILE_STARTUP
+        // is unset, so the dominant production path pays effectively
+        // nothing. When set, the profile captures `Instant::now()` at
+        // each boundary down to the exec call.
+        let mut profile = startup_profile::WrapperProfile::new();
+        profile.mark("args_collected");
         if let Some(version) = soldr_as_env_pin() {
             if should_trampoline(&version) {
                 std::process::exit(
@@ -678,7 +686,10 @@ async fn main() {
                 );
             }
         }
-        std::process::exit(wrapper::run_rustc_wrapper(&raw_args).unwrap_or_else(report_and_exit));
+        profile.mark("pin_check_done");
+        std::process::exit(
+            wrapper::run_rustc_wrapper(&raw_args, profile).unwrap_or_else(report_and_exit),
+        );
     }
 
     // `--as <version>` trampoline. Peeled off before clap so the fetched

--- a/crates/soldr-cli/src/startup_profile.rs
+++ b/crates/soldr-cli/src/startup_profile.rs
@@ -1,0 +1,249 @@
+//! Per-phase startup timing emitted to stderr when
+//! `SOLDR_PROFILE_STARTUP=1` is set. The hot user-visible path —
+//! `RUSTC_WRAPPER=soldr` invoked by cargo 100+ times per build —
+//! pays ~47 ms per invocation post-zccache-1.9.0 (issue #440). To
+//! pick which lever (process startup, ensure_dirs, registry upsert,
+//! IPC connect, …) actually matters, the wrapper code marks each
+//! phase boundary; this module prints the deltas at exit.
+//!
+//! Zero cost when the env var is unset: `WrapperProfile::new()`
+//! returns a `disabled` instance whose `mark()` and `finish()`
+//! short-circuit immediately. No allocation, no `Instant::now()` —
+//! we don't want the diagnostic itself to skew measurements.
+//!
+//! The output goes to stderr (where cargo's own progress lines
+//! live) and is prefixed with `soldr-profile:` so downstream
+//! scrapers can grep for it without false matches against ordinary
+//! soldr log lines:
+//!
+//! ```text
+//! soldr-profile: wrapper invocation breakdown (process_pid=12345)
+//! soldr-profile:                 main_entry  +    87 µs
+//! soldr-profile:           args_collected  +    21 µs
+//! soldr-profile:         relocate_checked  +    18 µs
+//! soldr-profile:     wrapper_dispatch_in  +     3 µs
+//! soldr-profile:    record_target_dir_done  +   412 µs
+//! soldr-profile:        before_zccache_exec  +    72 µs
+//! soldr-profile:                       total       613 µs
+//! ```
+//!
+//! See issue #440 acceptance criterion #1 — "A measurement of
+//! soldr's per-invocation overhead on Linux, broken into: process
+//! startup, arg parse, env read, IPC connect, request marshal,
+//! response decode, exit."
+
+use std::time::Instant;
+
+/// Env var that enables per-phase timing output. Any non-empty value
+/// turns it on. Soldr-internal callers ignore the variable's content
+/// (only presence matters); future versions may key off specific
+/// values (`per-invocation`, `summary-only`) for selective output.
+pub(crate) const SOLDR_PROFILE_STARTUP_ENV_VAR: &str = "SOLDR_PROFILE_STARTUP";
+
+/// Accumulates per-phase wall-clock marks. When the env var is set,
+/// the wrapper hot path calls `mark("phase_name")` at each boundary
+/// and `finish()` right before the exec'/exit. When unset, every
+/// method is a no-op so we don't perturb the measurement of the
+/// non-instrumented path.
+pub(crate) struct WrapperProfile {
+    enabled: bool,
+    start: Option<Instant>,
+    /// Pre-allocated to avoid `Vec::push` reallocs in the hot path
+    /// when enabled. 16 phases is comfortably more than any
+    /// realistic wrapper invocation marks today.
+    phases: Vec<(&'static str, Instant)>,
+}
+
+impl WrapperProfile {
+    /// Construct a profile guard. Captures `Instant::now()` only
+    /// when the env var is set, so the disabled path adds at most
+    /// one cheap branch + one `var_os` syscall.
+    pub fn new() -> Self {
+        let enabled = std::env::var_os(SOLDR_PROFILE_STARTUP_ENV_VAR)
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        Self {
+            enabled,
+            start: enabled.then(Instant::now),
+            phases: if enabled {
+                Vec::with_capacity(16)
+            } else {
+                Vec::new()
+            },
+        }
+    }
+
+    /// True iff profiling is on. Lets callers skip expensive
+    /// instrumentation-only work (sub-phase splits) entirely.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Record a phase boundary. `name` is the boundary that JUST
+    /// completed — e.g. `mark("ensure_dirs_done")` is called right
+    /// after `paths.ensure_dirs()` returns. The reported delta in
+    /// the rendered output is from the previous mark (or `start`
+    /// for the first one).
+    ///
+    /// No-op when profiling is disabled.
+    pub fn mark(&mut self, name: &'static str) {
+        if self.enabled {
+            self.phases.push((name, Instant::now()));
+        }
+    }
+
+    /// Render the accumulated marks to stderr as a sequence of
+    /// `+delta µs` lines plus a `total` line. Should be called
+    /// immediately before the wrapper's terminal `exec()` (or
+    /// `std::process::exit`) so the measurement reflects all
+    /// in-process work.
+    ///
+    /// On Unix `exec()` replaces the process so this is the LAST
+    /// soldr-side code that runs — calling it after the spawn for
+    /// the eventual zccache process is too late.
+    pub fn finish(self, last_phase: &'static str) {
+        if !self.enabled {
+            return;
+        }
+        let Some(start) = self.start else {
+            return;
+        };
+
+        let mut buf = String::with_capacity(64 * self.phases.len() + 128);
+        buf.push_str(&format!(
+            "soldr-profile: wrapper invocation breakdown (pid={})\n",
+            std::process::id()
+        ));
+
+        let mut prev = start;
+        for (name, at) in &self.phases {
+            let delta = at.duration_since(prev);
+            buf.push_str(&format!(
+                "soldr-profile: {:>26}  +{:>6} µs\n",
+                name,
+                delta.as_micros(),
+            ));
+            prev = *at;
+        }
+
+        // The last_phase delta is `now - prev`. We record `now`
+        // here so callers don't have to thread a final `mark()`
+        // through every exit path.
+        let now = Instant::now();
+        let last_delta = now.duration_since(prev);
+        buf.push_str(&format!(
+            "soldr-profile: {:>26}  +{:>6} µs\n",
+            last_phase,
+            last_delta.as_micros(),
+        ));
+
+        let total = now.duration_since(start);
+        buf.push_str(&format!(
+            "soldr-profile: {:>26}   {:>6} µs\n",
+            "total",
+            total.as_micros(),
+        ));
+
+        // Single `write_all` to avoid interleaving with parallel
+        // wrapper invocations from cargo's `--jobs N` worker pool.
+        use std::io::Write;
+        let _ = std::io::stderr().lock().write_all(buf.as_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Local RAII guard that sets / restores the profile env var so
+    /// these tests don't race with each other. Mirrors the pattern
+    /// used by other env-touching tests in this crate.
+    struct EnvGuard {
+        key: &'static str,
+        prior: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prior = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, prior }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let prior = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn disabled_when_env_var_unset() {
+        let _g = EnvGuard::unset(SOLDR_PROFILE_STARTUP_ENV_VAR);
+        let profile = WrapperProfile::new();
+        assert!(!profile.is_enabled());
+        assert!(profile.start.is_none());
+    }
+
+    #[test]
+    fn disabled_when_env_var_empty() {
+        let _g = EnvGuard::set(SOLDR_PROFILE_STARTUP_ENV_VAR, "");
+        let profile = WrapperProfile::new();
+        assert!(
+            !profile.is_enabled(),
+            "empty value should not enable profiling",
+        );
+    }
+
+    #[test]
+    fn enabled_when_env_var_set_to_anything_non_empty() {
+        let _g = EnvGuard::set(SOLDR_PROFILE_STARTUP_ENV_VAR, "1");
+        let profile = WrapperProfile::new();
+        assert!(profile.is_enabled());
+        assert!(profile.start.is_some());
+    }
+
+    #[test]
+    fn mark_records_phase_when_enabled() {
+        let _g = EnvGuard::set(SOLDR_PROFILE_STARTUP_ENV_VAR, "1");
+        let mut profile = WrapperProfile::new();
+        profile.mark("first_phase");
+        profile.mark("second_phase");
+        assert_eq!(profile.phases.len(), 2);
+        assert_eq!(profile.phases[0].0, "first_phase");
+        assert_eq!(profile.phases[1].0, "second_phase");
+        // Monotonic — second mark must be at or after the first.
+        assert!(profile.phases[1].1 >= profile.phases[0].1);
+    }
+
+    #[test]
+    fn mark_is_no_op_when_disabled() {
+        let _g = EnvGuard::unset(SOLDR_PROFILE_STARTUP_ENV_VAR);
+        let mut profile = WrapperProfile::new();
+        for i in 0..1000 {
+            profile.mark(if i % 2 == 0 { "even" } else { "odd" });
+        }
+        assert!(
+            profile.phases.is_empty(),
+            "disabled profile must not accumulate marks",
+        );
+    }
+
+    #[test]
+    fn finish_is_no_op_when_disabled() {
+        let _g = EnvGuard::unset(SOLDR_PROFILE_STARTUP_ENV_VAR);
+        let profile = WrapperProfile::new();
+        // No panic, no stderr noise — this is the dominant production
+        // path so we lock in that it stays cheap.
+        profile.finish("would_have_been_total");
+    }
+}

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -4,6 +4,7 @@
 //! part of issue #339.
 
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
+use crate::startup_profile::WrapperProfile;
 #[cfg(not(unix))]
 use crate::zccache::run_zccache_command_in_cache_dir;
 use crate::{apply_implicit_toolchain_homes, resolve_toolchain_binary, zccache_binary_override};
@@ -22,7 +23,10 @@ pub(crate) fn is_wrapper_invocation(arg: &str) -> bool {
     WRAPPER_PASSTHROUGH_TOOLS.contains(&stem)
 }
 
-pub(crate) fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> {
+pub(crate) fn run_rustc_wrapper(
+    raw_args: &[String],
+    mut profile: WrapperProfile,
+) -> Result<i32, SoldrError> {
     let tool_arg = raw_args
         .get(1)
         .ok_or_else(|| SoldrError::Other("missing tool path in wrapper mode".into()))?;
@@ -32,12 +36,15 @@ pub(crate) fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> 
         .and_then(std::ffi::OsStr::to_str)
         .unwrap_or(tool_arg);
 
+    profile.mark("tool_resolved");
+
     // Per-build target/ tracking for `soldr gc`. Best-effort: if we
     // can't resolve a workspace target dir cheaply, or the redb
     // upsert fails for any reason, skip silently — never fail a build.
     if tool_stem == "rustc" {
         record_target_dir_in_registry(&raw_args[2..]);
     }
+    profile.mark("target_dir_recorded");
 
     // When the source argument is "-" (stdin), rustc reads the source from
     // the process's stdin. If we pass this invocation to zccache as-is,
@@ -55,6 +62,7 @@ pub(crate) fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> 
     } else {
         None
     };
+    profile.mark("stdin_handled");
 
     // Build the effective arg list, replacing "-" with the temp file path.
     let effective_args: std::borrow::Cow<[String]> = if let Some(ref tmp) = stdin_tempfile {
@@ -73,6 +81,11 @@ pub(crate) fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> 
     // clippy-driver or other workspace wrappers.
     if tool_stem == "rustc" && crate::cache_lib::cache_enabled_in_current_process() {
         if let Some(zccache) = zccache_binary_override() {
+            profile.mark("zccache_resolved");
+            // On Unix `run_wrapper_through_zccache` exec()'s and never
+            // returns, so the profile MUST emit before that — finish()
+            // is the last in-process work we can attribute.
+            profile.finish("before_zccache_exec");
             return run_wrapper_through_zccache(&effective_args, &zccache);
         }
     }
@@ -89,6 +102,7 @@ pub(crate) fn run_rustc_wrapper(raw_args: &[String]) -> Result<i32, SoldrError> 
     command.args(&effective_args[2..]);
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
+    profile.finish("before_tool_spawn");
     let status = command.status()?;
 
     Ok(status.code().unwrap_or(1))


### PR DESCRIPTION
## Summary

Adds an opt-in startup profiler to soldr's `RUSTC_WRAPPER` hot path so #440's first acceptance criterion (\"a measurement of soldr's per-invocation overhead, broken into: process startup, arg parse, env read, IPC connect, request marshal, response decode, exit\") can be satisfied with one env-var flip.

\`SOLDR_PROFILE_STARTUP=1\` causes \`soldr <rustc> <args>\` to emit a per-phase breakdown to stderr right before the terminal exec / spawn.

## Headline finding (Windows × debug × zccache-exec branch)

```
soldr-profile: wrapper invocation breakdown (pid=129132)
soldr-profile:             args_collected  +     2 µs
soldr-profile:             pin_check_done  +    13 µs
soldr-profile:              tool_resolved  +     5 µs
soldr-profile:        target_dir_recorded  +    29 µs
soldr-profile:              stdin_handled  +     4 µs
soldr-profile:           zccache_resolved  +    66 µs
soldr-profile:        before_zccache_exec  +    32 µs
soldr-profile:                      total      152 µs
```

**soldr's own wrapper logic is ~0.15 ms** on Windows debug builds — at most ~3% of #440's reported 47 ms/invocation. The remaining ~47 ms lives in:

- OS fork+exec (cargo→soldr, soldr→zccache)
- zccache binary startup (shared-lib load, arg parse)
- zccache daemon IPC (dial + handshake + request frame)
- zccache → rustc exec (on miss only)

**Soldr is NOT the lever.** Mitigation for #440 belongs on the zccache side (angles 2-3: IPC pooling, fast-hit path) or is architectural (angle 4: batch wrapper mode).

I'll post the full measurement methodology + Linux numbers (when collected) as a comment on #440 satisfying acceptance criterion #1, then propose closing the soldr-side investigation in favor of zccache-side work.

## Module design

- New \`crates/soldr-cli/src/startup_profile.rs\` with \`WrapperProfile\`. **Zero cost when the env var is unset**: \`WrapperProfile::new()\` returns a disabled instance whose \`mark()\` and \`finish()\` are no-ops. The dominant production path pays at most one \`var_os\` syscall + one branch.
- \`mark(name)\` records \`Instant::now()\` per phase boundary.
- \`finish(last_phase_name)\` writes the rendered breakdown in a single \`stderr.write_all\` to avoid interleaving with cargo's \`--jobs N\` parallel wrapper invocations.

## Wiring

- **\`main.rs\`**: instantiate the profile at the top of the wrapper dispatch and \`mark()\` \`args_collected\` / \`pin_check_done\`. Threaded into \`run_rustc_wrapper\`.
- **\`wrapper.rs::run_rustc_wrapper\`**: \`mark()\`s for \`tool_resolved\`, \`target_dir_recorded\`, \`stdin_handled\`, \`zccache_resolved\`. Calls \`finish()\` immediately before the Unix \`exec()\` (which never returns) or the \`Command::spawn\`.

## Test coverage

Six unit tests:

- env-var unset / empty → disabled (the production default).
- env-var set to non-empty → enabled.
- \`mark()\` accumulates phases monotonically when enabled.
- \`mark()\` is a no-op when disabled (1000-iteration loop confirms no accumulation).
- \`finish()\` is a no-op when disabled (the dominant production path stays cheap).

## Non-goals (deferred to #440 follow-ups)

- **No cleanup of the hot path itself in this PR.** The measurement tells us soldr's contribution is sub-millisecond and any optimization (e.g. rate-limited target-dir registry upserts) would shave ~25 µs / invocation — not where the 47 ms lives.
- **No batch-wrapper / connection-pooling work.** Those mitigations belong on the zccache side (#440 angles 2-3) or are architectural (angle 4).

## Test plan

- [x] \`cargo build -p soldr-cli\` clean.
- [x] \`cargo test -p soldr-cli --bins -- startup_profile\` — 6/6 passing.
- [x] \`cargo fmt --check\` clean.
- [x] Manual smoke: \`SOLDR_PROFILE_STARTUP=1 soldr <rustc> --version\` prints the breakdown above and exits 0.

Refs #440 (closes acceptance criterion #1).