### PR TITLE
fix(core): host-arch aware Windows triple in two TargetTriple tests

### DIFF
--- a/crates/soldr-cli/src/core.rs
+++ b/crates/soldr-cli/src/core.rs
@@ -1206,7 +1206,15 @@ min_age_secs = 7200
     fn defaults_to_msvc_without_explicit_override() {
         let dir = tempdir().unwrap();
         let target = TargetTriple::detect_in_dir(dir.path()).unwrap();
-        assert_eq!(target.triple(), "x86_64-pc-windows-msvc");
+        // Runtime arch: Windows runners come in x86_64 AND aarch64 on
+        // GitHub Actions. Both are valid host triples — the test must
+        // expect the runner's actual arch, not a hardcoded x86_64.
+        let expected_arch = if cfg!(target_arch = "x86_64") {
+            "x86_64"
+        } else {
+            "aarch64"
+        };
+        assert_eq!(target.triple(), format!("{expected_arch}-pc-windows-msvc"));
     }
 
     #[test]
@@ -1273,8 +1281,16 @@ min_age_secs = 7200
         .unwrap();
 
         let _target = TargetTriple::detect_in_dir(dir.path()).unwrap();
+        // Ambiguous list → fall back to the host arch on Windows.
         #[cfg(target_os = "windows")]
-        assert_eq!(_target.triple(), "x86_64-pc-windows-msvc");
+        {
+            let expected_arch = if cfg!(target_arch = "x86_64") {
+                "x86_64"
+            } else {
+                "aarch64"
+            };
+            assert_eq!(_target.triple(), format!("{expected_arch}-pc-windows-msvc"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

\`defaults_to_msvc_without_explicit_override\` and \`ignores_ambiguous_toolchain_target_list\` hardcoded \`x86_64-pc-windows-msvc\` as the expected outcome on Windows. GitHub runners now include Windows ARM64 — on those runners \`TargetTriple::detect_in_dir\` correctly returns \`aarch64-pc-windows-msvc\`, and the hardcoded assertions fail.

## Failure on main

\`\`\`
core::tests::defaults_to_msvc_without_explicit_override ... FAILED
  left: \"aarch64-pc-windows-msvc\"
  right: \"x86_64-pc-windows-msvc\"
\`\`\`

## Fix

Compute the expected arch via \`cfg!(target_arch = ...)\` so the assertion matches whichever Windows host runs the suite. Production code already does the right thing — only the test expectations were stale.

## Test plan

- [x] Local Windows x86_64: both tests still pass
- [ ] Windows ARM64 CI: should now go green