### PR TITLE
chore: bump soldr to 0.7.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.38"
+version = "0.7.39"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.38"
+version = "0.7.39"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- bump soldr workspace/package metadata to 0.7.39
- release includes the long cache archive path fix from #541

## Verification
- `git diff --check`

Refs zackees/soldr#534