### PR TITLE
ci: enable strict setup-soldr zccache seed

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -117,12 +117,13 @@ jobs:
 
       - name: Setup soldr build cache
         id: setup_soldr
-        uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
+        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
         env:
           ACTION_WORKSPACE: ${{ github.workspace }}/soldr
         with:
           toolchain-file: rust-toolchain.ci.toml
           cache: true
+          zccache-seed-strict: true
           linker: platform-default
           cache-key-suffix: bootstrap-${{ inputs.target }}-native-cc-v2
           lockfile: Cargo.lock
@@ -213,7 +214,7 @@ jobs:
           & "${{ steps.soldr_binary.outputs.path }}" --version
 
       - name: Stop setup-soldr builder cache before bootstrap test
-        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
+        uses: zackees/setup-soldr/cleanup@be9cd32c413a696e85c13eaeef25400666dd5317
 
       - name: Build third-party app through soldr
         shell: pwsh

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -77,10 +77,11 @@ jobs:
           components: ${{ inputs.install_components }}
 
       - name: Setup soldr build cache
-        uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
+        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
         with:
           toolchain: 1.94.1
           cache: true
+          zccache-seed-strict: true
           cache-key-suffix: build-${{ inputs.shared_key }}-${{ inputs.cache_key }}
           prebuild-deps: soldr-cook
           prebuild-deps-flags: "--target ${{ inputs.target }}"
@@ -125,7 +126,7 @@ jobs:
           "LOCAL_SOLDR=$soldrPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
+        uses: zackees/setup-soldr/cleanup@be9cd32c413a696e85c13eaeef25400666dd5317
 
       - name: Run library tests
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup soldr build cache
-        uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
+        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
         with:
           toolchain: 1.94.1
           cache: true
+          zccache-seed-strict: true
           cache-key-suffix: lint-ubuntu
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -74,9 +74,10 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@0425f54e37b65c5c36be1fb73628019b3e1aabed
+        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
         with:
           cache: true
+          zccache-seed-strict: true
           linker: platform-default
           # Keep the action runtime cache separate from the Soldr build under
           # test. The dogfood build below overrides SOLDR_CACHE_DIR so soldr
@@ -143,7 +144,7 @@ jobs:
             setup-soldr-dogfood-zccache-v1-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Stop setup-soldr builder cache before dogfood build
-        uses: zackees/setup-soldr/cleanup@0425f54e37b65c5c36be1fb73628019b3e1aabed
+        uses: zackees/setup-soldr/cleanup@be9cd32c413a696e85c13eaeef25400666dd5317
 
       - name: Build through soldr
         shell: pwsh


### PR DESCRIPTION
## Summary
- bump normal soldr CI setup-soldr pins to `be9cd32c413a696e85c13eaeef25400666dd5317`
- enable `zccache-seed-strict: true` on soldr setup-soldr build-cache steps
- keep matching setup-soldr cleanup steps pinned to the same commit

## Why
The soldr dogfood and self-test jobs later run with isolated `SOLDR_CACHE_DIR` roots. With strict seeding enabled, setup fails immediately if setup-soldr cannot pin zccache, instead of allowing a later slow `cargo install zccache` fallback.

## Validation
- `git diff --check`
- `actionlint .github/workflows/ci.yml .github/workflows/_build-and-test.yml .github/workflows/_bootstrap-e2e.yml .github/workflows/setup-soldr-action.yml`
- `uv run --no-project --with pyyaml python -c <yaml parse check>`
