### PR TITLE
feat(toolchain): `soldr toolchain ensure --json` (#407 Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ Two categories, surfaced as first-class subcommands or via the generic fetch pat
 - `soldr rustup <args>` forwards to the system `rustup` binary. When the first non-flag positional is `target` or `component` and `rust-toolchain.toml` declares a `channel`, soldr injects `--toolchain <channel>` after the verb so per-toolchain state mutations land on the pinned toolchain. Pass `--toolchain` explicitly to opt out of injection.
 - `soldr toolchain install` reads `[toolchain].channel` from `rust-toolchain.toml` and runs `rustup toolchain install <channel> --profile minimal --no-self-update`.
 - `soldr toolchain prepare` chains install + `component add` + `target add` for every declared component / target, then `cargo install`s every entry under `[soldr.plugins]`.
+- `soldr toolchain ensure [--json]` (issue #407 Phase 2) auto-bootstraps rustup if missing, runs the same pipeline as `prepare`, then smoke-verifies the resolved toolchain with `cargo --version` / `rustc --version`. `--json` emits a stable `schema_version: 1` payload consumed by `setup-soldr#133`.
   - Manifest example:
     ```toml
     [toolchain]

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -436,6 +436,20 @@ pub(crate) enum ToolchainSubcommand {
     /// Install the channel and every declared component / target from
     /// `rust-toolchain.toml`. Stops at the first nonzero rustup exit.
     Prepare,
+    /// One-shot "make sure this host can build" verb (issue #407
+    /// Phase 2): auto-bootstraps `rustup` if missing, runs the same
+    /// install + component + target + plugin steps as `prepare`, then
+    /// smoke-verifies the resolved toolchain by spawning
+    /// `cargo --version` and `rustc --version`. Used by `setup-soldr`
+    /// (`setup-soldr#133`) to delegate its TS toolchain logic to the
+    /// soldr binary.
+    Ensure {
+        /// Emit the stable machine-facing JSON form
+        /// (`schema_version: 1`) for consumption by setup-soldr and
+        /// other tooling. See `docs/API.md` for the full schema.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(clap::Subcommand)]

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -33,6 +33,7 @@ mod self_relocate;
 mod shim_dir;
 mod startup_profile;
 mod toolchain;
+mod toolchain_ensure;
 mod trampoline;
 mod trampoline_workspace;
 mod wrapper;
@@ -123,7 +124,6 @@ const SOLDR_AS_ENV_VAR: &str = "SOLDR_AS";
 /// Sentinel that the currently-running soldr was itself invoked by another
 /// soldr through `--as`. Prevents infinite hand-offs.
 const SOLDR_TRAMPOLINING_ENV_VAR: &str = "SOLDR_TRAMPOLINING";
-
 
 #[tokio::main]
 async fn main() {
@@ -263,6 +263,9 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             }
             ToolchainSubcommand::Prepare => {
                 std::process::exit(toolchain::run_toolchain_prepare()?);
+            }
+            ToolchainSubcommand::Ensure { json } => {
+                std::process::exit(toolchain_ensure::run_toolchain_ensure(json).await?);
             }
         },
         Commands::Bootstrap { json } => {

--- a/crates/soldr-cli/src/toolchain.rs
+++ b/crates/soldr-cli/src/toolchain.rs
@@ -118,17 +118,43 @@ pub(crate) fn run_toolchain_prepare() -> Result<i32, SoldrError> {
         return Ok(0);
     };
 
+    let (code, _summary) = run_prepare_inner(channel, &manifest)?;
+    Ok(code)
+}
+
+/// Summary of what `prepare` actually did, used by
+/// [`crate::toolchain_ensure`] to populate the JSON payload.
+#[derive(Debug, Default)]
+pub(crate) struct PrepareSummary {
+    pub components_added: Vec<String>,
+    pub targets_added: Vec<String>,
+    pub plugins_installed: Vec<String>,
+}
+
+/// Shared inner driver for `prepare` / `ensure`. Returns the rustup /
+/// cargo exit code (0 on success) plus a [`PrepareSummary`] of what was
+/// actually attempted (we report every declared component/target/plugin
+/// rustup didn't error on; for now we cannot cheaply diff "already
+/// installed" from "newly installed" without parsing rustup output,
+/// which is fragile across versions).
+pub(crate) fn run_prepare_inner(
+    channel: &str,
+    manifest: &crate::core::RustToolchainManifest,
+) -> Result<(i32, PrepareSummary), SoldrError> {
+    let mut summary = PrepareSummary::default();
+
     let install_code = rustup_toolchain_install(channel)?;
     if install_code != 0 {
-        return Ok(install_code);
+        return Ok((install_code, summary));
     }
 
     if let Some(components) = manifest.components.as_deref() {
         for component in components {
             let code = rustup_component_add(channel, component)?;
             if code != 0 {
-                return Ok(code);
+                return Ok((code, summary));
             }
+            summary.components_added.push(component.clone());
         }
     }
 
@@ -136,42 +162,53 @@ pub(crate) fn run_toolchain_prepare() -> Result<i32, SoldrError> {
         for target in targets {
             let code = rustup_target_add(channel, target)?;
             if code != 0 {
-                return Ok(code);
+                return Ok((code, summary));
             }
+            summary.targets_added.push(target.clone());
         }
     }
 
     if let Some(soldr_section) = manifest.soldr.as_ref() {
         if !soldr_section.plugins.is_empty() {
-            let code = install_plugins(&soldr_section.plugins)?;
-            if code != 0 {
-                return Ok(code);
+            for (name, spec) in &soldr_section.plugins {
+                let code = cargo_install_plugin(name, spec)?;
+                if code != 0 {
+                    return Ok((code, summary));
+                }
+                summary
+                    .plugins_installed
+                    .push(format_plugin_label(name, spec));
             }
         }
     }
 
-    Ok(0)
+    Ok((0, summary))
 }
 
-/// Install every plugin declared under `[soldr.plugins]` via the
+/// Format a plugin entry as `name` or `name@version` for the JSON
+/// payload. Detailed specs with no version collapse to `name`; bare
+/// `*` specs also collapse to `name`.
+fn format_plugin_label(name: &str, spec: &crate::core::PluginSpec) -> String {
+    let version = match spec {
+        crate::core::PluginSpec::Version(v) => Some(v.as_str()),
+        crate::core::PluginSpec::Detailed { version, .. } => version.as_deref(),
+    };
+    let trimmed = version
+        .map(str::trim)
+        .filter(|v| !v.is_empty() && *v != "*");
+    match trimmed {
+        Some(v) => format!("{name}@{v}"),
+        None => name.to_string(),
+    }
+}
+
+/// Install one plugin declared under `[soldr.plugins]` via the
 /// resolved cargo binary (so installs respect soldr-managed
 /// `$CARGO_HOME`). We deliberately do NOT route through the rustc
 /// wrapper machinery — that path is meant for compile units, not
 /// dev-tool installation. The active cargo already honors
 /// `rust-toolchain.toml` at exec time, so no explicit channel is
 /// passed.
-fn install_plugins(
-    plugins: &std::collections::BTreeMap<String, crate::core::PluginSpec>,
-) -> Result<i32, SoldrError> {
-    for (name, spec) in plugins {
-        let code = cargo_install_plugin(name, spec)?;
-        if code != 0 {
-            return Ok(code);
-        }
-    }
-    Ok(0)
-}
-
 fn cargo_install_plugin(name: &str, spec: &crate::core::PluginSpec) -> Result<i32, SoldrError> {
     let cargo = resolve_toolchain_binary("cargo")?;
     let mut command = std::process::Command::new(&cargo);

--- a/crates/soldr-cli/src/toolchain_ensure.rs
+++ b/crates/soldr-cli/src/toolchain_ensure.rs
@@ -1,0 +1,269 @@
+//! `soldr toolchain ensure` — auto-bootstrap rustup if missing, run the
+//! `prepare` pipeline, then smoke-verify the resolved toolchain by
+//! spawning `cargo --version` and `rustc --version`. With `--json`,
+//! emits a stable machine-facing payload (`schema_version: 1`) that
+//! `setup-soldr#133` consumes to delegate its TS toolchain logic.
+//!
+//! Phase 2 of #407. The JSON schema is frozen at version 1 — bumping it
+//! requires a coordinated version bump in the consumer.
+
+use serde::Serialize;
+use std::time::Instant;
+
+use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
+use crate::{
+    apply_implicit_toolchain_homes, resolve_toolchain_binary,
+    toolchain::{run_prepare_inner, PrepareSummary},
+};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Serialize, Debug)]
+pub(crate) struct ToolchainEnsureOutput {
+    pub schema_version: u32,
+    pub channel: Option<String>,
+    pub rustup_bootstrapped: bool,
+    pub components_added: Vec<String>,
+    pub targets_added: Vec<String>,
+    pub plugins_installed: Vec<String>,
+    pub smoke_verify: SmokeVerify,
+    pub elapsed_ms: u128,
+}
+
+#[derive(Serialize, Debug, Default)]
+pub(crate) struct SmokeVerify {
+    pub cargo_version: Option<String>,
+    pub rustc_version: Option<String>,
+    pub ok: bool,
+}
+
+/// Implementation of `soldr toolchain ensure`. Returns the soldr exit
+/// code: 0 on success, non-zero when smoke verify fails or the
+/// underlying `prepare` pipeline reported a non-zero rustup / cargo
+/// exit. In `--json` mode the JSON payload is emitted unconditionally
+/// (even on smoke-verify failure) so the consumer can introspect.
+pub(crate) async fn run_toolchain_ensure(json: bool) -> Result<i32, SoldrError> {
+    let started = Instant::now();
+
+    // 1. Bootstrap rustup if missing. Auto-bootstrap respects
+    //    SOLDR_NO_BOOTSTRAP=1 by silently leaving the host unchanged —
+    //    `prepare` will then surface the usual "rustup not found"
+    //    diagnostic via the spawn-failure path. We deliberately don't
+    //    re-implement the no-bootstrap diagnostic here.
+    let rustup_bootstrapped = bootstrap_rustup_if_missing().await?;
+
+    // 2. Read the manifest. Missing manifest is not an error — emit the
+    //    schema-v1 empty payload so consumers can still parse it.
+    let workspace_root = std::env::current_dir().map_err(SoldrError::from)?;
+    let manifest = crate::core::read_rust_toolchain_manifest(&workspace_root)?;
+
+    // 3. Run the prepare pipeline if a channel is declared. Otherwise
+    //    skip it entirely (matching `prepare`'s no-channel behavior).
+    let (prepare_code, prepare_summary) = if let Some(channel) = manifest.channel.as_deref() {
+        run_prepare_inner(channel, &manifest)?
+    } else {
+        (0, PrepareSummary::default())
+    };
+
+    // 4. If prepare reported a non-zero exit, surface it without running
+    //    smoke verify (the toolchain is already broken).
+    if prepare_code != 0 {
+        if json {
+            emit_json(ToolchainEnsureOutput {
+                schema_version: SCHEMA_VERSION,
+                channel: manifest.channel.clone(),
+                rustup_bootstrapped,
+                components_added: prepare_summary.components_added,
+                targets_added: prepare_summary.targets_added,
+                plugins_installed: prepare_summary.plugins_installed,
+                smoke_verify: SmokeVerify::default(),
+                elapsed_ms: started.elapsed().as_millis(),
+            })?;
+        } else {
+            eprintln!("soldr toolchain ensure: prepare exited with status {prepare_code}");
+        }
+        return Ok(prepare_code);
+    }
+
+    // 5. Smoke verify only when a channel exists. Without a manifest
+    //    there's no toolchain to validate against.
+    let smoke = if manifest.channel.is_some() {
+        run_smoke_verify()?
+    } else {
+        SmokeVerify {
+            cargo_version: None,
+            rustc_version: None,
+            // No channel means nothing to verify; treat as ok so the
+            // exit code stays 0 (matches prepare's no-channel path).
+            ok: true,
+        }
+    };
+
+    let smoke_ok = smoke.ok;
+    let output = ToolchainEnsureOutput {
+        schema_version: SCHEMA_VERSION,
+        channel: manifest.channel.clone(),
+        rustup_bootstrapped,
+        components_added: prepare_summary.components_added,
+        targets_added: prepare_summary.targets_added,
+        plugins_installed: prepare_summary.plugins_installed,
+        smoke_verify: smoke,
+        elapsed_ms: started.elapsed().as_millis(),
+    };
+
+    if json {
+        emit_json(output)?;
+    } else {
+        emit_human(&output);
+    }
+
+    if smoke_ok {
+        Ok(0)
+    } else {
+        // Non-zero exit so shell-pipeline consumers (setup-soldr#133)
+        // can detect the failure without parsing JSON.
+        Ok(1)
+    }
+}
+
+async fn bootstrap_rustup_if_missing() -> Result<bool, SoldrError> {
+    // Honor the test-only `SOLDR_TEST_RUSTUP_BIN` override: when set, we
+    // are inside an integration test that has already pre-provisioned a
+    // fake rustup. Skip the bootstrap branch entirely.
+    if std::env::var_os(crate::TEST_RUSTUP_BIN_ENV_VAR).is_some_and(|v| !v.is_empty()) {
+        return Ok(false);
+    }
+
+    let paths = SoldrPaths::new()?;
+    match crate::fetch::auto_bootstrap_if_missing(&paths).await? {
+        crate::fetch::AutoBootstrapOutcome::AlreadyInstalled(_) => Ok(false),
+        crate::fetch::AutoBootstrapOutcome::Installed(_) => Ok(true),
+        // Opt-out leaves the host unchanged. The subsequent prepare run
+        // will surface the standard "rustup not found" message.
+        crate::fetch::AutoBootstrapOutcome::OptedOut => Ok(false),
+    }
+}
+
+fn run_smoke_verify() -> Result<SmokeVerify, SoldrError> {
+    let cargo_version = probe_version("cargo");
+    let rustc_version = probe_version("rustc");
+    let ok = cargo_version.is_some() && rustc_version.is_some();
+    Ok(SmokeVerify {
+        cargo_version,
+        rustc_version,
+        ok,
+    })
+}
+
+/// Spawn `<tool> --version` and capture stdout. Returns `None` when
+/// either the binary couldn't be resolved, the spawn failed, the exit
+/// status was non-zero, or stdout was empty. The `None` case is what
+/// drives `smoke_verify.ok = false`.
+fn probe_version(tool: &str) -> Option<String> {
+    let binary = resolve_toolchain_binary(tool).ok()?;
+    let mut command = std::process::Command::new(&binary);
+    command.arg("--version");
+    apply_implicit_toolchain_homes(&mut command);
+    suppress_windows_console_window(&mut command);
+    let output = command.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .map(str::trim)
+        .map(str::to_string)?;
+    if line.is_empty() {
+        None
+    } else {
+        Some(line)
+    }
+}
+
+fn emit_json(output: ToolchainEnsureOutput) -> Result<(), SoldrError> {
+    let payload = serde_json::to_string_pretty(&output)
+        .map_err(|e| SoldrError::Other(format!("ensure: failed to serialize JSON: {e}")))?;
+    println!("{payload}");
+    Ok(())
+}
+
+fn emit_human(output: &ToolchainEnsureOutput) {
+    match output.channel.as_deref() {
+        Some(channel) => println!("soldr toolchain ensure: channel {channel}"),
+        None => println!(
+            "soldr toolchain ensure: no rust-toolchain.toml channel found; \
+             nothing to install or verify."
+        ),
+    }
+    if output.rustup_bootstrapped {
+        println!("soldr toolchain ensure: bootstrapped rustup into soldr-managed bin dir");
+    }
+    if !output.components_added.is_empty() {
+        println!(
+            "soldr toolchain ensure: components installed: {}",
+            output.components_added.join(", ")
+        );
+    }
+    if !output.targets_added.is_empty() {
+        println!(
+            "soldr toolchain ensure: targets installed: {}",
+            output.targets_added.join(", ")
+        );
+    }
+    if !output.plugins_installed.is_empty() {
+        println!(
+            "soldr toolchain ensure: plugins installed: {}",
+            output.plugins_installed.join(", ")
+        );
+    }
+    if let Some(cargo) = output.smoke_verify.cargo_version.as_deref() {
+        println!("soldr toolchain ensure: smoke verify cargo: {cargo}");
+    }
+    if let Some(rustc) = output.smoke_verify.rustc_version.as_deref() {
+        println!("soldr toolchain ensure: smoke verify rustc: {rustc}");
+    }
+    if output.smoke_verify.ok {
+        println!("soldr toolchain ensure: smoke verify ok");
+    } else if output.channel.is_some() {
+        println!("soldr toolchain ensure: smoke verify FAILED");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn empty_smoke_verify_defaults_to_not_ok() {
+        let s = SmokeVerify::default();
+        assert!(!s.ok);
+        assert!(s.cargo_version.is_none());
+        assert!(s.rustc_version.is_none());
+    }
+
+    #[test]
+    fn json_serialises_schema_version_first_and_arrays_present() {
+        let output = ToolchainEnsureOutput {
+            schema_version: SCHEMA_VERSION,
+            channel: Some("1.94.1".to_string()),
+            rustup_bootstrapped: false,
+            components_added: vec!["clippy".to_string()],
+            targets_added: vec![],
+            plugins_installed: vec!["cargo-nextest@0.9".to_string()],
+            smoke_verify: SmokeVerify {
+                cargo_version: Some("cargo 1.94.1".to_string()),
+                rustc_version: Some("rustc 1.94.1".to_string()),
+                ok: true,
+            },
+            elapsed_ms: 42,
+        };
+        let json = serde_json::to_string(&output).expect("serialise");
+        let parsed: Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed["schema_version"], Value::from(1));
+        assert_eq!(parsed["channel"], Value::from("1.94.1"));
+        assert!(parsed["targets_added"].is_array());
+        assert_eq!(parsed["smoke_verify"]["ok"], Value::from(true));
+    }
+}

--- a/crates/soldr-cli/tests/cli_toolchain.rs
+++ b/crates/soldr-cli/tests/cli_toolchain.rs
@@ -505,3 +505,252 @@ fn toolchain_prepare_plugin_without_version_uses_no_version_flag() {
         "--version should be omitted when spec is \"*\": {invocation:?}"
     );
 }
+
+// ===========================================================================
+// Tests for `soldr toolchain ensure` — issue #407 Phase 2.
+//
+// `ensure` is `prepare` + a smoke verify (`cargo --version` / `rustc
+// --version`), with an optional `--json` output that setup-soldr will
+// consume. The schema is locked at version 1; bumping it requires a
+// version bump in `ToolchainEnsureOutput` AND in the consumers.
+// ===========================================================================
+
+#[test]
+fn toolchain_ensure_runs_prepare_then_smoke_verify_in_json_mode() {
+    let workspace = unique_temp_dir("toolchain-ensure-json");
+    seed_rust_toolchain_toml(
+        &workspace,
+        "[toolchain]\n\
+         channel = \"1.94.1\"\n\
+         components = [\"clippy\", \"rustfmt\"]\n\
+         targets = [\"x86_64-unknown-linux-musl\"]\n\
+         \n\
+         [soldr.plugins]\n\
+         cargo-nextest = \"0.9\"\n",
+    );
+    let rustup_log = workspace.join("rustup.log");
+    let cargo_log = workspace.join("cargo.log");
+    let rustup = install_logging_fake_rustup(&rustup_log);
+    let cargo =
+        install_logging_versioned_fake_cargo(&cargo_log, "cargo 1.94.1 (abc1234 2026-04-15)");
+    let rustc = install_versioned_fake_rustc("rustc 1.94.1 (def5678 2026-04-15)");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["toolchain", "ensure", "--json"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .output()
+        .expect("failed to run soldr toolchain ensure --json");
+
+    assert!(
+        output.status.success(),
+        "soldr toolchain ensure --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("ensure --json stdout not JSON: {stdout}"));
+
+    // Schema version is part of the contract setup-soldr#133 consumes.
+    assert_eq!(parsed["schema_version"], Value::from(1));
+    assert_eq!(parsed["channel"], Value::from("1.94.1"));
+    assert_eq!(parsed["rustup_bootstrapped"], Value::from(false));
+
+    // Components / targets / plugins MUST be present as arrays even when
+    // empty so consumers can index unconditionally.
+    let components = parsed["components_added"]
+        .as_array()
+        .expect("components_added missing or not array");
+    let component_strs: Vec<&str> = components
+        .iter()
+        .map(|v| v.as_str().expect("component not string"))
+        .collect();
+    assert!(component_strs.contains(&"clippy"));
+    assert!(component_strs.contains(&"rustfmt"));
+
+    let targets = parsed["targets_added"]
+        .as_array()
+        .expect("targets_added missing or not array");
+    let target_strs: Vec<&str> = targets
+        .iter()
+        .map(|v| v.as_str().expect("target not string"))
+        .collect();
+    assert_eq!(target_strs, vec!["x86_64-unknown-linux-musl"]);
+
+    let plugins = parsed["plugins_installed"]
+        .as_array()
+        .expect("plugins_installed missing or not array");
+    let plugin_strs: Vec<&str> = plugins
+        .iter()
+        .map(|v| v.as_str().expect("plugin not string"))
+        .collect();
+    assert_eq!(plugin_strs, vec!["cargo-nextest@0.9"]);
+
+    let smoke = &parsed["smoke_verify"];
+    assert_eq!(smoke["ok"], Value::from(true));
+    assert_eq!(
+        smoke["cargo_version"].as_str().unwrap_or(""),
+        "cargo 1.94.1 (abc1234 2026-04-15)"
+    );
+    assert_eq!(
+        smoke["rustc_version"].as_str().unwrap_or(""),
+        "rustc 1.94.1 (def5678 2026-04-15)"
+    );
+
+    // elapsed_ms is non-deterministic, but must exist and be a number.
+    assert!(
+        parsed["elapsed_ms"].is_number(),
+        "elapsed_ms must be numeric"
+    );
+
+    // Verify the rustup invocations are the same set `prepare` would run:
+    // install + 2 components + 1 target.
+    let rustup_invocations = read_logged_rustup_invocations(&rustup_log);
+    assert_eq!(
+        rustup_invocations.len(),
+        4,
+        "expected install + 2 components + 1 target rustup invocations: {rustup_invocations:?}"
+    );
+    assert_eq!(rustup_invocations[0][0], "toolchain");
+    assert_eq!(rustup_invocations[0][1], "install");
+
+    // Verify cargo was called once for the plugin AND once for --version
+    // (smoke verify). Both land in the same log.
+    let cargo_invocations = read_logged_cargo_invocations(&cargo_log);
+    let install_invocations: Vec<_> = cargo_invocations
+        .iter()
+        .filter(|inv| inv.first().map(String::as_str) == Some("install"))
+        .collect();
+    assert_eq!(
+        install_invocations.len(),
+        1,
+        "expected exactly one `cargo install` invocation for the plugin: {cargo_invocations:?}"
+    );
+    assert_eq!(
+        install_invocations[0].get(1).map(String::as_str),
+        Some("cargo-nextest")
+    );
+}
+
+#[test]
+fn toolchain_ensure_human_mode_succeeds_without_json() {
+    let workspace = unique_temp_dir("toolchain-ensure-human");
+    seed_rust_toolchain_toml(&workspace, "[toolchain]\nchannel = \"1.94.1\"\n");
+    let rustup_log = workspace.join("rustup.log");
+    let cargo_log = workspace.join("cargo.log");
+    let rustup = install_logging_fake_rustup(&rustup_log);
+    let cargo =
+        install_logging_versioned_fake_cargo(&cargo_log, "cargo 1.94.1 (abc1234 2026-04-15)");
+    let rustc = install_versioned_fake_rustc("rustc 1.94.1 (def5678 2026-04-15)");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["toolchain", "ensure"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .output()
+        .expect("failed to run soldr toolchain ensure");
+
+    assert!(
+        output.status.success(),
+        "soldr toolchain ensure (human mode) failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Human mode MUST NOT emit raw JSON on stdout.
+    assert!(
+        !stdout.trim_start().starts_with('{'),
+        "human-mode output must not be JSON: {stdout}"
+    );
+
+    // Sanity: the user-facing line mentions the resolved channel.
+    assert!(
+        stdout.contains("1.94.1"),
+        "expected channel in human output: {stdout}"
+    );
+}
+
+#[test]
+fn toolchain_ensure_json_reports_smoke_failure_when_rustc_returns_nonzero() {
+    let workspace = unique_temp_dir("toolchain-ensure-smoke-fail");
+    seed_rust_toolchain_toml(&workspace, "[toolchain]\nchannel = \"1.94.1\"\n");
+    let rustup_log = workspace.join("rustup.log");
+    let cargo_log = workspace.join("cargo.log");
+    let rustup = install_logging_fake_rustup(&rustup_log);
+    let cargo =
+        install_logging_versioned_fake_cargo(&cargo_log, "cargo 1.94.1 (abc1234 2026-04-15)");
+    let rustc = install_failing_fake_rustc();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["toolchain", "ensure", "--json"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .output()
+        .expect("failed to run soldr toolchain ensure --json (failing smoke)");
+
+    // Smoke failure is a soldr-level failure: the JSON must still be
+    // emitted (so callers can inspect it) but the exit code must be
+    // non-zero so shell scripts notice. setup-soldr#133 relies on this.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("ensure --json stdout not JSON: {stdout}"));
+    assert_eq!(parsed["schema_version"], Value::from(1));
+    let smoke = &parsed["smoke_verify"];
+    assert_eq!(
+        smoke["ok"],
+        Value::from(false),
+        "smoke_verify.ok must be false when rustc --version fails: {smoke}"
+    );
+    assert!(
+        !output.status.success(),
+        "ensure must exit non-zero when smoke verify fails (status={:?})",
+        output.status
+    );
+}
+
+#[test]
+fn toolchain_ensure_no_channel_emits_empty_schema_v1_payload() {
+    let workspace = unique_temp_dir("toolchain-ensure-no-channel");
+    // No rust-toolchain.toml at all: ensure must still emit valid JSON
+    // (schema_version=1, channel=null, no smoke verify) and exit 0.
+    let rustup_log = workspace.join("rustup.log");
+    let cargo_log = workspace.join("cargo.log");
+    let rustup = install_logging_fake_rustup(&rustup_log);
+    let cargo =
+        install_logging_versioned_fake_cargo(&cargo_log, "cargo 1.94.1 (abc1234 2026-04-15)");
+    let rustc = install_versioned_fake_rustc("rustc 1.94.1 (def5678 2026-04-15)");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["toolchain", "ensure", "--json"])
+        .current_dir(&workspace)
+        .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .output()
+        .expect("failed to run soldr toolchain ensure --json (no channel)");
+
+    assert!(
+        output.status.success(),
+        "ensure with no manifest must exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("ensure --json stdout not JSON: {stdout}"));
+    assert_eq!(parsed["schema_version"], Value::from(1));
+    assert!(
+        parsed["channel"].is_null(),
+        "channel must be null when no manifest: {parsed}"
+    );
+}

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -827,6 +827,160 @@ pub(crate) fn install_logging_fake_cargo(log_path: &Path) -> PathBuf {
     cargo
 }
 
+/// Fake `cargo` that responds to `--version` with a deterministic string
+/// (matching the real cargo `cargo X.Y.Z (sha date)` format used by
+/// `toolchain ensure --json`'s smoke verify) AND otherwise logs argv to
+/// `log_path`. Useful for the `ensure` test which needs both a valid
+/// `--version` capture AND to assert `cargo install` argv for plugins.
+///
+/// `version` must not contain literal `(` / `)` on Windows because cmd.exe
+/// `echo` treats those as block delimiters — we substitute them through the
+/// caret-escape `^(` / `^)` form on Windows automatically.
+pub(crate) fn fake_logging_versioned_cargo_script(log_path: &Path, version: &str) -> String {
+    #[cfg(windows)]
+    {
+        let escaped = escape_for_cmd_echo(version);
+        format!(
+            "@echo off\n\
+             if \"%~1\"==\"--version\" (\n\
+               echo {1}\n\
+               exit /b 0\n\
+             )\n\
+             setlocal enabledelayedexpansion\n\
+             set \"line=\"\n\
+             :loop\n\
+             if \"%~1\"==\"\" goto done\n\
+             if defined line (set \"line=!line!\u{1f}%~1\") else (set \"line=%~1\")\n\
+             shift\n\
+             goto loop\n\
+             :done\n\
+             echo !line!>>\"{0}\"\n\
+             exit /b 0\n",
+            log_path.display(),
+            escaped
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             if [ \"$1\" = \"--version\" ]; then\n\
+               echo '{1}'\n\
+               exit 0\n\
+             fi\n\
+             sep=$(printf '\\037')\n\
+             out=\"\"\n\
+             first=1\n\
+             for arg in \"$@\"; do\n\
+               if [ $first -eq 1 ]; then\n\
+                 out=\"$arg\"\n\
+                 first=0\n\
+               else\n\
+                 out=\"$out${{sep}}$arg\"\n\
+               fi\n\
+             done\n\
+             printf '%s\\n' \"$out\" >> \"{0}\"\n\
+             exit 0\n",
+            log_path.display(),
+            version
+        )
+    }
+}
+
+/// Escape `(` and `)` for inclusion in a cmd.exe `echo` line inside an
+/// `if (...) ( ... )` block (where the un-escaped parens close the block
+/// prematurely). The standard escape is `^(` / `^)`.
+#[cfg(windows)]
+fn escape_for_cmd_echo(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for ch in s.chars() {
+        match ch {
+            '(' => out.push_str("^("),
+            ')' => out.push_str("^)"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Install a fake `cargo` that responds to `--version` AND logs argv on
+/// every other invocation. Returns the path to the fake binary.
+pub(crate) fn install_logging_versioned_fake_cargo(log_path: &Path, version: &str) -> PathBuf {
+    let dir = unique_temp_dir("fake-cargo-versioned");
+    let cargo = fake_script_path(&dir, "cargo");
+    write_fake_script(
+        &cargo,
+        &fake_logging_versioned_cargo_script(log_path, version),
+    );
+    cargo
+}
+
+/// Fake `rustc` that responds to `--version` (deterministic) and
+/// otherwise exits 0. Used by the ensure JSON smoke-verify test.
+pub(crate) fn fake_versioned_rustc_script(version: &str) -> String {
+    #[cfg(windows)]
+    {
+        let escaped = escape_for_cmd_echo(version);
+        format!(
+            "@echo off\n\
+             if \"%~1\"==\"--version\" (\n\
+               echo {0}\n\
+               exit /b 0\n\
+             )\n\
+             exit /b 0\n",
+            escaped
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             if [ \"$1\" = \"--version\" ]; then\n\
+               echo '{0}'\n\
+               exit 0\n\
+             fi\n\
+             exit 0\n",
+            version
+        )
+    }
+}
+
+/// Install a fake `rustc` that responds to `--version` deterministically.
+/// Suitable for `SOLDR_TEST_RUSTC_BIN`.
+pub(crate) fn install_versioned_fake_rustc(version: &str) -> PathBuf {
+    let dir = unique_temp_dir("fake-rustc-versioned");
+    let rustc = fake_script_path(&dir, "rustc");
+    write_fake_script(&rustc, &fake_versioned_rustc_script(version));
+    rustc
+}
+
+/// Fake `rustc` that always exits non-zero on `--version`. Used to
+/// exercise the `smoke_verify.ok == false` branch.
+pub(crate) fn fake_failing_rustc_script() -> String {
+    #[cfg(windows)]
+    {
+        "@echo off\n\
+         echo simulated rustc failure 1>&2\n\
+         exit /b 1\n"
+            .to_string()
+    }
+    #[cfg(not(windows))]
+    {
+        "#!/bin/sh\n\
+         echo 'simulated rustc failure' >&2\n\
+         exit 1\n"
+            .to_string()
+    }
+}
+
+/// Install a fake `rustc` that fails any `--version` call.
+pub(crate) fn install_failing_fake_rustc() -> PathBuf {
+    let dir = unique_temp_dir("fake-rustc-failing");
+    let rustc = fake_script_path(&dir, "rustc");
+    write_fake_script(&rustc, &fake_failing_rustc_script());
+    rustc
+}
+
 /// Read every argv invocation logged by `fake_logging_cargo_script`.
 /// Each returned `Vec<String>` is one invocation, with argv split on
 /// the ASCII unit separator.

--- a/docs/API.md
+++ b/docs/API.md
@@ -414,6 +414,8 @@ pinned channel through every command.
 ```bash
 soldr toolchain install   # rustup toolchain install <channel> --profile minimal --no-self-update
 soldr toolchain prepare   # install + component add + target add + cargo install for [soldr.plugins]
+soldr toolchain ensure    # bootstrap rustup if missing, run `prepare`, smoke-verify (cargo/rustc --version)
+soldr toolchain ensure --json  # same, but emit a stable JSON payload (schema_version: 1)
 ```
 
 `prepare` runs, in order:
@@ -424,6 +426,59 @@ soldr toolchain prepare   # install + component add + target add + cargo install
 4. `cargo install <name> [--version V] [--locked] [--features ...] [--no-default-features]` for every entry in `[soldr.plugins]`
 
 The first non-zero exit short-circuits the chain.
+
+#### `soldr toolchain ensure`
+
+One-shot "make sure this host can build" verb (issue #407 Phase 2):
+
+1. Auto-bootstraps `rustup` into the soldr-managed bin dir if missing
+   (reuses the same logic as `soldr bootstrap`). Respects
+   `SOLDR_NO_BOOTSTRAP=1`.
+2. Runs the same `install` + `component add` + `target add` + plugin-
+   install pipeline as `prepare`.
+3. Smoke-verifies the resolved toolchain by spawning `cargo --version`
+   and `rustc --version`. Either failure marks the verify as failed and
+   exits non-zero.
+
+`ensure` is intended for one-stop bootstrap callers like
+[setup-soldr#133](https://github.com/zackees/setup-soldr/issues/133)
+that want to delegate every TS toolchain step to the soldr binary.
+Existing `install` and `prepare` output formats are unchanged.
+
+The `--json` payload (`schema_version: 1`) is the stable contract for
+those callers — fields may be added in future schema versions but
+existing field names and types will not change without a schema bump:
+
+```json
+{
+  "schema_version": 1,
+  "channel": "1.94.1",
+  "rustup_bootstrapped": false,
+  "components_added": ["rustfmt", "clippy"],
+  "targets_added": ["x86_64-pc-windows-gnu"],
+  "plugins_installed": ["cargo-zigbuild@0.18"],
+  "smoke_verify": {
+    "cargo_version": "cargo 1.94.1 (abc1234 2026-04-15)",
+    "rustc_version": "rustc 1.94.1 (def5678 2026-04-15)",
+    "ok": true
+  },
+  "elapsed_ms": 12345
+}
+```
+
+Notes on the schema:
+
+- `channel` is `null` when no `rust-toolchain.toml` is present; the rest
+  of the payload still serializes so consumers can parse unconditionally.
+- `rustup_bootstrapped` is `true` only when `ensure` actually fetched
+  rustup-init for this invocation. A pre-existing rustup or
+  `SOLDR_NO_BOOTSTRAP=1` keeps it `false`.
+- `components_added` / `targets_added` / `plugins_installed` mirror the
+  manifest entries that the `prepare` pipeline attempted. Plugin labels
+  are `name` for bare or `*` versions, otherwise `name@version`.
+- `smoke_verify.ok` is `false` when either spawn fails or returns
+  non-zero. The JSON payload is emitted in both success and failure
+  cases; only the process exit code differs.
 
 #### `[soldr.plugins]`
 


### PR DESCRIPTION
## Summary

Partially addresses #407 — Phase 2 of 4.
Wave 3.1 of zackees/soldr#514.

New `soldr toolchain ensure [--json]` subcommand:

1. Auto-bootstraps `rustup` into the soldr-managed bin dir if missing
   (reuses Phase 1's bootstrap logic; respects `SOLDR_NO_BOOTSTRAP=1`).
2. Runs the same `install` + `component add` + `target add` + plugin-
   install pipeline as `prepare`.
3. Smoke-verifies the resolved toolchain by spawning `cargo --version`
   and `rustc --version`. Either failure marks the verify as failed and
   exits non-zero.

With `--json`, emits a stable `schema_version: 1` payload that
setup-soldr#133 consumes to delegate its TS toolchain logic to the
soldr binary:

```json
{
  "schema_version": 1,
  "channel": "1.94.1",
  "rustup_bootstrapped": false,
  "components_added": ["rustfmt", "clippy"],
  "targets_added": ["x86_64-pc-windows-gnu"],
  "plugins_installed": ["cargo-zigbuild@0.18"],
  "smoke_verify": {
    "cargo_version": "cargo 1.94.1 (abc1234 2026-04-15)",
    "rustc_version": "rustc 1.94.1 (def5678 2026-04-15)",
    "ok": true
  },
  "elapsed_ms": 12345
}
```

Existing `install` and `prepare` output formats are unchanged. The JSON
schema is frozen at version 1 — bumping it requires a coordinated
version bump in the consumer.

TDD verified: 6 new tests written first (4 integration + 2 unit), all
initially red, all green after implementation:

- `toolchain_ensure_runs_prepare_then_smoke_verify_in_json_mode`
- `toolchain_ensure_human_mode_succeeds_without_json`
- `toolchain_ensure_json_reports_smoke_failure_when_rustc_returns_nonzero`
- `toolchain_ensure_no_channel_emits_empty_schema_v1_payload`
- `toolchain_ensure::tests::empty_smoke_verify_defaults_to_not_ok`
- `toolchain_ensure::tests::json_serialises_schema_version_first_and_arrays_present`

## Test plan

- [x] `soldr cargo test -p soldr-cli --test cli_toolchain` — 16/16 pass (12 pre-existing + 4 new ensure tests)
- [x] `soldr cargo test -p soldr-cli --bin soldr toolchain_ensure` — 2/2 pass
- [x] `soldr cargo fmt` — clean on all 8 files in this PR (pre-existing fmt drift on unrelated files left alone)
- [x] All `soldr cargo` invocations used the default zccache cache (no `--no-cache`, no `RUSTC_WRAPPER=` override)

Note: Pre-existing clippy `enum_variant_names` warnings on `GcListKind` (cli_args.rs) and `GcListKindFilter` (gc.rs) exist on `origin/main` (introduced by #506); they are out of scope for this PR. Pre-existing rustfmt drift on unrelated files also exists on origin/main and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)