### PR TITLE
feat(cache): soldr cache trim-target — pre-archive trim to bound target/ growth

### DIFF
--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -465,6 +465,331 @@ struct CachePruneTargetEntryOutput {
     action: &'static str,
 }
 
+/// Profile preset for `soldr cache trim-target`. The CLI maps this
+/// onto the actual rule selection inside [`run_cache_trim_target_command`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrimProfile {
+    /// Lightweight: orphan hash-sibling prune only.
+    Local,
+    /// Aggressive: prune + strip recreatable noise + drop
+    /// `incremental/`. The intended profile for CI cache transport.
+    Ci,
+}
+
+impl TrimProfile {
+    fn as_str(self) -> &'static str {
+        match self {
+            TrimProfile::Local => "local",
+            TrimProfile::Ci => "ci",
+        }
+    }
+}
+
+/// Trim a cargo `target/` directory in preparation for archival.
+///
+/// Composition order matters:
+/// 1. Refuse if a `.cargo-lock` is present (active build sentinel,
+///    reused from `prune_target`'s guard).
+/// 2. CI-only: remove `target/<profile>/incremental/` wholesale.
+///    rustc resets the incremental session on each fresh runner and
+///    the per-process cache contributes ~0% hit rate against the next
+///    job's invocation. Cargo recreates an empty `incremental/` on
+///    first build.
+/// 3. CI-only: run [`strip_target`] with every rule on. Removes large
+///    build-script stderr, `build-script-build*` binaries,
+///    `examples/`/`doc/`/`tests/`, and `.dwo`/`.pdb`/`.dSYM` debug
+///    sidecars under `deps/`.
+/// 4. Always: run [`prune_target`] to drop orphan hash-siblings in
+///    `deps/`, `.fingerprint/`, `incremental/` (if it still exists),
+///    and `build/`.
+///
+/// Steps 2–3 are gated on the CI profile because a developer running
+/// `soldr cache trim-target` locally generally wants to KEEP the
+/// incremental cache and the examples/doc artifacts. Step 4 is always
+/// safe (cargo never reads orphan hashes again).
+pub(crate) fn run_cache_trim_target_command(
+    target_dir: std::path::PathBuf,
+    profile: TrimProfile,
+    dry_run: bool,
+    json: bool,
+) -> Result<(), SoldrError> {
+    let canonical = std::path::absolute(&target_dir).unwrap_or_else(|_| target_dir.clone());
+
+    // Reuse the same refusal the prune-target subcommand applies. We
+    // call into prune_target below anyway, but checking up-front means
+    // CI-profile incremental/ removal also bails when a build is live.
+    if let Some(lock) = trim_find_cargo_lock(&canonical) {
+        return Err(SoldrError::Other(format!(
+            "cargo lock present at {} (active build?); refusing to trim",
+            lock.display()
+        )));
+    }
+
+    let mut incremental_removed: Vec<TrimIncrementalEntry> = Vec::new();
+    if matches!(profile, TrimProfile::Ci) {
+        incremental_removed = remove_incremental_dirs(&canonical, dry_run)?;
+    }
+
+    let strip_report = if matches!(profile, TrimProfile::Ci) {
+        let opts = crate::cache_lib::strip_target::StripTargetOptions {
+            dry_run,
+            ..crate::cache_lib::strip_target::StripTargetOptions::all(canonical.clone())
+        };
+        Some(
+            crate::cache_lib::strip_target::strip_target(&opts)
+                .map_err(|e| SoldrError::Other(format!("cache trim-target: strip failed: {e}")))?,
+        )
+    } else {
+        None
+    };
+
+    let prune_opts = crate::cache_lib::prune_target::PruneTargetOptions {
+        target_dir: canonical.clone(),
+        dry_run,
+    };
+    let prune_report = crate::cache_lib::prune_target::prune_target(&prune_opts)
+        .map_err(|e| SoldrError::Other(format!("cache trim-target: prune failed: {e}")))?;
+
+    let summary = TrimSummary {
+        target_dir: canonical.clone(),
+        profile,
+        dry_run,
+        incremental_removed,
+        strip_report,
+        prune_report,
+    };
+
+    if json {
+        let output = build_cache_trim_target_output(&summary);
+        print_json(&output)?;
+    } else {
+        print_cache_trim_target_text(&summary);
+    }
+    Ok(())
+}
+
+/// Walk `target/{,<profile>}/.cargo-lock` and return the first match.
+/// Copy of the algorithm in `prune_target::find_active_cargo_lock`,
+/// hoisted here so the CI-profile incremental-removal step short-
+/// circuits before any disk write.
+fn trim_find_cargo_lock(target_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let top = target_dir.join(".cargo-lock");
+    if top.exists() {
+        return Some(top);
+    }
+    let read = std::fs::read_dir(target_dir).ok()?;
+    for entry in read.flatten() {
+        let ft = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if !ft.is_dir() {
+            continue;
+        }
+        let candidate = entry.path().join(".cargo-lock");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Walk every `target/<profile>/incremental/` and remove the whole
+/// directory. Returns the per-profile sizes that were reclaimed (or
+/// would be reclaimed under dry-run) so the report can surface them.
+fn remove_incremental_dirs(
+    target_dir: &std::path::Path,
+    dry_run: bool,
+) -> Result<Vec<TrimIncrementalEntry>, SoldrError> {
+    let mut out = Vec::new();
+    let read = match std::fs::read_dir(target_dir) {
+        Ok(it) => it,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(err) => return Err(SoldrError::Other(format!("read_dir failed: {err}"))),
+    };
+    let incremental_name = crate::cache_lib::prune_target::INCREMENTAL_SUBDIR;
+    for entry in read.flatten() {
+        let ft = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if !ft.is_dir() {
+            continue;
+        }
+        let profile_path = entry.path();
+        // Skip dotted entries (.fingerprint et al. are not profiles).
+        if let Some(name) = profile_path.file_name().and_then(|n| n.to_str()) {
+            if name.starts_with('.') {
+                continue;
+            }
+        }
+        let incremental_path = profile_path.join(incremental_name);
+        if !incremental_path.is_dir() {
+            continue;
+        }
+        let size = trim_dir_size(&incremental_path);
+        if !dry_run {
+            if let Err(err) = std::fs::remove_dir_all(&incremental_path) {
+                return Err(SoldrError::Other(format!(
+                    "failed to remove {}: {}",
+                    incremental_path.display(),
+                    err
+                )));
+            }
+        }
+        out.push(TrimIncrementalEntry {
+            path: incremental_path,
+            size_bytes: size,
+        });
+    }
+    Ok(out)
+}
+
+fn trim_dir_size(path: &std::path::Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack: Vec<std::path::PathBuf> = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let read = match std::fs::read_dir(&dir) {
+            Ok(it) => it,
+            Err(_) => continue,
+        };
+        for entry in read.flatten() {
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.is_dir() {
+                stack.push(entry.path());
+            } else if metadata.is_file() {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    total
+}
+
+struct TrimIncrementalEntry {
+    path: std::path::PathBuf,
+    size_bytes: u64,
+}
+
+struct TrimSummary {
+    target_dir: std::path::PathBuf,
+    profile: TrimProfile,
+    dry_run: bool,
+    incremental_removed: Vec<TrimIncrementalEntry>,
+    strip_report: Option<crate::cache_lib::strip_target::StripReport>,
+    prune_report: crate::cache_lib::prune_target::PruneTargetReport,
+}
+
+fn build_cache_trim_target_output(summary: &TrimSummary) -> CacheTrimTargetOutput {
+    let incremental_bytes: u64 = summary
+        .incremental_removed
+        .iter()
+        .map(|e| e.size_bytes)
+        .sum();
+    let strip_bytes = summary
+        .strip_report
+        .as_ref()
+        .map(|r| r.reclaimed_bytes)
+        .unwrap_or(0);
+    let prune_bytes = summary.prune_report.reclaimed_bytes;
+    let total = incremental_bytes
+        .saturating_add(strip_bytes)
+        .saturating_add(prune_bytes);
+    CacheTrimTargetOutput {
+        schema_version: JSON_SCHEMA_VERSION,
+        command: "cache trim-target",
+        target_dir: summary.target_dir.display().to_string(),
+        profile: summary.profile.as_str(),
+        dry_run: summary.dry_run,
+        incremental_removed_count: summary.incremental_removed.len(),
+        incremental_reclaimed_bytes: incremental_bytes,
+        strip_deleted: summary
+            .strip_report
+            .as_ref()
+            .map(|r| r.deleted)
+            .unwrap_or(0),
+        strip_reclaimed_bytes: strip_bytes,
+        prune_scanned: summary.prune_report.scanned,
+        prune_kept: summary.prune_report.kept,
+        prune_deleted: summary.prune_report.deleted,
+        prune_reclaimed_bytes: prune_bytes,
+        total_reclaimed_bytes: total,
+        total_reclaimed_human: crate::cache_lib::target_registry::human_size(total),
+    }
+}
+
+fn print_cache_trim_target_text(summary: &TrimSummary) {
+    println!("soldr cache trim-target: {}", summary.target_dir.display());
+    println!(
+        "  profile: {}  mode: {}",
+        summary.profile.as_str(),
+        if summary.dry_run {
+            "dry-run (use --force to actually delete)"
+        } else {
+            "force"
+        }
+    );
+    let incremental_bytes: u64 = summary
+        .incremental_removed
+        .iter()
+        .map(|e| e.size_bytes)
+        .sum();
+    if !summary.incremental_removed.is_empty() {
+        println!(
+            "  incremental/: {} dirs, {}",
+            summary.incremental_removed.len(),
+            crate::cache_lib::target_registry::human_size(incremental_bytes),
+        );
+    }
+    if let Some(strip) = &summary.strip_report {
+        println!(
+            "  strip: deleted={} reclaimed={}",
+            strip.deleted,
+            crate::cache_lib::target_registry::human_size(strip.reclaimed_bytes),
+        );
+    }
+    println!(
+        "  prune: scanned={} kept={} deleted={} reclaimed={}",
+        summary.prune_report.scanned,
+        summary.prune_report.kept,
+        summary.prune_report.deleted,
+        crate::cache_lib::target_registry::human_size(summary.prune_report.reclaimed_bytes),
+    );
+    let total = incremental_bytes
+        .saturating_add(
+            summary
+                .strip_report
+                .as_ref()
+                .map(|r| r.reclaimed_bytes)
+                .unwrap_or(0),
+        )
+        .saturating_add(summary.prune_report.reclaimed_bytes);
+    println!(
+        "  total reclaimed: {}",
+        crate::cache_lib::target_registry::human_size(total),
+    );
+}
+
+#[derive(Serialize)]
+struct CacheTrimTargetOutput {
+    schema_version: u32,
+    command: &'static str,
+    target_dir: String,
+    profile: &'static str,
+    dry_run: bool,
+    incremental_removed_count: usize,
+    incremental_reclaimed_bytes: u64,
+    strip_deleted: usize,
+    strip_reclaimed_bytes: u64,
+    prune_scanned: usize,
+    prune_kept: usize,
+    prune_deleted: usize,
+    prune_reclaimed_bytes: u64,
+    total_reclaimed_bytes: u64,
+    total_reclaimed_human: String,
+}
+
 pub(crate) fn run_cache_report_command(json: bool) -> Result<(), SoldrError> {
     let output = collect_cache_report_output()?;
     if json {

--- a/crates/soldr-cli/src/cache_lib/mod.rs
+++ b/crates/soldr-cli/src/cache_lib/mod.rs
@@ -15,6 +15,7 @@ pub mod gc;
 pub mod prune_target;
 pub mod save;
 pub mod state_db;
+pub mod strip_target;
 pub mod target_registry;
 
 /// Directory for the auto-GC structured log (`~/.soldr/logs/auto-gc.log`).

--- a/crates/soldr-cli/src/cache_lib/prune_target.rs
+++ b/crates/soldr-cli/src/cache_lib/prune_target.rs
@@ -220,6 +220,38 @@ pub fn prune_target(opts: &PruneTargetOptions) -> Result<PruneTargetReport, Regi
 /// same suffix layout.
 const SUBDIRS_WITH_HASH_SUFFIXES: &[&str] = &["deps", ".fingerprint", "incremental", "build"];
 
+/// Files cargo writes that the wrapper must NEVER strip from an
+/// archived `target/` snapshot. Removing any of these on the load side
+/// invalidates the entire snapshot in cargo's eyes — dropping
+/// `.rustc_info.json` forces a full rebuild because cargo re-probes the
+/// toolchain on the next invocation.
+///
+/// Patterns are documentary only; the trim path enumerates them
+/// explicitly rather than glob-matching. Keep this list and the
+/// trim-target implementation in sync.
+pub const MUST_KEEP_BIT_EXACT: &[&str] = &[
+    "CACHEDIR.TAG",
+    ".rustc_info.json",
+    ".fingerprint/*/dep-*",
+    ".fingerprint/*/output-*",
+    ".fingerprint/*/invoked.timestamp",
+];
+
+/// Files that must NEVER appear inside an archived `target/` snapshot.
+/// `.cargo-lock` is a transient flock sentinel — replaying it on the
+/// load side would falsely signal an in-flight build to cargo. The
+/// pre-archive trim path explicitly skips these names; the existing
+/// [`find_active_cargo_lock`] also refuses to prune while one is
+/// present locally.
+pub const NEVER_ARCHIVE: &[&str] = &[".cargo-lock"];
+
+/// Profile-relative subdirectory whose contents are rustc's incremental
+/// compilation database. Excluded from CI-profile archives because
+/// rustc resets the incremental session on every fresh runner and
+/// the per-process cache contributes ~0% hit rate against the next
+/// CI job's invocation.
+pub const INCREMENTAL_SUBDIR: &str = "incremental";
+
 fn collect_scan_dirs(target_dir: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let profiles = match fs::read_dir(target_dir) {

--- a/crates/soldr-cli/src/cache_lib/strip_target.rs
+++ b/crates/soldr-cli/src/cache_lib/strip_target.rs
@@ -1,0 +1,644 @@
+//! Strip cargo-recreatable noise from a cargo `target/` directory.
+//!
+//! Complement to [`super::prune_target`]: where `prune_target` deletes
+//! orphan hash-suffixed siblings, this module removes whole categories
+//! of files that cargo can rebuild cheaply from cached artifacts. The
+//! intent is to shrink a `target/` snapshot before it is tarred up for
+//! transport across CI runners, so the rehydrate ships dramatically
+//! fewer bytes.
+//!
+//! Every rule is opt-in. Default `StripTargetOptions::none()` produces
+//! a no-op walk. Callers select rules explicitly.
+//!
+//! Categories
+//! ----------
+//!
+//! - **Large build-script stderr** (`target/<profile>/build/*/stderr`
+//!   above [`STDERR_KEEP_BELOW_BYTES`]). Crates like `ring`, `bindgen`,
+//!   `aws-lc-sys` dump tens of MB of inline-asm logspam here. Cargo
+//!   never reads it. Files below the threshold are preserved so a human
+//!   can still grep them.
+//! - **Build-script-build binaries** (`target/<profile>/build/*/build-script-build*`
+//!   and `.pdb` siblings). Cargo recompiles these from cached `.rlib`s
+//!   in seconds.
+//! - **Profile subdirs** (`target/<profile>/{examples,doc,tests}/`).
+//!   Useful for local dev, dead weight for CI cache archives.
+//! - **Debug sidecars** (`.dwo`, `.pdb`, `.dSYM/` under
+//!   `target/<profile>/deps/`). Cargo regenerates these on the next
+//!   build that asks for debuginfo.
+//!
+//! The caller is responsible for the `.cargo-lock` active-build guard;
+//! reuse [`super::prune_target::find_active_cargo_lock`] before calling
+//! this module so the strip never races a live build.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use thiserror::Error;
+
+/// Build-script `stderr` files **strictly larger** than this many bytes
+/// are eligible for stripping. The threshold (128 KiB) keeps small
+/// "no warnings" stubs around for grep-debuggability.
+pub const STDERR_KEEP_BELOW_BYTES: u64 = 128 * 1024;
+
+/// Top-level profile subdir names that the
+/// `strip_examples_doc_tests` rule clears wholesale.
+pub const EXAMPLES_DOC_TESTS_SUBDIRS: &[&str] = &["examples", "doc", "tests"];
+
+#[derive(Debug, Error)]
+pub enum StripError {
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct StripTargetOptions {
+    /// Path to a cargo `target/` directory to scan. Subdirectories
+    /// matching profile-shaped layouts (`target/<profile>/`) are
+    /// walked; everything else is left alone.
+    pub target_dir: PathBuf,
+    /// When `true`, no entries are deleted. The returned report still
+    /// describes the would-be action.
+    pub dry_run: bool,
+    /// Strip build-script `stderr` files larger than
+    /// [`STDERR_KEEP_BELOW_BYTES`].
+    pub strip_large_stderr: bool,
+    /// Strip `build-script-build*` binaries and their `.pdb` siblings.
+    pub strip_build_script_binaries: bool,
+    /// Strip `examples/`, `doc/`, `tests/` profile subdirs.
+    pub strip_examples_doc_tests: bool,
+    /// Strip `.dwo`, `.pdb`, `.dSYM/` debug sidecars under
+    /// `target/<profile>/deps/`.
+    pub strip_debug_sidecars: bool,
+}
+
+impl StripTargetOptions {
+    /// All rules off — dry-run by default. Use this and flip the
+    /// rules you want; mirrors `PruneTargetOptions::new`.
+    pub fn none(target_dir: PathBuf) -> Self {
+        Self {
+            target_dir,
+            dry_run: true,
+            strip_large_stderr: false,
+            strip_build_script_binaries: false,
+            strip_examples_doc_tests: false,
+            strip_debug_sidecars: false,
+        }
+    }
+
+    /// Every rule on; dry-run by default. The CI-profile preset for
+    /// `cache trim-target`.
+    pub fn all(target_dir: PathBuf) -> Self {
+        Self {
+            target_dir,
+            dry_run: true,
+            strip_large_stderr: true,
+            strip_build_script_binaries: true,
+            strip_examples_doc_tests: true,
+            strip_debug_sidecars: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StripCategory {
+    LargeStderr,
+    BuildScriptBinary,
+    ExamplesDocTests,
+    DebugSidecar,
+}
+
+impl StripCategory {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StripCategory::LargeStderr => "large_stderr",
+            StripCategory::BuildScriptBinary => "build_script_binary",
+            StripCategory::ExamplesDocTests => "examples_doc_tests",
+            StripCategory::DebugSidecar => "debug_sidecar",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StripEntry {
+    pub path: PathBuf,
+    pub category: StripCategory,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StripReport {
+    /// Number of profile dirs walked.
+    pub profiles_scanned: usize,
+    /// Number of entries deleted (or that would be deleted in dry-run).
+    pub deleted: usize,
+    /// Bytes reclaimed (or reclaimable) by the deletions.
+    pub reclaimed_bytes: u64,
+    /// Every entry the scan classified for deletion, in walk order.
+    pub entries: Vec<StripEntry>,
+}
+
+/// Walk a cargo `target/` directory and strip the categories enabled
+/// in `opts`.
+///
+/// Idempotent: a second run on the same directory finds nothing because
+/// the targeted files no longer exist.
+pub fn strip_target(opts: &StripTargetOptions) -> Result<StripReport, StripError> {
+    let target_dir = &opts.target_dir;
+    let metadata = fs::metadata(target_dir).map_err(|source| StripError::Io {
+        path: target_dir.clone(),
+        source,
+    })?;
+    if !metadata.is_dir() {
+        return Err(StripError::Io {
+            path: target_dir.clone(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "strip-target requires a directory",
+            ),
+        });
+    }
+
+    let profiles = read_profile_dirs(target_dir).map_err(|source| StripError::Io {
+        path: target_dir.clone(),
+        source,
+    })?;
+
+    let mut entries: Vec<StripEntry> = Vec::new();
+    let mut profiles_scanned = 0usize;
+
+    for profile in &profiles {
+        profiles_scanned += 1;
+        if opts.strip_large_stderr || opts.strip_build_script_binaries {
+            collect_build_subdir(profile, opts, &mut entries)?;
+        }
+        if opts.strip_examples_doc_tests {
+            collect_profile_subdirs(profile, EXAMPLES_DOC_TESTS_SUBDIRS, &mut entries)?;
+        }
+        if opts.strip_debug_sidecars {
+            collect_debug_sidecars_under_deps(profile, &mut entries)?;
+        }
+    }
+
+    let mut report = StripReport {
+        profiles_scanned,
+        ..StripReport::default()
+    };
+
+    if !opts.dry_run {
+        for entry in &entries {
+            delete_entry(&entry.path).map_err(|source| StripError::Io {
+                path: entry.path.clone(),
+                source,
+            })?;
+        }
+    }
+
+    report.deleted = entries.len();
+    for entry in &entries {
+        report.reclaimed_bytes = report.reclaimed_bytes.saturating_add(entry.size_bytes);
+    }
+    report.entries = entries;
+    Ok(report)
+}
+
+/// Enumerate `target/<profile>/` dirs. Skips dotted entries
+/// (`.fingerprint` is one of cargo's own state dirs at the top level,
+/// not a profile).
+fn read_profile_dirs(target_dir: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
+    let mut out = Vec::new();
+    let read = match fs::read_dir(target_dir) {
+        Ok(it) => it,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(err) => return Err(err),
+    };
+    for entry in read.flatten() {
+        let ft = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if !ft.is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(|s| s.to_string()) else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        out.push(entry.path());
+    }
+    Ok(out)
+}
+
+fn collect_build_subdir(
+    profile: &Path,
+    opts: &StripTargetOptions,
+    entries: &mut Vec<StripEntry>,
+) -> Result<(), StripError> {
+    let build = profile.join("build");
+    let read = match fs::read_dir(&build) {
+        Ok(it) => it,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            return Err(StripError::Io {
+                path: build,
+                source,
+            })
+        }
+    };
+    for unit in read.flatten() {
+        let unit_path = unit.path();
+        let ft = match unit.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if !ft.is_dir() {
+            continue;
+        }
+        let unit_read = match fs::read_dir(&unit_path) {
+            Ok(it) => it,
+            Err(_) => continue,
+        };
+        for child in unit_read.flatten() {
+            let child_path = child.path();
+            let Some(name) = child_path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if opts.strip_large_stderr && name == "stderr" {
+                let len = file_len(&child_path).unwrap_or(0);
+                if len > STDERR_KEEP_BELOW_BYTES {
+                    entries.push(StripEntry {
+                        path: child_path.clone(),
+                        category: StripCategory::LargeStderr,
+                        size_bytes: len,
+                    });
+                }
+                continue;
+            }
+            if opts.strip_build_script_binaries && is_build_script_binary(name) {
+                let len = file_len(&child_path).unwrap_or(0);
+                entries.push(StripEntry {
+                    path: child_path,
+                    category: StripCategory::BuildScriptBinary,
+                    size_bytes: len,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_build_script_binary(name: &str) -> bool {
+    let stem = name.split('.').next().unwrap_or(name);
+    stem == "build-script-build" || stem.starts_with("build-script-build-")
+}
+
+fn collect_profile_subdirs(
+    profile: &Path,
+    subdirs: &[&str],
+    entries: &mut Vec<StripEntry>,
+) -> Result<(), StripError> {
+    for sub in subdirs {
+        let path = profile.join(sub);
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(source) => return Err(StripError::Io { path, source }),
+        };
+        if !metadata.is_dir() {
+            continue;
+        }
+        let size = directory_size(&path);
+        entries.push(StripEntry {
+            path,
+            category: StripCategory::ExamplesDocTests,
+            size_bytes: size,
+        });
+    }
+    Ok(())
+}
+
+fn collect_debug_sidecars_under_deps(
+    profile: &Path,
+    entries: &mut Vec<StripEntry>,
+) -> Result<(), StripError> {
+    let deps = profile.join("deps");
+    let read = match fs::read_dir(&deps) {
+        Ok(it) => it,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => return Err(StripError::Io { path: deps, source }),
+    };
+    for entry in read.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let ft = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if ft.is_dir() {
+            if name.ends_with(".dSYM") {
+                let size = directory_size(&path);
+                entries.push(StripEntry {
+                    path,
+                    category: StripCategory::DebugSidecar,
+                    size_bytes: size,
+                });
+            }
+            continue;
+        }
+        if name.ends_with(".dwo") || name.ends_with(".pdb") {
+            let size = file_len(&path).unwrap_or(0);
+            entries.push(StripEntry {
+                path,
+                category: StripCategory::DebugSidecar,
+                size_bytes: size,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn file_len(path: &Path) -> Option<u64> {
+    fs::metadata(path).ok().map(|m| m.len())
+}
+
+fn directory_size(path: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack: Vec<PathBuf> = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let read = match fs::read_dir(&dir) {
+            Ok(it) => it,
+            Err(_) => continue,
+        };
+        for entry in read.flatten() {
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.is_dir() {
+                stack.push(entry.path());
+            } else if metadata.is_file() {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    total
+}
+
+fn delete_entry(path: &Path) -> Result<(), std::io::Error> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn touch_dir(path: &Path) {
+        fs::create_dir_all(path).unwrap();
+    }
+
+    fn write_bytes(path: &Path, bytes: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = File::create(path).unwrap();
+        f.write_all(bytes).unwrap();
+    }
+
+    #[test]
+    fn empty_target_is_a_noop() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let opts = StripTargetOptions {
+            dry_run: false,
+            ..StripTargetOptions::all(target)
+        };
+        let report = strip_target(&opts).unwrap();
+        assert_eq!(report.profiles_scanned, 0);
+        assert_eq!(report.deleted, 0);
+        assert!(report.entries.is_empty());
+    }
+
+    #[test]
+    fn large_stderr_dropped_small_kept() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let small = target.join("debug/build/ring-aaaa/stderr");
+        let large = target.join("debug/build/bindgen-bbbb/stderr");
+        write_bytes(&small, &[0u8; 1024]);
+        // > 128 KiB so it should be stripped.
+        write_bytes(&large, &vec![0u8; 200 * 1024]);
+
+        let opts = StripTargetOptions {
+            dry_run: false,
+            strip_large_stderr: true,
+            ..StripTargetOptions::none(target.clone())
+        };
+        let report = strip_target(&opts).unwrap();
+
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.entries[0].category, StripCategory::LargeStderr);
+        assert!(small.exists(), "small stderr must survive");
+        assert!(!large.exists(), "large stderr must be deleted");
+    }
+
+    #[test]
+    fn stderr_exactly_at_threshold_kept() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let at_threshold = target.join("debug/build/foo-aaaa/stderr");
+        write_bytes(&at_threshold, &vec![0u8; STDERR_KEEP_BELOW_BYTES as usize]);
+        let opts = StripTargetOptions {
+            dry_run: false,
+            strip_large_stderr: true,
+            ..StripTargetOptions::none(target)
+        };
+        let report = strip_target(&opts).unwrap();
+        assert_eq!(report.deleted, 0, "exact-threshold must survive");
+        assert!(at_threshold.exists());
+    }
+
+    #[test]
+    fn build_script_binary_dropped() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let bin_unix = target.join("debug/build/foo-aaaa/build-script-build");
+        let bin_win = target.join("debug/build/foo-aaaa/build-script-build.exe");
+        write_bytes(&bin_unix, b"unix binary");
+        write_bytes(&bin_win, b"win binary");
+        // Sibling that must NOT be touched.
+        let output = target.join("debug/build/foo-aaaa/output");
+        write_bytes(&output, b"sibling output");
+        let opts = StripTargetOptions {
+            dry_run: false,
+            strip_build_script_binaries: true,
+            ..StripTargetOptions::none(target)
+        };
+        let report = strip_target(&opts).unwrap();
+        assert_eq!(report.deleted, 2);
+        for e in &report.entries {
+            assert_eq!(e.category, StripCategory::BuildScriptBinary);
+        }
+        assert!(!bin_unix.exists());
+        assert!(!bin_win.exists());
+        assert!(output.exists(), "non-matching siblings stay");
+    }
+
+    #[test]
+    fn examples_doc_tests_dropped() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let ex = target.join("debug/examples");
+        let doc = target.join("debug/doc");
+        let tests = target.join("debug/tests");
+        let deps = target.join("debug/deps");
+        touch_dir(&ex);
+        touch_dir(&doc);
+        touch_dir(&tests);
+        touch_dir(&deps);
+        write_bytes(&ex.join("a"), b"x");
+        write_bytes(&doc.join("index.html"), b"x");
+        write_bytes(&tests.join("a"), b"x");
+        write_bytes(&deps.join("libfoo-aaaaaaaaaaaaa.rlib"), b"x");
+
+        let opts = StripTargetOptions {
+            dry_run: false,
+            strip_examples_doc_tests: true,
+            ..StripTargetOptions::none(target)
+        };
+        let report = strip_target(&opts).unwrap();
+        assert_eq!(report.deleted, 3);
+        for e in &report.entries {
+            assert_eq!(e.category, StripCategory::ExamplesDocTests);
+        }
+        assert!(!ex.exists());
+        assert!(!doc.exists());
+        assert!(!tests.exists());
+        assert!(deps.exists(), "deps/ must survive examples/doc/tests strip");
+    }
+
+    #[test]
+    fn debug_sidecars_dropped() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let deps = target.join("debug/deps");
+        touch_dir(&deps);
+        let rlib = deps.join("libfoo-aaaaaaaaaaaaa.rlib");
+        let pdb = deps.join("libfoo-aaaaaaaaaaaaa.pdb");
+        let dwo = deps.join("libfoo-aaaaaaaaaaaaa.dwo");
+        let dsym = deps.join("libfoo-aaaaaaaaaaaaa.dSYM");
+        write_bytes(&rlib, b"keep");
+        write_bytes(&pdb, b"drop pdb");
+        write_bytes(&dwo, b"drop dwo");
+        touch_dir(&dsym);
+        write_bytes(&dsym.join("Contents/Info.plist"), b"...");
+
+        let opts = StripTargetOptions {
+            dry_run: false,
+            strip_debug_sidecars: true,
+            ..StripTargetOptions::none(target)
+        };
+        let report = strip_target(&opts).unwrap();
+        assert_eq!(report.deleted, 3);
+        for e in &report.entries {
+            assert_eq!(e.category, StripCategory::DebugSidecar);
+        }
+        assert!(rlib.exists(), ".rlib must survive sidecar strip");
+        assert!(!pdb.exists());
+        assert!(!dwo.exists());
+        assert!(!dsym.exists());
+    }
+
+    #[test]
+    fn dry_run_reports_but_does_not_delete() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let large = target.join("debug/build/foo-aaaa/stderr");
+        write_bytes(&large, &vec![0u8; 200 * 1024]);
+        let opts = StripTargetOptions {
+            dry_run: true,
+            strip_large_stderr: true,
+            ..StripTargetOptions::none(target)
+        };
+        let report = strip_target(&opts).unwrap();
+        assert_eq!(report.deleted, 1);
+        assert!(large.exists(), "dry-run preserves files");
+    }
+
+    #[test]
+    fn none_opts_is_no_op_even_with_garbage_target() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let large = target.join("debug/build/foo-aaaa/stderr");
+        write_bytes(&large, &vec![0u8; 200 * 1024]);
+        let ex = target.join("debug/examples");
+        touch_dir(&ex);
+        write_bytes(&ex.join("a"), b"x");
+
+        let opts = StripTargetOptions {
+            dry_run: false,
+            ..StripTargetOptions::none(target)
+        };
+        let report = strip_target(&opts).unwrap();
+        assert_eq!(report.deleted, 0);
+        assert!(large.exists());
+        assert!(ex.exists());
+    }
+
+    #[test]
+    fn second_run_is_idempotent() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let large = target.join("debug/build/foo-aaaa/stderr");
+        write_bytes(&large, &vec![0u8; 200 * 1024]);
+
+        let opts = StripTargetOptions {
+            dry_run: false,
+            strip_large_stderr: true,
+            ..StripTargetOptions::none(target.clone())
+        };
+        let first = strip_target(&opts).unwrap();
+        assert_eq!(first.deleted, 1);
+        let second = strip_target(&opts).unwrap();
+        assert_eq!(second.deleted, 0, "second run finds nothing");
+    }
+
+    #[test]
+    fn rejects_non_directory_target() {
+        let temp = tempdir().unwrap();
+        let file = temp.path().join("not-a-dir");
+        write_bytes(&file, b"x");
+        let opts = StripTargetOptions::all(file);
+        let err = strip_target(&opts).expect_err("file path must error");
+        assert!(format!("{err}").contains("not-a-dir"));
+    }
+
+    #[test]
+    fn build_script_build_suffix_variants() {
+        assert!(is_build_script_binary("build-script-build"));
+        assert!(is_build_script_binary("build-script-build.exe"));
+        assert!(is_build_script_binary("build-script-build.pdb"));
+        assert!(is_build_script_binary("build-script-build-suffix.exe"));
+        assert!(!is_build_script_binary("build-script-other"));
+        assert!(!is_build_script_binary("invoked.timestamp"));
+    }
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -654,6 +654,55 @@ enum CacheSubcommand {
         #[arg(long)]
         json: bool,
     },
+    /// Trim cargo-recreatable noise from a `target/` directory before
+    /// it is archived for CI cache transport. Composes:
+    ///
+    ///   * orphan hash-sibling pruning (same as `cache prune-target`),
+    ///   * strip of build-script logspam, recreatable binaries, and
+    ///     debug sidecars (CI profile only),
+    ///   * removal of `target/<profile>/incremental/` (CI profile only).
+    ///
+    /// The CI profile is intended for `setup-soldr` to call before its
+    /// `actions/cache@v4` save step so the rehydrate ships dramatically
+    /// fewer bytes. Local profile only runs the hash-sibling prune.
+    ///
+    /// Dry-run by default. Pass `--force` to actually delete entries.
+    /// Refuses to run when a `.cargo-lock` is present (active build).
+    #[command(name = "trim-target")]
+    TrimTarget {
+        /// Path to the cargo `target/` directory to trim.
+        path: std::path::PathBuf,
+        /// Trim profile selector. `local` (default): only orphan
+        /// hash-sibling prune. `ci`: also strip recreatable noise +
+        /// remove incremental/.
+        #[arg(long, value_enum, default_value_t = TrimProfileArg::Local)]
+        profile: TrimProfileArg,
+        /// Explicit dry-run mode (this is the default).
+        #[arg(long, conflicts_with_all = ["force", "no_dry_run"])]
+        dry_run: bool,
+        /// Negate the dry-run default and actually delete entries.
+        #[arg(long = "no-dry-run", conflicts_with = "dry_run")]
+        no_dry_run: bool,
+        /// Actually delete entries. Equivalent to `--no-dry-run`.
+        #[arg(long, conflicts_with = "dry_run")]
+        force: bool,
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Trim profile presets for `cache trim-target`. Local keeps everything
+/// a developer might want to inspect (incremental/, examples/, large
+/// build-script stderr); CI strips it all in service of a smaller
+/// archive.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum TrimProfileArg {
+    /// Lightweight: only prune orphan hash siblings.
+    Local,
+    /// Aggressive: prune + strip recreatable noise + drop
+    /// `incremental/`.
+    Ci,
 }
 
 #[tokio::main]
@@ -871,6 +920,27 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 // is the documented default so we accept it explicitly.
                 let _ = dry_run;
                 cache::run_cache_prune_target_command(path, effective_dry_run, prune_json || json)?;
+            }
+            Some(CacheSubcommand::TrimTarget {
+                path,
+                profile,
+                dry_run,
+                no_dry_run,
+                force,
+                json: trim_json,
+            }) => {
+                let effective_dry_run = !(force || no_dry_run);
+                let _ = dry_run;
+                let trim_profile = match profile {
+                    TrimProfileArg::Local => cache::TrimProfile::Local,
+                    TrimProfileArg::Ci => cache::TrimProfile::Ci,
+                };
+                cache::run_cache_trim_target_command(
+                    path,
+                    trim_profile,
+                    effective_dry_run,
+                    trim_json || json,
+                )?;
             }
             None => {
                 let output = cache::collect_cache_output()?;

--- a/crates/soldr-cli/tests/cli_cache_trim.rs
+++ b/crates/soldr-cli/tests/cli_cache_trim.rs
@@ -1,0 +1,245 @@
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use serde_json::Value;
+use std::fs;
+use std::process::Command;
+
+fn write_bytes(path: &std::path::Path, bytes: &[u8]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(path, bytes).expect("write file");
+}
+
+fn touch_dir(path: &std::path::Path) {
+    fs::create_dir_all(path).expect("create dir");
+}
+
+#[test]
+fn cache_trim_target_ci_profile_strips_recreatable_noise() {
+    let cache_root = unique_temp_dir("cache-trim-target-ci");
+    let target = cache_root.join("target");
+
+    // Recreatable noise the CI profile should drop.
+    let large_stderr = target.join("debug/build/ring-aaaaaaaaaaaaa/stderr");
+    let build_script = target.join("debug/build/foo-bbbbbbbbbbbbb/build-script-build");
+    let incremental_dir = target.join("debug/incremental/foo-ccccccccccccc");
+    let examples_dir = target.join("debug/examples");
+
+    write_bytes(&large_stderr, &vec![0u8; 200 * 1024]);
+    write_bytes(&build_script, b"binary");
+    touch_dir(&incremental_dir);
+    write_bytes(&incremental_dir.join("inc.bin"), b"x");
+    touch_dir(&examples_dir);
+    write_bytes(&examples_dir.join("ex1"), b"x");
+
+    // Allowlisted bookkeeping that must survive (bit-exact).
+    let rustc_info = target.join(".rustc_info.json");
+    let cachedir_tag = target.join("CACHEDIR.TAG");
+    write_bytes(&rustc_info, b"{}");
+    write_bytes(&cachedir_tag, b"Signature: cachedir tag\n");
+
+    // Small stderr stays.
+    let small_stderr = target.join("debug/build/foo-bbbbbbbbbbbbb/stderr");
+    write_bytes(&small_stderr, b"no errors\n");
+
+    // Sibling that should NOT be touched.
+    let real_artifact = target.join("debug/deps/libreal-eeeeeeeeeeeee.rlib");
+    write_bytes(&real_artifact, b"keep me");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "trim-target"])
+        .arg(&target)
+        .args(["--profile", "ci", "--force", "--json"])
+        .output()
+        .expect("failed to run soldr cache trim-target --profile=ci --force --json");
+
+    assert!(
+        output.status.success(),
+        "cache trim-target failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .expect("cache trim-target --json must produce parseable JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "cache trim-target");
+    assert_eq!(json["profile"], "ci");
+    assert_eq!(json["dry_run"], false);
+    assert_eq!(json["incremental_removed_count"], 1);
+    // strip: large_stderr + build_script + examples = 3
+    assert_eq!(json["strip_deleted"], 3);
+    assert!(json["total_reclaimed_bytes"].as_u64().unwrap() > 0);
+
+    // Noise gone.
+    assert!(!large_stderr.exists(), "large stderr must be deleted");
+    assert!(
+        !build_script.exists(),
+        "build-script binary must be deleted"
+    );
+    assert!(
+        !target.join("debug/incremental").exists(),
+        "incremental/ must be deleted"
+    );
+    assert!(!examples_dir.exists(), "examples/ must be deleted");
+
+    // Bookkeeping survives bit-exact.
+    assert!(rustc_info.exists(), ".rustc_info.json must survive");
+    assert_eq!(
+        fs::read(&rustc_info).unwrap(),
+        b"{}",
+        ".rustc_info.json must be bit-exact"
+    );
+    assert!(cachedir_tag.exists(), "CACHEDIR.TAG must survive");
+
+    // Small stderr + real artifact untouched.
+    assert!(small_stderr.exists(), "small stderr must survive");
+    assert!(real_artifact.exists(), ".rlib in deps/ must survive");
+}
+
+#[test]
+fn cache_trim_target_local_profile_only_prunes_hash_siblings() {
+    let cache_root = unique_temp_dir("cache-trim-target-local");
+    let target = cache_root.join("target");
+    let parent = target.join("debug/deps");
+    fs::create_dir_all(&parent).expect("create deps dir");
+    let older = parent.join("libfoo-aaaaaaaaaaaaa.rlib");
+    let newer = parent.join("libfoo-bbbbbbbbbbbbb.rlib");
+    fs::write(&older, b"older").unwrap();
+    fs::write(&newer, b"newer-content").unwrap();
+
+    let older_when =
+        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    let newer_when =
+        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_500);
+    fs::File::options()
+        .write(true)
+        .open(&older)
+        .unwrap()
+        .set_modified(older_when)
+        .unwrap();
+    fs::File::options()
+        .write(true)
+        .open(&newer)
+        .unwrap()
+        .set_modified(newer_when)
+        .unwrap();
+
+    // Noise that the LOCAL profile must NOT touch.
+    let large_stderr = target.join("debug/build/ring-aaaaaaaaaaaaa/stderr");
+    let incremental_dir = target.join("debug/incremental/foo-ccccccccccccc");
+    write_bytes(&large_stderr, &vec![0u8; 200 * 1024]);
+    touch_dir(&incremental_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "trim-target"])
+        .arg(&target)
+        .args(["--profile", "local", "--force", "--json"])
+        .output()
+        .expect("failed to run soldr cache trim-target --profile=local --force --json");
+
+    assert!(
+        output.status.success(),
+        "cache trim-target failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse json");
+    assert_eq!(json["profile"], "local");
+    assert_eq!(json["incremental_removed_count"], 0);
+    assert_eq!(json["strip_deleted"], 0);
+    // prune still ran: scanned 3 (libfoo-aaa, libfoo-bbb, foo-ccc), but
+    // libfoo-* are bucketed together (delete 1), foo-ccc is alone.
+    assert!(json["prune_scanned"].as_u64().unwrap() >= 2);
+    assert!(json["prune_deleted"].as_u64().unwrap() >= 1);
+
+    // Local profile preserves noise.
+    assert!(
+        large_stderr.exists(),
+        "local profile must keep large stderr"
+    );
+    assert!(
+        incremental_dir.exists(),
+        "local profile must keep incremental/"
+    );
+
+    // Newest sibling survives.
+    assert!(newer.exists(), "newer sibling must survive");
+    assert!(!older.exists(), "older sibling must be pruned");
+}
+
+#[test]
+fn cache_trim_target_dry_run_does_not_modify_disk() {
+    let cache_root = unique_temp_dir("cache-trim-target-dry");
+    let target = cache_root.join("target");
+    let large_stderr = target.join("debug/build/ring-aaaaaaaaaaaaa/stderr");
+    let incremental_dir = target.join("debug/incremental/foo-ccccccccccccc");
+    write_bytes(&large_stderr, &vec![0u8; 200 * 1024]);
+    touch_dir(&incremental_dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "trim-target"])
+        .arg(&target)
+        .args(["--profile", "ci", "--dry-run", "--json"])
+        .output()
+        .expect("failed to run soldr cache trim-target --profile=ci --dry-run --json");
+
+    assert!(
+        output.status.success(),
+        "cache trim-target failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse json");
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["incremental_removed_count"], 1);
+    assert!(json["strip_deleted"].as_u64().unwrap() >= 1);
+
+    // Dry-run preserves everything.
+    assert!(large_stderr.exists(), "dry-run must preserve large stderr");
+    assert!(
+        incremental_dir.exists(),
+        "dry-run must preserve incremental/"
+    );
+}
+
+#[test]
+fn cache_trim_target_refuses_when_cargo_lock_present() {
+    let cache_root = unique_temp_dir("cache-trim-target-locked");
+    let target = cache_root.join("target");
+    let parent = target.join("debug/deps");
+    fs::create_dir_all(&parent).expect("create deps");
+    let rlib = parent.join("libfoo-aaaaaaaaaaaaa.rlib");
+    fs::write(&rlib, b"x").unwrap();
+    fs::write(target.join(".cargo-lock"), b"").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cache", "trim-target"])
+        .arg(&target)
+        .args(["--profile", "ci", "--force"])
+        .output()
+        .expect("failed to run soldr cache trim-target with lock");
+
+    assert!(
+        !output.status.success(),
+        "cache trim-target must refuse when .cargo-lock is present"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(".cargo-lock") || stderr.contains("active build"),
+        "stderr must mention .cargo-lock / active build: {stderr}"
+    );
+
+    // Nothing on disk should have been touched.
+    assert!(rlib.exists(), "lock refusal must not delete anything");
+    assert!(
+        target.join(".cargo-lock").exists(),
+        "lock file must survive"
+    );
+}


### PR DESCRIPTION
## Why

Cargo's `target/` directory grows unbounded across builds:
- Old hash-suffixed siblings (`libfoo-OLDHASH.rlib` and `libfoo-NEWHASH.rlib` both stay when a dep version changes — cargo never reclaims).
- `target/<profile>/incremental/` is multi-GB and contributes ~0% hit rate against the next CI job.
- Build-script `stderr` files (ring, bindgen, aws-lc-sys) can be tens of MB each.

`setup-soldr` ships `target/` between jobs via `actions/cache@v4`. The user-visible symptom: rehydrate gets slower run-over-run, because nothing trims the cache before it's tarred up. Per the planning report at `look-at-soldr-repo-kind-mochi.md`:

> The target archive in CI is too fat → rehydrate is slow → next build is slow.

This PR is the prevention pass — trim **early** in the workflow so garbage doesn't accumulate in the first place.

## What changes

New subcommand `soldr cache trim-target <path> --profile=ci|local [--dry-run|--force] [--json]`.

The CI profile composes five themes from the plan (1, 2, 3, 5, 9), in order:

1. **Refuse when a `.cargo-lock` is present** (active build sentinel; reused from `prune_target`'s existing guard).
2. **Remove `target/<profile>/incremental/`** wholesale. rustc resets the incremental session on each fresh runner; per-process cache is wasted on CI.
3. **Strip recreatable noise** via a new `cache_lib::strip_target` module:
   - build-script `stderr` > 128 KiB
   - `build-script-build*` binaries
   - `target/<profile>/{examples,doc,tests}/`
   - `.dwo` / `.pdb` / `.dSYM/` debug sidecars under `deps/`
4. **Prune orphan hash siblings** using the existing `prune_target` (newest-mtime per `(parent_dir, prefix)` bucket).

Local profile only runs step 4 — a developer usually wants to keep incremental/, examples/, and small build-script logs.

New `prune_target` consts document the allowlist:
- `MUST_KEEP_BIT_EXACT`: `CACHEDIR.TAG`, `.rustc_info.json`, fingerprint internals
- `NEVER_ARCHIVE`: `.cargo-lock`
- `INCREMENTAL_SUBDIR`: `incremental` (so future trim/save paths share the policy)

## Why this and not auto-GC

`auto_gc.rs` already exists, but it deletes WHOLE registered workspace `target/` directories under disk pressure. That's the right tool for a developer's host with 41 forgotten target/ dirs. It is the WRONG tool on a GH runner — there's only one `target/` per job, and you definitely don't want it deleted before the archive step.

This PR is the complement: trim files **inside** one `target/` to prevent garbage accumulation. The plan originally bundled an auto-GC-T2-pre-save step (Theme 8); I dropped it after confirming T2 semantics aren't what the plan author thought. Auto-GC should be **disabled** on GH runners; trim-target is the CI tool.

## Honest scope

This PR shrinks the **archive** (upload/download bytes). It does **NOT** yet translate to compile-time savings because zccache reports 0% hits on warm runs even after a successful cache restore. That's tracked in [zackees/zccache#353](https://github.com/zackees/zccache/issues/353) (a follow-up to the now-closed #320). The two workstreams are independent — ship both in parallel.

## Verification

- **11 new unit tests** in `crates/soldr-cli/src/cache_lib/strip_target.rs` — each rule, dry-run, idempotency, exact-threshold edge case, non-directory rejection, `none` opts as no-op.
- **4 new integration tests** in `crates/soldr-cli/tests/cli_cache_trim.rs` — CI profile end-to-end, local profile minimal touch, dry-run preservation, `.cargo-lock` refusal.
- `soldr cargo build -p soldr-cli` — clean (23 pre-existing warnings).
- `soldr cargo clippy --workspace` — clean (29 pre-existing warnings; no errors). Note: `-D warnings` would fail on pre-existing `core.rs:631-632` doc-lazy-continuation lints, reproduced on `origin/main`.
- `soldr cargo fmt --all -- --check` — clean.
- Existing tests: 19 `cli_cache` + 1 `cli_cache_prune` + 76 `cache_lib` unit tests still pass.

## Follow-ups (NOT in this PR)

- `setup-soldr` should call `soldr cache trim-target --profile=ci --force` before its build-cache `actions/cache@v4` save step (separate PR in `zackees/setup-soldr`).
- Per the plan, fingerprint-authoritative pruning (Theme 2 / PR 3 in the plan) layers on top of this PR as an opt-in flag, after CI burn-in.
- Perf-matrix row measuring archive size + restore time before/after this trim is recommended as a follow-up. Per `PERF.md` branch-naming, that would land on `perf/linux-trim-<scen>` so only the right cells fire.
- The compile-time payoff is gated on [zccache#353](https://github.com/zackees/zccache/issues/353).

## Plan reference

`look-at-soldr-repo-kind-mochi.md` — PR 1 ("pre-save trim v1") in the trimming plan, with Theme 8 dropped per the rationale above.

Generated with [Claude Code](https://claude.com/claude-code)
