### PR TITLE
fix: stabilize stdin rustc source paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.36"
+version = "0.7.37"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/src/cache_lib/mod.rs
+++ b/crates/soldr-cli/src/cache_lib/mod.rs
@@ -151,6 +151,11 @@ pub const MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR: &str = "SOLDR_MANAGED_ZCCACHE_CACHE
 /// can share cache hits. See issue #352.
 pub const ZCCACHE_PATH_REMAP_ENV_VAR: &str = "ZCCACHE_PATH_REMAP";
 
+/// zccache worktree-root override used as the logical root for path-remap
+/// normalization. soldr injects this with `ZCCACHE_PATH_REMAP=auto` so the
+/// default parent-cache path has a stable normalization anchor.
+pub const ZCCACHE_WORKTREE_ROOT_ENV_VAR: &str = "ZCCACHE_WORKTREE_ROOT";
+
 /// Soldr-side escape hatch for the default `ZCCACHE_PATH_REMAP=auto`
 /// injection. Accepts `auto` (default, equivalent to unset) and `off`.
 /// See issue #352.

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -80,7 +80,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.2";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -69,12 +69,12 @@ pub(crate) fn run_rustc_wrapper(
     // nothing, and exits 0 — masking any real compile error (e.g. E0554 from
     // build-script feature probes like rustix 0.37's `can_compile()`).
     //
-    // Fix: spill stdin to a temp file so both zccache and rustc see a real
-    // path. The temp file is created in the system temp directory and removed
-    // after the child exits. This keeps zccache in the loop (it can hash the
-    // file normally) while preserving the correct exit code.
+    // Fix: spill stdin to a content-addressed temp file so both zccache and
+    // rustc see a stable real path. This keeps zccache in the loop (it can
+    // hash the file normally) while preserving the correct exit code, and it
+    // lets identical feature probes converge on the same cache key.
     let stdin_tempfile = if raw_args[2..].iter().any(|a| a == "-") {
-        Some(spill_stdin_to_tempfile()?)
+        Some(spill_stdin_to_content_addressed_file()?)
     } else {
         None
     };
@@ -124,25 +124,94 @@ pub(crate) fn run_rustc_wrapper(
     Ok(status.code().unwrap_or(1))
 }
 
