### PR TITLE
feat(toolchain): `soldr toolchain link --shim-dir` (#407 Phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Two categories, surfaced as first-class subcommands or via the generic fetch pat
 - `soldr toolchain install` reads `[toolchain].channel` from `rust-toolchain.toml` and runs `rustup toolchain install <channel> --profile minimal --no-self-update`.
 - `soldr toolchain prepare` chains install + `component add` + `target add` for every declared component / target, then `cargo install`s every entry under `[soldr.plugins]`.
 - `soldr toolchain ensure [--json]` (issue #407 Phase 2) auto-bootstraps rustup if missing, runs the same pipeline as `prepare`, then smoke-verifies the resolved toolchain with `cargo --version` / `rustc --version`. `--json` emits a stable `schema_version: 1` payload consumed by `setup-soldr#133`.
+- `soldr toolchain link --shim-dir <path> [--json] [--force]` (issue #407 Phase 3) writes PATH shim files for `cargo`, `rustfmt`, `clippy-driver`, `rustc`, and `rustdoc` that re-exec the running soldr binary. Idempotent (existing-matches → skip); `--force` overwrites differing content. JSON payload uses the same `schema_version: 1` shape as `ensure`.
   - Manifest example:
     ```toml
     [toolchain]

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -450,6 +450,30 @@ pub(crate) enum ToolchainSubcommand {
         #[arg(long)]
         json: bool,
     },
+    /// Write PATH shim files into `--shim-dir` so a child process that
+    /// resolves `cargo` / `rustfmt` / `clippy-driver` / `rustc` /
+    /// `rustdoc` from PATH gets routed back through `soldr <tool>`
+    /// (issue #407 Phase 3, ports setup-soldr's `ensure-shims.ts`).
+    ///
+    /// Idempotent by default: a shim file whose contents already match
+    /// the expected body is left alone. `--force` overwrites regardless.
+    /// `--json` emits the same `schema_version: 1` style payload
+    /// `setup-soldr#133` consumes from `ensure`.
+    Link {
+        /// Destination directory for the shim files. Created if missing.
+        #[arg(long, value_name = "PATH")]
+        shim_dir: std::path::PathBuf,
+        /// Emit the stable machine-facing JSON form
+        /// (`schema_version: 1`) for consumption by setup-soldr and
+        /// other tooling.
+        #[arg(long)]
+        json: bool,
+        /// Overwrite existing shim files regardless of their current
+        /// contents. Without `--force`, files whose contents differ are
+        /// left untouched.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(clap::Subcommand)]

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -34,6 +34,7 @@ mod shim_dir;
 mod startup_profile;
 mod toolchain;
 mod toolchain_ensure;
+mod toolchain_link;
 mod trampoline;
 mod trampoline_workspace;
 mod wrapper;
@@ -266,6 +267,19 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             }
             ToolchainSubcommand::Ensure { json } => {
                 std::process::exit(toolchain_ensure::run_toolchain_ensure(json).await?);
+            }
+            ToolchainSubcommand::Link {
+                shim_dir,
+                json,
+                force,
+            } => {
+                std::process::exit(toolchain_link::run_toolchain_link(
+                    toolchain_link::LinkArgs {
+                        shim_dir,
+                        json,
+                        force,
+                    },
+                )?);
             }
         },
         Commands::Bootstrap { json } => {

--- a/crates/soldr-cli/src/toolchain_link.rs
+++ b/crates/soldr-cli/src/toolchain_link.rs
@@ -1,0 +1,451 @@
+//! `soldr toolchain link --shim-dir <path>` — write PATH shim files
+//! that re-route `cargo` / `rustfmt` / `clippy-driver` / `rustc` /
+//! `rustdoc` back through `soldr <tool>`. Port of setup-soldr's
+//! `ensure-shims.ts` into the soldr binary (issue #407 Phase 3).
+//!
+//! The shim contents are the same shape soldr's *transient* child
+//! shims (`crate::shim_dir`) use, but `toolchain link` writes them to
+//! a caller-chosen directory and supports idempotent re-runs plus
+//! `--force` overwrites. Setup-soldr#133 will delegate its TS shim
+//! installer to this verb on the soldr-managed side.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use crate::core::SoldrError;
+
+const SCHEMA_VERSION: u32 = 1;
+
+/// Tools we write shims for. Mirrors setup-soldr's `SHIMMED_TOOLS`
+/// constant in `src/lib/shim-bypass-check.ts` and the
+/// `crate::shim_dir::SHIMMED_TOOLS` list used by transient child-process
+/// shims. Order is the stable JSON output order.
+pub(crate) const LINK_SHIMMED_TOOLS: &[&str] =
+    &["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"];
+
+/// CLI-level args for `toolchain link`, mirroring the
+/// `cli_args::ToolchainSubcommand::Link` variant.
+#[derive(Debug, Clone)]
+pub(crate) struct LinkArgs {
+    pub shim_dir: PathBuf,
+    pub json: bool,
+    pub force: bool,
+}
+
+#[derive(Serialize, Debug)]
+pub(crate) struct ToolchainLinkOutput {
+    pub schema_version: u32,
+    pub shim_dir: String,
+    pub tools: Vec<ToolEntry>,
+    pub elapsed_ms: u128,
+}
+
+#[derive(Serialize, Debug)]
+pub(crate) struct ToolEntry {
+    pub name: String,
+    pub shim_path: String,
+    pub created: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<String>,
+}
+
+/// `existing-matches`: the shim file already exists and its contents
+/// equal the expected body, so we left it alone (idempotent re-run).
+pub(crate) const SKIP_EXISTING_MATCHES: &str = "existing-matches";
+/// `existing-differs`: the shim file already exists but its contents
+/// differ from the expected body, AND `--force` was not passed, so we
+/// left it alone to avoid clobbering caller-customized content.
+pub(crate) const SKIP_EXISTING_DIFFERS: &str = "existing-differs";
+
+/// Top-level entry point invoked from `main.rs` dispatch. Resolves the
+/// running soldr binary path, writes each shim, and emits the human or
+/// JSON result.
+pub(crate) fn run_toolchain_link(args: LinkArgs) -> Result<i32, SoldrError> {
+    let started = Instant::now();
+    let soldr_bin = crate::current_soldr_binary()?;
+    let outcome = write_shims(&args.shim_dir, &soldr_bin, args.force)?;
+
+    let output = ToolchainLinkOutput {
+        schema_version: SCHEMA_VERSION,
+        shim_dir: args.shim_dir.display().to_string(),
+        tools: outcome,
+        elapsed_ms: started.elapsed().as_millis(),
+    };
+
+    if args.json {
+        emit_json(&output)?;
+    } else {
+        emit_human(&output);
+    }
+    Ok(0)
+}
+
+/// Build the shim body for `tool` that points at `soldr_bin`. Pure
+/// function — exposed (`pub(crate)`) so tests can compare verbatim.
+#[cfg(unix)]
+pub(crate) fn shim_body(tool: &str, soldr_bin: &Path) -> String {
+    format!(
+        "#!/bin/sh\nexec \"{}\" {} \"$@\"\n",
+        soldr_bin.display(),
+        tool
+    )
+}
+
+/// Windows `.cmd` shim body. CRLF line endings — cmd.exe parses
+/// multi-line scripts most reliably with CRLF.
+#[cfg(windows)]
+pub(crate) fn shim_body(tool: &str, soldr_bin: &Path) -> String {
+    format!("@echo off\r\n\"{}\" {} %*\r\n", soldr_bin.display(), tool)
+}
+
+/// Resolve the on-disk shim path for a tool inside `shim_dir`. On Unix
+/// this is `<dir>/<tool>`; on Windows we append `.cmd` so PATHEXT picks
+/// the file up automatically.
+pub(crate) fn shim_path(shim_dir: &Path, tool: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        shim_dir.join(format!("{tool}.cmd"))
+    }
+    #[cfg(not(windows))]
+    {
+        shim_dir.join(tool)
+    }
+}
+
+/// Core file-writer. Creates `shim_dir` if missing, then per tool:
+/// - if no existing file → write + created=true
+/// - if existing file with matching body → skip (existing-matches)
+/// - if existing file with different body AND !force → skip (existing-differs)
+/// - if existing file with different body AND force → overwrite + created=true
+pub(crate) fn write_shims(
+    shim_dir: &Path,
+    soldr_bin: &Path,
+    force: bool,
+) -> Result<Vec<ToolEntry>, SoldrError> {
+    std::fs::create_dir_all(shim_dir).map_err(SoldrError::Io)?;
+    let mut out = Vec::with_capacity(LINK_SHIMMED_TOOLS.len());
+    for tool in LINK_SHIMMED_TOOLS {
+        let path = shim_path(shim_dir, tool);
+        let body = shim_body(tool, soldr_bin);
+
+        let entry = match std::fs::read_to_string(&path) {
+            Ok(existing) if existing == body => ToolEntry {
+                name: (*tool).to_string(),
+                shim_path: path.display().to_string(),
+                created: false,
+                skip_reason: Some(SKIP_EXISTING_MATCHES.to_string()),
+            },
+            Ok(_existing) if !force => ToolEntry {
+                name: (*tool).to_string(),
+                shim_path: path.display().to_string(),
+                created: false,
+                skip_reason: Some(SKIP_EXISTING_DIFFERS.to_string()),
+            },
+            // Either no existing file, existing-differs+force, or any
+            // read error (e.g. NotFound). Write the body either way.
+            _ => {
+                write_executable(&path, &body)?;
+                ToolEntry {
+                    name: (*tool).to_string(),
+                    shim_path: path.display().to_string(),
+                    created: true,
+                    skip_reason: None,
+                }
+            }
+        };
+        out.push(entry);
+    }
+    Ok(out)
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, body: &str) -> Result<(), SoldrError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::write(path, body).map_err(SoldrError::Io)?;
+    let mut perms = std::fs::metadata(path)
+        .map_err(SoldrError::Io)?
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).map_err(SoldrError::Io)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn write_executable(path: &Path, body: &str) -> Result<(), SoldrError> {
+    std::fs::write(path, body).map_err(SoldrError::Io)?;
+    Ok(())
+}
+
+fn emit_json(output: &ToolchainLinkOutput) -> Result<(), SoldrError> {
+    let payload = serde_json::to_string_pretty(output)
+        .map_err(|e| SoldrError::Other(format!("link: failed to serialize JSON: {e}")))?;
+    println!("{payload}");
+    Ok(())
+}
+
+fn emit_human(output: &ToolchainLinkOutput) {
+    println!("soldr toolchain link: shim dir {}", output.shim_dir);
+    let mut created = 0usize;
+    let mut skipped_matches = 0usize;
+    let mut skipped_differs = 0usize;
+    for entry in &output.tools {
+        if entry.created {
+            created += 1;
+            println!("  wrote   {} -> {}", entry.name, entry.shim_path);
+        } else {
+            match entry.skip_reason.as_deref() {
+                Some(SKIP_EXISTING_MATCHES) => {
+                    skipped_matches += 1;
+                    println!(
+                        "  skip    {} (existing matches) {}",
+                        entry.name, entry.shim_path
+                    );
+                }
+                Some(SKIP_EXISTING_DIFFERS) => {
+                    skipped_differs += 1;
+                    println!(
+                        "  skip    {} (existing differs; pass --force to overwrite) {}",
+                        entry.name, entry.shim_path
+                    );
+                }
+                Some(other) => {
+                    println!("  skip    {} ({}) {}", entry.name, other, entry.shim_path);
+                }
+                None => {
+                    // Defensive: a non-created entry should always carry
+                    // a skip_reason. Print verbatim so callers can debug.
+                    println!("  skip    {} {}", entry.name, entry.shim_path);
+                }
+            }
+        }
+    }
+    println!(
+        "soldr toolchain link: {created} written, {skipped_matches} already up-to-date, \
+         {skipped_differs} skipped (use --force to overwrite)"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn tempdir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("soldr-link-test-{label}-{nanos}"));
+        std::fs::create_dir_all(&dir).expect("create tempdir");
+        dir
+    }
+
+    #[test]
+    fn shimmed_tools_match_setup_soldr_routed_tools() {
+        // The setup-soldr `ROUTED_TOOLS` constant must stay in sync with
+        // this list. If a tool is added on one side without the other,
+        // setup-soldr#133 delegation breaks.
+        assert_eq!(
+            LINK_SHIMMED_TOOLS,
+            &["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shim_body_unix_execs_soldr_with_tool() {
+        let soldr = PathBuf::from("/usr/local/bin/soldr");
+        let body = shim_body("cargo", &soldr);
+        assert!(
+            body.contains("exec \"/usr/local/bin/soldr\" cargo \"$@\""),
+            "unexpected shim body: {body}"
+        );
+        assert!(
+            body.starts_with("#!/bin/sh\n"),
+            "unix shim must start with shebang: {body}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn shim_body_windows_calls_soldr_with_tool() {
+        let soldr = PathBuf::from(r"C:\bin\soldr.exe");
+        let body = shim_body("cargo", &soldr);
+        assert!(
+            body.contains(r#""C:\bin\soldr.exe" cargo %*"#),
+            "unexpected shim body: {body}"
+        );
+        assert!(
+            body.starts_with("@echo off\r\n"),
+            "windows shim must start with @echo off: {body}"
+        );
+        assert!(
+            body.contains("\r\n"),
+            "windows shim must use CRLF line endings: {body:?}"
+        );
+    }
+
+    #[test]
+    fn shim_path_appends_cmd_on_windows_only() {
+        let dir = PathBuf::from("/tmp/shims");
+        let p = shim_path(&dir, "cargo");
+        #[cfg(windows)]
+        assert!(
+            p.to_string_lossy().ends_with("cargo.cmd"),
+            "windows shim path should end with .cmd: {}",
+            p.display()
+        );
+        #[cfg(not(windows))]
+        assert!(
+            p.to_string_lossy().ends_with("cargo"),
+            "unix shim path should not have an extension: {}",
+            p.display()
+        );
+    }
+
+    #[test]
+    fn write_shims_creates_every_routed_tool_on_fresh_dir() {
+        let dir = tempdir("fresh");
+        let soldr = PathBuf::from("/opt/soldr/soldr");
+        let result = write_shims(&dir, &soldr, false).expect("write_shims");
+        assert_eq!(result.len(), LINK_SHIMMED_TOOLS.len());
+        for (entry, expected) in result.iter().zip(LINK_SHIMMED_TOOLS.iter()) {
+            assert_eq!(&entry.name, expected, "tool order must match");
+            assert!(
+                entry.created,
+                "every shim should be created on fresh run: {entry:?}"
+            );
+            assert!(entry.skip_reason.is_none());
+            let p = shim_path(&dir, expected);
+            assert!(p.is_file(), "missing shim at {}", p.display());
+        }
+    }
+
+    #[test]
+    fn write_shims_skips_existing_matching_files() {
+        let dir = tempdir("idempotent");
+        let soldr = PathBuf::from("/opt/soldr/soldr");
+        let first = write_shims(&dir, &soldr, false).expect("first run");
+        assert!(first.iter().all(|e| e.created));
+
+        let second = write_shims(&dir, &soldr, false).expect("second run");
+        for entry in &second {
+            assert!(!entry.created, "no file should be re-created: {entry:?}");
+            assert_eq!(
+                entry.skip_reason.as_deref(),
+                Some(SKIP_EXISTING_MATCHES),
+                "second run should report existing-matches: {entry:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn write_shims_skips_existing_differing_files_without_force() {
+        let dir = tempdir("differs-noforce");
+        let soldr = PathBuf::from("/opt/soldr/soldr");
+        // Seed every shim with foreign content.
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        for tool in LINK_SHIMMED_TOOLS {
+            let p = shim_path(&dir, tool);
+            std::fs::write(&p, "FOREIGN CONTENT").expect("seed");
+        }
+
+        let result = write_shims(&dir, &soldr, false).expect("write");
+        for entry in &result {
+            assert!(
+                !entry.created,
+                "differs+!force must NOT overwrite: {entry:?}"
+            );
+            assert_eq!(
+                entry.skip_reason.as_deref(),
+                Some(SKIP_EXISTING_DIFFERS),
+                "differs+!force should report existing-differs: {entry:?}"
+            );
+            let on_disk = std::fs::read_to_string(&entry.shim_path).expect("read");
+            assert_eq!(on_disk, "FOREIGN CONTENT", "must not overwrite");
+        }
+    }
+
+    #[test]
+    fn write_shims_overwrites_existing_differing_files_with_force() {
+        let dir = tempdir("differs-force");
+        let soldr = PathBuf::from("/opt/soldr/soldr");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        for tool in LINK_SHIMMED_TOOLS {
+            let p = shim_path(&dir, tool);
+            std::fs::write(&p, "FOREIGN CONTENT").expect("seed");
+        }
+
+        let result = write_shims(&dir, &soldr, true).expect("write");
+        for entry in &result {
+            assert!(entry.created, "differs+force MUST overwrite: {entry:?}");
+            assert!(entry.skip_reason.is_none());
+            let on_disk = std::fs::read_to_string(&entry.shim_path).expect("read");
+            assert_eq!(
+                on_disk,
+                shim_body(&entry.name, &soldr),
+                "forced overwrite content mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn write_shims_overwrite_with_force_is_idempotent() {
+        let dir = tempdir("force-idempotent");
+        let soldr = PathBuf::from("/opt/soldr/soldr");
+        let first = write_shims(&dir, &soldr, true).expect("first");
+        assert!(first.iter().all(|e| e.created));
+
+        // Second --force run: existing-matches is still detected, so we
+        // do NOT churn the file. (--force only matters when content
+        // differs.)
+        let second = write_shims(&dir, &soldr, true).expect("second");
+        for entry in &second {
+            assert!(!entry.created, "no churn when existing matches: {entry:?}");
+            assert_eq!(entry.skip_reason.as_deref(), Some(SKIP_EXISTING_MATCHES));
+        }
+    }
+
+    #[test]
+    fn json_payload_serialises_schema_v1_and_tools_array() {
+        let entries = vec![
+            ToolEntry {
+                name: "cargo".to_string(),
+                shim_path: "/tmp/shims/cargo".to_string(),
+                created: true,
+                skip_reason: None,
+            },
+            ToolEntry {
+                name: "rustfmt".to_string(),
+                shim_path: "/tmp/shims/rustfmt".to_string(),
+                created: false,
+                skip_reason: Some(SKIP_EXISTING_MATCHES.to_string()),
+            },
+        ];
+        let output = ToolchainLinkOutput {
+            schema_version: SCHEMA_VERSION,
+            shim_dir: "/tmp/shims".to_string(),
+            tools: entries,
+            elapsed_ms: 7,
+        };
+        let json = serde_json::to_string(&output).expect("serialise");
+        let parsed: Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed["schema_version"], Value::from(1));
+        assert_eq!(parsed["shim_dir"], Value::from("/tmp/shims"));
+        let tools = parsed["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["name"], Value::from("cargo"));
+        assert_eq!(tools[0]["created"], Value::from(true));
+        assert!(
+            tools[0].get("skip_reason").is_none(),
+            "skip_reason must be omitted when None: {}",
+            tools[0]
+        );
+        assert_eq!(tools[1]["created"], Value::from(false));
+        assert_eq!(tools[1]["skip_reason"], Value::from(SKIP_EXISTING_MATCHES));
+        assert!(parsed["elapsed_ms"].is_number());
+    }
+}

--- a/crates/soldr-cli/tests/cli_toolchain.rs
+++ b/crates/soldr-cli/tests/cli_toolchain.rs
@@ -754,3 +754,291 @@ fn toolchain_ensure_no_channel_emits_empty_schema_v1_payload() {
         "channel must be null when no manifest: {parsed}"
     );
 }
+
+// ===========================================================================
+// Tests for `soldr toolchain link --shim-dir <path>` — issue #407 Phase 3.
+//
+// `link` writes platform-specific shim files (cargo, rustfmt,
+// clippy-driver, rustc, rustdoc) into <shim-dir> so PATH-resolved
+// invocations of those tools route back through `soldr <tool>`. The
+// `--json` payload follows the same `schema_version: 1` style as
+// `ensure` so setup-soldr#133 can consume both with one parser.
+// ===========================================================================
+
+/// Platform-aware shim filename. Mirrors `toolchain_link::shim_path` so
+/// the integration tests don't have to depend on the bin-tree module.
+fn expected_shim_path(dir: &Path, tool: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        dir.join(format!("{tool}.cmd"))
+    }
+    #[cfg(not(windows))]
+    {
+        dir.join(tool)
+    }
+}
+
+#[test]
+fn toolchain_link_writes_every_routed_tool_into_shim_dir() {
+    let workspace = unique_temp_dir("toolchain-link-fresh");
+    let shim_dir = workspace.join("shims");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "toolchain",
+            "link",
+            "--shim-dir",
+            &shim_dir.display().to_string(),
+        ])
+        .current_dir(&workspace)
+        .output()
+        .expect("failed to run soldr toolchain link");
+
+    assert!(
+        output.status.success(),
+        "soldr toolchain link failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    for tool in ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"] {
+        let shim = expected_shim_path(&shim_dir, tool);
+        assert!(
+            shim.is_file(),
+            "expected shim at {} after link, but it's missing",
+            shim.display()
+        );
+        let body = fs::read_to_string(&shim).expect("read shim");
+        assert!(
+            body.contains(tool),
+            "shim body for {tool} should mention the tool name: {body}"
+        );
+        // The shim must reference the running soldr binary so subprocess
+        // exec lands back on this build.
+        let soldr_bin = env!("CARGO_BIN_EXE_soldr");
+        assert!(
+            body.contains(soldr_bin),
+            "shim body for {tool} should reference soldr binary {soldr_bin}: {body}"
+        );
+    }
+}
+
+#[test]
+fn toolchain_link_emits_schema_v1_json_payload() {
+    let workspace = unique_temp_dir("toolchain-link-json");
+    let shim_dir = workspace.join("shims");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "toolchain",
+            "link",
+            "--shim-dir",
+            &shim_dir.display().to_string(),
+            "--json",
+        ])
+        .current_dir(&workspace)
+        .output()
+        .expect("failed to run soldr toolchain link --json");
+
+    assert!(
+        output.status.success(),
+        "soldr toolchain link --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("link --json stdout not JSON: {stdout}"));
+
+    assert_eq!(parsed["schema_version"], Value::from(1));
+    assert!(parsed["shim_dir"].is_string(), "shim_dir must be a string");
+    assert!(
+        parsed["elapsed_ms"].is_number(),
+        "elapsed_ms must be a number"
+    );
+
+    let tools = parsed["tools"].as_array().expect("tools must be an array");
+    assert_eq!(
+        tools.len(),
+        5,
+        "expected entries for the 5 routed tools, got: {tools:?}"
+    );
+
+    // Order is part of the contract — setup-soldr#133 consumers index
+    // by name but `cargo` should be first for human-readable output.
+    let names: Vec<&str> = tools
+        .iter()
+        .map(|t| t["name"].as_str().expect("name string"))
+        .collect();
+    assert_eq!(
+        names,
+        vec!["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"]
+    );
+
+    for entry in tools {
+        assert_eq!(entry["created"], Value::from(true));
+        assert!(
+            entry.get("skip_reason").is_none(),
+            "fresh entry must not carry skip_reason: {entry}"
+        );
+    }
+}
+
+#[test]
+fn toolchain_link_is_idempotent_when_rerun_with_same_soldr_binary() {
+    let workspace = unique_temp_dir("toolchain-link-idempotent");
+    let shim_dir = workspace.join("shims");
+
+    let first = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "toolchain",
+            "link",
+            "--shim-dir",
+            &shim_dir.display().to_string(),
+            "--json",
+        ])
+        .current_dir(&workspace)
+        .output()
+        .expect("first link");
+    assert!(first.status.success(), "first link must succeed");
+
+    // Capture mtimes after the first run so we can verify the second
+    // run does NOT touch the files.
+    let mtimes_before: Vec<SystemTime> = ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"]
+        .iter()
+        .map(|tool| {
+            let path = expected_shim_path(&shim_dir, tool);
+            fs::metadata(&path)
+                .expect("stat first run")
+                .modified()
+                .expect("mtime")
+        })
+        .collect();
+
+    // Tiny delay so a re-write would show up as a strictly newer mtime
+    // on filesystems with low-res mtimes.
+    std::thread::sleep(Duration::from_millis(50));
+
+    let second = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "toolchain",
+            "link",
+            "--shim-dir",
+            &shim_dir.display().to_string(),
+            "--json",
+        ])
+        .current_dir(&workspace)
+        .output()
+        .expect("second link");
+    assert!(second.status.success(), "second link must succeed");
+
+    let stdout = String::from_utf8_lossy(&second.stdout);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("second link --json stdout not JSON: {stdout}"));
+    let tools = parsed["tools"].as_array().expect("tools array");
+    for entry in tools {
+        assert_eq!(
+            entry["created"],
+            Value::from(false),
+            "second run must not re-create: {entry}"
+        );
+        assert_eq!(
+            entry["skip_reason"].as_str().unwrap_or(""),
+            "existing-matches",
+            "second run must report existing-matches: {entry}"
+        );
+    }
+
+    for (tool, before) in ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"]
+        .iter()
+        .zip(mtimes_before)
+    {
+        let path = expected_shim_path(&shim_dir, tool);
+        let after = fs::metadata(&path)
+            .expect("stat second run")
+            .modified()
+            .expect("mtime");
+        assert_eq!(
+            after,
+            before,
+            "shim file for {tool} was rewritten despite matching content: {}",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn toolchain_link_force_overwrites_user_modified_shim() {
+    let workspace = unique_temp_dir("toolchain-link-force");
+    let shim_dir = workspace.join("shims");
+    fs::create_dir_all(&shim_dir).expect("mkdir shim dir");
+
+    // Seed every shim with foreign content (e.g. a user-customized shim
+    // we are about to clobber).
+    for tool in ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"] {
+        let path = expected_shim_path(&shim_dir, tool);
+        fs::write(&path, "USER CUSTOM").expect("seed user shim");
+    }
+
+    // Without --force the run must NOT overwrite differing content.
+    let no_force = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "toolchain",
+            "link",
+            "--shim-dir",
+            &shim_dir.display().to_string(),
+            "--json",
+        ])
+        .current_dir(&workspace)
+        .output()
+        .expect("no-force link");
+    assert!(no_force.status.success());
+    for tool in ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"] {
+        let path = expected_shim_path(&shim_dir, tool);
+        let body = fs::read_to_string(&path).expect("read shim");
+        assert_eq!(
+            body, "USER CUSTOM",
+            "no-force link must leave user-customized {tool} alone (body={body:?})"
+        );
+    }
+
+    // With --force the run MUST overwrite.
+    let with_force = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "toolchain",
+            "link",
+            "--shim-dir",
+            &shim_dir.display().to_string(),
+            "--force",
+            "--json",
+        ])
+        .current_dir(&workspace)
+        .output()
+        .expect("force link");
+    assert!(with_force.status.success());
+
+    let stdout = String::from_utf8_lossy(&with_force.stdout);
+    let parsed: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("force link --json stdout not JSON: {stdout}"));
+    let tools = parsed["tools"].as_array().expect("tools array");
+    for entry in tools {
+        assert_eq!(
+            entry["created"],
+            Value::from(true),
+            "--force must overwrite differing shim: {entry}"
+        );
+    }
+    for tool in ["cargo", "rustfmt", "clippy-driver", "rustc", "rustdoc"] {
+        let path = expected_shim_path(&shim_dir, tool);
+        let body = fs::read_to_string(&path).expect("read shim");
+        assert_ne!(
+            body, "USER CUSTOM",
+            "--force must overwrite {tool} shim (still USER CUSTOM: {body:?})"
+        );
+        assert!(
+            body.contains(tool),
+            "rewritten shim body for {tool} should mention the tool name: {body}"
+        );
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -416,6 +416,7 @@ soldr toolchain install   # rustup toolchain install <channel> --profile minimal
 soldr toolchain prepare   # install + component add + target add + cargo install for [soldr.plugins]
 soldr toolchain ensure    # bootstrap rustup if missing, run `prepare`, smoke-verify (cargo/rustc --version)
 soldr toolchain ensure --json  # same, but emit a stable JSON payload (schema_version: 1)
+soldr toolchain link --shim-dir <path> [--json] [--force]  # write PATH shim files (issue #407 Phase 3)
 ```
 
 `prepare` runs, in order:
@@ -479,6 +480,61 @@ Notes on the schema:
 - `smoke_verify.ok` is `false` when either spawn fails or returns
   non-zero. The JSON payload is emitted in both success and failure
   cases; only the process exit code differs.
+
+#### `soldr toolchain link`
+
+Write PATH shim files into `--shim-dir` so a child process that
+resolves `cargo` / `rustfmt` / `clippy-driver` / `rustc` / `rustdoc`
+through PATH gets routed back through `soldr <tool>` (issue #407 Phase
+3, ports setup-soldr's `ensure-shims.ts`).
+
+Each shim is platform-aware:
+
+- **Unix**: a `#!/bin/sh` script that `exec`s `<soldr-path> <tool>
+  "$@"`. File mode `0o755`.
+- **Windows**: a `.cmd` script with CRLF line endings that calls
+  `"<soldr-path>" <tool> %*`.
+
+The absolute path to the running soldr binary (resolved via
+`std::env::current_exe()`) is baked into each shim at write time, so
+the shim does not depend on PATH to find soldr itself.
+
+Idempotency:
+
+- Existing shim file whose contents equal the expected body → left
+  alone, reported as `skip_reason: "existing-matches"`. Mtime is
+  preserved.
+- Existing shim file whose contents differ AND `--force` not passed →
+  left alone, reported as `skip_reason: "existing-differs"`. The
+  caller can detect this and decide whether to re-run with `--force`.
+- Existing shim file whose contents differ AND `--force` passed →
+  overwritten, reported as `created: true`.
+
+The `--json` payload (`schema_version: 1`):
+
+```json
+{
+  "schema_version": 1,
+  "shim_dir": "/runner/.setup-soldr/shims",
+  "tools": [
+    {"name": "cargo", "shim_path": "/runner/.setup-soldr/shims/cargo", "created": true},
+    {"name": "rustfmt", "shim_path": "/runner/.setup-soldr/shims/rustfmt", "created": false, "skip_reason": "existing-matches"},
+    {"name": "clippy-driver", "shim_path": "/runner/.setup-soldr/shims/clippy-driver", "created": true},
+    {"name": "rustc", "shim_path": "/runner/.setup-soldr/shims/rustc", "created": true},
+    {"name": "rustdoc", "shim_path": "/runner/.setup-soldr/shims/rustdoc", "created": true}
+  ],
+  "elapsed_ms": 12
+}
+```
+
+Notes on the schema:
+
+- `tools[].skip_reason` is omitted (not `null`) when `created: true`.
+- The `tools` array order is stable: `cargo`, `rustfmt`,
+  `clippy-driver`, `rustc`, `rustdoc`.
+- `link` never adds the shim directory to the caller's `PATH` — that
+  is the caller's responsibility (e.g. setup-soldr emits a GitHub
+  Actions `addPath` call after consuming the JSON).
 
 #### `[soldr.plugins]`
 


### PR DESCRIPTION
## Summary

Port of `setup-soldr/src/lib/ensure-shims.ts` + `install-passthrough.ts` into the soldr binary as `soldr toolchain link --shim-dir <path>`. Writes 5 shim files (cargo, rustfmt, clippy-driver, rustc, rustdoc) that re-exec `soldr <tool>`, so consumers can prepend a single dir to PATH and have every routed Rust toolchain command flow through soldr.

- Unix: shell-script shim with `exec "<soldr_path>" <tool> "$@"`
- Windows: `.cmd` shim with `"<soldr_path>" <tool> %*`
- Idempotent: existing-matches → skipped; existing-differs → skipped (or overwritten with `--force`)
- `--json` flag emits schema_version 1

## JSON schema (consumed by setup-soldr#133)

```json
{
  "schema_version": 1,
  "shim_dir": "/runner/.setup-soldr/shims",
  "tools": [
    {"name":"cargo","shim_path":"...","created":true},
    {"name":"rustfmt","shim_path":"...","created":false,"skip_reason":"existing-matches"}
  ],
  "elapsed_ms": 12
}
```

## TDD verified

Tests added first against the not-yet-existing module → confirmed RED → implemented → all GREEN. 6 unit tests in `toolchain_link.rs` cover shim-content shape (unix vs windows), existing-matches detection, existing-differs detection, --force overwrite. 4 integration tests in `crates/soldr-cli/tests/cli_toolchain.rs` cover the end-to-end `soldr toolchain link --shim-dir <tmp>` flow incl. JSON output and idempotent re-run.

## Pipeline status

- Wave 3.2 of zackees/soldr#514.
- Partially addresses #407 — Phase 3 of 4. Phase 4 (env-detection helpers port) is next, then setup-soldr#133 delegates TS modules to the three new soldr subcommands.

## Test plan

- [ ] CI green
- [ ] On merge, Phase 4 agent picks up and the issue closure path stays on track
