### PR TITLE
fix(experiment): pin setup-soldr to a soldr version that has cook

### DIFF
--- a/.github/workflows/cache-delta-experiment.yml
+++ b/.github/workflows/cache-delta-experiment.yml
@@ -53,8 +53,15 @@ jobs:
         # workflow. Build-cache + target-cache off for the same
         # reason; we want exactly one cache mechanism active so the
         # measurements are clean.
+        #
+        # version: 0.7.29 because setup-soldr@v0's default is 0.7.24
+        # which predates `soldr cook` (the cook subcommand was added
+        # in PR #409, first released in 0.7.25). Without this pin
+        # the cook-cmd step falls through to External tool fetch
+        # and dies with `tool not found: cook`.
         uses: zackees/setup-soldr@d084d24f3f4b361a56fad52b3c37bcd0ead5a75e
         with:
+          version: "0.7.29"
           cache: false
           linker: platform-default
           cache-dir: ${{ runner.temp }}/cache-delta-exp-setup
@@ -142,6 +149,8 @@ jobs:
 
       - uses: zackees/setup-soldr@d084d24f3f4b361a56fad52b3c37bcd0ead5a75e
         with:
+          # 0.7.29 brings `soldr cook` — see delta job above for why.
+          version: "0.7.29"
           cache: false
           linker: platform-default
           cache-dir: ${{ runner.temp }}/cache-delta-exp-baseline-setup


### PR DESCRIPTION
## Summary

After PR #447 unblocked the workflow's YAML parse, both jobs hit a real runtime error:

```
soldr: fetching cook...
soldr: tool not found: cook: not found on crates.io
```

**Root cause**: `setup-soldr@v0`'s default version is **0.7.24**, which predates `soldr cook` (added in PR #409, first released in 0.7.25). With `cook` missing from the built-in dispatch table, soldr falls through to the External-subcommand handler and tries to resolve `cook` as a tool name on crates.io — fails, exits 1.

## Fix

Pin both `setup-soldr` invocations to `version: '0.7.29'` — the most recent release (`65607fc` on main). The `version` input is documented on `setup-soldr@v0`'s action.yml.

## Test plan

- [x] `actionlint` clean
- [ ] After merge, the workflow's path-trigger fires, soldr 0.7.29 installs, `soldr cook --tests` actually runs (no more "tool not found")
- [ ] First populated comparison table on the `compare` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)