### PR TITLE
feat(gc): cargo_git_checkouts walker + --git-checkouts purge (#323 slice 3)

### DIFF
--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -412,15 +412,21 @@ pub(crate) enum GcSubcommand {
         #[arg(long)]
         json: bool,
         /// Narrow the purge to a single taxonomy kind. Mutually exclusive
-        /// with `--registry-src`. Accepted values: `cargo_target`,
-        /// `cargo_registry_src` (#323 slice 2).
-        #[arg(long, value_enum, conflicts_with = "registry_src")]
+        /// with `--registry-src` / `--git-checkouts`. Accepted values:
+        /// `cargo_target`, `cargo_registry_src` (#323 slice 2),
+        /// `cargo_git_checkouts` (#323 slice 3).
+        #[arg(long, value_enum, conflicts_with_all = ["registry_src", "git_checkouts"])]
         kind: Option<GcListKind>,
         /// Shorthand for `--kind cargo_registry_src`. Walks
         /// `$CARGO_HOME/registry/src/<reg>/<crate>-<vers>/` and deletes
         /// the listed directories (#323 slice 2).
-        #[arg(long, conflicts_with = "kind")]
+        #[arg(long, conflicts_with_all = ["kind", "git_checkouts"])]
         registry_src: bool,
+        /// Shorthand for `--kind cargo_git_checkouts`. Walks
+        /// `$CARGO_HOME/git/checkouts/<repo>/<commit>/` and deletes
+        /// the listed directories (#323 slice 3).
+        #[arg(long, conflicts_with_all = ["kind", "registry_src"])]
+        git_checkouts: bool,
     },
     /// List every `target/` directory currently tracked in the soldr
     /// registry, without applying any age or size thresholds.
@@ -461,6 +467,10 @@ pub(crate) enum GcListKind {
     /// crate sources.
     #[value(name = "cargo_registry_src")]
     CargoRegistrySrc,
+    /// `$CARGO_HOME/git/checkouts/<repo>/<commit>/` git-source crate
+    /// checkouts (#323 slice 3).
+    #[value(name = "cargo_git_checkouts")]
+    CargoGitCheckouts,
 }
 
 #[derive(clap::Args)]

--- a/crates/soldr-cli/src/gc.rs
+++ b/crates/soldr-cli/src/gc.rs
@@ -24,6 +24,10 @@ const KIND_CARGO_TARGET: &str = "cargo_target";
 // crate sources. `purge_safety: derived` — cargo regenerates from the
 // matching `.crate` tarball in `registry/cache/` on demand.
 const KIND_CARGO_REGISTRY_SRC: &str = "cargo_registry_src";
+// Slice 3 of #323: `$CARGO_HOME/git/checkouts/<repo>/<commit>/` git-source
+// crate checkouts. `purge_safety: derived` — cargo regenerates by re-checking
+// out the bare repo in `$CARGO_HOME/git/db/<repo>/` on demand.
+const KIND_CARGO_GIT_CHECKOUTS: &str = "cargo_git_checkouts";
 const PURGE_SAFETY_DERIVED: &str = "derived";
 
 /// Taxonomy kinds accepted by `gc list --kind` / `gc purge --kind`
@@ -33,6 +37,7 @@ const PURGE_SAFETY_DERIVED: &str = "derived";
 pub(crate) enum GcListKindFilter {
     CargoTarget,
     CargoRegistrySrc,
+    CargoGitCheckouts,
 }
 
 impl From<crate::GcListKind> for GcListKindFilter {
@@ -40,6 +45,7 @@ impl From<crate::GcListKind> for GcListKindFilter {
         match value {
             crate::GcListKind::CargoTarget => GcListKindFilter::CargoTarget,
             crate::GcListKind::CargoRegistrySrc => GcListKindFilter::CargoRegistrySrc,
+            crate::GcListKind::CargoGitCheckouts => GcListKindFilter::CargoGitCheckouts,
         }
     }
 }
@@ -338,6 +344,8 @@ pub(crate) fn run_gc_list_command(
         kind_filter.is_none() || matches!(kind_filter, Some(GcListKindFilter::CargoTarget));
     let include_registry_src =
         kind_filter.is_none() || matches!(kind_filter, Some(GcListKindFilter::CargoRegistrySrc));
+    let include_git_checkouts =
+        kind_filter.is_none() || matches!(kind_filter, Some(GcListKindFilter::CargoGitCheckouts));
 
     let mut entries: Vec<GcListEntryOutput> = if include_targets {
         live_rows
@@ -367,6 +375,12 @@ pub(crate) fn run_gc_list_command(
     if include_registry_src {
         if let Some(cargo_home) = crate::core::resolve_cargo_home() {
             entries.extend(walk_cargo_registry_src(&cargo_home, now));
+        }
+    }
+
+    if include_git_checkouts {
+        if let Some(cargo_home) = crate::core::resolve_cargo_home() {
+            entries.extend(walk_cargo_git_checkouts(&cargo_home, now));
         }
     }
 
@@ -571,6 +585,87 @@ fn parse_crate_owner(dir_name: &str) -> Option<String> {
     None
 }
 
+// ---------------------------------------------------------------------------
+// cargo_git_checkouts walker (#323 slice 3).
+// ---------------------------------------------------------------------------
+
+/// Walk `$CARGO_HOME/git/checkouts/<repo>/<commit>/` and produce a
+/// `GcListEntryOutput` per checkout directory.
+///
+/// Layout reminder: cargo stores git-source crates as a bare clone at
+/// `~/.cargo/git/db/<repo>/` (the **primary** copy — never pruned by
+/// soldr because cargo owns it) and a per-commit worktree at
+/// `~/.cargo/git/checkouts/<repo>/<commit>/` (this is what we surface).
+/// The worktree is fully regeneratable from the bare clone, so safety
+/// class is `derived`.
+///
+/// `last_used_unix` is the directory's filesystem mtime today. Cargo's
+/// `$CARGO_HOME/.global-cache` SQLite tracker also records git-checkout
+/// touch events; integrating that lookup is straightforward but lives in
+/// a follow-up (mirrors the registry-src precedence introduced in #349).
+/// Until then the mtime fallback gives a usable approximation.
+fn walk_cargo_git_checkouts(cargo_home: &std::path::Path, now: i64) -> Vec<GcListEntryOutput> {
+    let checkouts_root = cargo_home.join("git").join("checkouts");
+    let repo_dirs = match std::fs::read_dir(&checkouts_root) {
+        Ok(iter) => iter,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut out: Vec<GcListEntryOutput> = Vec::new();
+    for repo_entry in repo_dirs.flatten() {
+        let repo_path = repo_entry.path();
+        let Ok(repo_meta) = repo_entry.metadata() else {
+            continue;
+        };
+        if !repo_meta.is_dir() {
+            continue;
+        }
+        let repo_dir_name = match repo_path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let commit_dirs = match std::fs::read_dir(&repo_path) {
+            Ok(iter) => iter,
+            Err(_) => continue,
+        };
+        for commit_entry in commit_dirs.flatten() {
+            let commit_path = commit_entry.path();
+            let Ok(commit_meta) = commit_entry.metadata() else {
+                continue;
+            };
+            if !commit_meta.is_dir() {
+                continue;
+            }
+            let commit_dir_name = match commit_path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            let (size_bytes, file_count) = fast_directory_size_and_files(&commit_path);
+            let last_used_unix = commit_meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+            let age_seconds = now.saturating_sub(last_used_unix);
+            out.push(GcListEntryOutput {
+                path: absolute_path_string(&commit_path),
+                last_used_unix,
+                age_seconds,
+                age_human: crate::cache_lib::target_registry::human_age(age_seconds),
+                size_bytes,
+                size_human: crate::cache_lib::target_registry::human_size(size_bytes),
+                file_count,
+                kind: KIND_CARGO_GIT_CHECKOUTS,
+                purge_safety: PURGE_SAFETY_DERIVED,
+                owner_crate: Some(format!("{repo_dir_name}@{commit_dir_name}")),
+                last_used_source: Some(LAST_USED_FROM_FS_MTIME),
+            });
+        }
+    }
+    out
+}
+
 #[derive(Serialize)]
 struct GcPurgeRegistrySrcOutput {
     schema_version: u32,
@@ -672,6 +767,119 @@ pub(crate) fn run_gc_purge_registry_src_command(
             command: "gc",
             mode: "purge",
             kind: KIND_CARGO_REGISTRY_SRC,
+            selected_count: selected.len(),
+            succeeded_count: deleted_paths.len(),
+            failed_count: failures.len(),
+            reclaimed_bytes,
+            reclaimed_human: crate::cache_lib::target_registry::human_size(reclaimed_bytes),
+            deleted_paths,
+            failures,
+        };
+        print_json(&output)?;
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct GcPurgeGitCheckoutsOutput {
+    schema_version: u32,
+    command: &'static str,
+    mode: &'static str,
+    kind: &'static str,
+    selected_count: usize,
+    succeeded_count: usize,
+    failed_count: usize,
+    reclaimed_bytes: u64,
+    reclaimed_human: String,
+    deleted_paths: Vec<String>,
+    failures: Vec<GcPurgeGitCheckoutsFailure>,
+}
+
+#[derive(Serialize)]
+struct GcPurgeGitCheckoutsFailure {
+    path: String,
+    error: String,
+}
+
+/// `soldr gc purge --git-checkouts --all` — walk
+/// `$CARGO_HOME/git/checkouts/<repo>/<commit>/` and `remove_dir_all` each
+/// entry. Matches the registry-src purge contract: per-dir failures are
+/// reported in the summary and the command exits 0 even if some
+/// deletions failed, so scripts can scrape the structured output.
+pub(crate) fn run_gc_purge_git_checkouts_command(
+    purge_all: bool,
+    json: bool,
+) -> Result<(), SoldrError> {
+    let cargo_home = crate::core::resolve_cargo_home().ok_or_else(|| {
+        SoldrError::Other(
+            "could not resolve $CARGO_HOME (no env var, no home directory)".to_string(),
+        )
+    })?;
+    let now = crate::cache_lib::target_registry::current_unix_seconds()
+        .map_err(|e| SoldrError::Other(format!("gc purge --git-checkouts clock error: {e}")))?;
+    let entries = walk_cargo_git_checkouts(&cargo_home, now);
+
+    if !json {
+        eprintln!(
+            "soldr gc purge --git-checkouts: cargo_home={}",
+            cargo_home.display()
+        );
+        eprintln!(
+            "soldr gc purge --git-checkouts: {} git checkout director{} on disk",
+            entries.len(),
+            if entries.len() == 1 { "y" } else { "ies" }
+        );
+    }
+
+    let mut selected: Vec<&GcListEntryOutput> = Vec::new();
+    for entry in &entries {
+        let should_delete = purge_all
+            || prompt_yes_no_default_yes(&format!(
+                "soldr gc: delete {} ({}, age {}) ? [Y/n] ",
+                entry.path, entry.size_human, entry.age_human,
+            ));
+        if should_delete {
+            selected.push(entry);
+        }
+    }
+
+    let mut deleted_paths: Vec<String> = Vec::new();
+    let mut failures: Vec<GcPurgeGitCheckoutsFailure> = Vec::new();
+    let mut reclaimed_bytes: u64 = 0;
+    for entry in &selected {
+        let path = std::path::PathBuf::from(&entry.path);
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => {
+                reclaimed_bytes = reclaimed_bytes.saturating_add(entry.size_bytes);
+                deleted_paths.push(entry.path.clone());
+            }
+            Err(e) => failures.push(GcPurgeGitCheckoutsFailure {
+                path: entry.path.clone(),
+                error: e.to_string(),
+            }),
+        }
+    }
+
+    if !json {
+        eprintln!(
+            "soldr gc purge --git-checkouts: selected {}; succeeded {}; failed {}; reclaimed {}",
+            selected.len(),
+            deleted_paths.len(),
+            failures.len(),
+            crate::cache_lib::target_registry::human_size(reclaimed_bytes),
+        );
+        for failure in &failures {
+            eprintln!(
+                "soldr gc purge --git-checkouts: failed to delete {}: {}",
+                failure.path, failure.error
+            );
+        }
+    } else {
+        let output = GcPurgeGitCheckoutsOutput {
+            schema_version: GC_JSON_SCHEMA_VERSION,
+            command: "gc",
+            mode: "purge",
+            kind: KIND_CARGO_GIT_CHECKOUTS,
             selected_count: selected.len(),
             succeeded_count: deleted_paths.len(),
             failed_count: failures.len(),

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -414,18 +414,27 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                     json,
                     kind,
                     registry_src,
+                    git_checkouts,
                 }) => {
                     // #323 slice 2: --registry-src is a shorthand for
                     // --kind cargo_registry_src; clap already enforces
                     // mutual exclusion.
+                    // #323 slice 3: --git-checkouts is a shorthand for
+                    // --kind cargo_git_checkouts.
                     let effective_kind = if registry_src {
                         Some(GcListKind::CargoRegistrySrc)
+                    } else if git_checkouts {
+                        Some(GcListKind::CargoGitCheckouts)
                     } else {
                         kind
                     };
                     match effective_kind {
                         Some(GcListKind::CargoRegistrySrc) => {
                             gc::run_gc_purge_registry_src_command(all, json)?;
+                            return Ok(());
+                        }
+                        Some(GcListKind::CargoGitCheckouts) => {
+                            gc::run_gc_purge_git_checkouts_command(all, json)?;
                             return Ok(());
                         }
                         Some(GcListKind::CargoTarget) | None => gc::GcInvocation {

--- a/crates/soldr-cli/tests/cli_gc_git_checkouts.rs
+++ b/crates/soldr-cli/tests/cli_gc_git_checkouts.rs
@@ -1,0 +1,181 @@
+//! Integration tests for the cargo_git_checkouts walker (#323 slice 3).
+//!
+//! Sandbox `$CARGO_HOME` to a tempdir so the walker never touches the
+//! developer's real `~/.cargo`.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Construct a fake `$CARGO_HOME` containing `git/checkouts/<repo>/` so
+/// the walker has somewhere to look.
+fn fresh_cargo_home(label: &str) -> PathBuf {
+    let cargo_home = unique_temp_dir(label);
+    fs::create_dir_all(cargo_home.join("git").join("checkouts"))
+        .expect("failed to create git/checkouts root");
+    cargo_home
+}
+
+/// Seed a per-commit checkout directory under
+/// `$CARGO_HOME/git/checkouts/<repo>/<commit>/` with one file inside so
+/// size is non-zero.
+fn seed_git_checkout(cargo_home: &Path, repo_dir: &str, commit_dir: &str) -> PathBuf {
+    let dir = cargo_home
+        .join("git")
+        .join("checkouts")
+        .join(repo_dir)
+        .join(commit_dir);
+    fs::create_dir_all(&dir).expect("failed to create checkout dir");
+    fs::write(dir.join("README.md"), b"// vendored git checkout\n")
+        .expect("failed to seed checkout file");
+    dir
+}
+
+#[test]
+fn gc_list_json_walks_cargo_git_checkouts_under_cargo_home() {
+    let cache_root = unique_temp_dir("gc-git-checkouts-walk-cache");
+    let cargo_home = fresh_cargo_home("gc-git-checkouts-walk-cargo");
+    let _a = seed_git_checkout(&cargo_home, "tokio-abc123", "deadbeef1234");
+    let _b = seed_git_checkout(&cargo_home, "serde-def456", "cafefacedeed");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "list", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .output()
+        .expect("failed to run soldr gc list --json");
+
+    assert!(
+        output.status.success(),
+        "gc list --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("gc list --json must produce JSON");
+    let entries = json["entries"].as_array().expect("entries array");
+    let checkouts: Vec<&Value> = entries
+        .iter()
+        .filter(|e| e["kind"].as_str() == Some("cargo_git_checkouts"))
+        .collect();
+    assert_eq!(
+        checkouts.len(),
+        2,
+        "expected two cargo_git_checkouts entries, got: {}",
+        serde_json::to_string_pretty(&entries).unwrap_or_default()
+    );
+
+    for entry in &checkouts {
+        assert_eq!(
+            entry["purge_safety"].as_str(),
+            Some("derived"),
+            "git checkouts must be derived class"
+        );
+        assert!(
+            entry["owner_crate"]
+                .as_str()
+                .map(|s| s.contains('@'))
+                .unwrap_or(false),
+            "owner_crate must contain repo@commit: {entry:?}"
+        );
+        assert_eq!(entry["last_used_source"].as_str(), Some("fs_mtime"));
+        assert!(entry["size_bytes"].as_u64().unwrap_or(0) > 0);
+    }
+}
+
+#[test]
+fn gc_list_json_kind_filter_narrows_to_cargo_git_checkouts() {
+    let cache_root = unique_temp_dir("gc-git-checkouts-filter-cache");
+    let cargo_home = fresh_cargo_home("gc-git-checkouts-filter-cargo");
+    let _x = seed_git_checkout(&cargo_home, "tokio-abc", "abc123");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "list", "--json", "--kind", "cargo_git_checkouts"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .output()
+        .expect("failed to run soldr gc list --json --kind cargo_git_checkouts");
+
+    assert!(output.status.success());
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("gc list --json must produce JSON");
+    let entries = json["entries"].as_array().expect("entries array");
+    assert!(
+        entries
+            .iter()
+            .all(|e| e["kind"].as_str() == Some("cargo_git_checkouts")),
+        "kind filter must return only cargo_git_checkouts: {entries:?}"
+    );
+    assert_eq!(entries.len(), 1);
+}
+
+#[test]
+fn gc_purge_git_checkouts_removes_checkout_directories() {
+    let cache_root = unique_temp_dir("gc-git-checkouts-purge-cache");
+    let cargo_home = fresh_cargo_home("gc-git-checkouts-purge-cargo");
+    let dir = seed_git_checkout(&cargo_home, "tokio-abc", "deadbeef");
+    assert!(dir.is_dir());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "purge", "--git-checkouts", "--all", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .output()
+        .expect("failed to run soldr gc purge --git-checkouts --all --json");
+
+    assert!(
+        output.status.success(),
+        "gc purge --git-checkouts failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("gc purge --json must produce JSON");
+    assert_eq!(json["mode"], "purge");
+    assert_eq!(json["kind"], "cargo_git_checkouts");
+    assert_eq!(json["selected_count"], 1);
+    assert_eq!(json["succeeded_count"], 1);
+    assert!(
+        json["reclaimed_bytes"].as_u64().unwrap_or(0) > 0,
+        "reclaimed_bytes must be non-zero: {json}"
+    );
+    assert!(!dir.exists(), "checkout dir must be removed after purge");
+}
+
+#[test]
+fn gc_purge_rejects_both_registry_src_and_git_checkouts() {
+    let cache_root = unique_temp_dir("gc-purge-mutex-cache");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "gc",
+            "purge",
+            "--registry-src",
+            "--git-checkouts",
+            "--all",
+            "--json",
+        ])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr gc purge --registry-src --git-checkouts");
+
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "purge should reject both flags being set"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used")
+            || stderr.contains("conflicts with")
+            || stderr.contains("conflict"),
+        "expected clap mutual-exclusion error in stderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

PR 3 in the #323 rollout. Extends \`soldr gc\` to enumerate and reclaim git-source crate checkouts at \`\$CARGO_HOME/git/checkouts/<repo>/<commit>/\`. These directories are typically 0–2 GB on a busy Rust dev box and are fully regeneratable from the bare clone in \`\$CARGO_HOME/git/db/<repo>/\` (which soldr never touches — that's the **primary** copy under the #323 safety taxonomy).

Surface mirrors slice 2:
- \`soldr gc list --kind cargo_git_checkouts\` — enumerate
- \`soldr gc purge --git-checkouts --all\` — shorthand
- \`soldr gc purge --kind cargo_git_checkouts --all\` — full form

\`--registry-src\`, \`--git-checkouts\`, and \`--kind\` are mutually exclusive (clap-enforced).

\`last_used_unix\` comes from the directory mtime; integrating cargo's \`.global-cache\` tracker mirrors the registry-src precedence from #349 and lives in a follow-up.

Refs #323. Refs #503.

## Test plan
- [x] \`soldr cargo build -p soldr-cli\`
- [x] \`soldr cargo test -p soldr-cli --test cli_gc_git_checkouts\` — 4 new tests pass
  - gc_list_json_walks_cargo_git_checkouts_under_cargo_home
  - gc_list_json_kind_filter_narrows_to_cargo_git_checkouts
  - gc_purge_git_checkouts_removes_checkout_directories
  - gc_purge_rejects_both_registry_src_and_git_checkouts
- [x] Regression: cli_gc (9), cli_gc_registry_src (6), cli_gc_extras (4) all still pass
- [x] SOLDR_BUILTIN_VERBS sync test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)