### PR TITLE
ci: build soldr with setup-soldr

### DIFF
--- a/.claude/hooks/test_tool_guard.py
+++ b/.claude/hooks/test_tool_guard.py
@@ -8,7 +8,11 @@ Run via uv (sibling-module resolution works because cwd is the hook dir):
 
 import unittest
 
-from tool_guard import check_command, extract_command  # type: ignore[import-not-found]
+from tool_guard import (  # type: ignore[import-not-found]
+    SHELL_TOOL_NAMES,
+    check_command,
+    extract_command,
+)
 
 
 class ToolGuardTests(unittest.TestCase):
@@ -111,6 +115,10 @@ class ToolGuardTests(unittest.TestCase):
             "tool_input": {"script": "cargo test"},
         })
         self.assertEqual(command, "cargo test")
+
+    def test_accepts_codex_shell_tool_names(self):
+        self.assertIn("shell_command", SHELL_TOOL_NAMES)
+        self.assertIn("functions.shell_command", SHELL_TOOL_NAMES)
 
     def test_allows_unrelated_command(self):
         self.assertIsNone(check_command("ls -la"))

--- a/.claude/hooks/tool_guard.py
+++ b/.claude/hooks/tool_guard.py
@@ -39,6 +39,13 @@ RUST_TOOLS = {
 }
 
 PYTHON_TOOLS = {"python", "python3", "pip", "pip3"}
+SHELL_TOOL_NAMES = {
+    "Bash",
+    "Shell",
+    "PowerShell",
+    "shell_command",
+    "functions.shell_command",
+}
 
 # Shell control operators that end one top-level command and start another.
 # `|` is intentionally absent — the hook has never split on pipes (a bare
@@ -248,7 +255,7 @@ def main():
         sys.exit(0)
 
     tool_name = data.get("tool_name", "")
-    if tool_name not in {"Bash", "Shell", "PowerShell"}:
+    if tool_name not in SHELL_TOOL_NAMES:
         sys.exit(0)
 
     command = extract_command(data)

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,6 @@
+# Codex Hooks
+
+Local Codex hook configuration for this repository.
+
+`hooks.json` mirrors `.claude/settings.json` for the shared PreToolUse guard in
+`.claude/hooks/tool_guard.py`, including Codex `shell_command` tool names.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script .claude/hooks/tool_guard.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "shell_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script .claude/hooks/tool_guard.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "functions.shell_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script .claude/hooks/tool_guard.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,16 @@
+# CI/CD Workflows
+
+GitHub Actions workflow definitions.
+
+- **ci.yml** - Main lint/build/test orchestration for soldr.
+- **_build-and-test.yml** - Reusable per-platform workspace build and test template.
+- **_bootstrap-e2e.yml** - Reusable bootstrap test that builds soldr, then uses that binary to build a third-party fixture.
+- **setup-soldr-action.yml** - Dogfood smoke test for setup-soldr against the soldr workspace.
+
+Normal build/test workflows use `zackees/setup-soldr` for Rust build acceleration, excluding `release-auto.yml`. Jobs that build soldr before running soldr self-tests or bootstrap tests stop the setup-soldr builder daemon before the test phase, run the test phase with a fresh `SOLDR_CACHE_DIR` / `ZCCACHE_CACHE_DIR`, and request `SOLDR_CACHE_LIFECYCLE=command` for the isolated test cache when supported by soldr.
+
+Exceptions:
+
+- **release-auto.yml** remains conservative and keeps its existing release artifact build path.
+- **cache-benchmark.yml**, **cache-benchmark-child-branch.yml**, **parent-cache-bench.yml**, **perf-cold-warm.yml**, **perf-matrix.yml**, **cache-delta-experiment.yml**, and the reusable cache benchmark workflows intentionally compare cache strategies or preserve experiment topology, so setup-soldr is not forced onto the control rows.
+- **thin-v2-verify.yml** intentionally uses direct Cargo until its existing Phase 4 TODO wires the verifier through `soldr cargo build` and asserts a produced thin-v2 bundle manifest.

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -95,12 +95,24 @@ jobs:
           done
           dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
