### PR TITLE
chore(release): soldr 0.7.29 + managed zccache 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.28"
+version = "0.7.29"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.28"
+version = "0.7.29"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -69,7 +69,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.8.2";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.9.0";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.8.2");
+    assert_eq!(json["managed_zccache_version"], "1.9.0");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.8.2");
+    assert_eq!(json["managed_zccache_version"], "1.9.0");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.8.2");
+    assert_eq!(json["managed_zccache_version"], "1.9.0");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.8.2");
+    assert_eq!(status_json["managed_version"], "1.9.0");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.8.2");
+    assert_eq!(json["managed_version"], "1.9.0");
 }
 
 #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.28",
+  "version": "0.7.29",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

- Bumps managed zccache pin **1.8.2 → 1.9.0** (latest upstream release, published 2026-05-22).
- Bumps soldr workspace version + npm package **0.7.28 → 0.7.29**.
- Triggers the Autonomous Release workflow on merge to `main`.

## Changes

- `MANAGED_ZCCACHE_VERSION` constant in `crates/soldr-cli/src/fetch/mod.rs`
- `[workspace.package].version` in `Cargo.toml` + matching entry in `Cargo.lock`
- `"version"` in `package.json`
- Test assertions in `cli_cache.rs` and `cli_install_zccache.rs` that hardcode the managed version string

Test data references to `zccache-v1.8.1/` inside `tests/lib_install_zccache.rs` are intentionally **not** touched — they exercise nested-dir archive extraction logic, not version tracking.

## Release-readiness checks (per CLAUDE.md)

- `Cargo.toml`: bumped to 0.7.29
- `package.json`: bumped to 0.7.29
- PyPI `soldr` 0.7.29: not published (404)
- npm `@zackees/soldr` 0.7.29: not published (404)
- `git ls-remote --tags origin v0.7.29`: tag does not exist

## Test plan

- [ ] CI green on this PR (workspace build + tests)
- [ ] After merge: Autonomous Release workflow runs, publishes `v0.7.29` tag, PyPI, npm, and GitHub Release with bundled zccache 1.9.0 archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)