### PR TITLE
chore: bump soldr to 0.7.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.37"
+version = "0.7.38"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- bump workspace/package version to 0.7.38 for the protobuf cook delta release
- update Cargo.lock and npm package metadata to match

## Verification
- soldr cargo metadata --locked --no-deps --format-version 1
- git diff --check
- package.json parsed as 0.7.38