### PR TITLE
feat(cache): add protobuf cook delta layers

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -136,21 +136,18 @@ jobs:
         working-directory: soldr
         run: git restore --worktree -- .
 
-      - name: Reset stale musl cache fallback artifacts
+      - name: Reset stale cache fallback artifacts
         if: >-
           ${{
-            contains(inputs.target, 'musl') &&
-            (
-              steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit' ||
-              steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'
-            )
+            steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit' ||
+            steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'
           }}
         shell: pwsh
         working-directory: soldr
         run: |
           $targetTripleDir = Join-Path "target" "${{ inputs.target }}"
           if (Test-Path -LiteralPath $targetTripleDir) {
-            Write-Host "Removing restored musl target artifacts from $targetTripleDir"
+            Write-Host "Removing restored target artifacts from $targetTripleDir"
             Remove-Item -LiteralPath $targetTripleDir -Recurse -Force
           }
 

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -145,6 +145,9 @@ jobs:
         shell: pwsh
         working-directory: soldr
         run: |
+          Write-Host "Disabling target-cache for later steps after a fallback setup-soldr restore."
+          "SOLDR_TARGET_CACHE_MODE=off" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
           $targetTripleDir = Join-Path "target" "${{ inputs.target }}"
           if (Test-Path -LiteralPath $targetTripleDir) {
             Write-Host "Removing restored target artifacts from $targetTripleDir"

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -77,6 +77,7 @@ jobs:
           components: ${{ inputs.install_components }}
 
       - name: Setup soldr build cache
+        id: setup_soldr
         uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
         with:
           toolchain: 1.94.1
@@ -89,6 +90,26 @@ jobs:
       - name: Restore checkout after soldr-cook
         shell: pwsh
         run: git restore --worktree -- .
+
+      - name: Reset stale cache fallback artifacts
+        if: >-
+          ${{
+            steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit' ||
+            steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'
+          }}
+        shell: pwsh
+        run: |
+          $targetTripleDir = Join-Path "target" "${{ inputs.target }}"
+          if (Test-Path -LiteralPath $targetTripleDir) {
+            Write-Host "Removing restored target artifacts from $targetTripleDir"
+            Remove-Item -LiteralPath $targetTripleDir -Recurse -Force
+          }
+
+          $artifactDir = Join-Path $env:ZCCACHE_CACHE_DIR "artifacts"
+          if (Test-Path -LiteralPath $artifactDir) {
+            Write-Host "Removing restored zccache artifacts from $artifactDir"
+            Remove-Item -LiteralPath $artifactDir -Recurse -Force
+          }
 
       - name: Install requested Rust components
         if: inputs.install_components != ''

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -99,6 +99,9 @@ jobs:
           }}
         shell: pwsh
         run: |
+          Write-Host "Disabling target-cache for later steps after a fallback setup-soldr restore."
+          "SOLDR_TARGET_CACHE_MODE=off" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
           $targetTripleDir = Join-Path "target" "${{ inputs.target }}"
           if (Test-Path -LiteralPath $targetTripleDir) {
             Write-Host "Removing restored target artifacts from $targetTripleDir"

--- a/crates/soldr-cli/src/cache_lib/README.md
+++ b/crates/soldr-cli/src/cache_lib/README.md
@@ -16,8 +16,8 @@ prune that ships to zccache via the thin Rust artifact plan.
   helpers (`$CARGO_HOME` cleanup orchestration).
 - `gc.rs` — soldr-side GC pass orchestrator: locations, summary, purge.
 - `save.rs` — `soldr save` / `soldr load` archive plumbing (mtime-
-  preserving tar.zst bundle of the build cache + source-fingerprint
-  manifest).
+  preserving tar.zst bundle of the build cache + protobuf
+  source/cache-file manifest, including base+delta cache layers).
 - `prune_target.rs` — per-build `target/` prune (orphan hash-sibling
   removal + `--keep-latest` aggressive mode). Tests live in
   `prune_target_tests.rs`, included via `#[path]` so `prune_target.rs`

--- a/crates/soldr-cli/src/cache_lib/manifest.proto
+++ b/crates/soldr-cli/src/cache_lib/manifest.proto
@@ -37,6 +37,27 @@ message Manifest {
   // recompute from `files.len()` if zero.
   uint64 source_file_count = 6;
   uint64 cache_file_count = 7;
+
+  // Cache archive layer kind. COMPLETE is the historical all-files
+  // archive. DELTA contains only changed/new cache files plus
+  // deleted_cache_paths tombstones against base_manifest_blake3.
+  CacheLayerKind cache_layer_kind = 8;
+
+  // Cache file metadata, sorted by path. COMPLETE archives include every
+  // cache file. DELTA archives include changed/new cache files plus
+  // metadata-only entries whose content matches the base but whose mtime
+  // should be replayed. Bytes are present under cache/ only for DELTA
+  // entries whose content is new or changed.
+  repeated CacheFile cache_files = 9;
+
+  // Base manifest digest for DELTA archives: BLAKE3 over the protobuf
+  // bytes of the base manifest file used to compute the delta.
+  bytes base_manifest_blake3 = 10;
+
+  // Cache paths present in the base layer but absent from the delta's
+  // source tree. Load applies these as tombstones before extracting the
+  // delta payload so restore is base + delta with delta winning.
+  repeated string deleted_cache_paths = 11;
 }
 
 message SourceFile {
@@ -56,4 +77,26 @@ message SourceFile {
   // for the replay decision. (Hash size adds <0.5 KB per 1000 files
   // after zstd — not worth truncating.)
   bytes blake3 = 4;
+}
+
+message CacheFile {
+  // Cache-dir-relative path, forward slashes on every platform.
+  string path = 1;
+
+  // mtime in nanoseconds since UNIX epoch. Cache artifacts can be more
+  // sensitive than source-file mtime replay, so this keeps the full
+  // Rust/filetime precision instead of the source mtime_ms field.
+  int64 mtime_ns = 2;
+
+  // File size in bytes. Cheap rejection signal for delta comparison.
+  uint64 size = 3;
+
+  // BLAKE3 hash of the cache file content.
+  bytes blake3 = 4;
+}
+
+enum CacheLayerKind {
+  COMPLETE = 0;
+  BASE = 1;
+  DELTA = 2;
 }

--- a/crates/soldr-cli/src/cache_lib/save.rs
+++ b/crates/soldr-cli/src/cache_lib/save.rs
@@ -33,6 +33,7 @@
 //! readers never have to guess the basename. Manifest carries
 //! `cache_dir_name = "cache"` for forward compat.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read};
 
@@ -56,7 +57,7 @@ pub mod proto {
     //! change the other — and bump `Manifest::version` if the change
     //! is breaking.
 
-    use prost::Message;
+    use prost::{Enumeration, Message};
 
     #[derive(Clone, PartialEq, Message)]
     pub struct Manifest {
@@ -74,6 +75,14 @@ pub mod proto {
         pub source_file_count: u64,
         #[prost(uint64, tag = "7")]
         pub cache_file_count: u64,
+        #[prost(enumeration = "CacheLayerKind", tag = "8")]
+        pub cache_layer_kind: i32,
+        #[prost(message, repeated, tag = "9")]
+        pub cache_files: ::prost::alloc::vec::Vec<CacheFile>,
+        #[prost(bytes = "vec", tag = "10")]
+        pub base_manifest_blake3: ::prost::alloc::vec::Vec<u8>,
+        #[prost(string, repeated, tag = "11")]
+        pub deleted_cache_paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     }
 
     #[derive(Clone, PartialEq, Message)]
@@ -87,9 +96,29 @@ pub mod proto {
         #[prost(bytes = "vec", tag = "4")]
         pub blake3: ::prost::alloc::vec::Vec<u8>,
     }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct CacheFile {
+        #[prost(string, tag = "1")]
+        pub path: ::prost::alloc::string::String,
+        #[prost(int64, tag = "2")]
+        pub mtime_ns: i64,
+        #[prost(uint64, tag = "3")]
+        pub size: u64,
+        #[prost(bytes = "vec", tag = "4")]
+        pub blake3: ::prost::alloc::vec::Vec<u8>,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Enumeration)]
+    #[repr(i32)]
+    pub enum CacheLayerKind {
+        Complete = 0,
+        Base = 1,
+        Delta = 2,
+    }
 }
 
-pub use proto::{Manifest, SourceFile};
+pub use proto::{CacheFile, CacheLayerKind, Manifest, SourceFile};
 
 /// Well-known filename for the manifest inside an archive.
 pub const MANIFEST_NAME: &str = "SOLDR_MANIFEST.pb";
@@ -148,11 +177,27 @@ fn mtime_ms(meta: &std::fs::Metadata) -> i64 {
         .unwrap_or(0)
 }
 
+fn mtime_ns(meta: &std::fs::Metadata) -> i64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0)
+}
+
 fn ms_to_systime(ms: i64) -> SystemTime {
     if ms < 0 {
         UNIX_EPOCH
     } else {
         UNIX_EPOCH + Duration::from_millis(ms as u64)
+    }
+}
+
+fn ns_to_systime(ns: i64) -> SystemTime {
+    if ns < 0 {
+        UNIX_EPOCH
+    } else {
+        UNIX_EPOCH + Duration::from_nanos(ns as u64)
     }
 }
 