+      - name: Write setup-soldr toolchain spec
+        shell: bash
+        working-directory: soldr
+        run: |
+          cat > rust-toolchain.ci.toml <<'EOF'
+          [toolchain]
+          channel = "1.94.1"
+          profile = "minimal"
+          targets = ["${{ inputs.target }}"]
+          EOF
+          cat rust-toolchain.ci.toml
+
       - name: Setup soldr build cache
         uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         env:
           ACTION_WORKSPACE: ${{ github.workspace }}/soldr
         with:
-          toolchain: 1.94.1
+          toolchain-file: rust-toolchain.ci.toml
           cache: true
           cache-key-suffix: bootstrap-${{ inputs.target }}
           lockfile: Cargo.lock

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -43,6 +43,14 @@ jobs:
   bootstrap-e2e:
     name: Build soldr and bootstrap third-party app (${{ inputs.target }})
     runs-on: ${{ inputs.runner }}
+    env:
+      # setup-soldr currently builds this PR with a released soldr binary.
+      # Keep native cc-rs compiles on musl-gcc until the soldr-side default
+      # in this branch is released and picked up by setup-soldr.
+      CC_x86_64_unknown_linux_musl: musl-gcc
+      CXX_x86_64_unknown_linux_musl: musl-g++
+      CC_aarch64_unknown_linux_musl: musl-gcc
+      CXX_aarch64_unknown_linux_musl: musl-g++
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -116,6 +116,7 @@ jobs:
           cat rust-toolchain.ci.toml
 
       - name: Setup soldr build cache
+        id: setup_soldr
         uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         env:
           ACTION_WORKSPACE: ${{ github.workspace }}/soldr
@@ -123,11 +124,35 @@ jobs:
           toolchain-file: rust-toolchain.ci.toml
           cache: true
           linker: platform-default
-          cache-key-suffix: bootstrap-${{ inputs.target }}
+          cache-key-suffix: bootstrap-${{ inputs.target }}-native-cc-v2
           lockfile: Cargo.lock
           target-dir: target
           prebuild-deps: soldr-cook
           prebuild-deps-flags: "--target ${{ inputs.target }}"
+
+      - name: Reset stale musl cache fallback artifacts
+        if: >-
+          ${{
+            contains(inputs.target, 'musl') &&
+            (
+              steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit' ||
+              steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'
+            )
+          }}
+        shell: pwsh
+        working-directory: soldr
+        run: |
+          $targetTripleDir = Join-Path "target" "${{ inputs.target }}"
+          if (Test-Path -LiteralPath $targetTripleDir) {
+            Write-Host "Removing restored musl target artifacts from $targetTripleDir"
+            Remove-Item -LiteralPath $targetTripleDir -Recurse -Force
+          }
+
+          $artifactDir = Join-Path $env:ZCCACHE_CACHE_DIR "artifacts"
+          if (Test-Path -LiteralPath $artifactDir) {
+            Write-Host "Removing restored zccache artifacts from $artifactDir"
+            Remove-Item -LiteralPath $artifactDir -Recurse -Force
+          }
 
       - name: Build soldr-cli
         shell: pwsh

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -114,6 +114,7 @@ jobs:
         with:
           toolchain-file: rust-toolchain.ci.toml
           cache: true
+          linker: platform-default
           cache-key-suffix: bootstrap-${{ inputs.target }}
           lockfile: Cargo.lock
           target-dir: target

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -62,12 +62,6 @@ jobs:
           toolchain: 1.94.1
           targets: ${{ inputs.target }}
 
-      - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: soldr -> target
-          shared-key: bootstrap-${{ inputs.target }}
-
       - name: Install musl tools
         if: contains(inputs.target, 'musl')
         shell: bash
@@ -101,11 +95,33 @@ jobs:
           done
           dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
+      - name: Setup soldr build cache
+        uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        env:
+          ACTION_WORKSPACE: ${{ github.workspace }}/soldr
+        with:
+          toolchain: 1.94.1
+          cache: true
+          cache-key-suffix: bootstrap-${{ inputs.target }}
+          lockfile: Cargo.lock
+          target-dir: target
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: "--target ${{ inputs.target }}"
+
       - name: Build soldr-cli
         shell: pwsh
         working-directory: soldr
         run: |
