### PR TITLE
chore(zccache): bump managed pin 1.9.1 -> 1.10.0

### DIFF
--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -69,7 +69,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.9.1";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.10.0";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.9.1");
+    assert_eq!(json["managed_zccache_version"], "1.10.0");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.9.1");
+    assert_eq!(json["managed_zccache_version"], "1.10.0");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.9.1");
+    assert_eq!(json["managed_zccache_version"], "1.10.0");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.9.1");
+    assert_eq!(status_json["managed_version"], "1.10.0");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.9.1");
+    assert_eq!(json["managed_version"], "1.10.0");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Bumps soldr's pinned managed-zccache version from 1.9.1 (2026-05-24T07:53Z) to **1.10.0** (2026-05-24T18:10Z, the latest release as of merge time).

New soldr installs and CI runners will fetch 1.10.0 from the GitHub Releases asset URL after this lands. Local devs with a pinned install via `soldr install-zccache` keep their current pin until they run `install-zccache --remove` or upgrade explicitly.

## Changes

- `crates/soldr-cli/src/fetch/mod.rs`: `MANAGED_ZCCACHE_VERSION` 1.9.1 → 1.10.0.
- `crates/soldr-cli/tests/cli_cache.rs`, `tests/cli_install_zccache.rs`: assertion strings updated to match.
- The two remaining `1.9.1` references (in `src/main.rs` doc + `src/rust_plan.rs` comment) describe the version a feature was introduced — intentionally left alone.

## Context

zccache PR #392 (`feat(cli): zccache cc subcommand for cc-rs build-script caching`) merged to zccache main ~2 minutes after 1.10.0 was tagged. **1.10.0 does NOT contain the explicit `zccache cc` subcommand**, but it does carry the gcc/clang/MSVC `CompilerFamily` detection in `compiler/detect.rs` that soldr#310's `CC="zccache <real-cc>"` injection relies on. The wrapper-mode invocation (`zccache <compiler> <args>`) has been the supported entry point since well before 1.10.0; #310's env injection works against any of the 1.x releases.

If the post-#310 perf-matrix run (currently queued — [run `26369503983`](https://github.com/zackees/soldr/actions/runs/26369503983)) shows sqlite-link clear the 3x gate on 1.9.1 alone, this bump is hygiene. If it doesn't, a follow-up bump to a 1.10.1 release that includes zccache PR #392 may be needed.

## Test plan

- [x] `soldr cargo build -p soldr-cli` (green)
- [x] `soldr cargo clippy -p soldr-cli --bin soldr --tests --no-deps -- -D warnings` (green)
- [x] `soldr cargo test -p soldr-cli --test cli_cache` (19 pass)
- [x] `soldr cargo test -p soldr-cli --test cli_install_zccache` (5 pass)
- [x] `soldr cargo test -p soldr-cli --test cli_cargo_native_cc` (6 pass — verifies the #310 injection still works against the new pin)

Local managed-fetch path was not exercised because this dev machine has a 1.8.1 pinned-install that overrides the managed-version resolution; the CI runners are fresh per job, so they exercise the new pin natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)