### PR TITLE
refactor(zccache): centralize lifecycle state

### DIFF
--- a/crates/soldr-cli/src/cache/mod.rs
+++ b/crates/soldr-cli/src/cache/mod.rs
@@ -7,7 +7,8 @@
 //! need to know about the submodule layout.
 
 use crate::core::{SoldrError, SoldrPaths};
-use crate::zccache::{managed_zccache_cache_dir, run_zccache_command_raw_in_cache_dir};
+use crate::zccache::managed_zccache_cache_dir;
+use crate::zccache_lifecycle::run_zccache_command_raw_in_cache_dir;
 use crate::{cached_active_zccache, cached_active_zccache_runtime, JSON_SCHEMA_VERSION};
 use serde::Serialize;
 
@@ -16,6 +17,10 @@ mod report;
 mod session;
 mod trim;
 
+pub(super) use crate::zccache_lifecycle::{
+    zccache_daemon_already_stopped, zccache_output_snippet, zccache_subcommand_unsupported,
+    ZCCACHE_ANALYZE_NOTE_LIMIT,
+};
 pub(crate) use install::run_install_zccache;
 pub(crate) use report::run_cache_report_command;
 pub(crate) use session::{
@@ -322,72 +327,4 @@ pub(crate) fn print_json<T: Serialize>(value: &T) -> Result<(), SoldrError> {
         .map_err(|e| SoldrError::Other(format!("failed to serialize JSON output: {e}")))?;
     println!();
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Cross-submodule helpers for parsing `zccache` exit / output phrases.
-// ---------------------------------------------------------------------------
-
-/// Heuristic: detect whether a `zccache <subcommand>` invocation failed
-/// because the subcommand does not exist in the running binary (clap
-/// emits "error: unrecognized subcommand"). Used to differentiate
-/// version-skew misses from real failures.
-pub(super) fn zccache_subcommand_unsupported(
-    output: &std::process::Output,
-    subcommand: &str,
-) -> bool {
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let needles = [
-        "unrecognized subcommand",
-        "unrecognized command",
-        "error: subcommand",
-        "invalid value for",
-    ];
-    let combined = format!("{stderr}\n{stdout}");
-    needles.iter().any(|n| combined.contains(n)) && combined.contains(subcommand)
-}
-
-pub(super) const ZCCACHE_ANALYZE_NOTE_LIMIT: usize = 1000;
-
-pub(super) fn zccache_output_snippet(output: &[u8]) -> Option<String> {
-    let text = String::from_utf8_lossy(output);
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    let mut compact = String::new();
-    let mut previous_was_space = false;
-    for ch in trimmed.chars() {
-        if ch.is_whitespace() {
-            if !previous_was_space {
-                compact.push(' ');
-                previous_was_space = true;
-            }
-        } else {
-            compact.push(ch);
-            previous_was_space = false;
-        }
-    }
-
-    let mut chars = compact.chars();
-    let mut snippet: String = chars.by_ref().take(ZCCACHE_ANALYZE_NOTE_LIMIT).collect();
-    if chars.next().is_some() {
-        snippet.push_str("...");
-    }
-    Some(snippet)
-}
-
-pub(super) fn zccache_daemon_already_stopped(output: &std::process::Output) -> bool {
-    let combined = format!(
-        "{}\n{}",
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout)
-    )
-    .to_ascii_lowercase();
-    combined.contains("daemon not running")
-        || combined.contains("no daemon to stop")
-        || combined.contains("not running")
-        || combined.contains("connection refused")
 }

--- a/crates/soldr-cli/src/cache/session.rs
+++ b/crates/soldr-cli/src/cache/session.rs
@@ -2,16 +2,12 @@
 //! lifecycle commands for the zccache daemon and its per-session journal.
 
 use crate::core::{SoldrError, SoldrPaths};
-use crate::zccache::{
-    command_stderr, managed_zccache_cache_dir, run_zccache_command_in_cache_dir,
-    run_zccache_command_raw_in_cache_dir, start_zccache_with_recovery,
+use crate::zccache::managed_zccache_cache_dir;
+use crate::zccache_lifecycle::{
+    ZccacheDaemonExitPollResult, ZccacheLifecycle, ZccacheSessionStartOptions,
 };
 use crate::{cached_active_zccache, fetch_active_zccache, JSON_SCHEMA_VERSION};
 use serde::Serialize;
-
-use super::{
-    zccache_daemon_already_stopped, zccache_output_snippet, zccache_subcommand_unsupported,
-};
 
 #[derive(Serialize)]
 struct SessionStartOutput {
@@ -129,35 +125,18 @@ pub(crate) async fn run_session_start_command(
     }
 
     let fetch = fetch_active_zccache(&paths).await?;
-    start_zccache_with_recovery(&fetch.binary_path, &zccache_dir)?;
-
-    let log_arg = session_log_path.display().to_string();
-    let journal_arg = journal_path.display().to_string();
-    let mut args: Vec<&str> = vec![
-        "session-start",
-        "--stats",
-        "--log",
-        &log_arg,
-        "--journal",
-        &journal_arg,
-    ];
-    if let Some(id_value) = id.as_deref() {
-        args.push("--id");
-        args.push(id_value);
-    }
-    let session_json = run_zccache_command_in_cache_dir(&fetch.binary_path, &args, &zccache_dir)?;
-    let session_id =
-        crate::cache_lib::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
-            SoldrError::Other(format!(
-                "failed to parse zccache session id from output: {}",
-                session_json.stdout.trim()
-            ))
-        })?;
+    let mut lifecycle = ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir);
+    let session = lifecycle.start_session(ZccacheSessionStartOptions {
+        id,
+        session_log_path: session_log_path.clone(),
+        journal_path: journal_path.clone(),
+        session_stats_path: session_stats_path.clone(),
+    })?;
 
     let output = SessionStartOutput {
         schema_version: JSON_SCHEMA_VERSION,
         command: "session-start",
-        session_id,
+        session_id: session.session_id,
         log_path: session_log_path.display().to_string(),
         journal_path: journal_path.display().to_string(),
         stats_path: session_stats_path.display().to_string(),
@@ -215,27 +194,17 @@ pub(crate) fn run_session_end_command(
         )
     })?;
 
-    let result = run_zccache_command_raw_in_cache_dir(
-        &fetch.binary_path,
-        &["session-end", &session_id, "--json"],
-        &zccache_dir,
-    )?;
-    let (stats, already_ended) = if result.status.success() {
-        let stdout = String::from_utf8_lossy(&result.stdout);
-        let parsed = if stdout.trim().is_empty() {
-            None
-        } else {
-            serde_json::from_str::<serde_json::Value>(stdout.trim()).ok()
-        };
-        (parsed, false)
-    } else if zccache_session_already_ended(&result) {
+    let mut lifecycle = ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir);
+    let result = lifecycle.end_session_json(&session_id)?;
+    let (stats, already_ended) = if result.already_ended {
         (None, true)
     } else {
-        return Err(SoldrError::Other(format!(
-            "zccache session-end {} --json failed: {}",
-            session_id,
-            command_stderr(&result)
-        )));
+        let parsed = if result.stdout.trim().is_empty() {
+            None
+        } else {
+            serde_json::from_str::<serde_json::Value>(result.stdout.trim()).ok()
+        };
+        (parsed, false)
     };
 
     let cleared = if clear {
@@ -275,14 +244,6 @@ pub(crate) fn run_session_end_command(
         }
     }
     Ok(())
-}
-
-fn zccache_session_already_ended(output: &std::process::Output) -> bool {
-    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
-    stderr.contains("session not found")
-        || stderr.contains("no such session")
-        || stderr.contains("already ended")
-        || stderr.contains("unknown session")
 }
 
 fn clear_session_artifacts(zccache_dir: &std::path::Path) -> Result<bool, SoldrError> {
@@ -333,22 +294,16 @@ pub(crate) async fn run_cache_shutdown_command(
         .ok()
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty());
+    let mut lifecycle = fetch
+        .as_ref()
+        .map(|fetch| ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir));
 
     // Step 1: end the active session so zccache flushes the per-session
     // journal before the daemon stops.
