### PR TITLE
chore(release): soldr 0.7.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.35"
+version = "0.7.36"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.35"
+version = "0.7.36"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.35",
+  "version": "0.7.36",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Internal-cleanup release on top of 0.7.35. No user-visible behavior changes.

## What's in 0.7.36

- **`refactor(soldr-cli)` (#520)** — split five files >1k LOC into sub-modules (gc.rs, rust_plan, trampoline, toolchain). Net diff: 34 files, +10106/-9694 — pure reorganization, no logic changes. Verified by the `tests/timed_test_lint.rs` lint accepting the new module paths.

## zccache pin

Stays at **1.11.0** — the latest published release on [zackees/zccache](https://github.com/zackees/zccache/releases/tag/1.11.0) as of 2026-05-26. No bump appropriate (already at the latest).

## Test plan

- [ ] CI green on this PR
- [ ] On merge, `Autonomous Release` publishes `v0.7.36` to GitHub Releases, PyPI (`soldr`), npm (`@zackees/soldr`)
