### PR TITLE
feat(save): --mtimes-only — promote preserve-source-mtimes into soldr CLI

### DIFF
--- a/crates/soldr-cli/src/cache_lib/save.rs
+++ b/crates/soldr-cli/src/cache_lib/save.rs
@@ -259,10 +259,12 @@ fn rel_to_posix(rel: &Path) -> String {
 #[derive(Debug, Clone)]
 pub struct SaveOptions<'a> {
     /// Workspace root to snapshot source mtimes from. `None` skips the
-    /// source-file portion entirely (cache-only archive).
+    /// source-file portion entirely (cache-only archive). Required when
+    /// `mtimes_only` is `true`.
     pub workspace: Option<&'a Path>,
-    /// Cache directory whose contents will be bundled.
-    pub cache_dir: &'a Path,
+    /// Cache directory whose contents will be bundled. `None` is only
+    /// permitted when `mtimes_only` is `true` (manifest-only archive).
+    pub cache_dir: Option<&'a Path>,
     /// Destination archive path.
     pub out: &'a Path,
     /// zstd compression level (1..=22). 3 is a good default; anything
@@ -271,6 +273,14 @@ pub struct SaveOptions<'a> {
     /// Number of rayon threads for the hash + tar walk. `None` uses the
     /// global rayon pool (`num_cpus`).
     pub threads: Option<usize>,
+    /// Produce a manifest-only archive: skip the cache-dir walk and
+    /// write a tar.zst whose sole entry is `SOLDR_MANIFEST.pb`. Requires
+    /// `workspace` to be `Some`. The intent is a standalone source-file
+    /// mtime snapshot that setup-soldr (or any other CI wrapper) can
+    /// produce + restore without bundling an artifact cache. The on-disk
+    /// shape is otherwise byte-identical to a normal save, so the same
+    /// `load()` path consumes it.
+    pub mtimes_only: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -281,15 +291,53 @@ pub struct SaveReport {
     pub elapsed_ms: u64,
 }
 
+/// Validate save inputs:
+/// * When `mtimes_only`, `workspace` MUST be `Some` and `cache_dir`
+///   MUST be `None` (passing both would silently ignore one of them).
+/// * Otherwise `cache_dir` MUST be `Some` (cache-only archives are the
+///   historical baseline behavior; an archive with neither a cache nor a
+///   workspace is empty and almost certainly a CLI mistake).
+fn validate_save_inputs(opts: &SaveOptions<'_>) -> Result<()> {
+    if opts.mtimes_only {
+        if opts.workspace.is_none() {
+            return Err(SaveLoadError::BareIo(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "soldr save --mtimes-only requires a --workspace to snapshot",
+            )));
+        }
+        if opts.cache_dir.is_some() {
+            return Err(SaveLoadError::BareIo(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "soldr save --mtimes-only must NOT be combined with --cache-dir",
+            )));
+        }
+    } else if opts.cache_dir.is_none() {
+        return Err(SaveLoadError::BareIo(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "soldr save requires either --cache-dir or --mtimes-only",
+        )));
+    }
+    Ok(())
+}
+
 /// Bundle `cache_dir` + a workspace-source-mtime snapshot into a single
 /// `.tar.zst` at `out`.
