### PR TITLE
ci: restore sources after soldr-cook

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -130,6 +130,11 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: "--target ${{ inputs.target }}"
 
+      - name: Restore checkout after soldr-cook
+        shell: pwsh
+        working-directory: soldr
+        run: git restore --worktree -- .
+
       - name: Reset stale musl cache fallback artifacts
         if: >-
           ${{

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -85,6 +85,10 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: "--target ${{ inputs.target }}"
 
+      - name: Restore checkout after soldr-cook
+        shell: pwsh
+        run: git restore --worktree -- .
+
       - name: Install requested Rust components
         if: inputs.install_components != ''
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
 
+      - name: Restore checkout after soldr-cook
+        shell: pwsh
+        run: git restore --worktree -- .
+
       - name: Install Rust components
         run: rustup component add rustfmt clippy
 

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -88,6 +88,10 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
 
+      - name: Restore checkout after soldr-cook
+        shell: pwsh
+        run: git restore --worktree -- .
+
       - name: Show action outputs
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary

- restore tracked checkout sources immediately after setup-soldr `soldr-cook` runs
- cover lint, per-platform build/test, bootstrap e2e, and setup-soldr dogfood workflows
- prevents cargo-chef skeleton placeholders from reaching `cargo fmt --check` or the real build/test commands

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/_build-and-test.yml .github/workflows/_bootstrap-e2e.yml .github/workflows/setup-soldr-action.yml`
- `soldr cargo fmt --all -- --check`
- `git diff --check`

Follow-up for zackees/zccache#405 after soldr main CI exposed placeholder source drift in Lint.