### PR TITLE
diagnose(experiment): print zccache stats + mtimes after build

### DIFF
--- a/.github/actions/cache-delta-experiment/action.yml
+++ b/.github/actions/cache-delta-experiment/action.yml
@@ -274,6 +274,55 @@ runs:
         ZCCACHE_CACHE_DIR: ${{ steps.keys.outputs.zccache-dir }}
       run: ${{ inputs.build-cmd }}
 
+    - name: Diagnose cache-hit posture
+      # Warm runs were showing the full per-build delta size,
+      # suggesting either (a) zccache isn't hitting the restored
+      # entries, or (b) the mtime-based diff over-counts. This step
+      # prints the per-session zccache stats and a sample of cache
+      # file mtimes so we can tell which it is on the next run.
+      if: always()
+      shell: bash
+      env:
+        SOLDR_CACHE_DIR: ${{ steps.keys.outputs.cache-dir }}
+        ZCCACHE_CACHE_DIR: ${{ steps.keys.outputs.zccache-dir }}
+      run: |
+        set +e
+        MARK="${{ steps.keys.outputs.cook-mark }}"
+        ZCCACHE_DIR="${{ steps.keys.outputs.zccache-dir }}"
+
+        echo "## Cache delta diagnostic" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        echo "--- soldr cache report ---"
+        soldr cache report --json 2>&1 | head -80 || true
+
+        echo ""
+        echo "--- cache dir size + counts ---"
+        if [ -d "$ZCCACHE_DIR" ]; then
+          du -sh "$ZCCACHE_DIR" || true
+          echo "total files: $(find "$ZCCACHE_DIR" -type f 2>/dev/null | wc -l)"
+        fi
+
+        echo ""
+        echo "--- cook-mark mtime ---"
+        if [ -f "$MARK" ]; then
+          stat -c '%Y %n  (%y)' "$MARK"
+        fi
+
+        echo ""
+        echo "--- 5 oldest files in cache (epoch + path) ---"
+        find "$ZCCACHE_DIR" -type f -printf '%T@ %p\n' 2>/dev/null \
+          | sort -n | head -5
+
+        echo ""
+        echo "--- 5 newest files in cache ---"
+        find "$ZCCACHE_DIR" -type f -printf '%T@ %p\n' 2>/dev/null \
+          | sort -rn | head -5
+
+        echo ""
+        echo "--- files newer than cook-mark (sample) ---"
+        ( cd "$ZCCACHE_DIR" && find . -type f -newer "$MARK" 2>/dev/null | head -10 )
+
     - name: Package build delta
       id: delta-tar
       shell: bash


### PR DESCRIPTION
## Summary

The experiment now produces real numbers but the warm-run delta is suspicious:

| run | cook upload | delta upload | baseline | ratio |
|---|---|---|---|---|
| cold (PR 8 merge) | 178 MB | 79 MB | 178 MB | 1.45× |
| warm dispatch | **0 MB** ✓ | 79 MB ❓ | 178 MB | 0.45× |
| warm push #1 | **0 MB** ✓ | 79 MB ❓ | 178 MB | 0.45× |
| warm push #2 | **0 MB** ✓ | 79 MB ❓ | 178 MB | 0.45× |

Cook layer is correctly skipping its re-upload on warm (cook-cache-hit). But the delta layer keeps growing back to 79 MB on every warm run — even though both layers were restored cleanly (logs show "applying cook layer (171M)" and "applying delta layer (76M)").

Two hypotheses:
1. **Cache key mismatch** — zccache misses the restored entries, recomputes from scratch. Possible cause: absolute-path embedding without path-remap when the workspace doesn't have a `.git/` checkout. `actions/checkout` normally creates `.git`, so this would be unexpected.
2. **mtime over-count** — `tar` extract doesn't preserve archive mtimes when the extracting user isn't root, OR something during the build touches mtimes on read.

## What this PR adds

A no-op-on-failure diagnostic step after the build that prints into the workflow log:
- `soldr cache report --json` — session hit/miss counts (near-100% hit means restored cache IS being used → over-count is mtime story; low hit rate means cache lookups are missing)
- `du -sh` and total file count of zccache dir
- cook-mark mtime
- 5 oldest and 5 newest files in the cache by mtime
- Sample of files reported as "newer than cook-mark"

`if: always()` so a failed build still emits the data.

## Test plan

- [x] `actionlint` clean (no new errors)
- [ ] After merge, the next workflow run produces a populated diagnostic block in the step log

🤖 Generated with [Claude Code](https://claude.com/claude-code)