### PR TITLE
fix(release): smoke test uses 'zstd -d' for cross-platform extraction

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -658,7 +658,11 @@ jobs:
           test -f "$archive" || { echo "missing archive: $archive" >&2; exit 1; }
 
           extract=$(mktemp -d)
-          tar --use-compress-program=unzstd -xf "$archive" -C "$extract"
+          # Use `zstd -d` rather than the `unzstd` symlink: Chocolatey's
+          # `zstandard` package on Windows ships zstd.exe only, not the
+          # POSIX-style `unzstd` alias, so the symlink form fails on the
+          # Windows release runners with `Cannot exec`.
+          tar --use-compress-program='zstd -d' -xf "$archive" -C "$extract"
           echo "--- extracted layout ---"
           ls -la "$extract"
 


### PR DESCRIPTION
## Summary

The "Smoke test combined tar.zst archive" step in `release-auto.yml` ran:

```
tar --use-compress-program=unzstd -xf "$archive" -C "$extract"
```

`unzstd` is a POSIX-style symlink shipped by the Linux/macOS zstd packages, but the Chocolatey `zstandard` package on Windows installs `zstd.exe` only. Windows x64 and Windows ARM64 release jobs both failed with:

```
tar (child): unzstd: Cannot exec: No such file or directory
tar: Child returned status 2
```

(Linux + macOS rows of the same dispatch run all reached this step and passed — see [run 26315054346](https://github.com/zackees/soldr/actions/runs/26315054346).)

## Fix

Switches to `tar --use-compress-program='zstd -d'`. `zstd -d` is the single decoder binary every supported platform's zstd package ships.

## Scope

`scripts/install.js`, `.github/actions/setup-soldr/ensure_soldr.py`, and `.github/actions/cache-delta-experiment/action.yml` also reference `unzstd` but are out of scope for this release-unblocker PR — they affect downstream consumers / benchmark workflows, not the release pipeline. Worth a separate cleanup pass.

## Test plan

- [ ] CI green on this PR
- [ ] After merge + `gh workflow run "Autonomous Release" -R zackees/soldr --ref main`: all 8 matrix rows reach upload/publish, soldr 0.7.29 lands on PyPI + npm + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)