### PR TITLE
feat: add command-lifetime cache shutdown

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -25,8 +25,13 @@ use crate::trampoline_workspace::{
     detect_workspace_verb, refresh_workspace_sidecar_after_cargo, try_workspace_trampoline,
     RawClippyCapture, WorkspaceDecision, WorkspaceVerb,
 };
-use crate::zccache::{finish_zccache_build, prepare_rustc_wrapper};
-use crate::{apply_implicit_toolchain_homes, gc, resolve_toolchain_binary, rust_plan, ZccacheSourceArg};
+use crate::zccache::{
+    cache_lifecycle_from_env, command_lifetime_shutdown_timeout, finish_zccache_build,
+    prepare_rustc_wrapper, stop_zccache_after_command, CacheLifecycle,
+};
+use crate::{
+    apply_implicit_toolchain_homes, gc, resolve_toolchain_binary, rust_plan, ZccacheSourceArg,
+};
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -189,6 +194,13 @@ pub(crate) async fn run_cargo_front_door(
             "`--no-cache` must appear before `cargo`, as in `soldr --no-cache cargo build`".into(),
         ));
     }
+
+    let cache_lifecycle = cache_lifecycle_from_env()?;
+    let command_lifetime_shutdown_timeout = if cache_lifecycle == CacheLifecycle::Command {
+        Some(command_lifetime_shutdown_timeout()?)
+    } else {
+        None
+    };
 
     // Strip soldr-private auto target-GC opt-out flags before any other
     // arg-vector handling so downstream code (trampolines, cargo spawn)
@@ -542,8 +554,15 @@ pub(crate) async fn run_cargo_front_door(
         }
     }
 
-    if let Some(session) = session {
-        finish_zccache_build(&session)?;
+    if let Some(session) = session.as_ref() {
+        let finish_result = finish_zccache_build(session);
+        let shutdown_result = if let Some(timeout) = command_lifetime_shutdown_timeout {
+            stop_zccache_after_command(session, timeout)
+        } else {
+            Ok(())
+        };
+        finish_result?;
+        shutdown_result?;
     }
     drop(trampoline_plan);
     drop(workspace_plan);

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -7,6 +7,72 @@ use crate::{
     current_soldr_binary, fetch_active_zccache, non_empty_env_path, ZccacheSourceArg,
     RUSTC_WRAPPER_OVERRIDE_ENV_VAR,
 };
+use std::ffi::OsStr;
+
+pub(crate) const SOLDR_CACHE_LIFECYCLE_ENV_VAR: &str = "SOLDR_CACHE_LIFECYCLE";
+pub(crate) const SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR: &str =
+    "SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CacheLifecycle {
+    Job,
+    Command,
+}
+
+pub(crate) fn cache_lifecycle_from_env() -> Result<CacheLifecycle, SoldrError> {
+    cache_lifecycle_from_env_value(std::env::var_os(SOLDR_CACHE_LIFECYCLE_ENV_VAR).as_deref())
+}
+
+pub(crate) fn cache_lifecycle_from_env_value(
+    value: Option<&OsStr>,
+) -> Result<CacheLifecycle, SoldrError> {
+    let Some(value) = value else {
+        return Ok(CacheLifecycle::Job);
+    };
+    let value = value.to_string_lossy();
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "" | "job" | "job-long" | "job-long-cache" | "default" => Ok(CacheLifecycle::Job),
+        "command" | "command-lifetime" | "self-build" => Ok(CacheLifecycle::Command),
+        _ => Err(SoldrError::Other(format!(
+            "{SOLDR_CACHE_LIFECYCLE_ENV_VAR} must be 'job' or 'command' (got {value:?})"
+        ))),
+    }
+}
+
+pub(crate) fn command_lifetime_shutdown_timeout() -> Result<std::time::Duration, SoldrError> {
+    Ok(std::time::Duration::from_secs(
+        command_lifetime_shutdown_timeout_seconds()?,
+    ))
+}
+
+fn command_lifetime_shutdown_timeout_seconds() -> Result<u64, SoldrError> {
+    match std::env::var(SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR) {
+        Ok(raw) => parse_shutdown_timeout_seconds(&raw),
+        Err(std::env::VarError::NotPresent) => Ok(30),
+        Err(err) => Err(SoldrError::Other(format!(
+            "{SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR} is not valid Unicode: {err}"
+        ))),
+    }
+}
+
+pub(crate) fn parse_shutdown_timeout_seconds(raw: &str) -> Result<u64, SoldrError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(30);
+    }
+    let seconds = trimmed.parse::<u64>().map_err(|err| {
+        SoldrError::Other(format!(
+            "{SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR} must be a positive integer number of seconds (got {raw:?}: {err})"
+        ))
+    })?;
+    if seconds == 0 {
+        return Err(SoldrError::Other(format!(
+            "{SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR} must be greater than zero"
+        )));
+    }
+    Ok(seconds)
+}
 
 pub(crate) struct ZccacheBuildSession {
     pub(crate) binary_path: std::path::PathBuf,
@@ -334,6 +400,82 @@ pub(crate) fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), 
         &["session-end", &session.session_id, "--json"],
         &output,
     )))
