### PR TITLE
Finish typed GC taxonomy slices

### DIFF
--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -512,21 +512,103 @@ pub(crate) enum GcSubcommand {
         #[arg(long)]
         json: bool,
         /// Narrow the purge to a single taxonomy kind. Mutually exclusive
-        /// with `--registry-src` / `--git-checkouts`. Accepted values:
-        /// `cargo_target`, `cargo_registry_src` (#323 slice 2),
-        /// `cargo_git_checkouts` (#323 slice 3).
-        #[arg(long, value_enum, conflicts_with_all = ["registry_src", "git_checkouts"])]
+        /// with shorthand flags. Report-only primary kinds are accepted
+        /// for parse consistency but rejected before deletion.
+        #[arg(
+            long,
+            value_enum,
+            conflicts_with_all = [
+                "registry_src",
+                "git_checkouts",
+                "target_incremental",
+                "build_scripts",
+                "doc",
+                "subcommand_caches",
+            ]
+        )]
         kind: Option<GcListKind>,
         /// Shorthand for `--kind cargo_registry_src`. Walks
         /// `$CARGO_HOME/registry/src/<reg>/<crate>-<vers>/` and deletes
         /// the listed directories (#323 slice 2).
-        #[arg(long, conflicts_with_all = ["kind", "git_checkouts"])]
+        #[arg(
+            long,
+            conflicts_with_all = [
+                "kind",
+                "git_checkouts",
+                "target_incremental",
+                "build_scripts",
+                "doc",
+                "subcommand_caches",
+            ]
+        )]
         registry_src: bool,
         /// Shorthand for `--kind cargo_git_checkouts`. Walks
         /// `$CARGO_HOME/git/checkouts/<repo>/<commit>/` and deletes
         /// the listed directories (#323 slice 3).
-        #[arg(long, conflicts_with_all = ["kind", "registry_src"])]
+        #[arg(
+            long,
+            conflicts_with_all = [
+                "kind",
+                "registry_src",
+                "target_incremental",
+                "build_scripts",
+                "doc",
+                "subcommand_caches",
+            ]
+        )]
         git_checkouts: bool,
+        /// Shorthand for `--kind cargo_target_incremental`.
+        #[arg(
+            long,
+            conflicts_with_all = [
+                "kind",
+                "registry_src",
+                "git_checkouts",
+                "build_scripts",
+                "doc",
+                "subcommand_caches",
+            ]
+        )]
+        target_incremental: bool,
+        /// Shorthand for `--kind cargo_target_build_script_binaries`.
+        #[arg(
+            long,
+            conflicts_with_all = [
+                "kind",
+                "registry_src",
+                "git_checkouts",
+                "target_incremental",
+                "doc",
+                "subcommand_caches",
+            ]
+        )]
+        build_scripts: bool,
+        /// Shorthand for `--kind cargo_target_doc`.
+        #[arg(
+            long,
+            conflicts_with_all = [
+                "kind",
+                "registry_src",
+                "git_checkouts",
+                "target_incremental",
+                "build_scripts",
+                "subcommand_caches",
+            ]
+        )]
+        doc: bool,
+        /// Shorthand for `--kind cargo_target_subcommand_caches`.
+        #[arg(
+            long,
+            conflicts_with_all = [
+                "kind",
+                "registry_src",
+                "git_checkouts",
+                "target_incremental",
+                "build_scripts",
+                "doc",
+            ]
+        )]
+        subcommand_caches: bool,
     },
     /// List every `target/` directory currently tracked in the soldr
     /// registry, without applying any age or size thresholds.
@@ -534,8 +616,7 @@ pub(crate) enum GcSubcommand {
         /// Emit the stable machine-facing JSON form for this command.
         #[arg(long)]
         json: bool,
-        /// Narrow the listing to a single taxonomy kind (#323 slice 2).
-        /// Accepted values: `cargo_target`, `cargo_registry_src`.
+        /// Narrow the listing to a single taxonomy kind.
         #[arg(long, value_enum)]
         kind: Option<GcListKind>,
     },
@@ -563,14 +644,38 @@ pub(crate) enum GcListKind {
     /// Workspace `target/` dirs tracked by the soldr registry.
     #[value(name = "cargo_target")]
     CargoTarget,
+    /// `target/<profile>/incremental/` directories under tracked targets.
+    #[value(name = "cargo_target_incremental")]
+    CargoTargetIncremental,
+    /// `target/<profile>/build/*/build-script-build*` binaries.
+    #[value(name = "cargo_target_build_script_binaries")]
+    CargoTargetBuildScriptBinaries,
+    /// `target/doc/` directories under tracked targets.
+    #[value(name = "cargo_target_doc")]
+    CargoTargetDoc,
+    /// Tool-owned cache directories under tracked targets.
+    #[value(name = "cargo_target_subcommand_caches")]
+    CargoTargetSubcommandCaches,
     /// `$CARGO_HOME/registry/src/<reg>/<crate>-<vers>/` extracted
     /// crate sources.
     #[value(name = "cargo_registry_src")]
     CargoRegistrySrc,
+    /// `$CARGO_HOME/registry/cache/<reg>/*.crate` package archives.
+    #[value(name = "cargo_registry_cache")]
+    CargoRegistryCache,
     /// `$CARGO_HOME/git/checkouts/<repo>/<commit>/` git-source crate
     /// checkouts (#323 slice 3).
     #[value(name = "cargo_git_checkouts")]
     CargoGitCheckouts,
+    /// `$CARGO_HOME/git/db/<repo>/` primary bare git clones.
+    #[value(name = "cargo_git_db")]
+    CargoGitDb,
+    /// `$CARGO_HOME/bin/<bin>` binaries installed by cargo.
+    #[value(name = "cargo_installed_binaries")]
+    CargoInstalledBinaries,
+    /// `$RUSTUP_HOME/toolchains/<channel>` installed Rust toolchains.
+    #[value(name = "rustup_toolchain")]
+    RustupToolchain,
 }
 
 #[derive(clap::Args)]

--- a/crates/soldr-cli/src/gc/mod.rs
+++ b/crates/soldr-cli/src/gc/mod.rs
@@ -27,8 +27,13 @@ mod walks;
 // Re-export the public CLI surface so `crate::gc::*` keeps matching
 // the call sites in `main.rs` and `cargo_front_door.rs`.
 pub(crate) use auto::maybe_kick_auto_gc;
-pub(crate) use cargo_native::{run_gc_cargo_command, run_gc_locations_command, run_gc_sweep_command};
-pub(crate) use purge::{run_gc_purge_git_checkouts_command, run_gc_purge_registry_src_command};
+pub(crate) use cargo_native::{
+    run_gc_cargo_command, run_gc_locations_command, run_gc_sweep_command,
+};
+pub(crate) use purge::{
+    run_gc_purge_git_checkouts_command, run_gc_purge_registry_src_command,
+    run_gc_purge_target_subtree_command,
+};
 
 // Items the tests file reaches through `super::*`. Keeping these
 // `use`d inside `mod.rs` makes the visibility explicit and survives