-/// Read all of stdin into a named temporary file and return the file.
+struct StdinSourceFile {
+    path: std::path::PathBuf,
+}
+
+impl StdinSourceFile {
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+/// Read all of stdin into a content-addressed source file and return it.
 ///
 /// The file has a `.rs` extension so rustc accepts it without flags, and
-/// lives in the system temp directory. It is deleted when the returned
-/// `NamedTempFile` value is dropped (i.e. after the child process exits).
-fn spill_stdin_to_tempfile() -> Result<tempfile::NamedTempFile, SoldrError> {
-    use std::io::{Read, Write as _};
-    let mut tmp = tempfile::Builder::new()
-        .prefix("soldr-stdin-")
-        .suffix(".rs")
-        .tempfile()
-        .map_err(|e| SoldrError::Other(format!("failed to create stdin temp file: {e}")))?;
+/// lives in the system temp directory as `soldr-stdin-<short_blake3>.rs`.
+/// It is intentionally retained so concurrent identical probes can share the
+/// same stable path.
+fn spill_stdin_to_content_addressed_file() -> Result<StdinSourceFile, SoldrError> {
+    use std::io::Read;
     let mut buf = Vec::new();
     std::io::stdin()
         .read_to_end(&mut buf)
         .map_err(|e| SoldrError::Other(format!("failed to read stdin: {e}")))?;
-    tmp.write_all(&buf)
+    materialize_stdin_source(&buf)
+}
+
+fn materialize_stdin_source(bytes: &[u8]) -> Result<StdinSourceFile, SoldrError> {
+    let hash = blake3::hash(bytes);
+    let hex = hash.to_hex();
+    let temp_dir = std::env::temp_dir();
+    let short_path = temp_dir.join(format!("soldr-stdin-{}.rs", &hex[..16]));
+    if ensure_stdin_source_path(&short_path, bytes)? {
+        return Ok(StdinSourceFile { path: short_path });
+    }
+
+    let full_path = temp_dir.join(format!("soldr-stdin-{hex}.rs"));
+    if ensure_stdin_source_path(&full_path, bytes)? {
+        return Ok(StdinSourceFile { path: full_path });
+    }
+
+    Err(SoldrError::Other(format!(
+        "stdin temp path hash collision at {}",
+        full_path.display()
+    )))
+}
+
+fn ensure_stdin_source_path(path: &std::path::Path, bytes: &[u8]) -> Result<bool, SoldrError> {
+    use std::io::Write as _;
+
+    match std::fs::read(path) {
+        Ok(existing) => return Ok(existing == bytes),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(SoldrError::Other(format!(
+                "failed to read existing stdin temp file {}: {err}",
+                path.display()
+            )));
+        }
+    }
+
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(|e| {
+        SoldrError::Other(format!(
+            "failed to create stdin temp file in {}: {e}",
+            parent.display()
+        ))
+    })?;
+    tmp.write_all(bytes)
         .map_err(|e| SoldrError::Other(format!("failed to write stdin temp file: {e}")))?;
-    Ok(tmp)
+    let _ = tmp.as_file().sync_all();
+
+    match tmp.persist_noclobber(path) {
+        Ok(_) => Ok(true),
+        Err(err) if err.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = err.file.close();
+            let existing = std::fs::read(path).map_err(|e| {
+                SoldrError::Other(format!(
+                    "failed to read raced stdin temp file {}: {e}",
+                    path.display()
+                ))
+            })?;
+            Ok(existing == bytes)
+        }
+        Err(err) => Err(SoldrError::Other(format!(
+            "failed to publish stdin temp file {}: {}",
+            path.display(),
+            err.error
+        ))),
+    }
 }
 
 fn run_wrapper_through_zccache(
@@ -337,6 +406,37 @@ pub(crate) use crate::wrapper_target::{record_target_dir_in_registry, TargetTouc
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stdin_source_path_is_content_addressed() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let bytes = format!("fn main() {{ let _ = {nonce}; }}\n");
+        let file = materialize_stdin_source(bytes.as_bytes()).unwrap();
+        let hash = blake3::hash(bytes.as_bytes()).to_hex();
+        let name = file.path().file_name().unwrap().to_string_lossy();
+
+        assert_eq!(name.as_ref(), format!("soldr-stdin-{}.rs", &hash[..16]));
+        assert_eq!(std::fs::read(file.path()).unwrap(), bytes.as_bytes());
+
+        let same = materialize_stdin_source(bytes.as_bytes()).unwrap();
+        assert_eq!(same.path(), file.path());
+    }
+
+    #[test]
+    fn stdin_source_paths_do_not_collide_for_distinct_content() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let a = materialize_stdin_source(format!("const A: u128 = {nonce};\n").as_bytes()).unwrap();
+        let b = materialize_stdin_source(format!("const B: u128 = {};\n", nonce + 1).as_bytes())
+            .unwrap();
+
+        assert_ne!(a.path(), b.path());
+    }
 
     // -------- stderr_indicates_unknown_session (issue #265) --------
 

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -57,9 +57,11 @@ pub(crate) fn resolve_path_remap_env(
 ) -> Option<&'static str> {
     // Rule 1: if the user already exported ZCCACHE_PATH_REMAP, never
     // overwrite. zccache itself decides what to do with their value
