### PR TITLE
fix(experiment): diagnostic step exits 0 unconditionally

### DIFF
--- a/.github/actions/cache-delta-experiment/action.yml
+++ b/.github/actions/cache-delta-experiment/action.yml
@@ -285,6 +285,13 @@ runs:
       env:
         SOLDR_CACHE_DIR: ${{ steps.keys.outputs.cache-dir }}
         ZCCACHE_CACHE_DIR: ${{ steps.keys.outputs.zccache-dir }}
+      # `set +e` disables errexit but GHA still uses `bash -e -o pipefail`,
+      # and `head -N` truncates pipes → SIGPIPE → upstream find exits
+      # non-zero → pipefail propagates → step fails. Wrap each
+      # potentially-fallible command with `|| true` and finish with
+      # `exit 0` so the diagnostic NEVER turns a successful build
+      # red. `if: always()` only saves us if the step's own exit
+      # code is 0.
       run: |
         set +e
         MARK="${{ steps.keys.outputs.cook-mark }}"
@@ -306,22 +313,24 @@ runs:
         echo ""
         echo "--- cook-mark mtime ---"
         if [ -f "$MARK" ]; then
-          stat -c '%Y %n  (%y)' "$MARK"
+          stat -c '%Y %n  (%y)' "$MARK" || true
         fi
 
         echo ""
         echo "--- 5 oldest files in cache (epoch + path) ---"
-        find "$ZCCACHE_DIR" -type f -printf '%T@ %p\n' 2>/dev/null \
-          | sort -n | head -5
+        ( find "$ZCCACHE_DIR" -type f -printf '%T@ %p\n' 2>/dev/null \
+          | sort -n | head -5 ) || true
 
         echo ""
         echo "--- 5 newest files in cache ---"
-        find "$ZCCACHE_DIR" -type f -printf '%T@ %p\n' 2>/dev/null \
-          | sort -rn | head -5
+        ( find "$ZCCACHE_DIR" -type f -printf '%T@ %p\n' 2>/dev/null \
+          | sort -rn | head -5 ) || true
 
         echo ""
         echo "--- files newer than cook-mark (sample) ---"
-        ( cd "$ZCCACHE_DIR" && find . -type f -newer "$MARK" 2>/dev/null | head -10 )
+        ( cd "$ZCCACHE_DIR" 2>/dev/null && find . -type f -newer "$MARK" 2>/dev/null | head -10 ) || true
+
+        exit 0
 
     - name: Package build delta
       id: delta-tar


### PR DESCRIPTION
## Summary

PR #455 added a post-build diagnostic step that surfaces zccache hit/miss counts + cache-dir mtime data. Side effect: the composite action's outer step ended with exit 1 on every run after that PR merged, because:

1. GHA's bash invocation is `bash -e -o pipefail` regardless of `set +e` in the script — `set +e` only disables errexit, not pipefail.
2. My last command was `find ... | head -10` — `head` truncates the pipe after 10 lines → SIGPIPE → upstream `find` exits non-zero → pipefail propagates → step fails with exit 1.

That turned what was a successful warm-cache build into a failed workflow, which short-circuited the comparison summary I added the diagnostics to investigate.

## Fix

- Wrap each pipeline in `|| true` so any SIGPIPE / non-zero leaf command is contained.
- End the script with an explicit `exit 0` so the step's exit code is independent of whatever the last diagnostic command did.

`if: always()` was already in place — but it only protected against PREVIOUS step failures, not failures within the diagnostic itself.

## Test plan

- [x] `actionlint` clean
- [ ] After merge, the workflow runs to completion and the diagnostic block populates in the step log without turning the step red

🤖 Generated with [Claude Code](https://claude.com/claude-code)