### PR TITLE
feat(cache): add --keep-latest prune mode + fingerprint recency rank (#316)

### DIFF
--- a/crates/soldr-cli/src/cache.rs
+++ b/crates/soldr-cli/src/cache.rs
@@ -343,21 +343,23 @@ fn zccache_output_snippet(output: &[u8]) -> Option<String> {
 pub(crate) fn run_cache_prune_target_command(
     target_dir: std::path::PathBuf,
     dry_run: bool,
+    keep_latest: bool,
     json: bool,
 ) -> Result<(), SoldrError> {
     let canonical = std::path::absolute(&target_dir).unwrap_or_else(|_| target_dir.clone());
     let opts = crate::cache_lib::prune_target::PruneTargetOptions {
         target_dir: canonical.clone(),
         dry_run,
+        keep_latest,
     };
     let report = crate::cache_lib::prune_target::prune_target(&opts)
         .map_err(|e| SoldrError::Other(format!("cache prune-target failed: {e}")))?;
 
     if json {
-        let output = build_cache_prune_target_output(&canonical, dry_run, &report);
+        let output = build_cache_prune_target_output(&canonical, dry_run, keep_latest, &report);
         print_json(&output)?;
     } else {
-        print_cache_prune_target_text(&canonical, dry_run, &report);
+        print_cache_prune_target_text(&canonical, dry_run, keep_latest, &report);
     }
     Ok(())
 }
@@ -365,6 +367,7 @@ pub(crate) fn run_cache_prune_target_command(
 fn build_cache_prune_target_output(
     target_dir: &std::path::Path,
     dry_run: bool,
+    keep_latest: bool,
     report: &crate::cache_lib::prune_target::PruneTargetReport,
 ) -> CachePruneTargetOutput {
     CachePruneTargetOutput {
@@ -372,11 +375,14 @@ fn build_cache_prune_target_output(
         command: "cache prune-target",
         target_dir: target_dir.display().to_string(),
         dry_run,
+        keep_latest,
         scanned: report.scanned,
         kept: report.kept,
         deleted: report.deleted,
         reclaimed_bytes: report.reclaimed_bytes,
         reclaimed_human: crate::cache_lib::target_registry::human_size(report.reclaimed_bytes),
+        keep_decisions_from_fingerprint: report.keep_decisions_from_fingerprint,
+        keep_decisions_from_mtime: report.keep_decisions_from_mtime,
         entries: report
             .entries
             .iter()
@@ -399,6 +405,7 @@ fn build_cache_prune_target_output(
 fn print_cache_prune_target_text(
     target_dir: &std::path::Path,
     dry_run: bool,
+    keep_latest: bool,
     report: &crate::cache_lib::prune_target::PruneTargetReport,
 ) {
     println!("soldr cache prune-target: {}", target_dir.display());
@@ -411,12 +418,26 @@ fn print_cache_prune_target_text(
         }
     );
     println!(
+        "  strategy: {}",
+        if keep_latest {
+            "keep-latest (one hash family per prefix; aggressive — issue #316)"
+        } else {
+            "orphan-siblings (newest entry per (parent_dir, prefix) — issue #336)"
+        }
+    );
+    println!(
         "  scanned={} kept={} deleted={} reclaimed={}",
         report.scanned,
         report.kept,
         report.deleted,
         crate::cache_lib::target_registry::human_size(report.reclaimed_bytes),
     );
+    if report.keep_decisions_from_fingerprint + report.keep_decisions_from_mtime > 0 {
+        println!(
+            "  rank source: {} fingerprint, {} fs-mtime",
+            report.keep_decisions_from_fingerprint, report.keep_decisions_from_mtime
+        );
+    }
     let mut shown = 0usize;
     for entry in &report.entries {
         if entry.action != crate::cache_lib::prune_target::PruneAction::Delete {
@@ -446,11 +467,21 @@ struct CachePruneTargetOutput {
     command: &'static str,
     target_dir: String,
     dry_run: bool,
+    /// True when invoked with `--keep-latest` (issue #316 aggressive
+    /// per-prefix bucketing); false for the legacy
+    /// `(parent_dir, prefix)` orphan-sibling prune (issue #336).
+    keep_latest: bool,
     scanned: usize,
     kept: usize,
     deleted: usize,
     reclaimed_bytes: u64,
     reclaimed_human: String,
+    /// Number of keep decisions whose rank came from cargo's
+    /// authoritative `.fingerprint/<prefix>-<hash>/invoked.timestamp`.
+    keep_decisions_from_fingerprint: usize,
+    /// Number of keep decisions that fell back to the entry's own
+    /// filesystem mtime (no matching fingerprint file existed).
+    keep_decisions_from_mtime: usize,
     entries: Vec<CachePruneTargetEntryOutput>,
 }
 
@@ -546,6 +577,7 @@ pub(crate) fn run_cache_trim_target_command(
     let prune_opts = crate::cache_lib::prune_target::PruneTargetOptions {
         target_dir: canonical.clone(),
         dry_run,
+        keep_latest: false,
     };
     let prune_report = crate::cache_lib::prune_target::prune_target(&prune_opts)
         .map_err(|e| SoldrError::Other(format!("cache trim-target: prune failed: {e}")))?;

--- a/crates/soldr-cli/src/cache_lib/prune_target.rs
+++ b/crates/soldr-cli/src/cache_lib/prune_target.rs
@@ -55,6 +55,30 @@ pub struct PruneTargetEntry {
     pub action: PruneAction,
 }
 
+/// Provenance of the recency timestamp used to rank a hash family.
+/// Recorded on each [`PruneTargetReport`] so consumers can tell when
+/// the keep decision used cargo's authoritative
+/// `.fingerprint/<prefix>-<hash>/invoked.timestamp` vs. a fallback to
+/// the entry's own mtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecencySource {
+    /// Recency came from `.fingerprint/<prefix>-<hash>/invoked.timestamp`,
+    /// cargo's authoritative per-artifact "last invoked" record.
+    FingerprintInvokedTimestamp,
+    /// Recency came from the entry's own filesystem mtime — used when
+    /// the matching `invoked.timestamp` file is missing or unreadable.
+    EntryMtime,
+}
+
+impl RecencySource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RecencySource::FingerprintInvokedTimestamp => "fingerprint_invoked_timestamp",
+            RecencySource::EntryMtime => "entry_mtime",
+        }
+    }
+}
+
 /// Options that drive [`prune_target`].
 #[derive(Debug, Clone)]
 pub struct PruneTargetOptions {
@@ -63,6 +87,19 @@ pub struct PruneTargetOptions {
     /// When `true`, no entries are deleted. The returned report still
     /// describes the plan.
     pub dry_run: bool,
+    /// When `true`, switch from the per-`(parent_dir, prefix)` bucket
+    /// strategy (issue #336 — drop orphan siblings inside each subdir)
+    /// to the aggressive per-`prefix` strategy (issue #316 — keep only
+    /// the **newest hash family** per logical artifact name, deleting
+    /// every other hash's files across `deps/`, `.fingerprint/`,
+    /// `incremental/`, and `build/`).
+    ///
+    /// The aggressive mode is what shrinks a heavily-rebuilt target/
+    /// from 16+ GB to ~2 GB on real workloads (issue #316). It is
+    /// destructive but bounded: the winning hash is the one with the
+    /// freshest mtime, and the active-`.cargo-lock` guard still
+    /// applies.
+    pub keep_latest: bool,
 }
 
 impl PruneTargetOptions {
@@ -70,6 +107,7 @@ impl PruneTargetOptions {
         Self {
             target_dir,
             dry_run: true,
+            keep_latest: false,
         }
     }
 }
@@ -88,6 +126,12 @@ pub struct PruneTargetReport {
     pub reclaimed_bytes: u64,
     /// Every classified entry, in the order they were scanned.
     pub entries: Vec<PruneTargetEntry>,
+    /// How many of the keep decisions used cargo's authoritative
+    /// `.fingerprint/<prefix>-<hash>/invoked.timestamp` mtime (the
+    /// same signal cargo's own `-Zgc` consults). The remainder fell
+    /// back to the entry's own filesystem mtime.
+    pub keep_decisions_from_fingerprint: usize,
+    pub keep_decisions_from_mtime: usize,
 }
 
 /// Scan a cargo `target/` directory and prune stale per-prefix
@@ -118,7 +162,6 @@ pub fn prune_target(opts: &PruneTargetOptions) -> Result<PruneTargetReport, Regi
 
     let scan_dirs = collect_scan_dirs(target_dir);
     let mut entries: Vec<PruneTargetEntry> = Vec::new();
-    let mut buckets: HashMap<(PathBuf, String), Vec<usize>> = HashMap::new();
 
     for parent in &scan_dirs {
         let read_dir = match fs::read_dir(parent) {
@@ -158,37 +201,33 @@ pub fn prune_target(opts: &PruneTargetOptions) -> Result<PruneTargetReport, Regi
                 mtime_unix,
                 action: PruneAction::Keep,
             };
-            let idx = entries.len();
-            buckets
-                .entry((parent.clone(), prefix.to_string()))
-                .or_default()
-                .push(idx);
             entries.push(entry);
         }
     }
 
-    // Classify within each bucket: newest mtime wins; if mtime ties,
-    // fall back to the lexicographically largest hash so the ordering
-    // is deterministic.
-    for indices in buckets.values_mut() {
-        indices.sort_by(|a, b| {
-            let ea = &entries[*a];
-            let eb = &entries[*b];
-            eb.mtime_unix
-                .cmp(&ea.mtime_unix)
-                .then_with(|| eb.hash.cmp(&ea.hash))
-        });
-        let mut iter = indices.iter().copied();
-        if let Some(keep) = iter.next() {
-            entries[keep].action = PruneAction::Keep;
-        }
-        for idx in iter {
-            entries[idx].action = PruneAction::Delete;
-        }
+    let mut fingerprint_decisions = 0usize;
+    let mut mtime_decisions = 0usize;
+
+    if opts.keep_latest {
+        classify_per_prefix(
+            &mut entries,
+            target_dir,
+            &mut fingerprint_decisions,
+            &mut mtime_decisions,
+        );
+    } else {
+        classify_per_parent_prefix(
+            &mut entries,
+            target_dir,
+            &mut fingerprint_decisions,
+            &mut mtime_decisions,
+        );
     }
 
     let mut report = PruneTargetReport {
         scanned: entries.len(),
+        keep_decisions_from_fingerprint: fingerprint_decisions,
+        keep_decisions_from_mtime: mtime_decisions,
         ..PruneTargetReport::default()
     };
 
@@ -212,6 +251,163 @@ pub fn prune_target(opts: &PruneTargetOptions) -> Result<PruneTargetReport, Regi
     }
     report.entries = entries;
     Ok(report)
+}
+
+/// Classic per-`(parent_dir, prefix)` bucketing (issue #336). Each
+/// subdirectory's set of hash-siblings is pruned independently, so
+/// the same prefix in `deps/`, `.fingerprint/`, etc. keeps its own
+/// newest entry. Conservative: cargo tolerates orphans across the
+/// four subdirs as long as the live entry inside each is current.
+fn classify_per_parent_prefix(
+    entries: &mut [PruneTargetEntry],
+    target_dir: &Path,
+    fingerprint_decisions: &mut usize,
+    mtime_decisions: &mut usize,
+) {
+    let mut buckets: HashMap<(PathBuf, String), Vec<usize>> = HashMap::new();
+    for (idx, entry) in entries.iter().enumerate() {
+        let parent = entry
+            .path
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_default();
+        buckets
+            .entry((parent, entry.prefix.clone()))
+            .or_default()
+            .push(idx);
+    }
+    for indices in buckets.values_mut() {
+        rank_indices(entries, indices, target_dir, fingerprint_decisions, mtime_decisions);
+        let mut iter = indices.iter().copied();
+        if let Some(keep) = iter.next() {
+            entries[keep].action = PruneAction::Keep;
+        }
+        for idx in iter {
+            entries[idx].action = PruneAction::Delete;
+        }
+    }
+}
+
+/// Aggressive per-`prefix` bucketing (issue #316 — `--keep-latest`).
+/// All entries sharing a prefix across `deps/`, `.fingerprint/`,
+/// `incremental/`, and `build/` form a single bucket. The newest
+/// **hash family** wins — every entry whose hash matches the winning
+/// hash is kept; entries with any other hash are deleted.
+///
+/// Cargo expects the four subdirs to stay consistent (a `deps/` entry
+/// for hash X must have a matching `.fingerprint/<prefix>-X/`), so
+/// keeping the whole family avoids partially-orphaned state.
+fn classify_per_prefix(
+    entries: &mut [PruneTargetEntry],
+    target_dir: &Path,
+    fingerprint_decisions: &mut usize,
+    mtime_decisions: &mut usize,
+) {
+    let mut buckets: HashMap<String, Vec<usize>> = HashMap::new();
+    for (idx, entry) in entries.iter().enumerate() {
+        buckets
+            .entry(entry.prefix.clone())
+            .or_default()
+            .push(idx);
+    }
+    for indices in buckets.values_mut() {
+        rank_indices(entries, indices, target_dir, fingerprint_decisions, mtime_decisions);
+        let winning_hash = match indices.first() {
+            Some(&idx) => entries[idx].hash.clone(),
+            None => continue,
+        };
+        for &idx in indices.iter() {
+            if entries[idx].hash == winning_hash {
+                entries[idx].action = PruneAction::Keep;
+            } else {
+                entries[idx].action = PruneAction::Delete;
+            }
+        }
+    }
+}
+
+/// Sort `indices` (offsets into `entries`) descending by the
+/// authoritative recency timestamp, falling back to the entry's own
+/// mtime. Within an equal timestamp the lexicographically larger hash
+/// wins, so the ordering is deterministic across filesystems with
+/// coarse mtime resolution.
+///
+/// Increments the appropriate counter for each NEWEST-entry decision
+/// based on which timestamp source supplied its rank.
+fn rank_indices(
+    entries: &[PruneTargetEntry],
+    indices: &mut Vec<usize>,
+    target_dir: &Path,
+    fingerprint_decisions: &mut usize,
+    mtime_decisions: &mut usize,
+) {
+    let ranked: Vec<(usize, i64, RecencySource)> = indices
+        .iter()
+        .map(|&idx| {
+            let entry = &entries[idx];
+            let (ts, source) = entry_recency(entry, target_dir);
+            (idx, ts, source)
+        })
+        .collect();
+    let mut sorted = ranked;
+    sorted.sort_by(|a, b| {
+        b.1.cmp(&a.1)
+            .then_with(|| entries[b.0].hash.cmp(&entries[a.0].hash))
+    });
+    if let Some(&(_, _, source)) = sorted.first() {
+        match source {
+            RecencySource::FingerprintInvokedTimestamp => *fingerprint_decisions += 1,
+            RecencySource::EntryMtime => *mtime_decisions += 1,
+        }
+    }
+    *indices = sorted.into_iter().map(|(idx, _, _)| idx).collect();
+}
+
+/// Resolve the recency timestamp for one entry. Prefers cargo's
+/// authoritative `.fingerprint/<crate>-<hash>/invoked.timestamp`
+/// mtime, since cargo touches it on every invocation that consults
+/// the artifact; falls back to the entry's own mtime when the
+/// fingerprint file is missing or unreadable.
+///
+/// Cargo names `.fingerprint/` dirs after the unadorned crate name
+/// (e.g. `foo-<hash>`), but the corresponding `deps/` entries carry
+/// a `lib` prefix for `rlib`/`dylib` targets (e.g.
+/// `libfoo-<hash>.rlib`). We look up `<prefix>-<hash>` first; if
+/// `<prefix>` starts with `lib` and that misses, we retry against
+/// `<prefix without lib>-<hash>`.
+pub(crate) fn entry_recency(
+    entry: &PruneTargetEntry,
+    target_dir: &Path,
+) -> (i64, RecencySource) {
+    let lib_stripped = entry.prefix.strip_prefix("lib");
+    let candidates: &[&str] = match lib_stripped {
+        Some(stripped) => &[entry.prefix.as_str(), stripped],
+        None => &[entry.prefix.as_str()],
+    };
+    let profiles = match fs::read_dir(target_dir) {
+        Ok(it) => it,
+        Err(_) => return (entry.mtime_unix, RecencySource::EntryMtime),
+    };
+    let profile_paths: Vec<PathBuf> = profiles.flatten().map(|e| e.path()).collect();
+    for candidate_prefix in candidates {
+        let stem = format!("{candidate_prefix}-{}", entry.hash);
+        for profile_path in &profile_paths {
+            let invoked = profile_path
+                .join(".fingerprint")
+                .join(&stem)
+                .join("invoked.timestamp");
+            if let Ok(meta) = fs::metadata(&invoked) {
+                let ts = meta
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0);
+                return (ts, RecencySource::FingerprintInvokedTimestamp);
+            }
+        }
+    }
+    (entry.mtime_unix, RecencySource::EntryMtime)
 }
 
 /// Standard cargo-managed subdirectories of `target/<profile>/` where
@@ -463,6 +659,7 @@ mod tests {
         let report = prune_target(&PruneTargetOptions {
             target_dir: target,
             dry_run: false,
+            keep_latest: false,
         })
         .unwrap();
 
@@ -493,6 +690,7 @@ mod tests {
         let report = prune_target(&PruneTargetOptions {
             target_dir: target,
             dry_run: false,
+            keep_latest: false,
         })
         .unwrap();
 
@@ -519,6 +717,7 @@ mod tests {
         let report = prune_target(&PruneTargetOptions {
             target_dir: target,
             dry_run: false,
+            keep_latest: false,
         })
         .unwrap();
         assert_eq!(report.scanned, 0, "no entries should match the scan dirs");
@@ -549,6 +748,7 @@ mod tests {
         let report = prune_target(&PruneTargetOptions {
             target_dir: target,
             dry_run: false,
+            keep_latest: false,
         })
         .unwrap();
         assert_eq!(report.scanned, 3);
@@ -574,6 +774,7 @@ mod tests {
         let report = prune_target(&PruneTargetOptions {
             target_dir: target,
             dry_run: true,
+            keep_latest: false,
         })
         .unwrap();
         assert_eq!(report.scanned, 2);
@@ -596,6 +797,7 @@ mod tests {
         let err = prune_target(&PruneTargetOptions {
             target_dir: target.clone(),
             dry_run: false,
+            keep_latest: false,
         })
         .expect_err("must refuse when top-level lock exists");
         assert!(format!("{err}").contains(".cargo-lock"));
@@ -615,6 +817,7 @@ mod tests {
         let err = prune_target(&PruneTargetOptions {
             target_dir: target,
             dry_run: false,
+            keep_latest: false,
         })
         .expect_err("must refuse when profile lock exists");
         assert!(format!("{err}").contains(".cargo-lock"));
@@ -636,15 +839,197 @@ mod tests {
         let _ = prune_target(&PruneTargetOptions {
             target_dir: target.clone(),
             dry_run: false,
+            keep_latest: false,
         })
         .unwrap();
         let second = prune_target(&PruneTargetOptions {
             target_dir: target,
             dry_run: false,
+            keep_latest: false,
         })
         .unwrap();
         assert_eq!(second.scanned, 1);
         assert_eq!(second.kept, 1);
         assert_eq!(second.deleted, 0);
+    }
+
+    // -----------------------------------------------------------------
+    // Aggressive --keep-latest mode (issue #316). The bucket key drops
+    // from `(parent, prefix)` to `prefix`; the winning hash family is
+    // preserved across all subdirs. Recency rank prefers cargo's own
+    // `.fingerprint/<prefix>-<hash>/invoked.timestamp` mtime over the
+    // entry's own mtime — see entry_recency.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn keep_latest_drops_old_hash_family_across_subdirs() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        // Hash A is the older family; hash B is newer. Each lives in
+        // deps/, .fingerprint/, build/.
+        let deps_a = target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib");
+        let fp_a = target.join("debug/.fingerprint/foo-aaaaaaaaaaaaa/invoked.timestamp");
+        let build_a = target.join("debug/build/foo-aaaaaaaaaaaaa");
+        let deps_b = target.join("debug/deps/libfoo-bbbbbbbbbbbbb.rlib");
+        let fp_b = target.join("debug/.fingerprint/foo-bbbbbbbbbbbbb/invoked.timestamp");
+        let build_b = target.join("debug/build/foo-bbbbbbbbbbbbb");
+        touch(&deps_a);
+        touch(&fp_a);
+        touch_dir(&build_a);
+        touch(&deps_b);
+        touch(&fp_b);
+        touch_dir(&build_b);
+
+        // Pin the fingerprint timestamps so the ranker prefers B over A
+        // (B is newer).
+        set_mtime(&fp_a, 1_700_000_000);
+        set_mtime(&fp_b, 1_700_000_500);
+        // Set entry mtimes to the OPPOSITE order so we can prove the
+        // ranker honored the fingerprint timestamps, not the entry
+        // mtimes.
+        set_mtime(&deps_a, 1_700_001_000);
+        set_mtime(&deps_b, 1_700_000_001);
+
+        let report = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: false,
+            keep_latest: true,
+        })
+        .unwrap();
+
+        // All six entries scanned. Family B (deps_b + fp_b + build_b)
+        // survives; family A is gone.
+        assert_eq!(report.scanned, 6);
+        assert_eq!(report.kept, 3);
+        assert_eq!(report.deleted, 3);
+        assert!(deps_b.exists());
+        assert!(fp_b.exists());
+        assert!(build_b.exists());
+        assert!(!deps_a.exists());
+        assert!(!fp_a.exists());
+        assert!(!build_a.exists());
+        // Authoritative-source counter ticked up.
+        assert!(
+            report.keep_decisions_from_fingerprint > 0,
+            "fingerprint mtime should drive the rank"
+        );
+    }
+
+    #[test]
+    fn keep_latest_falls_back_to_entry_mtime_when_fingerprint_missing() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let deps_a = target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib");
+        let deps_b = target.join("debug/deps/libfoo-bbbbbbbbbbbbb.rlib");
+        touch(&deps_a);
+        touch(&deps_b);
+        // No .fingerprint/ dir at all → forced fallback to entry mtime.
+        set_mtime(&deps_a, 1_700_000_000);
+        set_mtime(&deps_b, 1_700_000_500);
+
+        let report = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: false,
+            keep_latest: true,
+        })
+        .unwrap();
+
+        assert!(deps_b.exists(), "newer entry wins");
+        assert!(!deps_a.exists());
+        assert!(
+            report.keep_decisions_from_mtime > 0,
+            "fallback path should be reflected in the counter"
+        );
+        assert_eq!(report.keep_decisions_from_fingerprint, 0);
+    }
+
+    #[test]
+    fn keep_latest_keeps_one_family_when_only_one_hash_exists() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let deps = target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib");
+        let fp = target.join("debug/.fingerprint/foo-aaaaaaaaaaaaa/invoked.timestamp");
+        touch(&deps);
+        touch(&fp);
+
+        let report = prune_target(&PruneTargetOptions {
+            target_dir: target,
+            dry_run: false,
+            keep_latest: true,
+        })
+        .unwrap();
+        assert_eq!(report.scanned, 2);
+        assert_eq!(report.kept, 2);
+        assert_eq!(report.deleted, 0);
+        assert!(deps.exists());
+        assert!(fp.exists());
+    }
+
+    #[test]
+    fn keep_latest_respects_cargo_lock_guard() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let deps_a = target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib");
+        let deps_b = target.join("debug/deps/libfoo-bbbbbbbbbbbbb.rlib");
+        touch(&deps_a);
+        touch(&deps_b);
+        touch(&target.join(".cargo-lock"));
+
+        let err = prune_target(&PruneTargetOptions {
+            target_dir: target.clone(),
+            dry_run: false,
+            keep_latest: true,
+        })
+        .expect_err("--keep-latest must still refuse under an active lock");
+        assert!(format!("{err}").contains(".cargo-lock"));
+        // Neither hash family was touched.
+        assert!(deps_a.exists());
+        assert!(deps_b.exists());
+    }
+
+    #[test]
+    fn entry_recency_prefers_fingerprint_timestamp() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let deps_path = target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib");
+        let fp_path = target.join("debug/.fingerprint/foo-aaaaaaaaaaaaa/invoked.timestamp");
+        touch(&deps_path);
+        touch(&fp_path);
+        // Entry mtime is OLDER than fingerprint mtime — we expect the
+        // ranker to pick the (newer) fingerprint.
+        set_mtime(&deps_path, 1_700_000_000);
+        set_mtime(&fp_path, 1_700_005_000);
+
+        let entry = PruneTargetEntry {
+            path: deps_path,
+            prefix: "libfoo".to_string(),
+            hash: "aaaaaaaaaaaaa".to_string(),
+            size_bytes: 0,
+            mtime_unix: 1_700_000_000,
+            action: PruneAction::Keep,
+        };
+        let (ts, source) = entry_recency(&entry, &target);
+        assert_eq!(ts, 1_700_005_000);
+        assert_eq!(source, RecencySource::FingerprintInvokedTimestamp);
+    }
+
+    #[test]
+    fn entry_recency_falls_back_to_entry_mtime() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().to_path_buf();
+        let entry = PruneTargetEntry {
+            path: target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib"),
+            prefix: "libfoo".to_string(),
+            hash: "aaaaaaaaaaaaa".to_string(),
+            size_bytes: 0,
+            // Note: the entry's own mtime field is the rank when no
+            // fingerprint file exists on disk.
+            mtime_unix: 1_700_000_000,
+            action: PruneAction::Keep,
+        };
+        // No .fingerprint/ dir created.
+        let (ts, source) = entry_recency(&entry, &target);
+        assert_eq!(ts, 1_700_000_000);
+        assert_eq!(source, RecencySource::EntryMtime);
     }
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -717,6 +717,17 @@ enum CacheSubcommand {
         /// Actually delete entries. Equivalent to `--no-dry-run`.
         #[arg(long, conflicts_with = "dry_run")]
         force: bool,
+        /// Switch from the legacy per-`(parent_dir, prefix)` orphan
+        /// prune (issue #336) to the aggressive per-`prefix` strategy
+        /// (issue #316): keep only the **newest hash family** per
+        /// logical artifact name, deleting every other hash's files
+        /// across `deps/`, `.fingerprint/`, `incremental/`, and
+        /// `build/`. Recency is ranked by cargo's authoritative
+        /// `.fingerprint/<prefix>-<hash>/invoked.timestamp` mtime when
+        /// available, falling back to the entry's own filesystem
+        /// mtime.
+        #[arg(long = "keep-latest")]
+        keep_latest: bool,
         /// Emit the stable machine-facing JSON form for this command.
         #[arg(long)]
         json: bool,
@@ -980,13 +991,19 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 dry_run,
                 no_dry_run,
                 force,
+                keep_latest,
                 json: prune_json,
             }) => {
                 let effective_dry_run = !(force || no_dry_run);
                 // Either flag pair maps onto the same boolean; `dry_run`
                 // is the documented default so we accept it explicitly.
                 let _ = dry_run;
-                cache::run_cache_prune_target_command(path, effective_dry_run, prune_json || json)?;
+                cache::run_cache_prune_target_command(
+                    path,
+                    effective_dry_run,
+                    keep_latest,
+                    prune_json || json,
+                )?;
             }
             Some(CacheSubcommand::TrimTarget {
                 path,

--- a/docs/API.md
+++ b/docs/API.md
@@ -250,15 +250,37 @@ soldr cache --json
 
 #### `soldr cache prune-target <path>`
 
-First slice of issue #316. Prune stale per-prefix cargo build artifacts
-inside a given `target/` directory, keeping only the newest entry per
-`(parent_dir, prefix)` bucket. Scanned subdirectories under each
-profile (`debug/`, `release/`, …) are `deps/`, `.fingerprint/`,
-`incremental/`, and `build/`.
+Prune stale per-prefix cargo build artifacts inside a given `target/`
+directory. Scanned subdirectories under each profile (`debug/`,
+`release/`, …) are `deps/`, `.fingerprint/`, `incremental/`, and
+`build/`.
+
+Two strategies are available:
+
+- **Default — orphan siblings (issue #336).** Keep the newest entry per
+  `(parent_dir, prefix)` bucket. Each subdirectory's set of
+  hash-siblings is pruned independently. Conservative: cargo tolerates
+  orphans across the four subdirs as long as the live entry inside
+  each is current.
+- **`--keep-latest` — aggressive (issue #316).** Bucket by `prefix`
+  alone; keep only the **newest hash family** per logical artifact
+  name, deleting every other hash's files across the four subdirs.
+  Shrinks a heavily-rebuilt target/ from 16+ GB to ~2 GB on real
+  workloads. Use when you don't need the per-subdir orphan retention.
+
+**Recency ranking.** Both strategies prefer cargo's authoritative
+`target/<profile>/.fingerprint/<prefix>-<hash>/invoked.timestamp`
+mtime — the same signal cargo's unstable `-Zgc` uses — and fall back
+to the entry's own filesystem mtime when the fingerprint file is
+missing or unreadable. The JSON output reports per-decision
+provenance via `keep_decisions_from_fingerprint` and
+`keep_decisions_from_mtime`.
 
 ```bash
-soldr cache prune-target ./target                  # dry-run report
-soldr cache prune-target ./target --force          # actually delete
+soldr cache prune-target ./target                  # dry-run, orphan-siblings
+soldr cache prune-target ./target --keep-latest    # dry-run, aggressive
+soldr cache prune-target ./target --force          # actually delete (orphan-siblings)
+soldr cache prune-target ./target --keep-latest --force  # actually delete (aggressive)
 soldr cache prune-target ./target --dry-run --json # machine-readable plan
 ```
 
@@ -275,11 +297,14 @@ JSON schema (`--json`):
   "command": "cache prune-target",
   "target_dir": "<absolute path>",
   "dry_run": true,
+  "keep_latest": false,
   "scanned": 3,
   "kept": 1,
   "deleted": 2,
   "reclaimed_bytes": 0,
   "reclaimed_human": "0 B",
+  "keep_decisions_from_fingerprint": 1,
+  "keep_decisions_from_mtime": 0,
   "entries": [
     {
       "path": "<absolute path>",
@@ -294,7 +319,7 @@ JSON schema (`--json`):
 }
 ```
 
-Automatic pruning via `RUSTC_WRAPPER` pre/post-compile hooks is
+Automatic pre/post-compile pruning via `RUSTC_WRAPPER` hooks is
 deferred to a follow-up — the manual subcommand is intentionally
 opt-in until the behaviour is trusted on real `target/` directories.
 


### PR DESCRIPTION
## Summary

`soldr cache prune-target` gains a `--keep-latest` aggressive strategy and an authoritative-timestamp recency rank.

## What changed

### `--keep-latest` strategy

The default prune (issue #336) buckets entries by `(parent_dir, prefix)` and keeps the newest entry in each subdirectory. The new `--keep-latest` (issue #316) buckets by `prefix` alone, then keeps only the **newest hash family** per logical artifact name — deleting every other hash's files across `deps/`, `.fingerprint/`, `incremental/`, and `build/`. This is what shrinks a heavily-rebuilt target/ from 16+ GB → ~2 GB on real workloads.

### Fingerprint-timestamp recency rank

Both strategies now prefer cargo's authoritative per-artifact `.fingerprint/<crate>-<hash>/invoked.timestamp` mtime — the same signal cargo's unstable `-Zgc` consults — falling back to the entry's own filesystem mtime when the fingerprint file is missing or unreadable. Cargo names `.fingerprint/` dirs after the unadorned crate (e.g. `foo-<hash>/`), so the lookup retries with the `lib` prefix stripped when ranking `deps/lib<crate>-<hash>.rlib`.

The JSON output picks up `keep_decisions_from_fingerprint` / `keep_decisions_from_mtime` counters so consumers can tell which timestamp source drove each keep decision.

## Test coverage

20 unit tests in `prune_target::tests` pass (6 new). Tests prove the fingerprint timestamp wins even when entry mtimes disagree (the test deliberately inverts them), and the mtime fallback works when no fingerprint file exists.

## Out of scope

Auto pre/post-compile pruning via `RUSTC_WRAPPER` hooks is deferred — the manual subcommand is intentionally opt-in until the behaviour is trusted on real `target/` directories. Filed as a follow-up.

Refs #478, #336. Closes #316.

## Test plan
- [x] `cargo build` + `cargo clippy --no-deps` clean
- [x] 20 prune_target unit tests pass (including 6 new --keep-latest / recency-rank tests)
- [ ] Real-world soldr target/ run: verify aggressive mode reclaims expected bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)