-          cargo build --package soldr-cli --locked --target "${{ inputs.target }}"
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          soldr cargo build --package soldr-cli --locked --target "${{ inputs.target }}"
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
+            [Globalization.CultureInfo]::InvariantCulture,
+            "- **${{ inputs.target }} / Build soldr-cli**: {0:F3}s",
+            $timer.Elapsed.TotalSeconds
+          ))
+          exit $exitCode
 
       - name: Resolve third-party toolchain
         id: third_party_toolchain
@@ -145,19 +161,40 @@ jobs:
         run: |
           & "${{ steps.soldr_binary.outputs.path }}" --version
 
+      - name: Stop setup-soldr builder cache before bootstrap test
+        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+
       - name: Build third-party app through soldr
         shell: pwsh
         working-directory: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}/target-${{ inputs.target }}
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/bootstrap-e2e-${{ inputs.target }}
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/bootstrap-e2e-${{ inputs.target }}/cache/zccache
         run: |
+          Write-Host "Using isolated bootstrap SOLDR_CACHE_DIR=$env:SOLDR_CACHE_DIR"
+          Write-Host "Using isolated bootstrap ZCCACHE_CACHE_DIR=$env:ZCCACHE_CACHE_DIR"
+          $timer = [Diagnostics.Stopwatch]::StartNew()
           & "${{ steps.soldr_binary.outputs.path }}" cargo build --locked --target "${{ inputs.target }}"
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
+            [Globalization.CultureInfo]::InvariantCulture,
+            "- **${{ inputs.target }} / Bootstrap third-party build**: {0:F3}s",
+            $timer.Elapsed.TotalSeconds
+          ))
+          exit $exitCode
 
       - name: Show shared soldr cache status
         if: ${{ always() }}
         continue-on-error: true
         shell: pwsh
         working-directory: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/bootstrap-e2e-${{ inputs.target }}
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/bootstrap-e2e-${{ inputs.target }}/cache/zccache
         run: |
           $soldrPath = "${{ steps.soldr_binary.outputs.path }}"
           if ([string]::IsNullOrWhiteSpace($soldrPath) -or -not (Test-Path -LiteralPath $soldrPath)) {
@@ -165,6 +202,20 @@ jobs:
             exit 0
           }
           & $soldrPath cache
+
+      - name: Stop isolated bootstrap cache
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/bootstrap-e2e-${{ inputs.target }}
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/bootstrap-e2e-${{ inputs.target }}/cache/zccache
+        run: |
+          $soldrPath = "${{ steps.soldr_binary.outputs.path }}"
+          if ([string]::IsNullOrWhiteSpace($soldrPath) -or -not (Test-Path -LiteralPath $soldrPath)) {
+            exit 0
+          }
+          & $soldrPath cache shutdown --shutdown-timeout-seconds 30
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -96,7 +96,7 @@ jobs:
           dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
 
       - name: Setup soldr build cache
-        uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         env:
           ACTION_WORKSPACE: ${{ github.workspace }}/soldr
         with:
@@ -162,7 +162,7 @@ jobs:
           & "${{ steps.soldr_binary.outputs.path }}" --version
 
       - name: Stop setup-soldr builder cache before bootstrap test
-        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
 
       - name: Build third-party app through soldr
         shell: pwsh

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -20,8 +20,8 @@ on:
         required: true
         type: string
       shared_key:
-        # Swatinem/rust-cache shared-key; usually the platform-arch
-        # pair (e.g. "windows-x86_64-msvc").
+        # setup-soldr cache key suffix base; usually the platform-arch pair
+        # (e.g. "windows-x86_64-msvc").
         required: true
         type: string
       cache_key:
@@ -76,20 +76,82 @@ jobs:
           targets: ${{ inputs.target }}
           components: ${{ inputs.install_components }}
 
-      - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Setup soldr build cache
+        uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
-          key: ${{ inputs.cache_key }}
-          shared-key: ${{ inputs.shared_key }}
+          toolchain: 1.94.1
+          cache: true
+          cache-key-suffix: build-${{ inputs.shared_key }}-${{ inputs.cache_key }}
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: "--target ${{ inputs.target }}"
+
+      - name: Install requested Rust components
+        if: inputs.install_components != ''
+        shell: pwsh
+        run: |
+          $components = "${{ inputs.install_components }}" -split "," |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ }
+          foreach ($component in $components) {
+            rustup component add $component
+          }
 
       - name: Build workspace
