### PR TITLE
feat(cargo): auto pre/post-compile target prune hooks (#485)

### DIFF
--- a/crates/soldr-cli/src/cache_lib/auto_target_gc.rs
+++ b/crates/soldr-cli/src/cache_lib/auto_target_gc.rs
@@ -1,0 +1,239 @@
+//! Automatic pre- and post-compile `target/` prune hooks (issue #485 —
+//! follow-up to #316). Wires the existing
+//! [`super::prune_target::prune_target`] keep-latest strategy into the
+//! `soldr cargo` front door so accumulated hash-suffixed orphans never
+//! grow unbounded across rebuilds.
+//!
+//! The opt-out surface (flags + env var) lives in the front door; this
+//! module only executes a single pass and returns a summary.
+
+use super::prune_target::{prune_target, PruneTargetOptions};
+use std::path::Path;
+
+/// When the prune ran, relative to the cargo invocation. Used to label
+/// the stderr summary so users can tell which pass freed which bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoPrunePhase {
+    Before,
+    After,
+}
+
+impl AutoPrunePhase {
+    pub fn label(self) -> &'static str {
+        match self {
+            AutoPrunePhase::Before => "before",
+            AutoPrunePhase::After => "after",
+        }
+    }
+}
+
+/// Aggregated summary of one auto-prune pass. Empty when nothing was
+/// deleted or when the pass was skipped — callers use [`Self::is_empty`]
+/// to suppress the stderr line so silent operation stays silent.
+#[derive(Debug, Default, Clone)]
+pub struct AutoPruneOutcome {
+    pub phase: Option<AutoPrunePhase>,
+    pub deleted: usize,
+    pub reclaimed_bytes: u64,
+    /// True when the pass refused to run because an active `.cargo-lock`
+    /// was present. Surfaced for tests; never printed by default since
+    /// the issue spec asks for silence in that case.
+    pub skipped_for_active_lock: bool,
+}
+
+impl AutoPruneOutcome {
+    pub fn is_empty(&self) -> bool {
+        self.deleted == 0 && self.reclaimed_bytes == 0 && !self.skipped_for_active_lock
+    }
+}
+
+/// Best-effort prune of `target_dir` using the keep-latest strategy.
+/// Silently skipped (returns an empty outcome) on:
+///
+/// * missing or non-directory `target_dir`,
+/// * an active `.cargo-lock` (top-level or per-profile) — sets
+///   `skipped_for_active_lock` so a parallel `cargo` invocation sharing
+///   the same `target/` is never raced,
+/// * any I/O failure during the walk.
+///
+/// The auto-hook MUST NEVER fail a build, so all error paths collapse
+/// into "nothing happened this pass" rather than propagating to the
+/// caller.
+pub fn auto_prune_target(target_dir: &Path, phase: AutoPrunePhase) -> AutoPruneOutcome {
+    let metadata = match std::fs::metadata(target_dir) {
+        Ok(m) => m,
+        Err(_) => return AutoPruneOutcome::default(),
+    };
+    if !metadata.is_dir() {
+        return AutoPruneOutcome::default();
+    }
+
+    let opts = PruneTargetOptions {
+        target_dir: target_dir.to_path_buf(),
+        dry_run: false,
+        keep_latest: true,
+    };
+    match prune_target(&opts) {
+        Ok(report) => AutoPruneOutcome {
+            phase: Some(phase),
+            deleted: report.deleted,
+            reclaimed_bytes: report.reclaimed_bytes,
+            skipped_for_active_lock: false,
+        },
+        Err(err) => {
+            // The prune_target error type stringifies the active-lock
+            // refusal with a `.cargo-lock` substring; treat as a soft
+            // skip rather than a build failure.
+            let skipped_for_active_lock = err.to_string().contains(".cargo-lock");
+            AutoPruneOutcome {
+                phase: Some(phase),
+                deleted: 0,
+                reclaimed_bytes: 0,
+                skipped_for_active_lock,
+            }
+        }
+    }
+}
+
+/// Render a one-line stderr summary for a pass. Returns `None` when the
+/// outcome is empty (no deletions, no skip) so callers can stay silent.
+pub fn render_summary(outcome: &AutoPruneOutcome) -> Option<String> {
+    if outcome.is_empty() {
+        return None;
+    }
+    if outcome.skipped_for_active_lock {
+        return None;
+    }
+    let phase = outcome.phase.map(|p| p.label()).unwrap_or("auto");
+    Some(format!(
+        "soldr: target-gc ({phase}): pruned {} stale hash {}, reclaimed {}",
+        outcome.deleted,
+        if outcome.deleted == 1 {
+            "family"
+        } else {
+            "families"
+        },
+        super::target_registry::human_size(outcome.reclaimed_bytes),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::io::Write as _;
+    use tempfile::tempdir;
+
+    fn touch(path: &std::path::Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        File::create(path).unwrap();
+    }
+
+    fn write_bytes(path: &std::path::Path, n: usize) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = File::create(path).unwrap();
+        let buf = vec![0u8; n];
+        f.write_all(&buf).unwrap();
+    }
+
+    #[test]
+    fn auto_prune_target_missing_dir_is_silent() {
+        let temp = tempdir().unwrap();
+        let absent = temp.path().join("does-not-exist");
+        let outcome = auto_prune_target(&absent, AutoPrunePhase::Before);
+        assert!(outcome.is_empty());
+        assert!(render_summary(&outcome).is_none());
+    }
+
+    #[test]
+    fn auto_prune_target_skips_for_active_lock() {
+        let temp = tempdir().unwrap();
+        let target = temp.path();
+        touch(&target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib"));
+        touch(&target.join("debug/deps/libfoo-bbbbbbbbbbbbb.rlib"));
+        touch(&target.join(".cargo-lock"));
+        let outcome = auto_prune_target(target, AutoPrunePhase::Before);
+        assert!(
+            outcome.skipped_for_active_lock,
+            "active lock must short-circuit"
+        );
+        // No stderr line on the active-lock skip per spec.
+        assert!(render_summary(&outcome).is_none());
+        // No files touched.
+        assert!(target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib").exists());
+        assert!(target.join("debug/deps/libfoo-bbbbbbbbbbbbb.rlib").exists());
+    }
+
+    #[test]
+    fn auto_prune_target_deletes_stale_hash_family() {
+        let temp = tempdir().unwrap();
+        let target = temp.path();
+        let old = target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib");
+        let new = target.join("debug/deps/libfoo-bbbbbbbbbbbbb.rlib");
+        write_bytes(&old, 4096);
+        write_bytes(&new, 4096);
+        // Pin entry mtimes (no fingerprint dir → falls back to entry mtime).
+        let when_old = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        let when_new = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_500);
+        File::options()
+            .write(true)
+            .open(&old)
+            .unwrap()
+            .set_modified(when_old)
+            .unwrap();
+        File::options()
+            .write(true)
+            .open(&new)
+            .unwrap()
+            .set_modified(when_new)
+            .unwrap();
+
+        let outcome = auto_prune_target(target, AutoPrunePhase::After);
+        assert_eq!(outcome.deleted, 1);
+        assert!(outcome.reclaimed_bytes > 0);
+        assert_eq!(outcome.phase, Some(AutoPrunePhase::After));
+        assert!(render_summary(&outcome).is_some());
+        assert!(new.exists());
+        assert!(!old.exists());
+    }
+
+    #[test]
+    fn auto_prune_target_no_op_when_nothing_to_drop() {
+        let temp = tempdir().unwrap();
+        let target = temp.path();
+        let single = target.join("debug/deps/libfoo-aaaaaaaaaaaaa.rlib");
+        write_bytes(&single, 64);
+
+        let outcome = auto_prune_target(target, AutoPrunePhase::Before);
+        assert_eq!(outcome.deleted, 0);
+        assert!(outcome.is_empty());
+        assert!(render_summary(&outcome).is_none());
+        assert!(single.exists());
+    }
+
+    #[test]
+    fn summary_pluralizes_correctly() {
+        let one = AutoPruneOutcome {
+            phase: Some(AutoPrunePhase::Before),
+            deleted: 1,
+            reclaimed_bytes: 1024,
+            skipped_for_active_lock: false,
+        };
+        assert!(render_summary(&one)
+            .unwrap()
+            .contains("1 stale hash family"));
+        let many = AutoPruneOutcome {
+            phase: Some(AutoPrunePhase::After),
+            deleted: 3,
+            reclaimed_bytes: 2048,
+            skipped_for_active_lock: false,
+        };
+        assert!(render_summary(&many)
+            .unwrap()
+            .contains("3 stale hash families"));
+    }
+}

--- a/crates/soldr-cli/src/cache_lib/mod.rs
+++ b/crates/soldr-cli/src/cache_lib/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 pub mod auto_gc;
+pub mod auto_target_gc;
 pub mod cargo_global_cache;
 pub mod gc;
 pub mod prune_target;

--- a/crates/soldr-cli/src/cargo_front_door.rs
+++ b/crates/soldr-cli/src/cargo_front_door.rs
@@ -2,6 +2,7 @@
 //! injection, low-disk warning, and the cargo arg-parsing helpers shared
 //! with `rust_plan`. Extracted from `main.rs` as part of issue #339.
 
+use crate::cache_lib::auto_target_gc::{auto_prune_target, render_summary, AutoPrunePhase};
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
 use crate::fetch::VersionSpec;
 use crate::trampoline::{refresh_sidecar_after_cargo, try_run_trampoline, TrampolineDecision};
@@ -41,6 +42,106 @@ fn current_unix_ms() -> i64 {
         .unwrap_or(0)
 }
 
+/// Soldr-private opt-out flags for the auto target-GC hooks (#485).
+/// Stripped from the arg vector before forwarding to cargo, since
+/// cargo doesn't understand them.
+pub(crate) const NO_GC_TARGET_FLAG: &str = "--no-gc-target";
+pub(crate) const NO_GC_TARGET_BEFORE_FLAG: &str = "--no-gc-target-before";
+pub(crate) const NO_GC_TARGET_AFTER_FLAG: &str = "--no-gc-target-after";
+/// Env-var fallback for the wrapper-side path where cargo can't
+/// forward flags to soldr. Treated as equivalent to `--no-gc-target`
+/// when set to a non-empty value.
+pub(crate) const NO_GC_TARGET_ENV_VAR: &str = "SOLDR_NO_GC_TARGET";
+
+/// Outcome of stripping the `--no-gc-target*` flags from a cargo arg
+/// vector. Mirrors the env-var fallback so callers can union all
+/// inputs into a single before/after decision.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct GcTargetOptOut {
+    pub before: bool,
+    pub after: bool,
+}
+
+impl GcTargetOptOut {
+    fn merged_with_env(mut self) -> Self {
+        if env_disables_target_gc() {
+            self.before = true;
+            self.after = true;
+        }
+        self
+    }
+}
+
+fn env_disables_target_gc() -> bool {
+    std::env::var_os(NO_GC_TARGET_ENV_VAR)
+        .map(|v| {
+            let s = v.to_string_lossy();
+            let t = s.trim();
+            !t.is_empty() && !t.eq_ignore_ascii_case("0") && !t.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
+/// Remove soldr-private `--no-gc-target*` flags from the arg vector and
+/// return the cleaned slice plus which passes the caller asked to skip.
+/// Flags after the `--` separator are passed through untouched.
+pub(crate) fn strip_no_gc_target_flags(args: &[String]) -> (Vec<String>, GcTargetOptOut) {
+    let mut cleaned = Vec::with_capacity(args.len());
+    let mut opt_out = GcTargetOptOut::default();
+    let mut past_separator = false;
+    for arg in args {
+        if past_separator {
+            cleaned.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            past_separator = true;
+            cleaned.push(arg.clone());
+            continue;
+        }
+        match arg.as_str() {
+            NO_GC_TARGET_FLAG => {
+                opt_out.before = true;
+                opt_out.after = true;
+            }
+            NO_GC_TARGET_BEFORE_FLAG => opt_out.before = true,
+            NO_GC_TARGET_AFTER_FLAG => opt_out.after = true,
+            _ => cleaned.push(arg.clone()),
+        }
+    }
+    (cleaned, opt_out)
+}
+
+/// Resolve the cargo `target/` directory that an auto-prune pass should
+/// operate on. Mirrors cargo's resolution order:
+/// 1. `--target-dir <DIR>` inside the arg list.
+/// 2. `CARGO_TARGET_DIR` env var (if non-empty).
+/// 3. `<workspace_root>/target` derived from the nearest enclosing
+///    `Cargo.toml` to cwd.
+///
+/// Returns `None` when no manifest can be found cheaply — the auto-hook
+/// silently skips in that case rather than guessing.
+fn resolve_target_dir_for_gc(args: &[String]) -> Option<std::path::PathBuf> {
+    if let Some(value) = cargo_arg_value(args, "--target-dir") {
+        return Some(absolutize_path(std::path::PathBuf::from(value)));
+    }
+    if let Some(env_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        let s = env_dir.to_string_lossy().trim().to_string();
+        if !s.is_empty() {
+            return Some(absolutize_path(std::path::PathBuf::from(s)));
+        }
+    }
+    let manifest = crate::trampoline::find_nearest_manifest()?;
+    let manifest_dir = manifest.parent()?.to_path_buf();
+    Some(manifest_dir.join("target"))
+}
+
+fn emit_auto_prune_summary(outcome: &crate::cache_lib::auto_target_gc::AutoPruneOutcome) {
+    if let Some(line) = render_summary(outcome) {
+        eprintln!("{line}");
+    }
+}
+
 pub(crate) async fn run_cargo_front_door(
     args: &[String],
     cache_enabled: bool,
@@ -51,6 +152,13 @@ pub(crate) async fn run_cargo_front_door(
             "`--no-cache` must appear before `cargo`, as in `soldr --no-cache cargo build`".into(),
         ));
     }
+
+    // Strip soldr-private auto target-GC opt-out flags before any other
+    // arg-vector handling so downstream code (trampolines, cargo spawn)
+    // never sees them. The env-var fallback is unioned in below.
+    let (args_owned, gc_opt_out) = strip_no_gc_target_flags(args);
+    let gc_opt_out = gc_opt_out.merged_with_env();
+    let args: &[String] = &args_owned;
 
     // `cargo run` trampoline (issue #344). When the binary is already
     // up-to-date with the recorded sources, this exec's the binary
@@ -215,6 +323,23 @@ pub(crate) async fn run_cargo_front_door(
         }
     }
 
+    // Pre-compile target-GC (#485). Only on build-like cargo invocations
+    // (build/check/test/run/...) and only when the user hasn't opted out
+    // via --no-gc-target / --no-gc-target-before / SOLDR_NO_GC_TARGET.
+    // Uses the rust_plan target_dir when available so the hook respects
+    // any CARGO_TARGET_DIR / --target-dir override the same way cargo
+    // and rust_plan do.
+    if build_like_cargo && !gc_opt_out.before {
+        let target_dir = plan_ctx
+            .as_ref()
+            .map(|p| std::path::PathBuf::from(&p.target_dir))
+            .or_else(|| resolve_target_dir_for_gc(args));
+        if let Some(dir) = target_dir.as_deref() {
+            let outcome = auto_prune_target(dir, AutoPrunePhase::Before);
+            emit_auto_prune_summary(&outcome);
+        }
+    }
+
     // For clippy fall-through we need to TEE cargo's stdout/stderr so the
     // user sees diagnostics live AND we have a copy to store in the
     // sidecar for the next run. For build/check we don't need the output;
@@ -267,6 +392,22 @@ pub(crate) async fn run_cargo_front_door(
         if let Some(plan) = plan_ctx.as_ref() {
             rust_plan::run_zccache_rust_plan(plan, "save", true)?;
             rust_plan::write_warm_restore_sentinel(plan);
+        }
+        // Post-compile target-GC (#485). Same gating as the pre-pass —
+        // build-like cargo, no opt-out, resolve dir consistently with the
+        // pre-pass. The active-cargo-lock guard inside `auto_prune_target`
+        // is what keeps a parallel `cargo` in the same `target/` from
+        // racing this pass; we never emit a stderr line when that guard
+        // engages.
+        if build_like_cargo && !gc_opt_out.after {
+            let target_dir = plan_ctx
+                .as_ref()
+                .map(|p| std::path::PathBuf::from(&p.target_dir))
+                .or_else(|| resolve_target_dir_for_gc(args));
+            if let Some(dir) = target_dir.as_deref() {
+                let outcome = auto_prune_target(dir, AutoPrunePhase::After);
+                emit_auto_prune_summary(&outcome);
+            }
         }
         if let Some(plan) = trampoline_plan.as_ref() {
             refresh_sidecar_after_cargo(plan);

--- a/crates/soldr-cli/src/cargo_front_door_tests.rs
+++ b/crates/soldr-cli/src/cargo_front_door_tests.rs
@@ -4,6 +4,41 @@
 //! stays comfortably under the 1000-LOC ceiling.
 
 use super::*;
+use std::ffi::{OsStr, OsString};
+use std::sync::Mutex;
+
+/// Serialises tests that mutate process-wide environment variables so
+/// they don't race under parallel `cargo test`.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = &self.previous {
+            std::env::set_var(self.key, value);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
 
 #[test]
 fn low_disk_warning_formats_yellow_below_threshold() {
@@ -213,4 +248,123 @@ fn cargo_args_are_cacheable_for_watch_with_toolchain_pin() {
     assert!(cargo_args_are_cacheable(&argv(&[
         "+nightly", "watch", "-x", "build",
     ])));
+}
+
+// -------------------------------------------------------------------------
+// Auto target-GC flag stripping (#485). The soldr-private flags get pulled
+// out of the arg vector before cargo ever sees them. The env var path is
+// covered separately because it touches process state.
+// -------------------------------------------------------------------------
+
+#[test]
+fn strip_no_gc_target_flag_removes_combined_form() {
+    let (cleaned, opt) = strip_no_gc_target_flags(&argv(&["build", "--no-gc-target", "--release"]));
+    assert_eq!(cleaned, argv(&["build", "--release"]));
+    assert!(opt.before);
+    assert!(opt.after);
+}
+
+#[test]
+fn strip_no_gc_target_flag_removes_before_only() {
+    let (cleaned, opt) = strip_no_gc_target_flags(&argv(&["check", "--no-gc-target-before"]));
+    assert_eq!(cleaned, argv(&["check"]));
+    assert!(opt.before);
+    assert!(!opt.after);
+}
+
+#[test]
+fn strip_no_gc_target_flag_removes_after_only() {
+    let (cleaned, opt) =
+        strip_no_gc_target_flags(&argv(&["build", "--no-gc-target-after", "--workspace"]));
+    assert_eq!(cleaned, argv(&["build", "--workspace"]));
+    assert!(!opt.before);
+    assert!(opt.after);
+}
+
+#[test]
+fn strip_no_gc_target_flag_default_no_op() {
+    let (cleaned, opt) = strip_no_gc_target_flags(&argv(&["build", "--release"]));
+    assert_eq!(cleaned, argv(&["build", "--release"]));
+    assert!(!opt.before);
+    assert!(!opt.after);
+}
+
+#[test]
+fn strip_no_gc_target_flag_passes_through_after_separator() {
+    // Flags after `--` belong to the program cargo runs and must not be
+    // touched. This mirrors how `--no-trampoline` is handled.
+    let (cleaned, opt) = strip_no_gc_target_flags(&argv(&[
+        "run",
+        "--bin",
+        "foo",
+        "--",
+        "--no-gc-target",
+        "--no-gc-target-after",
+    ]));
+    assert_eq!(
+        cleaned,
+        argv(&[
+            "run",
+            "--bin",
+            "foo",
+            "--",
+            "--no-gc-target",
+            "--no-gc-target-after",
+        ])
+    );
+    assert!(!opt.before);
+    assert!(!opt.after);
+}
+
+#[test]
+fn strip_no_gc_target_flag_handles_repeated_flags() {
+    let (cleaned, opt) = strip_no_gc_target_flags(&argv(&[
+        "build",
+        "--no-gc-target-before",
+        "--no-gc-target-after",
+    ]));
+    assert_eq!(cleaned, argv(&["build"]));
+    assert!(opt.before);
+    assert!(opt.after);
+}
+
+#[test]
+fn env_disables_target_gc_truthy_values() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    for value in ["1", "true", "yes", "anything"] {
+        let _guard = EnvVarGuard::set(NO_GC_TARGET_ENV_VAR, value);
+        let merged = GcTargetOptOut::default().merged_with_env();
+        assert!(
+            merged.before && merged.after,
+            "env value {value:?} should force both opt-outs"
+        );
+    }
+}
+
+#[test]
+fn env_disables_target_gc_falsey_values_dont_opt_out() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    for value in ["", "0", "false", "False"] {
+        let _guard = EnvVarGuard::set(NO_GC_TARGET_ENV_VAR, value);
+        let merged = GcTargetOptOut::default().merged_with_env();
+        assert!(
+            !merged.before && !merged.after,
+            "env value {value:?} must not opt out"
+        );
+    }
+}
+
+#[test]
+fn env_disables_target_gc_preserves_explicit_flag_opt_outs() {
+    // If --no-gc-target-before is on the cli, the env var being unset
+    // must not silently re-enable the after pass.
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _guard = EnvVarGuard::remove(NO_GC_TARGET_ENV_VAR);
+    let merged = GcTargetOptOut {
+        before: true,
+        after: false,
+    }
+    .merged_with_env();
+    assert!(merged.before);
+    assert!(!merged.after);
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -326,9 +326,41 @@ JSON schema (`--json`):
 }
 ```
 
-Automatic pre/post-compile pruning via `RUSTC_WRAPPER` hooks is
-deferred to a follow-up — the manual subcommand is intentionally
-opt-in until the behaviour is trusted on real `target/` directories.
+**Automatic pre/post-compile pruning (issue #485).** The cargo front
+door (`soldr cargo <build-like-subcommand>`) runs the
+`--keep-latest` strategy against the resolved `target/` directory
+both BEFORE spawning cargo and AFTER cargo succeeds. Hooks engage
+for the same set of build-like subcommands that participate in
+soldr's compilation cache (build, check, test, clippy, run, doc,
+…). Non-build commands (e.g. `cargo metadata`) skip the hooks.
+
+When a pass actually frees bytes a single stderr summary is
+emitted, e.g.:
+
+```
+soldr: target-gc (before): pruned 4 stale hash families, reclaimed 218 MB
+```
+
+Passes that delete nothing stay silent. Passes that refuse because
+an active `.cargo-lock` is present (parallel cargo invocations
+sharing the same `target/`) also stay silent — the same guard the
+manual subcommand uses.
+
+Opt-out surface (all default-off; multiple may combine):
+
+- `--no-gc-target` — skip both pre- and post-compile passes for this
+  invocation. Stripped from the arg list before forwarding to cargo.
+- `--no-gc-target-before` — skip only the pre-compile pass.
+- `--no-gc-target-after` — skip only the post-compile pass.
+- `SOLDR_NO_GC_TARGET=1` — env-var equivalent of `--no-gc-target`,
+  for invocations the cargo arg list can't reach (e.g. a parent
+  process that spawns cargo without going through `soldr cargo`).
+  Truthy values (`1`, `true`, `yes`, any non-empty non-zero string)
+  enable the opt-out; `0`, `false`, and unset disable it.
+
+The hooks reuse the same `find_active_cargo_lock` guard as the
+manual subcommand, so a parallel cargo build in the same `target/`
+will never be raced.
 
 ### `soldr install-zccache`
 


### PR DESCRIPTION
## Summary

Wires the existing `prune_target::keep_latest` strategy (shipped in #484) into the `soldr cargo` front door so accumulated hash-suffixed orphans in `target/` never grow unbounded across rebuilds. Carries the deferral from #316.

- Default-on for build-like cargo subcommands (build / check / test / clippy / run / doc / nextest / chef / install / fix / bench / rustc).
- One stderr line per pass when something is actually freed; silent when there's nothing to drop or when the active-`.cargo-lock` guard engages.
- Opt-out flags + env var documented in `docs/API.md`.

## Behaviour change

For every build-like `soldr cargo …` invocation:

1. **Before cargo spawns**: resolve `target/` (rust_plan target dir → `--target-dir` → `CARGO_TARGET_DIR` → nearest `Cargo.toml`/target), run `prune_target` with `keep_latest=true, dry_run=false`. Emit summary if anything was deleted.
2. **After cargo succeeds**: same pass.

Non-build commands (`metadata`, `fmt`, …) are not bracketed.

## Opt-out surface

| Flag / env | Effect |
|---|---|
| \`--no-gc-target\` | skip both passes |
| \`--no-gc-target-before\` | skip the pre-compile pass |
| \`--no-gc-target-after\` | skip the post-compile pass |
| \`SOLDR_NO_GC_TARGET=1\` | env-var equivalent of \`--no-gc-target\` |

Soldr-private flags are stripped before forwarding the arg vector to cargo, same pattern as \`--no-trampoline\`. Truthy env values include \`1\`, \`true\`, \`yes\`, any non-empty non-zero string; \`0\` / \`false\` / unset disable.

## Concurrency safety

The auto-hook reuses \`prune_target\`'s existing \`find_active_cargo_lock\` guard. When a sibling \`cargo\` invocation is mid-build and holding \`target/.cargo-lock\` (or \`target/<profile>/.cargo-lock\`), the prune returns a refusal error and \`auto_prune_target\` translates that into a silent skip — never a failed build.

## Implementation

- New module \`crates/soldr-cli/src/cache_lib/auto_target_gc.rs\` owns the single-pass executor + summary renderer.
- \`cargo_front_door.rs\` gains the flag constants (\`NO_GC_TARGET_FLAG\` / \`NO_GC_TARGET_BEFORE_FLAG\` / \`NO_GC_TARGET_AFTER_FLAG\` / \`NO_GC_TARGET_ENV_VAR\`), the \`strip_no_gc_target_flags\` helper, a \`resolve_target_dir_for_gc\` resolver, and the two hook call sites bracketing \`command.status()\`.
- \`docs/API.md\` documents the flags, env var, and stderr summary.

## Test plan

- [x] \`soldr cargo test -p soldr-cli --lib cache_lib::auto_target_gc\` — 5 tests pass (missing-dir, active-lock, deletes, no-op, pluralization)
- [x] \`soldr cargo test -p soldr-cli --bin soldr -- strip_no_gc_target\` — 6 tests pass (combined, before-only, after-only, default, after \`--\` separator, repeated)
- [x] \`soldr cargo test -p soldr-cli --bin soldr -- env_disables_target_gc\` — 3 tests pass (truthy values, falsey values, explicit-flag preservation)
- [x] \`soldr cargo build -p soldr-cli\` (green)
- [x] \`soldr cargo clippy -p soldr-cli --bin soldr --tests --no-deps -- -D warnings\` (green)

Closes #485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)