+///
+/// When [`SaveOptions::mtimes_only`] is `true`, the cache walk is skipped
+/// entirely and the archive contains only `SOLDR_MANIFEST.pb`. That mode
+/// requires `workspace` to be `Some` — there is nothing else to snapshot.
 pub fn save(opts: &SaveOptions<'_>) -> Result<SaveReport> {
+    validate_save_inputs(opts)?;
     let start = std::time::Instant::now();
 
     // Build the manifest (parallel hash if a workspace is provided)
     // AND enumerate cache files concurrently. The two walks touch
     // disjoint directory trees, so running them in parallel halves
     // page-cache-cold first-walk latency on big workspaces.
+    //
+    // In `mtimes_only` mode the cache half is a no-op closure — we
+    // keep the join shape so the source walk still benefits from the
+    // shared rayon pool.
     let pool = build_pool(opts.threads)?;
     let (source_result, cache_files_paths): (Result<Vec<SourceFile>>, Result<Vec<PathBuf>>) = pool
         .install(|| {
@@ -315,10 +363,12 @@ pub fn save(opts: &SaveOptions<'_>) -> Result<SaveReport> {
                         .collect()
                 },
                 || -> Result<Vec<PathBuf>> {
-                    if opts.cache_dir.exists() {
-                        walk_cache_files(opts.cache_dir, opts.threads)
-                    } else {
-                        Ok(Vec::new())
+                    if opts.mtimes_only {
+                        return Ok(Vec::new());
+                    }
+                    match opts.cache_dir {
+                        Some(dir) if dir.exists() => walk_cache_files(dir, opts.threads),
+                        _ => Ok(Vec::new()),
                     }
                 },
             )
@@ -336,7 +386,16 @@ pub fn save(opts: &SaveOptions<'_>) -> Result<SaveReport> {
             .workspace
             .map(|p| p.display().to_string())
             .unwrap_or_default(),
-        cache_dir_name: CACHE_DIR_NAME.into(),
+        // Empty cache_dir_name signals an mtimes-only archive to any
+        // future reader that wants to short-circuit the cache-extract
+        // path without re-parsing the SaveOptions. The existing reader
+        // tolerates either value because it strips the CACHE_DIR_NAME
+        // prefix only when a `cache/...` entry shows up in the tar.
+        cache_dir_name: if opts.mtimes_only {
+            String::new()
+        } else {
+            CACHE_DIR_NAME.into()
+        },
         source_file_count: manifest_files.len() as u64,
         cache_file_count: 0,
         files: manifest_files,
@@ -393,10 +452,16 @@ pub fn save(opts: &SaveOptions<'_>) -> Result<SaveReport> {
         // zstd encoder, which does the heavy CPU work in its own
         // thread pool.
         if !cache_files_paths.is_empty() {
+            // cache_files_paths is non-empty only when we enumerated a
+            // real cache_dir above (i.e. not the mtimes_only branch),
+            // so this expect() is unreachable in practice.
+            let cache_dir = opts
+                .cache_dir
+                .expect("cache_files_paths non-empty implies cache_dir was set");
             cache_files = cache_files_paths.len() as u64;
             for abs in &cache_files_paths {
                 let rel = abs
-                    .strip_prefix(opts.cache_dir)
+                    .strip_prefix(cache_dir)
                     .map_err(|_| SaveLoadError::BadArchivePath(abs.display().to_string()))?;
                 let mut archive_path = PathBuf::from(CACHE_DIR_NAME);
                 archive_path.push(rel);
@@ -438,11 +503,21 @@ pub fn save(opts: &SaveOptions<'_>) -> Result<SaveReport> {
 #[derive(Debug, Clone)]
 pub struct LoadOptions<'a> {
     pub archive: &'a Path,
-    pub cache_dir: &'a Path,
+    /// Destination cache directory. `None` is only permitted when
+    /// `mtimes_only` is `true`; in that mode any `cache/...` tar entry
+    /// is treated as a hard error since the archive should not have
+    /// contained one.
+    pub cache_dir: Option<&'a Path>,
     /// Workspace whose source-file mtimes should be replayed. `None`
-    /// skips the mtime-replay step (cache-only load).
+    /// skips the mtime-replay step (cache-only load). Required when
+    /// `mtimes_only` is `true`.
     pub workspace: Option<&'a Path>,
     pub threads: Option<usize>,
+    /// Treat the archive as a manifest-only snapshot. Skip the cache
+    /// extraction step (the archive should not contain any `cache/...`
+    /// entries; one is an error). Requires `workspace` to be `Some` —
+    /// otherwise the load is a no-op.
+    pub mtimes_only: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -456,6 +531,34 @@ pub struct LoadReport {
     pub elapsed_ms: u64,
 }
 
+/// Validate load inputs:
+/// * When `mtimes_only`, `workspace` MUST be `Some` and `cache_dir`
+///   MUST be `None`. Mixing the two is a CLI mistake.
+/// * Otherwise `cache_dir` MUST be `Some` (the load has to know where
+///   to extract cache entries).
+fn validate_load_inputs(opts: &LoadOptions<'_>) -> Result<()> {
+    if opts.mtimes_only {
+        if opts.workspace.is_none() {
+            return Err(SaveLoadError::BareIo(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "soldr load --mtimes-only requires a --workspace to replay into",
+            )));
+        }
+        if opts.cache_dir.is_some() {
+            return Err(SaveLoadError::BareIo(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "soldr load --mtimes-only must NOT be combined with --cache-dir",
+            )));
+        }
+    } else if opts.cache_dir.is_none() {
+        return Err(SaveLoadError::BareIo(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "soldr load requires either --cache-dir or --mtimes-only",
+        )));
+    }
+    Ok(())
+}
+
 /// Decompress + restore an archive produced by [`save`].
 ///
 /// The implementation pipelines two operations:
@@ -465,10 +568,17 @@ pub struct LoadReport {
 ///      archive `save` produces), hand the mtime-replay work off to
 ///      the thread pool so it runs concurrently with the remaining
 ///      cache-file extraction.
+///
+/// When [`LoadOptions::mtimes_only`] is `true`, only the manifest entry
+/// is consumed; any `cache/...` entry in the archive is rejected as a
+/// hard error (the producer should not have included one).
 pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
+    validate_load_inputs(opts)?;
     let start = std::time::Instant::now();
 
-    std::fs::create_dir_all(opts.cache_dir).map_err(|e| io(opts.cache_dir, e))?;
+    if let Some(dir) = opts.cache_dir {
+        std::fs::create_dir_all(dir).map_err(|e| io(dir, e))?;
+    }
 
     let in_file = File::open(opts.archive).map_err(|e| io(opts.archive, e))?;
     let buf = BufReader::with_capacity(16 * 1024 * 1024, in_file);
@@ -515,14 +625,25 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
             continue;
         }
 
-        // Expect everything else under `cache/`.
+        // Expect everything else under `cache/`. In mtimes_only mode
+        // there should be no such entries — a producer-side bug if
+        // there is one, so reject it loudly.
         let stripped = match path.strip_prefix(CACHE_DIR_NAME) {
             Ok(p) => p.to_path_buf(),
             Err(_) => {
                 return Err(SaveLoadError::BadArchivePath(path.display().to_string()));
             }
         };
-        let dest = opts.cache_dir.join(&stripped);
+        if opts.mtimes_only {
+            return Err(SaveLoadError::BadArchivePath(format!(
+                "mtimes_only load refuses cache entry: {}",
+                path.display()
+            )));
+        }
+        // cache_dir is guaranteed Some by validate_load_inputs when we
+        // reach this branch.
+        let cache_dir = opts.cache_dir.expect("cache_dir checked at entry");
+        let dest = cache_dir.join(&stripped);
         if entry.header().entry_type() == tar::EntryType::Directory {
             std::fs::create_dir_all(&dest).map_err(|e| io(&dest, e))?;
             continue;

--- a/crates/soldr-cli/src/save_load.rs
+++ b/crates/soldr-cli/src/save_load.rs
@@ -15,13 +15,15 @@ use clap::Args;
 
 #[derive(Debug, Args)]
 pub struct SaveArgs {
-    /// Build-cache directory whose contents should be bundled.
+    /// Build-cache directory whose contents should be bundled. Omit
+    /// when `--mtimes-only` is set (manifest-only archive).
     #[arg(long, value_name = "DIR")]
-    pub cache_dir: PathBuf,
+    pub cache_dir: Option<PathBuf>,
 
     /// Workspace whose tracked source files should be snapshotted.
     /// Omit to produce a cache-only archive (no mtime snapshot — load
-    /// will still restore the cache but skip the replay).
+    /// will still restore the cache but skip the replay). Required when
+    /// `--mtimes-only` is set.
     #[arg(long, value_name = "DIR")]
     pub workspace: Option<PathBuf>,
 
@@ -40,9 +42,17 @@ pub struct SaveArgs {
     pub threads: Option<usize>,
 
     /// Emit a machine-readable JSON line summarising the save. Stable
-    /// schema: `{"source_files","cache_files","archive_bytes","elapsed_ms"}`.
+    /// schema: `{"source_files","cache_files","archive_bytes","elapsed_ms","mtimes_only"}`.
     #[arg(long)]
     pub json: bool,
+
+    /// Produce a manifest-only archive — only the source-file mtime
+    /// snapshot, no cache payload. Requires `--workspace`; mutually
+    /// exclusive with `--cache-dir`. This is the setup-soldr
+    /// `preserve-source-mtimes` feature, promoted into the soldr CLI
+    /// so any wrapper can produce the same sidecar.
+    #[arg(long = "mtimes-only")]
+    pub mtimes_only: bool,
 }
 
 #[derive(Debug, Args)]
@@ -51,12 +61,13 @@ pub struct LoadArgs {
     #[arg(long, value_name = "FILE")]
     pub archive: PathBuf,
 
-    /// Destination cache directory. Created if it doesn't exist.
+    /// Destination cache directory. Created if it doesn't exist. Omit
+    /// when `--mtimes-only` is set.
     #[arg(long, value_name = "DIR")]
-    pub cache_dir: PathBuf,
+    pub cache_dir: Option<PathBuf>,
 
     /// Workspace where source-file mtimes should be replayed. Omit
-    /// to restore the cache only.
+    /// to restore the cache only. Required when `--mtimes-only` is set.
     #[arg(long, value_name = "DIR")]
     pub workspace: Option<PathBuf>,
 
@@ -69,15 +80,22 @@ pub struct LoadArgs {
     /// schema: see `soldr save --json`'s counterpart fields.
     #[arg(long)]
     pub json: bool,
+
+    /// Treat the archive as a manifest-only snapshot — apply mtimes
+    /// only, refuse to extract any cache entries. Requires
+    /// `--workspace`; mutually exclusive with `--cache-dir`.
+    #[arg(long = "mtimes-only")]
+    pub mtimes_only: bool,
 }
 
 pub fn run_save(args: SaveArgs) -> i32 {
     let opts = SaveOptions {
         workspace: args.workspace.as_deref(),
-        cache_dir: &args.cache_dir,
+        cache_dir: args.cache_dir.as_deref(),
         out: &args.out,
         zstd_level: args.zstd_level,
         threads: args.threads,
+        mtimes_only: args.mtimes_only,
     };
     let report = match save(&opts) {
         Ok(r) => r,
@@ -88,16 +106,21 @@ pub fn run_save(args: SaveArgs) -> i32 {
     };
     if args.json {
         println!(
-            "{{\"source_files\":{},\"cache_files\":{},\"archive_bytes\":{},\"elapsed_ms\":{}}}",
-            report.source_files, report.cache_files, report.archive_bytes, report.elapsed_ms,
-        );
-    } else {
-        println!(
-            "soldr save: source_files={} cache_files={} archive_bytes={} elapsed_ms={} out={}",
+            "{{\"source_files\":{},\"cache_files\":{},\"archive_bytes\":{},\"elapsed_ms\":{},\"mtimes_only\":{}}}",
             report.source_files,
             report.cache_files,
             report.archive_bytes,
             report.elapsed_ms,
+            args.mtimes_only,
+        );
+    } else {
+        println!(
+            "soldr save: source_files={} cache_files={} archive_bytes={} elapsed_ms={} mtimes_only={} out={}",
+            report.source_files,
+            report.cache_files,
+            report.archive_bytes,
+            report.elapsed_ms,
+            args.mtimes_only,
             args.out.display(),
         );
     }
@@ -107,9 +130,10 @@ pub fn run_save(args: SaveArgs) -> i32 {
 pub fn run_load(args: LoadArgs) -> i32 {
     let opts = LoadOptions {
         archive: &args.archive,
-        cache_dir: &args.cache_dir,
+        cache_dir: args.cache_dir.as_deref(),
         workspace: args.workspace.as_deref(),
         threads: args.threads,
+        mtimes_only: args.mtimes_only,
     };
     let report = match load(&opts) {
         Ok(r) => r,

--- a/crates/soldr-cli/tests/save_bench.rs
+++ b/crates/soldr-cli/tests/save_bench.rs
@@ -80,10 +80,11 @@ fn perf_roundtrip_realistic() {
     let t0 = Instant::now();
     let sreport = save(&SaveOptions {
         workspace: Some(&ws),
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         out: &archive,
         zstd_level: DEFAULT_ZSTD_LEVEL,
         threads: None,
+        mtimes_only: false,
     })
     .expect("save ok");
     let save_elapsed = t0.elapsed();
@@ -98,9 +99,10 @@ fn perf_roundtrip_realistic() {
     let t0 = Instant::now();
     let lreport = load(&LoadOptions {
         archive: &archive,
-        cache_dir: &cache_restored,
+        cache_dir: Some(&cache_restored),
         workspace: Some(&ws),
         threads: None,
+        mtimes_only: false,
     })
     .expect("load ok");
     let load_elapsed = t0.elapsed();

--- a/crates/soldr-cli/tests/save_roundtrip.rs
+++ b/crates/soldr-cli/tests/save_roundtrip.rs
@@ -75,10 +75,11 @@ fn roundtrip_basic_mtime_restoration() {
 
     let report = save(&SaveOptions {
         workspace: Some(&ws),
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         out: &archive,
         zstd_level: DEFAULT_ZSTD_LEVEL,
         threads: None,
+        mtimes_only: false,
     })
     .expect("save ok");
     assert!(
@@ -103,9 +104,10 @@ fn roundtrip_basic_mtime_restoration() {
 
     let lreport = load(&LoadOptions {
         archive: &archive,
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         workspace: Some(&ws),
         threads: None,
+        mtimes_only: false,
     })
     .expect("load ok");
 
@@ -145,10 +147,11 @@ fn load_skips_content_changed_files() {
     let (_g, ws, cache, archive) = fixture();
     save(&SaveOptions {
         workspace: Some(&ws),
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         out: &archive,
         zstd_level: DEFAULT_ZSTD_LEVEL,
         threads: None,
+        mtimes_only: false,
     })
     .expect("save ok");
 
@@ -166,9 +169,10 @@ fn load_skips_content_changed_files() {
 
     let lreport = load(&LoadOptions {
         archive: &archive,
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         workspace: Some(&ws),
         threads: None,
+        mtimes_only: false,
     })
     .expect("load ok");
 
@@ -189,10 +193,11 @@ fn load_skips_missing_files() {
     let (_g, ws, cache, archive) = fixture();
     save(&SaveOptions {
         workspace: Some(&ws),
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         out: &archive,
         zstd_level: DEFAULT_ZSTD_LEVEL,
         threads: None,
+        mtimes_only: false,
     })
     .expect("save ok");
 
@@ -200,9 +205,10 @@ fn load_skips_missing_files() {
 
     let lreport = load(&LoadOptions {
         archive: &archive,
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         workspace: Some(&ws),
         threads: None,
+        mtimes_only: false,
     })
     .expect("load ok");
 
@@ -217,10 +223,11 @@ fn load_skips_size_mismatch_without_hashing() {
     let (_g, ws, cache, archive) = fixture();
     save(&SaveOptions {
         workspace: Some(&ws),
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         out: &archive,
         zstd_level: DEFAULT_ZSTD_LEVEL,
         threads: None,
+        mtimes_only: false,
     })
     .expect("save ok");
 
@@ -229,9 +236,10 @@ fn load_skips_size_mismatch_without_hashing() {
 
     let lreport = load(&LoadOptions {
         archive: &archive,
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         workspace: Some(&ws),
         threads: None,
+        mtimes_only: false,
     })
     .expect("load ok");
 
@@ -246,21 +254,255 @@ fn cache_only_archive_skips_mtime_replay() {
     let (_g, _ws, cache, archive) = fixture();
     save(&SaveOptions {
         workspace: None,
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         out: &archive,
         zstd_level: DEFAULT_ZSTD_LEVEL,
         threads: None,
+        mtimes_only: false,
     })
     .expect("save ok");
     fs::remove_dir_all(&cache).unwrap();
     let r = load(&LoadOptions {
         archive: &archive,
-        cache_dir: &cache,
+        cache_dir: Some(&cache),
         workspace: None,
         threads: None,
+        mtimes_only: false,
     })
     .expect("load ok");
     assert_eq!(r.cache_files_restored, 4);
     assert_eq!(r.source_files_in_manifest, 0);
     assert_eq!(r.mtimes_applied, 0);
+}
+
+// ---- mtimes-only mode (setup-soldr's preserve-source-mtimes feature
+// promoted into the soldr CLI; see plan PR 2). ----
+
+#[test]
+fn mtimes_only_save_and_load_roundtrip() {
+    let (_g, ws, _cache, archive) = fixture();
+
+    // Snapshot original mtimes so we can verify they survive the round
+    // trip. The fixture writes files with whatever the current clock
+    // says; we pin them to known values for assertion stability.
+    for (rel, ms) in [
+        ("Cargo.toml", 1_700_000_000_000i64),
+        ("Cargo.lock", 1_700_000_010_000),
+        ("src/main.rs", 1_700_000_020_000),
+        ("src/lib.rs", 1_700_000_030_000),
+        ("crates/sub/Cargo.toml", 1_700_000_040_000),
+        ("crates/sub/src/lib.rs", 1_700_000_050_000),
+    ] {
+        touch(&ws.join(rel), ms);
+    }
+
+    let sreport = save(&SaveOptions {
+        workspace: Some(&ws),
+        cache_dir: None,
+        out: &archive,
+        zstd_level: DEFAULT_ZSTD_LEVEL,
+        threads: None,
+        mtimes_only: true,
+    })
+    .expect("mtimes-only save ok");
+
+    assert!(
+        sreport.source_files >= 6,
+        "saw {} source files",
+        sreport.source_files
+    );
+    assert_eq!(
+        sreport.cache_files, 0,
+        "mtimes-only must NOT bundle any cache files"
+    );
+    assert!(sreport.archive_bytes > 0, "archive must not be empty");
+
+    // Simulate actions/checkout pushing every mtime forward — the
+    // standard CI scenario this feature exists to neutralize.
+    let later = 1_900_000_000_000i64;
+    for rel in [
+        "Cargo.toml",
+        "Cargo.lock",
+        "src/main.rs",
+        "src/lib.rs",
+        "crates/sub/Cargo.toml",
+        "crates/sub/src/lib.rs",
+    ] {
+        touch(&ws.join(rel), later);
+        assert_eq!(mtime_ms(&ws.join(rel)), later, "fixture mtime push failed");
+    }
+
+    let lreport = load(&LoadOptions {
+        archive: &archive,
+        cache_dir: None,
+        workspace: Some(&ws),
+        threads: None,
+        mtimes_only: true,
+    })
+    .expect("mtimes-only load ok");
+
+    assert_eq!(
+        lreport.cache_files_restored, 0,
+        "mtimes-only must NOT restore any cache files"
+    );
+    assert_eq!(lreport.mtimes_applied, sreport.source_files);
+    assert_eq!(lreport.mtimes_skipped_missing, 0);
+    assert_eq!(lreport.mtimes_skipped_size_mismatch, 0);
+    assert_eq!(lreport.mtimes_skipped_modified, 0);
+
+    // The pinned mtimes should be back where they were before checkout
+    // pushed them forward.
+    for (rel, want) in [
+        ("Cargo.toml", 1_700_000_000_000i64),
+        ("Cargo.lock", 1_700_000_010_000),
+        ("src/main.rs", 1_700_000_020_000),
+        ("src/lib.rs", 1_700_000_030_000),
+    ] {
+        let got = mtime_ms(&ws.join(rel));
+        assert_eq!(
+            got, want,
+            "{rel}: mtime not restored (got {got}, want {want})"
+        );
+    }
+}
+
+#[test]
+fn mtimes_only_load_refuses_modified_source() {
+    let (_g, ws, _cache, archive) = fixture();
+
+    save(&SaveOptions {
+        workspace: Some(&ws),
+        cache_dir: None,
+        out: &archive,
+        zstd_level: DEFAULT_ZSTD_LEVEL,
+        threads: None,
+        mtimes_only: true,
+    })
+    .expect("save ok");
+
+    // Modify a source file with SAME-SIZE content so we exercise the
+    // blake3 gate (size-mismatch would short-circuit before hashing).
+    // The blake3 gate must refuse to apply the mtime — protecting
+    // against the underbuild scenario.
+    let original = b"fn main() {}\n"; // 13 bytes
+    let altered = b"fn x_n() {}\n\n"; // 13 bytes, same length, different bytes
+    assert_eq!(
+        original.len(),
+        altered.len(),
+        "test prep: lengths must match"
+    );
+    write(&ws.join("src/main.rs"), altered);
+    let now_before = mtime_ms(&ws.join("src/main.rs"));
+
+    let r = load(&LoadOptions {
+        archive: &archive,
+        cache_dir: None,
+        workspace: Some(&ws),
+        threads: None,
+        mtimes_only: true,
+    })
+    .expect("load ok");
+
+    assert!(
+        r.mtimes_skipped_modified >= 1,
+        "blake3-modified source must be counted as skipped_modified, got {r:?}"
+    );
+    assert_eq!(
+        r.mtimes_skipped_size_mismatch, 0,
+        "no size mismatch expected, got {r:?}"
+    );
+
+    // Verify on disk: the modified file's mtime was NOT rewound.
+    let now_after = mtime_ms(&ws.join("src/main.rs"));
+    assert_eq!(
+        now_before, now_after,
+        "modified file's mtime must be left alone"
+    );
+}
+
+#[test]
+fn mtimes_only_save_without_workspace_errors() {
+    let (_g, _ws, _cache, archive) = fixture();
+    let err = save(&SaveOptions {
+        workspace: None,
+        cache_dir: None,
+        out: &archive,
+        zstd_level: DEFAULT_ZSTD_LEVEL,
+        threads: None,
+        mtimes_only: true,
+    })
+    .expect_err("save --mtimes-only without workspace must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("workspace") || msg.contains("--workspace"),
+        "error message must mention workspace: {msg}"
+    );
+}
+
+#[test]
+fn mtimes_only_save_with_cache_dir_errors() {
+    let (_g, ws, cache, archive) = fixture();
+    let err = save(&SaveOptions {
+        workspace: Some(&ws),
+        cache_dir: Some(&cache),
+        out: &archive,
+        zstd_level: DEFAULT_ZSTD_LEVEL,
+        threads: None,
+        mtimes_only: true,
+    })
+    .expect_err("save --mtimes-only WITH cache-dir must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cache") || msg.contains("--cache-dir"),
+        "error message must mention cache: {msg}"
+    );
+}
+
+#[test]
+fn mtimes_only_load_rejects_cache_entries() {
+    // Build a real cache+manifest archive, then try to load it as
+    // mtimes-only. The load must refuse the first cache entry it sees.
+    let (_g, ws, cache, archive) = fixture();
+    save(&SaveOptions {
+        workspace: Some(&ws),
+        cache_dir: Some(&cache),
+        out: &archive,
+        zstd_level: DEFAULT_ZSTD_LEVEL,
+        threads: None,
+        mtimes_only: false,
+    })
+    .expect("normal save ok");
+
+    let err = load(&LoadOptions {
+        archive: &archive,
+        cache_dir: None,
+        workspace: Some(&ws),
+        threads: None,
+        mtimes_only: true,
+    })
+    .expect_err("mtimes-only load of cache-bearing archive must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("mtimes_only") || msg.contains("cache"),
+        "error message must mention the cache entry rejection: {msg}"
+    );
+}
+
+#[test]
+fn save_without_cache_or_mtimes_only_errors() {
+    let (_g, ws, _cache, archive) = fixture();
+    let err = save(&SaveOptions {
+        workspace: Some(&ws),
+        cache_dir: None,
+        out: &archive,
+        zstd_level: DEFAULT_ZSTD_LEVEL,
+        threads: None,
+        mtimes_only: false,
+    })
+    .expect_err("save without cache and without mtimes_only must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("--cache-dir") || msg.contains("--mtimes-only"),
+        "error message must mention required flag: {msg}"
+    );
 }


### PR DESCRIPTION
## Why

The same size+content-hash-gated source-mtime snapshot/replay exists today in two parallel implementations:

- **Rust (this repo):** `cache_lib::save::replay_one` — used by `soldr save/load` to bundle a workspace mtime snapshot **alongside** a cache directory inside a single tar.zst.
- **TypeScript (setup-soldr):** `src/lib/source-mtime-snapshot.ts` — produces a separate JSON sidecar (`setup-soldr-source-mtimes.json`) that rides inside the build-cache tar.

The setup-soldr README explicitly notes this prototype "logically belongs in the soldr CLI eventually" — single source of truth, one set of tests, one performance profile.

This PR adds the missing piece: `--mtimes-only` so the mtime half of `soldr save/load` can be exercised **standalone** (no cache dir required). With this, setup-soldr can shell out to `soldr save --mtimes-only` and delete the TypeScript implementation.

## What changes

New flag on existing commands. Default behavior (no flag) is byte-identical to today.

| Command                                                          | Behavior                          |
|------------------------------------------------------------------|-----------------------------------|
| `soldr save --cache-dir DIR --out FILE`                          | Today's: cache only               |
| `soldr save --cache-dir DIR --workspace DIR --out FILE`          | Today's: cache + manifest         |
| **`soldr save --workspace DIR --mtimes-only --out FILE`**        | **NEW: manifest only**            |
| `soldr save --mtimes-only --out FILE` (no workspace)             | ERROR                             |
| `soldr save --out FILE` (no cache, no mtimes-only)               | ERROR                             |
| `soldr load --archive FILE --cache-dir DIR --workspace DIR`      | Today's: restore + replay         |
| **`soldr load --archive FILE --workspace DIR --mtimes-only`**    | **NEW: replay only, refuses cache** |
| `soldr load --archive FILE --mtimes-only` (no workspace)         | ERROR                             |

Schema additive: JSON output gains a `"mtimes_only"` field. Existing archives load with the same code path (manifest contents are the same shape; `cache_dir_name` is empty for mtimes-only and the load tolerates both values).

## API surgery

- `SaveOptions::cache_dir` and `LoadOptions::cache_dir` change from `&'a Path` to `Option<&'a Path>` so the manifest-only path can pass `None`.
- Both structs gain `pub mtimes_only: bool` (default false).
- Two private validators refuse inconsistent combinations:
  - `mtimes_only` without `workspace` → error
  - `mtimes_only` with `cache_dir` → error (mutually exclusive)
  - neither `mtimes_only` nor `cache_dir` → error (empty archive footgun)
- `replay_one` itself (the size+blake3-gated mtime applicator) is **unchanged**. Per memory note `feedback_no_mtime_normalize`, the unconditional `source-mtime-normalize` flow is abandoned; only the gated replay path is allowed. This PR does not weaken that.

## Tests

**Six new tests** in `tests/save_roundtrip.rs` (covers the new flag's matrix end-to-end):

- `mtimes_only_save_and_load_roundtrip` — snapshot, simulate actions/checkout pushing mtimes forward, restore, verify mtimes are back to the snapshot values; `cache_files_restored` stays at 0.
- `mtimes_only_load_refuses_modified_source` — same-size content change exercises the **blake3 gate** specifically (size mismatch would short-circuit before hashing); modified files are skipped, not underbuilt.
- `mtimes_only_save_without_workspace_errors` — validator catches.
- `mtimes_only_save_with_cache_dir_errors` — validator catches.
- `mtimes_only_load_rejects_cache_entries` — load of a real cache+manifest archive in mtimes-only mode fails loudly (producer-side bug detection).
- `save_without_cache_or_mtimes_only_errors` — validator catches the empty-archive footgun.

**All five pre-existing `save_roundtrip` tests still pass.** `tests/save_bench.rs` compiles and runs cleanly. `tests/save_roundtrip.rs` and `tests/save_bench.rs` were updated to wrap `cache_dir` in `Some(...)` and pass `mtimes_only: false` explicitly.

`soldr cargo clippy --workspace` clean (29 pre-existing warnings on `core.rs` doc-lazy-continuation; reproducible on `origin/main`, not from this PR). `soldr cargo fmt --all -- --check` clean.

## Honest scope

This PR adds the **soldr CLI surface**. The setup-soldr TS rip-out (replacing `src/lib/source-mtime-snapshot.ts` with a `soldr save --mtimes-only` invocation) is a separate follow-up PR in the setup-soldr repo, gated on a soldr release that ships this feature. The existing JSON sidecar in setup-soldr can stay readable for one release as a compat fallback.

## Plan reference

PR 2 of the "Trimming the soldr-shipped cargo target/ cache" plan (`look-at-soldr-repo-kind-mochi.md`). Independent of PR 1 ([soldr#463](https://github.com/zackees/soldr/pull/463), the trim-target work) — either can ship first.

Generated with [Claude Code](https://claude.com/claude-code)
