### PR TITLE
fix(test): poll Status for linked_zccache_pid race

### DIFF
--- a/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
+++ b/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
@@ -201,8 +201,15 @@ fn linked_zccache_is_stopped_on_daemon_shutdown() {
     }
     assert!(linked, "LinkZccache fire-and-forget never succeeded");
 
-    // Confirm the linkage landed in redb (via Status reply).
-    let info = client::status(&sock).expect("status");
+    // Confirm the linkage landed via Status. LinkZccache is fire-and-
+    // forget so the server task may not have applied it yet — poll
+    // up to 2 s before failing.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut info = client::status(&sock).expect("status");
+    while info.linked_zccache_pid.is_none() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+        info = client::status(&sock).expect("status");
+    }
     assert_eq!(info.linked_zccache_pid, Some(42));
 
     // Trigger shutdown via the explicit RPC.


### PR DESCRIPTION
## Summary

\`linked_zccache_is_stopped_on_daemon_shutdown\` (Phase 3 test added in #468) was racing on the fire-and-forget \`LinkZccache\` request — calling \`client::status\` immediately after \`submit_fire_and_forget\` returned, before the server task had necessarily applied the new linked PID to State.

Surfaces as Linux x64 CI failure on every recent main CI run:

\`\`\`
assertion \`left == right\` failed
  left: None
  right: Some(42)
at cli_daemon_zccache_link.rs:206
\`\`\`

Fix: poll Status for up to 2 s until \`linked_zccache_pid\` becomes \`Some(42)\`. Matches the polling pattern already in \`cli_daemon_target_touch\` for redb-write visibility.

## Test plan

- [x] Local Windows: previous + new daemon tests all green
- [ ] CI Linux x64 run on this branch