@@ -254,6 +299,48 @@ fn rel_to_posix(rel: &Path) -> String {
         .join("/")
 }
 
+fn manifest_rel_to_path(path: &str) -> Result<PathBuf> {
+    let mut out = PathBuf::new();
+    for part in path.split('/') {
+        if part.is_empty() || part == "." || part == ".." || part.contains('\\') {
+            return Err(SaveLoadError::BadArchivePath(path.to_string()));
+        }
+        out.push(part);
+    }
+    if out.as_os_str().is_empty() {
+        return Err(SaveLoadError::BadArchivePath(path.to_string()));
+    }
+    Ok(out)
+}
+
+fn archive_rel_to_path(path: &Path) -> Result<PathBuf> {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(part) => out.push(part),
+            _ => return Err(SaveLoadError::BadArchivePath(path.display().to_string())),
+        }
+    }
+    if out.as_os_str().is_empty() {
+        return Err(SaveLoadError::BadArchivePath(path.display().to_string()));
+    }
+    Ok(out)
+}
+
+fn cache_file_entry(cache_dir: &Path, abs: &Path) -> Result<CacheFile> {
+    let rel = abs
+        .strip_prefix(cache_dir)
+        .map_err(|_| SaveLoadError::BadArchivePath(abs.display().to_string()))?;
+    let meta = std::fs::metadata(abs).map_err(|e| io(abs, e))?;
+    let hash = hash_file(abs)?;
+    Ok(CacheFile {
+        path: rel_to_posix(rel),
+        mtime_ns: mtime_ns(&meta),
+        size: meta.len(),
+        blake3: hash.to_vec(),
+    })
+}
+
 // ---------- save ----------
 
 #[derive(Debug, Clone)]
@@ -287,8 +374,26 @@ pub struct SaveOptions<'a> {
 pub struct SaveReport {
     pub source_files: u64,
     pub cache_files: u64,
+    pub deleted_cache_files: u64,
     pub archive_bytes: u64,
     pub elapsed_ms: u64,
+}
+
+#[derive(Clone)]
+pub struct SaveDeltaOptions<'a> {
+    /// Workspace root to snapshot source mtimes from. `None` skips the
+    /// source-file portion entirely.
+    pub workspace: Option<&'a Path>,
+    /// Current cache directory whose changed/new files will be bundled.
+    pub cache_dir: &'a Path,
+    /// Base-layer manifest to compare current cache contents against.
+    pub base_manifest: &'a Manifest,
+    /// Destination delta archive path.
+    pub out: &'a Path,
+    /// zstd compression level (1..=22).
+    pub zstd_level: i32,
+    /// Number of rayon threads for hash + tar work.
+    pub threads: Option<usize>,
 }
 
 /// Validate save inputs:
@@ -375,8 +480,10 @@ pub fn save(opts: &SaveOptions<'_>) -> Result<SaveReport> {
         });
     let manifest_files = source_result?;
     let cache_files_paths = cache_files_paths?;
+    let cache_manifest_files =
+        build_cache_manifest_entries(&pool, opts.cache_dir, &cache_files_paths)?;
 