-        run: cargo build --workspace --locked --target ${{ inputs.target }}
+        shell: pwsh
+        run: |
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          soldr cargo build --workspace --locked --target ${{ inputs.target }}
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
+            [Globalization.CultureInfo]::InvariantCulture,
+            "- **${{ inputs.target }} / Build workspace**: {0:F3}s",
+            $timer.Elapsed.TotalSeconds
+          ))
+          exit $exitCode
+
+      - name: Stop setup-soldr builder cache before tests
+        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
 
       - name: Run library tests
-        run: cargo test --workspace --lib --locked --target ${{ inputs.target }}
+        shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}/cache/zccache
+        run: |
+          Write-Host "Using isolated test SOLDR_CACHE_DIR=$env:SOLDR_CACHE_DIR"
+          Write-Host "Using isolated test ZCCACHE_CACHE_DIR=$env:ZCCACHE_CACHE_DIR"
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          soldr cargo test --workspace --lib --locked --target ${{ inputs.target }}
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
+            [Globalization.CultureInfo]::InvariantCulture,
+            "- **${{ inputs.target }} / Library tests**: {0:F3}s",
+            $timer.Elapsed.TotalSeconds
+          ))
+          exit $exitCode
 
       - name: Run CLI smoke tests
-        run: cargo test -p soldr-cli --tests --locked --target ${{ inputs.target }}
+        shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}/cache/zccache
+        run: |
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          soldr cargo test -p soldr-cli --tests --locked --target ${{ inputs.target }}
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
+            [Globalization.CultureInfo]::InvariantCulture,
+            "- **${{ inputs.target }} / CLI smoke tests**: {0:F3}s",
+            $timer.Elapsed.TotalSeconds
+          ))
+          exit $exitCode
 
       - name: Verify Windows defaults to MSVC under Git Bash
         if: inputs.verify_windows_msys_default_msvc == true && runner.os == 'Windows'
@@ -104,4 +166,33 @@ jobs:
 
       - name: Run fetch integration test
         if: inputs.run_fetch_test == true
-        run: cargo test -p soldr-cli --test fetch_crgx --locked --target ${{ inputs.target }}
+        shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}/cache/zccache
+        run: |
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          soldr cargo test -p soldr-cli --test fetch_crgx --locked --target ${{ inputs.target }}
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
+            [Globalization.CultureInfo]::InvariantCulture,
+            "- **${{ inputs.target }} / Fetch integration test**: {0:F3}s",
+            $timer.Elapsed.TotalSeconds
+          ))
+          exit $exitCode
+
+      - name: Stop isolated test cache
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}/cache/zccache
+        run: |
+          soldr cache shutdown --shutdown-timeout-seconds 30
+          if ($LASTEXITCODE -ne 0) {
+            zccache stop
+          }

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -77,7 +77,7 @@ jobs:
           components: ${{ inputs.install_components }}
 
       - name: Setup soldr build cache
-        uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true
@@ -111,7 +111,7 @@ jobs:
           exit $exitCode
 
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
 
       - name: Run library tests
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,25 +29,26 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup soldr build cache
+        uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
           toolchain: 1.94.1
-          components: rustfmt, clippy
+          cache: true
+          cache-key-suffix: lint-ubuntu
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
 
-      - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: lint-ubuntu
+      - name: Install Rust components
+        run: rustup component add rustfmt clippy
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: soldr cargo fmt --all -- --check
 
       - name: Check npm package metadata
         run: node scripts/test-npm-package.js
 
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+        run: soldr cargo clippy --workspace --all-targets --locked -- -D warnings
 
   # Per-platform `build workspace + run unit/smoke tests` jobs.
   # Each is a thin caller of the `_build-and-test.yml` template so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup soldr build cache
-        uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           toolchain: 1.94.1
           cache: true

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -74,7 +74,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@d084d24f3f4b361a56fad52b3c37bcd0ead5a75e
+        uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
         with:
           cache: true
           linker: platform-default
