### PR TITLE
fix(experiment): pin setup-soldr to 0.7.28 (0.7.29 release not yet published)

### DIFF
--- a/.github/workflows/cache-delta-experiment.yml
+++ b/.github/workflows/cache-delta-experiment.yml
@@ -54,14 +54,21 @@ jobs:
         # reason; we want exactly one cache mechanism active so the
         # measurements are clean.
         #
-        # version: 0.7.29 because setup-soldr@v0's default is 0.7.24
+        # version: 0.7.28 because setup-soldr@v0's default is 0.7.24
         # which predates `soldr cook` (the cook subcommand was added
         # in PR #409, first released in 0.7.25). Without this pin
         # the cook-cmd step falls through to External tool fetch
         # and dies with `tool not found: cook`.
+        #
+        # Pinned at 0.7.28 specifically — that's the latest
+        # **published** GitHub Release. Cargo.toml/package.json on
+        # main may be bumped to a higher version (e.g. 0.7.29)
+        # before the release-auto workflow has built and published
+        # the matching tarball; setup-soldr fetches by tag, so an
+        # unpublished version 404s here.
         uses: zackees/setup-soldr@d084d24f3f4b361a56fad52b3c37bcd0ead5a75e
         with:
-          version: "0.7.29"
+          version: "0.7.28"
           cache: false
           linker: platform-default
           cache-dir: ${{ runner.temp }}/cache-delta-exp-setup
@@ -150,7 +157,7 @@ jobs:
       - uses: zackees/setup-soldr@d084d24f3f4b361a56fad52b3c37bcd0ead5a75e
         with:
           # 0.7.29 brings `soldr cook` — see delta job above for why.
-          version: "0.7.29"
+          version: "0.7.28"
           cache: false
           linker: platform-default
           cache-dir: ${{ runner.temp }}/cache-delta-exp-baseline-setup


### PR DESCRIPTION
## Summary

PR #448 pinned setup-soldr to soldr **0.7.29**, but that release tag hasn't been **published** to GitHub Releases yet — `Cargo.toml` on main was bumped to 0.7.29 in commit `65607fc`, but the release-auto workflow hasn't run / hasn't built the tarball:

```
setup-soldr failed: Error: GitHub API returned HTTP 404
for https://api.github.com/repos/zackees/soldr/releases/tags/v0.7.29
```

Drop to **0.7.28** — the latest *published* release. Still has `soldr cook` (added in #409, first released in 0.7.25).

Extended the comment to document the gotcha so the next person looking at this knows to check `gh release list` before pinning a version to setup-soldr — the version on Cargo.toml/package.json may run ahead of the published release.

## Test plan

- [x] `gh release list` confirms `v0.7.28` is the latest *published* tag
- [x] `actionlint` clean
- [ ] After merge, both jobs install soldr 0.7.28 successfully and `soldr cook --tests` proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)