-    let mut manifest = Manifest {
+    let manifest = Manifest {
         version: MANIFEST_VERSION,
         saved_at_ms: SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -397,8 +504,12 @@ pub fn save(opts: &SaveOptions<'_>) -> Result<SaveReport> {
             CACHE_DIR_NAME.into()
         },
         source_file_count: manifest_files.len() as u64,
-        cache_file_count: 0,
+        cache_file_count: cache_manifest_files.len() as u64,
         files: manifest_files,
+        cache_layer_kind: CacheLayerKind::Complete as i32,
+        cache_files: cache_manifest_files,
+        base_manifest_blake3: Vec::new(),
+        deleted_cache_paths: Vec::new(),
     };
 
     let manifest_bytes = {
@@ -487,15 +598,267 @@ pub fn save(opts: &SaveOptions<'_>) -> Result<SaveReport> {
         .into_inner()
         .map_err(|e| SaveLoadError::BareIo(e.into_error()))?;
 
-    manifest.cache_file_count = cache_files;
     let archive_bytes = std::fs::metadata(opts.out).map(|m| m.len()).unwrap_or(0);
 
     Ok(SaveReport {
         source_files: manifest.source_file_count,
         cache_files,
+        deleted_cache_files: 0,
         archive_bytes,
         elapsed_ms: start.elapsed().as_millis() as u64,
     })
+}
+
+pub fn save_delta(opts: &SaveDeltaOptions<'_>) -> Result<SaveReport> {
+    let start = std::time::Instant::now();
+    let pool = build_pool(opts.threads)?;
+
+    let (source_result, cache_files_paths): (Result<Vec<SourceFile>>, Result<Vec<PathBuf>>) = pool
+        .install(|| {
+            rayon::join(
+                || -> Result<Vec<SourceFile>> {
+                    let Some(ws) = opts.workspace else {
+                        return Ok(Vec::new());
+                    };
+                    let files = walk_workspace_files(ws, opts.threads)?;
+                    files
+                        .par_iter()
+                        .map(|rel| -> Result<SourceFile> {
+                            let abs = ws.join(rel);
+                            let meta = std::fs::metadata(&abs).map_err(|e| io(&abs, e))?;
+                            let hash = hash_file(&abs)?;
+                            Ok(SourceFile {
+                                path: rel_to_posix(rel),
+                                mtime_ms: mtime_ms(&meta),
+                                size: meta.len(),
+                                blake3: hash.to_vec(),
+                            })
+                        })
+                        .collect()
+                },
+                || -> Result<Vec<PathBuf>> {
+                    if opts.cache_dir.exists() {
+                        walk_cache_files(opts.cache_dir, opts.threads)
+                    } else {
+                        Ok(Vec::new())
+                    }
+                },
+            )
+        });
+    let manifest_files = source_result?;
+    let cache_files_paths = cache_files_paths?;
+    let cache_manifest_files =
+        build_cache_manifest_entries(&pool, Some(opts.cache_dir), &cache_files_paths)?;
+
+    let base_by_path: BTreeMap<&str, &CacheFile> = opts
+        .base_manifest
+        .cache_files
+        .iter()
+        .map(|entry| (entry.path.as_str(), entry))
+        .collect();
+    let current_by_path: BTreeMap<&str, (&CacheFile, &PathBuf)> = cache_manifest_files
+        .iter()
+        .zip(cache_files_paths.iter())
+        .map(|(entry, path)| (entry.path.as_str(), (entry, path)))
+        .collect();
+
+    let mut delta_entries = Vec::new();
+    let mut delta_paths = Vec::new();
+    for (path, (entry, abs)) in &current_by_path {
+        match base_by_path.get(path) {
+            Some(base) if cache_file_metadata_matches(base, entry) => {}
+            Some(base) if cache_file_content_matches(base, entry) => {
+                delta_entries.push((*entry).clone());
+            }
+            _ => {
+                delta_entries.push((*entry).clone());
+                delta_paths.push((*abs).clone());
+            }
+        }
+    }
+
+    let current_paths: BTreeSet<&str> = current_by_path.keys().copied().collect();
+    let deleted_cache_paths: Vec<String> = base_by_path
+        .keys()
+        .copied()
+        .filter(|path| !current_paths.contains(path))
+        .map(ToOwned::to_owned)
+        .collect();
+
+    let manifest = Manifest {
+        version: MANIFEST_VERSION,
+        saved_at_ms: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0),
+        workspace: opts
+            .workspace
+            .map(|p| p.display().to_string())
+            .unwrap_or_default(),
+        cache_dir_name: CACHE_DIR_NAME.into(),
+        source_file_count: manifest_files.len() as u64,
+        cache_file_count: delta_entries.len() as u64,
+        files: manifest_files,
+        cache_layer_kind: CacheLayerKind::Delta as i32,
+        cache_files: delta_entries,
+        base_manifest_blake3: manifest_digest(opts.base_manifest)?,
+        deleted_cache_paths,
+    };
+
+    write_delta_archive(
+        opts.out,
+        opts.zstd_level,
+        opts.threads,
+        &manifest,
+        opts.cache_dir,
+        &delta_paths,
+    )?;
+    let archive_bytes = std::fs::metadata(opts.out).map(|m| m.len()).unwrap_or(0);
+
+    Ok(SaveReport {
+        source_files: manifest.source_file_count,
+        cache_files: manifest.cache_file_count,
+        deleted_cache_files: manifest.deleted_cache_paths.len() as u64,
+        archive_bytes,
+        elapsed_ms: start.elapsed().as_millis() as u64,
+    })
+}
+
+fn build_cache_manifest_entries(
+    pool: &rayon::ThreadPool,
+    cache_dir: Option<&Path>,
+    cache_files_paths: &[PathBuf],
+) -> Result<Vec<CacheFile>> {
+    let Some(cache_dir) = cache_dir else {
+        return Ok(Vec::new());
+    };
+    pool.install(|| {
+        cache_files_paths
+            .par_iter()
+            .map(|abs| cache_file_entry(cache_dir, abs))
+            .collect()
+    })
+}
+
+fn cache_file_metadata_matches(left: &CacheFile, right: &CacheFile) -> bool {
+    left.size == right.size && left.mtime_ns == right.mtime_ns && left.blake3 == right.blake3
+}
+
+fn cache_file_content_matches(left: &CacheFile, right: &CacheFile) -> bool {
+    left.size == right.size && left.blake3 == right.blake3
+}
+
+fn encode_manifest(manifest: &Manifest) -> Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(manifest.encoded_len());
+    manifest.encode(&mut buf)?;
+    Ok(buf)
+}
+
+fn manifest_digest(manifest: &Manifest) -> Result<Vec<u8>> {
+    Ok(blake3::hash(&encode_manifest(manifest)?)
+        .as_bytes()
+        .to_vec())
+}
+
+fn write_delta_archive(
+    out: &Path,
+    zstd_level: i32,
+    threads: Option<usize>,
+    manifest: &Manifest,
+    cache_dir: &Path,
+    cache_files_paths: &[PathBuf],
+) -> Result<()> {
+    let manifest_bytes = encode_manifest(manifest)?;
+    if let Some(parent) = out.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| io(parent, e))?;
+        }
+    }
+    let out_file = File::create(out).map_err(|e| io(out, e))?;
+    let out_buf = BufWriter::with_capacity(8 * 1024 * 1024, out_file);
+    let mut zstd_encoder =
+        zstd::stream::write::Encoder::new(out_buf, zstd_level).map_err(SaveLoadError::Zstd)?;
+    zstd_encoder
+        .multithread(num_cpus_for(threads))
+        .map_err(SaveLoadError::Zstd)?;
+
+    {
+        let mut tar_builder = tar::Builder::new(&mut zstd_encoder);
+        tar_builder.mode(tar::HeaderMode::Deterministic);
+
+        let mut header = tar::Header::new_gnu();
+        header
+            .set_path(MANIFEST_NAME)
+            .map_err(SaveLoadError::BareIo)?;
+        header.set_size(manifest_bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_mtime(manifest.saved_at_ms.max(0) as u64 / 1000);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        tar_builder
+            .append(&header, &manifest_bytes[..])
+            .map_err(SaveLoadError::BareIo)?;
+
+        for abs in cache_files_paths {
+            let rel = abs
+                .strip_prefix(cache_dir)
+                .map_err(|_| SaveLoadError::BadArchivePath(abs.display().to_string()))?;
+            let mut archive_path = PathBuf::from(CACHE_DIR_NAME);
+            archive_path.push(rel);
+            let archive_path_str = rel_to_posix(&archive_path);
+            let mut file = File::open(abs).map_err(|e| io(abs, e))?;
+            let mut header = tar::Header::new_gnu();
+            let meta = std::fs::metadata(abs).map_err(|e| io(abs, e))?;
+            header.set_metadata(&meta);
+            header
+                .set_path(&archive_path_str)
+                .map_err(SaveLoadError::BareIo)?;
+            header.set_cksum();
+            tar_builder
+                .append(&header, &mut file)
+                .map_err(SaveLoadError::BareIo)?;
+        }
+        tar_builder.finish().map_err(SaveLoadError::BareIo)?;
+    }
+
+    let writer = zstd_encoder.finish().map_err(SaveLoadError::Zstd)?;
+    writer
+        .into_inner()
+        .map_err(|e| SaveLoadError::BareIo(e.into_error()))?;
+    Ok(())
+}
+
+pub fn read_manifest_from_archive(archive: &Path) -> Result<Manifest> {
+    let in_file = File::open(archive).map_err(|e| io(archive, e))?;
+    let buf = BufReader::with_capacity(16 * 1024 * 1024, in_file);
+    let zstd_reader = zstd::stream::read::Decoder::new(buf).map_err(SaveLoadError::Zstd)?;
+    let mut tar_reader = tar::Archive::new(zstd_reader);
+    for entry in tar_reader.entries().map_err(SaveLoadError::BareIo)? {
+        let mut entry = entry.map_err(SaveLoadError::BareIo)?;
+        let path = entry.path().map_err(SaveLoadError::BareIo)?.into_owned();
+        if path.as_os_str() != MANIFEST_NAME {
+            continue;
+        }
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf).map_err(SaveLoadError::BareIo)?;
+        return Ok(Manifest::decode(&buf[..])?);
+    }
+    Err(SaveLoadError::MissingManifest)
+}
+
+pub fn read_manifest_file(path: &Path) -> Result<Manifest> {
+    let bytes = std::fs::read(path).map_err(|e| io(path, e))?;
+    Ok(Manifest::decode(&bytes[..])?)
+}
+
+pub fn write_manifest_file(path: &Path, manifest: &Manifest) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| io(parent, e))?;
+        }
+    }
+    let bytes = encode_manifest(manifest)?;
+    std::fs::write(path, bytes).map_err(|e| io(path, e))
 }
 
 // ---------- load ----------
@@ -588,6 +951,7 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
     tar_reader.set_preserve_permissions(false);
 
     let mut manifest_bytes: Option<Vec<u8>> = None;
+    let mut manifest_decoded: Option<Manifest> = None;
     let mut cache_files_restored: u64 = 0;
     let pool = build_pool(opts.threads)?;
     // Holds the mtime-replay job once we've parsed the manifest and
@@ -602,18 +966,21 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
         if path.as_os_str() == MANIFEST_NAME {
             let mut buf = Vec::new();
             entry.read_to_end(&mut buf).map_err(SaveLoadError::BareIo)?;
+            let manifest: Manifest = prost::Message::decode(&buf[..])?;
+            if let Some(cache_dir) = opts.cache_dir {
+                apply_cache_tombstones(cache_dir, &manifest)?;
+            }
             manifest_bytes = Some(buf);
             // Kick off the mtime replay NOW so it runs in parallel
             // with the rest of the tar extraction. The cache files
             // and workspace source files live on disjoint trees so
             // their I/O doesn't fight.
             if let Some(ws) = opts.workspace {
-                let manifest: Manifest =
-                    prost::Message::decode(&manifest_bytes.as_ref().unwrap()[..])?;
+                let manifest_for_replay = manifest.clone();
                 let ws_owned = ws.to_path_buf();
                 let (tx, rx) = std::sync::mpsc::channel();
                 pool.spawn(move || {
-                    let outcomes: Vec<MtimeOutcome> = manifest
+                    let outcomes: Vec<MtimeOutcome> = manifest_for_replay
                         .files
                         .par_iter()
                         .map(|e| replay_one(&ws_owned, e))
@@ -622,6 +989,7 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
                 });
                 replay_handle = Some(rx);
             }
+            manifest_decoded = Some(manifest);
             continue;
         }
 
