### PR TITLE
fix(experiment): coordinate ZCCACHE_CACHE_DIR with SOLDR_CACHE_DIR overrides

### DIFF
--- a/.github/actions/cache-delta-experiment/action.yml
+++ b/.github/actions/cache-delta-experiment/action.yml
@@ -244,8 +244,15 @@ runs:
 
     - name: Run cook command
       shell: bash
+      # setup-soldr exports ZCCACHE_CACHE_DIR pointing at *its* cache
+      # dir; soldr (in managed-zccache mode) refuses to run when
+      # ZCCACHE_CACHE_DIR doesn't match the SOLDR_CACHE_DIR-derived
+      # path. Override BOTH here so they stay coordinated under the
+      # caller-supplied cache-dir. Same pattern setup-soldr-action.yml
+      # uses for the dogfood smoke (lines 142-143).
       env:
         SOLDR_CACHE_DIR: ${{ steps.keys.outputs.cache-dir }}
+        ZCCACHE_CACHE_DIR: ${{ steps.keys.outputs.zccache-dir }}
       run: ${{ inputs.cook-cmd }}
 
     - name: Touch cook mark
@@ -261,8 +268,10 @@ runs:
 
     - name: Run build command
       shell: bash
+      # See the cook step above for the env-pair rationale.
       env:
         SOLDR_CACHE_DIR: ${{ steps.keys.outputs.cache-dir }}
+        ZCCACHE_CACHE_DIR: ${{ steps.keys.outputs.zccache-dir }}
       run: ${{ inputs.build-cmd }}
 
     - name: Package build delta

--- a/.github/workflows/cache-delta-experiment.yml
+++ b/.github/workflows/cache-delta-experiment.yml
@@ -213,8 +213,11 @@ jobs:
         # Same step-level SOLDR_CACHE_DIR pattern as the delta job —
         # otherwise soldr falls back to $HOME/.soldr and the cache
         # restored via actions/cache above lives in the wrong place.
+        # ZCCACHE_CACHE_DIR must stay coordinated with SOLDR_CACHE_DIR
+        # or managed-zccache mode refuses to run.
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/cache-delta-exp-baseline
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/cache-delta-exp-baseline/cache/zccache
         run: |
           set -euo pipefail
           soldr cook


### PR DESCRIPTION
## Summary

After PR #450 made `soldr cook` parse correctly, both jobs hit:

```
soldr: ZCCACHE_CACHE_DIR is managed by soldr for managed zccache
builds. Unset it, set SOLDR_CACHE_DIR to choose soldr's cache root,
or set SOLDR_RUSTC_WRAPPER to use a custom wrapper.
```

`setup-soldr` exports `ZCCACHE_CACHE_DIR=<its-cache>/cache/zccache` into `$GITHUB_ENV` so subsequent steps inherit it. My cook+build steps then override `SOLDR_CACHE_DIR` to a different path — managed-zccache mode detects the mismatch and refuses.

**Fix**: set BOTH `SOLDR_CACHE_DIR` and `ZCCACHE_CACHE_DIR` together at step level so they stay coordinated under the caller-supplied cache-dir. Same pattern `setup-soldr-action.yml:142-143` uses for the dogfood smoke.

Touched both the composite action's internal cook + build steps and the workflow's baseline `Run cook + build` step.

## Test plan

- [x] `actionlint` clean
- [ ] After merge, both jobs proceed past the env-mismatch error and actually start compiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)