### PR TITLE
chore(release): soldr 0.7.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.34"
+version = "0.7.35"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.34"
+version = "0.7.35"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.34",
+  "version": "0.7.35",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

soldr 0.7.35 — final piece of the [zackees/soldr#514](https://github.com/zackees/soldr/issues/514) Wave 3 march. Ships the three new `toolchain` subcommands that setup-soldr#133's delegation layer needs, plus the per-test watchdog infrastructure.

## What's in 0.7.35

- **`feat(toolchain): \`soldr toolchain ensure --json\`** (#515 / Phase 2 of #407) — rustup-auto-bootstrap + install + smoke-verify with stable `schema_version: 1` JSON output.
- **`feat(toolchain): \`soldr toolchain link --shim-dir <path>\`** (#516 / Phase 3 of #407) — writes platform-aware PATH shim files (cargo/rustfmt/clippy-driver/rustc/rustdoc) that re-exec the running soldr binary. Idempotent; `--force` overwrites differing content; `--json` output.
- **`feat(toolchain): \`soldr toolchain doctor [--json]\`** (#518 / Phase 4 of #407) — env-detection probes (musl-cc availability, pre-populated `target/` warning) namespaced under `toolchain` to avoid colliding with the top-level `soldr doctor`.
- **`test(infra): per-test watchdog`** (#517) — `timed_test!` macro with 2-min default deadline + stack dump + process abort on hang. Includes a build-failing lint that catches new bare `#[test]` declarations.

## Test plan

- [ ] CI green on this PR
- [ ] On merge, `Autonomous Release` publishes `v0.7.35` to GitHub Releases, PyPI (`soldr`), npm (`@zackees/soldr`)
- [ ] setup-soldr#133 (Wave 3.4) bumps default to 0.7.35 and delegates its TS toolchain modules to the new subcommands

Closes the soldr-side of [#407](https://github.com/zackees/soldr/issues/407). [setup-soldr#133](https://github.com/zackees/setup-soldr/issues/133) (the paired consumer-side migration) is the next and final step before [zackees/soldr#514](https://github.com/zackees/soldr/issues/514) can close.
