### PR TITLE
refactor(cargo): introduce cache orchestration plan

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/cache_plan.rs
+++ b/crates/soldr-cli/src/cargo_front_door/cache_plan.rs
@@ -1,0 +1,360 @@
+use crate::cargo_front_door::profile_debug::CargoProfileDebugDefault;
+use crate::core::{SoldrError, SoldrPaths};
+use crate::native_cc;
+use crate::rust_plan::{self, RustArtifactPlanContext};
+use crate::zccache::{
+    finish_zccache_build, prepare_rustc_wrapper_plan, stop_zccache_after_command, RustcWrapperPlan,
+    ZccacheBuildSession,
+};
+use crate::ZccacheSourceArg;
+
+pub(crate) struct CargoCachePlan {
+    cache_enabled_for_cargo: bool,
+    rustc_wrapper: Option<RustcWrapperPlan>,
+    rust_artifact_plan: Option<RustArtifactPlanContext>,
+}
+
+impl CargoCachePlan {
+    pub(crate) async fn prepare(
+        cache_enabled_for_cargo: bool,
+        paths: &SoldrPaths,
+        zccache_source: ZccacheSourceArg,
+    ) -> Result<Self, SoldrError> {
+        let rustc_wrapper = if cache_enabled_for_cargo {
+            Some(prepare_rustc_wrapper_plan(paths, zccache_source).await?)
+        } else {
+            None
+        };
+        Ok(Self {
+            cache_enabled_for_cargo,
+            rustc_wrapper,
+            rust_artifact_plan: None,
+        })
+    }
+
+    pub(crate) fn apply_to_command(
+        &self,
+        command: &mut std::process::Command,
+        explicit_target: Option<&str>,
+    ) -> Result<(), SoldrError> {
+        command.env(
+            crate::cache_lib::CACHE_ENABLED_ENV_VAR,
+            crate::cache_lib::cache_enabled_env_value(self.cache_enabled_for_cargo),
+        );
+
+        if let Some(wrapper) = self.rustc_wrapper.as_ref() {
+            wrapper.apply_to_command(command)?;
+            if let Some(session) = wrapper.session() {
+                native_cc::inject_native_cache_env(command, &session.binary_path, explicit_target)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn prepare_rust_artifact_plan(
+        &mut self,
+        cargo: &std::path::Path,
+        rustc: &std::path::Path,
+        args: &[String],
+        cargo_profile_debug_default: Option<&CargoProfileDebugDefault>,
+    ) -> Result<(), SoldrError> {
+        let Some(session) = self.zccache_session() else {
+            return Ok(());
+        };
+        self.rust_artifact_plan = rust_plan::maybe_prepare_rust_artifact_plan(
+            cargo,
+            rustc,
+            args,
+            session,
+            cargo_profile_debug_default,
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn target_dir_for_hooks(&self, args: &[String]) -> Option<std::path::PathBuf> {
+        self.rust_artifact_plan
+            .as_ref()
+            .map(|plan| std::path::PathBuf::from(&plan.target_dir))
+            .or_else(|| super::resolve_target_dir_for_gc(args))
+    }
+
+    pub(crate) fn restore_rust_artifacts(&self) -> Result<(), SoldrError> {
+        let Some(plan) = self.rust_artifact_plan.as_ref() else {
+            return Ok(());
+        };
+        if let Some(reason) = rust_plan::should_skip_warm_restore(plan) {
+            eprintln!("{reason}");
+        } else if let Some(reason) = rust_plan::should_skip_restore_due_to_prepopulated_target(plan)
+        {
+            // Issue #480: refuse to restore on top of a target/ that cook
+            // (or a prior build) has already populated. The current zccache
+            // restore path reports `restored_file_count: 0 /
+            // artifact_absent_from_restored_plan: 1` and the subsequent
+            // cargo build dies on missing rmetas. Skipping restore lets
+            // cargo work with what's there.
+            eprintln!("{reason}");
+        } else {
+            rust_plan::run_zccache_rust_plan(plan, "restore", false)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn save_rust_artifacts(&self) -> Result<(), SoldrError> {
+        if let Some(plan) = self.rust_artifact_plan.as_ref() {
+            rust_plan::run_zccache_rust_plan(plan, "save", true)?;
+            rust_plan::write_warm_restore_sentinel(plan);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn prune_orphan_rmetas_after_failed_build(&self) {
+        if let Some(plan) = self.rust_artifact_plan.as_ref() {
+            rust_plan::prune_orphan_rmetas_after_failed_build(plan);
+        }
+    }
+
+    pub(crate) fn finish_zccache_session(
+        &self,
+        command_lifetime_shutdown_timeout: Option<std::time::Duration>,
+    ) -> Result<(), SoldrError> {
+        let Some(session) = self.zccache_session() else {
+            return Ok(());
+        };
+        let finish_result = finish_zccache_build(session);
+        let shutdown_result = if let Some(timeout) = command_lifetime_shutdown_timeout {
+            stop_zccache_after_command(session, timeout)
+        } else {
+            Ok(())
+        };
+        finish_result?;
+        shutdown_result?;
+        Ok(())
+    }
+
+    pub(crate) fn zccache_session(&self) -> Option<&ZccacheBuildSession> {
+        self.rustc_wrapper
+            .as_ref()
+            .and_then(RustcWrapperPlan::session)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zccache::{ManagedZccacheWrapperPlan, ZccacheChildEnv};
+    use std::ffi::{OsStr, OsString};
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn command_env_override(
+        command: &std::process::Command,
+        key: &'static str,
+    ) -> Option<Option<OsString>> {
+        command
+            .get_envs()
+            .find(|(candidate, _)| *candidate == OsStr::new(key))
+            .map(|(_, value)| value.map(OsString::from))
+    }
+
+    fn fake_session() -> ZccacheBuildSession {
+        ZccacheBuildSession {
+            binary_path: std::path::PathBuf::from("/tmp/zccache"),
+            cache_dir: std::path::PathBuf::from("/tmp/soldr-zccache"),
+            session_id: "session-1".into(),
+            session_log_path: std::path::PathBuf::from("/tmp/soldr-zccache/log"),
+            journal_path: std::path::PathBuf::from("/tmp/soldr-zccache/journal"),
+            session_stats_path: std::path::PathBuf::from("/tmp/soldr-zccache/stats.json"),
+        }
+    }
+
+    fn managed_wrapper_plan() -> RustcWrapperPlan {
+        RustcWrapperPlan::ManagedZccache(ManagedZccacheWrapperPlan {
+            session: fake_session(),
+            child_env: ZccacheChildEnv {
+                path_remap: Some("auto"),
+                worktree_root: Some(std::path::PathBuf::from("/tmp/worktree")),
+            },
+        })
+    }
+
+    #[test]
+    fn managed_plan_applies_session_and_path_remap_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _native = EnvGuard::set(native_cc::NATIVE_CACHE_ENV_VAR, "0");
+        let mut command = std::process::Command::new("cargo");
+        let plan = CargoCachePlan {
+            cache_enabled_for_cargo: true,
+            rustc_wrapper: Some(managed_wrapper_plan()),
+            rust_artifact_plan: None,
+        };
+
+        plan.apply_to_command(&mut command, Some("x86_64-unknown-linux-gnu"))
+            .expect("apply cache plan");
+
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::CACHE_ENABLED_ENV_VAR),
+            Some(Some(OsString::from(
+                crate::cache_lib::cache_enabled_env_value(true)
+            )))
+        );
+        assert!(command_env_override(&command, "RUSTC_WRAPPER")
+            .and_then(|value| value)
+            .is_some());
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::ZCCACHE_BINARY_ENV_VAR),
+            Some(Some(OsString::from("/tmp/zccache")))
+        );
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR),
+            Some(Some(OsString::from("session-1")))
+        );
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR),
+            Some(Some(OsString::from("auto")))
+        );
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR),
+            Some(Some(OsString::from("/tmp/worktree")))
+        );
+    }
+
+    #[test]
+    fn native_cache_opt_out_leaves_cc_and_cxx_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _native = EnvGuard::set(native_cc::NATIVE_CACHE_ENV_VAR, "0");
+        let _cc = EnvGuard::remove("CC");
+        let _cxx = EnvGuard::remove("CXX");
+        let mut command = std::process::Command::new("cargo");
+        let plan = CargoCachePlan {
+            cache_enabled_for_cargo: true,
+            rustc_wrapper: Some(managed_wrapper_plan()),
+            rust_artifact_plan: None,
+        };
+
+        plan.apply_to_command(&mut command, Some("x86_64-unknown-linux-gnu"))
+            .expect("apply cache plan");
+
+        assert_eq!(command_env_override(&command, "CC"), None);
+        assert_eq!(command_env_override(&command, "CXX"), None);
+    }
+
+    #[test]
+    fn custom_wrapper_plan_sets_wrapper_and_clears_managed_zccache_env() {
+        let mut command = std::process::Command::new("cargo");
+        command.env(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR, "/old/zccache");
+        command.env(
+            crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR,
+            "/old/cache",
+        );
+        command.env(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR, "old-session");
+        let plan = CargoCachePlan {
+            cache_enabled_for_cargo: true,
+            rustc_wrapper: Some(RustcWrapperPlan::Custom {
+                wrapper: OsString::from("sccache"),
+                sccache_dir: Some(std::path::PathBuf::from("/tmp/sccache")),
+            }),
+            rust_artifact_plan: None,
+        };
+
+        plan.apply_to_command(&mut command, None)
+            .expect("apply cache plan");
+
+        assert_eq!(
+            command_env_override(&command, "RUSTC_WRAPPER"),
+            Some(Some(OsString::from("sccache")))
+        );
+        assert_eq!(
+            command_env_override(&command, "SCCACHE_DIR"),
+            Some(Some(OsString::from("/tmp/sccache")))
+        );
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::ZCCACHE_BINARY_ENV_VAR),
+            Some(None)
+        );
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR),
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn disabled_wrapper_plan_removes_wrapper_and_managed_zccache_env() {
+        let mut command = std::process::Command::new("cargo");
+        command.env("RUSTC_WRAPPER", "old-wrapper");
+        command.env(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR, "/old/zccache");
+        command.env(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR, "old-session");
+        let plan = CargoCachePlan {
+            cache_enabled_for_cargo: true,
+            rustc_wrapper: Some(RustcWrapperPlan::Disabled),
+            rust_artifact_plan: None,
+        };
+
+        plan.apply_to_command(&mut command, None)
+            .expect("apply cache plan");
+
+        assert_eq!(command_env_override(&command, "RUSTC_WRAPPER"), Some(None));
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::ZCCACHE_BINARY_ENV_VAR),
+            Some(None)
+        );
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR),
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn non_cacheable_plan_marks_cache_disabled_without_touching_wrapper() {
+        let mut command = std::process::Command::new("cargo");
+        command.env("RUSTC_WRAPPER", "inherited-wrapper");
+        let plan = CargoCachePlan {
+            cache_enabled_for_cargo: false,
+            rustc_wrapper: None,
+            rust_artifact_plan: None,
+        };
+
+        plan.apply_to_command(&mut command, None)
+            .expect("apply cache plan");
+
+        assert_eq!(
+            command_env_override(&command, crate::cache_lib::CACHE_ENABLED_ENV_VAR),
+            Some(Some(OsString::from(
+                crate::cache_lib::cache_enabled_env_value(false)
+            )))
+        );
+        assert_eq!(
+            command_env_override(&command, "RUSTC_WRAPPER"),
+            Some(Some(OsString::from("inherited-wrapper")))
+        );
+    }
+}