@@ -629,7 +997,7 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
         // there should be no such entries — a producer-side bug if
         // there is one, so reject it loudly.
         let stripped = match path.strip_prefix(CACHE_DIR_NAME) {
-            Ok(p) => p.to_path_buf(),
+            Ok(p) => archive_rel_to_path(p)?,
             Err(_) => {
                 return Err(SaveLoadError::BadArchivePath(path.display().to_string()));
             }
@@ -657,14 +1025,23 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
         }
     }
 
-    let manifest_bytes = manifest_bytes.ok_or(SaveLoadError::MissingManifest)?;
-    let manifest: Manifest = prost::Message::decode(&manifest_bytes[..])?;
+    let manifest = match manifest_decoded {
+        Some(manifest) => manifest,
+        None => {
+            let manifest_bytes = manifest_bytes.ok_or(SaveLoadError::MissingManifest)?;
+            prost::Message::decode(&manifest_bytes[..])?
+        }
+    };
 
     let mut report = LoadReport {
         cache_files_restored,
         source_files_in_manifest: manifest.files.len() as u64,
         ..LoadReport::default()
     };
+
+    if let Some(cache_dir) = opts.cache_dir {
+        replay_cache_file_mtimes(cache_dir, &manifest.cache_files)?;
+    }
 
     // If we kicked off the replay early, wait for it. Otherwise (no
     // workspace, or first-run before manifest seen) run it inline
@@ -723,6 +1100,50 @@ fn replay_one(workspace: &Path, entry: &SourceFile) -> MtimeOutcome {
         return MtimeOutcome::Modified;
     }
     MtimeOutcome::Applied
+}
+
+fn apply_cache_tombstones(cache_dir: &Path, manifest: &Manifest) -> Result<()> {
+    if manifest.deleted_cache_paths.is_empty() {
+        return Ok(());
+    }
+    let restored_paths: BTreeSet<&str> = manifest
+        .cache_files
+        .iter()
+        .map(|entry| entry.path.as_str())
+        .collect();
+    for path in &manifest.deleted_cache_paths {
+        if restored_paths.contains(path.as_str()) {
+            continue;
+        }
+        let rel = manifest_rel_to_path(path)?;
+        let dest = cache_dir.join(rel);
+        match std::fs::metadata(&dest) {
+            Ok(meta) if meta.is_dir() => {
+                std::fs::remove_dir_all(&dest).map_err(|e| io(&dest, e))?
+            }
+            Ok(_) => std::fs::remove_file(&dest).map_err(|e| io(&dest, e))?,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(io(&dest, err)),
+        }
+    }
+    Ok(())
+}
+
+fn replay_cache_file_mtimes(cache_dir: &Path, entries: &[CacheFile]) -> Result<()> {
+    for entry in entries {
+        let rel = manifest_rel_to_path(&entry.path)?;
+        let abs = cache_dir.join(rel);
+        let Ok(meta) = std::fs::metadata(&abs) else {
+            continue;
+        };
+        if !meta.is_file() || meta.len() != entry.size {
+            continue;
+        }
+        let mtime = ns_to_systime(entry.mtime_ns);
+        let t = filetime::FileTime::from_system_time(mtime);
+        filetime::set_file_times(&abs, t, t).map_err(|e| io(&abs, e))?;
+    }
+    Ok(())
 }
 
 // ---------- thread-pool helpers ----------

--- a/crates/soldr-cli/src/fetch/install_zccache.rs
+++ b/crates/soldr-cli/src/fetch/install_zccache.rs
@@ -706,6 +706,41 @@ pub fn pinned_version_drift_from_managed(sidecar: &PinnedSidecar) -> bool {
     sidecar.version != "unknown" && sidecar.version != MANAGED_ZCCACHE_VERSION
 }
 
