### PR TITLE
fix(release): locate zccache binaries inside nested archive layout

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -345,11 +345,16 @@ jobs:
 
           suffix=""
           if [ "$ext" = "zip" ]; then suffix=".exe"; fi
+          # zccache release archives nest binaries under
+          # `zccache-v<version>-<target>/`. Older releases were flat, and
+          # nothing in the contract guarantees future archives won't
+          # change shape again — so locate each binary by name anywhere
+          # inside the staging tree instead of hard-coding a prefix.
           for b in zccache zccache-daemon zccache-fp; do
-            src="dist/zccache-stage/${b}${suffix}"
-            if [ ! -f "$src" ]; then
+            src=$(find dist/zccache-stage -type f -name "${b}${suffix}" -print -quit)
+            if [ -z "$src" ] || [ ! -f "$src" ]; then
               echo "expected ${b}${suffix} in extracted zccache archive; got:" >&2
-              ls -la dist/zccache-stage/ >&2
+              find dist/zccache-stage -maxdepth 3 -print >&2
               exit 1
             fi
             cp "$src" "dist/package/${b}${suffix}"


### PR DESCRIPTION
## Summary

The Autonomous Release "Fetch matched zccache release for combined archive" step assumed the upstream zccache tarball/zip extracted straight to `dist/zccache-stage/<binary>`. Every zccache release since 1.7.x actually nests under `zccache-v<version>-<target>/`, so the 0.7.29 release attempt failed on every matrix row:

```
expected zccache in extracted zccache archive; got:
drwxr-xr-x 2 runner runner 4096 May 22 18:32 zccache-v1.9.0-x86_64-unknown-linux-musl
```

(See run [26311092875](https://github.com/zackees/soldr/actions/runs/26311092875) — Linux/macOS/Windows × x64/ARM64 all failed at this step.)

## Why the bug only fires now

This is the first release attempt to exercise the step — PR #428 (soldr 0.7.28) shipped before the combined-archive workflow landed in PR #434, so the layout assumption never met reality.

## Fix

Switches the binary lookup to `find -name <binary>` rooted at the staging directory. Works with:
- The current nested layout (`zccache-v<version>-<target>/zccache`)
- A hypothetical future flat layout (`zccache`)

The failure path now `find`s the whole tree so any future shape change is visible in the log.

Verified locally that 1.8.2 and 1.9.0 archives both use the nested layout on tar.gz and zip — so the same fix would have been needed regardless of the version bump.

## Post-merge

The path filter (`Cargo.toml` / `package.json`) excludes `.github/`, so this PR alone won't re-trigger Autonomous Release. After merge, run:

```
gh workflow run "Autonomous Release" -R zackees/soldr --ref main
```

0.7.29 is still unpublished on PyPI / npm and `v0.7.29` is not tagged, so the prepare step will proceed.

## Test plan

- [ ] CI green on this PR
- [ ] After merge + manual workflow dispatch: build jobs reach the "Stage soldr binary alongside zccache trio" step on every matrix row
- [ ] Combined `.tar.zst` archive contains all three zccache binaries + soldr

🤖 Generated with [Claude Code](https://claude.com/claude-code)