--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -19,28 +19,27 @@
 use crate::cache_lib::auto_target_gc::{auto_prune_target, render_summary, AutoPrunePhase};
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
 use crate::fetch::VersionSpec;
-use crate::native_cc;
 use crate::trampoline::{refresh_sidecar_after_cargo, try_run_trampoline, TrampolineDecision};
 use crate::trampoline_workspace::{
     detect_workspace_verb, refresh_workspace_sidecar_after_cargo, try_workspace_trampoline,
     RawClippyCapture, WorkspaceDecision, WorkspaceVerb,
 };
 use crate::zccache::{
-    cache_lifecycle_from_env, command_lifetime_shutdown_timeout, finish_zccache_build,
-    prepare_rustc_wrapper, stop_zccache_after_command, CacheLifecycle,
+    cache_lifecycle_from_env, command_lifetime_shutdown_timeout, CacheLifecycle,
     SOLDR_CACHE_LIFECYCLE_ENV_VAR, SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR,
 };
-use crate::{
-    apply_implicit_toolchain_homes, gc, resolve_toolchain_binary, rust_plan, ZccacheSourceArg,
-};
+use crate::{apply_implicit_toolchain_homes, gc, resolve_toolchain_binary, ZccacheSourceArg};
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+mod cache_plan;
 mod disk;
 mod inputs;
 mod profile_debug;
 mod subcommand;
 mod target;
