### PR TITLE
chore(release): soldr 0.7.31 + thin-v2 default + zccache 1.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.30"
+version = "0.7.31"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.30",
+  "version": "0.7.31",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
Mint 0.7.31 so the just-merged thin-v2 default flip (#476, closes #461) actually reaches users via the release auto-publish flow. Without this PR, `should_release` stays `false` because Cargo.toml + package.json still say 0.7.30, and setup-soldr keeps pulling the unchanged 0.7.30 binary — meaning the 1.5 GB target-cache bundle stays 1.5 GB even though the code that would shrink it is already on main.

## Release contents

- **#476** — flip target-cache profile default to thin-v2, bump managed zccache 1.9.0 → 1.9.1, bump setup-soldr cache-key prefix `targetcache-thin-v1` → `targetcache-thin-v2` (closes #461).
- **#474** — perf(wrapper): skip daemon path when no `SOLDR_BUILD_SESSION_ID`.
- **#466, #467** — feat(daemon): introduce `soldr-daemon` for target/ tracking, Phase 1/2/3 (build sessions + linked zccache shutdown).
- **#465** — feat(save): `--mtimes-only` promoted into the CLI.
- **#463** — feat(cache): `soldr cache trim-target` pre-archive trim.
- Test hardening / lint cleanup (#470-#473).

## Pre-flight checks (per CLAUDE.md release rules)

| Source | Current | New |
|---|---|---|
| `Cargo.toml` `[workspace.package].version` | 0.7.30 | 0.7.31 |
| `package.json` `"version"` | 0.7.30 | 0.7.31 |
| `Cargo.lock` `soldr-cli` | 0.7.30 | 0.7.31 |
| PyPI `soldr` latest | 0.7.30 | — |
| npm `@zackees/soldr` latest | 0.7.30 | — |
| `git ls-remote --tags origin v0.7.31` | (none) | — |

No conflicts. Safe to merge to fire Auto-Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)