### PR TITLE
style: apply rustfmt

### DIFF
--- a/crates/soldr-cli/src/cache/session.rs
+++ b/crates/soldr-cli/src/cache/session.rs
@@ -697,13 +697,11 @@ fn zccache_flag_unsupported(output: &std::process::Output, flag: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::report::zccache_analyze_failure_note;
     use super::super::{
         zccache_daemon_already_stopped, zccache_output_snippet, ZCCACHE_ANALYZE_NOTE_LIMIT,
     };
-    use super::super::report::zccache_analyze_failure_note;
-    use super::{
-        clear_session_artifacts, zccache_flag_unsupported, zccache_session_already_ended,
-    };
+    use super::{clear_session_artifacts, zccache_flag_unsupported, zccache_session_already_ended};
     use std::process::Output;
 
     fn synthetic_output(stderr: &str, exit: i32) -> Output {

--- a/crates/soldr-cli/src/cache_lib/cargo_global_cache.rs
+++ b/crates/soldr-cli/src/cache_lib/cargo_global_cache.rs
@@ -56,9 +56,7 @@ pub fn read_registry_src_last_used(cargo_home: &Path) -> Option<HashMap<Registry
     read_registry_src_last_used_from_path(&path).ok()
 }
 
-fn read_registry_src_last_used_from_path(
-    path: &Path,
-) -> SqlResult<HashMap<RegistrySrcKey, i64>> {
+fn read_registry_src_last_used_from_path(path: &Path) -> SqlResult<HashMap<RegistrySrcKey, i64>> {
     // Read-only open: never mutates cargo's database. `NO_MUTEX` lets
     // multiple soldr invocations open the DB concurrently — cargo's
     // own writes coordinate through its package-cache lock above the
@@ -165,7 +163,8 @@ mod tests {
         // No `registry_src` / `registry_index` — cargo schema drift
         // (or someone else's DB at the same path). Falling back to
         // mtime is correct here.
-        conn.execute("CREATE TABLE unrelated (id INTEGER)", []).unwrap();
+        conn.execute("CREATE TABLE unrelated (id INTEGER)", [])
+            .unwrap();
         assert!(read_registry_src_last_used(tmp.path()).is_none());
     }
 

--- a/crates/soldr-cli/src/cache_lib/prune_target.rs
+++ b/crates/soldr-cli/src/cache_lib/prune_target.rs
@@ -277,7 +277,13 @@ fn classify_per_parent_prefix(
             .push(idx);
     }
     for indices in buckets.values_mut() {
-        rank_indices(entries, indices, target_dir, fingerprint_decisions, mtime_decisions);
+        rank_indices(
+            entries,
+            indices,
+            target_dir,
+            fingerprint_decisions,
+            mtime_decisions,
+        );
         let mut iter = indices.iter().copied();
         if let Some(keep) = iter.next() {
             entries[keep].action = PruneAction::Keep;
@@ -305,13 +311,16 @@ fn classify_per_prefix(
 ) {
     let mut buckets: HashMap<String, Vec<usize>> = HashMap::new();
     for (idx, entry) in entries.iter().enumerate() {
-        buckets
-            .entry(entry.prefix.clone())
-            .or_default()
-            .push(idx);
+        buckets.entry(entry.prefix.clone()).or_default().push(idx);
     }
     for indices in buckets.values_mut() {
-        rank_indices(entries, indices, target_dir, fingerprint_decisions, mtime_decisions);
+        rank_indices(
+            entries,
+            indices,
+            target_dir,
+            fingerprint_decisions,
+            mtime_decisions,
+        );
         let winning_hash = match indices.first() {
             Some(&idx) => entries[idx].hash.clone(),
             None => continue,
@@ -375,10 +384,7 @@ fn rank_indices(
 /// `libfoo-<hash>.rlib`). We look up `<prefix>-<hash>` first; if
 /// `<prefix>` starts with `lib` and that misses, we retry against
 /// `<prefix without lib>-<hash>`.
-pub(crate) fn entry_recency(
-    entry: &PruneTargetEntry,
-    target_dir: &Path,
-) -> (i64, RecencySource) {
+pub(crate) fn entry_recency(entry: &PruneTargetEntry, target_dir: &Path) -> (i64, RecencySource) {
     let lib_stripped = entry.prefix.strip_prefix("lib");
     let candidates: &[&str] = match lib_stripped {
         Some(stripped) => &[entry.prefix.as_str(), stripped],

--- a/crates/soldr-cli/src/cache_lib/strip_target.rs
+++ b/crates/soldr-cli/src/cache_lib/strip_target.rs
@@ -453,10 +453,7 @@ fn collect_incremental_dir(
     Ok(())
 }
 
-fn collect_stub_binaries(
-    profile: &Path,
-    entries: &mut Vec<StripEntry>,
-) -> Result<(), StripError> {
+fn collect_stub_binaries(profile: &Path, entries: &mut Vec<StripEntry>) -> Result<(), StripError> {
     // The synthetic stub binary cargo-chef produces lives at the
     // top of `target/<profile>/<name>(.exe)`, alongside `.pdb` and
     // `.dSYM/` debug siblings. Cargo's own state files start with
@@ -803,7 +800,10 @@ mod tests {
         let inc = target.join("release/incremental");
         let deps = target.join("release/deps");
         touch_dir(&inc);
-        write_bytes(&inc.join("s-abc/work-product.bin"), b"\0".repeat(1024).as_slice());
+        write_bytes(
+            &inc.join("s-abc/work-product.bin"),
+            b"\0".repeat(1024).as_slice(),
+        );
         write_bytes(&inc.join("s-abc/dep-graph.bin"), &[0u8; 256]);
         touch_dir(&deps);
         let rlib = deps.join("libfoo-aaaaaaaaaaaaa.rlib");
@@ -817,7 +817,10 @@ mod tests {
         let report = strip_target(&opts).unwrap();
         assert_eq!(report.deleted, 1, "the incremental/ dir is one entry");
         assert_eq!(report.entries[0].category, StripCategory::IncrementalDir);
-        assert!(report.entries[0].size_bytes > 0, "size should account for contents");
+        assert!(
+            report.entries[0].size_bytes > 0,
+            "size should account for contents"
+        );
         assert!(!inc.exists(), "incremental/ must be removed");
         assert!(rlib.exists(), "deps/ must survive incremental strip");
     }

--- a/crates/soldr-cli/src/cargo_front_door/disk.rs
+++ b/crates/soldr-cli/src/cargo_front_door/disk.rs
@@ -6,8 +6,8 @@
 //! `pub(super)`.
 
 use crate::core::SoldrError;
-use crate::TEST_FREE_DISK_BYTES_ENV_VAR;
 use crate::LOW_DISK_WARNING_THRESHOLD_BYTES;
+use crate::TEST_FREE_DISK_BYTES_ENV_VAR;
 
 pub(super) fn maybe_emit_low_disk_warning(path: &std::path::Path) {
     if let Some(message) =

--- a/crates/soldr-cli/src/cook.rs
+++ b/crates/soldr-cli/src/cook.rs
@@ -15,8 +15,8 @@
 //! `zackees/setup-soldr#110` for the GitHub Action that consumes the
 //! resulting `target/` tarball.
 
-use crate::cargo_front_door;
 use crate::cache_lib::strip_target::{strip_target, StripTargetOptions};
+use crate::cargo_front_door;
 use crate::core::SoldrError;
 use crate::ZccacheSourceArg;
 use std::path::{Path, PathBuf};

--- a/crates/soldr-cli/src/core/toolchain_resolve.rs
+++ b/crates/soldr-cli/src/core/toolchain_resolve.rs
@@ -17,7 +17,9 @@ use serde::Deserialize;
 
 use super::target_triple::{compile_time_arch, compile_time_host_os, TargetTriple};
 use super::toolchain_manifest::read_rust_toolchain_manifest;
-use super::{non_empty_env_path, CARGO_HOME_ENV_VAR, RUSTUP_HOME_ENV_VAR, RUSTUP_TOOLCHAIN_ENV_VAR};
+use super::{
+    non_empty_env_path, CARGO_HOME_ENV_VAR, RUSTUP_HOME_ENV_VAR, RUSTUP_TOOLCHAIN_ENV_VAR,
+};
 
 #[derive(Debug, Deserialize)]
 struct CargoConfigFile {

--- a/crates/soldr-cli/src/defender_probe.rs
+++ b/crates/soldr-cli/src/defender_probe.rs
@@ -184,9 +184,8 @@ pub fn write_probe_state(paths: &SoldrPaths, state: &DefenderProbeState) -> Resu
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let json = serde_json::to_vec_pretty(state).map_err(|e| {
-        SoldrError::Other(format!("failed to serialize defender-probe state: {e}"))
-    })?;
+    let json = serde_json::to_vec_pretty(state)
+        .map_err(|e| SoldrError::Other(format!("failed to serialize defender-probe state: {e}")))?;
     std::fs::write(&path, json)?;
     Ok(())
 }

--- a/crates/soldr-cli/src/doctor.rs
+++ b/crates/soldr-cli/src/doctor.rs
@@ -3,9 +3,7 @@
 
 use crate::cache::print_json;
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
-use crate::defender_probe::{
-    self, DefenderProbeState, DefenderVerdict, SCANNED_THRESHOLD_MS,
-};
+use crate::defender_probe::{self, DefenderProbeState, DefenderVerdict, SCANNED_THRESHOLD_MS};
 use crate::fetch::{ZccacheBinarySummary, ZccacheSource};
 use crate::{apply_implicit_toolchain_homes, rustup_binary, JSON_SCHEMA_VERSION};
 use serde::Serialize;
@@ -373,9 +371,7 @@ fn print_defender_probe_human(outcome: Option<&DefenderProbeOutcome>) {
                 "  recommendation: run bench/add_defender_exclusions.ps1 as admin, or move \
                  SOLDR_CACHE_DIR onto a trusted Dev Drive (Windows 11 22H2+)"
             );
-            println!(
-                "  threshold:     median > {SCANNED_THRESHOLD_MS} ms classifies as scanned"
-            );
+            println!("  threshold:     median > {SCANNED_THRESHOLD_MS} ms classifies as scanned");
         }
     }
 }

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -46,7 +46,9 @@ pub use zccache::{
     classify_zccache_source, managed_only_zccache_summary, pinned_zccache_summary,
     resolve_local_zccache, zccache_binary_summary, ZccacheBinarySummary, ZccacheSource,
 };
-pub use zccache_install::{cached_zccache_binary, fetch_zccache_with_paths, resolve_system_zccache};
+pub use zccache_install::{
+    cached_zccache_binary, fetch_zccache_with_paths, resolve_system_zccache,
+};
 
 pub(crate) use github::http_client;
 

--- a/crates/soldr-cli/src/gc/tests.rs
+++ b/crates/soldr-cli/src/gc/tests.rs
@@ -78,16 +78,10 @@ fn last_used_falls_back_to_mtime_when_key_missing() {
     let meta = fake_metadata_with_mtime(&f, 1_700_000_000);
     // Tracker exists (Some), but doesn't have a row for this crate.
     // The fallback must be per-crate, not per-tracker.
-    let map: std::collections::HashMap<
-        crate::cache_lib::cargo_global_cache::RegistrySrcKey,
-        i64,
-    > = std::collections::HashMap::new();
-    let (ts, source) = resolve_registry_src_last_used(
-        Some(&map),
-        "index.crates.io-abc123",
-        "serde-1.0.0",
-        &meta,
-    );
+    let map: std::collections::HashMap<crate::cache_lib::cargo_global_cache::RegistrySrcKey, i64> =
+        std::collections::HashMap::new();
+    let (ts, source) =
+        resolve_registry_src_last_used(Some(&map), "index.crates.io-abc123", "serde-1.0.0", &meta);
     assert_eq!(ts, 1_700_000_000);
     assert_eq!(source, "fs_mtime");
 }
@@ -100,10 +94,8 @@ fn last_used_falls_back_when_dir_name_is_not_versioned() {
     // `split_dir_name` returns None for names that don't match the
     // `<crate>-<digit-prefixed-version>` shape. The walker must then
     // fall back to mtime rather than crashing or returning 0.
-    let map: std::collections::HashMap<
-        crate::cache_lib::cargo_global_cache::RegistrySrcKey,
-        i64,
-    > = std::collections::HashMap::new();
+    let map: std::collections::HashMap<crate::cache_lib::cargo_global_cache::RegistrySrcKey, i64> =
+        std::collections::HashMap::new();
     let (ts, source) =
         resolve_registry_src_last_used(Some(&map), "index.crates.io-abc123", "bare-serde", &meta);
     assert_eq!(ts, 1_700_000_000);

--- a/crates/soldr-cli/src/linker.rs
+++ b/crates/soldr-cli/src/linker.rs
@@ -400,8 +400,8 @@ mod tests {
     #[test]
     fn fast_on_macos_falls_back_to_platform_default() {
         for triple in [MAC_X64, MAC_ARM] {
-            let i = resolve_for_target_with_probe(LinkerChoice::Fast, triple, &always_false)
-                .unwrap();
+            let i =
+                resolve_for_target_with_probe(LinkerChoice::Fast, triple, &always_false).unwrap();
             assert_eq!(
                 i,
                 LinkerInjection::default(),

--- a/crates/soldr-cli/src/rust_plan.rs
+++ b/crates/soldr-cli/src/rust_plan.rs
@@ -229,7 +229,6 @@ pub(crate) fn compute_plan_inputs_hash(plan: &RustArtifactPlan) -> String {
     stable_hash_json(&payload)
 }
 
-
 #[path = "rust_plan_warm_restore.rs"]
 mod warm_restore;
 pub(crate) use warm_restore::{
@@ -440,10 +439,7 @@ fn force_restore_enabled() -> bool {
 /// Count `.fingerprint/` directories under `root` (up to `max_depth` levels)
 /// that contain at least one entry. The walk stops descending once a
 /// `.fingerprint/` is encountered — cargo never nests another inside.
-pub(crate) fn count_populated_fingerprint_dirs(
-    root: &std::path::Path,
-    max_depth: usize,
-) -> usize {
+pub(crate) fn count_populated_fingerprint_dirs(root: &std::path::Path, max_depth: usize) -> usize {
     let mut count = 0usize;
     walk_for_fingerprint_dirs(root, max_depth, &mut count);
     count
@@ -475,7 +471,6 @@ fn walk_for_fingerprint_dirs(dir: &std::path::Path, remaining_depth: usize, coun
         }
     }
 }
-
 
 #[path = "rust_plan_env.rs"]
 mod env_resolvers;

--- a/crates/soldr-cli/src/rust_plan_env.rs
+++ b/crates/soldr-cli/src/rust_plan_env.rs
@@ -78,4 +78,3 @@ pub(crate) fn parse_rust_artifact_cache_tar_threads(
         ))),
     }
 }
-

--- a/crates/soldr-cli/src/rust_plan_tests/prepopulated_target.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/prepopulated_target.rs
@@ -65,8 +65,7 @@ fn seed_fingerprint_dir(target: &std::path::Path, profile: &str) -> std::path::P
     std::fs::create_dir_all(&fp).expect("create .fingerprint");
     let entry = fp.join("serde-abc123");
     std::fs::create_dir_all(&entry).expect("create fingerprint entry");
-    std::fs::write(entry.join("invoked.timestamp"), b"")
-        .expect("seed invoked.timestamp");
+    std::fs::write(entry.join("invoked.timestamp"), b"").expect("seed invoked.timestamp");
     fp
 }
 

--- a/crates/soldr-cli/src/shim_dir.rs
+++ b/crates/soldr-cli/src/shim_dir.rs
@@ -87,11 +87,7 @@ fn write_shim(dir: &Path, tool: &str, soldr_bin: &Path) -> Result<(), SoldrError
     // .cmd is the simplest cross-tool extension Windows resolves
     // automatically from PATH. Quoting the soldr path handles spaces.
     let path = dir.join(format!("{tool}.cmd"));
-    let body = format!(
-        "@echo off\r\n\"{}\" {} %*\r\n",
-        soldr_bin.display(),
-        tool
-    );
+    let body = format!("@echo off\r\n\"{}\" {} %*\r\n", soldr_bin.display(), tool);
     std::fs::write(&path, body).map_err(SoldrError::Io)
 }
 
@@ -105,7 +101,9 @@ fn write_shim(dir: &Path, tool: &str, soldr_bin: &Path) -> Result<(), SoldrError
         tool
     );
     std::fs::write(&path, body).map_err(SoldrError::Io)?;
-    let mut perms = std::fs::metadata(&path).map_err(SoldrError::Io)?.permissions();
+    let mut perms = std::fs::metadata(&path)
+        .map_err(SoldrError::Io)?
+        .permissions();
     perms.set_mode(0o755);
     std::fs::set_permissions(&path, perms).map_err(SoldrError::Io)?;
     Ok(())
@@ -145,11 +143,7 @@ mod tests {
             let expected = guard.path.join(format!("{tool}.cmd"));
             #[cfg(not(windows))]
             let expected = guard.path.join(tool);
-            assert!(
-                expected.is_file(),
-                "missing shim at {}",
-                expected.display()
-            );
+            assert!(expected.is_file(), "missing shim at {}", expected.display());
         }
     }
 
@@ -158,8 +152,7 @@ mod tests {
         let guard = build_shim_dir().expect("build_shim_dir");
         let mut cmd = std::process::Command::new("does-not-matter");
         apply_to_command(&mut cmd, &guard.path);
-        let envs: std::collections::HashMap<&OsStr, Option<&OsStr>> =
-            cmd.get_envs().collect();
+        let envs: std::collections::HashMap<&OsStr, Option<&OsStr>> = cmd.get_envs().collect();
         let sentinel_set = envs
             .get(OsStr::new(SOLDR_CHILD_SHIMS_ACTIVE_ENV_VAR))
             .copied()

--- a/crates/soldr-cli/src/trampoline.rs
+++ b/crates/soldr-cli/src/trampoline.rs
@@ -620,7 +620,10 @@ fn trailing_user_args(args: &[String]) -> Vec<String> {
 
 #[path = "trampoline_layout.rs"]
 mod layout;
-pub(crate) use layout::{compute_layout, effective_target_triple, find_nearest_manifest, resolve_bin_name, resolve_target_dir, Layout};
+pub(crate) use layout::{
+    compute_layout, effective_target_triple, find_nearest_manifest, resolve_bin_name,
+    resolve_target_dir, Layout,
+};
 
 // ---------------------------------------------------------------------------
 // Sidecar (de)serialization

--- a/crates/soldr-cli/src/trampoline_layout.rs
+++ b/crates/soldr-cli/src/trampoline_layout.rs
@@ -199,4 +199,3 @@ pub(crate) fn resolve_bin_name(parsed: &ParsedRunArgs) -> Result<Option<String>,
     }
     Ok(None)
 }
-


### PR DESCRIPTION
## Summary

- apply `rustfmt` to the files reported by the post-merge main Lint job after #529
- no semantic changes

## Validation

- `soldr cargo fmt --all -- --check`
- `git diff --check`

Follow-up to zackees/zccache#405 rollout work; fixes the red soldr main lint run after the setup-soldr pin bump.