### PR TITLE
ci: bump setup-soldr pin

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Setup soldr build cache
         id: setup_soldr
-        uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         env:
           ACTION_WORKSPACE: ${{ github.workspace }}/soldr
         with:
@@ -208,7 +208,7 @@ jobs:
           & "${{ steps.soldr_binary.outputs.path }}" --version
 
       - name: Stop setup-soldr builder cache before bootstrap test
-        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
 
       - name: Build third-party app through soldr
         shell: pwsh

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -77,7 +77,7 @@ jobs:
           components: ${{ inputs.install_components }}
 
       - name: Setup soldr build cache
-        uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true
@@ -111,7 +111,7 @@ jobs:
           exit $exitCode
 
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
 
       - name: Run library tests
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup soldr build cache
-        uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           toolchain: 1.94.1
           cache: true

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -74,7 +74,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
         with:
           cache: true
           linker: platform-default
@@ -139,7 +139,7 @@ jobs:
             setup-soldr-dogfood-zccache-v1-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Stop setup-soldr builder cache before dogfood build
-        uses: zackees/setup-soldr/cleanup@386201437808bbe52f97b05e531b0276f8e5cebf
+        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
 
       - name: Build through soldr
         shell: pwsh


### PR DESCRIPTION
## Summary

- bump setup-soldr and setup-soldr/cleanup workflow pins from `386201437808bbe52f97b05e531b0276f8e5cebf` to `0425f54e37b65c5c36be1fb73628019b3e1aabed`
- picks up setup-soldr#211 so isolated `SOLDR_CACHE_DIR` / `ZCCACHE_CACHE_DIR` test roots use the pinned zccache seed instead of rebuilding zccache from source

Part of zackees/zccache#405 and zackees/zccache#407.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`