### PR TITLE
test: isolate nested soldr subprocess env

### DIFF
--- a/.github/workflows/cache-delta-experiment.yml
+++ b/.github/workflows/cache-delta-experiment.yml
@@ -66,10 +66,11 @@ jobs:
         # before the release-auto workflow has built and published
         # the matching tarball; setup-soldr fetches by tag, so an
         # unpublished version 404s here.
-        uses: zackees/setup-soldr@d084d24f3f4b361a56fad52b3c37bcd0ead5a75e
+        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
         with:
           version: "0.7.28"
           cache: false
+          zccache-seed-strict: true
           linker: platform-default
           cache-dir: ${{ runner.temp }}/cache-delta-exp-setup
           build-cache: false
@@ -156,11 +157,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: zackees/setup-soldr@d084d24f3f4b361a56fad52b3c37bcd0ead5a75e
+      - uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
         with:
           # 0.7.29 brings `soldr cook` — see delta job above for why.
           version: "0.7.28"
           cache: false
+          zccache-seed-strict: true
           linker: platform-default
           cache-dir: ${{ runner.temp }}/cache-delta-exp-baseline-setup
           build-cache: false

--- a/crates/soldr-cli/tests/cli_cargo_linker.rs
+++ b/crates/soldr-cli/tests/cli_cargo_linker.rs
@@ -47,7 +47,7 @@ fn cargo_front_door_default_linker_does_not_inject_target_env() {
     let cache_root = unique_temp_dir("cargo-default-linker");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -78,7 +78,7 @@ fn cargo_front_door_rust_lld_injects_target_linker_env() {
     let cache_root = unique_temp_dir("cargo-rust-lld-linker");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -147,7 +147,7 @@ fn cargo_front_door_mold_on_non_linux_returns_clear_error() {
     let cache_root = unique_temp_dir("cargo-mold-non-linux");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -190,7 +190,7 @@ fn cargo_front_door_fast_picks_rust_lld_when_mold_absent() {
     let cache_root = unique_temp_dir("cargo-fast-linker");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)

--- a/crates/soldr-cli/tests/cli_cargo_wrappers.rs
+++ b/crates/soldr-cli/tests/cli_cargo_wrappers.rs
@@ -24,7 +24,7 @@ fn cargo_front_door_uses_real_tool_overrides_before_path_probe() {
         &fake_version_tool_script(&log_path, "shim-cargo"),
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_REAL_CARGO", &cargo)
@@ -59,7 +59,7 @@ fn cargo_front_door_does_not_start_cache_for_non_build_subcommands() {
     let cache_root = unique_temp_dir("cargo-non-build-no-cache");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "metadata"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -94,7 +94,7 @@ fn cargo_front_door_detects_build_after_global_cargo_options() {
     let cache_root = unique_temp_dir("cargo-global-options-cache");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "--manifest-path", "demo/Cargo.toml", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -125,7 +125,7 @@ fn cargo_front_door_preserves_jobserver_fds_into_managed_zccache_wrapper() {
     let cache_root = unique_temp_dir("cargo-jobserver-fds");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_jobserver_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "test", "--no-run"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -163,7 +163,7 @@ fn cache_enabled_zccache_build_completes_under_20_seconds() {
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
 
     let started = Instant::now();
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -201,7 +201,7 @@ fn managed_zccache_rejects_conflicting_cache_dir_override() {
     let cache_root = unique_temp_dir("cargo-conflicting-zccache-dir");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("ZCCACHE_CACHE_DIR", cache_root.join("user-zccache"))
@@ -234,7 +234,7 @@ fn nested_soldr_ignores_inherited_managed_zccache_cache_dir() {
     let child_zccache_dir = child_cache_root.join("cache").join("zccache");
     let log_path = child_cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &child_cache_root)
         .env("ZCCACHE_CACHE_DIR", &parent_zccache_dir)
@@ -280,7 +280,7 @@ fn managed_zccache_injects_normalized_path_remap_by_default() {
     fs::create_dir_all(repo_root.join(".git")).expect("failed to create fake git root");
     fs::create_dir_all(&nested).expect("failed to create nested cwd");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .current_dir(&nested)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -321,7 +321,7 @@ fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
     let wrapper = install_fake_wrapper(&log_path, "sccache");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -386,7 +386,7 @@ fn custom_sccache_wrapper_preserves_caller_sccache_dir() {
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
     let wrapper = install_fake_wrapper(&log_path, "sccache");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -427,7 +427,7 @@ fn empty_rustc_wrapper_override_disables_wrapper_injection() {
     let cache_root = unique_temp_dir("cargo-wrapper-disabled");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -467,7 +467,7 @@ fn no_cache_bypasses_wrapper_and_zccache() {
     let cache_root = unique_temp_dir("cargo-no-cache-fake");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["--no-cache", "cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -505,7 +505,7 @@ fn no_cache_bypasses_wrapper_and_zccache() {
 #[test]
 fn rustc_wrapper_mode_passes_through_to_rustc() {
     let rustc = rustup_which("rustc");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .arg(rustc)
         .arg("--version")
         .output()
@@ -538,7 +538,7 @@ fn repo_local_toolchain_homes_are_used_when_env_vars_are_unset() {
         vec!["rustfmt", "--version"],
         vec!["--no-cache", "rustc", "--version"],
     ] {
-        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        let output = isolated_soldr_command()
             .args(&args)
             .current_dir(&nested)
             .env("SOLDR_CACHE_DIR", &cache_root)
@@ -623,7 +623,7 @@ fn repo_local_cargo_bin_tools_work_without_rustup() {
         vec!["rustfmt", "--version"],
         vec!["--no-cache", "rustc", "--version"],
     ] {
-        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        let output = isolated_soldr_command()
             .args(&args)
             .current_dir(&nested)
             .env("SOLDR_CACHE_DIR", &cache_root)
@@ -678,7 +678,7 @@ fn explicit_toolchain_home_env_vars_win_over_repo_local_homes() {
     fs::create_dir_all(&repo_rustup_home).expect("failed to create repo-local .rustup");
     fs::create_dir_all(&nested).expect("failed to create nested working dir");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["--no-cache", "cargo", "--version"])
         .current_dir(&nested)
         .env("SOLDR_CACHE_DIR", &cache_root)

--- a/crates/soldr-cli/tests/cli_toolchain.rs
+++ b/crates/soldr-cli/tests/cli_toolchain.rs
@@ -24,7 +24,7 @@ timed_test!(
         let log_path = workspace.join("rustup.log");
         let rustup = install_logging_fake_rustup(&log_path);
 
-        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        let output = isolated_soldr_command()
             .args(["rustup", "show"])
             .current_dir(&workspace)
             .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -51,7 +51,7 @@ fn rustup_passthrough_injects_toolchain_for_target_add() {
     let log_path = workspace.join("rustup.log");
     let rustup = install_logging_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["rustup", "target", "add", "x86_64-unknown-linux-musl"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -86,7 +86,7 @@ fn rustup_passthrough_does_not_double_inject_toolchain() {
     let log_path = workspace.join("rustup.log");
     let rustup = install_logging_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args([
             "rustup",
             "target",
@@ -136,7 +136,7 @@ fn toolchain_install_invokes_rustup_with_channel() {
     let log_path = workspace.join("rustup.log");
     let rustup = install_logging_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["toolchain", "install"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -178,7 +178,7 @@ fn toolchain_prepare_installs_channel_components_and_targets() {
     let log_path = workspace.join("rustup.log");
     let rustup = install_logging_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["toolchain", "prepare"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -250,7 +250,7 @@ fn toolchain_prepare_installs_plugins_with_version() {
     let rustup = install_logging_fake_rustup(&rustup_log);
     let cargo = install_logging_fake_cargo(&cargo_log);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["toolchain", "prepare"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -300,7 +300,7 @@ fn toolchain_prepare_installs_plugin_with_locked_flag() {
     let rustup = install_logging_fake_rustup(&rustup_log);
     let cargo = install_logging_fake_cargo(&cargo_log);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["toolchain", "prepare"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -348,7 +348,7 @@ fn rustup_passthrough_injects_toolchain_for_component_add() {
     let log_path = workspace.join("rustup.log");
     let rustup = install_logging_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["rustup", "component", "add", "clippy"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -385,7 +385,7 @@ fn rustup_passthrough_does_not_inject_for_toolchain_list() {
     let log_path = workspace.join("rustup.log");
     let rustup = install_logging_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["rustup", "toolchain", "list"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -409,7 +409,7 @@ fn rustup_passthrough_forwards_version_flag_verbatim() {
     let log_path = workspace.join("rustup.log");
     let rustup = install_logging_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["rustup", "--version"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -431,7 +431,7 @@ fn rustup_passthrough_handles_target_add_equals_form_for_explicit_toolchain() {
     let log_path = workspace.join("rustup.log");
     let rustup = install_logging_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args([
             "rustup",
             "target",
@@ -480,7 +480,7 @@ fn toolchain_prepare_plugin_without_version_uses_no_version_flag() {
     let rustup = install_logging_fake_rustup(&rustup_log);
     let cargo = install_logging_fake_cargo(&cargo_log);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["toolchain", "prepare"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -542,7 +542,7 @@ fn toolchain_ensure_runs_prepare_then_smoke_verify_in_json_mode() {
         install_logging_versioned_fake_cargo(&cargo_log, "cargo 1.94.1 (abc1234 2026-04-15)");
     let rustc = install_versioned_fake_rustc("rustc 1.94.1 (def5678 2026-04-15)");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["toolchain", "ensure", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -654,7 +654,7 @@ fn toolchain_ensure_human_mode_succeeds_without_json() {
         install_logging_versioned_fake_cargo(&cargo_log, "cargo 1.94.1 (abc1234 2026-04-15)");
     let rustc = install_versioned_fake_rustc("rustc 1.94.1 (def5678 2026-04-15)");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["toolchain", "ensure"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -695,7 +695,7 @@ fn toolchain_ensure_json_reports_smoke_failure_when_rustc_returns_nonzero() {
         install_logging_versioned_fake_cargo(&cargo_log, "cargo 1.94.1 (abc1234 2026-04-15)");
     let rustc = install_failing_fake_rustc();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["toolchain", "ensure", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -736,7 +736,7 @@ fn toolchain_ensure_no_channel_emits_empty_schema_v1_payload() {
         install_logging_versioned_fake_cargo(&cargo_log, "cargo 1.94.1 (abc1234 2026-04-15)");
     let rustc = install_versioned_fake_rustc("rustc 1.94.1 (def5678 2026-04-15)");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args(["toolchain", "ensure", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -790,7 +790,7 @@ fn toolchain_link_writes_every_routed_tool_into_shim_dir() {
     let workspace = unique_temp_dir("toolchain-link-fresh");
     let shim_dir = workspace.join("shims");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args([
             "toolchain",
             "link",
@@ -835,7 +835,7 @@ fn toolchain_link_emits_schema_v1_json_payload() {
     let workspace = unique_temp_dir("toolchain-link-json");
     let shim_dir = workspace.join("shims");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = isolated_soldr_command()
         .args([
             "toolchain",
             "link",
@@ -897,7 +897,7 @@ fn toolchain_link_is_idempotent_when_rerun_with_same_soldr_binary() {
     let workspace = unique_temp_dir("toolchain-link-idempotent");
     let shim_dir = workspace.join("shims");
 
-    let first = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let first = isolated_soldr_command()
         .args([
             "toolchain",
             "link",
@@ -927,7 +927,7 @@ fn toolchain_link_is_idempotent_when_rerun_with_same_soldr_binary() {
     // on filesystems with low-res mtimes.
     std::thread::sleep(Duration::from_millis(50));
 
-    let second = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let second = isolated_soldr_command()
         .args([
             "toolchain",
             "link",
@@ -989,7 +989,7 @@ fn toolchain_link_force_overwrites_user_modified_shim() {
     }
 
     // Without --force the run must NOT overwrite differing content.
-    let no_force = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let no_force = isolated_soldr_command()
         .args([
             "toolchain",
             "link",
@@ -1011,7 +1011,7 @@ fn toolchain_link_force_overwrites_user_modified_shim() {
     }
 
     // With --force the run MUST overwrite.
-    let with_force = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let with_force = isolated_soldr_command()
         .args([
             "toolchain",
             "link",

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -13,6 +13,31 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
+pub(crate) fn isolated_soldr_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_soldr"));
+    scrub_outer_soldr_env(&mut command);
+    command
+}
+
+pub(crate) fn scrub_outer_soldr_env(command: &mut Command) -> &mut Command {
+    command
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .env_remove("SOLDR_LINKER")
+        .env_remove("CARGO_BUILD_TARGET")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("RUSTFLAGS");
+    for (name, _) in std::env::vars_os() {
+        if name
+            .to_str()
+            .is_some_and(|name| name.starts_with("CARGO_TARGET_"))
+        {
+            command.env_remove(name);
+        }
+    }
+    command
+}
+
 pub(crate) fn rustup_which(tool: &str) -> String {
     let output = Command::new("rustup")
         .args(["which", tool])


### PR DESCRIPTION
## Summary
- add an integration-test helper that starts nested `soldr` subprocesses without outer `RUSTC_WRAPPER`, `SOLDR_LINKER`, or `CARGO_TARGET_*` environment leakage
- use that helper in linker, wrapper, and toolchain integration tests that spawn nested soldr commands
- update remaining setup-soldr workflow pins to the current `@v0` SHA and enable strict zccache seed there too

## Verification
- `soldr cargo fmt --check`
- `python .github/scripts/verify_setup_soldr_pin.py`
- `git diff --check`
- `$env:SOLDR_LINKER='fast'; soldr cargo test -p soldr-cli --test cli_cargo_linker --test cli_cargo_wrappers --locked`
- `soldr --no-cache cargo test -p soldr-cli --test cli_toolchain --locked`

Refs zackees/zccache#405.