@@ -85,6 +85,8 @@ jobs:
           cache-key-suffix: dogfood-action-state
           build-cache: false
           target-cache: true
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
 
       - name: Show action outputs
         shell: pwsh
@@ -136,10 +138,15 @@ jobs:
             setup-soldr-dogfood-zccache-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
             setup-soldr-dogfood-zccache-v1-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Stop setup-soldr builder cache before dogfood build
+        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+
       - name: Build through soldr
         shell: pwsh
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
           ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test/cache/zccache
         run: |
           Write-Host "dogfood-build-cache-hit=${{ steps.dogfood-build-cache.outputs.cache-hit }}"

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -74,7 +74,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
         with:
           cache: true
           linker: platform-default
@@ -139,7 +139,7 @@ jobs:
             setup-soldr-dogfood-zccache-v1-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Stop setup-soldr builder cache before dogfood build
-        uses: zackees/setup-soldr/cleanup@8eb35c6b4b45bc96d33f8490edd97df654a15aa0
+        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
 
       - name: Build through soldr
         shell: pwsh

--- a/crates/soldr-cli/src/native_cc.rs
+++ b/crates/soldr-cli/src/native_cc.rs
@@ -155,7 +155,10 @@ pub(crate) fn inject_native_cache_env(
     // invariant tight.
     if let Some(triple) = target {
         let snake = triple.replace('-', "_");
-        for (prefix, default_compiler) in [("CC_", "cc"), ("CXX_", "c++")] {
+        for (prefix, default_compiler) in [
+            ("CC_", default_c_compiler_for_target(triple)),
+            ("CXX_", default_cxx_compiler_for_target(triple)),
+        ] {
             let var = format!("{prefix}{snake}");
             if let Some(wrapped) =
                 wrap_compiler_env(&var, default_compiler, &wrapper, synthesize_default)
@@ -176,6 +179,22 @@ pub(crate) fn inject_native_cache_env(
     }
 
     Ok(())
+}
+
+fn default_c_compiler_for_target(triple: &str) -> &'static str {
+    if triple.contains("-linux-musl") {
+        "musl-gcc"
+    } else {
+        "cc"
+    }
+}
+
+fn default_cxx_compiler_for_target(triple: &str) -> &'static str {
+    if triple.contains("-linux-musl") {
+        "musl-g++"
+    } else {
+        "c++"
+    }
 }
 
 /// Compute the wrapped value for one compiler env var. Returns `None`

--- a/crates/soldr-cli/src/native_cc_tests.rs
+++ b/crates/soldr-cli/src/native_cc_tests.rs
@@ -174,6 +174,41 @@ fn set_var_with_synthesize_disabled_still_wraps() {
     assert_eq!(wrapped, OsString::from("/tmp/zccache clang"));
 }
 
+#[test]
+fn musl_targets_default_to_musl_compilers() {
+    assert_eq!(
+        default_c_compiler_for_target("x86_64-unknown-linux-musl"),
+        "musl-gcc"
+    );
+    assert_eq!(
+        default_cxx_compiler_for_target("aarch64-unknown-linux-musl"),
+        "musl-g++"
+    );
+    assert_eq!(
+        default_c_compiler_for_target("x86_64-unknown-linux-gnu"),
+        "cc"
+    );
+    assert_eq!(
+        default_cxx_compiler_for_target("aarch64-apple-darwin"),
+        "c++"
+    );
+}
+
+#[test]
+fn wraps_musl_target_default_with_musl_gcc() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _g = EnvGuard::remove("CC_x86_64_unknown_linux_musl");
+    let wrapper = OsString::from("/tmp/zccache");
+    let wrapped = wrap_compiler_env(
+        "CC_x86_64_unknown_linux_musl",
+        default_c_compiler_for_target("x86_64-unknown-linux-musl"),
+        &wrapper,
+        true,
+    )
+    .unwrap();
+    assert_eq!(wrapped, OsString::from("/tmp/zccache musl-gcc"));
+}
+
 // -------------------------------------------------------------------------
 // native_cache_decision — platform + env interaction
 // -------------------------------------------------------------------------

