### PR TITLE
fix(test): serialize startup_profile env-var tests with a Mutex

### DIFF
--- a/crates/soldr-cli/src/startup_profile.rs
+++ b/crates/soldr-cli/src/startup_profile.rs
@@ -154,26 +154,46 @@ impl WrapperProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
-    /// Local RAII guard that sets / restores the profile env var so
-    /// these tests don't race with each other. Mirrors the pattern
-    /// used by other env-touching tests in this crate.
+    /// Test-wide lock that serializes the env-var mutations below.
+    /// Without it, parallel test execution can clobber
+    /// `SOLDR_PROFILE_STARTUP` between `EnvGuard::set` and the
+    /// next-line `WrapperProfile::new()` read — caught by CI Linux
+    /// x64 where `mark_records_phase_when_enabled` flaked with
+    /// `phases.len() == 0` instead of `2`. Reproes locally too if
+    /// you re-run the suite a few times.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Local RAII guard that sets / restores the profile env var
+    /// AND holds `ENV_LOCK` for the lifetime of the guard.
     struct EnvGuard {
         key: &'static str,
         prior: Option<std::ffi::OsString>,
+        _guard: std::sync::MutexGuard<'static, ()>,
     }
 
     impl EnvGuard {
         fn set(key: &'static str, value: &str) -> Self {
+            let guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
             let prior = std::env::var_os(key);
             std::env::set_var(key, value);
-            Self { key, prior }
+            Self {
+                key,
+                prior,
+                _guard: guard,
+            }
         }
 
         fn unset(key: &'static str) -> Self {
+            let guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
             let prior = std::env::var_os(key);
             std::env::remove_var(key);
-            Self { key, prior }
+            Self {
+                key,
+                prior,
+                _guard: guard,
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

\`startup_profile::tests\` mutates the same env var (\`SOLDR_PROFILE_STARTUP\`) across multiple test cases without a serializing lock. cargo runs unit tests in parallel by default — under contention the set→read window between \`EnvGuard::set\` and the next-line \`WrapperProfile::new()\` gets clobbered by another test's \`EnvGuard::unset\`.

## Failure on main

CI Linux x64:
\`\`\`
startup_profile::tests::mark_records_phase_when_enabled ... FAILED
  left: 0
  right: 2
at startup_profile.rs:221
\`\`\`

Also reproduces locally (the inverse case: \`disabled_when_env_var_empty\` fails when \`mark_records_phase_when_enabled\` sets the var concurrently).

## Fix

Introduce a \`static ENV_LOCK: Mutex<()>\` and hold it for the lifetime of each \`EnvGuard\`. Mirrors the same pattern already in use in \`self_relocate::tests\`.

## Test plan

- [x] Local 5x sequential \`startup_profile\` runs all green
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\` clean