+
+use cache_plan::CargoCachePlan;
 
 // -- Re-exports for cross-module callers --
 //
@@ -308,11 +307,6 @@ pub(crate) async fn run_cargo_front_door(
         None
     };
 
-    command.env(
-        crate::cache_lib::CACHE_ENABLED_ENV_VAR,
-        crate::cache_lib::cache_enabled_env_value(cache_enabled_for_cargo),
-    );
-
     // Phase 2: per-build session correlation. Stamp every wrapper
     // invocation with a u64 session id and fire BuildSessionStart to
     // the daemon (fire-and-forget). On exit we fire BuildSessionEnd
@@ -353,67 +347,23 @@ pub(crate) async fn run_cargo_front_door(
 
     target::apply_linker_override(&mut command, args, explicit_target.as_deref(), &paths)?;
 
-    let session = if cache_enabled_for_cargo {
-        prepare_rustc_wrapper(&mut command, &paths, zccache_source).await?
-    } else {
-        None
-    };
+    let mut cache_plan =
+        CargoCachePlan::prepare(cache_enabled_for_cargo, &paths, zccache_source).await?;
+    cache_plan.apply_to_command(&mut command, explicit_target.as_deref())?;
 
-    // Native C/C++ compiler caching (#310). Default-on when:
-    //   1. zccache wrapper mode is engaged for this cargo invocation
-    //      (i.e. `prepare_rustc_wrapper` returned a session), AND
-    //   2. the user hasn't set `SOLDR_NATIVE_CACHE` to a falsy value,
-    //      AND
-    //   3. the host platform is supported (Linux / macOS in v1; Windows
-    //      falls through silently — tracked as follow-up in #310).
-    //
-    // The injection prepends the same zccache binary path soldr just
-    // wired into RUSTC_WRAPPER to whatever cc-rs would discover for
-    // `CC` / `CXX` / `CC_<triple>` / `CXX_<triple>`. cc-rs honors
-    // `CC_KNOWN_WRAPPER_CUSTOM=zccache` to recognize the wrapper and
-    // dispatch to the real compiler underneath.
-    if let Some(session) = session.as_ref() {
-        native_cc::inject_native_cache_env(
-            &mut command,
-            &session.binary_path,
-            explicit_target.as_deref(),
-        )?;
-    }
-
-    let plan_ctx = if let Some(session) = session.as_ref() {
-        rust_plan::maybe_prepare_rust_artifact_plan(
-            &cargo,
-            &rustc,
-            args,
-            session,
-            cargo_profile_debug_default.as_ref(),
-        )?
-    } else {
-        None
-    };
+    cache_plan.prepare_rust_artifact_plan(
+        &cargo,
+        &rustc,
+        args,
+        cargo_profile_debug_default.as_ref(),
+    )?;
     if build_like_cargo {
-        let probe_path = plan_ctx
-            .as_ref()
-            .map(|plan| std::path::PathBuf::from(&plan.target_dir))
+        let probe_path = cache_plan
+            .target_dir_for_hooks(args)
             .unwrap_or_else(|| disk::cargo_disk_space_probe_path(args));
         disk::maybe_emit_low_disk_warning(&probe_path);
     }
-    if let Some(plan) = plan_ctx.as_ref() {
-        if let Some(reason) = rust_plan::should_skip_warm_restore(plan) {
-            eprintln!("{reason}");
-        } else if let Some(reason) = rust_plan::should_skip_restore_due_to_prepopulated_target(plan)
-        {
-            // Issue #480: refuse to restore on top of a target/ that cook
-            // (or a prior build) has already populated. The current zccache
-            // restore path reports `restored_file_count: 0 /
-            // artifact_absent_from_restored_plan: 1` and the subsequent
-            // cargo build dies on missing rmetas. Skipping restore lets
-            // cargo work with what's there.
-            eprintln!("{reason}");
-        } else {
-            rust_plan::run_zccache_rust_plan(plan, "restore", false)?;
-        }
-    }
+    cache_plan.restore_rust_artifacts()?;
 
     // Target-registry memoization for the wrapper hot path (#440).
     // Without this, every rustc invocation re-opens redb and writes
@@ -423,10 +373,7 @@ pub(crate) async fn run_cargo_front_door(
     // propagate a recorded-marker env var that lets the wrapper skip
     // its own redb work + daemon target-touch IPC.
     if build_like_cargo {
-        let target_dir_for_memo: Option<std::path::PathBuf> = plan_ctx
-            .as_ref()
-            .map(|p| std::path::PathBuf::from(&p.target_dir))
-            .or_else(|| resolve_target_dir_for_gc(args));
+        let target_dir_for_memo: Option<std::path::PathBuf> = cache_plan.target_dir_for_hooks(args);
         if let Some(dir) = target_dir_for_memo.as_deref() {
             if dir.is_dir() {
                 let canon = std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
@@ -451,10 +398,7 @@ pub(crate) async fn run_cargo_front_door(
     // any CARGO_TARGET_DIR / --target-dir override the same way cargo
     // and rust_plan do.
     if build_like_cargo && !gc_opt_out.before {
-        let target_dir = plan_ctx
-            .as_ref()
-            .map(|p| std::path::PathBuf::from(&p.target_dir))
-            .or_else(|| resolve_target_dir_for_gc(args));
+        let target_dir = cache_plan.target_dir_for_hooks(args);
         if let Some(dir) = target_dir.as_deref() {
             let outcome = auto_prune_target(dir, AutoPrunePhase::Before);
             emit_auto_prune_summary(&outcome);
@@ -511,10 +455,7 @@ pub(crate) async fn run_cargo_front_door(
 
     let post_cargo_result: Result<(), SoldrError> = (|| {
         if status.success() {
-            if let Some(plan) = plan_ctx.as_ref() {
-                rust_plan::run_zccache_rust_plan(plan, "save", true)?;
-                rust_plan::write_warm_restore_sentinel(plan);
-            }
+            cache_plan.save_rust_artifacts()?;
             // Post-compile target-GC (#485). Same gating as the pre-pass —
             // build-like cargo, no opt-out, resolve dir consistently with the
             // pre-pass. The active-cargo-lock guard inside `auto_prune_target`
@@ -522,10 +463,7 @@ pub(crate) async fn run_cargo_front_door(
             // racing this pass; we never emit a stderr line when that guard
             // engages.
             if build_like_cargo && !gc_opt_out.after {
-                let target_dir = plan_ctx
-                    .as_ref()
-                    .map(|p| std::path::PathBuf::from(&p.target_dir))
-                    .or_else(|| resolve_target_dir_for_gc(args));
+                let target_dir = cache_plan.target_dir_for_hooks(args);
                 if let Some(dir) = target_dir.as_deref() {
                     let outcome = auto_prune_target(dir, AutoPrunePhase::After);
                     emit_auto_prune_summary(&outcome);
@@ -537,7 +475,7 @@ pub(crate) async fn run_cargo_front_door(
             if let Some(plan) = workspace_plan.as_ref() {
                 refresh_workspace_sidecar_after_cargo(plan, clippy_capture);
             }
-        } else if let Some(plan) = plan_ctx.as_ref() {
+        } else {
             // A non-zero cargo exit can leave orphan `.rmeta` files (rmeta
             // emitted, then rustc aborted before the `.rlib` codegen pass)
             // in `target/<triple>/<profile>/deps/`. Subsequent invocations
@@ -545,7 +483,7 @@ pub(crate) async fn run_cargo_front_door(
             // `--extern X=orphan.rmeta` to dependents and rustc cannot link
             // an rmeta-only crate. Sweep them so the next build rebuilds
             // cleanly. See soldr#410.
-            rust_plan::prune_orphan_rmetas_after_failed_build(plan);
+            cache_plan.prune_orphan_rmetas_after_failed_build();
         }
         Ok(())
     })();
@@ -567,16 +505,7 @@ pub(crate) async fn run_cargo_front_door(
         }
     }
 
-    if let Some(session) = session.as_ref() {
-        let finish_result = finish_zccache_build(session);
-        let shutdown_result = if let Some(timeout) = command_lifetime_shutdown_timeout {
-            stop_zccache_after_command(session, timeout)
-        } else {
-            Ok(())
-        };
-        finish_result?;
-        shutdown_result?;
-    }
+    cache_plan.finish_zccache_session(command_lifetime_shutdown_timeout)?;
     post_cargo_result?;
     drop(trampoline_plan);
     drop(workspace_plan);

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -176,34 +176,163 @@ pub(crate) fn find_git_worktree_root(cwd: &std::path::Path) -> Option<std::path:
     None
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ZccacheChildEnv {
+    pub(crate) path_remap: Option<&'static str>,
+    pub(crate) worktree_root: Option<std::path::PathBuf>,
+}
+
+impl ZccacheChildEnv {
+    pub(crate) fn from_current_process() -> Result<Self, SoldrError> {
+        let user_zccache = std::env::var(crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR).ok();
+        let soldr_override = std::env::var(crate::cache_lib::SOLDR_PATH_REMAP_ENV_VAR).ok();
+        let user_worktree_root = std::env::var_os(crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR);
+        let cwd = std::env::current_dir()?;
+        Ok(Self::from_inputs(
+            user_zccache.as_deref(),
+            soldr_override.as_deref(),
+            user_worktree_root.as_deref(),
+            &cwd,
+        ))
+    }
+
+    pub(crate) fn from_inputs(
+        user_zccache: Option<&str>,
+        soldr_override: Option<&str>,
+        user_worktree_root: Option<&std::ffi::OsStr>,
+        cwd: &std::path::Path,
+    ) -> Self {
+        let path_remap = resolve_path_remap_env(user_zccache, soldr_override);
+        let worktree_root = if path_remap_auto_active(user_zccache, soldr_override) {
+            resolve_worktree_root_env(user_worktree_root, cwd)
+        } else {
+            None
+        };
+        Self {
+            path_remap,
+            worktree_root,
+        }
+    }
+
+    pub(crate) fn apply_to_command(&self, cargo: &mut std::process::Command) {
+        if let Some(value) = self.path_remap {
+            cargo.env(crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR, value);
+        }
+        if let Some(root) = self.worktree_root.as_ref() {
+            cargo.env(crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR, root);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ManagedZccacheWrapperPlan {
+    pub(crate) session: ZccacheBuildSession,
+    pub(crate) child_env: ZccacheChildEnv,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RustcWrapperPlan {
+    ManagedZccache(ManagedZccacheWrapperPlan),
+    Custom {
+        wrapper: std::ffi::OsString,
+        sccache_dir: Option<std::path::PathBuf>,
+    },
+    Disabled,
+}
+
+impl RustcWrapperPlan {
+    pub(crate) fn session(&self) -> Option<&ZccacheBuildSession> {
+        match self {
+            Self::ManagedZccache(plan) => Some(&plan.session),
+            Self::Custom { .. } | Self::Disabled => None,
+        }
+    }
+
+    pub(crate) fn apply_to_command(
+        &self,
+        cargo: &mut std::process::Command,
+    ) -> Result<(), SoldrError> {
+        match self {
+            Self::ManagedZccache(plan) => {
+                let session = &plan.session;
+                cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
+                cargo.env(
+                    crate::cache_lib::ZCCACHE_BINARY_ENV_VAR,
+                    &session.binary_path,
+                );
+                cargo.env(
+                    crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+                    &session.cache_dir,
+                );
+                cargo.env(
+                    crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR,
+                    &session.cache_dir,
+                );
+                cargo.env(
+                    crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR,
+                    &session.session_id,
+                );
+                plan.child_env.apply_to_command(cargo);
+            }
+            Self::Custom {
+                wrapper,
+                sccache_dir,
+            } => {
+                if let Some(sccache_dir) = sccache_dir {
+                    cargo.env("SCCACHE_DIR", sccache_dir);
+                }
+                cargo.env("RUSTC_WRAPPER", wrapper);
+                remove_managed_zccache_env(cargo);
+            }
+            Self::Disabled => {
+                cargo.env_remove("RUSTC_WRAPPER");
+                remove_managed_zccache_env(cargo);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn remove_managed_zccache_env(cargo: &mut std::process::Command) {
+    cargo.env_remove(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR);
+    cargo.env_remove(crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR);
+    cargo.env_remove(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR);
+}
+
 pub(crate) async fn prepare_rustc_wrapper(
     cargo: &mut std::process::Command,
     paths: &SoldrPaths,
     zccache_source: ZccacheSourceArg,
 ) -> Result<Option<ZccacheBuildSession>, SoldrError> {
+    let plan = prepare_rustc_wrapper_plan(paths, zccache_source).await?;
+    let session = plan.session().cloned();
+    plan.apply_to_command(cargo)?;
+    Ok(session)
+}
+
+pub(crate) async fn prepare_rustc_wrapper_plan(
+    paths: &SoldrPaths,
+    zccache_source: ZccacheSourceArg,
+) -> Result<RustcWrapperPlan, SoldrError> {
     match rustc_wrapper_mode() {
-        RustcWrapperMode::ManagedZccache => prepare_zccache_build(cargo, paths, zccache_source)
+        RustcWrapperMode::ManagedZccache => prepare_zccache_build(paths, zccache_source)
             .await
-            .map(Some),
+            .map(RustcWrapperPlan::ManagedZccache),
         RustcWrapperMode::Custom(wrapper) => {
-            if is_sccache_wrapper(&wrapper) && std::env::var_os("SCCACHE_DIR").is_none() {
-                let sccache_dir = crate::cache_lib::sccache_dir(paths);
-                std::fs::create_dir_all(&sccache_dir)?;
-                cargo.env("SCCACHE_DIR", sccache_dir);
-            }
-            cargo.env("RUSTC_WRAPPER", wrapper);
-            cargo.env_remove(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR);
-            cargo.env_remove(crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR);
-            cargo.env_remove(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR);
-            Ok(None)
+            let sccache_dir =
+                if is_sccache_wrapper(&wrapper) && std::env::var_os("SCCACHE_DIR").is_none() {
+                    let sccache_dir = crate::cache_lib::sccache_dir(paths);
+                    std::fs::create_dir_all(&sccache_dir)?;
+                    Some(sccache_dir)
+                } else {
+                    None
+                };
+            Ok(RustcWrapperPlan::Custom {
+                wrapper,
+                sccache_dir,
+            })
         }
-        RustcWrapperMode::Disabled => {
-            cargo.env_remove("RUSTC_WRAPPER");
-            cargo.env_remove(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR);
-            cargo.env_remove(crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR);
-            cargo.env_remove(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR);
-            Ok(None)
-        }
+        RustcWrapperMode::Disabled => Ok(RustcWrapperPlan::Disabled),
     }
 }
 
@@ -215,10 +344,9 @@ pub(crate) fn is_sccache_wrapper(wrapper: &std::ffi::OsStr) -> bool {
 }
 
 async fn prepare_zccache_build(
-    cargo: &mut std::process::Command,
     paths: &SoldrPaths,
     zccache_source: ZccacheSourceArg,
-) -> Result<ZccacheBuildSession, SoldrError> {
+) -> Result<ManagedZccacheWrapperPlan, SoldrError> {
     let zccache_dir = managed_zccache_cache_dir(paths)?;
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
@@ -258,21 +386,6 @@ async fn prepare_zccache_build(
         session_stats_path,
     })?;
 
-    cargo.env("RUSTC_WRAPPER", current_soldr_binary()?);
-    cargo.env(
-        crate::cache_lib::ZCCACHE_BINARY_ENV_VAR,
-        &session.binary_path,
-    );
-    cargo.env(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR, &zccache_dir);
-    cargo.env(
-        crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR,
-        &zccache_dir,
-    );
-    cargo.env(
-        crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR,
-        &session.session_id,
-    );
-
     // Tell the soldr-daemon which concrete zccache runtime/cache/session
     // this build owns so daemon shutdown can stop only that scoped daemon.
     crate::daemon::client::link_zccache(
@@ -285,25 +398,14 @@ async fn prepare_zccache_build(
         },
     );
 
-    // Parent-cache (Tier L1.x, issue #352): seed ZCCACHE_PATH_REMAP=auto
-    // and a logical worktree root so multiple worktrees of the same repo
-    // share zccache hits through normalized keys. Honor user-supplied
-    // ZCCACHE_* values, and the SOLDR_PATH_REMAP=off escape hatch.
-    let user_zccache = std::env::var(crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR).ok();
-    let soldr_override = std::env::var(crate::cache_lib::SOLDR_PATH_REMAP_ENV_VAR).ok();
-    if let Some(value) = resolve_path_remap_env(user_zccache.as_deref(), soldr_override.as_deref())
-    {
-        cargo.env(crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR, value);
-    }
-    if path_remap_auto_active(user_zccache.as_deref(), soldr_override.as_deref()) {
-        let user_worktree_root = std::env::var_os(crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR);
-        let cwd = std::env::current_dir()?;
-        if let Some(root) = resolve_worktree_root_env(user_worktree_root.as_deref(), &cwd) {
-            cargo.env(crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR, root);
-        }
-    }
-
-    Ok(session)
+    Ok(ManagedZccacheWrapperPlan {
+        session,
+        // Parent-cache (Tier L1.x, issue #352): seed ZCCACHE_PATH_REMAP=auto
+        // and a logical worktree root so multiple worktrees of the same repo
+        // share zccache hits through normalized keys. Honor user-supplied
+        // ZCCACHE_* values, and the SOLDR_PATH_REMAP=off escape hatch.
+        child_env: ZccacheChildEnv::from_current_process()?,
+    })
 }
 
 fn print_zccache_runtime_diagnostic(runtime: &ZccacheRuntime) {


### PR DESCRIPTION
Closes #546.

## Summary
- add `cargo_front_door::cache_plan::CargoCachePlan` to own cargo cache enablement, zccache wrapper application, native-CC env injection, rust-plan prepare/restore/save, target-dir selection, orphan-rmeta cleanup, and final zccache session shutdown
- add typed zccache wrapper plans (`RustcWrapperPlan`, `ManagedZccacheWrapperPlan`, `ZccacheChildEnv`) so managed/custom/disabled wrapper modes produce explicit env deltas before command mutation
- shrink `run_cargo_front_door` so it applies a cache plan instead of embedding zccache/native/rust-plan policy inline
- add unit coverage for managed/custom/disabled wrappers, native-cache opt-out, path-remap env, and non-cacheable cargo commands

## Follow-up filed during implementation
- Filed #551 and linked it from #543: Windows managed-zccache builds of crates with `build.rs` can hang in `cli_cargo_native_cc`; `--no-cache` passes. This appears separate from the plan extraction and is now tracked as a parent-refactor subissue per #543 instructions.

## Validation
- `soldr cargo fmt --all`
- `soldr cargo check -p soldr-cli --all-targets`
- `soldr cargo test -p soldr-cli cache_plan`
- `soldr cargo test -p soldr-cli zccache::tests`
- `soldr cargo test -p soldr-cli --test cli_cargo_basic`
- `soldr cargo test -p soldr-cli --test cli_cargo_wrappers`
- `soldr cargo test -p soldr-cli --test cli_rust_plan`
- `soldr cargo test -p soldr-cli --test cli_cargo_trampoline_workspace`
- `soldr cargo test -p soldr-cli --test cli_cargo_native_cc no_cache_global_disables_native_too -- --test-threads=1 --nocapture`
- `soldr cargo clippy -p soldr-cli --all-targets -- -D warnings`
- `soldr cargo test -p soldr-cli --lib`
- `soldr cargo test -p soldr-cli --bins`
- `git diff --check`
- `git diff --cached --check`

Known local validation gap: full `cli_cargo_native_cc` hangs on this Windows host in the managed zccache + `build.rs` path; tracked by #551.
