### PR TITLE
refactor(zccache): introduce runtime resolver contract

### DIFF
--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -18,7 +18,7 @@ from pathlib import Path
 # zccache + zccache-daemon + zccache-fp + crgx + manifest.json at its
 # root. The setup-soldr action extracts every binary into the install
 # dir and exports SOLDR_ZCCACHE_LOCAL_DIR + SOLDR_CRGX_LOCAL_DIR so
-# soldr's runtime resolution wires up the bundled tools without a
+# soldr's runtime resolver wires up the bundled tools without a
 # managed-download round trip.
 ARCHIVE_EXT = "tar.zst"
 ZCCACHE_BUNDLED_BINARIES = ("zccache", "zccache-daemon", "zccache-fp")

--- a/bin/soldr.js
+++ b/bin/soldr.js
@@ -23,8 +23,8 @@ if (!fs.existsSync(binaryPath)) {
 // Wire the bundled zccache trio (zccache, zccache-daemon, zccache-fp,
 // shipped alongside soldr in `bin/native/` since the combined-archive
 // release format landed) into soldr's local-zccache resolution path.
-// Soldr's `fetch_zccache_with_paths` checks SOLDR_ZCCACHE_LOCAL_DIR
-// ahead of the managed-download chain, so this turns the bundled
+// Soldr's ZccacheResolver checks SOLDR_ZCCACHE_LOCAL_DIR ahead of the
+// pinned and managed-download chain, so this turns the bundled
 // binaries into the active zccache automatically — no manual env
 // setup, no managed fetch over the network. Users who explicitly set
 // the env var themselves keep their override.

--- a/crates/soldr-cli/src/binaries.rs
+++ b/crates/soldr-cli/src/binaries.rs
@@ -267,15 +267,19 @@ pub(crate) fn current_soldr_binary() -> Result<std::path::PathBuf, SoldrError> {
 pub(crate) async fn fetch_active_zccache(
     paths: &SoldrPaths,
 ) -> Result<crate::fetch::FetchResult, SoldrError> {
+    fetch_active_zccache_runtime(paths).await?.to_fetch_result()
+}
+
+pub(crate) async fn fetch_active_zccache_runtime(
+    paths: &SoldrPaths,
+) -> Result<crate::fetch::ZccacheRuntime, SoldrError> {
     if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
-        return Ok(crate::fetch::FetchResult {
-            binary_path,
-            version: crate::fetch::MANAGED_ZCCACHE_VERSION.to_string(),
-            cached: true,
-        });
+        return crate::fetch::ZccacheRuntime::from_test_override(binary_path);
     }
 
-    crate::fetch::fetch_zccache_with_paths(paths).await
+    crate::fetch::ZccacheResolver::new(paths)?
+        .materialize_default()
+        .await
 }
 
 /// Same precedence chain as [`fetch_active_zccache`] but only reports
@@ -285,15 +289,26 @@ pub(crate) async fn fetch_active_zccache(
 pub(crate) fn cached_active_zccache(
     paths: &SoldrPaths,
 ) -> Result<Option<crate::fetch::FetchResult>, SoldrError> {
+    cached_active_zccache_runtime(paths)?
+        .map(|runtime| runtime.to_fetch_result())
+        .transpose()
+}
+
+pub(crate) fn cached_active_zccache_runtime(
+    paths: &SoldrPaths,
+) -> Result<Option<crate::fetch::ZccacheRuntime>, SoldrError> {
     if let Some(binary_path) = non_empty_env_path(TEST_ZCCACHE_BIN_ENV_VAR) {
-        return Ok(Some(crate::fetch::FetchResult {
+        return Ok(Some(crate::fetch::ZccacheRuntime::from_test_override(
             binary_path,
-            version: crate::fetch::MANAGED_ZCCACHE_VERSION.to_string(),
-            cached: true,
-        }));
+        )?));
     }
 
-    crate::fetch::cached_zccache_binary(paths)
+    let runtime = crate::fetch::ZccacheResolver::new(paths)?.inspect_default()?;
+    if runtime.is_missing() {
+        Ok(None)
+    } else {
+        Ok(Some(runtime))
+    }
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/src/cache/install.rs
+++ b/crates/soldr-cli/src/cache/install.rs
@@ -146,9 +146,18 @@ fn run_install_zccache_remove(json: bool) -> Result<(), SoldrError> {
 fn run_install_zccache_status(json: bool) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
     let sidecar = crate::fetch::read_pinned_sidecar(&paths)?;
+    let pinned_runtime = crate::fetch::ZccacheResolver::new(&paths)?.inspect_pinned()?;
     match sidecar {
         Some(sidecar) => {
             let drift = crate::fetch::pinned_version_drift_from_managed(&sidecar);
+            let install_dir = pinned_runtime
+                .as_ref()
+                .map(|runtime| runtime.runtime_dir.display().to_string())
+                .unwrap_or_else(|| {
+                    crate::fetch::pinned_zccache_dir(&paths)
+                        .display()
+                        .to_string()
+                });
             if json {
                 let pinned_value = serde_json::to_value(&sidecar).map_err(|e| {
                     SoldrError::Other(format!("install-zccache status: serialize sidecar: {e}"))
@@ -163,10 +172,7 @@ fn run_install_zccache_status(json: bool) -> Result<(), SoldrError> {
                 print_json(&output)?;
             } else {
                 println!("soldr install-zccache --status");
-                println!(
-                    "  install dir:  {}",
-                    crate::fetch::pinned_zccache_dir(&paths).display()
-                );
+                println!("  install dir:  {install_dir}");
                 println!(
                     "  source:       {} ({})",
                     sidecar.source_kind, sidecar.source_value

--- a/crates/soldr-cli/src/cache/mod.rs
+++ b/crates/soldr-cli/src/cache/mod.rs
@@ -8,7 +8,7 @@
 
 use crate::core::{SoldrError, SoldrPaths};
 use crate::zccache::{managed_zccache_cache_dir, run_zccache_command_raw_in_cache_dir};
-use crate::{cached_active_zccache, JSON_SCHEMA_VERSION};
+use crate::{cached_active_zccache, cached_active_zccache_runtime, JSON_SCHEMA_VERSION};
 use serde::Serialize;
 
 mod install;
@@ -179,8 +179,9 @@ pub(super) fn collect_zccache_status(
     let session_stats_path = crate::cache_lib::session_stats_path(&zccache_dir);
     let session_stats_present = session_stats_path.exists();
 
-    match cached_active_zccache(paths)? {
-        Some(fetch) => {
+    match cached_active_zccache_runtime(paths)? {
+        Some(runtime) => {
+            let fetch = runtime.to_fetch_result()?;
             // Use the raw helper so a non-zero exit with a "daemon not
             // running" stderr surfaces as success-with-empty-status rather
             // than a hard error — issue #426 made this case reachable in
@@ -209,7 +210,6 @@ pub(super) fn collect_zccache_status(
                     stderr.trim()
                 )));
             };
-            let source = crate::fetch::classify_zccache_source(paths, &fetch.binary_path);
             Ok(ZccacheStatusSnapshot {
                 cache_dir: zccache_dir.display().to_string(),
                 state_dir: zccache_dir.display().to_string(),
@@ -220,7 +220,7 @@ pub(super) fn collect_zccache_status(
                 session_stats_path: session_stats_path.display().to_string(),
                 session_stats_present,
                 binary_path: Some(fetch.binary_path.display().to_string()),
-                binary_source: source.as_str(),
+                binary_source: runtime.source.summary_source().as_str(),
                 binary_fetched: true,
                 status_lines,
                 status_empty,

--- a/crates/soldr-cli/src/doctor.rs
+++ b/crates/soldr-cli/src/doctor.rs
@@ -552,6 +552,18 @@ fn print_managed_zccache_human(summary: &ZccacheBinarySummary, superseded_by_pin
                 println!("  version:       {}", summary.version);
             }
         }
+        ZccacheSource::System => {
+            println!("  source:        system{suffix}");
+            if !summary.version.is_empty() {
+                println!("  version:       {}", summary.version);
+            }
+        }
+        ZccacheSource::TestOverride => {
+            println!("  source:        test-override{suffix}");
+            if !summary.version.is_empty() {
+                println!("  version:       {}", summary.version);
+            }
+        }
         ZccacheSource::Managed => {
             println!(
                 "  source:        managed ({}){suffix}",

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -41,6 +41,7 @@ pub mod archive;
 pub mod github;
 pub mod zccache;
 pub mod zccache_install;
+pub mod zccache_runtime;
 
 pub use zccache::{
     classify_zccache_source, managed_only_zccache_summary, pinned_zccache_summary,
@@ -49,6 +50,7 @@ pub use zccache::{
 pub use zccache_install::{
     cached_zccache_binary, fetch_zccache_with_paths, resolve_system_zccache,
 };
+pub use zccache_runtime::{ZccacheResolver, ZccacheRuntime, ZccacheRuntimeSource};
 
 pub(crate) use github::http_client;
 

--- a/crates/soldr-cli/src/fetch/zccache.rs
+++ b/crates/soldr-cli/src/fetch/zccache.rs
@@ -12,8 +12,7 @@ use crate::core::{SoldrError, SoldrPaths, TargetTriple};
 
 use super::install_zccache;
 use super::{
-    non_empty_env_path, FetchResult, MANAGED_ZCCACHE_PACKAGES, MANAGED_ZCCACHE_VERSION,
-    ZCCACHE_LOCAL_DIR_ENV_VAR,
+    FetchResult, MANAGED_ZCCACHE_PACKAGES, MANAGED_ZCCACHE_VERSION, ZCCACHE_LOCAL_DIR_ENV_VAR,
 };
 
 /// Summary of where soldr's managed zccache binaries live and what
@@ -59,6 +58,10 @@ pub enum ZccacheSource {
     /// Installed via `soldr install-zccache` into the
     /// `<SoldrPaths::bin>/zccache-pinned/` directory.
     Pinned,
+    /// Resolved from the user-requested `--zccache=system` path.
+    System,
+    /// Resolved from the test-only `SOLDR_TEST_ZCCACHE_BIN` override.
+    TestOverride,
     /// Nothing fetched yet — managed path, no binaries on disk.
     None,
 }
@@ -69,6 +72,8 @@ impl ZccacheSource {
             ZccacheSource::Managed => "managed",
             ZccacheSource::Local => "local",
             ZccacheSource::Pinned => "pinned",
+            ZccacheSource::System => "system",
+            ZccacheSource::TestOverride => "test-override",
             ZccacheSource::None => "none",
         }
     }
@@ -141,35 +146,15 @@ pub(crate) fn resolve_local_zccache_for_target(
 ) -> Result<FetchResult, SoldrError> {
     paths.ensure_dirs()?;
 
-    if !local_dir.exists() {
-        return Err(SoldrError::Other(format!(
-            "{ZCCACHE_LOCAL_DIR_ENV_VAR}={} does not exist",
-            local_dir.display()
-        )));
-    }
-    if !local_dir.is_dir() {
-        return Err(SoldrError::Other(format!(
-            "{ZCCACHE_LOCAL_DIR_ENV_VAR}={} is not a directory",
-            local_dir.display()
-        )));
-    }
-
-    // Locate every required binary up front so a missing daemon / fp
-    // doesn't get reported only after we've started copying the cli.
-    let binary_ext = target.binary_ext();
-    let mut sources: Vec<(String, PathBuf)> = Vec::with_capacity(MANAGED_ZCCACHE_PACKAGES.len());
-    for (_, binary_name) in MANAGED_ZCCACHE_PACKAGES {
-        let file_name = format!("{binary_name}{binary_ext}");
-        let candidate = local_dir.join(&file_name);
-        if !candidate.exists() {
-            return Err(SoldrError::Other(format!(
-                "{ZCCACHE_LOCAL_DIR_ENV_VAR}: expected {} at {}",
-                file_name,
-                candidate.display()
-            )));
-        }
-        sources.push((file_name, candidate));
-    }
+    let source_paths = local_zccache_source_paths_for_target(local_dir, target)?;
+    let sources: Vec<(String, PathBuf)> = source_paths
+        .iter()
+        .filter_map(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| (name.to_string(), path.clone()))
+        })
+        .collect();
 
     // Derive a content-addressed version label so multiple local
     // builds coexist (and so the runtime copy invalidates whenever
@@ -209,7 +194,43 @@ pub(crate) fn resolve_local_zccache_for_target(
 /// don't change, so re-running soldr doesn't re-copy. When hashing
 /// fails (read error, etc.), fall back to the literal `"local"` so
 /// the user still gets a working override.
-fn local_zccache_version_label(binary: &Path) -> String {
+pub(crate) fn local_zccache_source_paths_for_target(
+    local_dir: &Path,
+    target: &TargetTriple,
+) -> Result<[PathBuf; 3], SoldrError> {
+    if !local_dir.exists() {
+        return Err(SoldrError::Other(format!(
+            "{ZCCACHE_LOCAL_DIR_ENV_VAR}={} does not exist",
+            local_dir.display()
+        )));
+    }
+    if !local_dir.is_dir() {
+        return Err(SoldrError::Other(format!(
+            "{ZCCACHE_LOCAL_DIR_ENV_VAR}={} is not a directory",
+            local_dir.display()
+        )));
+    }
+
+    let binary_ext = target.binary_ext();
+    let paths = MANAGED_ZCCACHE_PACKAGES
+        .map(|(_, binary_name)| local_dir.join(format!("{binary_name}{binary_ext}")));
+    for path in &paths {
+        if !path.exists() {
+            let file_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("zccache binary");
+            return Err(SoldrError::Other(format!(
+                "{ZCCACHE_LOCAL_DIR_ENV_VAR}: expected {} at {}",
+                file_name,
+                path.display()
+            )));
+        }
+    }
+    Ok(paths)
+}
+
+pub(crate) fn local_zccache_version_label(binary: &Path) -> String {
     match std::fs::read(binary) {
         Ok(bytes) => format!("local-{}", sha256_short(&bytes)),
         Err(err) => {
@@ -351,32 +372,9 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), SoldrError> {
 pub fn managed_only_zccache_summary(
     paths: &SoldrPaths,
 ) -> Result<ZccacheBinarySummary, SoldrError> {
-    let target = TargetTriple::detect()?;
-    let runtime_dir = paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"));
-    let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
-    let any_present = cli.exists() || daemon.exists() || fp.exists();
-    let (debug_found, debug_expected) =
-        count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
-    Ok(ZccacheBinarySummary {
-        source: if any_present {
-            ZccacheSource::Managed
-        } else {
-            ZccacheSource::None
-        },
-        version: if any_present {
-            MANAGED_ZCCACHE_VERSION.to_string()
-        } else {
-            String::new()
-        },
-        symbol_path: runtime_dir.clone(),
-        runtime_dir,
-        source_dir: None,
-        cli_path: cli.exists().then_some(cli),
-        daemon_path: daemon.exists().then_some(daemon),
-        fp_path: fp.exists().then_some(fp),
-        debug_info_found: debug_found,
-        debug_info_expected: debug_expected,
-    })
+    Ok(super::zccache_runtime::ZccacheResolver::new(paths)?
+        .inspect_managed_only()?
+        .to_summary())
 }
 
 /// Snapshot of the pinned-install state independent of resolution
@@ -387,132 +385,15 @@ pub fn managed_only_zccache_summary(
 pub fn pinned_zccache_summary(
     paths: &SoldrPaths,
 ) -> Result<Option<ZccacheBinarySummary>, SoldrError> {
-    let target = TargetTriple::detect()?;
-    let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? else {
-        return Ok(None);
-    };
-    let runtime_dir = pinned.runtime_dir.clone();
-    let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
-    let (debug_found, debug_expected) =
-        count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
-    Ok(Some(ZccacheBinarySummary {
-        source: ZccacheSource::Pinned,
-        version: pinned.version,
-        symbol_path: runtime_dir.clone(),
-        runtime_dir,
-        source_dir: None,
-        cli_path: cli.exists().then_some(cli),
-        daemon_path: daemon.exists().then_some(daemon),
-        fp_path: fp.exists().then_some(fp),
-        debug_info_found: debug_found,
-        debug_info_expected: debug_expected,
-    }))
+    Ok(super::zccache_runtime::ZccacheResolver::new(paths)?
+        .inspect_pinned()?
+        .map(|runtime| runtime.to_summary()))
 }
 
 pub fn zccache_binary_summary(paths: &SoldrPaths) -> Result<ZccacheBinarySummary, SoldrError> {
-    let target = TargetTriple::detect()?;
-
-    if let Some(source_dir) = non_empty_env_path(ZCCACHE_LOCAL_DIR_ENV_VAR) {
-        // Idempotent: short-circuits when the destination already
-        // matches the source bytes.
-        let fetch = resolve_local_zccache_for_target(&source_dir, paths, &target)?;
-        let runtime_dir = fetch
-            .binary_path
-            .parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| paths.bin.clone());
-        let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
-        let (debug_found, debug_expected) =
-            count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
-        return Ok(ZccacheBinarySummary {
-            source: ZccacheSource::Local,
-            version: fetch.version,
-            symbol_path: runtime_dir.clone(),
-            runtime_dir,
-            source_dir: Some(source_dir),
-            cli_path: cli.exists().then_some(cli),
-            daemon_path: daemon.exists().then_some(daemon),
-            fp_path: fp.exists().then_some(fp),
-            debug_info_found: debug_found,
-            debug_info_expected: debug_expected,
-        });
-    }
-
-    if let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, &target)? {
-        if install_zccache::pinned_version_older_than_managed(&pinned.version) {
-            let runtime_dir = paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"));
-            let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
-            let any_present = cli.exists() || daemon.exists() || fp.exists();
-            let (debug_found, debug_expected) =
-                count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
-            return Ok(ZccacheBinarySummary {
-                source: if any_present {
-                    ZccacheSource::Managed
-                } else {
-                    ZccacheSource::None
-                },
-                version: if any_present {
-                    MANAGED_ZCCACHE_VERSION.to_string()
-                } else {
-                    String::new()
-                },
-                symbol_path: runtime_dir.clone(),
-                runtime_dir,
-                source_dir: None,
-                cli_path: cli.exists().then_some(cli),
-                daemon_path: daemon.exists().then_some(daemon),
-                fp_path: fp.exists().then_some(fp),
-                debug_info_found: debug_found,
-                debug_info_expected: debug_expected,
-            });
-        }
-        // `soldr install-zccache` install. Reports `pinned` so
-        // doctor can surface the override (and warn the managed path
-        // is superseded).
-        let runtime_dir = pinned.runtime_dir.clone();
-        let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
-        let (debug_found, debug_expected) =
-            count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
-        return Ok(ZccacheBinarySummary {
-            source: ZccacheSource::Pinned,
-            version: pinned.version,
-            symbol_path: runtime_dir.clone(),
-            runtime_dir,
-            source_dir: None,
-            cli_path: cli.exists().then_some(cli),
-            daemon_path: daemon.exists().then_some(daemon),
-            fp_path: fp.exists().then_some(fp),
-            debug_info_found: debug_found,
-            debug_info_expected: debug_expected,
-        });
-    }
-
-    // Managed path: inspect the cached version directory if it exists.
-    let runtime_dir = paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"));
-    let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, &target);
-    let any_present = cli.exists() || daemon.exists() || fp.exists();
-    let (debug_found, debug_expected) =
-        count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
-    Ok(ZccacheBinarySummary {
-        source: if any_present {
-            ZccacheSource::Managed
-        } else {
-            ZccacheSource::None
-        },
-        version: if any_present {
-            MANAGED_ZCCACHE_VERSION.to_string()
-        } else {
-            String::new()
-        },
-        symbol_path: runtime_dir.clone(),
-        runtime_dir,
-        source_dir: None,
-        cli_path: cli.exists().then_some(cli),
-        daemon_path: daemon.exists().then_some(daemon),
-        fp_path: fp.exists().then_some(fp),
-        debug_info_found: debug_found,
-        debug_info_expected: debug_expected,
-    })
+    Ok(super::zccache_runtime::ZccacheResolver::new(paths)?
+        .inspect_default()?
+        .to_summary())
 }
 
 pub(crate) fn canonical_zccache_paths(

--- a/crates/soldr-cli/src/fetch/zccache_install.rs
+++ b/crates/soldr-cli/src/fetch/zccache_install.rs
@@ -7,140 +7,25 @@ use std::path::PathBuf;
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths, TargetTriple};
 
 use super::github::RepoInfo;
-use super::zccache::resolve_local_zccache_for_target;
 use super::{
-    check_cache, fetch_repo_binary_with_paths, install_zccache, non_empty_env_path, FetchResult,
-    VersionSpec, MANAGED_ZCCACHE_INSTALL_ATTEMPTS, MANAGED_ZCCACHE_INSTALL_INITIAL_BACKOFF,
-    MANAGED_ZCCACHE_PACKAGES, MANAGED_ZCCACHE_VERSION, ZCCACHE_LOCAL_DIR_ENV_VAR,
+    FetchResult, MANAGED_ZCCACHE_INSTALL_ATTEMPTS, MANAGED_ZCCACHE_INSTALL_INITIAL_BACKOFF,
+    MANAGED_ZCCACHE_PACKAGES,
 };
 
 pub async fn fetch_zccache_with_paths(paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
-    paths.ensure_dirs()?;
-    let target = TargetTriple::detect()?;
-
-    // Local-build override (issue: zccache #276 daemon-stdio hang).
-    // When set, skip the managed fetch entirely and copy the user's
-    // locally-built binaries (+ PDBs) into the soldr cache so cdb /
-    // WinDbg can resolve symbols when attaching to the daemon.
-    if let Some(local_dir) = non_empty_env_path(ZCCACHE_LOCAL_DIR_ENV_VAR) {
-        return resolve_local_zccache_for_target(&local_dir, paths, &target);
-    }
-
-    // Pinned install (`soldr install-zccache <SOURCE>`). Sits
-    // between the env-var override and the managed download so users
-    // who pinned once never go back to the GitHub-Releases path.
-    //
-    // We deliberately do NOT print a "using pinned zccache from ..."
-    // line here: the cargo front door now emits a source-aware
-    // `soldr: zccache source: pinned|local|managed (...)` line via
-    // `classify_zccache_source` so users see exactly which binary won
-    // resolution. See issue #420 — the old per-branch eprintln paired
-    // with prepare_zccache_build's hard-coded "soldr: using managed
-    // zccache 1.8.1" was the smoking gun that fooled the perf-cluster
-    // debugging session.
-    if let Some(pinned) = resolve_usable_pinned_zccache(paths, &target)? {
-        return Ok(FetchResult {
-            binary_path: pinned.binary_path,
-            version: pinned.version,
-            cached: true,
-        });
-    }
-
-    let binary_names = ["zccache", "zccache-daemon", "zccache-fp"];
-
-    if let Some(result) = check_cache(
-        paths,
-        "zccache",
-        MANAGED_ZCCACHE_VERSION,
-        &binary_names,
-        &target,
-    )? {
-        return Ok(result);
-    }
-
-    let release_version = VersionSpec::Exact(MANAGED_ZCCACHE_VERSION.to_string());
-    // `fetch_repo_binary_with_paths` retries transient fetch errors
-    // internally (issue: flaky GitHub-Releases lookups during propagation
-    // windows surfaced as macOS CI flake on PR #431). Anything that
-    // survives those retries is either a hard 404 or a non-transient
-    // network class — both of which the cargo install fallback below can
-    // handle.
-    let repo = managed_zccache_repo();
-    let release_outcome = fetch_repo_binary_with_paths(
-        "zccache",
-        &binary_names,
-        &repo,
-        &release_version,
-        None,
-        paths,
-    )
-    .await;
-
-    match release_outcome {
-        Ok(result) => return Ok(result),
-        Err(err) if should_fallback_to_managed_zccache_cargo_install(&err) => {
-            eprintln!(
-                "soldr: managed zccache prebuilt unavailable ({err}); falling back to cargo install"
-            );
-        }
-        Err(err) => return Err(err),
-    }
-
-    let binary_path = install_zccache_from_crates_io(paths, MANAGED_ZCCACHE_VERSION, &target)?;
-
-    Ok(FetchResult {
-        binary_path,
-        version: MANAGED_ZCCACHE_VERSION.to_string(),
-        cached: false,
-    })
+    super::zccache_runtime::ZccacheResolver::new(paths)?
+        .materialize_default()
+        .await?
+        .to_fetch_result()
 }
 
 pub fn cached_zccache_binary(paths: &SoldrPaths) -> Result<Option<FetchResult>, SoldrError> {
-    let target = TargetTriple::detect()?;
-
-    // When SOLDR_ZCCACHE_LOCAL_DIR is set, surface the local build as
-    // the cached result so doctor / cache status can find it without
-    // forcing a copy. resolve_local_zccache_for_target is idempotent:
-    // it short-circuits when the destination already matches the
-    // source bytes.
-    if let Some(local_dir) = non_empty_env_path(ZCCACHE_LOCAL_DIR_ENV_VAR) {
-        return resolve_local_zccache_for_target(&local_dir, paths, &target).map(Some);
+    let runtime = super::zccache_runtime::ZccacheResolver::new(paths)?.inspect_default()?;
+    if runtime.is_missing() {
+        Ok(None)
+    } else {
+        Ok(Some(runtime.to_fetch_result()?))
     }
-
-    if let Some(pinned) = resolve_usable_pinned_zccache(paths, &target)? {
-        return Ok(Some(FetchResult {
-            binary_path: pinned.binary_path,
-            version: pinned.version,
-            cached: true,
-        }));
-    }
-
-    check_cache(
-        paths,
-        "zccache",
-        MANAGED_ZCCACHE_VERSION,
-        &["zccache", "zccache-daemon", "zccache-fp"],
-        &target,
-    )
-}
-
-fn resolve_usable_pinned_zccache(
-    paths: &SoldrPaths,
-    target: &TargetTriple,
-) -> Result<Option<install_zccache::PinnedResolution>, SoldrError> {
-    let Some(pinned) = install_zccache::resolve_pinned_zccache_for_target(paths, target)? else {
-        return Ok(None);
-    };
-    if install_zccache::pinned_version_older_than_managed(&pinned.version) {
-        eprintln!(
-            "soldr: ignoring pinned zccache {} at {} because this soldr requires managed zccache {} or newer",
-            pinned.version,
-            pinned.runtime_dir.display(),
-            MANAGED_ZCCACHE_VERSION
-        );
-        return Ok(None);
-    }
-    Ok(Some(pinned))
 }
 
 /// Locate `zccache` on the system `PATH` and use it directly instead
@@ -150,8 +35,9 @@ fn resolve_usable_pinned_zccache(
 ///
 /// Driven by the top-level `--zccache=system` CLI flag.
 pub fn resolve_system_zccache(_paths: &SoldrPaths) -> Result<FetchResult, SoldrError> {
-    let target = TargetTriple::detect()?;
-    resolve_system_zccache_for_target(&target)
+    super::zccache_runtime::ZccacheResolver::new(_paths)?
+        .materialize_system()?
+        .to_fetch_result()
 }
 
 pub(crate) fn resolve_system_zccache_for_target(
@@ -222,7 +108,7 @@ pub(crate) fn should_fallback_to_managed_zccache_cargo_install(error: &SoldrErro
     matches!(error, SoldrError::ToolNotFound(_) | SoldrError::Network(_))
 }
 
-fn install_zccache_from_crates_io(
+pub(crate) fn install_zccache_from_crates_io(
     paths: &SoldrPaths,
     version: &str,
     target: &TargetTriple,

--- a/crates/soldr-cli/src/fetch/zccache_runtime.rs
+++ b/crates/soldr-cli/src/fetch/zccache_runtime.rs
@@ -1,0 +1,410 @@
+//! Single zccache runtime/source contract.
+//!
+//! `ZccacheResolver` is the boundary between callers that only need to inspect
+//! what soldr would use and callers that are allowed to materialize or fetch a
+//! runtime. This keeps doctor/status paths read-only while preserving the cargo
+//! front door's local -> pinned -> managed precedence chain.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{SoldrError, SoldrPaths, TargetTriple};
+
+use super::install_zccache;
+use super::zccache::{
+    canonical_zccache_paths, count_debug_info_sidecars, local_zccache_source_paths_for_target,
+    local_zccache_version_label, resolve_local_zccache_for_target, ZccacheBinarySummary,
+    ZccacheSource,
+};
+use super::zccache_install::{
+    install_zccache_from_crates_io, managed_zccache_repo,
+    should_fallback_to_managed_zccache_cargo_install,
+};
+use super::{
+    check_cache, fetch_repo_binary_with_paths, non_empty_env_path, FetchResult, VersionSpec,
+    MANAGED_ZCCACHE_VERSION, ZCCACHE_LOCAL_DIR_ENV_VAR,
+};
+
+/// Exact branch that produced a zccache runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZccacheRuntimeSource {
+    /// Materialized or inspected from `SOLDR_ZCCACHE_LOCAL_DIR`.
+    Local,
+    /// Installed via `soldr install-zccache`.
+    Pinned,
+    /// Managed zccache already existed under soldr's bin cache.
+    ManagedCached,
+    /// Managed zccache came from GitHub Releases during this resolution.
+    ManagedDownloaded,
+    /// Managed zccache came from the crates.io fallback.
+    ManagedFallback,
+    /// User requested `--zccache=system`.
+    System,
+    /// Test-only override from `SOLDR_TEST_ZCCACHE_BIN`.
+    TestOverride,
+    /// Nothing is currently materialized for the managed path.
+    Missing,
+}
+
+impl ZccacheRuntimeSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ZccacheRuntimeSource::Local => "local",
+            ZccacheRuntimeSource::Pinned => "pinned",
+            ZccacheRuntimeSource::ManagedCached => "managed-cached",
+            ZccacheRuntimeSource::ManagedDownloaded => "managed-downloaded",
+            ZccacheRuntimeSource::ManagedFallback => "managed-fallback",
+            ZccacheRuntimeSource::System => "system",
+            ZccacheRuntimeSource::TestOverride => "test-override",
+            ZccacheRuntimeSource::Missing => "missing",
+        }
+    }
+
+    pub fn summary_source(self) -> ZccacheSource {
+        match self {
+            ZccacheRuntimeSource::Local => ZccacheSource::Local,
+            ZccacheRuntimeSource::Pinned => ZccacheSource::Pinned,
+            ZccacheRuntimeSource::ManagedCached
+            | ZccacheRuntimeSource::ManagedDownloaded
+            | ZccacheRuntimeSource::ManagedFallback => ZccacheSource::Managed,
+            ZccacheRuntimeSource::System => ZccacheSource::System,
+            ZccacheRuntimeSource::TestOverride => ZccacheSource::TestOverride,
+            ZccacheRuntimeSource::Missing => ZccacheSource::None,
+        }
+    }
+
+    pub fn is_missing(self) -> bool {
+        matches!(self, ZccacheRuntimeSource::Missing)
+    }
+}
+
+/// Resolved zccache runtime plus source metadata.
+#[derive(Debug, Clone)]
+pub struct ZccacheRuntime {
+    pub source: ZccacheRuntimeSource,
+    pub version: String,
+    pub runtime_dir: PathBuf,
+    pub source_dir: Option<PathBuf>,
+    pub cli_path: Option<PathBuf>,
+    pub daemon_path: Option<PathBuf>,
+    pub fp_path: Option<PathBuf>,
+    pub debug_info_found: usize,
+    pub debug_info_expected: usize,
+    pub symbol_path: PathBuf,
+    pub cached: bool,
+}
+
+impl ZccacheRuntime {
+    pub fn from_test_override(binary_path: PathBuf) -> Result<Self, SoldrError> {
+        let target = TargetTriple::detect()?;
+        Ok(Self::from_fetch_result(
+            ZccacheRuntimeSource::TestOverride,
+            FetchResult {
+                binary_path,
+                version: MANAGED_ZCCACHE_VERSION.to_string(),
+                cached: true,
+            },
+            None,
+            &target,
+        ))
+    }
+
+    pub fn is_missing(&self) -> bool {
+        self.source.is_missing()
+    }
+
+    pub fn to_fetch_result(&self) -> Result<FetchResult, SoldrError> {
+        let Some(binary_path) = self.cli_path.clone() else {
+            return Err(SoldrError::Other(format!(
+                "zccache runtime source {} has no CLI binary",
+                self.source.as_str()
+            )));
+        };
+        Ok(FetchResult {
+            binary_path,
+            version: self.version.clone(),
+            cached: self.cached,
+        })
+    }
+
+    pub fn to_summary(&self) -> ZccacheBinarySummary {
+        ZccacheBinarySummary {
+            source: self.source.summary_source(),
+            version: self.version.clone(),
+            runtime_dir: self.runtime_dir.clone(),
+            source_dir: self.source_dir.clone(),
+            cli_path: self.cli_path.clone(),
+            daemon_path: self.daemon_path.clone(),
+            fp_path: self.fp_path.clone(),
+            debug_info_found: self.debug_info_found,
+            debug_info_expected: self.debug_info_expected,
+            symbol_path: self.symbol_path.clone(),
+        }
+    }
+
+    fn from_fetch_result(
+        source: ZccacheRuntimeSource,
+        fetch: FetchResult,
+        source_dir: Option<PathBuf>,
+        target: &TargetTriple,
+    ) -> Self {
+        let runtime_dir = fetch
+            .binary_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_default();
+        let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, target);
+        let (debug_info_found, debug_info_expected) =
+            count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
+        Self {
+            source,
+            version: fetch.version,
+            symbol_path: runtime_dir.clone(),
+            runtime_dir,
+            source_dir,
+            cli_path: Some(fetch.binary_path),
+            daemon_path: daemon.exists().then_some(daemon),
+            fp_path: fp.exists().then_some(fp),
+            debug_info_found,
+            debug_info_expected,
+            cached: fetch.cached,
+        }
+    }
+
+    fn missing_managed(paths: &SoldrPaths, target: &TargetTriple) -> Self {
+        let runtime_dir = managed_runtime_dir(paths);
+        let (cli, daemon, fp) = canonical_zccache_paths(&runtime_dir, target);
+        let (debug_info_found, debug_info_expected) =
+            count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
+        Self {
+            source: ZccacheRuntimeSource::Missing,
+            version: String::new(),
+            symbol_path: runtime_dir.clone(),
+            runtime_dir,
+            source_dir: None,
+            cli_path: None,
+            daemon_path: None,
+            fp_path: None,
+            debug_info_found,
+            debug_info_expected,
+            cached: false,
+        }
+    }
+}
+
+/// Resolver bound to a soldr root and host target.
+pub struct ZccacheResolver<'a> {
+    paths: &'a SoldrPaths,
+    target: TargetTriple,
+}
+
+impl<'a> ZccacheResolver<'a> {
+    pub fn new(paths: &'a SoldrPaths) -> Result<Self, SoldrError> {
+        Ok(Self {
+            paths,
+            target: TargetTriple::detect()?,
+        })
+    }
+
+    /// Resolve the default cargo runtime, materializing local builds and
+    /// fetching managed zccache when necessary.
+    pub async fn materialize_default(&self) -> Result<ZccacheRuntime, SoldrError> {
+        self.paths.ensure_dirs()?;
+
+        if let Some(local_dir) = non_empty_env_path(ZCCACHE_LOCAL_DIR_ENV_VAR) {
+            let fetch = resolve_local_zccache_for_target(&local_dir, self.paths, &self.target)?;
+            return Ok(ZccacheRuntime::from_fetch_result(
+                ZccacheRuntimeSource::Local,
+                fetch,
+                Some(local_dir),
+                &self.target,
+            ));
+        }
+
+        if let Some(pinned) = self.resolve_usable_pinned(true)? {
+            return Ok(self.runtime_from_pinned(pinned));
+        }
+
+        if let Some(result) = self.managed_cached_fetch_result()? {
+            return Ok(ZccacheRuntime::from_fetch_result(
+                ZccacheRuntimeSource::ManagedCached,
+                result,
+                None,
+                &self.target,
+            ));
+        }
+
+        let release_version = VersionSpec::Exact(MANAGED_ZCCACHE_VERSION.to_string());
+        let repo = managed_zccache_repo();
+        let release_outcome = fetch_repo_binary_with_paths(
+            "zccache",
+            &["zccache", "zccache-daemon", "zccache-fp"],
+            &repo,
+            &release_version,
+            None,
+            self.paths,
+        )
+        .await;
+
+        match release_outcome {
+            Ok(result) => {
+                let source = if result.cached {
+                    ZccacheRuntimeSource::ManagedCached
+                } else {
+                    ZccacheRuntimeSource::ManagedDownloaded
+                };
+                Ok(ZccacheRuntime::from_fetch_result(
+                    source,
+                    result,
+                    None,
+                    &self.target,
+                ))
+            }
+            Err(err) if should_fallback_to_managed_zccache_cargo_install(&err) => {
+                eprintln!(
+                    "soldr: managed zccache prebuilt unavailable ({err}); falling back to cargo install"
+                );
+                let binary_path = install_zccache_from_crates_io(
+                    self.paths,
+                    MANAGED_ZCCACHE_VERSION,
+                    &self.target,
+                )?;
+                Ok(ZccacheRuntime::from_fetch_result(
+                    ZccacheRuntimeSource::ManagedFallback,
+                    FetchResult {
+                        binary_path,
+                        version: MANAGED_ZCCACHE_VERSION.to_string(),
+                        cached: false,
+                    },
+                    None,
+                    &self.target,
+                ))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Inspect the default runtime without copying local builds or fetching
+    /// managed binaries.
+    pub fn inspect_default(&self) -> Result<ZccacheRuntime, SoldrError> {
+        if let Some(local_dir) = non_empty_env_path(ZCCACHE_LOCAL_DIR_ENV_VAR) {
+            return self.inspect_local(&local_dir);
+        }
+
+        if let Some(pinned) = self.resolve_usable_pinned(false)? {
+            return Ok(self.runtime_from_pinned(pinned));
+        }
+
+        self.inspect_managed_only()
+    }
+
+    pub fn inspect_managed_only(&self) -> Result<ZccacheRuntime, SoldrError> {
+        if let Some(result) = self.managed_cached_fetch_result()? {
+            return Ok(ZccacheRuntime::from_fetch_result(
+                ZccacheRuntimeSource::ManagedCached,
+                result,
+                None,
+                &self.target,
+            ));
+        }
+        Ok(ZccacheRuntime::missing_managed(self.paths, &self.target))
+    }
+
+    pub fn inspect_pinned(&self) -> Result<Option<ZccacheRuntime>, SoldrError> {
+        let Some(pinned) =
+            install_zccache::resolve_pinned_zccache_for_target(self.paths, &self.target)?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(self.runtime_from_pinned(pinned)))
+    }
+
+    pub fn materialize_system(&self) -> Result<ZccacheRuntime, SoldrError> {
+        let path_dirs: Vec<PathBuf> = std::env::var_os("PATH")
+            .map(|value| std::env::split_paths(&value).collect())
+            .unwrap_or_default();
+        self.materialize_system_with_path_dirs(&path_dirs)
+    }
+
+    pub fn materialize_system_with_path_dirs(
+        &self,
+        path_dirs: &[PathBuf],
+    ) -> Result<ZccacheRuntime, SoldrError> {
+        let fetch =
+            super::zccache_install::resolve_system_zccache_with_path_dirs(&self.target, path_dirs)?;
+        Ok(ZccacheRuntime::from_fetch_result(
+            ZccacheRuntimeSource::System,
+            fetch,
+            None,
+            &self.target,
+        ))
+    }
+
+    fn inspect_local(&self, local_dir: &Path) -> Result<ZccacheRuntime, SoldrError> {
+        let [cli, daemon, fp] = local_zccache_source_paths_for_target(local_dir, &self.target)?;
+        let (debug_info_found, debug_info_expected) =
+            count_debug_info_sidecars(&[cli.as_path(), daemon.as_path(), fp.as_path()]);
+        Ok(ZccacheRuntime {
+            source: ZccacheRuntimeSource::Local,
+            version: local_zccache_version_label(&cli),
+            runtime_dir: local_dir.to_path_buf(),
+            source_dir: Some(local_dir.to_path_buf()),
+            cli_path: Some(cli),
+            daemon_path: Some(daemon),
+            fp_path: Some(fp),
+            debug_info_found,
+            debug_info_expected,
+            symbol_path: local_dir.to_path_buf(),
+            cached: true,
+        })
+    }
+
+    fn runtime_from_pinned(&self, pinned: install_zccache::PinnedResolution) -> ZccacheRuntime {
+        ZccacheRuntime::from_fetch_result(
+            ZccacheRuntimeSource::Pinned,
+            FetchResult {
+                binary_path: pinned.binary_path,
+                version: pinned.version,
+                cached: true,
+            },
+            None,
+            &self.target,
+        )
+    }
+
+    fn managed_cached_fetch_result(&self) -> Result<Option<FetchResult>, SoldrError> {
+        check_cache(
+            self.paths,
+            "zccache",
+            MANAGED_ZCCACHE_VERSION,
+            &["zccache", "zccache-daemon", "zccache-fp"],
+            &self.target,
+        )
+    }
+
+    fn resolve_usable_pinned(
+        &self,
+        log_stale_pin: bool,
+    ) -> Result<Option<install_zccache::PinnedResolution>, SoldrError> {
+        let Some(pinned) =
+            install_zccache::resolve_pinned_zccache_for_target(self.paths, &self.target)?
+        else {
+            return Ok(None);
+        };
+        if install_zccache::pinned_version_older_than_managed(&pinned.version) {
+            if log_stale_pin {
+                eprintln!(
+                    "soldr: ignoring pinned zccache {} at {} because this soldr requires managed zccache {} or newer",
+                    pinned.version,
+                    pinned.runtime_dir.display(),
+                    MANAGED_ZCCACHE_VERSION
+                );
+            }
+            return Ok(None);
+        }
+        Ok(Some(pinned))
+    }
+}
+
+fn managed_runtime_dir(paths: &SoldrPaths) -> PathBuf {
+    paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"))
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -61,9 +61,10 @@ use crate::fetch::VersionSpec;
 
 #[allow(unused_imports)]
 pub(crate) use binaries::{
-    apply_implicit_toolchain_homes, cached_active_zccache, current_soldr_binary,
-    fetch_active_zccache, non_empty_env_path, parse_tool_spec, resolve_toolchain_binary,
-    rustup_binary, rustup_resolution_failure, zccache_binary_override,
+    apply_implicit_toolchain_homes, cached_active_zccache, cached_active_zccache_runtime,
+    current_soldr_binary, fetch_active_zccache, fetch_active_zccache_runtime, non_empty_env_path,
+    parse_tool_spec, resolve_toolchain_binary, rustup_binary, rustup_resolution_failure,
+    zccache_binary_override,
 };
 
 pub(crate) const TEST_CARGO_BIN_ENV_VAR: &str = "SOLDR_TEST_CARGO_BIN";

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -2,9 +2,9 @@
 //! Extracted from `main.rs` as part of issue #339.
 
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
-use crate::fetch::ZccacheSource;
+use crate::fetch::{ZccacheRuntime, ZccacheRuntimeSource};
 use crate::{
-    current_soldr_binary, fetch_active_zccache, non_empty_env_path, ZccacheSourceArg,
+    current_soldr_binary, fetch_active_zccache_runtime, non_empty_env_path, ZccacheSourceArg,
     RUSTC_WRAPPER_OVERRIDE_ENV_VAR,
 };
 use std::ffi::OsStr;
@@ -221,63 +221,20 @@ async fn prepare_zccache_build(
     let zccache_dir = managed_zccache_cache_dir(paths)?;
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
-    let fetch = match zccache_source {
-        ZccacheSourceArg::Managed => fetch_active_zccache(paths).await?,
-        ZccacheSourceArg::System => crate::fetch::resolve_system_zccache(paths)?,
+    let runtime = match zccache_source {
+        ZccacheSourceArg::Managed => fetch_active_zccache_runtime(paths).await?,
+        ZccacheSourceArg::System => {
+            crate::fetch::ZccacheResolver::new(paths)?.materialize_system()?
+        }
     };
+    let fetch = runtime.to_fetch_result()?;
 
     // Source-aware diagnostic (issue #420). The old "soldr: using
     // managed zccache 1.8.1" line printed even when the pinned install
     // won resolution, which sent three perf-cluster runs chasing the
     // wrong binary. Print exactly one line that names the actual
     // source, runtime dir, and version of the binary we just resolved.
-    let source = if matches!(zccache_source, ZccacheSourceArg::System) {
-        ZccacheSource::None // `--zccache=system` doesn't go through the precedence chain.
-    } else {
-        crate::fetch::classify_zccache_source(paths, &fetch.binary_path)
-    };
-    let runtime_dir = fetch
-        .binary_path
-        .parent()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|| "<unknown>".into());
-    match source {
-        ZccacheSource::Pinned => eprintln!(
-            "soldr: zccache source: pinned ({runtime_dir}) version={}",
-            fetch.version
-        ),
-        ZccacheSource::Local => eprintln!(
-            "soldr: zccache source: local ({runtime_dir}) version={}",
-            fetch.version
-        ),
-        ZccacheSource::Managed => {
-            if fetch.cached {
-                eprintln!(
-                    "soldr: zccache source: managed ({runtime_dir}) version={} (cached)",
-                    fetch.version
-                );
-            } else {
-                eprintln!(
-                    "soldr: zccache source: managed ({runtime_dir}) version={} (downloaded)",
-                    fetch.version
-                );
-            }
-        }
-        ZccacheSource::None => {
-            if matches!(zccache_source, ZccacheSourceArg::System) {
-                eprintln!(
-                    "soldr: zccache source: system ({runtime_dir}) version={}",
-                    fetch.version
-                );
-            } else {
-                eprintln!(
-                    "soldr: zccache source: unrecognized ({runtime_dir}) version={} \
-                     — likely SOLDR_TEST_ZCCACHE_BIN override",
-                    fetch.version
-                );
-            }
-        }
-    }
+    print_zccache_runtime_diagnostic(&runtime);
 
     // When the resolved zccache CLI binary differs from the one a
     // previous soldr invocation started the daemon with, the live
@@ -363,6 +320,44 @@ async fn prepare_zccache_build(
         journal_path,
         session_stats_path,
     })
+}
+
+fn print_zccache_runtime_diagnostic(runtime: &ZccacheRuntime) {
+    let runtime_dir = runtime.runtime_dir.display();
+    match runtime.source {
+        ZccacheRuntimeSource::Pinned => eprintln!(
+            "soldr: zccache source: pinned ({runtime_dir}) version={}",
+            runtime.version
+        ),
+        ZccacheRuntimeSource::Local => eprintln!(
+            "soldr: zccache source: local ({runtime_dir}) version={}",
+            runtime.version
+        ),
+        ZccacheRuntimeSource::ManagedCached => eprintln!(
+            "soldr: zccache source: managed ({runtime_dir}) version={} (cached)",
+            runtime.version
+        ),
+        ZccacheRuntimeSource::ManagedDownloaded => eprintln!(
+            "soldr: zccache source: managed ({runtime_dir}) version={} (downloaded)",
+            runtime.version
+        ),
+        ZccacheRuntimeSource::ManagedFallback => eprintln!(
+            "soldr: zccache source: managed ({runtime_dir}) version={} (cargo-install fallback)",
+            runtime.version
+        ),
+        ZccacheRuntimeSource::System => eprintln!(
+            "soldr: zccache source: system ({runtime_dir}) version={}",
+            runtime.version
+        ),
+        ZccacheRuntimeSource::TestOverride => eprintln!(
+            "soldr: zccache source: test-override ({runtime_dir}) version={}",
+            runtime.version
+        ),
+        ZccacheRuntimeSource::Missing => eprintln!(
+            "soldr: zccache source: missing ({runtime_dir}) version={}",
+            runtime.version
+        ),
+    }
 }
 
 pub(crate) fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError> {

--- a/crates/soldr-cli/tests/cli_doctor.rs
+++ b/crates/soldr-cli/tests/cli_doctor.rs
@@ -354,9 +354,10 @@ fn doctor_surfaces_local_zccache_override_when_env_var_set() {
     let runtime_dir = json["managed_zccache"]["runtime_dir"]
         .as_str()
         .expect("runtime_dir present");
-    assert!(
-        runtime_dir.contains("zccache-local-"),
-        "runtime_dir should be hash-suffixed: {runtime_dir}"
+    assert_eq!(
+        Path::new(runtime_dir),
+        local_build.as_path(),
+        "doctor should inspect the local build directly without materializing a runtime copy"
     );
     // 2/3 PDBs were planted.
     assert_eq!(json["managed_zccache"]["debug_info_found"], 2);
@@ -374,12 +375,8 @@ fn doctor_surfaces_local_zccache_override_when_env_var_set() {
         Some("local-build")
     );
 
-    // Issue #365 — every binary soldr resolves (cli, daemon, fp) must
-    // live under the override dir. The previous coverage only asserted
-    // the runtime_dir hash; this confirms the per-binary paths the
-    // child process actually executes are all under it. This is the
-    // path soldr propagates to cargo via SOLDR_ZCCACHE_BIN and the
-    // path the zccache CLI uses for its sibling-daemon lookup.
+    // Doctor is an inspect-only path, so it reports the local source
+    // trio directly instead of copying into `zccache-local-*`.
     let cli_path = json["managed_zccache"]["cli_path"]
         .as_str()
         .expect("cli_path present");
@@ -395,10 +392,25 @@ fn doctor_surfaces_local_zccache_override_when_env_var_set() {
             "{label}_path must live under runtime_dir; runtime_dir={runtime_dir} {label}_path={value}"
         );
         assert!(
-            value.contains("zccache-local-"),
-            "{label}_path must resolve under the SOLDR_ZCCACHE_LOCAL_DIR-derived dir: {value}"
+            value.contains("local-build"),
+            "{label}_path must resolve under SOLDR_ZCCACHE_LOCAL_DIR without copying: {value}"
         );
     }
+    let soldr_bin = soldr_cache.join("bin");
+    let local_copy_present = fs::read_dir(&soldr_bin)
+        .ok()
+        .into_iter()
+        .flat_map(|entries| entries.filter_map(Result::ok))
+        .any(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("zccache-local-"))
+        });
+    assert!(
+        !local_copy_present,
+        "doctor --json must not materialize SOLDR_ZCCACHE_LOCAL_DIR into the soldr bin cache"
+    );
 }
 
 #[test]

--- a/crates/soldr-cli/tests/cli_install_zccache_resolution.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache_resolution.rs
@@ -41,12 +41,14 @@ use serde_json::Value;
 use soldr_cli::core::SoldrPaths;
 use soldr_cli::fetch::{
     cached_zccache_binary, classify_zccache_source, fetch_zccache_with_paths,
-    install_zccache_from_source, FetchResult, InstallSource, ZccacheSource,
-    MANAGED_ZCCACHE_VERSION, PINNED_ZCCACHE_DIRNAME, ZCCACHE_LOCAL_DIR_ENV_VAR,
+    install_zccache_from_source, pinned_zccache_dir, FetchResult, InstallSource, ZccacheResolver,
+    ZccacheRuntime, ZccacheRuntimeSource, ZccacheSource, MANAGED_ZCCACHE_VERSION,
+    PINNED_ZCCACHE_DIRNAME, ZCCACHE_LOCAL_DIR_ENV_VAR,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, MutexGuard};
 
 /// Tests in this file run blocking installs via `tokio::test`; pull in
 /// the runtime so `install_zccache_from_source` (which is `async`)
@@ -90,17 +92,34 @@ fn seed_managed_cache(paths: &SoldrPaths) -> PathBuf {
     managed_dir
 }
 
+fn has_zccache_local_copy(paths: &SoldrPaths) -> bool {
+    fs::read_dir(&paths.bin)
+        .ok()
+        .into_iter()
+        .flat_map(|entries| entries.filter_map(Result::ok))
+        .any(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("zccache-local-"))
+        })
+}
+
 /// Reset env state that would otherwise leak across tests. Restored on
 /// drop. We unset the override vars so neither the local-dir override
 /// (`SOLDR_ZCCACHE_LOCAL_DIR`) nor the test override
 /// (`SOLDR_TEST_ZCCACHE_BIN`) shadows the pinned resolution path under
 /// test.
 struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
     saved: Vec<(String, Option<std::ffi::OsString>)>,
 }
 
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
 impl EnvGuard {
     fn isolate(keys: &[&str]) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
         let mut saved = Vec::with_capacity(keys.len());
         for key in keys {
             saved.push((key.to_string(), std::env::var_os(key)));
@@ -108,7 +127,7 @@ impl EnvGuard {
                 std::env::remove_var(key);
             }
         }
-        Self { saved }
+        Self { _lock: lock, saved }
     }
 }
 
@@ -202,6 +221,140 @@ async fn cached_zccache_binary_returns_pinned_over_managed_cache() {
         paths.bin.join(PINNED_ZCCACHE_DIRNAME),
         "cached_zccache_binary must return the pinned binary, not the managed cache (issue #420)"
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn zccache_runtime_inspects_local_without_copying_then_materializes_for_fetch() {
+    let _guard = EnvGuard::isolate(&[ZCCACHE_LOCAL_DIR_ENV_VAR, "SOLDR_TEST_ZCCACHE_BIN"]);
+    let tmp = unique_temp_dir("runtime-local-read-only");
+    let paths = SoldrPaths::with_root(tmp.join("soldr-root"));
+    let local = tmp.join("local-build");
+    write_fake(&local, &bin_name("zccache"), b"LOCAL_CLI_BYTES");
+    write_fake(&local, &bin_name("zccache-daemon"), b"LOCAL_DAEMON_BYTES");
+    write_fake(&local, &bin_name("zccache-fp"), b"LOCAL_FP_BYTES");
+
+    unsafe {
+        std::env::set_var(ZCCACHE_LOCAL_DIR_ENV_VAR, &local);
+    }
+
+    let inspected = ZccacheResolver::new(&paths)
+        .expect("resolver")
+        .inspect_default()
+        .expect("inspect local");
+    assert_eq!(inspected.source, ZccacheRuntimeSource::Local);
+    assert_eq!(inspected.runtime_dir, local);
+    assert_eq!(inspected.source_dir.as_deref(), Some(local.as_path()));
+    assert_eq!(
+        inspected.cli_path.as_deref(),
+        Some(local.join(bin_name("zccache")).as_path())
+    );
+    assert!(
+        !has_zccache_local_copy(&paths),
+        "inspect_default must not materialize SOLDR_ZCCACHE_LOCAL_DIR into the soldr bin cache"
+    );
+
+    let cached = cached_zccache_binary(&paths)
+        .expect("cached local")
+        .expect("local override should count as cached");
+    assert_eq!(cached.binary_path, local.join(bin_name("zccache")));
+    assert!(
+        !has_zccache_local_copy(&paths),
+        "cached_zccache_binary must remain read-only for local overrides"
+    );
+
+    let fetched = fetch_zccache_with_paths(&paths)
+        .await
+        .expect("materialize local");
+    let fetched_parent = fetched.binary_path.parent().expect("parent");
+    assert!(
+        fetched_parent.starts_with(&paths.bin),
+        "materialized local runtime should live under soldr bin cache: {}",
+        fetched_parent.display()
+    );
+    assert!(
+        fetched_parent
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("zccache-local-")),
+        "materialized local runtime should use the content-addressed local key"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn zccache_runtime_exposes_managed_cached_and_custom_cache_root() {
+    let _guard = EnvGuard::isolate(&[ZCCACHE_LOCAL_DIR_ENV_VAR, "SOLDR_TEST_ZCCACHE_BIN"]);
+    let tmp = unique_temp_dir("runtime-managed-custom-root");
+    let custom_root = tmp.join("custom-soldr-cache");
+    let paths = SoldrPaths::with_root(custom_root.clone());
+    let managed_dir = seed_managed_cache(&paths);
+
+    let runtime = ZccacheResolver::new(&paths)
+        .expect("resolver")
+        .inspect_default()
+        .expect("inspect managed");
+    assert_eq!(runtime.source, ZccacheRuntimeSource::ManagedCached);
+    assert_eq!(runtime.runtime_dir, managed_dir);
+    assert!(
+        runtime.runtime_dir.starts_with(custom_root.join("bin")),
+        "runtime must honor the caller's SoldrPaths root"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn zccache_runtime_ignores_stale_pin_for_default_resolution() {
+    let _guard = EnvGuard::isolate(&[ZCCACHE_LOCAL_DIR_ENV_VAR, "SOLDR_TEST_ZCCACHE_BIN"]);
+    let tmp = unique_temp_dir("runtime-stale-pin");
+    let paths = SoldrPaths::with_root(tmp.join("soldr-root"));
+    let managed_dir = seed_managed_cache(&paths);
+    let pin_src = seed_pin_source(&tmp);
+    install_zccache_from_source(&InstallSource::Path(pin_src), &paths)
+        .await
+        .expect("install pin");
+
+    let sidecar_path = pinned_zccache_dir(&paths).join("source.json");
+    let mut sidecar: Value =
+        serde_json::from_slice(&fs::read(&sidecar_path).expect("read sidecar")).expect("sidecar");
+    sidecar["version"] = Value::String("0.1.0".to_string());
+    fs::write(
+        &sidecar_path,
+        serde_json::to_vec_pretty(&sidecar).expect("encode sidecar"),
+    )
+    .expect("write stale sidecar");
+
+    let runtime = ZccacheResolver::new(&paths)
+        .expect("resolver")
+        .inspect_default()
+        .expect("inspect default");
+    assert_eq!(runtime.source, ZccacheRuntimeSource::ManagedCached);
+    assert_eq!(runtime.runtime_dir, managed_dir);
+}
+
+#[test]
+fn zccache_runtime_exposes_system_and_test_override_sources() {
+    let _guard = EnvGuard::isolate(&[ZCCACHE_LOCAL_DIR_ENV_VAR, "SOLDR_TEST_ZCCACHE_BIN"]);
+    let tmp = unique_temp_dir("runtime-system-test-override");
+    let paths = SoldrPaths::with_root(tmp.join("soldr-root"));
+    let system_bin = tmp.join("system-bin");
+    write_fake(&system_bin, &bin_name("zccache"), b"SYSTEM_CLI_BYTES");
+    write_fake(
+        &system_bin,
+        &bin_name("zccache-daemon"),
+        b"SYSTEM_DAEMON_BYTES",
+    );
+    write_fake(&system_bin, &bin_name("zccache-fp"), b"SYSTEM_FP_BYTES");
+
+    let system = ZccacheResolver::new(&paths)
+        .expect("resolver")
+        .materialize_system_with_path_dirs(std::slice::from_ref(&system_bin))
+        .expect("system runtime");
+    assert_eq!(system.source, ZccacheRuntimeSource::System);
+    assert_eq!(system.runtime_dir, system_bin);
+
+    let test_bin = tmp.join(bin_name("zccache-test"));
+    fs::write(&test_bin, b"TEST_OVERRIDE_BYTES").expect("write test override");
+    let test = ZccacheRuntime::from_test_override(test_bin.clone()).expect("test override");
+    assert_eq!(test.source, ZccacheRuntimeSource::TestOverride);
+    assert_eq!(test.cli_path.as_deref(), Some(test_bin.as_path()));
 }
 
 // ---------------------------------------------------------------------

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -16,8 +16,8 @@ const PACKAGE_JSON = require(path.join(PACKAGE_ROOT, "package.json"));
 // alongside its matching-target zccache trio (zccache, zccache-daemon,
 // zccache-fp) and a same-target crgx. One fetch installs everything,
 // and `bin/soldr.js` wires SOLDR_ZCCACHE_LOCAL_DIR + SOLDR_CRGX_LOCAL_DIR
-// to the install dir so soldr finds the sibling binaries without going
-// through the managed-download path.
+// to the install dir so soldr's runtime resolver finds the sibling binaries
+// without going through the managed-download path.
 const ARCHIVE_EXT = "tar.zst";
 
 const TARGETS = {
@@ -253,8 +253,8 @@ async function install() {
     fs.rmSync(nativeDir, { recursive: true, force: true });
     fs.mkdirSync(nativeDir, { recursive: true });
 
-    // Copy every bundled binary so soldr can find its sibling zccache
-    // via SOLDR_ZCCACHE_LOCAL_DIR and its sibling crgx via
+    // Copy every bundled binary so soldr's runtime resolver can find
+    // its sibling zccache via SOLDR_ZCCACHE_LOCAL_DIR and crgx via
     // SOLDR_CRGX_LOCAL_DIR (both wired up by `bin/soldr.js` before
     // exec). The archive layout is flat — all five binaries live at
     // the archive root.


### PR DESCRIPTION
Closes #544.
Part of #543.

## Summary

- Add `ZccacheRuntime`, `ZccacheRuntimeSource`, and `ZccacheResolver` as the single source/source-resolution contract for local, pinned, managed cached/downloaded/fallback, system, test override, and missing zccache states.
- Route fetch/cached/system resolution, cargo diagnostics, cache/status, doctor summaries, and install-zccache status through the runtime contract instead of re-classifying binary paths at call sites.
- Make inspect-only local resolution read-only: doctor/status now inspect `SOLDR_ZCCACHE_LOCAL_DIR` directly and only materialize the content-addressed `zccache-local-*` copy on fetch/build paths.
- Align setup-soldr/npm comments with the new runtime resolver contract.

## Test Plan

- [x] `soldr cargo fmt --all`
- [x] `soldr cargo check -p soldr-cli --all-targets`
- [x] `soldr cargo clippy -p soldr-cli --all-targets -- -D warnings`
- [x] `soldr cargo test -p soldr-cli --lib`
- [x] `soldr cargo test -p soldr-cli --bins`
- [x] `soldr cargo test -p soldr-cli --test cli_install_zccache_resolution`
- [x] `soldr cargo test -p soldr-cli --test cli_doctor doctor_surfaces_local_zccache_override_when_env_var_set`
- [x] `soldr cargo test -p soldr-cli --test lib_install_zccache`
- [x] `soldr cargo test -p soldr-cli --test cli_cache`
- [x] `node scripts/test-npm-package.js`
- [x] `uv run --no-project python -m py_compile .github/actions/setup-soldr/ensure_soldr.py`
- [x] `git diff --check --cached`

Note: `soldr cargo test -p soldr-cli --all-targets` was also attempted, but the full integration run exceeded the 10 minute command timeout and left child processes; I stopped those before continuing with the targeted suites above.