+}
+
+pub(crate) fn stop_zccache_after_command(
+    session: &ZccacheBuildSession,
+    timeout: std::time::Duration,
+) -> Result<(), SoldrError> {
+    let output =
+        run_zccache_command_raw_in_cache_dir(&session.binary_path, &["stop"], &session.cache_dir)?;
+    if output.status.success() {
+        eprintln!("soldr: command-lifetime cache: zccache stop requested");
+    } else if zccache_daemon_already_stopped_output(&output) {
+        eprintln!("soldr: command-lifetime cache: zccache daemon already stopped");
+        return Ok(());
+    } else {
+        return Err(SoldrError::Other(zccache_command_failure_message(
+            &["stop"],
+            &output,
+        )));
+    }
+
+    match poll_zccache_daemon_exit(&session.binary_path, &session.cache_dir, timeout) {
+        ZccacheDaemonExitPollResult::Exited => {
+            eprintln!("soldr: command-lifetime cache: zccache daemon exited");
+            Ok(())
+        }
+        ZccacheDaemonExitPollResult::TimedOut => Err(SoldrError::Other(format!(
+            "command-lifetime cache: zccache daemon did not exit within {}s",
+            timeout.as_secs()
+        ))),
+        ZccacheDaemonExitPollResult::PollFailed(err) => Err(SoldrError::Other(format!(
+            "command-lifetime cache: could not confirm zccache daemon exit: {err}"
+        ))),
+    }
+}
+
+enum ZccacheDaemonExitPollResult {
+    Exited,
+    TimedOut,
+    PollFailed(String),
+}
+
+fn poll_zccache_daemon_exit(
+    binary: &std::path::Path,
+    cache_dir: &std::path::Path,
+    timeout: std::time::Duration,
+) -> ZccacheDaemonExitPollResult {
+    let deadline = std::time::Instant::now() + timeout;
+    let poll_interval = std::time::Duration::from_millis(100);
+    loop {
+        match run_zccache_command_raw_in_cache_dir(binary, &["status"], cache_dir) {
+            Ok(output) => {
+                if zccache_daemon_already_stopped_output(&output) {
+                    return ZccacheDaemonExitPollResult::Exited;
+                }
+            }
+            Err(err) => return ZccacheDaemonExitPollResult::PollFailed(err.to_string()),
+        }
+        if std::time::Instant::now() >= deadline {
+            return ZccacheDaemonExitPollResult::TimedOut;
+        }
+        std::thread::sleep(poll_interval);
+    }
+}
+
+fn zccache_daemon_already_stopped_output(output: &std::process::Output) -> bool {
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    )
+    .to_ascii_lowercase();
+    combined.contains("daemon not running")
+        || combined.contains("no daemon to stop")
+        || combined.contains("no daemon")
+        || combined.contains("not running")
+        || combined.contains("connection refused")
 }
 
 fn finish_zccache_build_text_fallback(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
@@ -1000,5 +1142,49 @@ mod tests {
             effective_daemon_rust_log(Some("zccache_daemon=trace")),
             "zccache_daemon=trace"
         );
+    }
+
+    #[test]
+    fn cache_lifecycle_defaults_to_job_long_cache() {
+        assert_eq!(
+            cache_lifecycle_from_env_value(None).unwrap(),
+            CacheLifecycle::Job
+        );
+        assert_eq!(
+            cache_lifecycle_from_env_value(Some(OsStr::new(""))).unwrap(),
+            CacheLifecycle::Job
+        );
+        assert_eq!(
+            cache_lifecycle_from_env_value(Some(OsStr::new("job"))).unwrap(),
+            CacheLifecycle::Job
+        );
+    }
+
+    #[test]
+    fn cache_lifecycle_accepts_command_lifetime_aliases() {
+        for value in ["command", "COMMAND", "command-lifetime", "self-build"] {
+            assert_eq!(
+                cache_lifecycle_from_env_value(Some(OsStr::new(value))).unwrap(),
+                CacheLifecycle::Command,
+                "expected {value:?} to enable command-lifetime cache shutdown"
+            );
+        }
+    }
+
+    #[test]
+    fn cache_lifecycle_rejects_unknown_values() {
+        let err = cache_lifecycle_from_env_value(Some(OsStr::new("forever"))).unwrap_err();
+        assert!(
+            err.to_string().contains(SOLDR_CACHE_LIFECYCLE_ENV_VAR),
+            "expected env var name in error: {err}"
+        );
+    }
+
+    #[test]
+    fn command_lifetime_shutdown_timeout_parser_defaults_and_validates() {
+        assert_eq!(parse_shutdown_timeout_seconds("").unwrap(), 30);
+        assert_eq!(parse_shutdown_timeout_seconds(" 5 ").unwrap(), 5);
+        assert!(parse_shutdown_timeout_seconds("0").is_err());
+        assert!(parse_shutdown_timeout_seconds("abc").is_err());
     }
 }

