### PR TITLE
chore(release): soldr 0.7.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.31"
+version = "0.7.32"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.31"
+version = "0.7.32"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.31",
+  "version": "0.7.32",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Release: soldr 0.7.32

Bumps `[workspace.package].version` in `Cargo.toml` and `"version"` in `package.json` from 0.7.31 → 0.7.32 to trigger `Autonomous Release`.

### Pre-flight check (per CLAUDE.md)

| Registry / tag | 0.7.32 state |
|---|---|
| `git ls-remote --tags origin v0.7.32` | empty (no tag) |
| PyPI `soldr` 0.7.32 | 404 (unreleased) |
| npm `@zackees/soldr@0.7.32` | 404 (unreleased) |
| `Cargo.toml` | bumped → 0.7.32 |
| `package.json` | bumped → 0.7.32 |

All four registries confirmed free; safe to merge for an automated cut.

### What ships in 0.7.32

| # | PR | Title |
|---|---|---|
| #310 | #494 | feat(cargo): inject zccache CC/CXX env vars for native C/C++ caching |
| (zccache pin) | #496 | chore(zccache): bump managed pin 1.9.1 → 1.10.0 |
| #485 | #488 | feat(cargo): auto pre/post-compile target prune hooks |
| #440 | #489 | perf(wrapper): memoize target-registry write across rustc invocations |
| #342 | #490 | feat(trampoline): content-hash oracle replaces mtime+size as the freshness signal |

**User-visible highlights:**

- **Native C/C++ caching is on by default.** `soldr cargo build` now injects `CC="<zccache> <real-cc>"` / `CXX="<zccache> <real-c++>"` plus `CC_KNOWN_WRAPPER_CUSTOM=zccache` so cc-rs invocations from cargo build scripts (e.g. `rusqlite[bundled]`'s ~50 C source files) hit zccache. Opt-out via `SOLDR_NATIVE_CACHE=0`. Windows wraps user-explicit CC; Unix synthesizes a `cc` default.
- **Managed zccache pin: 1.9.1 → 1.10.0.** New installs and fresh CI runners fetch the newer release. Local users with `soldr install-zccache <path>` pins are unaffected.
- **82× speedup on the wrapper hot path** — `target_dir_recorded_*` median per rustc invocation dropped from 19.5 ms to 238 µs on Windows (#440 / PR #489).
- **Target-GC hooks.** `soldr cargo build` now runs `prune_target` before and after every build-like cargo invocation; opt-out via `--no-gc-target` / `--no-gc-target-before` / `--no-gc-target-after` / `SOLDR_NO_GC_TARGET=1` (#485 / PR #488).
- **Content-hash trampoline oracle.** `soldr cargo run` now uses blake3 content hashes (with mtime+size as a fast skip-hint) so tar-mtime-epoch restores, clock skew, and same-second edits all stay correct (#342 / PR #490).

### Test plan

- [x] `soldr cargo build -p soldr-cli` (green with new version)
- [x] Pre-flight registry check (above)
- [ ] CI matrix on this PR
- [ ] Autonomous Release picks up the merge and tags `v0.7.32`
- [ ] PyPI `soldr==0.7.32` published
- [ ] npm `@zackees/soldr@0.7.32` published

🤖 Generated with [Claude Code](https://claude.com/claude-code)
