### PR TITLE
chore(release): soldr 0.7.33 — zccache 1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.32"
+version = "0.7.33"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.32"
+version = "0.7.33"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/src/cache_lib/gc.rs
+++ b/crates/soldr-cli/src/cache_lib/gc.rs
@@ -592,14 +592,35 @@ mod tests {
 
     #[test]
     fn gc_log_cleanup_removes_entries_past_retention() {
+        // Use explicit mtime manipulation rather than wall-clock sleeps:
+        // APFS / NTFS / ext4 all have different mtime resolutions, and a
+        // sleep-based version of this test was flaking on macOS CI when
+        // the cleanup wall-clock crossed the retention boundary for both
+        // files. `FileTimes::set_modified` is millisecond-precise on every
+        // supported platform.
         let dir = tempdir().unwrap();
         let stale = dir.path().join("stale.log");
         let fresh = dir.path().join("fresh.log");
         std::fs::write(&stale, b"old").unwrap();
-        std::thread::sleep(Duration::from_millis(30));
         std::fs::write(&fresh, b"new").unwrap();
 
-        let removed = cleanup_old_gc_logs_with_retention(dir.path(), Duration::from_millis(15))
+        let now = SystemTime::now();
+        let stale_mtime = now.checked_sub(Duration::from_secs(60)).unwrap();
+        let fresh_mtime = now;
+        std::fs::File::options()
+            .write(true)
+            .open(&stale)
+            .unwrap()
+            .set_modified(stale_mtime)
+            .unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&fresh)
+            .unwrap()
+            .set_modified(fresh_mtime)
+            .unwrap();
+
+        let removed = cleanup_old_gc_logs_with_retention(dir.path(), Duration::from_secs(30))
             .expect("cleanup old logs");
 
         assert_eq!(removed, 1);

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -69,7 +69,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.10.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.0";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.10.0");
+    assert_eq!(json["managed_zccache_version"], "1.11.0");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.10.0");
+    assert_eq!(json["managed_zccache_version"], "1.11.0");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.10.0");
+    assert_eq!(json["managed_zccache_version"], "1.11.0");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.10.0");
+    assert_eq!(status_json["managed_version"], "1.11.0");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.10.0");
+    assert_eq!(json["managed_version"], "1.11.0");
 }
 
 #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.32",
+  "version": "0.7.33",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Bumps the managed zccache pin from 1.10.0 -> 1.11.0 and the soldr workspace version from 0.7.32 -> 0.7.33.

zccache 1.11.0 (https://github.com/zackees/zccache/releases/tag/1.11.0) adds the \`zccache cc\` subcommand (zccache PR #392). soldr has been injecting \`CC=\"zccache cc\"\` since #310 in 0.7.32; this bump promotes that injection from the wrap-mode fallback to zccache's first-class \`cc\` codepath.

## Test plan
- [x] \`soldr cargo build -p soldr-cli\`
- [x] \`soldr cargo test -p soldr-cli --test cli_cache\` — 19 tests pass (3 version-string fixtures updated)
- [x] \`soldr cargo test -p soldr-cli --test cli_install_zccache\` — 6 tests pass (2 fixtures updated)
- [x] \`soldr cargo test -p soldr-cli --bin soldr native_cc\` — 16 tests pass

Triggers autonomous release on merge per CLAUDE.md release-publishing rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)