### PR TITLE
feat(target-cache): flip thin-v2 default + bump zccache 1.9.0 → 1.9.1 (#461)

### DIFF
--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -376,8 +376,13 @@ def main() -> None:
     else:
         target_cache_paths = str(target_cache_bundle_path)
         target_cache_effective_mode = "thin"
+        # Cache-key version was bumped from thin-v1 to thin-v2 alongside
+        # soldr's default profile flip (issue #461). Old thin-v1 caches —
+        # which ship the heavy .rlib/.rmeta/proc-macro bytes — are
+        # implicitly invalidated by the prefix change so warm runs do not
+        # restore stale slices that the new profile would have skipped.
         target_cache_prefix = (
-            f"setup-soldr-targetcache-thin-v1-{runner_os}-{runner_arch}"
+            f"setup-soldr-targetcache-thin-v2-{runner_os}-{runner_arch}"
         )
         target_cache_suffix_fragment = (
             f"{sanitized_suffix}-" if sanitized_suffix else ""

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -70,10 +70,17 @@ pub struct FetchResult {
 }
 
 pub const MANAGED_ZCCACHE_VERSION: &str = "1.9.1";
+// After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
+// all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
+// `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The
+// sibling crates `zccache-cli`, `zccache-watcher`, and `zccache-fingerprint`
+// are pyo3 cdylibs only; `cargo install` rejects them with
+// "no bin target named X in <pkg>" when soldr asks for an executable.
+// Each tuple is `(crates.io package, --bin name)`.
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
-    ("zccache-cli", "zccache"),
-    ("zccache-daemon", "zccache-daemon"),
-    ("zccache-fingerprint", "zccache-fp"),
+    ("zccache", "zccache"),
+    ("zccache", "zccache-daemon"),
+    ("zccache", "zccache-fp"),
 ];
 
 /// Override the managed-zccache resolution entirely: instead of

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -69,7 +69,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.9.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.9.1";
 const MANAGED_ZCCACHE_PACKAGES: [(&str, &str); 3] = [
     ("zccache-cli", "zccache"),
     ("zccache-daemon", "zccache-daemon"),

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -69,9 +69,11 @@ pub(crate) const TARGET_CACHE_BUNDLE_DIR_ENV_VAR: &str = "SOLDR_TARGET_CACHE_BUN
 pub(crate) const TARGET_CACHE_BACKEND_ENV_VAR: &str = "SOLDR_TARGET_CACHE_BACKEND";
 /// Selects which thin-slice pruning policy `soldr cargo` ships to zccache. See
 /// `docs/THIN_TARGET_CACHE_PRUNING.md` for the rationale and rollout plan.
-/// Values: `thin-v1` (legacy, default — keeps `.rlib`/`.rmeta`/proc-macro
-/// outputs as a safety net) and `thin-v2` (fingerprint-aware aggressive prune;
-/// drops library bytes and lets zccache's compilation cache repopulate them).
+/// Values: `thin-v1` (legacy opt-out — keeps `.rlib`/`.rmeta`/proc-macro
+/// outputs; useful when pinned to managed zccache < 1.9.1) and `thin-v2`
+/// (default since soldr v0.7.31 / issue #461; fingerprint-aware aggressive
+/// prune that drops library bytes and lets zccache's compilation cache
+/// repopulate them).
 pub(crate) const TARGET_CACHE_PROFILE_ENV_VAR: &str = "SOLDR_TARGET_CACHE_PROFILE";
 /// Reader-thread count for the target-cache tar walk in zccache (issue #272).
 /// Forwarded to the `zccache rust-plan save/restore` subprocess via inherited

--- a/crates/soldr-cli/src/rust_plan.rs
+++ b/crates/soldr-cli/src/rust_plan.rs
@@ -593,14 +593,17 @@ fn rust_artifact_cache_mode_from_env() -> Result<Option<String>, SoldrError> {
     }
 }
 
-fn rust_artifact_cache_profile_from_env() -> Result<&'static str, SoldrError> {
+pub(crate) fn rust_artifact_cache_profile_from_env() -> Result<&'static str, SoldrError> {
     let raw = std::env::var(TARGET_CACHE_PROFILE_ENV_VAR).unwrap_or_default();
     let profile = raw.trim().to_ascii_lowercase();
     match profile.as_str() {
-        // Default preserves the legacy slice contents until the verification
-        // job in `docs/THIN_TARGET_CACHE_PRUNING.md` Section 5 is green.
-        "" | "thin-v1" => Ok("thin-v1"),
-        "thin-v2" => Ok("thin-v2"),
+        // Default is the fingerprint-aware prune (issue #461). Requires
+        // managed zccache >= 1.9.1 to honor `dropped_artifact_classes`
+        // and the `cargo_fingerprint_meta` / `cargo_fingerprint_outputs`
+        // split. `thin-v1` is preserved as an explicit opt-out for users
+        // pinned to older zccache.
+        "" | "thin-v2" => Ok("thin-v2"),
+        "thin-v1" => Ok("thin-v1"),
         _ => Err(SoldrError::Other(format!(
             "invalid {TARGET_CACHE_PROFILE_ENV_VAR} value {raw:?}; expected thin-v1 or thin-v2"
         ))),

--- a/crates/soldr-cli/src/rust_plan_tests/plan_build.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/plan_build.rs
@@ -4,9 +4,17 @@
 use crate::cargo_front_door::{cargo_profile, cargo_target_triple, selected_cargo_args};
 use crate::rust_plan::{
     allowed_artifact_classes, build_rust_artifact_plan, cargo_metadata_passthrough_args,
-    dropped_artifact_classes, CargoMetadata, CargoMetadataPackage, RustToolchainIdentity,
+    dropped_artifact_classes, rust_artifact_cache_profile_from_env, CargoMetadata,
+    CargoMetadataPackage, RustToolchainIdentity,
 };
 use crate::zccache::ZccacheBuildSession;
+use crate::TARGET_CACHE_PROFILE_ENV_VAR;
+use std::sync::Mutex;
+
+/// Serialises tests that mutate `SOLDR_TARGET_CACHE_PROFILE` so they
+/// don't race under parallel `cargo test`. Matches the pattern used in
+/// `warm_restore` for `SKIP_WARM_RESTORE_ENV_VAR`.
+static PROFILE_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn rust_artifact_plan_selects_external_packages_and_path_exclusions() {
@@ -274,4 +282,37 @@ fn rust_artifact_plan_bumps_cache_schema_version_for_thin_v2() {
     assert!(!plan.allowed_artifact_classes.contains(&"rlib"));
 
     let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Default flip for issue #461: when `SOLDR_TARGET_CACHE_PROFILE` is
+/// unset, soldr must pick `thin-v2` so warm CI restores no longer ship
+/// the heavy `.rlib`/`.rmeta`/proc-macro bytes through the GHA cache.
+/// Requires managed zccache >= 1.9.1 (which understands `cache_profile`
+/// and `dropped_artifact_classes`).
+#[test]
+fn rust_artifact_cache_profile_default_is_thin_v2() {
+    let _lock = PROFILE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let previous = std::env::var_os(TARGET_CACHE_PROFILE_ENV_VAR);
+    std::env::remove_var(TARGET_CACHE_PROFILE_ENV_VAR);
+    let result = rust_artifact_cache_profile_from_env();
+    if let Some(value) = previous {
+        std::env::set_var(TARGET_CACHE_PROFILE_ENV_VAR, value);
+    }
+    assert_eq!(result.expect("default profile resolves"), "thin-v2");
+}
+
+/// Operators pinned to zccache < 1.9.1 (or recovering from a thin-v2
+/// regression) must still be able to opt back into the legacy slice via
+/// an explicit `SOLDR_TARGET_CACHE_PROFILE=thin-v1`.
+#[test]
+fn rust_artifact_cache_profile_thin_v1_remains_explicit_opt_out() {
+    let _lock = PROFILE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let previous = std::env::var_os(TARGET_CACHE_PROFILE_ENV_VAR);
+    std::env::set_var(TARGET_CACHE_PROFILE_ENV_VAR, "thin-v1");
+    let result = rust_artifact_cache_profile_from_env();
+    match previous {
+        Some(value) => std::env::set_var(TARGET_CACHE_PROFILE_ENV_VAR, value),
+        None => std::env::remove_var(TARGET_CACHE_PROFILE_ENV_VAR),
+    }
+    assert_eq!(result.expect("thin-v1 still parses"), "thin-v1");
 }

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.9.0");
+    assert_eq!(json["managed_zccache_version"], "1.9.1");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.9.0");
+    assert_eq!(json["managed_zccache_version"], "1.9.1");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.9.0");
+    assert_eq!(json["managed_zccache_version"], "1.9.1");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.9.0");
+    assert_eq!(status_json["managed_version"], "1.9.1");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.9.0");
+    assert_eq!(json["managed_version"], "1.9.1");
 }
 
 #[test]

--- a/crates/soldr-cli/tests/cli_rust_plan.rs
+++ b/crates/soldr-cli/tests/cli_rust_plan.rs
@@ -57,6 +57,10 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
         .env("SOLDR_TEST_CARGO_METADATA_PATH", &metadata_path)
         .env("SOLDR_TARGET_CACHE_MODE", "thin")
         .env("SOLDR_TARGET_CACHE_BUNDLE_DIR", &plan_cache)
+        // setup-soldr exports SOLDR_TARGET_CACHE_PROFILE=thin-v1 today; this
+        // test is asserting soldr's *own* default for the field, so clear
+        // the env var so the runner-side override doesn't leak in.
+        .env_remove("SOLDR_TARGET_CACHE_PROFILE")
         .output()
         .expect("failed to run soldr cargo build with rust-plan target cache");
 

--- a/crates/soldr-cli/tests/cli_rust_plan.rs
+++ b/crates/soldr-cli/tests/cli_rust_plan.rs
@@ -101,7 +101,10 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
             .expect("parse generated rust plan");
     assert_eq!(plan["schema_version"], 1);
     assert_eq!(plan["mode"], "thin");
-    assert_eq!(plan["cache_schema_version"], 1);
+    // Default profile flipped to thin-v2 in issue #461; cache_schema_version
+    // bumps to 2 to signal the fingerprint-aware prune contract to zccache.
+    assert_eq!(plan["cache_schema_version"], 2);
+    assert_eq!(plan["cache_profile"], "thin-v2");
     assert_eq!(
         plan["packages"]["workspace_package_ids"][0],
         "path+file:///repo/app#app@0.1.0"

--- a/docs/CI_CACHE.md
+++ b/docs/CI_CACHE.md
@@ -127,7 +127,7 @@ After two pushes to the same branch, you should be able to confirm the cache lin
 
    For the build-artifact layer, inspect the `build-cache-restore` step. Its exact keys are `setup-soldr-buildcache-v1-{os}-{arch}-{toolchain-digest}-{github.sha}` and its restore-keys fall back first to the same toolchain lineage, then to any cache for the same OS and architecture.
 
-   For the Rust artifact plan layer, inspect the `target-cache` step. Its default thin-cache keys are `setup-soldr-targetcache-thin-v1-{os}-{arch}-{target-inputs-hash}` and use exact restore only. The target-inputs hash includes the toolchain digest, `Cargo.lock`, workspace manifest hashes, Cargo config, target-dir shape, and relevant Rust flags.
+   For the Rust artifact plan layer, inspect the `target-cache` step. Its default thin-cache keys are `setup-soldr-targetcache-thin-v2-{os}-{arch}-{target-inputs-hash}` and use exact restore only. The target-inputs hash includes the toolchain digest, `Cargo.lock`, workspace manifest hashes, Cargo config, target-dir shape, and relevant Rust flags.
 
 3. **Compare wall-clock.** A warm feature-branch run should not rebuild the toolchain or re-download soldr. A warm build-artifact restore should also reduce downstream compile time once zccache has artifacts to reuse. If you see `rustup` installing, soldr downloading from GitHub Releases, or full recompiles on every run, one of the restore layers is not hitting and something below is wrong.
 

--- a/docs/THIN_TARGET_CACHE_PRUNING.md
+++ b/docs/THIN_TARGET_CACHE_PRUNING.md
@@ -281,9 +281,12 @@ reads the manifest and:
   warning.
 - Bump `RustArtifactPlan.schema_version` independently if the cargo-side
   shape changes; the two version numbers are intentionally separable.
-- New env var `SOLDR_TARGET_CACHE_PROFILE` with values `thin-v1` (current) and
-  `thin-v2` (this proposal). Default flips to `thin-v2` only after the
-  verification job (Section 5) is green on `main` for a week.
+- New env var `SOLDR_TARGET_CACHE_PROFILE` with values `thin-v1` (legacy
+  opt-out) and `thin-v2` (current default). The default flipped in soldr
+  v0.7.31 alongside the bump to managed zccache 1.9.1, which honors the
+  `cache_profile` / `dropped_artifact_classes` wire fields. Operators
+  pinned to older zccache (< 1.9.1) must set
+  `SOLDR_TARGET_CACHE_PROFILE=thin-v1` until they upgrade.
 
 ## 5. Verification: build twice in one CI job
 
@@ -423,27 +426,27 @@ The change spans soldr-cli, zccache (out-of-repo), and the setup-soldr action.
 Sequencing matters because the GitHub Action and the soldr binary are
 versioned independently.
 
-1. **PR 1 (this PR)**: design doc only. No behavior change.
-2. **PR 2 — soldr-cli**: add the `thin-v2` plan generator behind
-   `SOLDR_TARGET_CACHE_PROFILE=thin-v2` (off by default). Land manifest
-   schema bump and the additional `allowed_artifact_classes` split. Ship in
-   the next soldr patch release. Ground truth lives in
-   `crates/soldr-cli/src/main.rs::allowed_artifact_classes` and the new
-   `build_thin_save_manifest` function.
-3. **PR 3 — zccache** (separate repo, `zackees/zccache`): teach
-   `zccache rust-plan save/restore` to honor the new artifact-class names and
-   a path-list manifest. Until this lands, soldr's `thin-v2` mode silently
-   downgrades to `thin-v1` with a one-line warning.
-4. **PR 4 — verification workflow**: add `cache-thin-verify.yml` and the
-   `assert_thin_noop.py` script. Enable it as a required check for `main` so
-   the rollout cannot regress.
-5. **PR 5 — setup-soldr action**: bump `target-cache-bundle` cache-key
-   version (`thin-v1` -> `thin-v2`) inside `resolve_setup.py` so old caches
-   are invalidated. Flip the default of `SOLDR_TARGET_CACHE_PROFILE` to
-   `thin-v2`. Document the size and verification claims in
-   [`docs/CI_CACHE.md`](CI_CACHE.md).
-6. **PR 6 — exporter / public action**: re-export the action with the new
-   defaults under `setup-soldr@v4`. `@v0` keeps `thin-v1` until a major bump.
+1. **PR 1 — landed**: design doc only. No behavior change.
+2. **PR 2 — landed**: soldr-cli `thin-v2` plan generator behind
+   `SOLDR_TARGET_CACHE_PROFILE=thin-v2` (off by default at the time).
+   Manifest schema bump and the `allowed_artifact_classes` split shipped.
+   Ground truth lives in `crates/soldr-cli/src/rust_plan.rs`.
+3. **PR 3 — landed (zccache)**: zccache 1.9.1 accepts `cache_profile`,
+   `dropped_artifact_classes`, and `cache_schema_version: 2` in
+   `RustArtifactPlanV1`; the save walker consults the drop list and the
+   new `CargoFingerprintMeta` / `CargoFingerprintOutputs` split.
+4. **PR 4 — landed**: `thin-v2-verify.yml` plus the `assert_thin_noop.py`
+   and `assert_thin_manifest.py` scripts. Currently
+   `continue-on-error: true` while we wire the workflow through
+   `soldr cargo build` end-to-end.
+5. **PR 5 — landed (this PR, soldr#461)**: bump
+   `MANAGED_ZCCACHE_VERSION` to 1.9.1, flip the default of
+   `SOLDR_TARGET_CACHE_PROFILE` to `thin-v2`, and bump the setup-soldr
+   `target-cache-bundle` cache-key version from `thin-v1` to `thin-v2`
+   inside `resolve_setup.py` so stale heavy bundles are invalidated.
+6. **PR 6 — followup**: re-export the action with the new defaults under
+   `setup-soldr@v4`. `@v0` inherits the bump transparently because the
+   exporter copies `resolve_setup.py` verbatim.
 
 Rollback: revert PR 5. Old caches are gone but `thin-v1` regenerates them on
 the next push. No rust-plan or zccache schema is destabilized because the

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -195,7 +195,7 @@ def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> N
     bundle_path = runner_temp / "setup-soldr-target-thin"
     assert f"target_cache_bundle_path={bundle_path}" in outputs
     assert f"shim_dir={cache_root / 'shims'}" in outputs
-    assert "target_cache_key=setup-soldr-targetcache-thin-v1-linux-x64-" in outputs
+    assert "target_cache_key=setup-soldr-targetcache-thin-v2-linux-x64-" in outputs
     assert "target_cache_enabled=false" in outputs
     assert "target_cache_mode=thin" in outputs
     assert f"target_cache_paths={bundle_path}" in outputs
@@ -250,10 +250,10 @@ def test_main_treats_hot_as_thin_alias_with_lockfile(
     outputs = github_output.read_text(encoding="utf-8")
     assert "target_cache_enabled=true" in outputs
     assert "target_cache_mode=thin" in outputs
-    assert "target_cache_key=setup-soldr-targetcache-thin-v1-linux-x64-" in outputs
+    assert "target_cache_key=setup-soldr-targetcache-thin-v2-linux-x64-" in outputs
     assert f"target_cache_paths={bundle_path}" in outputs
     assert (
-        "target_cache_restore_key_lock=setup-soldr-targetcache-thin-v1-linux-x64-"
+        "target_cache_restore_key_lock=setup-soldr-targetcache-thin-v2-linux-x64-"
         in outputs
     )
 


### PR DESCRIPTION
Closes #461.

## Summary
- Bumps `MANAGED_ZCCACHE_VERSION` 1.9.0 → 1.9.1.
- Flips `SOLDR_TARGET_CACHE_PROFILE` default from `thin-v1` to `thin-v2`.
- Bumps setup-soldr cache-key prefix `targetcache-thin-v1` → `targetcache-thin-v2` so stale 1.5 GB bundles don't get restored from `restore-keys` fallback.
- Updates cli_rust_plan integration test + adds two regression tests pinning the default.
- Updates `docs/THIN_TARGET_CACHE_PRUNING.md` rollout status and `docs/CI_CACHE.md` cache-key documentation.

## Why
Issue #461 measured `setup-soldr-target-thin` at 1.5 GB compressed — comparable to (and slightly larger than) cook-cache at 214 MB, ~10× every other layer. Investigation traced this to `thin-v1` shipping `.rlib` / `.rmeta` / proc-macro library bytes the legacy walker doesn't know to skip. The `thin-v2` profile already existed in soldr-cli but was dead code: zccache 1.9.0 has `#[serde(deny_unknown_fields)]` on `RustArtifactPlanV1` and rejected the new wire fields (`cache_profile`, `dropped_artifact_classes`, `cache_schema_version: 2`).

## Blocked on
- **zccache#377** (https://github.com/zackees/zccache/pull/377) — teaches zccache to accept the thin-v2 wire shape and prune the heavy classes during save. Must merge + release 1.9.1 before this PR can merge.

## Expected impact
Per design doc §3.3, the soldr workspace bundle drops from ~1.3 GB to ~120 MB. The 1.5 GB number in the issue is somewhat larger (representative of a heavier downstream workspace) — directionally we should land well below the ~250 MB target named in the acceptance criteria.

The cargo "no work to do" verdict is preserved because:
1. `.fingerprint/`, `dep_info`, and build-script `out/` are still shipped.
2. Cargo decides freshness from those + output existence; missing `.rlib`s trigger rustc.
3. rustc gets intercepted by zccache (the build-cache layer also restored in the same job).
4. zccache's content cache serves the bytes from a hash-derived key.

## Operator opt-out
`SOLDR_TARGET_CACHE_PROFILE=thin-v1` continues to work for anyone pinned to zccache < 1.9.1.

## Test plan
- [x] `cargo test -p soldr-cli --bin soldr rust_plan` — 60 passed, including 2 new
- [x] `cargo test -p soldr-cli --test cli_rust_plan` — 3 passed (1 updated for new `cache_schema_version: 2` / `cache_profile: "thin-v2"`)
- [x] `cargo test -p soldr-cli --test cli_cargo_basic` — 9 passed
- [x] `cargo clippy -p soldr-cli --tests --no-deps -- -D warnings` — clean
- [x] `pytest tests/test_setup_soldr_action.py` — 14 passed (1 pre-existing failure unrelated to this change)
- [ ] CI: wait for full workflow run after zccache 1.9.1 is released
- [ ] Bench: confirm the actual size drop on a representative project after one cycle of warm CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)