### PR TITLE
feat(toolchain): `soldr toolchain doctor --json` env-detection probes (#407 Phase 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Two categories, surfaced as first-class subcommands or via the generic fetch pat
 - `soldr toolchain prepare` chains install + `component add` + `target add` for every declared component / target, then `cargo install`s every entry under `[soldr.plugins]`.
 - `soldr toolchain ensure [--json]` (issue #407 Phase 2) auto-bootstraps rustup if missing, runs the same pipeline as `prepare`, then smoke-verifies the resolved toolchain with `cargo --version` / `rustc --version`. `--json` emits a stable `schema_version: 1` payload consumed by `setup-soldr#133`.
 - `soldr toolchain link --shim-dir <path> [--json] [--force]` (issue #407 Phase 3) writes PATH shim files for `cargo`, `rustfmt`, `clippy-driver`, `rustc`, and `rustdoc` that re-exec the running soldr binary. Idempotent (existing-matches → skip); `--force` overwrites differing content. JSON payload uses the same `schema_version: 1` shape as `ensure`.
+- `soldr toolchain doctor [--json]` (issue #407 Phase 4) runs env-detection probes (musl-cc availability, pre-populated `target/` warning) and emits either a human summary or the same `schema_version: 1` JSON shape as `ensure`/`link`. Namespaced under `toolchain` to avoid colliding with the top-level `soldr doctor` system check.
   - Manifest example:
     ```toml
     [toolchain]

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -474,6 +474,23 @@ pub(crate) enum ToolchainSubcommand {
         #[arg(long)]
         force: bool,
     },
+    /// Run env-detection probes (musl-cc availability, pre-populated
+    /// `target/` warning, host triple summary) and emit either a
+    /// human-readable summary or the stable `schema_version: 1` JSON
+    /// payload consumed by `setup-soldr#133` (issue #407 Phase 4,
+    /// ports the env-detection halves of setup-soldr's
+    /// `detect-musl-cc.ts`, `detect-shared-target-warning.ts`, and
+    /// `diagnostics.ts`).
+    ///
+    /// Namespaced under `toolchain` to avoid colliding with the
+    /// top-level `soldr doctor` system check.
+    Doctor {
+        /// Emit the stable machine-facing JSON form
+        /// (`schema_version: 1`) for consumption by setup-soldr and
+        /// other tooling.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(clap::Subcommand)]

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -33,6 +33,7 @@ mod self_relocate;
 mod shim_dir;
 mod startup_profile;
 mod toolchain;
+mod toolchain_doctor;
 mod toolchain_ensure;
 mod toolchain_link;
 mod trampoline;
@@ -288,6 +289,9 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                         force,
                     },
                 )?);
+            }
+            ToolchainSubcommand::Doctor { json } => {
+                std::process::exit(toolchain_doctor::run_toolchain_doctor(json)?);
             }
         },
         Commands::Bootstrap { json } => {

--- a/crates/soldr-cli/src/toolchain_doctor.rs
+++ b/crates/soldr-cli/src/toolchain_doctor.rs
@@ -1,0 +1,425 @@
+//! `soldr toolchain doctor [--json]` — env-detection probes that ship
+//! the diagnostic intel `setup-soldr` used to compute in TypeScript.
+//! Phase 4 of #407 (Wave 3.3 of zackees/soldr#514).
+//!
+//! Ports the env-detection halves of three setup-soldr modules:
+//!   * `detect-musl-cc.ts` — locate `musl-gcc` / `musl-clang` so
+//!     `*-unknown-linux-musl` cross-compiles don't silently link against
+//!     host glibc.
+//!   * `detect-shared-target-warning.ts` — flag a pre-populated cargo
+//!     `target/` directory that will collide with rust-plan restore.
+//!   * `diagnostics.ts` — env-detection helpers only (the GitHub
+//!     Actions dump stays in setup-soldr).
+//!
+//! Each probe is a pure function over its inputs; the wrapping
+//! [`run_toolchain_doctor`] orchestrates them and emits either a
+//! human-readable summary or the stable `schema_version: 1` JSON
+//! payload that setup-soldr#133 will consume.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use crate::core::SoldrError;
+
+const SCHEMA_VERSION: u32 = 1;
+
+/// Distinct from the top-level `soldr doctor` subcommand: this one is
+/// namespaced under `toolchain` and performs pure env-detection probes
+/// rather than the full system check.
+pub(crate) fn run_toolchain_doctor(json: bool) -> Result<i32, SoldrError> {
+    let started = Instant::now();
+    let host = HostInfo::detect();
+    let workspace = std::env::current_dir().map_err(SoldrError::from)?;
+
+    let probes = vec![
+        probe_musl_cc(&host),
+        probe_shared_target_warning(&workspace),
+    ];
+
+    let all_ok = probes.iter().all(|p| p.ok);
+    let output = DoctorOutput {
+        schema_version: SCHEMA_VERSION,
+        host: host.clone(),
+        probes,
+        elapsed_ms: started.elapsed().as_millis(),
+    };
+
+    if json {
+        emit_json(&output)?;
+    } else {
+        emit_human(&output);
+    }
+
+    Ok(if all_ok { 0 } else { 1 })
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct HostInfo {
+    pub os: String,
+    pub arch: String,
+    pub libc: String,
+}
+
+impl HostInfo {
+    pub(crate) fn detect() -> HostInfo {
+        HostInfo {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            libc: detect_libc(),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn detect_libc() -> String {
+    // We can't introspect glibc-vs-musl at compile-time without a build
+    // script; default to "gnu" for the standard linux-gnu host triple
+    // and leave the musl-cc probe to determine whether musl tooling is
+    // available.
+    "gnu".to_string()
+}
+
+#[cfg(target_os = "windows")]
+fn detect_libc() -> String {
+    // CLAUDE.md mandates MSVC on Windows; the GNU host is opt-in.
+    "msvc".to_string()
+}
+
+#[cfg(target_os = "macos")]
+fn detect_libc() -> String {
+    "darwin".to_string()
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+fn detect_libc() -> String {
+    "unknown".to_string()
+}
+
+#[derive(Serialize, Debug)]
+pub(crate) struct DoctorOutput {
+    pub schema_version: u32,
+    pub host: HostInfo,
+    pub probes: Vec<ProbeResult>,
+    pub elapsed_ms: u128,
+}
+
+#[derive(Serialize, Debug)]
+pub(crate) struct ProbeResult {
+    pub name: String,
+    pub ok: bool,
+    pub details: Value,
+}
+
+/// Probe name for `musl-gcc` / `musl-clang` detection (ports
+/// `detect-musl-cc.ts`'s env-detection half).
+pub(crate) const PROBE_MUSL_CC: &str = "musl-cc";
+/// Probe name for the pre-populated-target warning (ports
+/// `detect-shared-target-warning.ts`).
+pub(crate) const PROBE_SHARED_TARGET_WARNING: &str = "shared-target-warning";
+
+/// Detect availability of a musl C compiler on PATH. On non-Linux
+/// hosts the probe is skipped (ok=true, details=`{"skipped": "not-linux"}`)
+/// since musl cross-compilers are only meaningful for
+/// `*-unknown-linux-musl` targets.
+pub(crate) fn probe_musl_cc(host: &HostInfo) -> ProbeResult {
+    if host.os != "linux" {
+        return ProbeResult {
+            name: PROBE_MUSL_CC.to_string(),
+            ok: true,
+            details: json!({ "skipped": "not-linux" }),
+        };
+    }
+
+    let candidates = ["musl-gcc", "musl-clang"];
+    for cmd in candidates {
+        if let Some(found) = find_on_path(cmd) {
+            let version = read_version(&found).unwrap_or_default();
+            return ProbeResult {
+                name: PROBE_MUSL_CC.to_string(),
+                ok: true,
+                details: json!({
+                    "musl_cc": found.display().to_string(),
+                    "tool": cmd,
+                    "version": version,
+                }),
+            };
+        }
+    }
+
+    // No musl-cc found. Not all linux hosts need musl tooling, so we
+    // return ok=true with a `found: false` detail rather than failing
+    // the entire doctor run. setup-soldr's TS predecessor was similarly
+    // permissive — it only emitted a warning at most.
+    ProbeResult {
+        name: PROBE_MUSL_CC.to_string(),
+        ok: true,
+        details: json!({
+            "found": false,
+            "searched": candidates,
+        }),
+    }
+}
+
+/// Probe whether the current workspace already contains a pre-populated
+/// `target/` directory that would collide with `rust-plan restore`.
+/// Mirrors the `.fingerprint/`-based detector in `rust_plan.rs` (added
+/// in PR #508) and `detect-shared-target-warning.ts`.
+pub(crate) fn probe_shared_target_warning(workspace: &Path) -> ProbeResult {
+    let target_dir = workspace.join("target");
+    if !target_dir.is_dir() {
+        return ProbeResult {
+            name: PROBE_SHARED_TARGET_WARNING.to_string(),
+            ok: true,
+            details: json!({
+                "target_dir": target_dir.display().to_string(),
+                "fingerprint_dirs_found": 0,
+                "would_warn": false,
+                "reason": "no-target-dir",
+            }),
+        };
+    }
+
+    let fingerprint_dirs_found = crate::rust_plan::count_populated_fingerprint_dirs(&target_dir, 3);
+    let would_warn = fingerprint_dirs_found > 0;
+    // ok=true even when would_warn=true: the probe successfully made a
+    // diagnosis. The caller decides whether the warning is a blocker.
+    ProbeResult {
+        name: PROBE_SHARED_TARGET_WARNING.to_string(),
+        ok: true,
+        details: json!({
+            "target_dir": target_dir.display().to_string(),
+            "fingerprint_dirs_found": fingerprint_dirs_found,
+            "would_warn": would_warn,
+        }),
+    }
+}
+
+/// PATH lookup helper. Mirrors setup-soldr's `findOnPathSync`.
+fn find_on_path(cmd: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    let exts: &[&str] = if cfg!(windows) { &["", ".exe"] } else { &[""] };
+    for dir in std::env::split_paths(&path) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        for ext in exts {
+            let candidate: PathBuf = if ext.is_empty() {
+                dir.join(cmd)
+            } else {
+                dir.join(format!("{cmd}{ext}"))
+            };
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Run `<bin> --version` and capture the first line of stdout. Returns
+/// `None` when the spawn fails, the exit code is non-zero, or stdout is
+/// empty.
+fn read_version<P: AsRef<OsStr>>(bin: P) -> Option<String> {
+    let output = std::process::Command::new(bin.as_ref())
+        .arg("--version")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .map(str::trim)
+        .map(str::to_string)?;
+    if line.is_empty() {
+        None
+    } else {
+        Some(line)
+    }
+}
+
+fn emit_json(output: &DoctorOutput) -> Result<(), SoldrError> {
+    let payload = serde_json::to_string_pretty(output)
+        .map_err(|e| SoldrError::Other(format!("doctor: failed to serialize JSON: {e}")))?;
+    println!("{payload}");
+    Ok(())
+}
+
+fn emit_human(output: &DoctorOutput) {
+    println!(
+        "soldr toolchain doctor: host {os}/{arch}/{libc}",
+        os = output.host.os,
+        arch = output.host.arch,
+        libc = output.host.libc,
+    );
+    for probe in &output.probes {
+        let status = if probe.ok { "ok" } else { "FAIL" };
+        println!("  [{status}] {} {}", probe.name, probe.details);
+    }
+    println!("soldr toolchain doctor: {} ms", output.elapsed_ms);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn tempdir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("soldr-doctor-test-{label}-{nanos}"));
+        fs::create_dir_all(&dir).expect("create tempdir");
+        dir
+    }
+
+    crate::timed_test!(host_info_serializes_with_three_string_fields, {
+        let host = HostInfo {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            libc: "gnu".to_string(),
+        };
+        let json = serde_json::to_value(&host).expect("serialize");
+        assert_eq!(json["os"], Value::from("linux"));
+        assert_eq!(json["arch"], Value::from("x86_64"));
+        assert_eq!(json["libc"], Value::from("gnu"));
+    });
+
+    crate::timed_test!(host_info_detect_populates_all_fields, {
+        let host = HostInfo::detect();
+        assert!(!host.os.is_empty(), "os should not be empty: {host:?}");
+        assert!(!host.arch.is_empty(), "arch should not be empty: {host:?}");
+        assert!(!host.libc.is_empty(), "libc should not be empty: {host:?}");
+    });
+
+    crate::timed_test!(probe_musl_cc_is_skipped_on_non_linux, {
+        let host = HostInfo {
+            os: "macos".to_string(),
+            arch: "aarch64".to_string(),
+            libc: "darwin".to_string(),
+        };
+        let probe = probe_musl_cc(&host);
+        assert_eq!(probe.name, PROBE_MUSL_CC);
+        assert!(probe.ok, "non-linux probe should report ok=true");
+        assert_eq!(
+            probe.details["skipped"],
+            Value::from("not-linux"),
+            "non-linux probe should report skipped=not-linux: {}",
+            probe.details
+        );
+    });
+
+    crate::timed_test!(probe_musl_cc_on_linux_returns_search_metadata, {
+        // We can't guarantee musl is installed on the test host, so just
+        // assert that the linux path returns either a found-tool record
+        // (with `musl_cc` populated) or a not-found record (`found: false`).
+        let host = HostInfo {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            libc: "gnu".to_string(),
+        };
+        let probe = probe_musl_cc(&host);
+        assert_eq!(probe.name, PROBE_MUSL_CC);
+        assert!(probe.ok);
+        assert!(
+            probe.details.get("skipped").is_none(),
+            "linux probe must NOT be skipped: {}",
+            probe.details
+        );
+        let has_musl_cc = probe.details.get("musl_cc").is_some();
+        let has_found_false = probe.details.get("found").and_then(Value::as_bool) == Some(false);
+        assert!(
+            has_musl_cc || has_found_false,
+            "linux probe must report either a found musl-cc or found=false: {}",
+            probe.details
+        );
+    });
+
+    crate::timed_test!(probe_shared_target_warning_reports_no_target_dir, {
+        let dir = tempdir("no-target");
+        let probe = probe_shared_target_warning(&dir);
+        assert_eq!(probe.name, PROBE_SHARED_TARGET_WARNING);
+        assert!(probe.ok);
+        assert_eq!(probe.details["would_warn"], Value::from(false));
+        assert_eq!(probe.details["fingerprint_dirs_found"], Value::from(0));
+        assert_eq!(probe.details["reason"], Value::from("no-target-dir"));
+    });
+
+    crate::timed_test!(probe_shared_target_warning_clean_target_dir, {
+        let dir = tempdir("clean-target");
+        // Empty target/ dir — exists but has no `.fingerprint/`.
+        fs::create_dir_all(dir.join("target")).expect("mkdir target");
+        let probe = probe_shared_target_warning(&dir);
+        assert!(probe.ok);
+        assert_eq!(probe.details["would_warn"], Value::from(false));
+        assert_eq!(probe.details["fingerprint_dirs_found"], Value::from(0));
+    });
+
+    crate::timed_test!(
+        probe_shared_target_warning_detects_populated_fingerprint_dir,
+        {
+            let dir = tempdir("populated-target");
+            // Mirror cargo's layout: target/<profile>/.fingerprint/<crate>/...
+            let fingerprint = dir.join("target").join("debug").join(".fingerprint");
+            fs::create_dir_all(fingerprint.join("some-crate-abc123")).expect("mkdir fingerprint");
+            fs::write(
+                fingerprint
+                    .join("some-crate-abc123")
+                    .join("invoked.timestamp"),
+                "",
+            )
+            .expect("seed fingerprint entry");
+
+            let probe = probe_shared_target_warning(&dir);
+            assert!(probe.ok);
+            assert_eq!(probe.details["would_warn"], Value::from(true));
+            assert!(
+                probe.details["fingerprint_dirs_found"]
+                    .as_u64()
+                    .unwrap_or(0)
+                    >= 1,
+                "expected at least 1 fingerprint dir, got {}",
+                probe.details["fingerprint_dirs_found"]
+            );
+        }
+    );
+
+    crate::timed_test!(doctor_output_serializes_schema_version_one, {
+        let output = DoctorOutput {
+            schema_version: SCHEMA_VERSION,
+            host: HostInfo {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                libc: "gnu".to_string(),
+            },
+            probes: vec![
+                ProbeResult {
+                    name: PROBE_MUSL_CC.to_string(),
+                    ok: true,
+                    details: json!({"skipped": "not-linux"}),
+                },
+                ProbeResult {
+                    name: PROBE_SHARED_TARGET_WARNING.to_string(),
+                    ok: true,
+                    details: json!({"would_warn": false, "fingerprint_dirs_found": 0}),
+                },
+            ],
+            elapsed_ms: 7,
+        };
+        let json = serde_json::to_value(&output).expect("serialize");
+        assert_eq!(json["schema_version"], Value::from(1));
+        assert!(json["host"].is_object());
+        let probes = json["probes"].as_array().expect("probes array");
+        assert_eq!(probes.len(), 2);
+        assert_eq!(probes[0]["name"], Value::from(PROBE_MUSL_CC));
+        assert_eq!(probes[1]["name"], Value::from(PROBE_SHARED_TARGET_WARNING));
+        assert!(json["elapsed_ms"].is_number());
+    });
+}

--- a/crates/soldr-cli/tests/cli_toolchain_doctor.rs
+++ b/crates/soldr-cli/tests/cli_toolchain_doctor.rs
@@ -1,0 +1,153 @@
+//! Integration tests for `soldr toolchain doctor [--json]` (issue #407
+//! Phase 4). The subcommand exposes env-detection probes that
+//! setup-soldr#133 will consume to delegate its TS modules
+//! (`detect-musl-cc.ts`, `detect-shared-target-warning.ts`,
+//! env-detection helpers from `diagnostics.ts`) to the soldr binary.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use serde_json::Value;
+use soldr_cli::timed_test;
+use std::fs;
+use std::process::Command;
+use std::time::Duration;
+
+timed_test!(
+    toolchain_doctor_json_emits_schema_version_one_with_host_and_probes,
+    Duration::from_secs(120),
+    {
+        let workspace = unique_temp_dir("toolchain-doctor-json");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+            .args(["toolchain", "doctor", "--json"])
+            .current_dir(&workspace)
+            .output()
+            .expect("failed to run soldr toolchain doctor --json");
+
+        assert!(
+            output.status.success(),
+            "soldr toolchain doctor --json failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let parsed: Value = serde_json::from_str(&stdout)
+            .unwrap_or_else(|_| panic!("doctor --json stdout not JSON: {stdout}"));
+
+        // Schema header.
+        assert_eq!(parsed["schema_version"], Value::from(1));
+        // Host triple summary.
+        let host = parsed["host"].as_object().expect("host object");
+        assert!(host.contains_key("os"), "host.os missing: {host:?}");
+        assert!(host.contains_key("arch"), "host.arch missing: {host:?}");
+        assert!(host.contains_key("libc"), "host.libc missing: {host:?}");
+        assert!(host["os"].is_string());
+        assert!(host["arch"].is_string());
+        assert!(host["libc"].is_string());
+        // Probes array contains both expected probe names in stable order.
+        let probes = parsed["probes"].as_array().expect("probes array");
+        assert_eq!(probes.len(), 2, "expected 2 probes, got {}", probes.len());
+        assert_eq!(probes[0]["name"], Value::from("musl-cc"));
+        assert_eq!(probes[1]["name"], Value::from("shared-target-warning"));
+        // Each probe MUST carry an `ok` boolean and a `details` object.
+        for probe in probes {
+            assert!(probe["ok"].is_boolean(), "probe.ok must be bool: {probe}");
+            assert!(
+                probe["details"].is_object(),
+                "probe.details must be object: {probe}"
+            );
+        }
+        assert!(parsed["elapsed_ms"].is_number());
+    }
+);
+
+timed_test!(
+    toolchain_doctor_human_mode_prints_summary_lines,
+    Duration::from_secs(120),
+    {
+        let workspace = unique_temp_dir("toolchain-doctor-human");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+            .args(["toolchain", "doctor"])
+            .current_dir(&workspace)
+            .output()
+            .expect("failed to run soldr toolchain doctor");
+
+        assert!(
+            output.status.success(),
+            "soldr toolchain doctor (human) failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // Human output should mention each probe name and the doctor banner.
+        assert!(
+            stdout.contains("soldr toolchain doctor"),
+            "human output missing banner: {stdout}"
+        );
+        assert!(
+            stdout.contains("musl-cc"),
+            "human output missing musl-cc probe: {stdout}"
+        );
+        assert!(
+            stdout.contains("shared-target-warning"),
+            "human output missing shared-target-warning probe: {stdout}"
+        );
+    }
+);
+
+timed_test!(
+    toolchain_doctor_detects_populated_fingerprint_dir_in_workspace,
+    Duration::from_secs(120),
+    {
+        let workspace = unique_temp_dir("toolchain-doctor-populated");
+        // Seed a populated cargo `.fingerprint/` so the shared-target
+        // probe reports would_warn=true.
+        let fingerprint = workspace
+            .join("target")
+            .join("debug")
+            .join(".fingerprint")
+            .join("crate-abc");
+        fs::create_dir_all(&fingerprint).expect("mkdir fingerprint");
+        fs::write(fingerprint.join("invoked.timestamp"), "").expect("seed fingerprint");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+            .args(["toolchain", "doctor", "--json"])
+            .current_dir(&workspace)
+            .output()
+            .expect("failed to run soldr toolchain doctor --json");
+
+        assert!(
+            output.status.success(),
+            "soldr toolchain doctor --json failed (populated target)\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let parsed: Value = serde_json::from_str(&String::from_utf8_lossy(&output.stdout))
+            .expect("doctor --json stdout not JSON");
+        let shared = parsed["probes"]
+            .as_array()
+            .expect("probes array")
+            .iter()
+            .find(|p| p["name"] == "shared-target-warning")
+            .expect("missing shared-target-warning probe in JSON");
+        assert_eq!(
+            shared["details"]["would_warn"],
+            Value::from(true),
+            "shared-target probe should report would_warn=true when fingerprints exist: {shared}"
+        );
+        assert!(
+            shared["details"]["fingerprint_dirs_found"]
+                .as_u64()
+                .unwrap_or(0)
+                >= 1,
+            "fingerprint_dirs_found should be >=1: {shared}"
+        );
+    }
+);

--- a/docs/API.md
+++ b/docs/API.md
@@ -417,6 +417,7 @@ soldr toolchain prepare   # install + component add + target add + cargo install
 soldr toolchain ensure    # bootstrap rustup if missing, run `prepare`, smoke-verify (cargo/rustc --version)
 soldr toolchain ensure --json  # same, but emit a stable JSON payload (schema_version: 1)
 soldr toolchain link --shim-dir <path> [--json] [--force]  # write PATH shim files (issue #407 Phase 3)
+soldr toolchain doctor [--json]   # run env-detection probes (musl-cc, shared target/) (issue #407 Phase 4)
 ```
 
 `prepare` runs, in order:
@@ -535,6 +536,78 @@ Notes on the schema:
 - `link` never adds the shim directory to the caller's `PATH` — that
   is the caller's responsibility (e.g. setup-soldr emits a GitHub
   Actions `addPath` call after consuming the JSON).
+
+#### `soldr toolchain doctor`
+
+Run env-detection probes that ship the diagnostic intel `setup-soldr`
+used to compute in TypeScript (issue #407 Phase 4, ports the
+env-detection halves of setup-soldr's `detect-musl-cc.ts`,
+`detect-shared-target-warning.ts`, and `diagnostics.ts`).
+
+Namespaced under `toolchain` to avoid colliding with the top-level
+`soldr doctor` system check.
+
+Probes (run in stable order):
+
+1. **`musl-cc`** — scans `PATH` for `musl-gcc` / `musl-clang` and, if
+   found, captures the first line of `--version` output. Auto-skipped on
+   non-Linux hosts (`details.skipped = "not-linux"`). When the host is
+   Linux but no musl C compiler is on `PATH`, the probe still reports
+   `ok: true` with `details.found = false` — not all Linux workflows
+   need musl tooling, so missing it is informational rather than fatal.
+2. **`shared-target-warning`** — walks the current workspace's
+   `target/` (up to 3 levels deep) looking for a populated
+   cargo `.fingerprint/` directory. Mirrors the prepopulated-target
+   detector landed in PR #508. Reports `would_warn: true` when at least
+   one fingerprint dir is found, signalling that a subsequent
+   `soldr cargo build` may collide with the rust-plan restore path.
+
+Exit code: `0` when every probe reports `ok: true`, `1` otherwise.
+
+The `--json` payload (`schema_version: 1`) is the stable contract for
+`setup-soldr#133` and similar consumers:
+
+```json
+{
+  "schema_version": 1,
+  "host": {"os": "linux", "arch": "x86_64", "libc": "gnu"},
+  "probes": [
+    {
+      "name": "musl-cc",
+      "ok": true,
+      "details": {
+        "musl_cc": "/usr/bin/musl-gcc",
+        "tool": "musl-gcc",
+        "version": "musl-tools 1.2.5-1"
+      }
+    },
+    {
+      "name": "shared-target-warning",
+      "ok": true,
+      "details": {
+        "target_dir": "/workspace/target",
+        "fingerprint_dirs_found": 0,
+        "would_warn": false
+      }
+    }
+  ],
+  "elapsed_ms": 12
+}
+```
+
+Notes on the schema:
+
+- `host.os` is `std::env::consts::OS` (`linux` / `windows` / `macos`).
+- `host.arch` is `std::env::consts::ARCH` (`x86_64` / `aarch64` / …).
+- `host.libc` is `gnu` on Linux, `msvc` on Windows, `darwin` on macOS
+  (CLAUDE.md mandates MSVC-default on Windows).
+- The `probes` array preserves declaration order: `musl-cc` first,
+  `shared-target-warning` second. Future probes will be appended.
+- Each probe's `details` object is probe-specific. Consumers must
+  switch on `probe.name` before reading nested keys.
+- `probe.ok = false` is reserved for future probes; today both probes
+  always set `ok: true` because a missing musl-cc or a clean target/
+  is informational rather than blocking.
 
 #### `[soldr.plugins]`
 


### PR DESCRIPTION
Closes #407 — Phase 4 of 4 (final phase). Phases 2 (`ensure`) and 3 (`link`) shipped in #515 + #516. Wave 3.3 of zackees/soldr#514.

After this lands, setup-soldr#133 can delegate its TypeScript env-detection modules (`detect-musl-cc.ts`, `detect-shared-target-warning.ts`, and the env-detection helpers in `diagnostics.ts`) to the three new soldr subcommands (`ensure`, `link`, `doctor`) and close the cross-repo migration.

## What this adds

A new `soldr toolchain doctor [--json]` subcommand that runs env-detection probes and emits structured output. Namespaced under `toolchain` (alongside `install`, `prepare`, `ensure`, `link`) to avoid colliding with the existing top-level `soldr doctor` system check.

Two probes ship:

1. **`musl-cc`** — scans `PATH` for `musl-gcc` / `musl-clang` and captures the first line of `--version` output. Auto-skipped on non-Linux hosts (`details.skipped = "not-linux"`). Linux hosts without musl tooling report `ok: true, details.found = false` — informational rather than fatal.
2. **`shared-target-warning`** — walks the current workspace's `target/` (depth 3) for a populated cargo `.fingerprint/` directory. Reuses `rust_plan::count_populated_fingerprint_dirs` from PR #508. Reports `would_warn: true` when a fingerprint dir is found.

## JSON schema (`schema_version: 1`)

```json
{
  "schema_version": 1,
  "host": {"os": "linux", "arch": "x86_64", "libc": "gnu"},
  "probes": [
    {
      "name": "musl-cc",
      "ok": true,
      "details": {"musl_cc": "/usr/bin/musl-gcc", "tool": "musl-gcc", "version": "musl-tools 1.2.5-1"}
    },
    {
      "name": "shared-target-warning",
      "ok": true,
      "details": {
        "target_dir": "/workspace/target",
        "fingerprint_dirs_found": 0,
        "would_warn": false
      }
    }
  ],
  "elapsed_ms": 12
}
```

Exit code: `0` when every probe reports `ok: true`, `1` otherwise.

## TDD verification

11 new tests written first using `timed_test!` (all RED → all GREEN after implementation):

* **8 unit tests** in `src/toolchain_doctor.rs`:
  - `host_info_serializes_with_three_string_fields`
  - `host_info_detect_populates_all_fields`
  - `probe_musl_cc_is_skipped_on_non_linux`
  - `probe_musl_cc_on_linux_returns_search_metadata`
  - `probe_shared_target_warning_reports_no_target_dir`
  - `probe_shared_target_warning_clean_target_dir`
  - `probe_shared_target_warning_detects_populated_fingerprint_dir`
  - `doctor_output_serializes_schema_version_one`
* **3 integration tests** in `tests/cli_toolchain_doctor.rs`:
  - `toolchain_doctor_json_emits_schema_version_one_with_host_and_probes`
  - `toolchain_doctor_human_mode_prints_summary_lines`
  - `toolchain_doctor_detects_populated_fingerprint_dir_in_workspace`

All new tests use `crate::timed_test!` / `soldr_cli::timed_test!` — the lint at `tests/timed_test_lint.rs` passes the new files without an allowlist entry.

## Files touched

* `crates/soldr-cli/src/toolchain_doctor.rs` (new, 422 lines)
* `crates/soldr-cli/src/cli_args.rs` — adds `ToolchainSubcommand::Doctor { json: bool }` variant
* `crates/soldr-cli/src/main.rs` — registers module + dispatches subcommand
* `crates/soldr-cli/tests/cli_toolchain_doctor.rs` (new)
* `docs/API.md` — full `#### soldr toolchain doctor` section + bash usage line
* `CLAUDE.md` — one-line entry under the toolchain commands list

## Test plan

- [x] `soldr cargo build -p soldr-cli` — clean build
- [x] `soldr cargo test -p soldr-cli --bin soldr` — 580 unit tests pass (8 new)
- [x] `soldr cargo test -p soldr-cli --lib` — 215 lib tests pass
- [x] `soldr cargo test -p soldr-cli --test cli_toolchain_doctor` — 3/3 pass
- [x] `soldr cargo test -p soldr-cli --test cli_toolchain` — 20/20 pass (existing toolchain coverage unchanged)
- [x] `soldr cargo test -p soldr-cli --test cli_doctor` — 5/5 pass (top-level `soldr doctor` unaffected)
- [x] `soldr cargo test -p soldr-cli --test cli_dispatch` — 3/3 pass (clap parser intact)
- [x] `soldr cargo test -p soldr-cli --test timed_test_lint` — pass (new files use `timed_test!`)
- [x] `soldr cargo test -p soldr-cli --test monocrate_guard` — pass
- [x] `rustfmt --check` on the four touched / new Rust source files — clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings -A clippy::enum_variant_names` — clean (the `enum_variant_names` allow filter only suppresses two pre-existing warnings outside this PR)
- [x] End-to-end smoke: `soldr toolchain doctor --json` emits valid JSON; human mode prints the expected summary lines; `--help` documents the subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)