### PR TITLE
feat(gc): derive cargo_registry_src last_used from .global-cache (#349)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +466,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +619,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -607,6 +640,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -933,6 +975,17 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1355,6 +1408,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1664,7 @@ dependencies = [
  "rayon",
  "redb",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -1998,6 +2066,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ walkdir = "2"
 jwalk = "0.8"
 zstd = { version = "0.13", default-features = false, features = ["zstdmt"] }
 filetime = "0.2"
+# Read-only access to cargo's `$CARGO_HOME/.global-cache` SQLite database
+# (issue #349). `bundled` compiles SQLite ourselves so neither the
+# managed wheel nor the cargo-install path needs a system libsqlite3.
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [workspace.lints.rust]
 unused_mut = "deny"

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -22,6 +22,7 @@ prost = { workspace = true }
 rayon = { workspace = true }
 redb = { workspace = true }
 reqwest = { workspace = true }
+rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/soldr-cli/src/cache_lib/cargo_global_cache.rs
+++ b/crates/soldr-cli/src/cache_lib/cargo_global_cache.rs
@@ -1,0 +1,223 @@
+//! Read-only access to cargo's `$CARGO_HOME/.global-cache` SQLite
+//! database (issue #349).
+//!
+//! Cargo maintains accurate last-access timestamps for everything it
+//! tracks in `~/.cargo/.global-cache` so its own `cargo clean gc` /
+//! `-Zgc` can evict the least-recently-used entries. That data is more
+//! accurate than the directory mtimes we used to derive in
+//! `walk_cargo_registry_src`, where `cargo build` re-extracting an
+//! existing crate source dir can leave the mtime stale.
+//!
+//! This module exposes a single function: open the SQLite file
+//! read-only, run a join against `registry_src` and `registry_index`,
+//! and return a map keyed by `(registry-hash, crate, version)`. Any
+//! failure (missing file, locked database, schema drift, table
+//! missing) yields `None` so the caller falls back to mtime.
+//!
+//! Schema documented inline in cargo's source:
+//! <https://github.com/rust-lang/cargo/blob/master/src/cargo/core/global_cache_tracker.rs>
+
+use rusqlite::{Connection, OpenFlags, Result as SqlResult};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Path of the SQLite database cargo writes to.
+pub const GLOBAL_CACHE_DB_FILENAME: &str = ".global-cache";
+
+/// Map key: `(registry-hash-dirname, crate-name, version)`. The
+/// registry-hash matches the directory name under
+/// `$CARGO_HOME/registry/src/`, e.g. `index.crates.io-6f17d22bba15001f`.
+pub type RegistrySrcKey = (String, String, String);
+
+/// Resolve the path of cargo's global cache database for the given
+/// `$CARGO_HOME`. Does not check that the file exists.
+pub fn global_cache_db_path(cargo_home: &Path) -> PathBuf {
+    cargo_home.join(GLOBAL_CACHE_DB_FILENAME)
+}
+
+/// Read `registry_src.timestamp` joined with `registry_index.name`
+/// (the registry-hash dirname) and return a map of last-used Unix
+/// seconds keyed by `(registry-hash, crate, version)`.
+///
+/// Returns `None` when:
+///
+/// - The database file does not exist.
+/// - The SQLite open call fails (file is locked, permissions denied,
+///   etc.).
+/// - Either `registry_src` or `registry_index` is missing.
+/// - The expected columns are missing or have an incompatible type.
+///
+/// The caller falls back to filesystem mtime in all of those cases.
+pub fn read_registry_src_last_used(cargo_home: &Path) -> Option<HashMap<RegistrySrcKey, i64>> {
+    let path = global_cache_db_path(cargo_home);
+    if !path.is_file() {
+        return None;
+    }
+    read_registry_src_last_used_from_path(&path).ok()
+}
+
+fn read_registry_src_last_used_from_path(
+    path: &Path,
+) -> SqlResult<HashMap<RegistrySrcKey, i64>> {
+    // Read-only open: never mutates cargo's database. `NO_MUTEX` lets
+    // multiple soldr invocations open the DB concurrently — cargo's
+    // own writes coordinate through its package-cache lock above the
+    // SQLite layer.
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+    let conn = Connection::open_with_flags(path, flags)?;
+    // Read-only busy-timeout: a brief wait while cargo finishes a
+    // write is preferable to an immediate SQLITE_BUSY error.
+    conn.busy_timeout(std::time::Duration::from_millis(500))?;
+
+    let mut stmt = conn.prepare(
+        "SELECT registry_index.name, registry_src.name, registry_src.version, registry_src.timestamp \
+         FROM registry_src \
+         JOIN registry_index ON registry_src.registry_id = registry_index.id",
+    )?;
+
+    let mut rows = stmt.query([])?;
+    let mut out: HashMap<RegistrySrcKey, i64> = HashMap::new();
+    while let Some(row) = rows.next()? {
+        let registry_hash: String = row.get(0)?;
+        let crate_name: String = row.get(1)?;
+        let version: String = row.get(2)?;
+        let timestamp: i64 = row.get(3)?;
+        out.insert((registry_hash, crate_name, version), timestamp);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+    use tempfile::tempdir;
+
+    /// Build a minimal SQLite database that matches the schema soldr
+    /// reads. We don't need a full cargo install — just the two tables
+    /// and the join columns.
+    fn make_global_cache_db(cargo_home: &Path) -> PathBuf {
+        let path = global_cache_db_path(cargo_home);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE registry_index (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                name TEXT UNIQUE NOT NULL,
+                timestamp INTEGER NOT NULL
+            );
+            CREATE TABLE registry_src (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                registry_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                version TEXT NOT NULL,
+                size INTEGER NOT NULL,
+                timestamp INTEGER NOT NULL,
+                UNIQUE (registry_id, name, version)
+            );
+            "#,
+        )
+        .unwrap();
+        path
+    }
+
+    fn insert_registry(conn: &Connection, name: &str, ts: i64) -> i64 {
+        conn.execute(
+            "INSERT INTO registry_index (name, timestamp) VALUES (?, ?)",
+            params![name, ts],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn insert_registry_src(
+        conn: &Connection,
+        registry_id: i64,
+        name: &str,
+        version: &str,
+        ts: i64,
+    ) {
+        conn.execute(
+            "INSERT INTO registry_src (registry_id, name, version, size, timestamp) VALUES (?, ?, ?, ?, ?)",
+            params![registry_id, name, version, 0i64, ts],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn returns_none_when_db_missing() {
+        let tmp = tempdir().unwrap();
+        assert!(read_registry_src_last_used(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_file_is_not_a_sqlite_database() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(global_cache_db_path(tmp.path()), b"not a database").unwrap();
+        assert!(read_registry_src_last_used(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_schema_is_unrelated() {
+        let tmp = tempdir().unwrap();
+        let path = global_cache_db_path(tmp.path());
+        let conn = Connection::open(&path).unwrap();
+        // No `registry_src` / `registry_index` — cargo schema drift
+        // (or someone else's DB at the same path). Falling back to
+        // mtime is correct here.
+        conn.execute("CREATE TABLE unrelated (id INTEGER)", []).unwrap();
+        assert!(read_registry_src_last_used(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn returns_joined_map_for_well_formed_db() {
+        let tmp = tempdir().unwrap();
+        let db_path = make_global_cache_db(tmp.path());
+        let conn = Connection::open(&db_path).unwrap();
+        let crates_io = insert_registry(&conn, "index.crates.io-6f17d22bba15001f", 1700);
+        let alt = insert_registry(&conn, "alt-registry-deadbeef", 1800);
+        insert_registry_src(&conn, crates_io, "serde", "1.0.0", 1000);
+        insert_registry_src(&conn, crates_io, "serde", "1.1.0", 2000);
+        insert_registry_src(&conn, alt, "private-thing", "0.1.0", 3000);
+        drop(conn);
+
+        let map = read_registry_src_last_used(tmp.path()).expect("populated db must return Some");
+        assert_eq!(
+            map.get(&(
+                "index.crates.io-6f17d22bba15001f".to_string(),
+                "serde".to_string(),
+                "1.0.0".to_string()
+            )),
+            Some(&1000)
+        );
+        assert_eq!(
+            map.get(&(
+                "index.crates.io-6f17d22bba15001f".to_string(),
+                "serde".to_string(),
+                "1.1.0".to_string()
+            )),
+            Some(&2000)
+        );
+        assert_eq!(
+            map.get(&(
+                "alt-registry-deadbeef".to_string(),
+                "private-thing".to_string(),
+                "0.1.0".to_string()
+            )),
+            Some(&3000)
+        );
+        assert_eq!(map.len(), 3);
+    }
+
+    #[test]
+    fn empty_tables_yield_empty_map_not_none() {
+        // The DB exists, schema matches, but there are no rows yet —
+        // an empty map (Some) tells the caller "consult me, I have
+        // no data on this crate" rather than the "missing/locked DB"
+        // signal None implies.
+        let tmp = tempdir().unwrap();
+        make_global_cache_db(tmp.path());
+        let map = read_registry_src_last_used(tmp.path()).unwrap();
+        assert!(map.is_empty());
+    }
+}

--- a/crates/soldr-cli/src/cache_lib/mod.rs
+++ b/crates/soldr-cli/src/cache_lib/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 pub mod auto_gc;
+pub mod cargo_global_cache;
 pub mod gc;
 pub mod prune_target;
 pub mod save;

--- a/crates/soldr-cli/src/gc.rs
+++ b/crates/soldr-cli/src/gc.rs
@@ -229,6 +229,16 @@ struct GcListEntryOutput {
     /// on `cargo_target` entries that lack the concept (#323 slice 2).
     #[serde(skip_serializing_if = "Option::is_none")]
     owner_crate: Option<String>,
+    /// Provenance of `last_used_unix` (#349). Present on
+    /// `cargo_registry_src` entries; omitted for `cargo_target` where
+    /// only mtime is available today. Values:
+    ///
+    /// - `"global_cache"` — cargo's own `$CARGO_HOME/.global-cache`
+    ///   SQLite tracker produced the timestamp.
+    /// - `"fs_mtime"` — the directory mtime, used when the tracker is
+    ///   missing / locked / schema-drift / has no row for this crate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_used_source: Option<&'static str>,
 }
 
 #[derive(Serialize)]
@@ -346,6 +356,7 @@ pub(crate) fn run_gc_list_command(
                     kind: KIND_CARGO_TARGET,
                     purge_safety: PURGE_SAFETY_DERIVED,
                     owner_crate: None,
+                    last_used_source: None,
                 }
             })
             .collect()
@@ -401,19 +412,34 @@ pub(crate) fn run_gc_list_command(
 // cargo_registry_src walker (#323 slice 2).
 // ---------------------------------------------------------------------------
 
+/// Provenance tag for `last_used_unix` (#349).
+const LAST_USED_FROM_GLOBAL_CACHE: &str = "global_cache";
+const LAST_USED_FROM_FS_MTIME: &str = "fs_mtime";
+
 /// Walk `$CARGO_HOME/registry/src/<registry-hash-dir>/<crate>-<vers>/`
 /// and produce a `GcListEntryOutput` per crate directory.
 ///
-/// `last_used` is derived from the directory's own filesystem mtime.
-/// Cargo's `~/.cargo/.global-cache` SQLite database has more accurate
-/// last-access data; reading it is tracked as a follow-up (see issue
-/// linked in the slice 2 PR body).
+/// `last_used_unix` is preferentially derived from cargo's own
+/// `$CARGO_HOME/.global-cache` SQLite tracker (#349). When the
+/// tracker is missing, locked, schema-drifted, or has no row for a
+/// particular crate, we fall back to the directory's filesystem
+/// mtime. The `last_used_source` field on each entry records which
+/// provenance produced the timestamp so JSON consumers can gate
+/// metrics on it.
 fn walk_cargo_registry_src(cargo_home: &std::path::Path, now: i64) -> Vec<GcListEntryOutput> {
     let registry_src = cargo_home.join("registry").join("src");
     let registry_dirs = match std::fs::read_dir(&registry_src) {
         Ok(iter) => iter,
         Err(_) => return Vec::new(),
     };
+
+    // Try the global-cache tracker once up-front. None covers the
+    // "missing / locked / schema-drift" cases; every crate then falls
+    // back to mtime. An empty Some(..) means the tracker exists but
+    // has no rows; each crate that misses the lookup still falls
+    // back individually.
+    let global_cache =
+        crate::cache_lib::cargo_global_cache::read_registry_src_last_used(cargo_home);
 
     let mut out: Vec<GcListEntryOutput> = Vec::new();
     for reg_entry in registry_dirs.flatten() {
@@ -424,6 +450,10 @@ fn walk_cargo_registry_src(cargo_home: &std::path::Path, now: i64) -> Vec<GcList
         if !reg_meta.is_dir() {
             continue;
         }
+        let registry_hash = match reg_path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
         let crate_dirs = match std::fs::read_dir(&reg_path) {
             Ok(iter) => iter,
             Err(_) => continue,
@@ -442,12 +472,12 @@ fn walk_cargo_registry_src(cargo_home: &std::path::Path, now: i64) -> Vec<GcList
             };
             let owner_crate = parse_crate_owner(&dir_name);
             let (size_bytes, file_count) = fast_directory_size_and_files(&crate_path);
-            let last_used_unix = meta
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs() as i64)
-                .unwrap_or(0);
+            let (last_used_unix, last_used_source) = resolve_registry_src_last_used(
+                global_cache.as_ref(),
+                &registry_hash,
+                &dir_name,
+                &meta,
+            );
             let age_seconds = now.saturating_sub(last_used_unix);
             out.push(GcListEntryOutput {
                 path: absolute_path_string(&crate_path),
@@ -460,10 +490,63 @@ fn walk_cargo_registry_src(cargo_home: &std::path::Path, now: i64) -> Vec<GcList
                 kind: KIND_CARGO_REGISTRY_SRC,
                 purge_safety: PURGE_SAFETY_DERIVED,
                 owner_crate,
+                last_used_source: Some(last_used_source),
             });
         }
     }
     out
+}
+
+/// Pick the `last_used_unix` value (and its provenance tag) for one
+/// crate source directory. Pulled out so the precedence rule can be
+/// unit-tested without a real cargo install on disk.
+///
+/// Returns `(unix_seconds, "global_cache" | "fs_mtime")`.
+fn resolve_registry_src_last_used(
+    global_cache: Option<&std::collections::HashMap<
+        crate::cache_lib::cargo_global_cache::RegistrySrcKey,
+        i64,
+    >>,
+    registry_hash: &str,
+    dir_name: &str,
+    meta: &std::fs::Metadata,
+) -> (i64, &'static str) {
+    if let (Some(map), Some((crate_name, version))) = (global_cache, split_dir_name(dir_name)) {
+        let key = (
+            registry_hash.to_string(),
+            crate_name.to_string(),
+            version.to_string(),
+        );
+        if let Some(&ts) = map.get(&key) {
+            return (ts, LAST_USED_FROM_GLOBAL_CACHE);
+        }
+    }
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    (mtime, LAST_USED_FROM_FS_MTIME)
+}
+
+/// Split `<crate>-<version>` directory names into `(crate, version)`
+/// using the same rule as [`parse_crate_owner`]: the last hyphen
+/// followed by an ASCII digit is the boundary. Returns `None` for
+/// names that don't match the shape (e.g. a bare `serde/` dir).
+fn split_dir_name(dir_name: &str) -> Option<(&str, &str)> {
+    let bytes = dir_name.as_bytes();
+    for (idx, &b) in bytes.iter().enumerate().rev() {
+        if b == b'-' && idx + 1 < bytes.len() && bytes[idx + 1].is_ascii_digit() {
+            let (name, rest) = dir_name.split_at(idx);
+            let version = &rest[1..];
+            if name.is_empty() {
+                return None;
+            }
+            return Some((name, version));
+        }
+    }
+    None
 }
 
 /// Parse `<crate>-<vers>` directory names into `Some("<crate>@<vers>")`.

--- a/crates/soldr-cli/src/gc_tests.rs
+++ b/crates/soldr-cli/src/gc_tests.rs
@@ -21,3 +21,111 @@ fn gc_purge_worker_count_is_bounded() {
     assert_eq!(gc_purge_worker_count_for(2), 2);
     assert_eq!(gc_purge_worker_count_for(16), 4);
 }
+
+// -------------------------------------------------------------------
+// last-used resolution for cargo_registry_src entries (issue #349).
+// The precedence rule is: prefer cargo's `.global-cache` SQLite row
+// when one exists for `(registry, crate, version)`; otherwise fall
+// back to the directory's filesystem mtime.
+// -------------------------------------------------------------------
+
+fn fake_metadata_with_mtime(temp_path: &std::path::Path, mtime_unix: u64) -> std::fs::Metadata {
+    // Construct a synthetic file with a controlled mtime so the test
+    // exercises real `Metadata::modified()` rather than mocking the
+    // OS layer. `filetime::set_file_mtime` is in dev-deps.
+    std::fs::write(temp_path, b"x").unwrap();
+    let ft = filetime::FileTime::from_unix_time(mtime_unix as i64, 0);
+    filetime::set_file_mtime(temp_path, ft).unwrap();
+    std::fs::metadata(temp_path).unwrap()
+}
+
+#[test]
+fn last_used_prefers_global_cache_when_key_present() {
+    let tmp = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("probe");
+    let meta = fake_metadata_with_mtime(&f, 1_700_000_000);
+    let mut map: std::collections::HashMap<
+        crate::cache_lib::cargo_global_cache::RegistrySrcKey,
+        i64,
+    > = std::collections::HashMap::new();
+    map.insert(
+        (
+            "index.crates.io-abc123".to_string(),
+            "serde".to_string(),
+            "1.0.0".to_string(),
+        ),
+        1_800_000_000,
+    );
+    let (ts, source) =
+        resolve_registry_src_last_used(Some(&map), "index.crates.io-abc123", "serde-1.0.0", &meta);
+    assert_eq!(ts, 1_800_000_000);
+    assert_eq!(source, "global_cache");
+}
+
+#[test]
+fn last_used_falls_back_to_mtime_when_tracker_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("probe");
+    let meta = fake_metadata_with_mtime(&f, 1_700_000_000);
+    let (ts, source) =
+        resolve_registry_src_last_used(None, "index.crates.io-abc123", "serde-1.0.0", &meta);
+    assert_eq!(ts, 1_700_000_000);
+    assert_eq!(source, "fs_mtime");
+}
+
+#[test]
+fn last_used_falls_back_to_mtime_when_key_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("probe");
+    let meta = fake_metadata_with_mtime(&f, 1_700_000_000);
+    // Tracker exists (Some), but doesn't have a row for this crate.
+    // The fallback must be per-crate, not per-tracker.
+    let map: std::collections::HashMap<
+        crate::cache_lib::cargo_global_cache::RegistrySrcKey,
+        i64,
+    > = std::collections::HashMap::new();
+    let (ts, source) = resolve_registry_src_last_used(
+        Some(&map),
+        "index.crates.io-abc123",
+        "serde-1.0.0",
+        &meta,
+    );
+    assert_eq!(ts, 1_700_000_000);
+    assert_eq!(source, "fs_mtime");
+}
+
+#[test]
+fn last_used_falls_back_when_dir_name_is_not_versioned() {
+    let tmp = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("probe");
+    let meta = fake_metadata_with_mtime(&f, 1_700_000_000);
+    // `split_dir_name` returns None for names that don't match the
+    // `<crate>-<digit-prefixed-version>` shape. The walker must then
+    // fall back to mtime rather than crashing or returning 0.
+    let map: std::collections::HashMap<
+        crate::cache_lib::cargo_global_cache::RegistrySrcKey,
+        i64,
+    > = std::collections::HashMap::new();
+    let (ts, source) =
+        resolve_registry_src_last_used(Some(&map), "index.crates.io-abc123", "bare-serde", &meta);
+    assert_eq!(ts, 1_700_000_000);
+    assert_eq!(source, "fs_mtime");
+}
+
+#[test]
+fn split_dir_name_recovers_crate_and_version() {
+    assert_eq!(split_dir_name("serde-1.0.0"), Some(("serde", "1.0.0")));
+    assert_eq!(
+        split_dir_name("syn-2.0.16"),
+        Some(("syn", "2.0.16"))
+    );
+    // Hyphenated crate names with a numeric-suffix version still pick
+    // the last digit-prefixed hyphen.
+    assert_eq!(
+        split_dir_name("aws-lc-sys-0.21.1"),
+        Some(("aws-lc-sys", "0.21.1"))
+    );
+    // No digit-prefixed hyphen → None.
+    assert_eq!(split_dir_name("serde"), None);
+    assert_eq!(split_dir_name("foo-bar"), None);
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -600,6 +600,18 @@ The summary includes the registry path, eligible candidate count, total
 reclaimable size, skipped/dropped counts, and the largest eligible
 target directories with size and last-used age.
 
+**`cargo_registry_src` last-used provenance (issue #349).** When
+`soldr gc list --kind cargo_registry_src` (or unfiltered `gc list`)
+walks `$CARGO_HOME/registry/src/...`, each entry's `last_used_unix`
+field is preferentially derived from cargo's own
+`$CARGO_HOME/.global-cache` SQLite tracker — the same data cargo's
+unstable `-Zgc` uses to evict least-recently-used crate sources. When
+the tracker is missing, locked, schema-drifted, or has no row for a
+particular crate, soldr falls back to the directory's filesystem
+mtime. The provenance is exposed as `last_used_source` on each entry:
+`"global_cache"` or `"fs_mtime"`. The field is omitted from
+`cargo_target` entries (no comparable tracker exists).
+
 Configure additional allowlist roots via `~/.soldr/config.toml`:
 
 ```toml


### PR DESCRIPTION
## Summary

`soldr gc list --kind cargo_registry_src` now consults cargo's own `$CARGO_HOME/.global-cache` SQLite tracker before falling back to the directory's filesystem mtime. Cargo updates the tracker on every *use*; mtime only updates when cargo re-extracts the source dir, so the old mtime-only path systematically over-reports staleness for crates that were merely *read* by recent builds. This brings soldr's GC heuristic in line with cargo's own unstable `-Zgc clean gc` rules and unblocks the auto-GC tier targeting in #323.

## Implementation

- New module `cache_lib/cargo_global_cache.rs` opens the SQLite database read-only (with a 500 ms busy-timeout), runs `registry_src JOIN registry_index`, and returns `HashMap<(registry_hash, crate, version), unix_seconds>`. Any failure (missing file, malformed SQLite, schema drift, locked DB, missing tables) yields `None` so the walker falls back to mtime per-crate.
- `walk_cargo_registry_src` calls the helper once up-front; the new pure `resolve_registry_src_last_used()` makes the precedence rule unit-testable.
- `GcListEntryOutput` gains a `last_used_source` field (`"global_cache"` or `"fs_mtime"`), omitted via `skip_serializing_if` on `cargo_target` entries. JSON output stays backwards-compatible.
- Adds `rusqlite = { version = "0.32", features = ["bundled"] }` so neither maturin wheels nor `cargo install` need a system libsqlite3.

## What changed

- 10 unit tests (5 in the new module, 5 in `gc::tests`).
- `docs/API.md` documents the new provenance field.

Refs #478, #323. Closes #349.

## Test plan
- [x] `cargo build` succeeds with bundled SQLite
- [x] `cargo clippy -p soldr-cli --no-deps` clean
- [x] 5 `cargo_global_cache` tests + 5 `gc::tests::last_used` tests pass
- [ ] Real cargo install: verify `gc list --kind cargo_registry_src --json` reports `"last_used_source": "global_cache"` for recently-touched crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)