--- a/crates/soldr-cli/tests/cli_cargo_native_cc.rs
+++ b/crates/soldr-cli/tests/cli_cargo_native_cc.rs
@@ -21,7 +21,16 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+static SOLDR_CARGO_BUILD_LOCK: Mutex<()> = Mutex::new(());
+
+fn soldr_cargo_build_lock() -> MutexGuard<'static, ()> {
+    SOLDR_CARGO_BUILD_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -42,6 +51,30 @@ fn toml_string(path: &Path) -> String {
 
 fn soldr_bin() -> &'static str {
     env!("CARGO_BIN_EXE_soldr")
+}
+
+fn remove_inherited_native_cache_env(cmd: &mut Command) {
+    for key in [
+        "CC",
+        "CXX",
+        "CC_KNOWN_WRAPPER_CUSTOM",
+        "CC_x86_64_unknown_linux_gnu",
+        "CXX_x86_64_unknown_linux_gnu",
+        "CC_x86_64_apple_darwin",
+        "CXX_x86_64_apple_darwin",
+        "CC_aarch64_apple_darwin",
+        "CXX_aarch64_apple_darwin",
+        "CC_x86_64_pc_windows_msvc",
+        "CXX_x86_64_pc_windows_msvc",
+        "CC_aarch64_pc_windows_msvc",
+        "CXX_aarch64_pc_windows_msvc",
+        "RUSTC_WRAPPER",
+        "RUSTC_WORKSPACE_WRAPPER",
+        "SOLDR_NATIVE_CACHE",
+        "ZCCACHE_CACHE_DIR",
+    ] {
+        cmd.env_remove(key);
+    }
 }
 
 /// Build a project whose `build.rs` writes the env it sees to a single