-    // (including the empty string).
-    if user_zccache.is_some() {
-        return None;
+    // (except that an empty/whitespace-only value is treated as unset).
+    if let Some(value) = user_zccache {
+        if !value.trim().is_empty() {
+            return None;
+        }
     }
 
     // Rule 2: SOLDR_PATH_REMAP=off (case-insensitive) suppresses the
@@ -71,6 +73,40 @@ pub(crate) fn resolve_path_remap_env(
     }
 
     Some("auto")
+}
+
+pub(crate) fn path_remap_auto_active(
+    user_zccache: Option<&str>,
+    soldr_override: Option<&str>,
+) -> bool {
+    match user_zccache
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(value) => value.eq_ignore_ascii_case("auto"),
+        None => resolve_path_remap_env(None, soldr_override).is_some(),
+    }
+}
+
+pub(crate) fn resolve_worktree_root_env(
+    user_worktree_root: Option<&std::ffi::OsStr>,
+    cwd: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    if user_worktree_root.is_some_and(|value| !value.is_empty()) {
+        return None;
+    }
+
+    find_git_worktree_root(cwd).or_else(|| Some(cwd.to_path_buf()))
+}
+
+pub(crate) fn find_git_worktree_root(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
+    for candidate in cwd.ancestors() {
+        let dot_git = candidate.join(".git");
+        if dot_git.is_dir() || dot_git.is_file() {
+            return Some(candidate.to_path_buf());
+        }
+    }
+    None
 }
 
 pub(crate) async fn prepare_rustc_wrapper(
@@ -235,15 +271,22 @@ async fn prepare_zccache_build(
         .max(1);
     crate::daemon::client::link_zccache(paths, zccache_token);
 
-    // Parent-cache (Tier L1.x, issue #352): seed ZCCACHE_PATH_REMAP=auto so
-    // multiple worktrees of the same repo share zccache hits. Honor any
-    // user-supplied ZCCACHE_PATH_REMAP, and the SOLDR_PATH_REMAP=off
-    // escape hatch.
+    // Parent-cache (Tier L1.x, issue #352): seed ZCCACHE_PATH_REMAP=auto
+    // and a logical worktree root so multiple worktrees of the same repo
+    // share zccache hits through normalized keys. Honor user-supplied
+    // ZCCACHE_* values, and the SOLDR_PATH_REMAP=off escape hatch.
     let user_zccache = std::env::var(crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR).ok();
     let soldr_override = std::env::var(crate::cache_lib::SOLDR_PATH_REMAP_ENV_VAR).ok();
     if let Some(value) = resolve_path_remap_env(user_zccache.as_deref(), soldr_override.as_deref())
     {
         cargo.env(crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR, value);
+    }
+    if path_remap_auto_active(user_zccache.as_deref(), soldr_override.as_deref()) {
+        let user_worktree_root = std::env::var_os(crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR);
+        let cwd = std::env::current_dir()?;
+        if let Some(root) = resolve_worktree_root_env(user_worktree_root.as_deref(), &cwd) {
+            cargo.env(crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR, root);
+        }
     }
 
     Ok(ZccacheBuildSession {
@@ -553,9 +596,8 @@ fn run_zccache_start_command(
     binary: &std::path::Path,
     cache_dir: &std::path::Path,
 ) -> Result<std::process::Output, SoldrError> {
-    let rust_log = effective_daemon_rust_log(
-        std::env::var(SOLDR_DAEMON_RUST_LOG_ENV_VAR).ok().as_deref(),
-    );
+    let rust_log =
+        effective_daemon_rust_log(std::env::var(SOLDR_DAEMON_RUST_LOG_ENV_VAR).ok().as_deref());
     run_zccache_command_raw_with_env(
         binary,
         &["start"],
@@ -800,7 +842,13 @@ mod tests {
     fn path_remap_preserves_user_value_when_zccache_already_set_to_non_auto() {
         assert_eq!(resolve_path_remap_env(Some("disabled"), None), None);
         assert_eq!(resolve_path_remap_env(Some("disabled"), Some("auto")), None);
-        assert_eq!(resolve_path_remap_env(Some(""), None), None);
+    }
+
+    #[test]
+    fn path_remap_treats_empty_user_value_as_unset() {
+        assert_eq!(resolve_path_remap_env(Some(""), None), Some("auto"));
+        assert_eq!(resolve_path_remap_env(Some("   "), None), Some("auto"));
+        assert_eq!(resolve_path_remap_env(Some(""), Some("off")), None);
     }
 
     #[test]
@@ -810,6 +858,56 @@ mod tests {
         // in the inherited environment.
         assert_eq!(resolve_path_remap_env(Some("auto"), None), None);
         assert_eq!(resolve_path_remap_env(Some("auto"), Some("off")), None);
+    }
+
+    #[test]
+    fn path_remap_auto_active_tracks_child_state() {
+        assert!(path_remap_auto_active(None, None));
+        assert!(path_remap_auto_active(Some(""), None));
+        assert!(path_remap_auto_active(Some("auto"), Some("off")));
+        assert!(!path_remap_auto_active(None, Some("off")));
+        assert!(!path_remap_auto_active(Some("disabled"), None));
+    }
+
+    #[test]
+    fn worktree_root_env_uses_git_root_by_default() {
+        let temp = unique_test_dir("worktree-root-git");
+        let root = temp.join("repo");
+        let nested = root.join("crates").join("demo");
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(find_git_worktree_root(&nested), Some(root.clone()));
+        assert_eq!(resolve_worktree_root_env(None, &nested), Some(root));
+    }
+
+    #[test]
+    fn worktree_root_env_falls_back_to_cwd_without_git_root() {
+        let temp = unique_test_dir("worktree-root-cwd");
+        let cwd = temp.join("repo");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        assert_eq!(find_git_worktree_root(&cwd), None);
+        assert_eq!(resolve_worktree_root_env(None, &cwd), Some(cwd));
+    }
+
+    #[test]
+    fn worktree_root_env_preserves_user_value() {
+        let cwd = std::path::Path::new("/repo");
+        assert_eq!(
+            resolve_worktree_root_env(Some(OsStr::new("/custom/root")), cwd),
+            None
+        );
+    }
+
+    fn unique_test_dir(label: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
     }
 
     // ---------------------------------------------------------------

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.11.0");
+    assert_eq!(json["managed_zccache_version"], "1.11.2");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.11.0");
+    assert_eq!(json["managed_zccache_version"], "1.11.2");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.11.0");
+    assert_eq!(json["managed_zccache_version"], "1.11.2");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_cargo_wrappers.rs
+++ b/crates/soldr-cli/tests/cli_cargo_wrappers.rs
@@ -271,6 +271,51 @@ fn nested_soldr_ignores_inherited_managed_zccache_cache_dir() {
 }
 
 #[test]
+fn managed_zccache_injects_normalized_path_remap_by_default() {
+    let cache_root = unique_temp_dir("cargo-normalized-remap");
+    let log_path = cache_root.join("tool.log");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let repo_root = unique_temp_dir("cargo-normalized-remap-repo");
+    let nested = repo_root.join("crates").join("demo");
+    fs::create_dir_all(repo_root.join(".git")).expect("failed to create fake git root");
+    fs::create_dir_all(&nested).expect("failed to create nested cwd");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .current_dir(&nested)
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("ZCCACHE_PATH_REMAP")
+        .env_remove("ZCCACHE_WORKTREE_ROOT")
+        .env_remove("SOLDR_PATH_REMAP")
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run soldr cargo build with normalized remap defaults");
+
+    assert!(
+        output.status.success(),
+        "normalized remap front door failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("path_remap=auto"),
+        "managed zccache should enable path remap by default: {log}"
+    );
+    assert!(
+        path_display_variants(&repo_root)
+            .iter()
+            .any(|path| log.contains(&format!("worktree_root={path}"))),
+        "managed zccache should pass the git root as ZCCACHE_WORKTREE_ROOT: {log}"
+    );
+}
+
+#[test]
 fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
     let cache_root = unique_temp_dir("cargo-custom-wrapper");
     let log_path = cache_root.join("tool.log");

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.11.0");
+    assert_eq!(status_json["managed_version"], "1.11.2");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.11.0");
+    assert_eq!(json["managed_version"], "1.11.2");
 }
 
 #[test]

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -183,7 +183,7 @@ pub(crate) fn fake_cargo_script(log_path: &Path) -> String {
                if defined SOLDR_TEST_CARGO_METADATA_PATH (\n\
                  type \"%SOLDR_TEST_CARGO_METADATA_PATH%\"\n\
                ) else (\n\
-                 echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR% zccache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+                 echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR% zccache_dir=%ZCCACHE_CACHE_DIR% path_remap=%ZCCACHE_PATH_REMAP% worktree_root=%ZCCACHE_WORKTREE_ROOT%>>\"{0}\"\n\
                  for /f \"tokens=1,* delims==\" %%A in ('set CARGO_TARGET_ 2^>nul') do @echo cargo_target_env %%A=%%B>>\"{0}\"\n\
                  for /f \"tokens=1,* delims==\" %%A in ('set CARGO_PROFILE_ 2^>nul') do @echo cargo_profile_env %%A=%%B>>\"{0}\"\n\
                  echo {{}}\n\
@@ -195,7 +195,7 @@ pub(crate) fn fake_cargo_script(log_path: &Path) -> String {
                echo cargo 1.0.0-test\n\
                exit /b 0\n\
              )\n\
-             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR% zccache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+             echo cargo wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% sccache_dir=%SCCACHE_DIR% zccache_dir=%ZCCACHE_CACHE_DIR% path_remap=%ZCCACHE_PATH_REMAP% worktree_root=%ZCCACHE_WORKTREE_ROOT%>>\"{0}\"\n\
              for /f \"tokens=1,* delims==\" %%A in ('set CARGO_TARGET_ 2^>nul') do @echo cargo_target_env %%A=%%B>>\"{0}\"\n\
              for /f \"tokens=1,* delims==\" %%A in ('set CARGO_PROFILE_ 2^>nul') do @echo cargo_profile_env %%A=%%B>>\"{0}\"\n\
              if defined RUSTC_WRAPPER (\n\
@@ -225,7 +225,7 @@ pub(crate) fn fake_cargo_script(log_path: &Path) -> String {
                if [ -n \"${{SOLDR_TEST_CARGO_METADATA_PATH:-}}\" ]; then\n\
                  cat \"$SOLDR_TEST_CARGO_METADATA_PATH\"\n\
                else\n\
-                 echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+                 echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}} path_remap=${{ZCCACHE_PATH_REMAP:-}} worktree_root=${{ZCCACHE_WORKTREE_ROOT:-}}\" >> \"{0}\"\n\
                  log_cargo_target_envs\n\
                  log_cargo_profile_envs\n\
                  echo '{{}}'\n\
@@ -237,7 +237,7 @@ pub(crate) fn fake_cargo_script(log_path: &Path) -> String {
                echo 'cargo 1.0.0-test'\n\
                exit 0\n\
              fi\n\
-             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+             echo \"cargo wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} sccache_dir=${{SCCACHE_DIR:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}} path_remap=${{ZCCACHE_PATH_REMAP:-}} worktree_root=${{ZCCACHE_WORKTREE_ROOT:-}}\" >> \"{0}\"\n\
              log_cargo_target_envs\n\
              log_cargo_profile_envs\n\
              if [ -n \"${{RUSTC_WRAPPER:-}}\" ]; then\n\

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.36",
+  "version": "0.7.37",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- stabilize rustc stdin source paths with content-addressed temp files
- add the managed worktree root path remap by default
- bump managed zccache to 1.11.2 and soldr to 0.7.37

## Release sequencing
This schedules the soldr v0.7.37 release after merge so setup-soldr can safely move its default to 0.7.37 afterward. zccache 1.11.2 is already published and includes the stdout artifact persistence fix needed before this soldr pin.

## Validation
- cargo test -p soldr-cli stdin_source_path -- --nocapture
- cargo test -p soldr-cli managed_zccache_injects_normalized_path_remap_by_default -- --nocapture
- cargo test -p soldr-cli --test cli_cache -- --nocapture
- cargo test -p soldr-cli --test cli_install_zccache -- --nocapture
- git diff --check HEAD^..HEAD

Note: cargo fmt --check currently reports pre-existing formatting drift outside this change.