### PR TITLE
fix: scrub cache lifecycle env before cargo

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -114,6 +114,16 @@ jobs:
           ))
           exit $exitCode
 
+      - name: Resolve built soldr binary
+        shell: pwsh
+        run: |
+          $exeName = if ($IsWindows) { "soldr.exe" } else { "soldr" }
+          $soldrPath = Join-Path $env:GITHUB_WORKSPACE "target/${{ inputs.target }}/debug/$exeName"
+          if (-not (Test-Path -LiteralPath $soldrPath)) {
+            throw "built soldr binary not found at $soldrPath"
+          }
+          "LOCAL_SOLDR=$soldrPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Stop setup-soldr builder cache before tests
         uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
 
@@ -128,7 +138,7 @@ jobs:
           Write-Host "Using isolated test SOLDR_CACHE_DIR=$env:SOLDR_CACHE_DIR"
           Write-Host "Using isolated test ZCCACHE_CACHE_DIR=$env:ZCCACHE_CACHE_DIR"
           $timer = [Diagnostics.Stopwatch]::StartNew()
-          soldr cargo test --workspace --lib --locked --target ${{ inputs.target }}
+          & $env:LOCAL_SOLDR cargo test --workspace --lib --locked --target ${{ inputs.target }}
           $exitCode = $LASTEXITCODE
           $timer.Stop()
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
@@ -147,7 +157,7 @@ jobs:
           ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}/cache/zccache
         run: |
           $timer = [Diagnostics.Stopwatch]::StartNew()
-          soldr cargo test -p soldr-cli --tests --locked --target ${{ inputs.target }}
+          & $env:LOCAL_SOLDR cargo test -p soldr-cli --tests --locked --target ${{ inputs.target }}
           $exitCode = $LASTEXITCODE
           $timer.Stop()
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
@@ -178,7 +188,7 @@ jobs:
           ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}/cache/zccache
         run: |
           $timer = [Diagnostics.Stopwatch]::StartNew()
-          soldr cargo test -p soldr-cli --test fetch_crgx --locked --target ${{ inputs.target }}
+          & $env:LOCAL_SOLDR cargo test -p soldr-cli --test fetch_crgx --locked --target ${{ inputs.target }}
           $exitCode = $LASTEXITCODE
           $timer.Stop()
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
@@ -196,7 +206,7 @@ jobs:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}
           ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}/cache/zccache
         run: |
-          soldr cache shutdown --shutdown-timeout-seconds 30
+          & $env:LOCAL_SOLDR cache shutdown --shutdown-timeout-seconds 30
           if ($LASTEXITCODE -ne 0) {
             zccache stop
           }

--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -28,6 +28,7 @@ use crate::trampoline_workspace::{
 use crate::zccache::{
     cache_lifecycle_from_env, command_lifetime_shutdown_timeout, finish_zccache_build,
     prepare_rustc_wrapper, stop_zccache_after_command, CacheLifecycle,
+    SOLDR_CACHE_LIFECYCLE_ENV_VAR, SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR,
 };
 use crate::{
     apply_implicit_toolchain_homes, gc, resolve_toolchain_binary, rust_plan, ZccacheSourceArg,
@@ -184,6 +185,11 @@ fn emit_auto_prune_summary(outcome: &crate::cache_lib::auto_target_gc::AutoPrune
     }
 }
 
+fn scrub_soldr_cache_lifecycle_env_for_child_cargo(command: &mut std::process::Command) {
+    command.env_remove(SOLDR_CACHE_LIFECYCLE_ENV_VAR);
+    command.env_remove(SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR);
+}
+
 pub(crate) async fn run_cargo_front_door(
     args: &[String],
     cache_enabled: bool,
@@ -283,6 +289,10 @@ pub(crate) async fn run_cargo_front_door(
     command.args(args);
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
+    // These soldr control variables are consumed by this front-door
+    // process. Letting cargo inherit them leaks daemon lifecycle policy
+    // into build scripts and test binaries that may spawn nested soldr.
+    scrub_soldr_cache_lifecycle_env_for_child_cargo(&mut command);
     // soldr cargo is the top of the invocation tree, so any inherited
     // MAKEFLAGS/CARGO_MAKEFLAGS points at jobserver fds that aren't open in
     // our process. Stripping them lets cargo start a fresh jobserver instead

--- a/crates/soldr-cli/src/cargo_front_door/tests.rs
+++ b/crates/soldr-cli/src/cargo_front_door/tests.rs
@@ -41,6 +41,34 @@ impl Drop for EnvVarGuard {
     }
 }
 
+fn command_env_override(
+    command: &std::process::Command,
+    key: &'static str,
+) -> Option<Option<OsString>> {
+    command
+        .get_envs()
+        .find(|(candidate, _)| *candidate == OsStr::new(key))
+        .map(|(_, value)| value.map(OsString::from))
+}
+
+#[test]
+fn child_cargo_scrubs_soldr_cache_lifecycle_controls() {
+    let mut command = std::process::Command::new("cargo");
+    command.env(SOLDR_CACHE_LIFECYCLE_ENV_VAR, "command");
+    command.env(SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR, "1");
+
+    scrub_soldr_cache_lifecycle_env_for_child_cargo(&mut command);
+
+    assert_eq!(
+        command_env_override(&command, SOLDR_CACHE_LIFECYCLE_ENV_VAR),
+        Some(None)
+    );
+    assert_eq!(
+        command_env_override(&command, SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR),
+        Some(None)
+    );
+}
+
 #[test]
 fn low_disk_warning_formats_yellow_below_threshold() {
     let message = low_disk_warning_for_free_bytes(1536 * 1024 * 1024, true)


### PR DESCRIPTION
## Summary

- scrub `SOLDR_CACHE_LIFECYCLE` and `SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS` before spawning cargo so build scripts/tests do not inherit soldr daemon lifecycle policy
- run `_build-and-test.yml` post-build test phases through the freshly built `target/<triple>/debug/soldr` binary instead of the setup-soldr-installed binary
- add a unit regression check for child cargo env removal

## Validation

- `actionlint .github/workflows/_build-and-test.yml`
- `soldr cargo fmt --all -- --check`
- `git diff --check`
- `soldr cargo test -p soldr-cli --bin soldr cargo_front_door::tests::child_cargo_scrubs_soldr_cache_lifecycle_controls --locked`
- With outer `SOLDR_CACHE_LIFECYCLE=command`, local branch binary: `target/x86_64-pc-windows-msvc/debug/soldr.exe cargo test -p soldr-cli --test cli_cargo_basic --locked --target x86_64-pc-windows-msvc -- --nocapture`

Closes #535.