@@ -53,15 +58,25 @@ use purge::{
 // emit entries with other kinds (registry-src, git-checkouts, in-target
 // subtrees, …) without further schema churn.
 pub(super) const KIND_CARGO_TARGET: &str = "cargo_target";
+pub(super) const KIND_CARGO_TARGET_INCREMENTAL: &str = "cargo_target_incremental";
+pub(super) const KIND_CARGO_TARGET_BUILD_SCRIPT_BINARIES: &str =
+    "cargo_target_build_script_binaries";
+pub(super) const KIND_CARGO_TARGET_DOC: &str = "cargo_target_doc";
+pub(super) const KIND_CARGO_TARGET_SUBCOMMAND_CACHES: &str = "cargo_target_subcommand_caches";
 // Slice 2 of #323: `$CARGO_HOME/registry/src/<reg>/<crate>-<vers>/` extracted
 // crate sources. `purge_safety: derived` — cargo regenerates from the
 // matching `.crate` tarball in `registry/cache/` on demand.
 pub(super) const KIND_CARGO_REGISTRY_SRC: &str = "cargo_registry_src";
+pub(super) const KIND_CARGO_REGISTRY_CACHE: &str = "cargo_registry_cache";
 // Slice 3 of #323: `$CARGO_HOME/git/checkouts/<repo>/<commit>/` git-source
 // crate checkouts. `purge_safety: derived` — cargo regenerates by re-checking
 // out the bare repo in `$CARGO_HOME/git/db/<repo>/` on demand.
 pub(super) const KIND_CARGO_GIT_CHECKOUTS: &str = "cargo_git_checkouts";
+pub(super) const KIND_CARGO_GIT_DB: &str = "cargo_git_db";
+pub(super) const KIND_CARGO_INSTALLED_BINARIES: &str = "cargo_installed_binaries";
+pub(super) const KIND_RUSTUP_TOOLCHAIN: &str = "rustup_toolchain";
 pub(super) const PURGE_SAFETY_DERIVED: &str = "derived";
+pub(super) const PURGE_SAFETY_PRIMARY: &str = "primary";
 
 /// Taxonomy kinds accepted by `gc list --kind` / `gc purge --kind`
 /// (#323 slice 2). The CLI's clap `ValueEnum` converts into this so the
@@ -69,17 +84,67 @@ pub(super) const PURGE_SAFETY_DERIVED: &str = "derived";
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum GcListKindFilter {
     CargoTarget,
+    CargoTargetIncremental,
+    CargoTargetBuildScriptBinaries,
+    CargoTargetDoc,
+    CargoTargetSubcommandCaches,
     CargoRegistrySrc,
+    CargoRegistryCache,
     CargoGitCheckouts,
+    CargoGitDb,
+    CargoInstalledBinaries,
+    RustupToolchain,
 }
 
 impl From<crate::GcListKind> for GcListKindFilter {
     fn from(value: crate::GcListKind) -> Self {
         match value {
             crate::GcListKind::CargoTarget => GcListKindFilter::CargoTarget,
+            crate::GcListKind::CargoTargetIncremental => GcListKindFilter::CargoTargetIncremental,
+            crate::GcListKind::CargoTargetBuildScriptBinaries => {
+                GcListKindFilter::CargoTargetBuildScriptBinaries
+            }
+            crate::GcListKind::CargoTargetDoc => GcListKindFilter::CargoTargetDoc,
+            crate::GcListKind::CargoTargetSubcommandCaches => {
+                GcListKindFilter::CargoTargetSubcommandCaches
+            }
             crate::GcListKind::CargoRegistrySrc => GcListKindFilter::CargoRegistrySrc,
+            crate::GcListKind::CargoRegistryCache => GcListKindFilter::CargoRegistryCache,
             crate::GcListKind::CargoGitCheckouts => GcListKindFilter::CargoGitCheckouts,
+            crate::GcListKind::CargoGitDb => GcListKindFilter::CargoGitDb,
+            crate::GcListKind::CargoInstalledBinaries => GcListKindFilter::CargoInstalledBinaries,
+            crate::GcListKind::RustupToolchain => GcListKindFilter::RustupToolchain,
         }
+    }
+}
+
+impl GcListKindFilter {
+    pub(crate) fn kind_name(self) -> &'static str {
+        match self {
+            GcListKindFilter::CargoTarget => KIND_CARGO_TARGET,
+            GcListKindFilter::CargoTargetIncremental => KIND_CARGO_TARGET_INCREMENTAL,
+            GcListKindFilter::CargoTargetBuildScriptBinaries => {
+                KIND_CARGO_TARGET_BUILD_SCRIPT_BINARIES
+            }
+            GcListKindFilter::CargoTargetDoc => KIND_CARGO_TARGET_DOC,
+            GcListKindFilter::CargoTargetSubcommandCaches => KIND_CARGO_TARGET_SUBCOMMAND_CACHES,
+            GcListKindFilter::CargoRegistrySrc => KIND_CARGO_REGISTRY_SRC,
+            GcListKindFilter::CargoRegistryCache => KIND_CARGO_REGISTRY_CACHE,
+            GcListKindFilter::CargoGitCheckouts => KIND_CARGO_GIT_CHECKOUTS,
+            GcListKindFilter::CargoGitDb => KIND_CARGO_GIT_DB,
+            GcListKindFilter::CargoInstalledBinaries => KIND_CARGO_INSTALLED_BINARIES,
+            GcListKindFilter::RustupToolchain => KIND_RUSTUP_TOOLCHAIN,
+        }
+    }
+
+    pub(crate) fn is_target_subtree(self) -> bool {
+        matches!(
+            self,
+            GcListKindFilter::CargoTargetIncremental
+                | GcListKindFilter::CargoTargetBuildScriptBinaries
+                | GcListKindFilter::CargoTargetDoc
+                | GcListKindFilter::CargoTargetSubcommandCaches
+        )
     }
 }
 
