### PR TITLE
ci: isolate Git Bash MSVC smoke from cache env

### DIFF
--- a/.github/scripts/windows-msys-default-msvc.sh
+++ b/.github/scripts/windows-msys-default-msvc.sh
@@ -6,6 +6,7 @@ fixture="$workspace_unix/crates/soldr-cli/tests/fixtures/windows-msvc-default"
 fake_tools="$(mktemp -d)"
 target_dir_win="$RUNNER_TEMP\\soldr-msys-default-msvc"
 target_dir_unix="$(cygpath -u "$target_dir_win")"
+cache_dir_win="$RUNNER_TEMP\\soldr-msys-default-msvc-cache"
 soldr_exe="${SOLDR_EXE:-$workspace_unix/target/debug/soldr.exe}"
 
 if [[ -n "${SOLDR_EXE:-}" ]]; then
@@ -28,12 +29,25 @@ EOF
 
 export PATH="$fake_tools:$PATH"
 export CARGO_TARGET_DIR="$target_dir_win"
+export SOLDR_CACHE_DIR="$cache_dir_win"
+export ZCCACHE_CACHE_DIR="$cache_dir_win\\cache\\zccache"
+unset SOLDR_BUILD_CACHE_MODE
+unset SOLDR_TARGET_CACHE_MODE
+unset SOLDR_TARGET_CACHE_DIR
+unset SOLDR_TARGET_CACHE_BUNDLE_DIR
+unset SOLDR_TARGET_CACHE_BACKEND
+unset SOLDR_TARGET_CACHE_PROFILE
+unset SOLDR_LINKER
+unset RUSTC_WRAPPER
+unset RUSTC_WORKSPACE_WRAPPER
 
 cd "$fixture"
-"$soldr_exe" cargo build --locked
+"$soldr_exe" --no-cache cargo build --locked
 
 artifact="$target_dir_unix/x86_64-pc-windows-msvc/debug/windows-msvc-default.exe"
 if [[ ! -f "$artifact" ]]; then
   echo "expected MSVC artifact at $artifact" >&2
+  echo "observed fixture artifacts:" >&2
+  find "$target_dir_unix" -maxdepth 5 -type f -name 'windows-msvc-default*.exe' -print >&2 || true
   exit 1
 fi


### PR DESCRIPTION
## Summary

- isolate the Git Bash MSVC-default smoke script from inherited setup-soldr cache/linker env
- run the fixture build with `soldr --no-cache cargo build --locked`, matching the Rust regression test's intent
- print observed fixture artifacts on failure so future target-layout failures are diagnosable

## Validation

- `soldr cargo build --package soldr-cli --locked --target x86_64-pc-windows-msvc`
- local Git Bash smoke with inherited `SOLDR_TARGET_CACHE_*` and `SOLDR_LINKER=fast` set
- `git diff --check`

Follow-up for zackees/zccache#405 after main CI exposed this main-only Windows x64 path.