### PR TITLE
fix(experiment): force ZCCACHE_PATH_REMAP=auto + print env diagnostics

### DIFF
--- a/.github/actions/cache-delta-experiment/action.yml
+++ b/.github/actions/cache-delta-experiment/action.yml
@@ -250,9 +250,18 @@ runs:
       # path. Override BOTH here so they stay coordinated under the
       # caller-supplied cache-dir. Same pattern setup-soldr-action.yml
       # uses for the dogfood smoke (lines 142-143).
+      #
+      # ZCCACHE_PATH_REMAP=auto explicitly: the first warm run showed
+      # zccache hit_rate=0 with 199 misses — soldr's
+      # parent-cache-sharing path-remap injection (which is supposed
+      # to be default-on for managed builds per CLAUDE.md) wasn't in
+      # the inherited env. Without remap, absolute source paths get
+      # baked into cache keys → cross-run drift kills hits. Force it
+      # here so cold writes and warm reads end up with the same keys.
       env:
         SOLDR_CACHE_DIR: ${{ steps.keys.outputs.cache-dir }}
         ZCCACHE_CACHE_DIR: ${{ steps.keys.outputs.zccache-dir }}
+        ZCCACHE_PATH_REMAP: auto
       run: ${{ inputs.cook-cmd }}
 
     - name: Touch cook mark
@@ -268,10 +277,14 @@ runs:
 
     - name: Run build command
       shell: bash
-      # See the cook step above for the env-pair rationale.
+      # See the cook step above for the env-trio rationale. ALL of
+      # SOLDR_CACHE_DIR / ZCCACHE_CACHE_DIR / ZCCACHE_PATH_REMAP must
+      # stay aligned with the cook step so the cache keys cook
+      # produced are the same ones build looks up.
       env:
         SOLDR_CACHE_DIR: ${{ steps.keys.outputs.cache-dir }}
         ZCCACHE_CACHE_DIR: ${{ steps.keys.outputs.zccache-dir }}
+        ZCCACHE_PATH_REMAP: auto
       run: ${{ inputs.build-cmd }}
 
     - name: Diagnose cache-hit posture
@@ -299,6 +312,21 @@ runs:
 
         echo "## Cache delta diagnostic" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        echo "--- cache-key environment ---"
+        # zccache hash keys depend on a handful of env vars + the
+        # workspace layout (path-remap mode). Print what we actually
+        # have so cache-miss debugging is grounded.
+        env | grep -E '^(ZCCACHE_|SOLDR_|RUSTUP_TOOLCHAIN|RUSTC|CARGO_)' \
+          | LC_ALL=C sort || true
+        echo ""
+        echo "--- .git present in workspace? ---"
+        if [ -d .git ]; then
+          echo "yes ($(git rev-parse --short HEAD 2>/dev/null || echo '??'))"
+        else
+          echo "no — path-remap auto-detect falls back to no remap"
+        fi
+        echo ""
 
         echo "--- soldr cache report ---"
         soldr cache report --json 2>&1 | head -80 || true


### PR DESCRIPTION
## Summary

The diagnostic landed in #455 + #456 surfaced the real problem on warm runs:

```
"hit_rate": 0.0,
"hits": 0,
"misses": 199,
```

Restored cache exists on disk (oldest entries' mtimes are 80 min older than the cook-mark, so they survived the round-trip), but zccache hits NONE of them. Every compile re-writes the same content under a different key.

`CLAUDE.md`'s parent-cache-sharing section is the smoking gun:

> **Parent-cache sharing is default-on**: For managed-zccache builds soldr seeds `ZCCACHE_PATH_REMAP=auto` on the child cargo (issue #352). zccache normalizes absolute source paths inside compiled artifacts so two git worktrees of the same repo serve each other's cache hits via hardlinks. Requires a real `.git/` checkout — tarball/zip checkouts silently fall back to no remap.

The first warm run's env dump showed neither `ZCCACHE_PATH_REMAP` nor `SOLDR_PATH_REMAP` set — soldr's auto-injection didn't fire. Possibly because setup-soldr passes `build-cache: false target-cache: false` which affects remap injection too.

## Changes

- Explicit `ZCCACHE_PATH_REMAP=auto` on cook + build env so cache keys cook writes are the same ones build looks up.
- Extended diagnostic to print all `ZCCACHE_*`/`SOLDR_*`/`RUSTUP_TOOLCHAIN`/`RUSTC*`/`CARGO_*` env vars (so we can verify the override took effect) and check whether the workspace has `.git/`.

## What this run will tell us

- If hits jump from 0% to >0% → diagnosis confirmed, delta cache actually saves CI time (not just upload bytes).
- If hits stay 0% → there's a different reason zccache misses, dig deeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)