-    if let (Some(session_id), Some(fetch)) = (env_session_id.as_deref(), fetch.as_ref()) {
-        let end = run_zccache_command_raw_in_cache_dir(
-            &fetch.binary_path,
-            &["session-end", session_id, "--json"],
-            &zccache_dir,
-        )?;
-        if end.status.success() || zccache_session_already_ended(&end) {
-            output.session_id = Some(session_id.to_string());
-        } else {
-            notes.push(format!(
-                "session-end {session_id} failed: {}",
-                command_stderr(&end)
-            ));
+    if let (Some(session_id), Some(lifecycle)) = (env_session_id.as_deref(), lifecycle.as_mut()) {
+        match lifecycle.end_session_json(session_id) {
+            Ok(_) => output.session_id = Some(session_id.to_string()),
+            Err(err) => notes.push(format!("session-end {session_id} failed: {err}")),
         }
     }
 
@@ -387,38 +342,20 @@ pub(crate) async fn run_cache_shutdown_command(
     // Step 3: graceful daemon stop (triggers depgraph flush in zccache
     // 1.8.x). `zccache stop` is synchronous and returns once the daemon
     // process has exited.
-    if let Some(fetch) = fetch.as_ref() {
-        let mut args: Vec<&str> = vec!["stop"];
-        if no_depgraph_save {
-            // The flag exists upstream as `--no-depgraph-cache` on
-            // `zccache start`. Forward the equivalent suppressor on
-            // stop when zccache exposes it; if not, surface a note so
-            // operators know it was a no-op.
-            args.push("--no-depgraph-save");
-        }
-        let stop_result =
-            run_zccache_command_raw_in_cache_dir(&fetch.binary_path, &args, &zccache_dir)?;
-        if stop_result.status.success() {
-            output.daemon_stopped = true;
-        } else if no_depgraph_save && zccache_flag_unsupported(&stop_result, "--no-depgraph-save") {
+    if let Some(lifecycle) = lifecycle.as_mut() {
+        let stop_result = lifecycle.stop(no_depgraph_save)?;
+        if stop_result.unsupported_no_depgraph_save {
             notes.push(
                 "zccache stop does not support --no-depgraph-save; retrying with default flush"
                     .into(),
             );
-            let retry =
-                run_zccache_command_raw_in_cache_dir(&fetch.binary_path, &["stop"], &zccache_dir)?;
-            if retry.status.success() {
-                output.daemon_stopped = true;
-            } else if !zccache_daemon_already_stopped(&retry) {
-                notes.push(format!("zccache stop failed: {}", command_stderr(&retry)));
-            }
-        } else if zccache_daemon_already_stopped(&stop_result) {
+        }
+        if stop_result.stopped {
+            output.daemon_stopped = true;
+        } else if stop_result.already_stopped {
             notes.push("daemon was already stopped".into());
-        } else {
-            notes.push(format!(
-                "zccache stop failed: {}",
-                command_stderr(&stop_result)
-            ));
+        } else if let Some(failure) = stop_result.failure {
+            notes.push(format!("zccache stop failed: {failure}"));
         }
     } else {
         notes.push("managed zccache binary not yet fetched; nothing to stop".into());
@@ -440,22 +377,20 @@ pub(crate) async fn run_cache_shutdown_command(
     // to know zccache's IPC layout.
     let mut polled_for_exit = false;
     if wait && output.daemon_stopped {
-        if let Some(fetch) = fetch.as_ref() {
+        if let Some(lifecycle) = lifecycle.as_ref() {
             polled_for_exit = true;
-            match poll_zccache_daemon_exit(
-                &fetch.binary_path,
-                &zccache_dir,
-                std::time::Duration::from_secs(shutdown_timeout_seconds),
-            ) {
-                DaemonExitPollResult::Exited => {
+            match lifecycle
+                .poll_daemon_exit(std::time::Duration::from_secs(shutdown_timeout_seconds))
+            {
+                ZccacheDaemonExitPollResult::Exited => {
                     output.daemon_exited = true;
                 }
-                DaemonExitPollResult::TimedOut => {
+                ZccacheDaemonExitPollResult::TimedOut => {
                     notes.push(format!(
                         "daemon did not exit within {shutdown_timeout_seconds}s after `zccache stop`; depgraph state may not be durable on disk"
                     ));
                 }
-                DaemonExitPollResult::PollFailed(err) => {
+                ZccacheDaemonExitPollResult::PollFailed(err) => {
                     notes.push(format!(
                         "could not confirm daemon exit (polling `zccache status` failed): {err}"
                     ));
@@ -510,66 +445,6 @@ pub(crate) async fn run_cache_shutdown_command(
     Ok(())
 }
 
-/// Result of polling `zccache status` after a `zccache stop`. Used by
-/// `run_cache_shutdown_command` to determine whether the daemon's
-/// depgraph snapshot is durable on disk.
-enum DaemonExitPollResult {
-    /// `zccache status` reported the daemon is no longer running.
-    Exited,
-    /// Deadline elapsed before the daemon stopped responding.
-    TimedOut,
-    /// `zccache status` itself failed in an unexpected way (e.g. the
-    /// binary became unreadable). The shutdown is treated as
-    /// indeterminate.
-    PollFailed(String),
-}
-
-fn poll_zccache_daemon_exit(
-    binary: &std::path::Path,
-    zccache_dir: &std::path::Path,
-    timeout: std::time::Duration,
-) -> DaemonExitPollResult {
-    let deadline = std::time::Instant::now() + timeout;
-    let poll_interval = std::time::Duration::from_millis(100);
-    loop {
-        match run_zccache_command_raw_in_cache_dir(binary, &["status"], zccache_dir) {
-            Ok(output) => {
-                // If `zccache status` errored out with a
-                // daemon-not-running phrase, the daemon is gone and
-                // the on-disk state from `stop` is durable.
-                if !output.status.success() && zccache_daemon_already_stopped(&output) {
-                    return DaemonExitPollResult::Exited;
-                }
-                // Some zccache builds may print the daemon-stopped
-                // marker on stdout while still exiting 0 (e.g. a
-                // future "status --json" with state="stopped"). Cover
-                // that path too without committing to a JSON schema.
-                let combined = format!(
-                    "{}\n{}",
-                    String::from_utf8_lossy(&output.stdout),
-                    String::from_utf8_lossy(&output.stderr)
-                )
-                .to_ascii_lowercase();
-                if combined.contains("daemon not running")
-                    || combined.contains("no daemon")
-                    || combined.contains("connection refused")
-                {
-                    return DaemonExitPollResult::Exited;
-                }
-            }
-            Err(err) => {
-                // Spawning zccache itself failed — surface the cause,
-                // do not retry.
-                return DaemonExitPollResult::PollFailed(err.to_string());
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            return DaemonExitPollResult::TimedOut;
-        }
-        std::thread::sleep(poll_interval);
-    }
-}
-
 pub(crate) async fn run_cache_flush_command(json: bool) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
     let zccache_dir = managed_zccache_cache_dir(&paths)?;
@@ -591,67 +466,38 @@ pub(crate) async fn run_cache_flush_command(json: bool) -> Result<(), SoldrError
         // re-emit the upstream stats verbatim; fall back to plain
         // `zccache flush` when the build does not yet support
         // `--json`.
-        let result = run_zccache_command_raw_in_cache_dir(
-            &fetch.binary_path,
-            &["flush", "--json"],
-            &zccache_dir,
-        )?;
-        if result.status.success() {
-            output.flushed = true;
-            let stdout = String::from_utf8_lossy(&result.stdout);
-            let trimmed = stdout.trim();
-            if !trimmed.is_empty() {
-                output.stats = serde_json::from_str(trimmed).ok();
-                if output.stats.is_none() {
-                    output.notes.push(format!(
-                        "zccache flush --json stdout was not valid JSON: {}",
-                        zccache_output_snippet(trimmed.as_bytes())
-                            .unwrap_or_else(|| "<empty>".into())
-                    ));
-                }
-            }
-        } else if zccache_flag_unsupported(&result, "--json") {
-            // zccache does not yet implement `flush --json`. Retry the
-            // bare form so we still get a durable on-disk snapshot.
-            let retry =
-                run_zccache_command_raw_in_cache_dir(&fetch.binary_path, &["flush"], &zccache_dir)?;
-            if retry.status.success() {
-                output.flushed = true;
-                output.notes.push(format!(
-                    "zccache flush --json not supported by managed zccache {}; ran `zccache flush` instead",
-                    crate::fetch::MANAGED_ZCCACHE_VERSION
-                ));
-            } else if zccache_subcommand_unsupported(&retry, "flush") {
-                output.notes.push(format!(
-                    "managed zccache {} does not yet implement the `flush` subcommand; upgrade for soldr#383 CI checkpointing",
-                    crate::fetch::MANAGED_ZCCACHE_VERSION
-                ));
-            } else if zccache_daemon_already_stopped(&retry) {
-                output.notes.push(
-                    "daemon was not running; nothing to flush (state on disk is already durable)"
-                        .into(),
-                );
-            } else {
-                return Err(SoldrError::Other(format!(
-                    "zccache flush failed: {}",
-                    command_stderr(&retry)
-                )));
-            }
-        } else if zccache_subcommand_unsupported(&result, "flush") {
+        let mut lifecycle = ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir);
+        let result = lifecycle.flush()?;
+        output.flushed = result.flushed;
+        output.stats = result.stats;
+        if let Some(snippet) = result.invalid_json {
+            output.notes.push(format!(
+                "zccache flush --json stdout was not valid JSON: {snippet}"
+            ));
+        }
+        if result.json_unsupported && result.flushed {
+            output.notes.push(format!(
+                "zccache flush --json not supported by managed zccache {}; ran `zccache flush` instead",
+                crate::fetch::MANAGED_ZCCACHE_VERSION
+            ));
+        }
+        if result.subcommand_unsupported {
             output.notes.push(format!(
                 "managed zccache {} does not yet implement the `flush` subcommand; upgrade for soldr#383 CI checkpointing",
                 crate::fetch::MANAGED_ZCCACHE_VERSION
             ));
-        } else if zccache_daemon_already_stopped(&result) {
+        } else if result.already_stopped {
             output.notes.push(
                 "daemon was not running; nothing to flush (state on disk is already durable)"
                     .into(),
             );
-        } else {
-            return Err(SoldrError::Other(format!(
-                "zccache flush --json failed: {}",
-                command_stderr(&result)
-            )));
+        } else if let Some(failure) = result.failure {
+            let command = if result.json_unsupported {
+                "zccache flush"
+            } else {
+                "zccache flush --json"
+            };
+            return Err(SoldrError::Other(format!("{command} failed: {failure}")));
         }
     } else {
         output
@@ -684,24 +530,14 @@ pub(crate) async fn run_cache_flush_command(json: bool) -> Result<(), SoldrError
     Ok(())
 }
 
-fn zccache_flag_unsupported(output: &std::process::Output, flag: &str) -> bool {
-    let combined = format!(
-        "{}\n{}",
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout)
-    );
-    combined.contains("unexpected argument") && combined.contains(flag.trim_start_matches('-'))
-        || combined.contains(&format!("unknown flag: {flag}"))
-        || combined.contains(&format!("unrecognized option {flag}"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::report::zccache_analyze_failure_note;
     use super::super::{
         zccache_daemon_already_stopped, zccache_output_snippet, ZCCACHE_ANALYZE_NOTE_LIMIT,
     };
-    use super::{clear_session_artifacts, zccache_flag_unsupported, zccache_session_already_ended};
+    use super::clear_session_artifacts;
+    use crate::zccache_lifecycle::{zccache_flag_unsupported, zccache_session_already_ended};
     use std::process::Output;
 
     fn synthetic_output(stderr: &str, exit: i32) -> Output {
@@ -832,14 +668,15 @@ mod tests {
     /// the deadline expires (which would mask the underlying error).
     #[test]
     fn poll_zccache_daemon_exit_surfaces_spawn_failure() {
-        use super::{poll_zccache_daemon_exit, DaemonExitPollResult};
+        use crate::zccache_lifecycle::{ZccacheDaemonExitPollResult, ZccacheLifecycle};
         use std::time::Duration;
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let bogus = tmp.path().join("definitely-not-zccache");
-        let result = poll_zccache_daemon_exit(&bogus, tmp.path(), Duration::from_millis(50));
+        let lifecycle = ZccacheLifecycle::new(&bogus, tmp.path());
+        let result = lifecycle.poll_daemon_exit(Duration::from_millis(50));
         assert!(
-            matches!(result, DaemonExitPollResult::PollFailed(_)),
+            matches!(result, ZccacheDaemonExitPollResult::PollFailed(_)),
             "expected PollFailed when zccache binary cannot be spawned"
         );
     }

--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -509,43 +509,46 @@ pub(crate) async fn run_cargo_front_door(
         current_unix_ms(),
     );
 
-    if status.success() {
-        if let Some(plan) = plan_ctx.as_ref() {
-            rust_plan::run_zccache_rust_plan(plan, "save", true)?;
-            rust_plan::write_warm_restore_sentinel(plan);
-        }
-        // Post-compile target-GC (#485). Same gating as the pre-pass —
-        // build-like cargo, no opt-out, resolve dir consistently with the
-        // pre-pass. The active-cargo-lock guard inside `auto_prune_target`
-        // is what keeps a parallel `cargo` in the same `target/` from
-        // racing this pass; we never emit a stderr line when that guard
-        // engages.
-        if build_like_cargo && !gc_opt_out.after {
-            let target_dir = plan_ctx
-                .as_ref()
-                .map(|p| std::path::PathBuf::from(&p.target_dir))
-                .or_else(|| resolve_target_dir_for_gc(args));
-            if let Some(dir) = target_dir.as_deref() {
-                let outcome = auto_prune_target(dir, AutoPrunePhase::After);
-                emit_auto_prune_summary(&outcome);
+    let post_cargo_result: Result<(), SoldrError> = (|| {
+        if status.success() {
+            if let Some(plan) = plan_ctx.as_ref() {
+                rust_plan::run_zccache_rust_plan(plan, "save", true)?;
+                rust_plan::write_warm_restore_sentinel(plan);
             }
+            // Post-compile target-GC (#485). Same gating as the pre-pass —
+            // build-like cargo, no opt-out, resolve dir consistently with the
+            // pre-pass. The active-cargo-lock guard inside `auto_prune_target`
+            // is what keeps a parallel `cargo` in the same `target/` from
+            // racing this pass; we never emit a stderr line when that guard
+            // engages.
+            if build_like_cargo && !gc_opt_out.after {
+                let target_dir = plan_ctx
+                    .as_ref()
+                    .map(|p| std::path::PathBuf::from(&p.target_dir))
+                    .or_else(|| resolve_target_dir_for_gc(args));
+                if let Some(dir) = target_dir.as_deref() {
+                    let outcome = auto_prune_target(dir, AutoPrunePhase::After);
+                    emit_auto_prune_summary(&outcome);
+                }
+            }
+            if let Some(plan) = trampoline_plan.as_ref() {
+                refresh_sidecar_after_cargo(plan);
+            }
+            if let Some(plan) = workspace_plan.as_ref() {
+                refresh_workspace_sidecar_after_cargo(plan, clippy_capture);
+            }
+        } else if let Some(plan) = plan_ctx.as_ref() {
+            // A non-zero cargo exit can leave orphan `.rmeta` files (rmeta
+            // emitted, then rustc aborted before the `.rlib` codegen pass)
+            // in `target/<triple>/<profile>/deps/`. Subsequent invocations
+            // then fail with `E0463: can't find crate` because cargo passes
+            // `--extern X=orphan.rmeta` to dependents and rustc cannot link
+            // an rmeta-only crate. Sweep them so the next build rebuilds
+            // cleanly. See soldr#410.
+            rust_plan::prune_orphan_rmetas_after_failed_build(plan);
         }
-        if let Some(plan) = trampoline_plan.as_ref() {
-            refresh_sidecar_after_cargo(plan);
-        }
-        if let Some(plan) = workspace_plan.as_ref() {
-            refresh_workspace_sidecar_after_cargo(plan, clippy_capture);
-        }
-    } else if let Some(plan) = plan_ctx.as_ref() {
-        // A non-zero cargo exit can leave orphan `.rmeta` files (rmeta
-        // emitted, then rustc aborted before the `.rlib` codegen pass)
-        // in `target/<triple>/<profile>/deps/`. Subsequent invocations
-        // then fail with `E0463: can't find crate` because cargo passes
-        // `--extern X=orphan.rmeta` to dependents and rustc cannot link
-        // an rmeta-only crate. Sweep them so the next build rebuilds
-        // cleanly. See soldr#410.
-        rust_plan::prune_orphan_rmetas_after_failed_build(plan);
-    }
+        Ok(())
+    })();
 
     // After cargo fails, look at whatever stderr we captured for a
     // recognizable build-script-spawn-ENOENT pattern (#422 — minimal
@@ -574,6 +577,7 @@ pub(crate) async fn run_cargo_front_door(
         finish_result?;
         shutdown_result?;
     }
+    post_cargo_result?;
     drop(trampoline_plan);
     drop(workspace_plan);
     Ok(status.code().unwrap_or(1))

--- a/crates/soldr-cli/src/daemon/client.rs
+++ b/crates/soldr-cli/src/daemon/client.rs
@@ -166,9 +166,9 @@ pub fn record_compile(
     );
 }
 
-pub fn link_zccache(paths: &SoldrPaths, zccache_pid: u32) {
+pub fn link_zccache(paths: &SoldrPaths, link: crate::daemon::protocol::ZccacheDaemonLink) {
     let sock = default_sock_path(paths);
-    let _ = submit_fire_and_forget(&sock, &Request::LinkZccache { zccache_pid });
+    let _ = submit_fire_and_forget(&sock, &Request::LinkZccache { link });
 }
 
 /// Wrapper-side entry point. Tries the daemon first; on any failure,

--- a/crates/soldr-cli/src/daemon/db.rs
+++ b/crates/soldr-cli/src/daemon/db.rs
@@ -1,16 +1,16 @@
 //! Daemon-side redb tables for build session correlation and the
-//! linked-zccache PID. Opens `~/.soldr/state.redb` per call and drops
+//! linked-zccache runtime identity. Opens `~/.soldr/state.redb` per call and drops
 //! the handle on return — redb refuses concurrent multi-process opens
 //! and the wrapper / GC tools open the same file directly.
 //!
 //! Tables live alongside the existing `target_registry_targets`:
 //! - `daemon_builds`  : u64 session_id → bincoded BuildRecord
 //! - `daemon_events`  : u64 event_id   → bincoded Event
-//! - `daemon_meta`    : `&str` key     → u64 (next event id, linked
-//!   zccache PID, ...)
+//! - `daemon_meta`    : `&str` key     → u64 (next event id, ...)
+//! - `daemon_zccache_link` : `&str` key → bincoded ZccacheDaemonLink
 
 use crate::cache_lib::target_registry::RegistryError;
-use crate::daemon::protocol::BuildRecord;
+use crate::daemon::protocol::{BuildRecord, ZccacheDaemonLink};
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -18,9 +18,10 @@ use std::path::{Path, PathBuf};
 const BUILDS: TableDefinition<u64, &[u8]> = TableDefinition::new("daemon_builds");
 const EVENTS: TableDefinition<u64, &[u8]> = TableDefinition::new("daemon_events");
 const META: TableDefinition<&str, u64> = TableDefinition::new("daemon_meta");
+const ZCCACHE_LINK: TableDefinition<&str, &[u8]> = TableDefinition::new("daemon_zccache_link");
 
 const META_NEXT_EVENT_ID: &str = "next_event_id";
-const META_LINKED_ZCCACHE_PID: &str = "linked_zccache_pid";
+const LINKED_ZCCACHE_KEY: &str = "active";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum EventKind {
@@ -59,6 +60,7 @@ fn init_tables(db: &Database) -> Result<(), RegistryError> {
         let _ = txn.open_table(BUILDS)?;
         let _ = txn.open_table(EVENTS)?;
         let _ = txn.open_table(META)?;
+        let _ = txn.open_table(ZCCACHE_LINK)?;
     }
     txn.commit()?;
     Ok(())
@@ -207,19 +209,23 @@ pub fn aggregate_session(
     Ok((count, slowest_us, slowest_name))
 }
 
-/// Set the linked zccache PID. None clears it.
-pub fn set_linked_zccache_pid(db_path: &Path, pid: Option<u32>) -> Result<(), RegistryError> {
+/// Set the linked zccache runtime/cache/session identity. None clears it.
+pub fn set_linked_zccache(
+    db_path: &Path,
+    link: Option<&ZccacheDaemonLink>,
+) -> Result<(), RegistryError> {
     let db = open_db(db_path)?;
     init_tables(&db)?;
     let txn = db.begin_write()?;
     {
-        let mut meta = txn.open_table(META)?;
-        match pid {
-            Some(p) => {
-                meta.insert(META_LINKED_ZCCACHE_PID, &(p as u64))?;
+        let mut table = txn.open_table(ZCCACHE_LINK)?;
+        match link {
+            Some(link) => {
+                let bytes = bincode::serialize(link).map_err(bincode_err)?;
+                table.insert(LINKED_ZCCACHE_KEY, bytes.as_slice())?;
             }
             None => {
-                meta.remove(META_LINKED_ZCCACHE_PID)?;
+                table.remove(LINKED_ZCCACHE_KEY)?;
             }
         }
     }
@@ -227,12 +233,16 @@ pub fn set_linked_zccache_pid(db_path: &Path, pid: Option<u32>) -> Result<(), Re
     Ok(())
 }
 
-pub fn get_linked_zccache_pid(db_path: &Path) -> Result<Option<u32>, RegistryError> {
+pub fn get_linked_zccache(db_path: &Path) -> Result<Option<ZccacheDaemonLink>, RegistryError> {
     let db = open_db(db_path)?;
     init_tables(&db)?;
     let txn = db.begin_read()?;
-    let meta = txn.open_table(META)?;
-    Ok(meta.get(META_LINKED_ZCCACHE_PID)?.map(|v| v.value() as u32))
+    let table = txn.open_table(ZCCACHE_LINK)?;
+    let Some(row) = table.get(LINKED_ZCCACHE_KEY)? else {
+        return Ok(None);
+    };
+    let link: ZccacheDaemonLink = bincode::deserialize(row.value()).map_err(bincode_err)?;
+    Ok(Some(link))
 }
 
 /// Delete `daemon_events` rows older than `cutoff_ms`. Returns the
@@ -405,14 +415,20 @@ mod tests {
     }
 
     #[test]
-    fn linked_zccache_pid_round_trips() {
+    fn linked_zccache_identity_round_trips() {
         let temp = TempDir::new().expect("tempdir");
         let path = temp.path().join("state.redb");
-        assert_eq!(get_linked_zccache_pid(&path).expect("get"), None);
-        set_linked_zccache_pid(&path, Some(12345)).expect("set");
-        assert_eq!(get_linked_zccache_pid(&path).expect("get"), Some(12345));
-        set_linked_zccache_pid(&path, None).expect("clear");
-        assert_eq!(get_linked_zccache_pid(&path).expect("get"), None);
+        let link = ZccacheDaemonLink {
+            binary_path: "/tmp/zccache".into(),
+            cache_dir: "/tmp/cache".into(),
+            session_id: Some("session-1".into()),
+            source: "managed".into(),
+        };
+        assert_eq!(get_linked_zccache(&path).expect("get"), None);
+        set_linked_zccache(&path, Some(&link)).expect("set");
+        assert_eq!(get_linked_zccache(&path).expect("get"), Some(link));
+        set_linked_zccache(&path, None).expect("clear");
+        assert_eq!(get_linked_zccache(&path).expect("get"), None);
     }
 
     #[test]

--- a/crates/soldr-cli/src/daemon/protocol.rs
+++ b/crates/soldr-cli/src/daemon/protocol.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Maximum bincode body size. 64 KiB is comfortably above the largest
 /// realistic record (path strings, a few timestamps). Frames larger than
@@ -62,11 +62,11 @@ pub enum Request {
     /// `total_wall_ms >= threshold_ms`, sorted desc by `total_wall_ms`,
     /// capped at `limit`.
     ListSlowBuilds { threshold_ms: u64, limit: u32 },
-    /// Fire-and-forget: tell the daemon which zccache daemon PID is
+    /// Fire-and-forget: tell the daemon which zccache runtime/cache/session is
     /// linked to this soldr-daemon's session. On daemon shutdown
-    /// (explicit RPC, signal, or idle timeout), the daemon spawns
-    /// `zccache stop` against this PID before exiting.
-    LinkZccache { zccache_pid: u32 },
+    /// (explicit RPC, signal, or idle timeout), the daemon issues
+    /// `zccache stop` with the recorded cache dir before exiting.
+    LinkZccache { link: ZccacheDaemonLink },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -84,7 +84,15 @@ pub struct StatusInfo {
     pub uptime_secs: u64,
     pub request_count: u64,
     /// Set by `LinkZccache`; cleared on daemon shutdown.
-    pub linked_zccache_pid: Option<u32>,
+    pub linked_zccache: Option<ZccacheDaemonLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ZccacheDaemonLink {
+    pub binary_path: String,
+    pub cache_dir: String,
+    pub session_id: Option<String>,
+    pub source: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -12,7 +12,9 @@ use crate::core::SoldrPaths;
 use crate::daemon::db;
 use crate::daemon::ipc::{read_frame_async, write_frame_async};
 use crate::daemon::lifecycle::{append_lifecycle_event, is_live, remove_pid_file, write_pid_file};
-use crate::daemon::protocol::{BuildRecord, Request, Response, StatusInfo, PROTOCOL_VERSION};
+use crate::daemon::protocol::{
+    BuildRecord, Request, Response, StatusInfo, ZccacheDaemonLink, PROTOCOL_VERSION,
+};
 use crate::daemon::zccache_link;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -76,9 +78,9 @@ struct State {
     /// writer ordering and build-session correlation, not avoiding
     /// the per-write fs::open cost.
     db_path: PathBuf,
-    /// Linked zccache PID kept in memory for fast `Status` replies;
+    /// Linked zccache runtime kept in memory for fast `Status` replies;
     /// also persisted to redb so a daemon restart can resume shutdown.
-    linked_zccache_pid: std::sync::Mutex<Option<u32>>,
+    linked_zccache: std::sync::Mutex<Option<ZccacheDaemonLink>>,
     start_instant: Instant,
     request_count: AtomicU64,
     last_activity_ms: AtomicU64,
@@ -107,10 +109,11 @@ impl State {
             pid: std::process::id(),
             uptime_secs: self.start_instant.elapsed().as_secs(),
             request_count: self.request_count.load(Ordering::Relaxed),
-            linked_zccache_pid: *self
-                .linked_zccache_pid
+            linked_zccache: self
+                .linked_zccache
                 .lock()
-                .unwrap_or_else(|p| p.into_inner()),
+                .unwrap_or_else(|p| p.into_inner())
+                .clone(),
         }
     }
 }
@@ -141,12 +144,12 @@ async fn run_async(opts: ServerOptions) -> Result<(), ServerError> {
     // Initialize the Phase 2 daemon tables (idempotent). Errors here
     // are non-fatal — Phase 1 target tracking still works without them.
     let _ = db::ensure_initialized(&db_path);
-    // Resume any linked zccache PID persisted across daemon restarts.
-    let resumed_pid = db::get_linked_zccache_pid(&db_path).ok().flatten();
+    // Resume any linked zccache identity persisted across daemon restarts.
+    let resumed_link = db::get_linked_zccache(&db_path).ok().flatten();
     let start_instant = Instant::now();
     let state = Arc::new(State {
         db_path,
-        linked_zccache_pid: std::sync::Mutex::new(resumed_pid),
+        linked_zccache: std::sync::Mutex::new(resumed_link),
         start_instant,
         request_count: AtomicU64::new(0),
         last_activity_ms: AtomicU64::new(0),
@@ -383,12 +386,12 @@ where
                 db::list_slow_builds(&state.db_path, threshold_ms, limit).unwrap_or_default();
             let _ = write_frame_async(&mut stream, &Response::Builds(rows)).await;
         }
-        Request::LinkZccache { zccache_pid } => {
+        Request::LinkZccache { link } => {
             // Persist to redb so a restart can still stop the linked
             // daemon, AND cache in-process for fast Status replies.
-            let _ = db::set_linked_zccache_pid(&state.db_path, Some(zccache_pid));
-            if let Ok(mut guard) = state.linked_zccache_pid.lock() {
-                *guard = Some(zccache_pid);
+            let _ = db::set_linked_zccache(&state.db_path, Some(&link));
+            if let Ok(mut guard) = state.linked_zccache.lock() {
+                *guard = Some(link);
             }
         }
     }

--- a/crates/soldr-cli/src/daemon/zccache_link.rs
+++ b/crates/soldr-cli/src/daemon/zccache_link.rs
@@ -1,103 +1,32 @@
-//! Linked zccache lifecycle (Phase 3). When the soldr-daemon's
-//! session has registered a zccache daemon PID via `LinkZccache`, the
-//! soldr-daemon's own shutdown (explicit RPC, signal, OR idle timeout)
-//! runs `zccache stop` against that PID before exiting.
+//! Linked zccache lifecycle. When the soldr-daemon's session has
+//! registered a zccache runtime/cache/session via `LinkZccache`, the
+//! soldr-daemon's own shutdown runs `zccache stop` against that exact
+//! cache namespace before exiting.
 
 use crate::core::SoldrPaths;
 use crate::daemon::db;
-use std::path::Path;
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use crate::zccache_lifecycle::ZccacheLifecycle;
+use std::time::Duration;
 
 const STOP_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Best-effort: if a linked zccache PID is recorded, spawn
-/// `zccache stop` and wait up to 5 s. All errors are swallowed —
-/// the soldr-daemon exits regardless so a hung zccache can't keep
-/// soldr-daemon alive.
+/// Best-effort: if a linked zccache runtime is recorded, spawn
+/// `zccache stop` with its recorded cache dir and wait up to 5 seconds.
+/// All errors are swallowed so a hung zccache cannot keep soldr-daemon alive.
 pub fn stop_linked_zccache(paths: &SoldrPaths) {
     let db_path = db::db_path(paths);
-    let Ok(Some(_pid)) = db::get_linked_zccache_pid(&db_path) else {
-        return;
-    };
-    let Some(zccache_bin) = resolve_zccache_binary(paths) else {
-        let _ = db::set_linked_zccache_pid(&db_path, None);
+    let Ok(Some(link)) = db::get_linked_zccache(&db_path) else {
         return;
     };
 
-    let mut cmd = Command::new(&zccache_bin);
-    cmd.arg("stop")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    let Ok(mut child) = cmd.spawn() else {
-        let _ = db::set_linked_zccache_pid(&db_path, None);
+    let binary_path = std::path::PathBuf::from(&link.binary_path);
+    let cache_dir = std::path::PathBuf::from(&link.cache_dir);
+    if !binary_path.exists() {
+        let _ = db::set_linked_zccache(&db_path, None);
         return;
-    };
-    let deadline = Instant::now() + STOP_TIMEOUT;
-    while Instant::now() < deadline {
-        match child.try_wait() {
-            Ok(Some(_)) => break,
-            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
-            Err(_) => break,
-        }
     }
-    if matches!(child.try_wait(), Ok(None)) {
-        let _ = child.kill();
-        let _ = child.wait();
-    }
-    let _ = db::set_linked_zccache_pid(&db_path, None);
-}
 
-/// Resolve the zccache binary path the daemon should use to issue
-/// `stop`. Mirrors the precedence chain the CLI uses, minus any
-/// network fetch — if no cached binary exists, no stop attempt is made.
-fn resolve_zccache_binary(paths: &SoldrPaths) -> Option<std::path::PathBuf> {
-    // SOLDR_ZCCACHE_BIN env var (test/debug override) wins outright.
-    if let Some(env_bin) = std::env::var_os(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR) {
-        let p = std::path::PathBuf::from(env_bin);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    // Cache-pinned install: ~/.soldr/bin/zccache-pinned/zccache[.exe]
-    let pinned = paths.pinned_bin.join("zccache-pinned").join(zccache_stem());
-    if pinned.exists() {
-        return Some(pinned);
-    }
-    // Managed install dir under ~/.soldr/bin/zccache-<version>/. Walk
-    // the bin/ dir and pick any zccache* directory's binary; without
-    // version pinning at hand, the most-recently-modified wins so the
-    // last install drives our stop.
-    let bin_dir = &paths.bin;
-    let mut best: Option<(std::time::SystemTime, std::path::PathBuf)> = None;
-    if let Ok(entries) = std::fs::read_dir(bin_dir) {
-        for entry in entries.flatten() {
-            let candidate = entry.path().join(zccache_stem());
-            if !candidate.exists() {
-                continue;
-            }
-            let mtime = entry
-                .metadata()
-                .and_then(|m| m.modified())
-                .ok()
-                .unwrap_or(std::time::UNIX_EPOCH);
-            match &best {
-                Some((current, _)) if mtime <= *current => {}
-                _ => best = Some((mtime, candidate)),
-            }
-        }
-    }
-    let resolved = best.map(|(_, p)| p);
-    let _ = bin_dir; // touch
-    let _: Option<&Path> = None; // silence unused warning when feature gates flip
-    resolved
-}
-
-fn zccache_stem() -> &'static str {
-    if cfg!(windows) {
-        "zccache.exe"
-    } else {
-        "zccache"
-    }
+    let mut lifecycle = ZccacheLifecycle::new(binary_path, cache_dir);
+    let _ = lifecycle.stop_best_effort_with_process_timeout(STOP_TIMEOUT);
+    let _ = db::set_linked_zccache(&db_path, None);
 }

--- a/crates/soldr-cli/src/lib.rs
+++ b/crates/soldr-cli/src/lib.rs
@@ -24,6 +24,7 @@ pub mod self_relocate;
 /// `tests/cli_wrapper_perf.rs` can drive it in-process (issue #474).
 /// The bin tree declares the same module via `main.rs`.
 pub mod wrapper_target;
+pub mod zccache_lifecycle;
 
 /// Per-test watchdog (`timed_test!` macro + `run_with_watchdog`).
 /// Exposed from the lib tree so both unit tests in `src/` and

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -41,6 +41,7 @@ mod trampoline_workspace;
 mod wrapper;
 mod wrapper_target;
 mod zccache;
+mod zccache_lifecycle;
 
 // Per-test watchdog (`timed_test!` macro + `run_with_watchdog`).
 // Declared (without a cfg gate) so unit tests under `src/` that use
@@ -908,7 +909,7 @@ fn run_daemon_command(command: DaemonSubcommand) -> Result<(), SoldrError> {
                         "pid": info.pid,
                         "uptime_secs": info.uptime_secs,
                         "request_count": info.request_count,
-                        "linked_zccache_pid": info.linked_zccache_pid,
+                        "linked_zccache": info.linked_zccache,
                     });
                     println!("{}", serde_json::to_string(&payload).unwrap_or_default());
                 } else {

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -6,7 +6,7 @@
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
 use crate::startup_profile::WrapperProfile;
 #[cfg(not(unix))]
-use crate::zccache::run_zccache_command_in_cache_dir;
+use crate::zccache_lifecycle::{stderr_indicates_unknown_session, ZccacheLifecycle};
 use crate::{apply_implicit_toolchain_homes, resolve_toolchain_binary, zccache_binary_override};
 
 /// Known toolchain binaries that cargo may invoke through RUSTC_WRAPPER
@@ -340,20 +340,6 @@ fn run_wrapper_through_zccache_windows(
     Ok(retry_status.code().unwrap_or(1))
 }
 
-/// Returns `true` iff `stderr` contains the literal substring
-/// `unknown session:` somewhere in its bytes. Tolerates non-UTF-8 input.
-///
-/// Extracted as a pure helper so the retry trigger can be unit-tested
-/// without spawning a real zccache.
-#[cfg_attr(unix, allow(dead_code))]
-pub(crate) fn stderr_indicates_unknown_session(stderr: &[u8]) -> bool {
-    const NEEDLE: &[u8] = b"unknown session:";
-    if stderr.len() < NEEDLE.len() {
-        return false;
-    }
-    stderr.windows(NEEDLE.len()).any(|w| w == NEEDLE)
-}
-
 /// Run `zccache session-start --stats --log <path> --journal <path>` against
 /// the cache dir the wrapper invocation inherits from cargo, and return the
 /// parsed session id. Mirrors the args used by `prepare_zccache_build`.
@@ -376,18 +362,15 @@ fn allocate_replacement_session(zccache: &std::path::Path) -> Result<String, Sol
     let session_log_path_arg = session_log_path.display().to_string();
     let journal_path = crate::cache_lib::session_journal_path(&cache_dir);
     let journal_path_arg = journal_path.display().to_string();
-    let session_json = run_zccache_command_in_cache_dir(
-        zccache,
-        &[
-            "session-start",
-            "--stats",
-            "--log",
-            &session_log_path_arg,
-            "--journal",
-            &journal_path_arg,
-        ],
-        &cache_dir,
-    )?;
+    let lifecycle = ZccacheLifecycle::new(zccache, &cache_dir);
+    let session_json = lifecycle.run(&[
+        "session-start",
+        "--stats",
+        "--log",
+        &session_log_path_arg,
+        "--journal",
+        &journal_path_arg,
+    ])?;
     crate::cache_lib::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
         SoldrError::Other(format!(
             "failed to parse zccache session id from output: {}",

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -1,13 +1,23 @@
 //! Zccache build-session orchestration and zccache subprocess helpers.
 //! Extracted from `main.rs` as part of issue #339.
 
-use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
+use crate::core::{SoldrError, SoldrPaths};
 use crate::fetch::{ZccacheRuntime, ZccacheRuntimeSource};
+use crate::zccache_lifecycle::{
+    zccache_command_failure_message, zccache_json_flag_unsupported, ZccacheLifecycle,
+    ZccacheSessionStartOptions,
+};
 use crate::{
     current_soldr_binary, fetch_active_zccache_runtime, non_empty_env_path, ZccacheSourceArg,
     RUSTC_WRAPPER_OVERRIDE_ENV_VAR,
 };
 use std::ffi::OsStr;
+
+pub(crate) use crate::zccache_lifecycle::{
+    command_stderr, effective_daemon_rust_log, run_zccache_command_in_cache_dir,
+    run_zccache_command_raw_in_cache_dir, run_zccache_command_strings_in_cache_dir,
+    start_zccache_with_recovery, ZccacheBuildSession, SOLDR_DAEMON_RUST_LOG_ENV_VAR,
+};
 
 pub(crate) const SOLDR_CACHE_LIFECYCLE_ENV_VAR: &str = "SOLDR_CACHE_LIFECYCLE";
 pub(crate) const SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR: &str =
@@ -72,15 +82,6 @@ pub(crate) fn parse_shutdown_timeout_seconds(raw: &str) -> Result<u64, SoldrErro
         )));
     }
     Ok(seconds)
-}
-
-pub(crate) struct ZccacheBuildSession {
-    pub(crate) binary_path: std::path::PathBuf,
-    pub(crate) cache_dir: std::path::PathBuf,
-    pub(crate) session_id: String,
-    pub(crate) session_log_path: std::path::PathBuf,
-    pub(crate) journal_path: std::path::PathBuf,
-    pub(crate) session_stats_path: std::path::PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -246,53 +247,43 @@ async fn prepare_zccache_build(
     // would keep handling requests. Evict it explicitly here.
     evict_zccache_daemon_if_binary_changed(&fetch.binary_path, &zccache_dir)?;
 
-    start_zccache_with_recovery(&fetch.binary_path, &zccache_dir)?;
-
     let session_log_path = crate::cache_lib::session_log_path(&zccache_dir);
-    let session_log_path_arg = session_log_path.display().to_string();
     let journal_path = crate::cache_lib::session_journal_path(&zccache_dir);
-    let journal_path_arg = journal_path.display().to_string();
     let session_stats_path = crate::cache_lib::session_stats_path(&zccache_dir);
-    let session_json = run_zccache_command_in_cache_dir(
-        &fetch.binary_path,
-        &[
-            "session-start",
-            "--stats",
-            "--log",
-            &session_log_path_arg,
-            "--journal",
-            &journal_path_arg,
-        ],
-        &zccache_dir,
-    )?;
-    let session_id =
-        crate::cache_lib::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
-            SoldrError::Other(format!(
-                "failed to parse zccache session id from output: {}",
-                session_json.stdout.trim()
-            ))
-        })?;
+    let mut lifecycle = ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir);
+    let session = lifecycle.start_session(ZccacheSessionStartOptions {
+        id: None,
+        session_log_path,
+        journal_path,
+        session_stats_path,
+    })?;
 
     cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
-    cargo.env(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR, &fetch.binary_path);
+    cargo.env(
+        crate::cache_lib::ZCCACHE_BINARY_ENV_VAR,
+        &session.binary_path,
+    );
     cargo.env(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR, &zccache_dir);
     cargo.env(
         crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR,
         &zccache_dir,
     );
-    cargo.env(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR, &session_id);
+    cargo.env(
+        crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR,
+        &session.session_id,
+    );
 
-    // Phase 3: tell the soldr-daemon (if running) that this session is
-    // linked to a zccache daemon. The PID field is informational —
-    // shutdown invokes the global `zccache stop` rather than targeting
-    // a specific PID — so we record the session-id hash modulo u32 as a
-    // distinct, non-zero token. Fire-and-forget; nothing about the
-    // cargo build depends on it.
-    let zccache_token = session_id
-        .bytes()
-        .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32))
-        .max(1);
-    crate::daemon::client::link_zccache(paths, zccache_token);
+    // Tell the soldr-daemon which concrete zccache runtime/cache/session
+    // this build owns so daemon shutdown can stop only that scoped daemon.
+    crate::daemon::client::link_zccache(
+        paths,
+        crate::daemon::protocol::ZccacheDaemonLink {
+            binary_path: session.binary_path.display().to_string(),
+            cache_dir: session.cache_dir.display().to_string(),
+            session_id: Some(session.session_id.clone()),
+            source: runtime.source.summary_source().as_str().to_string(),
+        },
+    );
 
     // Parent-cache (Tier L1.x, issue #352): seed ZCCACHE_PATH_REMAP=auto
     // and a logical worktree root so multiple worktrees of the same repo
@@ -312,14 +303,7 @@ async fn prepare_zccache_build(
         }
     }
 
-    Ok(ZccacheBuildSession {
-        binary_path: fetch.binary_path,
-        cache_dir: zccache_dir,
-        session_id,
-        session_log_path,
-        journal_path,
-        session_stats_path,
-    })
+    Ok(session)
 }
 
 fn print_zccache_runtime_diagnostic(runtime: &ZccacheRuntime) {
@@ -361,11 +345,8 @@ fn print_zccache_runtime_diagnostic(runtime: &ZccacheRuntime) {
 }
 
 pub(crate) fn finish_zccache_build(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
-    let output = run_zccache_command_raw_in_cache_dir(
-        &session.binary_path,
-        &["session-end", &session.session_id, "--json"],
-        &session.cache_dir,
-    )?;
+    let lifecycle = ZccacheLifecycle::from_session(session);
+    let output = lifecycle.run_raw(&["session-end", &session.session_id, "--json"])?;
     if session.session_log_path.exists() {
         eprintln!(
             "soldr: zccache session log: {}",
@@ -401,76 +382,34 @@ pub(crate) fn stop_zccache_after_command(
     session: &ZccacheBuildSession,
     timeout: std::time::Duration,
 ) -> Result<(), SoldrError> {
-    let output =
-        run_zccache_command_raw_in_cache_dir(&session.binary_path, &["stop"], &session.cache_dir)?;
-    if output.status.success() {
+    let mut lifecycle = ZccacheLifecycle::from_session(session);
+    let output = lifecycle.stop(false)?;
+    if output.stopped {
         eprintln!("soldr: command-lifetime cache: zccache stop requested");
-    } else if zccache_daemon_already_stopped_output(&output) {
+    } else if output.already_stopped {
         eprintln!("soldr: command-lifetime cache: zccache daemon already stopped");
         return Ok(());
-    } else {
-        return Err(SoldrError::Other(zccache_command_failure_message(
-            &["stop"],
-            &output,
-        )));
+    } else if let Some(failure) = output.failure {
+        return Err(SoldrError::Other(format!("zccache stop failed: {failure}")));
     }
 
-    match poll_zccache_daemon_exit(&session.binary_path, &session.cache_dir, timeout) {
-        ZccacheDaemonExitPollResult::Exited => {
+    match lifecycle.poll_daemon_exit(timeout) {
+        crate::zccache_lifecycle::ZccacheDaemonExitPollResult::Exited => {
             eprintln!("soldr: command-lifetime cache: zccache daemon exited");
             Ok(())
         }
-        ZccacheDaemonExitPollResult::TimedOut => Err(SoldrError::Other(format!(
-            "command-lifetime cache: zccache daemon did not exit within {}s",
-            timeout.as_secs()
-        ))),
-        ZccacheDaemonExitPollResult::PollFailed(err) => Err(SoldrError::Other(format!(
-            "command-lifetime cache: could not confirm zccache daemon exit: {err}"
-        ))),
-    }
-}
-
-enum ZccacheDaemonExitPollResult {
-    Exited,
-    TimedOut,
-    PollFailed(String),
-}
-
-fn poll_zccache_daemon_exit(
-    binary: &std::path::Path,
-    cache_dir: &std::path::Path,
-    timeout: std::time::Duration,
-) -> ZccacheDaemonExitPollResult {
-    let deadline = std::time::Instant::now() + timeout;
-    let poll_interval = std::time::Duration::from_millis(100);
-    loop {
-        match run_zccache_command_raw_in_cache_dir(binary, &["status"], cache_dir) {
-            Ok(output) => {
-                if zccache_daemon_already_stopped_output(&output) {
-                    return ZccacheDaemonExitPollResult::Exited;
-                }
-            }
-            Err(err) => return ZccacheDaemonExitPollResult::PollFailed(err.to_string()),
+        crate::zccache_lifecycle::ZccacheDaemonExitPollResult::TimedOut => {
+            Err(SoldrError::Other(format!(
+                "command-lifetime cache: zccache daemon did not exit within {}s",
+                timeout.as_secs()
+            )))
         }
-        if std::time::Instant::now() >= deadline {
-            return ZccacheDaemonExitPollResult::TimedOut;
+        crate::zccache_lifecycle::ZccacheDaemonExitPollResult::PollFailed(err) => {
+            Err(SoldrError::Other(format!(
+                "command-lifetime cache: could not confirm zccache daemon exit: {err}"
+            )))
         }
-        std::thread::sleep(poll_interval);
     }
-}
-
-fn zccache_daemon_already_stopped_output(output: &std::process::Output) -> bool {
-    let combined = format!(
-        "{}\n{}",
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout)
-    )
-    .to_ascii_lowercase();
-    combined.contains("daemon not running")
-        || combined.contains("no daemon to stop")
-        || combined.contains("no daemon")
-        || combined.contains("not running")
-        || combined.contains("connection refused")
 }
 
 fn finish_zccache_build_text_fallback(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
@@ -561,17 +500,6 @@ fn json_f64(value: &serde_json::Value, key: &str) -> Option<f64> {
     value.get(key).and_then(serde_json::Value::as_f64)
 }
 
-fn zccache_json_flag_unsupported(output: &std::process::Output) -> bool {
-    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
-    stderr.contains("unexpected argument")
-        || stderr.contains("unrecognized option")
-        || stderr.contains("found argument")
-}
-
-pub(crate) struct CommandOutput {
-    pub(crate) stdout: String,
-}
-
 pub(crate) fn managed_zccache_cache_dir(
     paths: &SoldrPaths,
 ) -> Result<std::path::PathBuf, SoldrError> {
@@ -600,45 +528,6 @@ pub(crate) fn normalize_path_for_compare(
     } else {
         Ok(std::env::current_dir()?.join(path))
     }
-}
-
-pub(crate) fn run_zccache_command_in_cache_dir(
-    binary: &std::path::Path,
-    args: &[&str],
-    cache_dir: &std::path::Path,
-) -> Result<CommandOutput, SoldrError> {
-    run_zccache_command_with_env(
-        binary,
-        args,
-        &[(
-            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-            cache_dir.as_os_str(),
-        )],
-    )
-}
-
-pub(crate) fn run_zccache_command_strings_in_cache_dir(
-    binary: &std::path::Path,
-    args: &[String],
-    cache_dir: &std::path::Path,
-) -> Result<CommandOutput, SoldrError> {
-    let output = run_zccache_command_raw_strings_with_env(
-        binary,
-        args,
-        &[(
-            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-            cache_dir.as_os_str(),
-        )],
-    )?;
-    if !output.status.success() {
-        return Err(SoldrError::Other(zccache_command_failure_message_strings(
-            args, &output,
-        )));
-    }
-
-    Ok(CommandOutput {
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-    })
 }
 
 /// Name of the marker file inside the zccache cache dir that records
@@ -702,201 +591,6 @@ pub(crate) fn evict_zccache_daemon_if_binary_changed(
         );
     }
     Ok(())
-}
-
-/// Soldr-side escape hatch for the RUST_LOG value that gets injected into
-/// `zccache start`. Power users can set this to something like
-/// `info,zccache_artifact=debug` when they need a specific level on the
-/// daemon without the daemon inheriting (and being narrowed by) the
-/// parent's RUST_LOG.
-pub(crate) const SOLDR_DAEMON_RUST_LOG_ENV_VAR: &str = "SOLDR_DAEMON_RUST_LOG";
-
-/// Compute the `RUST_LOG` value soldr should set when invoking
-/// `zccache start`. The daemon spawned by `zccache start` inherits the
-/// invocation's env; if `RUST_LOG` narrows the filter to a subset of
-/// `zccache_*` modules (e.g. `zccache_daemon=info`), INFO logs from
-/// sibling crates (`zccache_artifact`, `zccache_fscache`, etc.) silently
-/// vanish from the daemon spawn log. To keep cross-crate observability
-/// soldr forces a bare `info` directive at daemon spawn unless the user
-/// asks for something specific via `SOLDR_DAEMON_RUST_LOG`.
-///
-/// Returns the value soldr should pass through as `RUST_LOG` on the
-/// `zccache start` invocation. See issue #416.
-pub(crate) fn effective_daemon_rust_log(soldr_override: Option<&str>) -> String {
-    match soldr_override {
-        Some(v) if !v.trim().is_empty() => v.to_string(),
-        _ => "info".to_string(),
-    }
-}
-
-fn run_zccache_start_command(
-    binary: &std::path::Path,
-    cache_dir: &std::path::Path,
-) -> Result<std::process::Output, SoldrError> {
-    let rust_log =
-        effective_daemon_rust_log(std::env::var(SOLDR_DAEMON_RUST_LOG_ENV_VAR).ok().as_deref());
-    run_zccache_command_raw_with_env(
-        binary,
-        &["start"],
-        &[
-            (
-                crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-                cache_dir.as_os_str(),
-            ),
-            ("RUST_LOG", std::ffi::OsStr::new(rust_log.as_str())),
-        ],
-    )
-}
-
-pub(crate) fn start_zccache_with_recovery(
-    binary: &std::path::Path,
-    cache_dir: &std::path::Path,
-) -> Result<(), SoldrError> {
-    let start = run_zccache_start_command(binary, cache_dir)?;
-    if start.status.success() {
-        return Ok(());
-    }
-
-    let initial_stderr = command_stderr(&start);
-    if !is_stale_zccache_daemon_start_failure(&initial_stderr) {
-        return Err(SoldrError::Other(zccache_command_failure_message(
-            &["start"],
-            &start,
-        )));
-    }
-
-    eprintln!(
-        "soldr: zccache start reported an unresponsive daemon; stopping stale state and retrying"
-    );
-    let stop_diagnostic = match run_zccache_command_raw_in_cache_dir(binary, &["stop"], cache_dir) {
-        Ok(stop) if stop.status.success() => None,
-        Ok(stop) => Some(zccache_command_failure_message(&["stop"], &stop)),
-        Err(err) => Some(format!("failed to invoke zccache stop: {err}")),
-    };
-
-    match run_zccache_start_command(binary, cache_dir) {
-        Ok(retry) if retry.status.success() => Ok(()),
-        Ok(retry) => {
-            let mut message = format!(
-                "zccache start failed after stale daemon recovery retry: {}",
-                command_stderr(&retry)
-            );
-            message.push_str(&format!(
-                "\ninitial zccache start failure: {}",
-                initial_stderr
-            ));
-            if let Some(stop_diagnostic) = stop_diagnostic {
-                message.push_str(&format!("\nzccache stop diagnostic: {stop_diagnostic}"));
-            }
-            Err(SoldrError::Other(message))
-        }
-        Err(err) => {
-            let mut message =
-                format!("failed to invoke zccache start during stale daemon recovery retry: {err}");
-            message.push_str(&format!(
-                "\ninitial zccache start failure: {}",
-                initial_stderr
-            ));
-            if let Some(stop_diagnostic) = stop_diagnostic {
-                message.push_str(&format!("\nzccache stop diagnostic: {stop_diagnostic}"));
-            }
-            Err(SoldrError::Other(message))
-        }
-    }
-}
-
-fn is_stale_zccache_daemon_start_failure(stderr: &str) -> bool {
-    let stderr = stderr.to_ascii_lowercase();
-    stderr.contains("not accepting connections")
-        || (stderr.contains("daemon process") && stderr.contains("exists"))
-}
-
-pub(crate) fn run_zccache_command_raw_in_cache_dir(
-    binary: &std::path::Path,
-    args: &[&str],
-    cache_dir: &std::path::Path,
-) -> Result<std::process::Output, SoldrError> {
-    run_zccache_command_raw_with_env(
-        binary,
-        args,
-        &[(
-            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-            cache_dir.as_os_str(),
-        )],
-    )
-}
-
-fn run_zccache_command_with_env(
-    binary: &std::path::Path,
-    args: &[&str],
-    envs: &[(&str, &std::ffi::OsStr)],
-) -> Result<CommandOutput, SoldrError> {
-    let output = run_zccache_command_raw_with_env(binary, args, envs)?;
-    if !output.status.success() {
-        return Err(SoldrError::Other(zccache_command_failure_message(
-            args, &output,
-        )));
-    }
-
-    Ok(CommandOutput {
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-    })
-}
-
-fn run_zccache_command_raw_with_env(
-    binary: &std::path::Path,
-    args: &[&str],
-    envs: &[(&str, &std::ffi::OsStr)],
-) -> Result<std::process::Output, SoldrError> {
-    let mut command = std::process::Command::new(binary);
-    command.args(args);
-    for &(name, value) in envs {
-        command.env(name, value);
-    }
-    suppress_windows_console_window(&mut command);
-    Ok(command.output()?)
-}
-
-fn run_zccache_command_raw_strings_with_env(
-    binary: &std::path::Path,
-    args: &[String],
-    envs: &[(&str, &std::ffi::OsStr)],
-) -> Result<std::process::Output, SoldrError> {
-    let mut command = std::process::Command::new(binary);
-    command.args(args);
-    for &(name, value) in envs {
-        command.env(name, value);
-    }
-    suppress_windows_console_window(&mut command);
-    Ok(command.output()?)
-}
-
-fn zccache_command_failure_message(args: &[&str], output: &std::process::Output) -> String {
-    format!(
-        "zccache {} failed: {}",
-        args.join(" "),
-        command_stderr(output)
-    )
-}
-
-fn zccache_command_failure_message_strings(
-    args: &[String],
-    output: &std::process::Output,
-) -> String {
-    format!(
-        "zccache {} failed: {}",
-        args.join(" "),
-        command_stderr(output)
-    )
-}
-
-pub(crate) fn command_stderr(output: &std::process::Output) -> String {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if stderr.is_empty() {
-        format!("exit status {}", output.status)
-    } else {
-        stderr
-    }
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/src/zccache_lifecycle.rs
+++ b/crates/soldr-cli/src/zccache_lifecycle.rs
@@ -1,0 +1,831 @@
+//! Shared zccache daemon/session lifecycle helpers.
+//!
+//! This module owns the state transitions and output classifiers used by the
+//! cargo front door, `soldr session`, `soldr cache`, wrapper retry handling,
+//! and soldr-daemon linked shutdown.
+
+use crate::core::{suppress_windows_console_window, SoldrError};
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ZccacheLifecycleState {
+    Ready,
+    DaemonStarted,
+    SessionActive,
+    SessionEnded,
+    Stopped,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ZccacheBuildSession {
+    pub(crate) binary_path: PathBuf,
+    pub(crate) cache_dir: PathBuf,
+    pub(crate) session_id: String,
+    pub(crate) session_log_path: PathBuf,
+    pub(crate) journal_path: PathBuf,
+    pub(crate) session_stats_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ZccacheSessionStartOptions {
+    pub(crate) id: Option<String>,
+    pub(crate) session_log_path: PathBuf,
+    pub(crate) journal_path: PathBuf,
+    pub(crate) session_stats_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ZccacheSessionEndOutcome {
+    pub(crate) stdout: String,
+    pub(crate) already_ended: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ZccacheStopOutcome {
+    pub(crate) stopped: bool,
+    pub(crate) already_stopped: bool,
+    pub(crate) unsupported_no_depgraph_save: bool,
+    pub(crate) failure: Option<String>,
+}
+
+impl ZccacheStopOutcome {
+    pub(crate) fn stopped() -> Self {
+        Self {
+            stopped: true,
+            already_stopped: false,
+            unsupported_no_depgraph_save: false,
+            failure: None,
+        }
+    }
+
+    fn already_stopped() -> Self {
+        Self {
+            stopped: false,
+            already_stopped: true,
+            unsupported_no_depgraph_save: false,
+            failure: None,
+        }
+    }
+
+    fn failed(message: String) -> Self {
+        Self {
+            stopped: false,
+            already_stopped: false,
+            unsupported_no_depgraph_save: false,
+            failure: Some(message),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ZccacheFlushOutcome {
+    pub(crate) flushed: bool,
+    pub(crate) stats: Option<serde_json::Value>,
+    pub(crate) json_unsupported: bool,
+    pub(crate) subcommand_unsupported: bool,
+    pub(crate) already_stopped: bool,
+    pub(crate) invalid_json: Option<String>,
+    pub(crate) failure: Option<String>,
+}
+
+impl ZccacheFlushOutcome {
+    fn no_op() -> Self {
+        Self {
+            flushed: false,
+            stats: None,
+            json_unsupported: false,
+            subcommand_unsupported: false,
+            already_stopped: false,
+            invalid_json: None,
+            failure: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ZccacheDaemonExitPollResult {
+    Exited,
+    TimedOut,
+    PollFailed(String),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ZccacheLifecycle {
+    binary_path: PathBuf,
+    cache_dir: PathBuf,
+    state: ZccacheLifecycleState,
+}
+
+impl ZccacheLifecycle {
+    pub(crate) fn new(binary_path: impl Into<PathBuf>, cache_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            binary_path: binary_path.into(),
+            cache_dir: cache_dir.into(),
+            state: ZccacheLifecycleState::Ready,
+        }
+    }
+
+    pub(crate) fn from_session(session: &ZccacheBuildSession) -> Self {
+        Self {
+            binary_path: session.binary_path.clone(),
+            cache_dir: session.cache_dir.clone(),
+            state: ZccacheLifecycleState::SessionActive,
+        }
+    }
+
+    pub(crate) fn binary_path(&self) -> &Path {
+        &self.binary_path
+    }
+
+    pub(crate) fn cache_dir(&self) -> &Path {
+        &self.cache_dir
+    }
+
+    pub(crate) fn state(&self) -> ZccacheLifecycleState {
+        self.state
+    }
+
+    pub(crate) fn start_with_recovery(&mut self) -> Result<(), SoldrError> {
+        start_zccache_with_recovery(&self.binary_path, &self.cache_dir)?;
+        self.state = ZccacheLifecycleState::DaemonStarted;
+        Ok(())
+    }
+
+    pub(crate) fn start_session(
+        &mut self,
+        options: ZccacheSessionStartOptions,
+    ) -> Result<ZccacheBuildSession, SoldrError> {
+        self.start_with_recovery()?;
+
+        let log_arg = options.session_log_path.display().to_string();
+        let journal_arg = options.journal_path.display().to_string();
+        let mut args: Vec<&str> = vec![
+            "session-start",
+            "--stats",
+            "--log",
+            &log_arg,
+            "--journal",
+            &journal_arg,
+        ];
+        if let Some(id) = options.id.as_deref() {
+            args.push("--id");
+            args.push(id);
+        }
+
+        let session_json = self.run(&args)?;
+        let session_id = crate::cache_lib::parse_zccache_session_id(&session_json.stdout)
+            .ok_or_else(|| {
+                SoldrError::Other(format!(
+                    "failed to parse zccache session id from output: {}",
+                    session_json.stdout.trim()
+                ))
+            })?;
+
+        self.state = ZccacheLifecycleState::SessionActive;
+        Ok(ZccacheBuildSession {
+            binary_path: self.binary_path.clone(),
+            cache_dir: self.cache_dir.clone(),
+            session_id,
+            session_log_path: options.session_log_path,
+            journal_path: options.journal_path,
+            session_stats_path: options.session_stats_path,
+        })
+    }
+
+    pub(crate) fn end_session_json(
+        &mut self,
+        session_id: &str,
+    ) -> Result<ZccacheSessionEndOutcome, SoldrError> {
+        let output = self.run_raw(&["session-end", session_id, "--json"])?;
+        if output.status.success() {
+            self.state = ZccacheLifecycleState::SessionEnded;
+            return Ok(ZccacheSessionEndOutcome {
+                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                already_ended: false,
+            });
+        }
+        if zccache_session_already_ended(&output) {
+            self.state = ZccacheLifecycleState::SessionEnded;
+            return Ok(ZccacheSessionEndOutcome {
+                stdout: String::new(),
+                already_ended: true,
+            });
+        }
+        Err(SoldrError::Other(zccache_command_failure_message(
+            &["session-end", session_id, "--json"],
+            &output,
+        )))
+    }
+
+    pub(crate) fn stop(
+        &mut self,
+        no_depgraph_save: bool,
+    ) -> Result<ZccacheStopOutcome, SoldrError> {
+        let mut args: Vec<&str> = vec!["stop"];
+        if no_depgraph_save {
+            args.push("--no-depgraph-save");
+        }
+        let output = self.run_raw(&args)?;
+        if output.status.success() {
+            self.state = ZccacheLifecycleState::Stopped;
+            return Ok(ZccacheStopOutcome::stopped());
+        }
+        if no_depgraph_save && zccache_flag_unsupported(&output, "--no-depgraph-save") {
+            let retry = self.run_raw(&["stop"])?;
+            if retry.status.success() {
+                self.state = ZccacheLifecycleState::Stopped;
+                return Ok(ZccacheStopOutcome {
+                    unsupported_no_depgraph_save: true,
+                    ..ZccacheStopOutcome::stopped()
+                });
+            }
+            if zccache_daemon_already_stopped(&retry) {
+                self.state = ZccacheLifecycleState::Stopped;
+                return Ok(ZccacheStopOutcome {
+                    unsupported_no_depgraph_save: true,
+                    ..ZccacheStopOutcome::already_stopped()
+                });
+            }
+            return Ok(ZccacheStopOutcome {
+                unsupported_no_depgraph_save: true,
+                ..ZccacheStopOutcome::failed(command_stderr(&retry))
+            });
+        }
+        if zccache_daemon_already_stopped(&output) {
+            self.state = ZccacheLifecycleState::Stopped;
+            return Ok(ZccacheStopOutcome::already_stopped());
+        }
+        Ok(ZccacheStopOutcome::failed(command_stderr(&output)))
+    }
+
+    pub(crate) fn stop_best_effort_with_process_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<(), SoldrError> {
+        let mut child = command_with_cache_dir(&self.binary_path, &["stop"], &self.cache_dir);
+        child
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut child = child.spawn()?;
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    self.state = ZccacheLifecycleState::Stopped;
+                    return Ok(());
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+                Err(err) => return Err(SoldrError::from(err)),
+            }
+        }
+        if matches!(child.try_wait(), Ok(None)) {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        self.state = ZccacheLifecycleState::Stopped;
+        Ok(())
+    }
+
+    pub(crate) fn poll_daemon_exit(&self, timeout: Duration) -> ZccacheDaemonExitPollResult {
+        poll_zccache_daemon_exit(&self.binary_path, &self.cache_dir, timeout)
+    }
+
+    pub(crate) fn flush(&mut self) -> Result<ZccacheFlushOutcome, SoldrError> {
+        let result = self.run_raw(&["flush", "--json"])?;
+        if result.status.success() {
+            let stdout = String::from_utf8_lossy(&result.stdout);
+            let trimmed = stdout.trim();
+            let mut outcome = ZccacheFlushOutcome {
+                flushed: true,
+                ..ZccacheFlushOutcome::no_op()
+            };
+            if !trimmed.is_empty() {
+                outcome.stats = serde_json::from_str(trimmed).ok();
+                if outcome.stats.is_none() {
+                    outcome.invalid_json = Some(
+                        zccache_output_snippet(trimmed.as_bytes())
+                            .unwrap_or_else(|| "<empty>".into()),
+                    );
+                }
+            }
+            return Ok(outcome);
+        }
+
+        if zccache_flag_unsupported(&result, "--json") {
+            let retry = self.run_raw(&["flush"])?;
+            if retry.status.success() {
+                return Ok(ZccacheFlushOutcome {
+                    flushed: true,
+                    json_unsupported: true,
+                    ..ZccacheFlushOutcome::no_op()
+                });
+            }
+            if zccache_subcommand_unsupported(&retry, "flush") {
+                return Ok(ZccacheFlushOutcome {
+                    json_unsupported: true,
+                    subcommand_unsupported: true,
+                    ..ZccacheFlushOutcome::no_op()
+                });
+            }
+            if zccache_daemon_already_stopped(&retry) {
+                return Ok(ZccacheFlushOutcome {
+                    json_unsupported: true,
+                    already_stopped: true,
+                    ..ZccacheFlushOutcome::no_op()
+                });
+            }
+            return Ok(ZccacheFlushOutcome {
+                json_unsupported: true,
+                failure: Some(command_stderr(&retry)),
+                ..ZccacheFlushOutcome::no_op()
+            });
+        }
+
+        if zccache_subcommand_unsupported(&result, "flush") {
+            return Ok(ZccacheFlushOutcome {
+                subcommand_unsupported: true,
+                ..ZccacheFlushOutcome::no_op()
+            });
+        }
+        if zccache_daemon_already_stopped(&result) {
+            return Ok(ZccacheFlushOutcome {
+                already_stopped: true,
+                ..ZccacheFlushOutcome::no_op()
+            });
+        }
+        Ok(ZccacheFlushOutcome {
+            failure: Some(command_stderr(&result)),
+            ..ZccacheFlushOutcome::no_op()
+        })
+    }
+
+    pub(crate) fn run(&self, args: &[&str]) -> Result<CommandOutput, SoldrError> {
+        run_zccache_command_in_cache_dir(&self.binary_path, args, &self.cache_dir)
+    }
+
+    pub(crate) fn run_raw(&self, args: &[&str]) -> Result<Output, SoldrError> {
+        run_zccache_command_raw_in_cache_dir(&self.binary_path, args, &self.cache_dir)
+    }
+}
+
+pub(crate) struct CommandOutput {
+    pub(crate) stdout: String,
+}
+
+pub(crate) fn run_zccache_command_in_cache_dir(
+    binary: &Path,
+    args: &[&str],
+    cache_dir: &Path,
+) -> Result<CommandOutput, SoldrError> {
+    run_zccache_command_with_env(
+        binary,
+        args,
+        &[(
+            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+            cache_dir.as_os_str(),
+        )],
+    )
+}
+
+pub(crate) fn run_zccache_command_strings_in_cache_dir(
+    binary: &Path,
+    args: &[String],
+    cache_dir: &Path,
+) -> Result<CommandOutput, SoldrError> {
+    let output = run_zccache_command_raw_strings_with_env(
+        binary,
+        args,
+        &[(
+            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+            cache_dir.as_os_str(),
+        )],
+    )?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(zccache_command_failure_message_strings(
+            args, &output,
+        )));
+    }
+
+    Ok(CommandOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+    })
+}
+
+pub(crate) fn run_zccache_command_raw_in_cache_dir(
+    binary: &Path,
+    args: &[&str],
+    cache_dir: &Path,
+) -> Result<Output, SoldrError> {
+    run_zccache_command_raw_with_env(
+        binary,
+        args,
+        &[(
+            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+            cache_dir.as_os_str(),
+        )],
+    )
+}
+
+fn run_zccache_command_with_env(
+    binary: &Path,
+    args: &[&str],
+    envs: &[(&str, &OsStr)],
+) -> Result<CommandOutput, SoldrError> {
+    let output = run_zccache_command_raw_with_env(binary, args, envs)?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(zccache_command_failure_message(
+            args, &output,
+        )));
+    }
+
+    Ok(CommandOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+    })
+}
+
+fn run_zccache_command_raw_with_env(
+    binary: &Path,
+    args: &[&str],
+    envs: &[(&str, &OsStr)],
+) -> Result<Output, SoldrError> {
+    let mut command = command_with_env(binary, args, envs);
+    Ok(command.output()?)
+}
+
+fn run_zccache_command_raw_strings_with_env(
+    binary: &Path,
+    args: &[String],
+    envs: &[(&str, &OsStr)],
+) -> Result<Output, SoldrError> {
+    let mut command = Command::new(binary);
+    command.args(args);
+    for &(name, value) in envs {
+        command.env(name, value);
+    }
+    suppress_windows_console_window(&mut command);
+    Ok(command.output()?)
+}
+
+fn command_with_cache_dir(binary: &Path, args: &[&str], cache_dir: &Path) -> Command {
+    command_with_env(
+        binary,
+        args,
+        &[(
+            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+            cache_dir.as_os_str(),
+        )],
+    )
+}
+
+fn command_with_env(binary: &Path, args: &[&str], envs: &[(&str, &OsStr)]) -> Command {
+    let mut command = Command::new(binary);
+    command.args(args);
+    for &(name, value) in envs {
+        command.env(name, value);
+    }
+    suppress_windows_console_window(&mut command);
+    command
+}
+
+/// Soldr-side escape hatch for the RUST_LOG value that gets injected into
+/// `zccache start`.
+pub(crate) const SOLDR_DAEMON_RUST_LOG_ENV_VAR: &str = "SOLDR_DAEMON_RUST_LOG";
+
+pub(crate) fn effective_daemon_rust_log(soldr_override: Option<&str>) -> String {
+    match soldr_override {
+        Some(v) if !v.trim().is_empty() => v.to_string(),
+        _ => "info".to_string(),
+    }
+}
+
+fn run_zccache_start_command(binary: &Path, cache_dir: &Path) -> Result<Output, SoldrError> {
+    let rust_log =
+        effective_daemon_rust_log(std::env::var(SOLDR_DAEMON_RUST_LOG_ENV_VAR).ok().as_deref());
+    run_zccache_command_raw_with_env(
+        binary,
+        &["start"],
+        &[
+            (
+                crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+                cache_dir.as_os_str(),
+            ),
+            ("RUST_LOG", OsStr::new(rust_log.as_str())),
+        ],
+    )
+}
+
+pub(crate) fn start_zccache_with_recovery(
+    binary: &Path,
+    cache_dir: &Path,
+) -> Result<(), SoldrError> {
+    let start = run_zccache_start_command(binary, cache_dir)?;
+    if start.status.success() {
+        return Ok(());
+    }
+
+    let initial_stderr = command_stderr(&start);
+    if !is_stale_zccache_daemon_start_failure(&initial_stderr) {
+        return Err(SoldrError::Other(zccache_command_failure_message(
+            &["start"],
+            &start,
+        )));
+    }
+
+    eprintln!(
+        "soldr: zccache start reported an unresponsive daemon; stopping stale state and retrying"
+    );
+    let stop_diagnostic = match run_zccache_command_raw_in_cache_dir(binary, &["stop"], cache_dir) {
+        Ok(stop) if stop.status.success() => None,
+        Ok(stop) => Some(zccache_command_failure_message(&["stop"], &stop)),
+        Err(err) => Some(format!("failed to invoke zccache stop: {err}")),
+    };
+
+    match run_zccache_start_command(binary, cache_dir) {
+        Ok(retry) if retry.status.success() => Ok(()),
+        Ok(retry) => {
+            let mut message = format!(
+                "zccache start failed after stale daemon recovery retry: {}",
+                command_stderr(&retry)
+            );
+            message.push_str(&format!(
+                "\ninitial zccache start failure: {}",
+                initial_stderr
+            ));
+            if let Some(stop_diagnostic) = stop_diagnostic {
+                message.push_str(&format!("\nzccache stop diagnostic: {stop_diagnostic}"));
+            }
+            Err(SoldrError::Other(message))
+        }
+        Err(err) => {
+            let mut message =
+                format!("failed to invoke zccache start during stale daemon recovery retry: {err}");
+            message.push_str(&format!(
+                "\ninitial zccache start failure: {}",
+                initial_stderr
+            ));
+            if let Some(stop_diagnostic) = stop_diagnostic {
+                message.push_str(&format!("\nzccache stop diagnostic: {stop_diagnostic}"));
+            }
+            Err(SoldrError::Other(message))
+        }
+    }
+}
+
+fn is_stale_zccache_daemon_start_failure(stderr: &str) -> bool {
+    let stderr = stderr.to_ascii_lowercase();
+    stderr.contains("not accepting connections")
+        || (stderr.contains("daemon process") && stderr.contains("exists"))
+}
+
+pub(crate) fn poll_zccache_daemon_exit(
+    binary: &Path,
+    cache_dir: &Path,
+    timeout: Duration,
+) -> ZccacheDaemonExitPollResult {
+    let deadline = Instant::now() + timeout;
+    let poll_interval = Duration::from_millis(100);
+    loop {
+        match run_zccache_command_raw_in_cache_dir(binary, &["status"], cache_dir) {
+            Ok(output) => {
+                if zccache_daemon_already_stopped(&output) {
+                    return ZccacheDaemonExitPollResult::Exited;
+                }
+            }
+            Err(err) => return ZccacheDaemonExitPollResult::PollFailed(err.to_string()),
+        }
+        if Instant::now() >= deadline {
+            return ZccacheDaemonExitPollResult::TimedOut;
+        }
+        std::thread::sleep(poll_interval);
+    }
+}
+
+pub(crate) fn zccache_session_already_ended(output: &Output) -> bool {
+    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+    stderr.contains("session not found")
+        || stderr.contains("no such session")
+        || stderr.contains("already ended")
+        || stderr.contains("unknown session")
+}
+
+pub(crate) fn zccache_json_flag_unsupported(output: &Output) -> bool {
+    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+    stderr.contains("unexpected argument")
+        || stderr.contains("unrecognized option")
+        || stderr.contains("found argument")
+}
+
+pub(crate) fn zccache_flag_unsupported(output: &Output, flag: &str) -> bool {
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    combined.contains("unexpected argument") && combined.contains(flag.trim_start_matches('-'))
+        || combined.contains(&format!("unknown flag: {flag}"))
+        || combined.contains(&format!("unrecognized option {flag}"))
+}
+
+pub(crate) fn zccache_subcommand_unsupported(output: &Output, subcommand: &str) -> bool {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let needles = [
+        "unrecognized subcommand",
+        "unrecognized command",
+        "error: subcommand",
+        "invalid value for",
+    ];
+    let combined = format!("{stderr}\n{stdout}");
+    needles.iter().any(|n| combined.contains(n)) && combined.contains(subcommand)
+}
+
+pub(crate) const ZCCACHE_ANALYZE_NOTE_LIMIT: usize = 1000;
+
+pub(crate) fn zccache_output_snippet(output: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(output);
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut compact = String::new();
+    let mut previous_was_space = false;
+    for ch in trimmed.chars() {
+        if ch.is_whitespace() {
+            if !previous_was_space {
+                compact.push(' ');
+                previous_was_space = true;
+            }
+        } else {
+            compact.push(ch);
+            previous_was_space = false;
+        }
+    }
+
+    let mut chars = compact.chars();
+    let mut snippet: String = chars.by_ref().take(ZCCACHE_ANALYZE_NOTE_LIMIT).collect();
+    if chars.next().is_some() {
+        snippet.push_str("...");
+    }
+    Some(snippet)
+}
+
+pub(crate) fn zccache_daemon_already_stopped(output: &Output) -> bool {
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    )
+    .to_ascii_lowercase();
+    combined.contains("daemon not running")
+        || combined.contains("no daemon to stop")
+        || combined.contains("no daemon")
+        || combined.contains("not running")
+        || combined.contains("connection refused")
+}
+
+/// Returns `true` iff `stderr` contains the literal substring
+/// `unknown session:` somewhere in its bytes. Tolerates non-UTF-8 input.
+pub(crate) fn stderr_indicates_unknown_session(stderr: &[u8]) -> bool {
+    const NEEDLE: &[u8] = b"unknown session:";
+    if stderr.len() < NEEDLE.len() {
+        return false;
+    }
+    stderr.windows(NEEDLE.len()).any(|w| w == NEEDLE)
+}
+
+pub(crate) fn zccache_command_failure_message(args: &[&str], output: &Output) -> String {
+    format!(
+        "zccache {} failed: {}",
+        args.join(" "),
+        command_stderr(output)
+    )
+}
+
+fn zccache_command_failure_message_strings(args: &[String], output: &Output) -> String {
+    format!(
+        "zccache {} failed: {}",
+        args.join(" "),
+        command_stderr(output)
+    )
+}
+
+pub(crate) fn command_stderr(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if stderr.is_empty() {
+        format!("exit status {}", output.status)
+    } else {
+        stderr
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Output;
+
+    fn synthetic_output(stderr: &str, exit: i32) -> Output {
+        #[cfg(unix)]
+        let status = {
+            use std::os::unix::process::ExitStatusExt;
+            std::process::ExitStatus::from_raw((exit & 0xFF) << 8)
+        };
+        #[cfg(windows)]
+        let status = {
+            use std::os::windows::process::ExitStatusExt;
+            std::process::ExitStatus::from_raw(exit as u32)
+        };
+        Output {
+            status,
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    crate::timed_test!(lifecycle_state_transitions_are_explicit, {
+        let lifecycle = ZccacheLifecycle::new("zccache", "cache");
+        assert_eq!(lifecycle.state(), ZccacheLifecycleState::Ready);
+        assert_eq!(lifecycle.binary_path(), Path::new("zccache"));
+        assert_eq!(lifecycle.cache_dir(), Path::new("cache"));
+    });
+
+    crate::timed_test!(session_already_ended_detects_common_states, {
+        for needle in [
+            "session not found",
+            "no such session",
+            "already ended",
+            "unknown session abc",
+        ] {
+            assert!(
+                zccache_session_already_ended(&synthetic_output(needle, 1)),
+                "expected {needle:?} to indicate ended session"
+            );
+        }
+        assert!(!zccache_session_already_ended(&synthetic_output(
+            "permission denied",
+            1
+        )));
+    });
+
+    crate::timed_test!(daemon_already_stopped_detects_common_states, {
+        for needle in [
+            "daemon not running",
+            "No daemon to stop",
+            "no daemon",
+            "connection refused",
+        ] {
+            assert!(
+                zccache_daemon_already_stopped(&synthetic_output(needle, 1)),
+                "expected {needle:?} to indicate daemon already stopped"
+            );
+        }
+    });
+
+    crate::timed_test!(flag_unsupported_detects_clap_phrasing, {
+        let out = synthetic_output("error: unexpected argument '--no-depgraph-save'", 2);
+        assert!(zccache_flag_unsupported(&out, "--no-depgraph-save"));
+        let unrelated = synthetic_output("error: permission denied", 2);
+        assert!(!zccache_flag_unsupported(&unrelated, "--no-depgraph-save"));
+    });
+
+    crate::timed_test!(output_snippet_omits_empty_output, {
+        assert_eq!(zccache_output_snippet(b""), None);
+        assert_eq!(zccache_output_snippet(b" \n\t "), None);
+    });
+
+    crate::timed_test!(output_snippet_compacts_whitespace, {
+        assert_eq!(
+            zccache_output_snippet(b"  first line\n\nsecond\tline  ").as_deref(),
+            Some("first line second line")
+        );
+    });
+
+    crate::timed_test!(output_snippet_truncates_long_output, {
+        let output = "x".repeat(ZCCACHE_ANALYZE_NOTE_LIMIT + 10);
+        let snippet = zccache_output_snippet(output.as_bytes()).unwrap();
+        assert_eq!(snippet.len(), ZCCACHE_ANALYZE_NOTE_LIMIT + 3);
+        assert!(snippet.ends_with("..."));
+    });
+
+    crate::timed_test!(unknown_session_detector_matches_exact_zccache_line, {
+        let stderr = b"zccache error: unknown session: abc-123\n";
+        assert!(stderr_indicates_unknown_session(stderr));
+    });
+
+    crate::timed_test!(unknown_session_detector_matches_substring_not_line_shape, {
+        let stderr = b"prelude blah blah unknown session: 0000 trailing\n";
+        assert!(stderr_indicates_unknown_session(stderr));
+    });
+
+    crate::timed_test!(
+        unknown_session_detector_does_not_match_other_session_text,
+        {
+            let stderr = b"zccache info: session started\nzccache info: session ok\n";
+            assert!(!stderr_indicates_unknown_session(stderr));
+        }
+    );
+}

--- a/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
+++ b/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
@@ -1,6 +1,6 @@
-//! Phase 3: when the soldr-daemon's session linked a zccache daemon,
-//! shutting down the soldr-daemon must spawn `zccache stop` against the
-//! cache-pinned binary before the soldr-daemon exits.
+//! When the soldr-daemon's session links a zccache runtime/cache/session,
+//! shutting down the soldr-daemon must spawn `zccache stop` against that
+//! exact cache namespace before the soldr-daemon exits.
 //!
 //! The test installs a fake `zccache` binary under
 //! `<cache>/bin/zccache-pinned/zccache[.exe]` that logs every invocation
@@ -72,7 +72,7 @@ fn install_fake_zccache(cache_root: &Path, log_path: &Path) -> PathBuf {
         use std::os::unix::fs::PermissionsExt;
         let script = format!(
             "#!/bin/sh\n\
-             echo \"zccache $*\" >> \"{}\"\n\
+             echo \"zccache $* cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{}\"\n\
              exit 0\n",
             log_path.display()
         );
@@ -172,7 +172,11 @@ fn linked_zccache_is_stopped_on_daemon_shutdown() {
     let log_path = unique_temp_dir("zccache-link-log").join("zccache-calls.log");
 
     // Install a fake zccache that logs every invocation.
-    let _bin = install_fake_zccache(&cache_root, &log_path);
+    let bin = install_fake_zccache(&cache_root, &log_path);
+    let linked_cache_dir = cache_root.join("cache").join("linked-zccache");
+    let unrelated_cache_dir = cache_root.join("cache").join("unrelated-zccache");
+    std::fs::create_dir_all(&linked_cache_dir).expect("linked cache dir");
+    std::fs::create_dir_all(&unrelated_cache_dir).expect("unrelated cache dir");
 
     let mut daemon = DaemonProc::spawn(&cache_root, &home_root);
 
@@ -190,7 +194,14 @@ fn linked_zccache_is_stopped_on_daemon_shutdown() {
     while Instant::now() < deadline {
         if client::submit_fire_and_forget(
             &sock,
-            &soldr_cli::daemon::protocol::Request::LinkZccache { zccache_pid: 42 },
+            &soldr_cli::daemon::protocol::Request::LinkZccache {
+                link: soldr_cli::daemon::protocol::ZccacheDaemonLink {
+                    binary_path: bin.display().to_string(),
+                    cache_dir: linked_cache_dir.display().to_string(),
+                    session_id: Some("linked-session".into()),
+                    source: "test".into(),
+                },
+            },
         )
         .is_ok()
         {
@@ -206,11 +217,14 @@ fn linked_zccache_is_stopped_on_daemon_shutdown() {
     // up to 2 s before failing.
     let deadline = Instant::now() + Duration::from_secs(2);
     let mut info = client::status(&sock).expect("status");
-    while info.linked_zccache_pid.is_none() && Instant::now() < deadline {
+    while info.linked_zccache.is_none() && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(50));
         info = client::status(&sock).expect("status");
     }
-    assert_eq!(info.linked_zccache_pid, Some(42));
+    let linked = info.linked_zccache.expect("linked zccache status");
+    assert_eq!(linked.cache_dir, linked_cache_dir.display().to_string());
+    assert_eq!(linked.binary_path, bin.display().to_string());
+    assert_eq!(linked.session_id.as_deref(), Some("linked-session"));
 
     // Trigger shutdown via the explicit RPC.
     client::shutdown(&sock).expect("shutdown");
@@ -221,12 +235,18 @@ fn linked_zccache_is_stopped_on_daemon_shutdown() {
 
     // The fake zccache must have been invoked with `stop`.
     let calls = std::fs::read_to_string(&log_path).unwrap_or_default();
+    let linked_stop = format!("zccache stop cache_dir={}", linked_cache_dir.display());
     assert!(
-        calls.lines().any(|l| l.trim() == "zccache stop"),
-        "expected `zccache stop` invocation; log contents:\n{calls}"
+        calls.lines().any(|l| l.trim() == linked_stop),
+        "expected scoped `zccache stop` invocation {linked_stop:?}; log contents:\n{calls}"
+    );
+    assert!(
+        !calls.contains(&unrelated_cache_dir.display().to_string()),
+        "shutdown touched unrelated zccache cache dir {}; log contents:\n{calls}",
+        unrelated_cache_dir.display()
     );
 
-    // And the linked PID must have been cleared on shutdown.
-    let pid = db::get_linked_zccache_pid(&cache_root.join("state.redb")).expect("get");
-    assert_eq!(pid, None, "linked zccache pid must be cleared on shutdown");
+    // And the linked identity must have been cleared on shutdown.
+    let link = db::get_linked_zccache(&cache_root.join("state.redb")).expect("get");
+    assert_eq!(link, None, "linked zccache must be cleared on shutdown");
 }


### PR DESCRIPTION
Closes #545.

## Summary
- add a shared `zccache_lifecycle` module for start, session-start/session-end, stop, flush, daemon-exit polling, command execution, and zccache output classifiers
- route `soldr cargo`, `soldr session`, `soldr cache flush/shutdown`, wrapper unknown-session retry handling, and daemon-linked shutdown through the shared lifecycle helpers
- replace the daemon's synthetic linked zccache PID token with a structured link identity (`binary_path`, `cache_dir`, `session_id`, `source`) so daemon shutdown stops the exact zccache cache namespace it linked
- bump the soldr daemon protocol version because the bincode request/status payload shape changed
- ensure post-cargo soldr failures still allow zccache session finalization and command-lifetime shutdown before the error returns

## Validation
- `soldr cargo fmt --all`
- `soldr cargo check -p soldr-cli --all-targets`
- `soldr cargo test -p soldr-cli zccache_lifecycle`
- `soldr cargo test -p soldr-cli --test cli_cache`
- `soldr cargo test -p soldr-cli --test cli_unknown_session_retry`
- `soldr cargo clippy -p soldr-cli --all-targets -- -D warnings`
- `soldr cargo test -p soldr-cli --lib`
- `soldr cargo test -p soldr-cli --bins`
- `soldr cargo test -p soldr-cli --test timed_test_lint`
- `soldr cargo test -p soldr-cli --test cli_daemon_zccache_link`
- `soldr cargo test -p soldr-cli --test cli_cargo_basic`
- `soldr cargo test -p soldr-cli --test cli_cargo_wrappers`
- `soldr cargo test -p soldr-cli --test cli_rust_plan`
- `soldr cargo test -p soldr-cli --test cli_daemon_lifecycle`
- `soldr cargo test -p soldr-cli --lib daemon::ipc`
- `soldr cargo test -p soldr-cli --lib linked_zccache_identity_round_trips`
- `git diff --check`
- `git diff --cached --check`

Note: `cli_daemon_zccache_link` is `cfg(not(windows))`, so it compiles but runs zero tests on this Windows host; it exercises the scoped linked-zccache shutdown behavior on Unix/macOS CI.
