### PR TITLE
fix(release): pre-create tag + bundle wheels with archives in GH release

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -730,16 +730,51 @@ jobs:
           pattern: release-soldr-*
           merge-multiple: true
 
+      # Wheels ship as GH-release assets alongside the .tar.zst archives.
+      # This is parity with what `publish-pypi` uploads to PyPI: the same
+      # 6 platform wheels become offline-installable via
+      # `pip install <release-asset-url>`, and the assets are attestation-
+      # covered via the same SHA256SUMS file below.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: dist
+          pattern: pypi-soldr-*
+          merge-multiple: true
+
       - name: Generate release checksums
         shell: bash
         run: |
           set -euo pipefail
           cd dist
+          # Glob expansion happens before the `>` redirect creates the
+          # output file, so SHA256SUMS.txt is never present in the set
+          # it's writing.
           sha256sum soldr-* > "soldr-${{ needs.prepare.outputs.version }}-SHA256SUMS.txt"
 
       - uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-checksums: dist/soldr-${{ needs.prepare.outputs.version }}-SHA256SUMS.txt
+
+      # Pre-create the tag via the git refs API instead of letting
+      # `gh release create --target <sha>` create it implicitly.
+      # Rationale: on workflow_dispatch runs (vs push) the GITHUB_TOKEN
+      # cannot create-via-release at a protected branch's HEAD — `gh
+      # release create` returns "HTTP 403: Resource not accessible by
+      # integration" even though the job log shows `Contents: write`.
+      # The /git/refs endpoint accepts the same token at this repo, so
+      # creating the tag first lets the subsequent release-create see an
+      # existing tag and skip the implicit-tag-creation that was the
+      # source of the 403.
+      - name: Pre-create release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -X POST \
+            -f "ref=refs/tags/${{ needs.prepare.outputs.version }}" \
+            -f "sha=${{ needs.prepare.outputs.commit_sha }}"
 
       - name: Create draft GitHub Release
         env:


### PR DESCRIPTION
## Summary

Two related changes to the `publish` (Attest and publish release assets) job:

1. **Wheels ship as GH-release assets.** Download `pypi-soldr-*` artifacts alongside `release-soldr-*` so the same 6 platform wheels that go to PyPI also land on the GitHub Release. The SHA256SUMS file and build-provenance attestation now cover archives + wheels.

2. **Pre-create the release tag** via `gh api .../git/refs` before `gh release create`, instead of letting `gh release create --target <sha>` create it implicitly.

## Why the tag-creation change

On `workflow_dispatch` runs at this repo, GITHUB_TOKEN cannot create-via-release at a protected branch's HEAD — `gh release create` returns:

```
HTTP 403: Resource not accessible by integration (https://api.github.com/repos/zackees/soldr/releases)
```

…even though the job's GITHUB_TOKEN Permissions log shows `Contents: write`. The same call succeeds on `push` runs. Compare:

| Run | Event | `gh release create` |
|---|---|---|
| [26315593667](https://github.com/zackees/soldr/actions/runs/26315593667) (recovery dispatch for 0.7.29) | `workflow_dispatch` | **403** |
| [26320054141](https://github.com/zackees/soldr/actions/runs/26320054141) (0.7.30 PR merge) | `push` | success |

Empirical fix: hit `/git/refs` first (which accepts the same GITHUB_TOKEN on this repo), then `gh release create` sees an existing tag and skips the implicit tag-creation that was triggering the 403 under workflow_dispatch.

**No PAT involved** — same GITHUB_TOKEN, just routed through a different endpoint for the tag-creation half.

## Why the wheels-on-GH-release change

0.7.29 shipped wheels to PyPI but the GH release page had no wheels. Anyone wanting an offline install (`pip install <release-url>/soldr-0.7.29-py3-none-manylinux_2_39_x86_64.whl`) couldn't. With this change, 0.7.31+ releases will include both archives and wheels atomically (one `gh release create` call), avoiding the immutability trap that locked 0.7.29 / 0.7.30 from having wheels backfilled.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: next version bump triggers Autonomous Release; the publish job's new "Pre-create release tag" step succeeds, and the resulting GH release contains 8 archives + 6 wheels + SHA256SUMS = 15 assets
- [ ] Re-test workflow_dispatch path: dispatch on main after this lands and verify the publish job completes (a manual dispatch with current tag/version state will skip publish, so the real test is the next version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)