--- a/crates/soldr-cli/tests/cli_cargo_basic.rs
+++ b/crates/soldr-cli/tests/cli_cargo_basic.rs
@@ -258,6 +258,90 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
     assert_eq!(stats_json["misses"], 3);
 }
 
+#[test]
+fn command_lifetime_cache_stops_zccache_after_successful_cargo() {
+    let cache_root = unique_temp_dir("cargo-command-lifetime-success");
+    let log_path = cache_root.join("tool.log");
+    let down_marker = cache_root.join("zccache-down");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_CACHE_LIFECYCLE", "command")
+        .env("SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS", "1")
+        .env("SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER", &down_marker)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run soldr cargo build with command-lifetime cache");
+
+    assert!(
+        output.status.success(),
+        "command-lifetime build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert_command_lifetime_shutdown_order(&log);
+    let zccache_cache_dir = cache_root.join("cache").join("zccache");
+    assert!(
+        path_display_variants(&zccache_cache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("zccache stop cache_dir={path}"))),
+        "command-lifetime stop must use the soldr-managed cache root: {log}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("command-lifetime cache: zccache daemon exited"),
+        "expected command-lifetime shutdown diagnostic: {stderr}"
+    );
+}
+
+#[test]
+fn command_lifetime_cache_stops_zccache_after_failing_cargo() {
+    let cache_root = unique_temp_dir("cargo-command-lifetime-fail");
+    let log_path = cache_root.join("tool.log");
+    let down_marker = cache_root.join("zccache-down");
+    let tool_dir = unique_temp_dir("fake-failing-cargo-toolchain");
+    let cargo = fake_script_path(&tool_dir, "cargo");
+    let rustc = fake_script_path(&tool_dir, "rustc");
+    let zccache = fake_script_path(&tool_dir, "zccache");
+    write_fake_script(&cargo, &fake_failing_cargo_script(&log_path));
+    write_fake_script(&rustc, &fake_rustc_script(&log_path));
+    write_fake_script(&zccache, &fake_zccache_script(&log_path));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_CACHE_LIFECYCLE", "command")
+        .env("SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS", "1")
+        .env("SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER", &down_marker)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run failing soldr cargo build with command-lifetime cache");
+
+    assert!(
+        !output.status.success(),
+        "failing cargo should propagate a non-zero exit status"
+    );
+    assert_eq!(output.status.code(), Some(17));
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert!(
+        log.contains("cargo failing"),
+        "failing cargo should have run before shutdown: {log}"
+    );
+    assert_command_lifetime_shutdown_order(&log);
+}
+
 #[cfg(windows)]
 #[test]
 fn windows_worktree_copy_relocates_wrapper_and_original_dir_can_be_removed() {
@@ -445,4 +529,38 @@ fn cargo_front_door_respects_dev_debug_in_cargo_config_toml() {
         !stderr.contains("Cargo profile.dev.debug is unspecified"),
         "explicit .cargo/config.toml profile.dev.debug should suppress warning: {stderr}"
     );
+}
+
+fn assert_command_lifetime_shutdown_order(log: &str) {
+    let session_end = log
+        .find("zccache session-end test-session --json")
+        .unwrap_or_else(|| panic!("session-end missing from fake zccache log: {log}"));
+    let stop = log
+        .find("zccache stop")
+        .unwrap_or_else(|| panic!("zccache stop missing from fake zccache log: {log}"));
+    assert!(
+        session_end < stop,
+        "command-lifetime shutdown must finalize stats before stopping daemon: {log}"
+    );
+}
+
+fn fake_failing_cargo_script(log_path: &Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\n\
+             echo cargo failing wrapper=%RUSTC_WRAPPER% rustc=%RUSTC% cache=%SOLDR_CACHE_ENABLED% session=%ZCCACHE_SESSION_ID% zccache_dir=%ZCCACHE_CACHE_DIR%>>\"{}\"\n\
+             exit /b 17\n",
+            log_path.display()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!(
+            "#!/bin/sh\n\
+             echo \"cargo failing wrapper=${{RUSTC_WRAPPER:-}} rustc=${{RUSTC:-}} cache=${{SOLDR_CACHE_ENABLED:-}} session=${{ZCCACHE_SESSION_ID:-}} zccache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{}\"\n\
+             exit 17\n",
+            log_path.display()
+        )
+    }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1116,6 +1116,8 @@ Commands:
 | `SOLDR_ZCCACHE_BIN` | Managed zccache binary path passed from soldr front door into wrapper mode | unset |
 | `SOLDR_ZCCACHE_LOCAL_DIR` | Override the managed-zccache resolution: instead of fetching from GitHub Releases (or installing from crates.io), use the locally-built binaries in this directory. Expected to contain `zccache.exe`, `zccache-daemon.exe`, and `zccache-fp.exe` (or no-extension equivalents on Unix). Adjacent `.pdb` files (Windows), `.dwp` files (Linux), or `.dSYM` directories (macOS) are copied alongside so debuggers can resolve symbols. Used to chase the zccache daemon-stdio hang on Windows where the released binary ships without easily discoverable PDBs. Run `soldr doctor` to confirm the resolved `symbol path`. | unset |
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
+| `SOLDR_CACHE_LIFECYCLE` | zccache daemon lifetime for `soldr cargo ...`. `job` keeps the scoped daemon alive for later soldr invocations in the same job. `command` ends the zccache session and stops the scoped daemon before `soldr cargo ...` exits; intended for self-build CI where later tests must not inherit the builder daemon. | `job` |
+| `SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS` | Maximum seconds to wait for command-lifetime zccache shutdown confirmation after `zccache stop`. | `30` |
 | `SOLDR_RELOCATED_EXE` | Internal recursion guard set after Windows self-relocation | unset |
 | `SOLDR_ORIGINAL_EXE` | Internal path to the original executable when Windows self-relocation is active | unset |
 | `ZCCACHE_CACHE_DIR` | zccache cache-root override set by soldr for managed zccache commands | `~/.soldr/cache/zccache` |
