### PR TITLE
fix(rust_plan): skip restore on cook-prepopulated target/ (#480)

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door.rs
+++ b/crates/soldr-cli/src/cargo_front_door.rs
@@ -340,6 +340,15 @@ pub(crate) async fn run_cargo_front_door(
     if let Some(plan) = plan_ctx.as_ref() {
         if let Some(reason) = rust_plan::should_skip_warm_restore(plan) {
             eprintln!("{reason}");
+        } else if let Some(reason) = rust_plan::should_skip_restore_due_to_prepopulated_target(plan)
+        {
+            // Issue #480: refuse to restore on top of a target/ that cook
+            // (or a prior build) has already populated. The current zccache
+            // restore path reports `restored_file_count: 0 /
+            // artifact_absent_from_restored_plan: 1` and the subsequent
+            // cargo build dies on missing rmetas. Skipping restore lets
+            // cargo work with what's there.
+            eprintln!("{reason}");
         } else {
             rust_plan::run_zccache_rust_plan(plan, "restore", false)?;
         }

--- a/crates/soldr-cli/src/rust_plan.rs
+++ b/crates/soldr-cli/src/rust_plan.rs
@@ -370,6 +370,112 @@ fn walk_for_deps_dirs(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Pre-populated target/ restore guard (issue #480).
+// ---------------------------------------------------------------------------
+//
+// When `cargo chef cook` (or any prior `soldr cargo build`) has populated
+// `target/`, running `zccache rust-plan restore` on top of the existing tree
+// can produce the failure mode described in #480: `restored_file_count: 0 /
+// artifact_absent_from_restored_plan: 1`, followed by cargo failing because
+// the expected `.rmeta` files aren't where it left them.
+//
+// This guard detects that case (cargo `.fingerprint/` dirs already on disk)
+// and skips restore, letting cargo work with the existing target tree. The
+// warm-restore short-circuit (#229) covers the in-job repeat case where the
+// plan inputs hash matches; this guard covers the cross-context case where
+// cook saved one plan and the consumer build computes a different inputs
+// hash but reuses the same target/.
+
+/// Env var to override the prepopulated-target restore guard. When set to a
+/// truthy value (anything other than "", "0", "false", "no", "off") the
+/// guard is bypassed and `rust-plan restore` runs even when the target tree
+/// already contains cargo fingerprints. Provided as an escape hatch for users
+/// who specifically want the old behavior.
+pub(crate) const SOLDR_FORCE_RESTORE_ENV_VAR: &str = "SOLDR_RUST_PLAN_FORCE_RESTORE";
+
+/// Returns `Some(reason)` when the prepopulated-target guard wants to skip
+/// `rust-plan restore` for this plan; `None` when restore should proceed.
+///
+/// "Prepopulated" is detected by walking `<target>/` shallowly for any
+/// `.fingerprint/` directory with at least one entry. Cargo writes
+/// `.fingerprint/<crate>-<hash>/` for every unit it compiles, and cook's
+/// `cargo chef cook` step produces a populated `.fingerprint/` as a
+/// side-effect of building the dep stub.
+pub(crate) fn should_skip_restore_due_to_prepopulated_target(
+    plan: &RustArtifactPlanContext,
+) -> Option<String> {
+    if force_restore_enabled() {
+        return None;
+    }
+    let target_root = std::path::PathBuf::from(&plan.target_dir);
+    if !target_root.exists() {
+        return None;
+    }
+    let populated = count_populated_fingerprint_dirs(&target_root, 3);
+    if populated == 0 {
+        return None;
+    }
+    Some(format!(
+        "soldr: skipping rust-plan restore; target dir {} is prepopulated \
+         with {} cargo .fingerprint dir{} (likely cook output or prior build, #480). \
+         Restoring on top of an existing tree can poison the build with \
+         `artifact_absent_from_restored_plan`; cargo will work with the \
+         existing artifacts instead. Set {}=1 to override.",
+        plan.target_dir,
+        populated,
+        if populated == 1 { "" } else { "s" },
+        SOLDR_FORCE_RESTORE_ENV_VAR,
+    ))
+}
+
+fn force_restore_enabled() -> bool {
+    let Some(raw) = std::env::var_os(SOLDR_FORCE_RESTORE_ENV_VAR) else {
+        return false;
+    };
+    let lowered = raw.to_string_lossy().trim().to_ascii_lowercase();
+    !matches!(lowered.as_str(), "" | "0" | "false" | "no" | "off")
+}
+
+/// Count `.fingerprint/` directories under `root` (up to `max_depth` levels)
+/// that contain at least one entry. The walk stops descending once a
+/// `.fingerprint/` is encountered — cargo never nests another inside.
+pub(crate) fn count_populated_fingerprint_dirs(
+    root: &std::path::Path,
+    max_depth: usize,
+) -> usize {
+    let mut count = 0usize;
+    walk_for_fingerprint_dirs(root, max_depth, &mut count);
+    count
+}
+
+fn walk_for_fingerprint_dirs(dir: &std::path::Path, remaining_depth: usize, count: &mut usize) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        if !ft.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        if path.file_name().is_some_and(|n| n == ".fingerprint") {
+            // Only count as "populated" if at least one entry exists.
+            let populated = std::fs::read_dir(&path)
+                .map(|mut iter| iter.next().is_some())
+                .unwrap_or(false);
+            if populated {
+                *count += 1;
+            }
+            continue;
+        }
+        if remaining_depth > 0 {
+            walk_for_fingerprint_dirs(&path, remaining_depth - 1, count);
+        }
+    }
+}
+
 
 #[path = "rust_plan_env.rs"]
 mod env_resolvers;

--- a/crates/soldr-cli/src/rust_plan_tests/mod.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/mod.rs
@@ -7,5 +7,6 @@ mod bundle_walk;
 mod manifest;
 mod orphan_rmeta;
 mod plan_build;
+mod prepopulated_target;
 mod warm_restore;
 mod wire_compat;

--- a/crates/soldr-cli/src/rust_plan_tests/prepopulated_target.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/prepopulated_target.rs
@@ -1,0 +1,192 @@
+//! Tests for the prepopulated-target restore guard (issue #480).
+//!
+//! Verifies that `should_skip_restore_due_to_prepopulated_target` fires
+//! when cargo `.fingerprint/` dirs already exist under `target/` and stays
+//! quiet on an empty or absent tree. Also covers the
+//! `SOLDR_RUST_PLAN_FORCE_RESTORE` override that lets operators bypass the
+//! guard for diagnostic purposes.
+
+use crate::rust_plan::{
+    count_populated_fingerprint_dirs, should_skip_restore_due_to_prepopulated_target,
+    RustArtifactPlanContext, SOLDR_FORCE_RESTORE_ENV_VAR,
+};
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tempfile::TempDir;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = &self.previous {
+            std::env::set_var(self.key, value);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+fn make_plan_ctx(target_dir: &std::path::Path) -> RustArtifactPlanContext {
+    RustArtifactPlanContext {
+        path: PathBuf::from("/tmp/plan.json"),
+        zccache_binary: PathBuf::from("/tmp/zccache"),
+        cache_dir: PathBuf::from("/tmp/cache"),
+        zccache_daemon_cache_dir: PathBuf::from("/tmp/cache"),
+        session_id: "session".to_string(),
+        journal_path: PathBuf::from("/tmp/journal"),
+        backend: "auto".to_string(),
+        cache_profile: Some("thin-v2"),
+        plan_inputs_hash: "hash".to_string(),
+        target_dir: target_dir.display().to_string(),
+    }
+}
+
+fn seed_fingerprint_dir(target: &std::path::Path, profile: &str) -> std::path::PathBuf {
+    let fp = target.join(profile).join(".fingerprint");
+    std::fs::create_dir_all(&fp).expect("create .fingerprint");
+    let entry = fp.join("serde-abc123");
+    std::fs::create_dir_all(&entry).expect("create fingerprint entry");
+    std::fs::write(entry.join("invoked.timestamp"), b"")
+        .expect("seed invoked.timestamp");
+    fp
+}
+
+#[test]
+fn skip_reason_emitted_when_fingerprint_present() {
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = EnvVarGuard::remove(SOLDR_FORCE_RESTORE_ENV_VAR);
+
+    let target = TempDir::new().expect("tempdir");
+    seed_fingerprint_dir(target.path(), "release");
+    let ctx = make_plan_ctx(target.path());
+    let reason = should_skip_restore_due_to_prepopulated_target(&ctx);
+    assert!(reason.is_some(), "expected skip reason; got None");
+    let msg = reason.unwrap();
+    assert!(
+        msg.contains("prepopulated"),
+        "skip reason must mention prepopulated state: {msg}"
+    );
+    assert!(
+        msg.contains(SOLDR_FORCE_RESTORE_ENV_VAR),
+        "skip reason must mention the override env var: {msg}"
+    );
+}
+
+#[test]
+fn no_skip_when_target_absent() {
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = EnvVarGuard::remove(SOLDR_FORCE_RESTORE_ENV_VAR);
+
+    let ctx = make_plan_ctx(std::path::Path::new("/nonexistent/path/to/target"));
+    let reason = should_skip_restore_due_to_prepopulated_target(&ctx);
+    assert!(
+        reason.is_none(),
+        "expected no skip when target/ does not exist: {reason:?}"
+    );
+}
+
+#[test]
+fn no_skip_when_target_empty() {
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = EnvVarGuard::remove(SOLDR_FORCE_RESTORE_ENV_VAR);
+
+    let target = TempDir::new().expect("tempdir");
+    let ctx = make_plan_ctx(target.path());
+    let reason = should_skip_restore_due_to_prepopulated_target(&ctx);
+    assert!(
+        reason.is_none(),
+        "expected no skip when target/ is empty: {reason:?}"
+    );
+}
+
+#[test]
+fn no_skip_when_fingerprint_dir_empty() {
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = EnvVarGuard::remove(SOLDR_FORCE_RESTORE_ENV_VAR);
+
+    let target = TempDir::new().expect("tempdir");
+    let fp = target.path().join("release").join(".fingerprint");
+    std::fs::create_dir_all(&fp).expect("create empty .fingerprint");
+    let ctx = make_plan_ctx(target.path());
+    let reason = should_skip_restore_due_to_prepopulated_target(&ctx);
+    assert!(
+        reason.is_none(),
+        "empty .fingerprint/ must not trigger the guard: {reason:?}"
+    );
+}
+
+#[test]
+fn force_restore_env_var_overrides_guard() {
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = EnvVarGuard::set(SOLDR_FORCE_RESTORE_ENV_VAR, "1");
+
+    let target = TempDir::new().expect("tempdir");
+    seed_fingerprint_dir(target.path(), "release");
+    let ctx = make_plan_ctx(target.path());
+    let reason = should_skip_restore_due_to_prepopulated_target(&ctx);
+    assert!(
+        reason.is_none(),
+        "force-restore env var must bypass guard: {reason:?}"
+    );
+}
+
+#[test]
+fn force_restore_env_var_falsy_does_not_override() {
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = EnvVarGuard::set(SOLDR_FORCE_RESTORE_ENV_VAR, "0");
+
+    let target = TempDir::new().expect("tempdir");
+    seed_fingerprint_dir(target.path(), "release");
+    let ctx = make_plan_ctx(target.path());
+    let reason = should_skip_restore_due_to_prepopulated_target(&ctx);
+    assert!(
+        reason.is_some(),
+        "falsy SOLDR_RUST_PLAN_FORCE_RESTORE must not bypass guard"
+    );
+}
+
+#[test]
+fn walker_finds_fingerprint_under_explicit_triple_layout() {
+    // `target/<triple>/<profile>/.fingerprint/` shape used by
+    // `cargo build --target <triple>`.
+    let target = TempDir::new().expect("tempdir");
+    let fp = target
+        .path()
+        .join("x86_64-unknown-linux-gnu")
+        .join("release")
+        .join(".fingerprint");
+    std::fs::create_dir_all(&fp).expect("create nested .fingerprint");
+    std::fs::create_dir_all(fp.join("serde-abc")).expect("create entry");
+
+    let count = count_populated_fingerprint_dirs(target.path(), 3);
+    assert_eq!(count, 1, "walker should find triple-nested fingerprint");
+}
+
+#[test]
+fn walker_counts_multiple_profile_fingerprints() {
+    let target = TempDir::new().expect("tempdir");
+    seed_fingerprint_dir(target.path(), "release");
+    seed_fingerprint_dir(target.path(), "debug");
+
+    let count = count_populated_fingerprint_dirs(target.path(), 3);
+    assert_eq!(count, 2, "walker should count both profile fingerprints");
+}


### PR DESCRIPTION
## Summary

Fixes the cook-prepopulated target/ failure mode reported in #480. When \`cargo chef cook\` (or any prior \`soldr cargo build\`) has populated target/, running \`zccache rust-plan restore\` on top of the existing tree currently surfaces \`restored_file_count: 0 / artifact_absent_from_restored_plan: 1\` and the subsequent \`cargo build -p <subset>\` dies on missing \`lib<dep>-*.rmeta\`.

Per the #480 acceptance list, option 3 (\"soldr refuses up-front rather than letting the silent restore happen\") is the option that lives in soldr (the merge / synthetic-plan options live in zccache). This PR implements that: a shallow walk of target/ looks for any populated \`.fingerprint/\` directory (cargo writes one per compiled unit), and when found the restore step is skipped with a clear advisory message. Cargo then works with the existing artifacts instead of getting poisoned by a half-restore.

The existing warm-restore short-circuit (#229) still covers the in-job repeat case where the saved plan's inputs hash matches; this new guard covers the cross-context case where cook saved one plan and the consumer build computes a different inputs hash but reuses the same target/.

Escape hatch: \`SOLDR_RUST_PLAN_FORCE_RESTORE=1\` bypasses the guard for operators who want the prior behavior (e.g., for diagnostics).

This restores cook+consumer-build flows for every \`zackees/setup-soldr@v0\` consumer of \`prebuild-deps: cargo-chef\` without requiring \`prebuild-deps: none\` or a separate \`--target-dir\`.

Closes #480.
Refs #503.

## Test plan
- [x] \`soldr cargo build -p soldr-cli\`
- [x] \`soldr cargo test -p soldr-cli --bin soldr rust_plan::tests\` — all 70 tests pass (8 new in \`prepopulated_target\` suite)
  - skip_reason_emitted_when_fingerprint_present
  - no_skip_when_target_absent
  - no_skip_when_target_empty
  - no_skip_when_fingerprint_dir_empty
  - force_restore_env_var_overrides_guard
  - force_restore_env_var_falsy_does_not_override
  - walker_finds_fingerprint_under_explicit_triple_layout
  - walker_counts_multiple_profile_fingerprints

🤖 Generated with [Claude Code](https://claude.com/claude-code)