### PR TITLE
chore(release): soldr 0.7.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.33"
+version = "0.7.34"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.33",
+  "version": "0.7.34",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

- Bump `[workspace.package].version` and matching `package.json`/`Cargo.lock` from 0.7.33 → 0.7.34.
- Triggers the autonomous-release workflow to cut `v0.7.34` on merge.

## What's in 0.7.34

- `fix(linker)` — skip `-fuse-ld=lld` injection on macOS for `SOLDR_LINKER=fast` / `=rust-lld`. Apple clang rejects `-fuse-ld=lld` because stock macOS toolchains don't ship the `ld64.lld` shim it resolves to; this was breaking cc-rs build scripts in setup-soldr workflows on macOS runners. Linux/Windows behavior unchanged. (#509 / #511)

## Test plan

- [ ] CI green on this PR
- [ ] On merge, `Autonomous Release` publishes `v0.7.34` to GitHub Releases, PyPI (`soldr`), npm (`@zackees/soldr`)