@@ -1137,6 +1139,13 @@ When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr 
 When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must match the cache root derived from `SOLDR_CACHE_DIR`; conflicting values are rejected. Custom wrapper modes leave caller-provided wrapper environment alone — when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has set `SCCACHE_DIR` themselves, soldr forwards their value rather than overriding it.
 
 `soldr cargo ...` only starts the managed build cache for compile-like Cargo subcommands such as `build`, `check`, `test`, `run`, `doc`, `clippy`, and `nextest`. Non-build Cargo commands such as `cargo metadata` and `cargo --version` pass through without starting zccache.
+
+Set `SOLDR_CACHE_LIFECYCLE=command` for self-build jobs that use soldr only as
+the builder and then run tests against zccache or soldr itself. The command
+lifetime mode finalizes zccache session stats first, then runs `zccache stop`
+against soldr's scoped `ZCCACHE_CACHE_DIR` and waits until `zccache status`
+reports that daemon is gone. It does not kill unrelated zccache daemons rooted
+at other cache directories.
 
 On Windows, soldr may copy the running `soldr.exe` into `SOLDR_CACHE_DIR/runtime/soldr-self/<version-and-hash>/soldr.exe` and re-run the command from that relocated copy before build orchestration starts. This keeps disposable worktree builds from repeatedly using the worktree-local `soldr.exe` as `RUSTC_WRAPPER`. The trampoline sets `SOLDR_RELOCATED_EXE=1` and `SOLDR_ORIGINAL_EXE=<original path>` as a recursion guard and preserves argv, inherited environment, stdio, and exit status. Stale relocated copies are purged by a best-effort runtime GC step that runs periodically and skips copies that cannot be removed because they are still locked.
 


### PR DESCRIPTION
## Summary
- adds `SOLDR_CACHE_LIFECYCLE=command` for opt-in command-lifetime zccache daemon cleanup after `soldr cargo ...`
- finalizes zccache session stats before stopping the scoped daemon rooted at soldr's managed `ZCCACHE_CACHE_DIR`
- waits for `zccache status` to report the daemon is gone, with `SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS` as the timeout knob
- documents the new env vars and self-build use case

## Test Plan
- [x] `cargo test -p soldr-cli --test cli_cargo_basic command_lifetime_cache -- --nocapture`
- [x] `cargo test -p soldr-cli --bin soldr cache_lifecycle`
- [x] `cargo test -p soldr-cli --bin soldr command_lifetime_shutdown_timeout_parser`
- [x] `cargo test -p soldr-cli --test cli_cargo_basic`
- [x] `cargo check -p soldr-cli`
- [x] `git diff --check`

Closes #525.
Part of zackees/zccache#405.