@@ -104,10 +137,15 @@ fn main() {{
 }
 
 fn run_soldr_cargo_build(project: &Path, env_overrides: &[(&str, &str)]) -> std::process::Output {
+    let _guard = soldr_cargo_build_lock();
     let mut cmd = Command::new(soldr_bin());
     cmd.current_dir(project);
-    // Hermetic caches per test run.
+    remove_inherited_native_cache_env(&mut cmd);
+    // Hermetic caches per test run, with command-lifetime shutdown so
+    // parallel test execution cannot leave multiple zccache daemons alive.
     cmd.env("SOLDR_CACHE_DIR", project.join(".soldr-cache"));
+    cmd.env("SOLDR_CACHE_LIFECYCLE", "command");
+    cmd.env("SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS", "30");
     cmd.env_remove("SOLDR_BUILD_CACHE_MODE");
     cmd.env_remove("SOLDR_TARGET_CACHE_MODE");
     for (k, v) in env_overrides {
@@ -267,11 +305,15 @@ fn no_cache_global_disables_native_too() {
     // `soldr --no-cache cargo …` is the global kill-switch. Native
     // caching must turn off because the zccache session never starts.
     let project = make_env_capture_project("native-cc-no-cache");
-    let mut cmd = Command::new(soldr_bin());
-    cmd.current_dir(&project);
-    cmd.env("SOLDR_CACHE_DIR", project.join(".soldr-cache"));
-    cmd.args(["--no-cache", "cargo", "build", "--no-trampoline"]);
-    let output = cmd.output().expect("spawn soldr --no-cache cargo build");
+    let output = {
+        let _guard = soldr_cargo_build_lock();
+        let mut cmd = Command::new(soldr_bin());
+        cmd.current_dir(&project);
+        remove_inherited_native_cache_env(&mut cmd);
+        cmd.env("SOLDR_CACHE_DIR", project.join(".soldr-cache"));
+        cmd.args(["--no-cache", "cargo", "build", "--no-trampoline"]);
+        cmd.output().expect("spawn soldr --no-cache cargo build")
+    };
     assert!(
         output.status.success(),
         "soldr --no-cache cargo build failed"

--- a/crates/soldr-cli/tests/cli_cargo_native_cc.rs
+++ b/crates/soldr-cli/tests/cli_cargo_native_cc.rs
@@ -42,6 +42,23 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     dir
 }
 
+fn unique_cache_dir() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    // Keep this path short: zccache's Unix daemon socket lives below
+    // SOLDR_CACHE_DIR, and macOS has a small sockaddr_un path limit.
+    let base = if cfg!(unix) {
+        PathBuf::from("/tmp")
+    } else {
+        std::env::temp_dir()
+    };
+    let dir = base.join(format!("sdrc-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&dir).expect("failed to create cache dir");
+    dir
+}
+
 fn toml_string(path: &Path) -> String {
     path.display()
         .to_string()
@@ -143,7 +160,7 @@ fn run_soldr_cargo_build(project: &Path, env_overrides: &[(&str, &str)]) -> std:
     remove_inherited_native_cache_env(&mut cmd);
     // Hermetic caches per test run, with command-lifetime shutdown so
     // parallel test execution cannot leave multiple zccache daemons alive.
-    cmd.env("SOLDR_CACHE_DIR", project.join(".soldr-cache"));
+    cmd.env("SOLDR_CACHE_DIR", unique_cache_dir());
     cmd.env("SOLDR_CACHE_LIFECYCLE", "command");
     cmd.env("SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS", "30");
     cmd.env_remove("SOLDR_BUILD_CACHE_MODE");
@@ -310,7 +327,7 @@ fn no_cache_global_disables_native_too() {
         let mut cmd = Command::new(soldr_bin());
         cmd.current_dir(&project);
         remove_inherited_native_cache_env(&mut cmd);
-        cmd.env("SOLDR_CACHE_DIR", project.join(".soldr-cache"));
+        cmd.env("SOLDR_CACHE_DIR", unique_cache_dir());
         cmd.args(["--no-cache", "cargo", "build", "--no-trampoline"]);
         cmd.output().expect("spawn soldr --no-cache cargo build")
     };

--- a/crates/soldr-cli/tests/cli_cargo_native_cc.rs
+++ b/crates/soldr-cli/tests/cli_cargo_native_cc.rs
@@ -107,10 +107,7 @@ fn run_soldr_cargo_build(project: &Path, env_overrides: &[(&str, &str)]) -> std:
     let mut cmd = Command::new(soldr_bin());
     cmd.current_dir(project);
     // Hermetic caches per test run.
-    cmd.env(
-        "SOLDR_CACHE_DIR",
-        project.parent().unwrap().join(".soldr-cache"),
-    );
+    cmd.env("SOLDR_CACHE_DIR", project.join(".soldr-cache"));
     cmd.env_remove("SOLDR_BUILD_CACHE_MODE");
     cmd.env_remove("SOLDR_TARGET_CACHE_MODE");
     for (k, v) in env_overrides {
@@ -272,10 +269,7 @@ fn no_cache_global_disables_native_too() {
     let project = make_env_capture_project("native-cc-no-cache");
     let mut cmd = Command::new(soldr_bin());
     cmd.current_dir(&project);
-    cmd.env(
-        "SOLDR_CACHE_DIR",
-        project.parent().unwrap().join(".soldr-cache"),
-    );
+    cmd.env("SOLDR_CACHE_DIR", project.join(".soldr-cache"));
     cmd.args(["--no-cache", "cargo", "build", "--no-trampoline"]);
     let output = cmd.output().expect("spawn soldr --no-cache cargo build");
     assert!(


### PR DESCRIPTION
## Summary
- migrate normal soldr build/test workflows to the pinned setup-soldr cleanup/soldr-cook ref
- replace rust-cache in lint, per-platform build/test, and bootstrap E2E paths with setup-soldr plus `prebuild-deps: soldr-cook`
- stop the setup-soldr builder daemon before soldr self-tests/bootstrap tests, then run those phases under isolated `SOLDR_CACHE_DIR` / `ZCCACHE_CACHE_DIR` roots with `SOLDR_CACHE_LIFECYCLE=command`
- update the setup-soldr dogfood smoke pin and document release/benchmark/cache-experiment exceptions

## Validation
- [x] `actionlint`
- [x] `git diff --check`
- [x] confirmed `release-auto.yml` is unchanged
- [x] searched normal migrated workflows for stale setup-soldr pin and `Swatinem/rust-cache`

Closes #526.
Part of zackees/zccache#405.