@@ -268,6 +333,18 @@ pub(super) struct GcListEntryOutput {
     /// on `cargo_target` entries that lack the concept (#323 slice 2).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) owner_crate: Option<String>,
+    /// Workspace owning a target-derived entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) owner_workspace: Option<String>,
+    /// Repository-ish owner for Cargo git database entries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) owner_repo: Option<String>,
+    /// Binary name for Cargo-installed executable entries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) owner_binary: Option<String>,
+    /// Toolchain name for rustup toolchain entries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) owner_toolchain: Option<String>,
     /// Provenance of `last_used_unix` (#349). Present on
     /// `cargo_registry_src` entries; omitted for `cargo_target` where
     /// only mtime is available today. Values:
@@ -329,6 +406,7 @@ pub(crate) fn run_gc_list_command(
 
     let mut entries: Vec<GcListEntryOutput> = if include_targets {
         live_rows
+            .clone()
             .into_par_iter()
             .map(|row| {
                 let (size_bytes, file_count) = fast_directory_size_and_files(&row.path);
@@ -344,6 +422,14 @@ pub(crate) fn run_gc_list_command(
                     kind: KIND_CARGO_TARGET,
                     purge_safety: PURGE_SAFETY_DERIVED,
                     owner_crate: None,
+                    owner_workspace: Some(
+                        crate::cache_lib::target_registry::workspace_root_for_target(&row.path)
+                            .display()
+                            .to_string(),
+                    ),
+                    owner_repo: None,
+                    owner_binary: None,
+                    owner_toolchain: None,
                     last_used_source: None,
                 }
             })
@@ -362,6 +448,24 @@ pub(crate) fn run_gc_list_command(
         if let Some(cargo_home) = crate::core::resolve_cargo_home() {
             entries.extend(walks::walk_cargo_git_checkouts(&cargo_home, now));
         }
+    }
+
+    entries.extend(walks::walk_cargo_target_subtrees(
+        &live_rows,
+        now,
+        kind_filter,
+    ));
+
+    if let Some(cargo_home) = crate::core::resolve_cargo_home() {
+        entries.extend(walks::walk_cargo_report_only(&cargo_home, now, kind_filter));
+    }
+
+    if let Some(rustup_home) = crate::core::resolve_rustup_home() {
+        entries.extend(walks::walk_rustup_toolchains(
+            &rustup_home,
+            now,
+            kind_filter,
+        ));
     }
 
     let pruned_missing = registry

--- a/crates/soldr-cli/src/gc/purge.rs
+++ b/crates/soldr-cli/src/gc/purge.rs
@@ -14,10 +14,10 @@ use std::io::Write;
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 
-use super::walks::{walk_cargo_git_checkouts, walk_cargo_registry_src};
+use super::walks::{walk_cargo_git_checkouts, walk_cargo_registry_src, walk_cargo_target_subtrees};
 use super::{
-    GcCandidateOutput, GcListEntryOutput, GC_JSON_SCHEMA_VERSION, KIND_CARGO_GIT_CHECKOUTS,
-    KIND_CARGO_REGISTRY_SRC, KIND_CARGO_TARGET, PURGE_SAFETY_DERIVED,
+    GcCandidateOutput, GcListEntryOutput, GcListKindFilter, GC_JSON_SCHEMA_VERSION,
+    KIND_CARGO_GIT_CHECKOUTS, KIND_CARGO_REGISTRY_SRC, KIND_CARGO_TARGET, PURGE_SAFETY_DERIVED,
 };
 
 #[derive(Serialize)]
@@ -237,6 +237,153 @@ pub(crate) fn run_gc_purge_git_checkouts_command(
             selected_count: selected.len(),
             succeeded_count: deleted_paths.len(),
             failed_count: failures.len(),
+            reclaimed_bytes,
+            reclaimed_human: crate::cache_lib::target_registry::human_size(reclaimed_bytes),
+            deleted_paths,
+            failures,
+        };
+        print_json(&output)?;
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct GcPurgeTargetSubtreeOutput {
+    schema_version: u32,
+    command: &'static str,
+    mode: &'static str,
+    kind: &'static str,
+    selected_count: usize,
+    succeeded_count: usize,
+    failed_count: usize,
+    skipped_locked_targets: usize,
+    reclaimed_bytes: u64,
+    reclaimed_human: String,
+    deleted_paths: Vec<String>,
+    failures: Vec<GcPurgeTargetSubtreeFailure>,
+}
+
+#[derive(Serialize)]
+struct GcPurgeTargetSubtreeFailure {
+    path: String,
+    error: String,
+}
+
+/// `soldr gc purge --target-incremental|--build-scripts|--doc|--subcommand-caches`.
+/// Walks target subtree entries from the tracked target registry and deletes
+/// only the selected derived kind. If any Cargo build lock is present under a
+/// target, that whole target is skipped as an active-build guard.
+pub(crate) fn run_gc_purge_target_subtree_command(
+    kind: GcListKindFilter,
+    purge_all: bool,
+    json: bool,
+) -> Result<(), SoldrError> {
+    if !kind.is_target_subtree() {
+        return Err(SoldrError::Other(format!(
+            "gc purge --kind {} is not an in-target subtree kind",
+            kind.kind_name()
+        )));
+    }
+
+    let paths = SoldrPaths::new()?;
+    let db_path = crate::cache_lib::data_db_path(&paths);
+    let registry = crate::cache_lib::target_registry::TargetRegistry::open(&db_path)
+        .map_err(|e| SoldrError::Other(format!("failed to open soldr registry: {e}")))?;
+    let rows = registry
+        .list()
+        .map_err(|e| SoldrError::Other(format!("gc purge {} failed: {e}", kind.kind_name())))?;
+    let now = crate::cache_lib::target_registry::current_unix_seconds().map_err(|e| {
+        SoldrError::Other(format!("gc purge {} clock error: {e}", kind.kind_name()))
+    })?;
+
+    let mut live_rows = Vec::new();
+    let mut skipped_locked_targets = 0usize;
+    for row in rows {
+        if !row.path.exists() {
+            continue;
+        }
+        if find_active_cargo_lock(&row.path).is_some() {
+            skipped_locked_targets += 1;
+            continue;
+        }
+        live_rows.push(row);
+    }
+
+    let entries = walk_cargo_target_subtrees(&live_rows, now, Some(kind));
+
+    if !json {
+        eprintln!(
+            "soldr gc purge --kind {}: scanned {} tracked target dir{} ({} locked target{} skipped)",
+            kind.kind_name(),
+            live_rows.len(),
+            if live_rows.len() == 1 { "" } else { "s" },
+            skipped_locked_targets,
+            if skipped_locked_targets == 1 { "" } else { "s" },
+        );
+        eprintln!(
+            "soldr gc purge --kind {}: {} entr{} on disk",
+            kind.kind_name(),
+            entries.len(),
+            if entries.len() == 1 { "y" } else { "ies" }
+        );
+    }
+
+    let mut selected: Vec<&GcListEntryOutput> = Vec::new();
+    for entry in &entries {
+        let should_delete = purge_all
+            || prompt_yes_no_default_yes(&format!(
+                "soldr gc: delete {} ({}, age {}) ? [Y/n] ",
+                entry.path, entry.size_human, entry.age_human,
+            ));
+        if should_delete {
+            selected.push(entry);
+        }
+    }
+
+    let mut deleted_paths: Vec<String> = Vec::new();
+    let mut failures: Vec<GcPurgeTargetSubtreeFailure> = Vec::new();
+    let mut reclaimed_bytes: u64 = 0;
+    for entry in &selected {
+        let path = std::path::PathBuf::from(&entry.path);
+        match delete_path(&path) {
+            Ok(()) => {
+                reclaimed_bytes = reclaimed_bytes.saturating_add(entry.size_bytes);
+                deleted_paths.push(entry.path.clone());
+            }
+            Err(e) => failures.push(GcPurgeTargetSubtreeFailure {
+                path: entry.path.clone(),
+                error: e.to_string(),
+            }),
+        }
+    }
+
+    if !json {
+        eprintln!(
+            "soldr gc purge --kind {}: selected {}; succeeded {}; failed {}; reclaimed {}",
+            kind.kind_name(),
+            selected.len(),
+            deleted_paths.len(),
+            failures.len(),
+            crate::cache_lib::target_registry::human_size(reclaimed_bytes),
+        );
+        for failure in &failures {
+            eprintln!(
+                "soldr gc purge --kind {}: failed to delete {}: {}",
+                kind.kind_name(),
+                failure.path,
+                failure.error
+            );
+        }
+    } else {
+        let output = GcPurgeTargetSubtreeOutput {
+            schema_version: GC_JSON_SCHEMA_VERSION,
+            command: "gc",
+            mode: "purge",
+            kind: kind.kind_name(),
+            selected_count: selected.len(),
+            succeeded_count: deleted_paths.len(),
+            failed_count: failures.len(),
+            skipped_locked_targets,
             reclaimed_bytes,
             reclaimed_human: crate::cache_lib::target_registry::human_size(reclaimed_bytes),
             deleted_paths,
@@ -489,6 +636,37 @@ pub(super) fn prompt_yes_no_default_yes(prompt: &str) -> bool {
 
 pub(crate) fn parse_gc_purge_answer(input: &str) -> bool {
     matches!(input.trim().to_ascii_lowercase().as_str(), "" | "y" | "yes")
+}
+
+fn find_active_cargo_lock(target_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let top_lock = target_dir.join(".cargo-lock");
+    if top_lock.exists() {
+        return Some(top_lock);
+    }
+    let profiles = std::fs::read_dir(target_dir).ok()?;
+    for entry in profiles.flatten() {
+        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let candidate = entry.path().join(".cargo-lock");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn delete_path(path: &std::path::Path) -> Result<(), std::io::Error> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    if metadata.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
 }
 
 /// Resolve the configured `gc.allowlist_roots`, falling back to

--- a/crates/soldr-cli/src/gc/walks.rs
+++ b/crates/soldr-cli/src/gc/walks.rs
@@ -7,8 +7,30 @@
 //! parallel directory sizer that several gc surfaces share.
 
 use super::{
-    GcListEntryOutput, KIND_CARGO_GIT_CHECKOUTS, KIND_CARGO_REGISTRY_SRC, PURGE_SAFETY_DERIVED,
+    GcListEntryOutput, GcListKindFilter, KIND_CARGO_GIT_CHECKOUTS, KIND_CARGO_GIT_DB,
+    KIND_CARGO_INSTALLED_BINARIES, KIND_CARGO_REGISTRY_CACHE, KIND_CARGO_REGISTRY_SRC,
+    KIND_CARGO_TARGET_BUILD_SCRIPT_BINARIES, KIND_CARGO_TARGET_DOC, KIND_CARGO_TARGET_INCREMENTAL,
+    KIND_CARGO_TARGET_SUBCOMMAND_CACHES, KIND_RUSTUP_TOOLCHAIN, PURGE_SAFETY_DERIVED,
+    PURGE_SAFETY_PRIMARY,
 };
+
+const SUBCOMMAND_CACHE_DIRS: &[&str] = &[
+    "criterion",
+    "llvm-cov",
+    "coverage",
+    "nextest",
+    "tarpaulin",
+    "wasm-bindgen",
+];
+
+#[derive(Default)]
+struct EntryOwners {
+    owner_workspace: Option<String>,
+    owner_crate: Option<String>,
+    owner_repo: Option<String>,
+    owner_binary: Option<String>,
+    owner_toolchain: Option<String>,
+}
 
 /// Provenance tag for `last_used_unix` (#349).
 pub(super) const LAST_USED_FROM_GLOBAL_CACHE: &str = "global_cache";
@@ -149,6 +171,10 @@ pub(super) fn walk_cargo_registry_src(
                 kind: KIND_CARGO_REGISTRY_SRC,
                 purge_safety: PURGE_SAFETY_DERIVED,
                 owner_crate,
+                owner_workspace: None,
+                owner_repo: None,
+                owner_binary: None,
+                owner_toolchain: None,
                 last_used_source: Some(last_used_source),
             });
         }
@@ -306,9 +332,358 @@ pub(super) fn walk_cargo_git_checkouts(
                 kind: KIND_CARGO_GIT_CHECKOUTS,
                 purge_safety: PURGE_SAFETY_DERIVED,
                 owner_crate: Some(format!("{repo_dir_name}@{commit_dir_name}")),
+                owner_workspace: None,
+                owner_repo: Some(repo_dir_name.clone()),
+                owner_binary: None,
+                owner_toolchain: None,
                 last_used_source: Some(LAST_USED_FROM_FS_MTIME),
             });
         }
     }
     out
+}
+
+// ---------------------------------------------------------------------------
+// Tracked target subtree walkers (#323 slice 4).
+// ---------------------------------------------------------------------------
+
+pub(super) fn walk_cargo_target_subtrees(
+    rows: &[crate::cache_lib::target_registry::TargetRow],
+    now: i64,
+    kind_filter: Option<GcListKindFilter>,
+) -> Vec<GcListEntryOutput> {
+    if matches!(kind_filter, Some(kind) if !kind.is_target_subtree()) {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    for row in rows {
+        let owner_workspace =
+            crate::cache_lib::target_registry::workspace_root_for_target(&row.path)
+                .display()
+                .to_string();
+
+        if kind_filter.is_none()
+            || matches!(kind_filter, Some(GcListKindFilter::CargoTargetIncremental))
+        {
+            for profile in profile_dirs(&row.path) {
+                let path = profile.join("incremental");
+                if let Some(entry) = entry_output_for_path(
+                    &path,
+                    KIND_CARGO_TARGET_INCREMENTAL,
+                    PURGE_SAFETY_DERIVED,
+                    now,
+                    EntryOwners {
+                        owner_workspace: Some(owner_workspace.clone()),
+                        ..EntryOwners::default()
+                    },
+                ) {
+                    out.push(entry);
+                }
+            }
+        }
+
+        if kind_filter.is_none()
+            || matches!(
+                kind_filter,
+                Some(GcListKindFilter::CargoTargetBuildScriptBinaries)
+            )
+        {
+            for profile in profile_dirs(&row.path) {
+                let build_dir = profile.join("build");
+                let read = match std::fs::read_dir(&build_dir) {
+                    Ok(it) => it,
+                    Err(_) => continue,
+                };
+                for unit in read.flatten() {
+                    if !unit.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                        continue;
+                    }
+                    let unit_read = match std::fs::read_dir(unit.path()) {
+                        Ok(it) => it,
+                        Err(_) => continue,
+                    };
+                    for child in unit_read.flatten() {
+                        let path = child.path();
+                        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                            continue;
+                        };
+                        if !is_build_script_binary(name) {
+                            continue;
+                        }
+                        if let Some(entry) = entry_output_for_path(
+                            &path,
+                            KIND_CARGO_TARGET_BUILD_SCRIPT_BINARIES,
+                            PURGE_SAFETY_DERIVED,
+                            now,
+                            EntryOwners {
+                                owner_workspace: Some(owner_workspace.clone()),
+                                ..EntryOwners::default()
+                            },
+                        ) {
+                            out.push(entry);
+                        }
+                    }
+                }
+            }
+        }
+
+        if kind_filter.is_none() || matches!(kind_filter, Some(GcListKindFilter::CargoTargetDoc)) {
+            let path = row.path.join("doc");
+            if let Some(entry) = entry_output_for_path(
+                &path,
+                KIND_CARGO_TARGET_DOC,
+                PURGE_SAFETY_DERIVED,
+                now,
+                EntryOwners {
+                    owner_workspace: Some(owner_workspace.clone()),
+                    ..EntryOwners::default()
+                },
+            ) {
+                out.push(entry);
+            }
+        }
+
+        if kind_filter.is_none()
+            || matches!(
+                kind_filter,
+                Some(GcListKindFilter::CargoTargetSubcommandCaches)
+            )
+        {
+            for name in SUBCOMMAND_CACHE_DIRS {
+                let path = row.path.join(name);
+                if let Some(entry) = entry_output_for_path(
+                    &path,
+                    KIND_CARGO_TARGET_SUBCOMMAND_CACHES,
+                    PURGE_SAFETY_DERIVED,
+                    now,
+                    EntryOwners {
+                        owner_workspace: Some(owner_workspace.clone()),
+                        ..EntryOwners::default()
+                    },
+                ) {
+                    out.push(entry);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn profile_dirs(target_dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let read = match std::fs::read_dir(target_dir) {
+        Ok(it) => it,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for entry in read.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(|s| s.to_string()) else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        out.push(entry.path());
+    }
+    out
+}
+
+fn is_build_script_binary(name: &str) -> bool {
+    let stem = name.split('.').next().unwrap_or(name);
+    stem == "build-script-build" || stem.starts_with("build-script-build-")
+}
+
+// ---------------------------------------------------------------------------
+// Report-only global walkers (#323 slice 5).
+// ---------------------------------------------------------------------------
+
+pub(super) fn walk_cargo_report_only(
+    cargo_home: &std::path::Path,
+    now: i64,
+    kind_filter: Option<GcListKindFilter>,
+) -> Vec<GcListEntryOutput> {
+    let mut out = Vec::new();
+
+    if kind_filter.is_none() || matches!(kind_filter, Some(GcListKindFilter::CargoRegistryCache)) {
+        let cache_root = cargo_home.join("registry").join("cache");
+        if let Ok(registries) = std::fs::read_dir(cache_root) {
+            for registry in registries.flatten() {
+                if !registry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                    continue;
+                }
+                let crates = match std::fs::read_dir(registry.path()) {
+                    Ok(it) => it,
+                    Err(_) => continue,
+                };
+                for crate_file in crates.flatten() {
+                    let path = crate_file.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("crate") {
+                        continue;
+                    }
+                    let owner = path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .and_then(parse_crate_owner);
+                    if let Some(entry) = entry_output_for_path(
+                        &path,
+                        KIND_CARGO_REGISTRY_CACHE,
+                        PURGE_SAFETY_PRIMARY,
+                        now,
+                        EntryOwners {
+                            owner_crate: owner,
+                            ..EntryOwners::default()
+                        },
+                    ) {
+                        out.push(entry);
+                    }
+                }
+            }
+        }
+    }
+
+    if kind_filter.is_none() || matches!(kind_filter, Some(GcListKindFilter::CargoGitDb)) {
+        let db_root = cargo_home.join("git").join("db");
+        if let Ok(repos) = std::fs::read_dir(db_root) {
+            for repo in repos.flatten() {
+                let path = repo.path();
+                let owner_repo = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(str::to_string);
+                if let Some(entry) = entry_output_for_path(
+                    &path,
+                    KIND_CARGO_GIT_DB,
+                    PURGE_SAFETY_PRIMARY,
+                    now,
+                    EntryOwners {
+                        owner_repo,
+                        ..EntryOwners::default()
+                    },
+                ) {
+                    out.push(entry);
+                }
+            }
+        }
+    }
+
+    if kind_filter.is_none()
+        || matches!(kind_filter, Some(GcListKindFilter::CargoInstalledBinaries))
+    {
+        let bin_root = cargo_home.join("bin");
+        if let Ok(bins) = std::fs::read_dir(bin_root) {
+            for bin in bins.flatten() {
+                let path = bin.path();
+                let owner_binary = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(str::to_string);
+                if let Some(entry) = entry_output_for_path(
+                    &path,
+                    KIND_CARGO_INSTALLED_BINARIES,
+                    PURGE_SAFETY_PRIMARY,
+                    now,
+                    EntryOwners {
+                        owner_binary,
+                        ..EntryOwners::default()
+                    },
+                ) {
+                    out.push(entry);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+pub(super) fn walk_rustup_toolchains(
+    rustup_home: &std::path::Path,
+    now: i64,
+    kind_filter: Option<GcListKindFilter>,
+) -> Vec<GcListEntryOutput> {
+    if !(kind_filter.is_none() || matches!(kind_filter, Some(GcListKindFilter::RustupToolchain))) {
+        return Vec::new();
+    }
+
+    let toolchains_root = rustup_home.join("toolchains");
+    let toolchains = match std::fs::read_dir(toolchains_root) {
+        Ok(it) => it,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    for toolchain in toolchains.flatten() {
+        let path = toolchain.path();
+        let owner_toolchain = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_string);
+        if let Some(entry) = entry_output_for_path(
+            &path,
+            KIND_RUSTUP_TOOLCHAIN,
+            PURGE_SAFETY_PRIMARY,
+            now,
+            EntryOwners {
+                owner_toolchain,
+                ..EntryOwners::default()
+            },
+        ) {
+            out.push(entry);
+        }
+    }
+    out
+}
+
+fn entry_output_for_path(
+    path: &std::path::Path,
+    kind: &'static str,
+    purge_safety: &'static str,
+    now: i64,
+    owners: EntryOwners,
+) -> Option<GcListEntryOutput> {
+    let metadata = std::fs::symlink_metadata(path).ok()?;
+    if metadata.file_type().is_symlink() {
+        return None;
+    }
+    let (size_bytes, file_count) = if metadata.is_file() {
+        (metadata.len(), 1)
+    } else if metadata.is_dir() {
+        fast_directory_size_and_files(path)
+    } else {
+        return None;
+    };
+    let last_used_unix = mtime_unix(&metadata);
+    let age_seconds = now.saturating_sub(last_used_unix);
+    Some(GcListEntryOutput {
+        path: absolute_path_string(path),
+        last_used_unix,
+        age_seconds,
+        age_human: crate::cache_lib::target_registry::human_age(age_seconds),
+        size_bytes,
+        size_human: crate::cache_lib::target_registry::human_size(size_bytes),
+        file_count,
+        kind,
+        purge_safety,
+        owner_crate: owners.owner_crate,
+        owner_workspace: owners.owner_workspace,
+        owner_repo: owners.owner_repo,
+        owner_binary: owners.owner_binary,
+        owner_toolchain: owners.owner_toolchain,
+        last_used_source: Some(LAST_USED_FROM_FS_MTIME),
+    })
+}
+
+fn mtime_unix(metadata: &std::fs::Metadata) -> i64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -448,16 +448,30 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                     kind,
                     registry_src,
                     git_checkouts,
+                    target_incremental,
+                    build_scripts,
+                    doc,
+                    subcommand_caches,
                 }) => {
                     // #323 slice 2: --registry-src is a shorthand for
                     // --kind cargo_registry_src; clap already enforces
                     // mutual exclusion.
                     // #323 slice 3: --git-checkouts is a shorthand for
                     // --kind cargo_git_checkouts.
+                    // #323 slice 4: in-target subtree shorthands map to
+                    // their explicit taxonomy kinds.
                     let effective_kind = if registry_src {
                         Some(GcListKind::CargoRegistrySrc)
                     } else if git_checkouts {
                         Some(GcListKind::CargoGitCheckouts)
+                    } else if target_incremental {
+                        Some(GcListKind::CargoTargetIncremental)
+                    } else if build_scripts {
+                        Some(GcListKind::CargoTargetBuildScriptBinaries)
+                    } else if doc {
+                        Some(GcListKind::CargoTargetDoc)
+                    } else if subcommand_caches {
+                        Some(GcListKind::CargoTargetSubcommandCaches)
                     } else {
                         kind
                     };
@@ -469,6 +483,36 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                         Some(GcListKind::CargoGitCheckouts) => {
                             gc::run_gc_purge_git_checkouts_command(all, json)?;
                             return Ok(());
+                        }
+                        Some(
+                            GcListKind::CargoTargetIncremental
+                            | GcListKind::CargoTargetBuildScriptBinaries
+                            | GcListKind::CargoTargetDoc
+                            | GcListKind::CargoTargetSubcommandCaches,
+                        ) => {
+                            gc::run_gc_purge_target_subtree_command(
+                                effective_kind.expect("matched Some").into(),
+                                all,
+                                json,
+                            )?;
+                            return Ok(());
+                        }
+                        Some(
+                            GcListKind::CargoRegistryCache
+                            | GcListKind::CargoGitDb
+                            | GcListKind::CargoInstalledBinaries
+                            | GcListKind::RustupToolchain,
+                        ) => {
+                            let kind_name = match effective_kind.expect("matched Some") {
+                                GcListKind::CargoRegistryCache => "cargo_registry_cache",
+                                GcListKind::CargoGitDb => "cargo_git_db",
+                                GcListKind::CargoInstalledBinaries => "cargo_installed_binaries",
+                                GcListKind::RustupToolchain => "rustup_toolchain",
+                                _ => "selected kind",
+                            };
+                            return Err(SoldrError::Other(format!(
+                                "gc purge --kind {kind_name} is report-only; cargo/rustup own deletion for this primary cache"
+                            )));
                         }
                         Some(GcListKind::CargoTarget) | None => gc::GcInvocation {
                             mode: gc::GcMode::Purge { all },

--- a/crates/soldr-cli/tests/cli_gc.rs
+++ b/crates/soldr-cli/tests/cli_gc.rs
@@ -221,8 +221,10 @@ fn gc_list_json_reports_built_project_target_dir() {
     let project_dir = unique_temp_dir("gc-list-project");
     // #323 slice 2: sandbox CARGO_HOME so the registry_src walker
     // doesn't see the developer's real `~/.cargo` and inject
-    // cargo_registry_src entries into this test's assertions.
+    // cargo_registry_src entries into this test's assertions. Also
+    // sandbox RUSTUP_HOME now that `gc list` reports rustup toolchains.
     let sandbox_cargo_home = unique_temp_dir("gc-list-build-cargo-home");
+    let sandbox_rustup_home = unique_temp_dir("gc-list-build-rustup-home");
 
     fs::write(
         project_dir.join("Cargo.toml"),
@@ -240,6 +242,11 @@ fn gc_list_json_reports_built_project_target_dir() {
         .current_dir(&project_dir)
         .env("RUSTC_WRAPPER", soldr_bin)
         .env("SOLDR_CACHE_DIR", &cache_root)
+        // This fixture intentionally exercises soldr as a plain
+        // RUSTC_WRAPPER, not as a child of the outer `soldr cargo test`
+        // session that may be running this integration test.
+        .env_remove(soldr_cli::cache_lib::SOLDR_BUILD_SESSION_ID_ENV_VAR)
+        .env_remove(soldr_cli::wrapper_target::TARGET_REGISTRY_RECORDED_ENV_VAR)
         // No zccache binary override → soldr wrapper records the target
         // dir, then falls through to invoking rustc directly.
         .env_remove("SOLDR_TEST_ZCCACHE_BIN")
@@ -263,6 +270,7 @@ fn gc_list_json_reports_built_project_target_dir() {
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &sandbox_cargo_home)
+        .env("RUSTUP_HOME", &sandbox_rustup_home)
         .output()
         .expect("failed to run soldr gc list --json");
 
@@ -303,6 +311,8 @@ fn gc_list_json_reports_built_project_target_dir() {
     });
 
     let path_str = entry["path"].as_str().expect("entry path");
+    assert_eq!(entry["kind"].as_str(), Some("cargo_target"));
+    assert_eq!(entry["purge_safety"].as_str(), Some("derived"));
     assert!(
         PathBuf::from(path_str).is_absolute(),
         "gc list entries must use absolute paths: {path_str}"
@@ -329,7 +339,18 @@ fn gc_list_json_reports_built_project_target_dir() {
             entry.get("exists").is_none(),
             "missing rows are pruned, so `exists` should not appear on listed entries"
         );
-        assert_eq!(entry["kind"].as_str(), Some("cargo_target"));
+        let kind = entry["kind"].as_str().expect("every entry must have kind");
+        assert!(
+            matches!(
+                kind,
+                "cargo_target"
+                    | "cargo_target_incremental"
+                    | "cargo_target_build_script_binaries"
+                    | "cargo_target_doc"
+                    | "cargo_target_subcommand_caches"
+            ),
+            "unexpected gc list kind: {kind}"
+        );
         assert_eq!(entry["purge_safety"].as_str(), Some("derived"));
     }
 }
@@ -363,8 +384,10 @@ fn gc_list_json_prunes_missing_registry_rows_in_one_pass() {
     let cache_root = unique_temp_dir("gc-list-prune");
     let dev_root = cache_root.join("dev-root");
     // #323 slice 2: sandbox CARGO_HOME so the registry_src walker
-    // doesn't contribute extra entries to entry_count assertions.
+    // doesn't contribute extra entries to entry_count assertions. Also
+    // sandbox RUSTUP_HOME now that `gc list` reports rustup toolchains.
     let sandbox_cargo_home = unique_temp_dir("gc-list-prune-cargo-home");
+    let sandbox_rustup_home = unique_temp_dir("gc-list-prune-rustup-home");
 
     let live_workspace = dev_root.join("live-project");
     let live_target = live_workspace.join("target");
@@ -396,6 +419,7 @@ fn gc_list_json_prunes_missing_registry_rows_in_one_pass() {
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &sandbox_cargo_home)
+        .env("RUSTUP_HOME", &sandbox_rustup_home)
         .output()
         .expect("failed to run soldr gc list --json");
     assert!(

--- a/crates/soldr-cli/tests/cli_gc_report_only.rs
+++ b/crates/soldr-cli/tests/cli_gc_report_only.rs
@@ -1,0 +1,134 @@
+//! Integration tests for report-only primary GC kinds (#323 slice 5).
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use serde_json::Value;
+use soldr_cli::timed_test;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn write_file(path: &Path, body: &[u8]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create parent dir");
+    }
+    fs::write(path, body).expect("failed to write fixture file");
+}
+
+fn seed_report_only_roots(label: &str) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let cache_root = unique_temp_dir(&format!("{label}-soldr-cache"));
+    let cargo_home = unique_temp_dir(&format!("{label}-cargo-home"));
+    let rustup_home = unique_temp_dir(&format!("{label}-rustup-home"));
+
+    let registry_cache =
+        cargo_home.join("registry/cache/index.crates.io-abc123/serde-1.0.213.crate");
+    write_file(&registry_cache, b"crate tarball");
+
+    let git_db = cargo_home.join("git/db/tokio-abc123");
+    write_file(&git_db.join("objects/pack/pack.bin"), b"git db");
+
+    let installed_bin = cargo_home.join("bin/cargo-demo.exe");
+    write_file(&installed_bin, b"binary");
+
+    let rustup_toolchain = rustup_home.join("toolchains/1.94.1-test");
+    write_file(&rustup_toolchain.join("bin/rustc.exe"), b"rustc");
+
+    (cache_root, cargo_home, rustup_home, registry_cache)
+}
+
+timed_test!(
+    gc_list_json_reports_primary_kinds_without_purge_eligibility,
+    {
+        let (cache_root, cargo_home, rustup_home, _registry_cache) =
+            seed_report_only_roots("gc-report-only-list");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+            .args(["gc", "list", "--json"])
+            .env("SOLDR_CACHE_DIR", &cache_root)
+            .env("CARGO_HOME", &cargo_home)
+            .env("RUSTUP_HOME", &rustup_home)
+            .output()
+            .expect("failed to run soldr gc list --json");
+
+        assert!(
+            output.status.success(),
+            "gc list failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let json: Value = serde_json::from_slice(&output.stdout).expect("gc list must be JSON");
+        let entries = json["entries"].as_array().expect("entries");
+        for kind in [
+            "cargo_registry_cache",
+            "cargo_git_db",
+            "cargo_installed_binaries",
+            "rustup_toolchain",
+        ] {
+            let entry = entries
+                .iter()
+                .find(|entry| entry["kind"].as_str() == Some(kind))
+                .unwrap_or_else(|| panic!("missing {kind}: {entries:?}"));
+            assert_eq!(entry["purge_safety"].as_str(), Some("primary"));
+            assert!(entry["size_bytes"].as_u64().unwrap_or(0) > 0);
+            assert!(entry["file_count"].as_u64().unwrap_or(0) > 0);
+        }
+
+        let registry_entry = entries
+            .iter()
+            .find(|entry| entry["kind"].as_str() == Some("cargo_registry_cache"))
+            .expect("registry cache entry");
+        assert_eq!(
+            registry_entry["owner_crate"].as_str(),
+            Some("serde@1.0.213")
+        );
+
+        let toolchain_entry = entries
+            .iter()
+            .find(|entry| entry["kind"].as_str() == Some("rustup_toolchain"))
+            .expect("rustup toolchain entry");
+        assert_eq!(
+            toolchain_entry["owner_toolchain"].as_str(),
+            Some("1.94.1-test")
+        );
+    }
+);
+
+timed_test!(gc_purge_report_only_kind_is_rejected_and_preserves_files, {
+    let (cache_root, cargo_home, rustup_home, registry_cache) =
+        seed_report_only_roots("gc-report-only-purge");
+    assert!(registry_cache.exists());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "gc",
+            "purge",
+            "--kind",
+            "cargo_registry_cache",
+            "--all",
+            "--json",
+        ])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .env("RUSTUP_HOME", &rustup_home)
+        .output()
+        .expect("failed to run soldr gc purge report-only kind");
+
+    assert!(
+        !output.status.success(),
+        "report-only kind must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("report-only"),
+        "stderr should explain report-only safety: {stderr}"
+    );
+    assert!(
+        registry_cache.exists(),
+        "report-only purge must not delete {}",
+        registry_cache.display()
+    );
+});

--- a/crates/soldr-cli/tests/cli_gc_target_subtrees.rs
+++ b/crates/soldr-cli/tests/cli_gc_target_subtrees.rs
@@ -1,0 +1,157 @@
+//! Integration tests for the in-target subtree GC kinds (#323 slice 4).
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use serde_json::Value;
+use soldr_cli::timed_test;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn sandbox_env(label: &str) -> (PathBuf, PathBuf) {
+    (
+        unique_temp_dir(&format!("{label}-cargo-home")),
+        unique_temp_dir(&format!("{label}-rustup-home")),
+    )
+}
+
+fn write_file(path: &Path, body: &[u8]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create parent dir");
+    }
+    fs::write(path, body).expect("failed to write fixture file");
+}
+
+fn seed_all_target_subtrees(cache_root: &Path) -> PathBuf {
+    let target = seed_gc_candidate(cache_root, "target-subtrees-project");
+    write_file(
+        &target.join("debug/incremental/s-abc/work-product.bin"),
+        b"inc",
+    );
+    write_file(
+        &target.join("debug/build/demo-aaaaaaaaaaaaa/build-script-build.exe"),
+        b"build script",
+    );
+    write_file(&target.join("doc/index.html"), b"docs");
+    write_file(&target.join("criterion/report/index.html"), b"criterion");
+    target
+}
+
+fn seed_one_target_subtree(label: &str, kind: &str) -> (PathBuf, PathBuf) {
+    let cache_root = unique_temp_dir(label);
+    let target = seed_gc_candidate(&cache_root, label);
+    let victim = match kind {
+        "cargo_target_incremental" => {
+            let path = target.join("debug/incremental");
+            write_file(&path.join("s-abc/work-product.bin"), b"inc");
+            path
+        }
+        "cargo_target_build_script_binaries" => {
+            let path = target.join("debug/build/demo-aaaaaaaaaaaaa/build-script-build.exe");
+            write_file(&path, b"build script");
+            path
+        }
+        "cargo_target_doc" => {
+            let path = target.join("doc");
+            write_file(&path.join("index.html"), b"docs");
+            path
+        }
+        "cargo_target_subcommand_caches" => {
+            let path = target.join("nextest");
+            write_file(&path.join("archive.bin"), b"nextest");
+            path
+        }
+        other => panic!("unexpected kind {other}"),
+    };
+    (cache_root, victim)
+}
+
+timed_test!(gc_list_json_walks_target_subtree_kinds, {
+    let cache_root = unique_temp_dir("gc-list-target-subtrees");
+    let target = seed_all_target_subtrees(&cache_root);
+    let (cargo_home, rustup_home) = sandbox_env("gc-list-target-subtrees");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["gc", "list", "--json"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("CARGO_HOME", &cargo_home)
+        .env("RUSTUP_HOME", &rustup_home)
+        .output()
+        .expect("failed to run soldr gc list --json");
+
+    assert!(
+        output.status.success(),
+        "gc list failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gc list must be JSON");
+    let entries = json["entries"].as_array().expect("entries");
+    let expected_workspace = target.parent().unwrap().display().to_string();
+    for kind in [
+        "cargo_target_incremental",
+        "cargo_target_build_script_binaries",
+        "cargo_target_doc",
+        "cargo_target_subcommand_caches",
+    ] {
+        let entry = entries
+            .iter()
+            .find(|entry| entry["kind"].as_str() == Some(kind))
+            .unwrap_or_else(|| panic!("missing {kind}: {entries:?}"));
+        assert_eq!(entry["purge_safety"].as_str(), Some("derived"));
+        assert_eq!(
+            entry["owner_workspace"].as_str(),
+            Some(expected_workspace.as_str())
+        );
+        assert!(entry["size_bytes"].as_u64().unwrap_or(0) > 0);
+        assert!(entry["file_count"].as_u64().unwrap_or(0) > 0);
+    }
+});
+
+timed_test!(gc_purge_target_subtree_flags_delete_only_selected_kind, {
+    let cases = [
+        ("--target-incremental", "cargo_target_incremental"),
+        ("--build-scripts", "cargo_target_build_script_binaries"),
+        ("--doc", "cargo_target_doc"),
+        ("--subcommand-caches", "cargo_target_subcommand_caches"),
+    ];
+
+    for (flag, kind) in cases {
+        let label = format!("gc-purge-{}", kind.replace('_', "-"));
+        let (cache_root, victim) = seed_one_target_subtree(&label, kind);
+        assert!(
+            victim.exists(),
+            "precondition victim exists: {}",
+            victim.display()
+        );
+        let (cargo_home, rustup_home) = sandbox_env(&label);
+
+        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+            .args(["gc", "purge", flag, "--all", "--json"])
+            .env("SOLDR_CACHE_DIR", &cache_root)
+            .env("CARGO_HOME", &cargo_home)
+            .env("RUSTUP_HOME", &rustup_home)
+            .output()
+            .expect("failed to run soldr gc purge subtree flag");
+
+        assert!(
+            output.status.success(),
+            "gc purge {flag} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let json: Value = serde_json::from_slice(&output.stdout).expect("purge must be JSON");
+        assert_eq!(json["kind"].as_str(), Some(kind));
+        assert_eq!(json["selected_count"].as_u64(), Some(1));
+        assert_eq!(json["succeeded_count"].as_u64(), Some(1));
+        assert!(
+            !victim.exists(),
+            "victim should be deleted: {}",
+            victim.display()
+        );
+    }
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -852,6 +852,13 @@ soldr gc purge                                # interactive deletion flow
 soldr gc purge --all                          # delete every eligible candidate
 soldr gc purge --older-than 30d --larger-than 1GB
 soldr gc purge --json                         # machine-readable purge report
+soldr gc list --kind cargo_target_incremental # list one taxonomy kind
+soldr gc purge --target-incremental --all      # delete target/<profile>/incremental/
+soldr gc purge --build-scripts --all           # delete build-script-build binaries
+soldr gc purge --doc --all                     # delete target/doc/
+soldr gc purge --subcommand-caches --all       # delete target/{criterion,nextest,...}/
+soldr gc purge --registry-src --all            # delete extracted registry sources
+soldr gc purge --git-checkouts --all           # delete git checkout worktrees
 ```
 
 Defaults:
@@ -874,6 +881,27 @@ Safety guards (from `docs/TARGET_GC_PROPOSAL.md`):
 The summary includes the registry path, eligible candidate count, total
 reclaimable size, skipped/dropped counts, and the largest eligible
 target directories with size and last-used age.
+
+`gc list --json` uses the issue #323 taxonomy. Derived kinds can be
+purged through explicit opt-in flags or `--kind`; primary kinds are
+report-only and `gc purge --kind <primary>` is rejected before deletion.
+
+Derived purge kinds:
+
+- `cargo_target` (default `gc purge` behavior)
+- `cargo_target_incremental`
+- `cargo_target_build_script_binaries`
+- `cargo_target_doc`
+- `cargo_target_subcommand_caches`
+- `cargo_registry_src`
+- `cargo_git_checkouts`
+
+Report-only primary kinds:
+
+- `cargo_registry_cache`
+- `cargo_git_db`
+- `cargo_installed_binaries`
+- `rustup_toolchain`
 
 **`cargo_registry_src` last-used provenance (issue #349).** When
 `soldr gc list --kind cargo_registry_src` (or unfiltered `gc list`)


### PR DESCRIPTION
## Summary
- Add in-target subtree GC kinds and purge shorthands for incremental state, build-script binaries, docs, and subcommand caches.
- Add report-only primary GC kinds for Cargo registry cache, Cargo git DBs, installed Cargo binaries, and rustup toolchains.
- Extend JSON output and docs, and add focused coverage for purge behavior and report-only rejection.

## Verification
- `soldr --no-cache cargo clippy -p soldr-cli --tests --no-deps -- -D warnings`
- `soldr --no-cache cargo test -p soldr-cli --test cli_gc --test cli_gc_registry_src --test cli_gc_git_checkouts --test cli_gc_target_subtrees --test cli_gc_report_only --test timed_test_lint`

Closes #323