### PR TITLE
fix(experiment): drop unsupported --tests flag from soldr cook

### DIFF
--- a/.github/workflows/cache-delta-experiment.yml
+++ b/.github/workflows/cache-delta-experiment.yml
@@ -101,10 +101,12 @@ jobs:
           shared-key: x86_64-unknown-linux-gnu
           # Cook + build commands. Both go through soldr so the
           # zccache RUSTC_WRAPPER picks up the layered cache dir
-          # naturally. --tests on cook is intentional — we want
-          # cook to prepare the dev-deps tree so the build step
-          # below benefits from the same cache.
-          cook-cmd: soldr cook --tests
+          # naturally. soldr cook with no flags prepares the
+          # default (release) dep tree, which is what `cargo build`
+          # below needs. (Earlier revisions passed `--tests` here
+          # but soldr cook rejects unknown flags pre-`--`; not
+          # worth threading through for the experiment.)
+          cook-cmd: soldr cook
           build-cmd: soldr cargo build --package soldr-cli --locked
 
       - name: Save layers (cleanup)
@@ -215,7 +217,7 @@ jobs:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/cache-delta-exp-baseline
         run: |
           set -euo pipefail
-          soldr cook --tests
+          soldr cook
           soldr cargo build --package soldr-cli --locked
 
       - id: measure


### PR DESCRIPTION
## Summary

After PR #449 unblocked the install side, both jobs hit:

```
soldr: soldr cook: unknown flag `--tests` — pass project-specific
options after `--`
```

`soldr cook --tests` doesn't parse — `--tests` would be a cargo-chef passthrough flag and would require `soldr cook -- --tests`. Drop it entirely: the default `soldr cook` run prepares the release dep tree, which is exactly what `cargo build --package soldr-cli --locked` (the build-cmd) needs.

## Test plan

- [x] `actionlint` clean
- [ ] After merge, `soldr cook` finishes successfully and the build step is exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)