+/// True when a recorded pinned version is known to be older than the
+/// managed zccache version this soldr build was compiled against.
+/// Unknown or non-semver versions stay usable because we cannot prove
+/// they are stale.
+pub fn pinned_version_older_than_managed(version: &str) -> bool {
+    match (
+        parse_semver_triplet(version),
+        parse_semver_triplet(MANAGED_ZCCACHE_VERSION),
+    ) {
+        (Some(pinned), Some(managed)) => pinned < managed,
+        _ => false,
+    }
+}
+
+fn parse_semver_triplet(version: &str) -> Option<(u64, u64, u64)> {
+    let version = version.trim().strip_prefix('v').unwrap_or(version.trim());
+    let mut parts = version.split('.');
+    let major = parse_semver_component(parts.next()?)?;
+    let minor = parse_semver_component(parts.next().unwrap_or("0"))?;
+    let patch = parse_semver_component(parts.next().unwrap_or("0"))?;
+    Some((major, minor, patch))
+}
+
+fn parse_semver_component(component: &str) -> Option<u64> {
+    let digits: String = component
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
 /// Compact ISO-8601 / RFC3339 timestamp (UTC, second precision). Rolls
 /// its own formatter so we don't have to take a chrono / time dep just
 /// for one timestamp.
@@ -806,6 +841,15 @@ mod tests {
         assert!(!pinned_version_drift_from_managed(&sidecar));
         sidecar.version = "0.0.1".to_string();
         assert!(pinned_version_drift_from_managed(&sidecar));
+    }
+
+    #[test]
+    fn stale_helper_only_rejects_known_older_versions() {
+        assert!(!pinned_version_older_than_managed("unknown"));
+        assert!(!pinned_version_older_than_managed(MANAGED_ZCCACHE_VERSION));
+        assert!(!pinned_version_older_than_managed("99.0.0"));
+        assert!(pinned_version_older_than_managed("0.0.1"));
+        assert!(pinned_version_older_than_managed("v0.0.1"));
     }
 
     fn sample_sidecar(version: &str) -> PinnedSidecar {

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -82,7 +82,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.2";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.3";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -82,7 +82,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.3";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.4";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/src/fetch/zccache.rs
+++ b/crates/soldr-cli/src/fetch/zccache.rs
@@ -439,6 +439,33 @@ pub fn zccache_binary_summary(paths: &SoldrPaths) -> Result<ZccacheBinarySummary
     }
 
     if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
+        if install_zccache::pinned_version_older_than_managed(&pinned.version) {
+            let runtime_dir = paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"));
+            let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
+            let any_present = cli.exists() || daemon.exists() || fp.exists();
+            let (debug_found, debug_expected) =
+                count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
+            return Ok(ZccacheBinarySummary {
+                source: if any_present {
+                    ZccacheSource::Managed
+                } else {
+                    ZccacheSource::None
+                },
+                version: if any_present {
+                    MANAGED_ZCCACHE_VERSION.to_string()
+                } else {
+                    String::new()
+                },
+                symbol_path: runtime_dir.clone(),
+                runtime_dir,
+                source_dir: None,
+                cli_path: cli.exists().then_some(cli),
+                daemon_path: daemon.exists().then_some(daemon),
+                fp_path: fp.exists().then_some(fp),
+                debug_info_found: debug_found,
+                debug_info_expected: debug_expected,
+            });
+        }
         // `soldr install-zccache` install. Reports `pinned` so
         // doctor can surface the override (and warn the managed path
         // is superseded).

--- a/crates/soldr-cli/src/fetch/zccache_install.rs
+++ b/crates/soldr-cli/src/fetch/zccache_install.rs
@@ -38,7 +38,7 @@ pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult,
     // with prepare_zccache_build's hard-coded "soldr: using managed
     // zccache 1.8.1" was the smoking gun that fooled the perf-cluster
     // debugging session.
-    if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
+    if let Some(pinned) = resolve_usable_pinned_zccache(paths, &target)? {
         return Ok(FetchResult {
             binary_path: pinned.binary_path,
             version: pinned.version,
@@ -107,7 +107,7 @@ pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, 
         return resolve_local_zccache_for_target(&local_dir, paths, &target).map(Some);
     }
 
-    if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
+    if let Some(pinned) = resolve_usable_pinned_zccache(paths, &target)? {
         return Ok(Some(FetchResult {
             binary_path: pinned.binary_path,
             version: pinned.version,
@@ -122,6 +122,25 @@ pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, 
         &["zccache", "zccache-daemon", "zccache-fp"],
         &target,
     )
+}
+
+fn resolve_usable_pinned_zccache(
+    paths: &SoldrPaths,
+    target: &TargetTriple,
+) -> Result<Option<install_zccache::PinnedResolution>, SoldrError> {
+    let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, target)? else {
+        return Ok(None);
+    };
+    if install_zccache::pinned_version_older_than_managed(&pinned.version) {
+        eprintln!(
+            "soldr: ignoring pinned zccache {} at {} because this soldr requires managed zccache {} or newer",
+            pinned.version,
+            pinned.runtime_dir.display(),
+            MANAGED_ZCCACHE_VERSION
+        );
+        return Ok(None);
+    }
+    Ok(Some(pinned))
 }
 
 /// Locate `zccache` on the system `PATH` and use it directly instead

--- a/crates/soldr-cli/src/rust_plan.rs
+++ b/crates/soldr-cli/src/rust_plan.rs
@@ -21,6 +21,9 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
+#[path = "rust_plan_proto.rs"]
+mod rust_plan_proto;
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct CargoMetadata {
     pub(crate) packages: Vec<CargoMetadataPackage>,
@@ -167,10 +170,9 @@ pub(crate) fn maybe_prepare_rust_artifact_plan(
     )?;
     let plan_dir = session.cache_dir.join("plans");
     std::fs::create_dir_all(&plan_dir)?;
-    let plan_path = plan_dir.join("last-rust-artifact-plan.json");
-    let plan_json = serde_json::to_string_pretty(&plan)
-        .map_err(|e| SoldrError::Other(format!("failed to serialize Rust artifact plan: {e}")))?;
-    std::fs::write(&plan_path, plan_json)?;
+    let plan_path = plan_dir.join("last-rust-artifact-plan.pb");
+    let plan_bytes = rust_plan_proto::plan_to_proto_bytes(&plan)?;
+    std::fs::write(&plan_path, plan_bytes)?;
 
     let plan_inputs_hash = compute_plan_inputs_hash(&plan);
     let target_dir = plan.target_dir.clone();

--- a/crates/soldr-cli/src/rust_plan_manifest.proto
+++ b/crates/soldr-cli/src/rust_plan_manifest.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package zccache.rust_plan.v1;
+
+message RustArtifactPlanV1 {
+  uint32 schema_version = 1;
+  uint32 mode = 2;
+  string workspace_root = 3;
+  string target_dir = 4;
+  RustToolchainIdentity toolchain = 5;
+  string target_triple = 6;
+  string profile = 7;
+  RustPlanInputs inputs = 8;
+  RustPlanPackages packages = 9;
+  repeated uint32 allowed_artifact_classes = 10;
+  uint32 cache_schema_version = 11;
+  string journal_log_path = 12;
+  string cache_profile = 13;
+  repeated uint32 dropped_artifact_classes = 14;
+}
+
+message RustToolchainIdentity {
+  string rustc = 1;
+  string cargo = 2;
+  string channel = 3;
+  string host = 4;
+}
+
+message RustPlanInputs {
+  string features_hash = 1;
+  string rustflags_hash = 2;
+  string env_hash = 3;
+  string lockfile_hash = 4;
+  string cargo_config_hash = 5;
+  repeated string manifest_hashes = 6;
+}
+
+message RustPlanPackages {
+  repeated string selected_package_ids = 1;
+  repeated string workspace_package_ids = 2;
+  repeated string excluded_path_package_ids = 3;
+}
+
+message RustArtifactBundleManifest {
+  uint32 manifest_schema_version = 1;
+  uint32 plan_schema_version = 2;
+  uint32 cache_schema_version = 3;
+  uint32 mode = 4;
+  string cache_key = 5;
+  uint64 created_at_secs = 6;
+  string plan_identity_hash = 7;
+  repeated RustBundledArtifact artifacts = 8;
+  uint32 layer_kind = 9;
+  string base_cache_key = 10;
+  repeated string deleted_paths = 11;
+}
+
+message RustBundledArtifact {
+  string relative_path = 1;
+  uint32 class = 2;
+  uint64 size = 3;
+  string content_hash = 4;
+  uint64 mtime_unix_nanos = 5;
+}

--- a/crates/soldr-cli/src/rust_plan_proto.rs
+++ b/crates/soldr-cli/src/rust_plan_proto.rs
@@ -1,0 +1,166 @@
+//! Hand-written prost types for the zccache `rust-plan` protobuf schema.
+//!
+//! The schema file lives next to this module as `rust_plan_manifest.proto`.
+//! Keep the two in sync with zccache's `zccache.rust_plan.v1` schema.
+
+use prost::Message as _;
+
+use crate::core::SoldrError;
+
+use super::RustArtifactPlan;
+
+pub mod wire {
+    use prost::Message;
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct RustArtifactPlanV1 {
+        #[prost(uint32, tag = "1")]
+        pub schema_version: u32,
+        #[prost(uint32, tag = "2")]
+        pub mode: u32,
+        #[prost(string, tag = "3")]
+        pub workspace_root: String,
+        #[prost(string, tag = "4")]
+        pub target_dir: String,
+        #[prost(message, optional, tag = "5")]
+        pub toolchain: Option<RustToolchainIdentity>,
+        #[prost(string, tag = "6")]
+        pub target_triple: String,
+        #[prost(string, tag = "7")]
+        pub profile: String,
+        #[prost(message, optional, tag = "8")]
+        pub inputs: Option<RustPlanInputs>,
+        #[prost(message, optional, tag = "9")]
+        pub packages: Option<RustPlanPackages>,
+        #[prost(uint32, repeated, tag = "10")]
+        pub allowed_artifact_classes: Vec<u32>,
+        #[prost(uint32, tag = "11")]
+        pub cache_schema_version: u32,
+        #[prost(string, tag = "12")]
+        pub journal_log_path: String,
+        #[prost(string, tag = "13")]
+        pub cache_profile: String,
+        #[prost(uint32, repeated, tag = "14")]
+        pub dropped_artifact_classes: Vec<u32>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct RustToolchainIdentity {
+        #[prost(string, tag = "1")]
+        pub rustc: String,
+        #[prost(string, tag = "2")]
+        pub cargo: String,
+        #[prost(string, tag = "3")]
+        pub channel: String,
+        #[prost(string, tag = "4")]
+        pub host: String,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct RustPlanInputs {
+        #[prost(string, tag = "1")]
+        pub features_hash: String,
+        #[prost(string, tag = "2")]
+        pub rustflags_hash: String,
+        #[prost(string, tag = "3")]
+        pub env_hash: String,
+        #[prost(string, tag = "4")]
+        pub lockfile_hash: String,
+        #[prost(string, tag = "5")]
+        pub cargo_config_hash: String,
+        #[prost(string, repeated, tag = "6")]
+        pub manifest_hashes: Vec<String>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct RustPlanPackages {
+        #[prost(string, repeated, tag = "1")]
+        pub selected_package_ids: Vec<String>,
+        #[prost(string, repeated, tag = "2")]
+        pub workspace_package_ids: Vec<String>,
+        #[prost(string, repeated, tag = "3")]
+        pub excluded_path_package_ids: Vec<String>,
+    }
+}
+
+pub(super) fn plan_to_proto_bytes(plan: &RustArtifactPlan) -> Result<Vec<u8>, SoldrError> {
+    let proto = wire::RustArtifactPlanV1 {
+        schema_version: plan.schema_version,
+        mode: plan_mode_to_proto(&plan.mode)?,
+        workspace_root: plan.workspace_root.clone(),
+        target_dir: plan.target_dir.clone(),
+        toolchain: Some(wire::RustToolchainIdentity {
+            rustc: plan.toolchain.rustc.clone(),
+            cargo: plan.toolchain.cargo.clone(),
+            channel: plan.toolchain.channel.clone(),
+            host: plan.toolchain.host.clone(),
+        }),
+        target_triple: plan.target_triple.clone(),
+        profile: plan.profile.clone(),
+        inputs: Some(wire::RustPlanInputs {
+            features_hash: plan.inputs.features_hash.clone(),
+            rustflags_hash: plan.inputs.rustflags_hash.clone(),
+            env_hash: plan.inputs.env_hash.clone(),
+            lockfile_hash: plan.inputs.lockfile_hash.clone(),
+            cargo_config_hash: plan.inputs.cargo_config_hash.clone(),
+            manifest_hashes: plan.inputs.manifest_hashes.clone(),
+        }),
+        packages: Some(wire::RustPlanPackages {
+            selected_package_ids: plan.packages.selected_package_ids.clone(),
+            workspace_package_ids: plan.packages.workspace_package_ids.clone(),
+            excluded_path_package_ids: plan.packages.excluded_path_package_ids.clone(),
+        }),
+        allowed_artifact_classes: plan
+            .allowed_artifact_classes
+            .iter()
+            .map(artifact_class_to_proto)
+            .collect::<Result<Vec<_>, _>>()?,
+        cache_schema_version: plan.cache_schema_version,
+        journal_log_path: plan.journal_log_path.clone().unwrap_or_default(),
+        cache_profile: plan.cache_profile.unwrap_or_default().to_string(),
+        dropped_artifact_classes: plan
+            .dropped_artifact_classes
+            .iter()
+            .map(artifact_class_to_proto)
+            .collect::<Result<Vec<_>, _>>()?,
+    };
+    let mut bytes = Vec::with_capacity(proto.encoded_len());
+    proto
+        .encode(&mut bytes)
+        .map_err(|err| SoldrError::Other(format!("failed to encode Rust artifact plan: {err}")))?;
+    Ok(bytes)
+}
+
+fn plan_mode_to_proto(mode: &str) -> Result<u32, SoldrError> {
+    match mode {
+        "thin" => Ok(1),
+        "full" => Ok(2),
+        other => Err(SoldrError::Other(format!(
+            "invalid Rust artifact plan mode {other:?}"
+        ))),
+    }
+}
+
+fn artifact_class_to_proto(class: &&'static str) -> Result<u32, SoldrError> {
+    match *class {
+        "rlib" => Ok(1),
+        "rmeta" => Ok(2),
+        "dep_info" => Ok(3),
+        "proc_macro" => Ok(4),
+        "shared_lib" => Ok(5),
+        "cargo_fingerprint" => Ok(6),
+        "cargo_fingerprint_meta" => Ok(7),
+        "cargo_fingerprint_outputs" => Ok(8),
+        "build_script_metadata" => Ok(9),
+        "build_script_output" => Ok(10),
+        "build_script_build" => Ok(11),
+        "incremental" => Ok(12),
+        "dwo" => Ok(13),
+        "pdb" => Ok(14),
+        "dsym" => Ok(15),
+        "full_target" => Ok(16),
+        other => Err(SoldrError::Other(format!(
+            "invalid Rust artifact class {other:?}"
+        ))),
+    }
+}

--- a/crates/soldr-cli/src/save_load.rs
+++ b/crates/soldr-cli/src/save_load.rs
@@ -10,7 +10,10 @@
 
 use std::path::PathBuf;
 
-use crate::cache_lib::save::{load, save, LoadOptions, SaveOptions, DEFAULT_ZSTD_LEVEL};
+use crate::cache_lib::save::{
+    load, read_manifest_file, read_manifest_from_archive, save, save_delta, write_manifest_file,
+    LoadOptions, SaveDeltaOptions, SaveOptions, DEFAULT_ZSTD_LEVEL,
+};
 use clap::Args;
 
 #[derive(Debug, Args)]
@@ -53,6 +56,11 @@ pub struct SaveArgs {
     /// so any wrapper can produce the same sidecar.
     #[arg(long = "mtimes-only")]
     pub mtimes_only: bool,
+
+    /// Produce a delta archive by comparing `--cache-dir` against this
+    /// protobuf manifest from a previously restored base archive.
+    #[arg(long, value_name = "FILE")]
+    pub delta_from_manifest: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -86,9 +94,68 @@ pub struct LoadArgs {
     /// `--workspace`; mutually exclusive with `--cache-dir`.
     #[arg(long = "mtimes-only")]
     pub mtimes_only: bool,
+
+    /// Write the archive's protobuf manifest to this path after a
+    /// successful load, for later `soldr save --delta-from-manifest`.
+    #[arg(long, value_name = "FILE")]
+    pub manifest_out: Option<PathBuf>,
 }
 
 pub fn run_save(args: SaveArgs) -> i32 {
+    if let Some(base_manifest_path) = args.delta_from_manifest.as_deref() {
+        let Some(cache_dir) = args.cache_dir.as_deref() else {
+            eprintln!("soldr save: --delta-from-manifest requires --cache-dir");
+            return 1;
+        };
+        if args.mtimes_only {
+            eprintln!("soldr save: --delta-from-manifest cannot be combined with --mtimes-only");
+            return 1;
+        }
+        let base_manifest = match read_manifest_file(base_manifest_path) {
+            Ok(manifest) => manifest,
+            Err(err) => {
+                eprintln!("soldr save: failed to read base manifest: {err}");
+                return 1;
+            }
+        };
+        let opts = SaveDeltaOptions {
+            workspace: args.workspace.as_deref(),
+            cache_dir,
+            base_manifest: &base_manifest,
+            out: &args.out,
+            zstd_level: args.zstd_level,
+            threads: args.threads,
+        };
+        let report = match save_delta(&opts) {
+            Ok(r) => r,
+            Err(err) => {
+                eprintln!("soldr save: {err}");
+                return 1;
+            }
+        };
+        if args.json {
+            println!(
+                "{{\"source_files\":{},\"cache_files\":{},\"deleted_cache_files\":{},\"archive_bytes\":{},\"elapsed_ms\":{},\"delta\":true}}",
+                report.source_files,
+                report.cache_files,
+                report.deleted_cache_files,
+                report.archive_bytes,
+                report.elapsed_ms,
+            );
+        } else {
+            println!(
+                "soldr save: source_files={} cache_files={} deleted_cache_files={} archive_bytes={} elapsed_ms={} delta=true out={}",
+                report.source_files,
+                report.cache_files,
+                report.deleted_cache_files,
+                report.archive_bytes,
+                report.elapsed_ms,
+                args.out.display(),
+            );
+        }
+        return 0;
+    }
+
     let opts = SaveOptions {
         workspace: args.workspace.as_deref(),
         cache_dir: args.cache_dir.as_deref(),
@@ -142,6 +209,19 @@ pub fn run_load(args: LoadArgs) -> i32 {
             return 1;
         }
     };
+    if let Some(out) = args.manifest_out.as_deref() {
+        let manifest = match read_manifest_from_archive(&args.archive) {
+            Ok(manifest) => manifest,
+            Err(err) => {
+                eprintln!("soldr load: failed to read manifest for --manifest-out: {err}");
+                return 1;
+            }
+        };
+        if let Err(err) = write_manifest_file(out, &manifest) {
+            eprintln!("soldr load: failed to write --manifest-out: {err}");
+            return 1;
+        }
+    }
     if args.json {
         println!(
             "{{\"cache_files_restored\":{},\"source_files_in_manifest\":{},\"mtimes_applied\":{},\"mtimes_skipped_missing\":{},\"mtimes_skipped_size_mismatch\":{},\"mtimes_skipped_modified\":{},\"elapsed_ms\":{}}}",

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.11.2");
+    assert_eq!(json["managed_zccache_version"], "1.11.3");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.11.2");
+    assert_eq!(json["managed_zccache_version"], "1.11.3");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.11.2");
+    assert_eq!(json["managed_zccache_version"], "1.11.3");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.11.3");
+    assert_eq!(json["managed_zccache_version"], "1.11.4");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.11.3");
+    assert_eq!(json["managed_zccache_version"], "1.11.4");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.11.3");
+    assert_eq!(json["managed_zccache_version"], "1.11.4");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.11.3");
+    assert_eq!(status_json["managed_version"], "1.11.4");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.11.3");
+    assert_eq!(json["managed_version"], "1.11.4");
 }
 
 #[test]

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.11.2");
+    assert_eq!(status_json["managed_version"], "1.11.3");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.11.2");
+    assert_eq!(json["managed_version"], "1.11.3");
 }
 
 #[test]

--- a/crates/soldr-cli/tests/cli_rust_plan.rs
+++ b/crates/soldr-cli/tests/cli_rust_plan.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::*;
-use serde_json::Value;
+use prost::Message as _;
 use std::io::Write;
 use std::process::Command;
 use std::{
@@ -11,6 +11,30 @@ use std::{
     path::{Path, PathBuf},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct RustArtifactPlanProto {
+    #[prost(uint32, tag = "1")]
+    schema_version: u32,
+    #[prost(uint32, tag = "2")]
+    mode: u32,
+    #[prost(message, optional, tag = "9")]
+    packages: Option<RustPlanPackagesProto>,
+    #[prost(uint32, tag = "11")]
+    cache_schema_version: u32,
+    #[prost(string, tag = "13")]
+    cache_profile: String,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct RustPlanPackagesProto {
+    #[prost(string, repeated, tag = "1")]
+    selected_package_ids: Vec<String>,
+    #[prost(string, repeated, tag = "2")]
+    workspace_package_ids: Vec<String>,
+    #[prost(string, repeated, tag = "3")]
+    excluded_path_package_ids: Vec<String>,
+}
 
 #[test]
 fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
@@ -99,26 +123,25 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
         .join("cache")
         .join("zccache")
         .join("plans")
-        .join("last-rust-artifact-plan.json");
-    let plan: Value =
-        serde_json::from_str(&fs::read_to_string(&plan_path).expect("read generated rust plan"))
-            .expect("parse generated rust plan");
-    assert_eq!(plan["schema_version"], 1);
-    assert_eq!(plan["mode"], "thin");
+        .join("last-rust-artifact-plan.pb");
+    let plan_bytes = fs::read(&plan_path).expect("read generated rust plan");
+    let plan = RustArtifactPlanProto::decode(plan_bytes.as_slice())
+        .expect("parse generated rust plan protobuf");
+    assert_eq!(plan.schema_version, 1);
+    assert_eq!(plan.mode, 1);
     // Default profile flipped to thin-v2 in issue #461; cache_schema_version
     // bumps to 2 to signal the fingerprint-aware prune contract to zccache.
-    assert_eq!(plan["cache_schema_version"], 2);
-    assert_eq!(plan["cache_profile"], "thin-v2");
+    assert_eq!(plan.cache_schema_version, 2);
+    assert_eq!(plan.cache_profile, "thin-v2");
+    let packages = plan.packages.expect("packages should be present");
     assert_eq!(
-        plan["packages"]["workspace_package_ids"][0],
+        packages.workspace_package_ids[0],
         "path+file:///repo/app#app@0.1.0"
     );
     assert!(
-        plan["packages"]["selected_package_ids"][0]
-            .as_str()
-            .unwrap()
-            .contains("serde"),
-        "external dependency should be selected in generated plan: {plan}"
+        packages.selected_package_ids[0].contains("serde"),
+        "external dependency should be selected in generated plan: {:?}",
+        packages.selected_package_ids
     );
 }
 

--- a/crates/soldr-cli/tests/lib_install_zccache.rs
+++ b/crates/soldr-cli/tests/lib_install_zccache.rs
@@ -352,6 +352,40 @@ async fn resolution_chain_pinned_overrides_managed_default() {
     );
 }
 
+#[tokio::test]
+async fn known_stale_pinned_zccache_does_not_override_managed_cache() {
+    let _guard = isolate_local_dir_env();
+    let tmp = tempfile::tempdir().unwrap();
+    let soldr_root = tmp.path().join("soldr-root");
+    let paths = SoldrPaths::with_root(soldr_root);
+
+    let src = seed_dir_source(tmp.path());
+    install_zccache_from_source(&InstallSource::Path(src), &paths)
+        .await
+        .expect("install");
+
+    let mut sidecar = read_pinned_sidecar(&paths).unwrap().unwrap();
+    sidecar.version = "1.11.2".to_string();
+    let sidecar_path = pinned_zccache_dir(&paths).join("source.json");
+    fs::write(&sidecar_path, serde_json::to_vec_pretty(&sidecar).unwrap()).unwrap();
+
+    let managed_dir = paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"));
+    write_fake(&managed_dir, &bin_name("zccache"), b"managed-cli");
+    write_fake(&managed_dir, &bin_name("zccache-daemon"), b"managed-daemon");
+    write_fake(&managed_dir, &bin_name("zccache-fp"), b"managed-fp");
+
+    let cached = soldr_cli::fetch::cached_zccache_binary(&paths)
+        .unwrap()
+        .expect("managed cache should be reported");
+    assert!(
+        cached.binary_path.starts_with(&managed_dir),
+        "expected managed path under {} but got {}",
+        managed_dir.display(),
+        cached.binary_path.display()
+    );
+    assert_eq!(cached.version, MANAGED_ZCCACHE_VERSION);
+}
+
 // ---------------------------------------------------------------------
 // PathGuard — RAII wrapper that sets PATH for the duration of a test
 // and restores it on drop. Tests that touch PATH MUST hold the global

--- a/crates/soldr-cli/tests/save_roundtrip.rs
+++ b/crates/soldr-cli/tests/save_roundtrip.rs
@@ -9,7 +9,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use soldr_cli::cache_lib::save::{load, save, LoadOptions, SaveOptions, DEFAULT_ZSTD_LEVEL};
+use soldr_cli::cache_lib::save::{
+    load, read_manifest_from_archive, save, save_delta, CacheLayerKind, LoadOptions,
+    SaveDeltaOptions, SaveOptions, DEFAULT_ZSTD_LEVEL,
+};
 
 fn write(path: &Path, content: &[u8]) {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -29,6 +32,21 @@ fn mtime_ms(path: &Path) -> i64 {
 fn touch(path: &Path, ms: i64) {
     let t = filetime::FileTime::from_system_time(UNIX_EPOCH + Duration::from_millis(ms as u64));
     filetime::set_file_times(path, t, t).unwrap();
+}
+
+fn archive_paths(archive: &Path) -> Vec<String> {
+    let file = fs::File::open(archive).unwrap();
+    let reader = std::io::BufReader::new(file);
+    let zstd = zstd::stream::read::Decoder::new(reader).unwrap();
+    let mut tar = tar::Archive::new(zstd);
+    let mut paths = Vec::new();
+    for entry in tar.entries().unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path().unwrap().to_string_lossy().replace('\\', "/");
+        paths.push(path);
+    }
+    paths.sort();
+    paths
 }
 
 /// Make a tiny realistic workspace + cache.
@@ -504,5 +522,140 @@ fn save_without_cache_or_mtimes_only_errors() {
     assert!(
         msg.contains("--cache-dir") || msg.contains("--mtimes-only"),
         "error message must mention required flag: {msg}"
+    );
+}
+
+#[test]
+fn delta_cache_roundtrip_restores_base_overlay_tombstones_and_mtimes() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    let base_archive = dir.path().join("base.tar.zst");
+    let delta_archive = dir.path().join("delta.tar.zst");
+    let restore = dir.path().join("restore");
+
+    let large = vec![0xAB; 256 * 1024];
+    write(&cache.join("deps/large.rlib"), &large);
+    write(&cache.join("deps/changed.rmeta"), b"base-content\n");
+    write(&cache.join("deps/deleted.d"), b"delete-me\n");
+    write(&cache.join("deps/mtime-only.d"), b"same-content\n");
+
+    let large_mtime = 1_700_000_000_000i64;
+    let changed_base_mtime = 1_700_000_010_000i64;
+    let deleted_mtime = 1_700_000_020_000i64;
+    let mtime_only_base_mtime = 1_700_000_025_000i64;
+    touch(&cache.join("deps/large.rlib"), large_mtime);
+    touch(&cache.join("deps/changed.rmeta"), changed_base_mtime);
+    touch(&cache.join("deps/deleted.d"), deleted_mtime);
+    touch(&cache.join("deps/mtime-only.d"), mtime_only_base_mtime);
+
+    let base_report = save(&SaveOptions {
+        workspace: None,
+        cache_dir: Some(&cache),
+        out: &base_archive,
+        zstd_level: DEFAULT_ZSTD_LEVEL,
+        threads: Some(1),
+        mtimes_only: false,
+    })
+    .expect("base save ok");
+    assert_eq!(base_report.cache_files, 4);
+
+    let base_manifest = read_manifest_from_archive(&base_archive).expect("base manifest");
+    assert_eq!(
+        base_manifest.cache_layer_kind,
+        CacheLayerKind::Complete as i32
+    );
+    assert_eq!(base_manifest.cache_files.len(), 4);
+
+    write(&cache.join("deps/changed.rmeta"), b"delta-content\n");
+    fs::remove_file(cache.join("deps/deleted.d")).unwrap();
+    write(&cache.join("deps/new.rmeta"), b"new-content\n");
+    let changed_delta_mtime = 1_700_000_030_000i64;
+    let new_mtime = 1_700_000_040_000i64;
+    let mtime_only_delta_mtime = 1_700_000_050_000i64;
+    touch(&cache.join("deps/changed.rmeta"), changed_delta_mtime);
+    touch(&cache.join("deps/new.rmeta"), new_mtime);
+    touch(&cache.join("deps/mtime-only.d"), mtime_only_delta_mtime);
+
+    let delta_report = save_delta(&SaveDeltaOptions {
+        workspace: None,
+        cache_dir: &cache,
+        base_manifest: &base_manifest,
+        out: &delta_archive,
+        zstd_level: DEFAULT_ZSTD_LEVEL,
+        threads: Some(1),
+    })
+    .expect("delta save ok");
+    assert_eq!(
+        delta_report.cache_files, 3,
+        "changed/new files plus a metadata-only mtime update"
+    );
+    assert_eq!(delta_report.deleted_cache_files, 1);
+
+    let delta_manifest = read_manifest_from_archive(&delta_archive).expect("delta manifest");
+    assert_eq!(
+        delta_manifest.cache_layer_kind,
+        CacheLayerKind::Delta as i32
+    );
+    assert_eq!(delta_manifest.deleted_cache_paths, vec!["deps/deleted.d"]);
+    assert!(
+        delta_manifest
+            .cache_files
+            .iter()
+            .any(|entry| entry.path == "deps/mtime-only.d"),
+        "mtime-only change should be carried in protobuf metadata"
+    );
+    let paths = archive_paths(&delta_archive);
+    assert!(paths.contains(&"SOLDR_MANIFEST.pb".to_string()));
+    assert!(paths.contains(&"cache/deps/changed.rmeta".to_string()));
+    assert!(paths.contains(&"cache/deps/new.rmeta".to_string()));
+    assert!(
+        !paths.contains(&"cache/deps/large.rlib".to_string()),
+        "unchanged large files must stay out of the delta archive"
+    );
+    assert!(
+        !paths.contains(&"cache/deps/mtime-only.d".to_string()),
+        "mtime-only changes should not upload file bytes"
+    );
+
+    load(&LoadOptions {
+        archive: &base_archive,
+        cache_dir: Some(&restore),
+        workspace: None,
+        threads: Some(1),
+        mtimes_only: false,
+    })
+    .expect("base load ok");
+    load(&LoadOptions {
+        archive: &delta_archive,
+        cache_dir: Some(&restore),
+        workspace: None,
+        threads: Some(1),
+        mtimes_only: false,
+    })
+    .expect("delta load ok");
+
+    assert_eq!(fs::read(restore.join("deps/large.rlib")).unwrap(), large);
+    assert_eq!(
+        fs::read(restore.join("deps/changed.rmeta")).unwrap(),
+        b"delta-content\n"
+    );
+    assert_eq!(
+        fs::read(restore.join("deps/new.rmeta")).unwrap(),
+        b"new-content\n"
+    );
+    assert_eq!(
+        fs::read(restore.join("deps/mtime-only.d")).unwrap(),
+        b"same-content\n"
+    );
+    assert!(!restore.join("deps/deleted.d").exists());
+    assert_eq!(mtime_ms(&restore.join("deps/large.rlib")), large_mtime);
+    assert_eq!(
+        mtime_ms(&restore.join("deps/changed.rmeta")),
+        changed_delta_mtime
+    );
+    assert_eq!(mtime_ms(&restore.join("deps/new.rmeta")), new_mtime);
+    assert_eq!(
+        mtime_ms(&restore.join("deps/mtime-only.d")),
+        mtime_only_delta_mtime
     );
 }

--- a/tests/test_setup_soldr_pins.py
+++ b/tests/test_setup_soldr_pins.py
@@ -46,6 +46,7 @@ def test_ci_resets_restore_key_target_artifacts_before_self_builds() -> None:
         assert "id: setup_soldr" in workflow
         assert "steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'" in workflow
         assert "steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit'" in workflow
+        assert "SOLDR_TARGET_CACHE_MODE=off" in workflow
         assert 'Join-Path "target" "${{ inputs.target }}"' in workflow
         assert 'Join-Path $env:ZCCACHE_CACHE_DIR "artifacts"' in workflow
 

--- a/tests/test_setup_soldr_pins.py
+++ b/tests/test_setup_soldr_pins.py
@@ -29,11 +29,27 @@ def test_soldr_self_builds_use_pinned_public_setup_soldr() -> None:
     bootstrap = (
         REPO_ROOT / ".github" / "workflows" / "_bootstrap-e2e.yml"
     ).read_text(encoding="utf-8")
-    release = (REPO_ROOT / ".github" / "workflows" / "release-auto.yml").read_text(
+
+    assert "uses: ./soldr" not in bootstrap
+    assert "uses: zackees/setup-soldr@" in bootstrap
+
+
+def test_ci_resets_restore_key_target_artifacts_before_self_builds() -> None:
+    bootstrap = (
+        REPO_ROOT / ".github" / "workflows" / "_bootstrap-e2e.yml"
+    ).read_text(encoding="utf-8")
+    build = (REPO_ROOT / ".github" / "workflows" / "_build-and-test.yml").read_text(
         encoding="utf-8"
     )
 
-    assert "uses: ./soldr" not in bootstrap
-    assert "uses: ./" not in release
-    assert "uses: zackees/setup-soldr@" in bootstrap
-    assert "uses: zackees/setup-soldr@" in release
+    for workflow in (bootstrap, build):
+        assert "id: setup_soldr" in workflow
+        assert "steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'" in workflow
+        assert "steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit'" in workflow
+        assert 'Join-Path "target" "${{ inputs.target }}"' in workflow
+        assert 'Join-Path $env:ZCCACHE_CACHE_DIR "artifacts"' in workflow
+
+    reset_block = bootstrap.split("Reset stale cache fallback artifacts", 1)[1].split(
+        "Build soldr-cli", 1
+    )[0]
+    assert "contains(inputs.target, 'musl')" not in reset_block


### PR DESCRIPTION
## Summary
- add protobuf cache-file metadata to `soldr save/load` manifests, including layer kind, base digest, tombstones, mtimes, size, and BLAKE3
- add `soldr save --delta-from-manifest` and `soldr load --manifest-out` so setup-soldr can restore a base archive and then save a small delta archive
- switch the zccache rust-plan handoff to protobuf and bump managed zccache to 1.11.3
- add an explicit base+delta roundtrip unit test covering changed files, unchanged base files, tombstones, metadata-only mtime updates, and no upload of unchanged large files

## Tests
- `soldr cargo fmt --all -- --check`
- `soldr cargo test -p soldr-cli --test save_roundtrip`
- `soldr cargo test -p soldr-cli --test cli_rust_plan`
- `soldr cargo test -p soldr-cli --test cli_cache`
- `soldr cargo test -p soldr-cli --test cli_install_zccache_resolution`
- `soldr cargo clippy -p soldr-cli --all-targets -- -D warnings`

Closes #533
Part of #534
