### PR TITLE
fix(experiment): render comparison ratio row as plain markdown

### DIFF
--- a/.github/workflows/cache-delta-experiment.yml
+++ b/.github/workflows/cache-delta-experiment.yml
@@ -300,7 +300,7 @@ jobs:
             echo "| upload bytes — cook layer | ${delta_cook_fmt} | included in baseline single layer |"
             echo "| upload bytes — delta layer | ${delta_delta_fmt} | n/a |"
             echo "| **upload bytes — total** | **${delta_total_fmt}** | **${baseline_fmt}** |"
-            echo "| ratio (delta / baseline) | colspan: ${ratio_fmt} | |"
+            echo "| ratio (delta / baseline) | ${ratio_fmt} | _lower is better_ |"
             echo ""
             echo "_Cold runs: ratio ~1.0 expected (both upload the full cook output)._"
             echo "_Warm runs (same Cargo.lock + rust-toolchain.toml): delta should drop to per-PR-only writes, baseline re-uploads everything._"


### PR DESCRIPTION
## Summary

The compare job's summary table had a row that emitted fake markdown syntax:

```
| ratio (delta / baseline) | colspan: ${ratio_fmt} | |
```

`colspan:` is not a markdown thing — GitHub renders the literal string in cell 2 with an empty cell 3, making the ratio row look broken in the workflow summary.

Replace with a plain two-data-cell row:

```
| ratio (delta / baseline) | 1.45× (144.6%) | _lower is better_ |
```

Cosmetic-only — no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)