### PR TITLE
chore: green up Lint CI + make cli_doctor tests hermetic

### DIFF
--- a/crates/soldr-cli/src/core.rs
+++ b/crates/soldr-cli/src/core.rs
@@ -22,6 +22,7 @@ pub enum Arch {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)] // `MacOs` ends with `Os` by design — it's the canonical Rust spelling.
 pub enum Os {
     Linux,
     MacOs,

--- a/crates/soldr-cli/src/fuzzy_match.rs
+++ b/crates/soldr-cli/src/fuzzy_match.rs
@@ -98,10 +98,10 @@ pub(crate) fn levenshtein(a: &str, b: &str) -> usize {
 /// of the query length for longer strings.
 fn distance_threshold(query: &str) -> usize {
     let len = query.chars().count();
-    // ceil(0.3 × len) without floating-point: (len * 3 + 9) / 10
+    // ceil(0.3 × len) without floating-point: `(len * 3).div_ceil(10)`
     // gives the same value as `(len as f64 * 0.3).ceil() as usize`
     // for non-negative integer len up to usize::MAX / 4.
-    let scaled = (len * 3 + 9) / 10;
+    let scaled = (len * 3).div_ceil(10);
     scaled.max(2)
 }
 
@@ -123,7 +123,7 @@ pub(crate) fn suggest_close_match<'a>(query: &str, candidates: &'a [&'a str]) ->
         return None;
     }
     // Exact match → no suggestion (the regular dispatch handles it).
-    if candidates.iter().any(|c| *c == query) {
+    if candidates.contains(&query) {
         return None;
     }
 

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1,3 +1,10 @@
+// Mirror lib.rs: the bin tree compiles the same `fetch::*`,
+// `cache_lib::*`, `core::*` modules independently of the lib tree.
+// Items declared for external (lib) callers are dead from the bin's
+// perspective and would trip `-D warnings` on CI. lib.rs has the same
+// allow.
+#![allow(dead_code, unused_imports)]
+
 use clap::{Parser, Subcommand};
 
 mod binaries;
@@ -1119,7 +1126,7 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             // we fire the network fetch. The fetch still runs — the
             // suggestion is advisory.
             if let Some(suggestion) =
-                fuzzy_match::suggest_close_match(&crate_name, &SOLDR_BUILTIN_VERBS)
+                fuzzy_match::suggest_close_match(&crate_name, SOLDR_BUILTIN_VERBS)
             {
                 eprintln!("soldr: '{crate_name}' is not a known built-in soldr verb.");
                 eprintln!("soldr: did you mean: {suggestion}?");

--- a/crates/soldr-cli/tests/cli_doctor.rs
+++ b/crates/soldr-cli/tests/cli_doctor.rs
@@ -160,10 +160,20 @@ fn doctor_reports_drift_when_component_missing() {
         },
     );
 
+    // Isolate SOLDR_CACHE_DIR / HOME / USERPROFILE so the doctor's
+    // zccache-bundle probe (which inspects `~/.soldr/bin/zccache-pinned/`)
+    // can't trip on a stale pinned install in the host's real
+    // `~/.soldr/`. Without this, a stale pinned-zccache `source.json`
+    // on the dev machine causes `soldr doctor` to exit 1 with empty
+    // stdout — a real bug worth fixing in `resolve_pinned_zccache`
+    // separately, but the test should be hermetic regardless.
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["doctor", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_CACHE_DIR", &workspace)
+        .env("HOME", &workspace)
+        .env("USERPROFILE", &workspace)
         .output()
         .expect("failed to run soldr doctor --json");
 
@@ -215,10 +225,20 @@ fn doctor_reports_no_drift_when_everything_installed() {
         },
     );
 
+    // Isolate SOLDR_CACHE_DIR / HOME / USERPROFILE so the doctor's
+    // zccache-bundle probe (which inspects `~/.soldr/bin/zccache-pinned/`)
+    // can't trip on a stale pinned install in the host's real
+    // `~/.soldr/`. Without this, a stale pinned-zccache `source.json`
+    // on the dev machine causes `soldr doctor` to exit 1 with empty
+    // stdout — a real bug worth fixing in `resolve_pinned_zccache`
+    // separately, but the test should be hermetic regardless.
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["doctor", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_CACHE_DIR", &workspace)
+        .env("HOME", &workspace)
+        .env("USERPROFILE", &workspace)
         .output()
         .expect("failed to run soldr doctor --json");
 
@@ -402,10 +422,20 @@ fn doctor_reports_missing_target() {
         },
     );
 
+    // Isolate SOLDR_CACHE_DIR / HOME / USERPROFILE so the doctor's
+    // zccache-bundle probe (which inspects `~/.soldr/bin/zccache-pinned/`)
+    // can't trip on a stale pinned install in the host's real
+    // `~/.soldr/`. Without this, a stale pinned-zccache `source.json`
+    // on the dev machine causes `soldr doctor` to exit 1 with empty
+    // stdout — a real bug worth fixing in `resolve_pinned_zccache`
+    // separately, but the test should be hermetic regardless.
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["doctor", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_CACHE_DIR", &workspace)
+        .env("HOME", &workspace)
+        .env("USERPROFILE", &workspace)
         .output()
         .expect("failed to run soldr doctor --json");
 


### PR DESCRIPTION
## Summary

The CI **Lint** job has been red on \`main\` for some time because the bin tree surfaces dead-code / unused-import errors against items that exist for the lib tree (integration tests). \`lib.rs\` already has \`#![allow(dead_code)]\` for exactly this reason; this PR mirrors that intent on \`main.rs\` plus fixes the four actual clippy lints flagged by the same job.

It also addresses a host-state-dependent flake in \`cli_doctor\` by isolating \`SOLDR_CACHE_DIR\` / \`HOME\` / \`USERPROFILE\`.

## Changes

- **\`main.rs\`** — add \`#![allow(dead_code, unused_imports)]\` to mirror \`lib.rs\`'s shared-module compilation intent
- **\`core.rs\`** — \`#[allow(clippy::enum_variant_names)]\` on \`Os\` (\`MacOs\` ends with \`Os\` by design)
- **\`fuzzy_match.rs\`** — replace manual \`(len * 3 + 9) / 10\` with \`(len * 3).div_ceil(10)\`; replace \`iter().any()\` with \`contains()\`
- **\`main.rs\`** — drop needless \`&\` in \`suggest_close_match(…, &SOLDR_BUILTIN_VERBS)\`
- **\`tests/cli_doctor.rs\`** — pass per-test temp dir as \`SOLDR_CACHE_DIR\` / \`HOME\` / \`USERPROFILE\` so a stale local \`~/.soldr/bin/zccache-pinned/source.json\` can't trip the test

## Test plan

- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\` — no errors, no warnings
- [x] \`cargo fmt --all -- --check\` — clean
- [x] All 5 \`cli_doctor\` cases pass
- [x] 184 lib unit tests + 463 bin unit tests pass
- [x] Integration test sweep — no new failures
- [x] Phase 1/2/3 daemon tests still green

## Underlying bug noted

\`resolve_pinned_zccache\` uses \`TargetTriple::detect()\` which respects \`rust-toolchain.toml\`'s declared \`targets\` — on Windows that means a workspace declaring \`targets = ["x86_64-unknown-linux-musl"]\` makes the pinned-binary check look for \`zccache\` (no \`.exe\`) instead of \`zccache.exe\`. The test isolation here unblocks the CI lint gate without re-opening that scope; a separate bug issue should track the underlying \`resolve_pinned_zccache\` fix to always check the host triple for installed-binary validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)