### PR TITLE
refactor(setup-soldr): add zccache runtime contract

### DIFF
--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -13,16 +13,17 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-# Soldr releases ship a single .tar.zst archive per target since the
-# combined-bundle refactor (#XXX). The archive contains soldr +
-# zccache + zccache-daemon + zccache-fp + crgx + manifest.json at its
-# root. The setup-soldr action extracts every binary into the install
-# dir and exports SOLDR_ZCCACHE_LOCAL_DIR + SOLDR_CRGX_LOCAL_DIR so
-# soldr's runtime resolver wires up the bundled tools without a
-# managed-download round trip.
-ARCHIVE_EXT = "tar.zst"
-ZCCACHE_BUNDLED_BINARIES = ("zccache", "zccache-daemon", "zccache-fp")
-CRGX_BUNDLED_BINARY = "crgx"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from zccache_contract import (  # noqa: E402
+    ARCHIVE_EXT,
+    CRGX_LOCAL_DIR_ENV,
+    CRGX_BUNDLED_BINARY,
+    MANIFEST_NAME,
+    ZCCACHE_BUNDLED_BINARIES,
+    ZCCACHE_LOCAL_DIR_ENV,
+    locate_extracted_file,
+    validate_release_manifest,
+)
 
 
 def _normalize_version(value: str) -> str:
@@ -98,9 +99,7 @@ def _select_asset(release: dict[str, object], target: str) -> tuple[str, str]:
         name = str(asset.get("name", ""))
         if name.endswith(suffix):
             return name, str(asset["browser_download_url"])
-    raise RuntimeError(
-        f"no release asset found for target {target} (looking for *{suffix})"
-    )
+    raise RuntimeError(f"no release asset found for target {target} (looking for *{suffix})")
 
 
 def _extract_archive(archive_path: Path, out_dir: Path) -> None:
@@ -132,10 +131,29 @@ def _extract_archive(archive_path: Path, out_dir: Path) -> None:
 
 
 def _locate_binary(out_dir: Path, binary_name: str) -> Path:
-    for candidate in out_dir.rglob(binary_name):
-        if candidate.is_file():
-            return candidate
-    raise RuntimeError(f"downloaded archive did not contain {binary_name}")
+    return locate_extracted_file(out_dir, binary_name)
+
+
+def _bundled_files_present(install_dir: Path, bases: tuple[str, ...]) -> bool:
+    binary_ext = ".exe" if os.name == "nt" else ""
+    return all((install_dir / f"{base}{binary_ext}").is_file() for base in bases)
+
+
+def _export_bundle_env(install_dir: Path) -> None:
+    github_env = os.environ.get("GITHUB_ENV")
+    if not github_env:
+        return
+    with open(github_env, "a", encoding="utf-8") as fh:
+        if not os.environ.get(ZCCACHE_LOCAL_DIR_ENV) and _bundled_files_present(
+            install_dir,
+            ZCCACHE_BUNDLED_BINARIES,
+        ):
+            fh.write(f"{ZCCACHE_LOCAL_DIR_ENV}={install_dir}\n")
+        if not os.environ.get(CRGX_LOCAL_DIR_ENV) and _bundled_files_present(
+            install_dir,
+            (CRGX_BUNDLED_BINARY,),
+        ):
+            fh.write(f"{CRGX_LOCAL_DIR_ENV}={install_dir}\n")
 
 
 def main() -> None:
@@ -147,7 +165,10 @@ def main() -> None:
 
     current = _installed_version(binary_path)
     if current is not None:
-        if not requested_version or _normalize_version(current) == _normalize_version(requested_version):
+        if not requested_version or _normalize_version(current) == _normalize_version(
+            requested_version
+        ):
+            _export_bundle_env(install_dir)
             output = os.environ.get("GITHUB_OUTPUT")
             if output:
                 with open(output, "a", encoding="utf-8") as fh:
@@ -159,7 +180,7 @@ def main() -> None:
     release = _fetch_release(repo, requested_version)
     asset_name, download_url = _select_asset(release, target)
     tag_name = str(release["tag_name"])
-    zccache_ext = ".exe" if os.name == "nt" else ""
+    binary_ext = ".exe" if os.name == "nt" else ""
 
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)
@@ -168,16 +189,27 @@ def main() -> None:
         urllib.request.urlretrieve(download_url, archive_path)
         _extract_archive(archive_path, extract_dir)
 
+        manifest_path = _locate_binary(extract_dir, MANIFEST_NAME)
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        validate_release_manifest(
+            manifest,
+            soldr_target=target,
+            windows=os.name == "nt",
+            extract_dir=extract_dir,
+        )
+
         # Stage soldr.
         source = _locate_binary(extract_dir, binary_name)
         shutil.copy2(source, binary_path)
         if os.name != "nt":
-            binary_path.chmod(binary_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            binary_path.chmod(
+                binary_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+            )
 
         # Stage the bundled zccache trio next to soldr so the install
         # dir works as a self-contained SOLDR_ZCCACHE_LOCAL_DIR.
         for base in ZCCACHE_BUNDLED_BINARIES:
-            file_name = f"{base}{zccache_ext}"
+            file_name = f"{base}{binary_ext}"
             zccache_src = _locate_binary(extract_dir, file_name)
             zccache_dst = install_dir / file_name
             shutil.copy2(zccache_src, zccache_dst)
@@ -188,46 +220,18 @@ def main() -> None:
 
         # Stage the bundled crgx next to soldr so the install dir
         # also doubles as SOLDR_CRGX_LOCAL_DIR for `soldr crgx ...`.
-        # Archives shipped before the crgx-bundling landed won't
-        # include crgx — treat that as a best-effort skip rather than
-        # a hard failure (the runtime fetch path still works).
-        crgx_file_name = f"{CRGX_BUNDLED_BINARY}{zccache_ext}"
-        crgx_present = False
-        try:
-            crgx_src = _locate_binary(extract_dir, crgx_file_name)
-        except RuntimeError:
-            crgx_src = None
-        if crgx_src is not None:
-            crgx_dst = install_dir / crgx_file_name
-            shutil.copy2(crgx_src, crgx_dst)
-            if os.name != "nt":
-                crgx_dst.chmod(
-                    crgx_dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
-                )
-            crgx_present = True
+        crgx_file_name = f"{CRGX_BUNDLED_BINARY}{binary_ext}"
+        crgx_src = _locate_binary(extract_dir, crgx_file_name)
+        crgx_dst = install_dir / crgx_file_name
+        shutil.copy2(crgx_src, crgx_dst)
+        if os.name != "nt":
+            crgx_dst.chmod(
+                crgx_dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+            )
 
-        # Optional: surface manifest.json next to the binaries.
-        manifest_src = extract_dir.rglob("manifest.json")
-        for candidate in manifest_src:
-            if candidate.is_file():
-                shutil.copy2(candidate, install_dir / "manifest.json")
-                break
+        shutil.copy2(manifest_path, install_dir / MANIFEST_NAME)
 
-    # Export SOLDR_ZCCACHE_LOCAL_DIR + SOLDR_CRGX_LOCAL_DIR to
-    # GITHUB_ENV so subsequent steps see the bundled tools without a
-    # managed-fetch round trip. Don't clobber an explicit caller
-    # setting if it's already in the env.
-    github_env = os.environ.get("GITHUB_ENV")
-    if github_env and not os.environ.get("SOLDR_ZCCACHE_LOCAL_DIR"):
-        with open(github_env, "a", encoding="utf-8") as fh:
-            fh.write(f"SOLDR_ZCCACHE_LOCAL_DIR={install_dir}\n")
-    if (
-        github_env
-        and crgx_present
-        and not os.environ.get("SOLDR_CRGX_LOCAL_DIR")
-    ):
-        with open(github_env, "a", encoding="utf-8") as fh:
-            fh.write(f"SOLDR_CRGX_LOCAL_DIR={install_dir}\n")
+    _export_bundle_env(install_dir)
 
     output = os.environ.get("GITHUB_OUTPUT")
     if output:

--- a/.github/actions/setup-soldr/zccache_contract.py
+++ b/.github/actions/setup-soldr/zccache_contract.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTRACT_PATH = REPO_ROOT / "contracts" / "zccache-runtime.v1.json"
+
+
+def load_contract(path: Path = CONTRACT_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+CONTRACT = load_contract()
+ARCHIVE_EXT = str(CONTRACT["release_archive"]["extension"])
+MANIFEST_NAME = str(CONTRACT["release_archive"]["manifest_name"])
+MANIFEST_MIN_SCHEMA_VERSION = int(CONTRACT["release_archive"]["manifest_min_schema_version"])
+ZCCACHE_BUNDLED_BINARIES = tuple(CONTRACT["zccache"]["required_binaries"])
+CRGX_BUNDLED_BINARY = str(CONTRACT["crgx"]["required_binaries"][0])
+RELEASE_BUNDLED_BINARIES = tuple(CONTRACT["release_archive"]["required_binaries"])
+ZCCACHE_LOCAL_DIR_ENV = str(CONTRACT["zccache"]["local_dir_env"])
+CRGX_LOCAL_DIR_ENV = str(CONTRACT["crgx"]["local_dir_env"])
+
+
+def binary_name(base: str, *, windows: bool) -> str:
+    return f"{base}.exe" if windows else base
+
+
+def release_binary_names(*, windows: bool) -> tuple[str, ...]:
+    return tuple(binary_name(base, windows=windows) for base in RELEASE_BUNDLED_BINARIES)
+
+
+def zccache_target_for_soldr_target(soldr_target: str) -> str:
+    if "-unknown-linux-" not in soldr_target:
+        return soldr_target
+    arch, _, _ = soldr_target.partition("-unknown-linux-")
+    libc = CONTRACT["release_archive"]["linux_zccache_target_libc"]
+    return f"{arch}-unknown-linux-{libc}"
+
+
+def _sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _manifest_binaries(manifest: dict[str, Any]) -> dict[str, str]:
+    binaries: dict[str, str] = {}
+    soldr = manifest.get("soldr", {})
+    if isinstance(soldr, dict):
+        binary = soldr.get("binary")
+        sha = soldr.get("sha256")
+        if isinstance(binary, str) and isinstance(sha, str):
+            binaries[binary] = sha
+    zccache = manifest.get("zccache", {})
+    if isinstance(zccache, dict):
+        for entry in zccache.get("binaries", []):
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            sha = entry.get("sha256")
+            if isinstance(name, str) and isinstance(sha, str):
+                binaries[name] = sha
+    crgx = manifest.get("crgx", {})
+    if isinstance(crgx, dict):
+        binary = crgx.get("binary")
+        sha = crgx.get("sha256")
+        if isinstance(binary, str) and isinstance(sha, str):
+            binaries[binary] = sha
+    return binaries
+
+
+def validate_release_manifest(
+    manifest: dict[str, Any],
+    *,
+    soldr_target: str,
+    windows: bool,
+    extract_dir: Path,
+) -> None:
+    schema_version = manifest.get("schema_version")
+    if not isinstance(schema_version, int) or schema_version < MANIFEST_MIN_SCHEMA_VERSION:
+        raise RuntimeError(
+            f"release manifest schema_version must be >= {MANIFEST_MIN_SCHEMA_VERSION}"
+        )
+    archive = manifest.get("archive")
+    if not isinstance(archive, dict) or archive.get("format") != ARCHIVE_EXT:
+        raise RuntimeError(f"release manifest archive.format must be {ARCHIVE_EXT}")
+    soldr = manifest.get("soldr")
+    if not isinstance(soldr, dict) or soldr.get("target") != soldr_target:
+        raise RuntimeError(f"release manifest soldr.target must be {soldr_target}")
+    zccache = manifest.get("zccache")
+    expected_zccache_target = zccache_target_for_soldr_target(soldr_target)
+    if not isinstance(zccache, dict) or zccache.get("target") != expected_zccache_target:
+        raise RuntimeError(f"release manifest zccache.target must be {expected_zccache_target}")
+    crgx = manifest.get("crgx")
+    if not isinstance(crgx, dict) or crgx.get("target") != soldr_target:
+        raise RuntimeError(f"release manifest crgx.target must be {soldr_target}")
+
+    expected_names = set(release_binary_names(windows=windows))
+    manifest_binaries = _manifest_binaries(manifest)
+    missing = sorted(expected_names.difference(manifest_binaries))
+    if missing:
+        raise RuntimeError(
+            f"release manifest is missing bundled binary records: {', '.join(missing)}"
+        )
+
+    for name in sorted(expected_names):
+        expected_sha = manifest_binaries[name].lower()
+        if len(expected_sha) != 64 or any(ch not in "0123456789abcdef" for ch in expected_sha):
+            raise RuntimeError(f"release manifest sha256 for {name} is not lowercase hex")
+        binary_path = locate_extracted_file(extract_dir, name)
+        actual_sha = _sha256_file(binary_path)
+        if actual_sha != expected_sha:
+            raise RuntimeError(
+                f"release manifest sha256 mismatch for {name}: expected {expected_sha}, got {actual_sha}"
+            )
+
+
+def locate_extracted_file(root: Path, file_name: str) -> Path:
+    for candidate in root.rglob(file_name):
+        if candidate.is_file():
+            return candidate
+    raise RuntimeError(f"downloaded archive did not contain {file_name}")

--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Setup soldr build cache
         id: setup_soldr
-        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
+        uses: zackees/setup-soldr@8074343a15b9a6eac2336993787b1b312c961cf4
         env:
           ACTION_WORKSPACE: ${{ github.workspace }}/soldr
         with:
@@ -214,7 +214,7 @@ jobs:
           & "${{ steps.soldr_binary.outputs.path }}" --version
 
       - name: Stop setup-soldr builder cache before bootstrap test
-        uses: zackees/setup-soldr/cleanup@be9cd32c413a696e85c13eaeef25400666dd5317
+        uses: zackees/setup-soldr/cleanup@8074343a15b9a6eac2336993787b1b312c961cf4
 
       - name: Build third-party app through soldr
         shell: pwsh

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Setup soldr build cache
         id: setup_soldr
-        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
+        uses: zackees/setup-soldr@8074343a15b9a6eac2336993787b1b312c961cf4
         with:
           toolchain: 1.94.1
           cache: true
@@ -150,7 +150,7 @@ jobs:
           "LOCAL_SOLDR=$soldrPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Stop setup-soldr builder cache before tests
-        uses: zackees/setup-soldr/cleanup@be9cd32c413a696e85c13eaeef25400666dd5317
+        uses: zackees/setup-soldr/cleanup@8074343a15b9a6eac2336993787b1b312c961cf4
 
       - name: Run library tests
         shell: pwsh

--- a/.github/workflows/cache-delta-experiment.yml
+++ b/.github/workflows/cache-delta-experiment.yml
@@ -66,7 +66,7 @@ jobs:
         # before the release-auto workflow has built and published
         # the matching tarball; setup-soldr fetches by tag, so an
         # unpublished version 404s here.
-        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
+        uses: zackees/setup-soldr@8074343a15b9a6eac2336993787b1b312c961cf4
         with:
           version: "0.7.28"
           cache: false
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
+      - uses: zackees/setup-soldr@8074343a15b9a6eac2336993787b1b312c961cf4
         with:
           # 0.7.29 brings `soldr cook` — see delta job above for why.
           version: "0.7.28"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup soldr build cache
-        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
+        uses: zackees/setup-soldr@8074343a15b9a6eac2336993787b1b312c961cf4
         with:
           toolchain: 1.94.1
           cache: true

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -74,7 +74,7 @@ jobs:
       - id: setup
         # This is zackees/setup-soldr@v0 pinned to a full SHA
         # because this repository's ruleset requires SHA-pinned actions.
-        uses: zackees/setup-soldr@be9cd32c413a696e85c13eaeef25400666dd5317
+        uses: zackees/setup-soldr@8074343a15b9a6eac2336993787b1b312c961cf4
         with:
           cache: true
           zccache-seed-strict: true
@@ -144,7 +144,7 @@ jobs:
             setup-soldr-dogfood-zccache-v1-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Stop setup-soldr builder cache before dogfood build
-        uses: zackees/setup-soldr/cleanup@be9cd32c413a696e85c13eaeef25400666dd5317
+        uses: zackees/setup-soldr/cleanup@8074343a15b9a6eac2336993787b1b312c961cf4
 
       - name: Build through soldr
         shell: pwsh

--- a/bin/soldr.js
+++ b/bin/soldr.js
@@ -4,6 +4,7 @@
 const childProcess = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const zccacheContract = require("../scripts/zccache-contract");
 
 const binaryName = process.platform === "win32" ? "soldr.exe" : "soldr";
 const nativeDir = path.join(__dirname, "native");
@@ -30,13 +31,14 @@ if (!fs.existsSync(binaryPath)) {
 // the env var themselves keep their override.
 const exeExt = process.platform === "win32" ? ".exe" : "";
 const childEnv = { ...process.env };
+const zccacheLocalDirEnv = zccacheContract.CONTRACT.zccache.local_dir_env;
 if (
-  !childEnv.SOLDR_ZCCACHE_LOCAL_DIR &&
-  fs.existsSync(path.join(nativeDir, `zccache${exeExt}`)) &&
-  fs.existsSync(path.join(nativeDir, `zccache-daemon${exeExt}`)) &&
-  fs.existsSync(path.join(nativeDir, `zccache-fp${exeExt}`))
+  !childEnv[zccacheLocalDirEnv] &&
+  zccacheContract.ZCCACHE_BUNDLED_BINARIES.every((baseName) =>
+    fs.existsSync(path.join(nativeDir, `${baseName}${exeExt}`)),
+  )
 ) {
-  childEnv.SOLDR_ZCCACHE_LOCAL_DIR = nativeDir;
+  childEnv[zccacheLocalDirEnv] = nativeDir;
 }
 
 // Same wiring for the bundled crgx binary (shipped alongside soldr
@@ -45,11 +47,12 @@ if (
 // SOLDR_CRGX_LOCAL_DIR ahead of the GitHub Releases / crates.io
 // fetch chain, so `soldr crgx ...` runs the bundled binary with no
 // network round trip. Caller-set overrides win.
+const crgxLocalDirEnv = zccacheContract.CONTRACT.crgx.local_dir_env;
 if (
-  !childEnv.SOLDR_CRGX_LOCAL_DIR &&
-  fs.existsSync(path.join(nativeDir, `crgx${exeExt}`))
+  !childEnv[crgxLocalDirEnv] &&
+  fs.existsSync(path.join(nativeDir, `${zccacheContract.CRGX_BUNDLED_BINARY}${exeExt}`))
 ) {
-  childEnv.SOLDR_CRGX_LOCAL_DIR = nativeDir;
+  childEnv[crgxLocalDirEnv] = nativeDir;
 }
 
 const child = childProcess.spawn(binaryPath, process.argv.slice(2), {

--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "name": "soldr-zccache-runtime",
+  "release_archive": {
+    "extension": "tar.zst",
+    "compression_level": 19,
+    "manifest_name": "manifest.json",
+    "manifest_min_schema_version": 2,
+    "sha256_algorithm": "sha256",
+    "required_binaries": [
+      "soldr",
+      "zccache",
+      "zccache-daemon",
+      "zccache-fp",
+      "crgx"
+    ],
+    "linux_zccache_target_libc": "musl"
+  },
+  "zccache": {
+    "managed_version": "1.11.4",
+    "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
+    "cache_dir_env": "ZCCACHE_CACHE_DIR",
+    "required_binaries": [
+      "zccache",
+      "zccache-daemon",
+      "zccache-fp"
+    ],
+    "manifest_block": "zccache"
+  },
+  "crgx": {
+    "managed_version": "0.1.0",
+    "local_dir_env": "SOLDR_CRGX_LOCAL_DIR",
+    "required_binaries": [
+      "crgx"
+    ],
+    "manifest_block": "crgx"
+  },
+  "setup_action": {
+    "cache_root_env": "SOLDR_CACHE_DIR",
+    "native_cache_env": "SOLDR_NATIVE_CACHE",
+    "contract_module": ".github/actions/setup-soldr/zccache_contract.py",
+    "exported_contract": "contracts/zccache-runtime.v1.json"
+  },
+  "npm": {
+    "native_dir": "bin/native",
+    "launcher": "bin/soldr.js",
+    "installer": "scripts/install.js",
+    "contract_loader": "scripts/zccache-contract.js"
+  }
+}

--- a/crates/soldr-cli/src/cargo_front_door/cache_plan.rs
+++ b/crates/soldr-cli/src/cargo_front_door/cache_plan.rs
@@ -207,8 +207,7 @@ mod tests {
         })
     }
 
-    #[test]
-    fn managed_plan_applies_session_and_path_remap_env() {
+    crate::timed_test!(managed_plan_applies_session_and_path_remap_env, {
         let _lock = ENV_LOCK.lock().unwrap();
         let _native = EnvGuard::set(native_cc::NATIVE_CACHE_ENV_VAR, "0");
         let mut command = std::process::Command::new("cargo");
@@ -246,10 +245,9 @@ mod tests {
             command_env_override(&command, crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR),
             Some(Some(OsString::from("/tmp/worktree")))
         );
-    }
+    });
 
-    #[test]
-    fn native_cache_opt_out_leaves_cc_and_cxx_unset() {
+    crate::timed_test!(native_cache_opt_out_leaves_cc_and_cxx_unset, {
         let _lock = ENV_LOCK.lock().unwrap();
         let _native = EnvGuard::set(native_cc::NATIVE_CACHE_ENV_VAR, "0");
         let _cc = EnvGuard::remove("CC");
@@ -266,95 +264,101 @@ mod tests {
 
         assert_eq!(command_env_override(&command, "CC"), None);
         assert_eq!(command_env_override(&command, "CXX"), None);
-    }
+    });
 
-    #[test]
-    fn custom_wrapper_plan_sets_wrapper_and_clears_managed_zccache_env() {
-        let mut command = std::process::Command::new("cargo");
-        command.env(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR, "/old/zccache");
-        command.env(
-            crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR,
-            "/old/cache",
-        );
-        command.env(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR, "old-session");
-        let plan = CargoCachePlan {
-            cache_enabled_for_cargo: true,
-            rustc_wrapper: Some(RustcWrapperPlan::Custom {
-                wrapper: OsString::from("sccache"),
-                sccache_dir: Some(std::path::PathBuf::from("/tmp/sccache")),
-            }),
-            rust_artifact_plan: None,
-        };
+    crate::timed_test!(
+        custom_wrapper_plan_sets_wrapper_and_clears_managed_zccache_env,
+        {
+            let mut command = std::process::Command::new("cargo");
+            command.env(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR, "/old/zccache");
+            command.env(
+                crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR,
+                "/old/cache",
+            );
+            command.env(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR, "old-session");
+            let plan = CargoCachePlan {
+                cache_enabled_for_cargo: true,
+                rustc_wrapper: Some(RustcWrapperPlan::Custom {
+                    wrapper: OsString::from("sccache"),
+                    sccache_dir: Some(std::path::PathBuf::from("/tmp/sccache")),
+                }),
+                rust_artifact_plan: None,
+            };
 
-        plan.apply_to_command(&mut command, None)
-            .expect("apply cache plan");
+            plan.apply_to_command(&mut command, None)
+                .expect("apply cache plan");
 
-        assert_eq!(
-            command_env_override(&command, "RUSTC_WRAPPER"),
-            Some(Some(OsString::from("sccache")))
-        );
-        assert_eq!(
-            command_env_override(&command, "SCCACHE_DIR"),
-            Some(Some(OsString::from("/tmp/sccache")))
-        );
-        assert_eq!(
-            command_env_override(&command, crate::cache_lib::ZCCACHE_BINARY_ENV_VAR),
-            Some(None)
-        );
-        assert_eq!(
-            command_env_override(&command, crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR),
-            Some(None)
-        );
-    }
+            assert_eq!(
+                command_env_override(&command, "RUSTC_WRAPPER"),
+                Some(Some(OsString::from("sccache")))
+            );
+            assert_eq!(
+                command_env_override(&command, "SCCACHE_DIR"),
+                Some(Some(OsString::from("/tmp/sccache")))
+            );
+            assert_eq!(
+                command_env_override(&command, crate::cache_lib::ZCCACHE_BINARY_ENV_VAR),
+                Some(None)
+            );
+            assert_eq!(
+                command_env_override(&command, crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR),
+                Some(None)
+            );
+        }
+    );
 
-    #[test]
-    fn disabled_wrapper_plan_removes_wrapper_and_managed_zccache_env() {
-        let mut command = std::process::Command::new("cargo");
-        command.env("RUSTC_WRAPPER", "old-wrapper");
-        command.env(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR, "/old/zccache");
-        command.env(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR, "old-session");
-        let plan = CargoCachePlan {
-            cache_enabled_for_cargo: true,
-            rustc_wrapper: Some(RustcWrapperPlan::Disabled),
-            rust_artifact_plan: None,
-        };
+    crate::timed_test!(
+        disabled_wrapper_plan_removes_wrapper_and_managed_zccache_env,
+        {
+            let mut command = std::process::Command::new("cargo");
+            command.env("RUSTC_WRAPPER", "old-wrapper");
+            command.env(crate::cache_lib::ZCCACHE_BINARY_ENV_VAR, "/old/zccache");
+            command.env(crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR, "old-session");
+            let plan = CargoCachePlan {
+                cache_enabled_for_cargo: true,
+                rustc_wrapper: Some(RustcWrapperPlan::Disabled),
+                rust_artifact_plan: None,
+            };
 
-        plan.apply_to_command(&mut command, None)
-            .expect("apply cache plan");
+            plan.apply_to_command(&mut command, None)
+                .expect("apply cache plan");
 
-        assert_eq!(command_env_override(&command, "RUSTC_WRAPPER"), Some(None));
-        assert_eq!(
-            command_env_override(&command, crate::cache_lib::ZCCACHE_BINARY_ENV_VAR),
-            Some(None)
-        );
-        assert_eq!(
-            command_env_override(&command, crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR),
-            Some(None)
-        );
-    }
+            assert_eq!(command_env_override(&command, "RUSTC_WRAPPER"), Some(None));
+            assert_eq!(
+                command_env_override(&command, crate::cache_lib::ZCCACHE_BINARY_ENV_VAR),
+                Some(None)
+            );
+            assert_eq!(
+                command_env_override(&command, crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR),
+                Some(None)
+            );
+        }
+    );
 
-    #[test]
-    fn non_cacheable_plan_marks_cache_disabled_without_touching_wrapper() {
-        let mut command = std::process::Command::new("cargo");
-        command.env("RUSTC_WRAPPER", "inherited-wrapper");
-        let plan = CargoCachePlan {
-            cache_enabled_for_cargo: false,
-            rustc_wrapper: None,
-            rust_artifact_plan: None,
-        };
+    crate::timed_test!(
+        non_cacheable_plan_marks_cache_disabled_without_touching_wrapper,
+        {
+            let mut command = std::process::Command::new("cargo");
+            command.env("RUSTC_WRAPPER", "inherited-wrapper");
+            let plan = CargoCachePlan {
+                cache_enabled_for_cargo: false,
+                rustc_wrapper: None,
+                rust_artifact_plan: None,
+            };
 
-        plan.apply_to_command(&mut command, None)
-            .expect("apply cache plan");
+            plan.apply_to_command(&mut command, None)
+                .expect("apply cache plan");
 
-        assert_eq!(
-            command_env_override(&command, crate::cache_lib::CACHE_ENABLED_ENV_VAR),
-            Some(Some(OsString::from(
-                crate::cache_lib::cache_enabled_env_value(false)
-            )))
-        );
-        assert_eq!(
-            command_env_override(&command, "RUSTC_WRAPPER"),
-            Some(Some(OsString::from("inherited-wrapper")))
-        );
-    }
+            assert_eq!(
+                command_env_override(&command, crate::cache_lib::CACHE_ENABLED_ENV_VAR),
+                Some(Some(OsString::from(
+                    crate::cache_lib::cache_enabled_env_value(false)
+                )))
+            );
+            assert_eq!(
+                command_env_override(&command, "RUSTC_WRAPPER"),
+                Some(Some(OsString::from("inherited-wrapper")))
+            );
+        }
+    );
 }

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -43,6 +43,9 @@ pub mod zccache;
 pub mod zccache_install;
 pub mod zccache_runtime;
 
+#[cfg(test)]
+mod zccache_contract_tests;
+
 pub use zccache::{
     classify_zccache_source, managed_only_zccache_summary, pinned_zccache_summary,
     resolve_local_zccache, zccache_binary_summary, ZccacheBinarySummary, ZccacheSource,

--- a/crates/soldr-cli/src/fetch/zccache_contract_tests.rs
+++ b/crates/soldr-cli/src/fetch/zccache_contract_tests.rs
@@ -3,8 +3,7 @@ use super::{
     MANAGED_ZCCACHE_VERSION, ZCCACHE_LOCAL_DIR_ENV_VAR,
 };
 
-#[test]
-fn zccache_runtime_contract_matches_rust_constants() {
+crate::timed_test!(zccache_runtime_contract_matches_rust_constants, {
     let contract: serde_json::Value = serde_json::from_str(include_str!(
         "../../../../contracts/zccache-runtime.v1.json"
     ))
@@ -49,4 +48,4 @@ fn zccache_runtime_contract_matches_rust_constants() {
         release_bins,
         vec!["soldr", "zccache", "zccache-daemon", "zccache-fp", "crgx"]
     );
-}
+});

--- a/crates/soldr-cli/src/fetch/zccache_contract_tests.rs
+++ b/crates/soldr-cli/src/fetch/zccache_contract_tests.rs
@@ -1,0 +1,52 @@
+use super::{
+    CRGX_LOCAL_DIR_ENV_VAR, MANAGED_CRGX_VERSION, MANAGED_ZCCACHE_PACKAGES,
+    MANAGED_ZCCACHE_VERSION, ZCCACHE_LOCAL_DIR_ENV_VAR,
+};
+
+#[test]
+fn zccache_runtime_contract_matches_rust_constants() {
+    let contract: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../../contracts/zccache-runtime.v1.json"
+    ))
+    .expect("zccache runtime contract should be valid JSON");
+
+    assert_eq!(
+        contract["zccache"]["managed_version"].as_str(),
+        Some(MANAGED_ZCCACHE_VERSION)
+    );
+    assert_eq!(
+        contract["zccache"]["local_dir_env"].as_str(),
+        Some(ZCCACHE_LOCAL_DIR_ENV_VAR)
+    );
+    assert_eq!(
+        contract["crgx"]["managed_version"].as_str(),
+        Some(MANAGED_CRGX_VERSION)
+    );
+    assert_eq!(
+        contract["crgx"]["local_dir_env"].as_str(),
+        Some(CRGX_LOCAL_DIR_ENV_VAR)
+    );
+
+    let contract_zccache_bins: Vec<&str> = contract["zccache"]["required_binaries"]
+        .as_array()
+        .expect("zccache.required_binaries should be an array")
+        .iter()
+        .map(|value| value.as_str().expect("binary name should be a string"))
+        .collect();
+    let rust_zccache_bins: Vec<&str> = MANAGED_ZCCACHE_PACKAGES
+        .iter()
+        .map(|(_, binary)| *binary)
+        .collect();
+    assert_eq!(contract_zccache_bins, rust_zccache_bins);
+
+    let release_bins: Vec<&str> = contract["release_archive"]["required_binaries"]
+        .as_array()
+        .expect("release_archive.required_binaries should be an array")
+        .iter()
+        .map(|value| value.as_str().expect("binary name should be a string"))
+        .collect();
+    assert_eq!(
+        release_bins,
+        vec!["soldr", "zccache", "zccache-daemon", "zccache-fp", "crgx"]
+    );
+}

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -389,6 +389,7 @@ pub(crate) use crate::wrapper_target::{record_target_dir_in_registry, TargetTouc
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::zccache_lifecycle::stderr_indicates_unknown_session;
 
     #[test]
     fn stdin_source_path_is_content_addressed() {

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -89,18 +89,20 @@ Do not publish an npm version until the matching GitHub Release has these files:
 - `soldr-vX.Y.Z-SHA256SUMS.txt`
 
 Each archive is a `.tar.zst` at zstd compression level 19 and bundles
-four binaries plus a `manifest.json` at the archive root:
+five binaries plus a `manifest.json` at the archive root:
 
 - `soldr` (or `soldr.exe`) — the soldr CLI itself.
 - `zccache`, `zccache-daemon`, `zccache-fp` — the matching-target
   zccache trio (Linux gnu archives carry the musl zccache because
   zccache ships musl-only on Linux upstream; statically linked, runs
   on glibc).
-- `manifest.json` — schema_version 1 descriptor with soldr / zccache
-  versions, target triples, per-binary sha256s, archive format. See
-  `release-auto.yml`'s `Write manifest.json` step for the exact shape.
+- `crgx` (or `crgx.exe`) - the matching-target crgx binary.
+- `manifest.json` - schema_version 2 descriptor with soldr / zccache /
+  crgx versions, target triples, per-binary sha256s, and archive format.
+  The expected archive layout is versioned in
+  `contracts/zccache-runtime.v1.json`.
 
-The npm install wrapper unpacks all four binaries into `bin/native/`
-and `bin/soldr.js` exports `SOLDR_ZCCACHE_LOCAL_DIR` to that dir
-before spawning soldr, so the bundled zccache is picked up
+The npm install wrapper validates `manifest.json`, unpacks all five binaries
+into `bin/native/`, and `bin/soldr.js` exports `SOLDR_ZCCACHE_LOCAL_DIR`
+to that dir before spawning soldr, so the bundled zccache is picked up
 automatically.

--- a/docs/ZCCACHE_RUNTIME_CONTRACT.md
+++ b/docs/ZCCACHE_RUNTIME_CONTRACT.md
@@ -1,0 +1,23 @@
+# Zccache Runtime Contract
+
+`contracts/zccache-runtime.v1.json` is the shared contract for the zccache
+runtime soldr ships and wires through setup-soldr and npm.
+
+The contract fixes these cross-runtime expectations:
+
+- Release archives are `.tar.zst` bundles containing `soldr`, `zccache`,
+  `zccache-daemon`, `zccache-fp`, `crgx`, and `manifest.json`.
+- `manifest.json` is the authoritative per-archive descriptor for schema
+  version, archive format, soldr target, zccache target, bundled binary names,
+  and per-binary `sha256` values.
+- Setup-soldr and npm install must stage the same zccache trio and export
+  `SOLDR_ZCCACHE_LOCAL_DIR` only when that trio is present.
+- Setup-soldr and npm must use the same local crgx env var:
+  `SOLDR_CRGX_LOCAL_DIR`.
+- Rust runtime constants, action helpers, npm scripts, public-action exporter
+  fixtures, release workflow manifest generation, and docs are covered by tests
+  against the same contract file.
+
+Linux soldr archives are still split by glibc/musl target. The bundled zccache
+target recorded in `manifest.json` is musl for Linux because upstream zccache
+ships the static musl variant used by both Linux archive families.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   },
   "files": [
     "bin/soldr.js",
+    "contracts/zccache-runtime.v1.json",
     "scripts/install.js",
+    "scripts/zccache-contract.js",
     "scripts/test-npm-package.js",
     "README.md",
     "LICENSE"

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -8,6 +8,7 @@ const http = require("http");
 const https = require("https");
 const os = require("os");
 const path = require("path");
+const zccacheContract = require("./zccache-contract");
 
 const PACKAGE_ROOT = path.resolve(__dirname, "..");
 const PACKAGE_JSON = require(path.join(PACKAGE_ROOT, "package.json"));
@@ -18,7 +19,7 @@ const PACKAGE_JSON = require(path.join(PACKAGE_ROOT, "package.json"));
 // and `bin/soldr.js` wires SOLDR_ZCCACHE_LOCAL_DIR + SOLDR_CRGX_LOCAL_DIR
 // to the install dir so soldr's runtime resolver finds the sibling binaries
 // without going through the managed-download path.
-const ARCHIVE_EXT = "tar.zst";
+const ARCHIVE_EXT = zccacheContract.ARCHIVE_EXT;
 
 const TARGETS = {
   "linux-x64-gnu": { triple: "x86_64-unknown-linux-gnu", binary: "soldr" },
@@ -37,13 +38,7 @@ const TARGETS = {
 // `Build crgx from pinned source` steps drop into `dist/package/`
 // before the tar.zst is built. `.exe` suffix is appended at install
 // time based on `target.binary`.
-const BUNDLED_BINARIES = [
-  "soldr",
-  "zccache",
-  "zccache-daemon",
-  "zccache-fp",
-  "crgx",
-];
+const BUNDLED_BINARIES = zccacheContract.RELEASE_BUNDLED_BINARIES;
 
 // Detect whether the running Linux uses musl or glibc. Three layered probes:
 //   1. process.report.header.glibcVersionRuntime is the documented Node
@@ -259,6 +254,22 @@ async function install() {
     // exec). The archive layout is flat — all five binaries live at
     // the archive root.
     const binaryExt = target.binary.endsWith(".exe") ? ".exe" : "";
+    const manifestSrc = findExtractedBinary(extractDir, zccacheContract.MANIFEST_NAME);
+    if (!manifestSrc) {
+      throw new Error(`release archive ${filename} did not contain ${zccacheContract.MANIFEST_NAME}`);
+    }
+    const manifest = JSON.parse(fs.readFileSync(manifestSrc, "utf8"));
+    zccacheContract.validateReleaseManifest(manifest, {
+      soldrTarget: target.triple,
+      platform: process.platform,
+      findFile: (name) => {
+        const filePath = findExtractedBinary(extractDir, name);
+        if (!filePath) {
+          throw new Error(`release archive ${filename} did not contain ${name}`);
+        }
+        return filePath;
+      },
+    });
     for (const baseName of BUNDLED_BINARIES) {
       const fileName = `${baseName}${binaryExt}`;
       const src = findExtractedBinary(extractDir, fileName);
@@ -275,12 +286,7 @@ async function install() {
     // Drop manifest.json alongside the binaries so downstream tooling
     // (and humans reading `bin/native/`) can introspect provenance —
     // soldr / zccache versions, target triples, build commit, sha256s.
-    // Best-effort: archives shipped before the manifest convention
-    // landed simply won't have one.
-    const manifestSrc = findExtractedBinary(extractDir, "manifest.json");
-    if (manifestSrc) {
-      fs.copyFileSync(manifestSrc, path.join(nativeDir, "manifest.json"));
-    }
+    fs.copyFileSync(manifestSrc, path.join(nativeDir, zccacheContract.MANIFEST_NAME));
 
     console.log(
       `soldr: installed ${target.triple} (soldr + zccache trio + crgx) into ${nativeDir}`,

--- a/scripts/test-npm-package.js
+++ b/scripts/test-npm-package.js
@@ -8,6 +8,7 @@ const assert = require("assert");
 const root = path.resolve(__dirname, "..");
 const pkg = require(path.join(root, "package.json"));
 const install = require(path.join(root, "scripts", "install.js"));
+const zccacheContract = require(path.join(root, "scripts", "zccache-contract.js"));
 
 function tomlSection(toml, sectionName) {
   const header = `[${sectionName}]`;
@@ -66,7 +67,9 @@ assert.strictEqual(pkg.bin.soldr, "bin/soldr.js");
 assert.strictEqual(pkg.repository.url, "git+https://github.com/zackees/soldr.git");
 assert.deepStrictEqual(pkg.files, [
   "bin/soldr.js",
+  "contracts/zccache-runtime.v1.json",
   "scripts/install.js",
+  "scripts/zccache-contract.js",
   "scripts/test-npm-package.js",
   "README.md",
   "LICENSE",
@@ -118,6 +121,17 @@ assert.strictEqual(
   ),
   "abc123",
 );
+
+assert.strictEqual(install.ARCHIVE_EXT, "tar.zst");
+assert.deepStrictEqual(
+  install.BUNDLED_BINARIES,
+  zccacheContract.RELEASE_BUNDLED_BINARIES,
+);
+assert.deepStrictEqual(zccacheContract.ZCCACHE_BUNDLED_BINARIES, [
+  "zccache",
+  "zccache-daemon",
+  "zccache-fp",
+]);
 
 // Every TARGETS entry must drop the `archive` field — the combined
 // archive format is fixed (.tar.zst) so the per-target field is dead

--- a/scripts/zccache-contract.js
+++ b/scripts/zccache-contract.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const PACKAGE_ROOT = path.resolve(__dirname, "..");
+const CONTRACT_PATH = path.join(PACKAGE_ROOT, "contracts", "zccache-runtime.v1.json");
+const CONTRACT = JSON.parse(fs.readFileSync(CONTRACT_PATH, "utf8"));
+
+const ARCHIVE_EXT = CONTRACT.release_archive.extension;
+const MANIFEST_NAME = CONTRACT.release_archive.manifest_name;
+const MANIFEST_MIN_SCHEMA_VERSION = CONTRACT.release_archive.manifest_min_schema_version;
+const RELEASE_BUNDLED_BINARIES = Object.freeze([...CONTRACT.release_archive.required_binaries]);
+const ZCCACHE_BUNDLED_BINARIES = Object.freeze([...CONTRACT.zccache.required_binaries]);
+const CRGX_BUNDLED_BINARY = CONTRACT.crgx.required_binaries[0];
+
+function binaryName(baseName, platform = process.platform) {
+  return `${baseName}${platform === "win32" ? ".exe" : ""}`;
+}
+
+function releaseBinaryNames(platform = process.platform) {
+  return RELEASE_BUNDLED_BINARIES.map((baseName) => binaryName(baseName, platform));
+}
+
+function zccacheTargetForSoldrTarget(soldrTarget) {
+  if (!soldrTarget.includes("-unknown-linux-")) {
+    return soldrTarget;
+  }
+  const arch = soldrTarget.split("-unknown-linux-", 1)[0];
+  return `${arch}-unknown-linux-${CONTRACT.release_archive.linux_zccache_target_libc}`;
+}
+
+function sha256File(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function collectManifestBinaries(manifest) {
+  const binaries = new Map();
+  if (manifest.soldr && manifest.soldr.binary && manifest.soldr.sha256) {
+    binaries.set(manifest.soldr.binary, manifest.soldr.sha256);
+  }
+  const zccacheBinaries = (manifest.zccache && manifest.zccache.binaries) || [];
+  for (const entry of zccacheBinaries) {
+    if (entry && entry.name && entry.sha256) {
+      binaries.set(entry.name, entry.sha256);
+    }
+  }
+  if (manifest.crgx && manifest.crgx.binary && manifest.crgx.sha256) {
+    binaries.set(manifest.crgx.binary, manifest.crgx.sha256);
+  }
+  return binaries;
+}
+
+function validateReleaseManifest(manifest, options) {
+  const { soldrTarget, platform = process.platform, findFile } = options;
+  if (!Number.isInteger(manifest.schema_version) || manifest.schema_version < MANIFEST_MIN_SCHEMA_VERSION) {
+    throw new Error(`release manifest schema_version must be >= ${MANIFEST_MIN_SCHEMA_VERSION}`);
+  }
+  if (!manifest.archive || manifest.archive.format !== ARCHIVE_EXT) {
+    throw new Error(`release manifest archive.format must be ${ARCHIVE_EXT}`);
+  }
+  if (!manifest.soldr || manifest.soldr.target !== soldrTarget) {
+    throw new Error(`release manifest soldr.target must be ${soldrTarget}`);
+  }
+  const expectedZccacheTarget = zccacheTargetForSoldrTarget(soldrTarget);
+  if (!manifest.zccache || manifest.zccache.target !== expectedZccacheTarget) {
+    throw new Error(`release manifest zccache.target must be ${expectedZccacheTarget}`);
+  }
+  if (!manifest.crgx || manifest.crgx.target !== soldrTarget) {
+    throw new Error(`release manifest crgx.target must be ${soldrTarget}`);
+  }
+
+  const expectedNames = releaseBinaryNames(platform);
+  const manifestBinaries = collectManifestBinaries(manifest);
+  for (const name of expectedNames) {
+    if (!manifestBinaries.has(name)) {
+      throw new Error(`release manifest is missing bundled binary record for ${name}`);
+    }
+    const expectedSha = String(manifestBinaries.get(name)).toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(expectedSha)) {
+      throw new Error(`release manifest sha256 for ${name} is not lowercase hex`);
+    }
+    const filePath = findFile(name);
+    const actualSha = sha256File(filePath);
+    if (actualSha !== expectedSha) {
+      throw new Error(`release manifest sha256 mismatch for ${name}: expected ${expectedSha}, got ${actualSha}`);
+    }
+  }
+}
+
+module.exports = {
+  ARCHIVE_EXT,
+  CONTRACT,
+  CONTRACT_PATH,
+  CRGX_BUNDLED_BINARY,
+  MANIFEST_NAME,
+  RELEASE_BUNDLED_BINARIES,
+  ZCCACHE_BUNDLED_BINARIES,
+  binaryName,
+  releaseBinaryNames,
+  validateReleaseManifest,
+  zccacheTargetForSoldrTarget,
+};

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -12,6 +12,8 @@ HELPER_SCRIPT_PATHS = (
     Path(".github/actions/setup-soldr/ensure_soldr.py"),
     Path(".github/actions/setup-soldr/install_tool_shims.py"),
     Path(".github/actions/setup-soldr/verify_soldr.py"),
+    Path(".github/actions/setup-soldr/zccache_contract.py"),
+    Path("contracts/zccache-runtime.v1.json"),
 )
 
 PUBLIC_ACTION_REPO = "zackees/setup-soldr"
@@ -19,7 +21,7 @@ PUBLIC_README = """# setup-soldr
 
 Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring a cacheable runner-local root for Soldr, Cargo, and rustup state.
 
-This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
+This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137, `docs/SETUP_SOLDR_PUBLIC_ACTION.md`, and `contracts/zccache-runtime.v1.json`.
 
 ## Usage
 
@@ -125,6 +127,7 @@ jobs:
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
 - The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
+- Released archives are validated against the versioned zccache runtime contract before setup-soldr exports `SOLDR_ZCCACHE_LOCAL_DIR`.
 - The default target cache mode is `thin`, which avoids action-owned `target/` snapshots by having soldr pass a bounded Rust artifact plan to zccache. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 - Native C/C++ compiler caching is on by default. Build-script work (bundled SQLite, ring, etc.) runs through zccache without any extra wiring. Set `native-cache: false` to opt out of just the native wrapping while keeping Rust caching intact, or use `soldr --no-cache cargo ...` at command time to disable both layers.

--- a/tests/fixtures/setup_soldr_exporter/expected_README.md
+++ b/tests/fixtures/setup_soldr_exporter/expected_README.md
@@ -2,7 +2,7 @@
 
 Public GitHub Action for installing one released `soldr` binary, provisioning the resolved Rust toolchain with `rustup`, and restoring a cacheable runner-local root for Soldr, Cargo, and rustup state.
 
-This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137 and `docs/SETUP_SOLDR_PUBLIC_ACTION.md`.
+This repository is intended to be generated from `zackees/soldr`. The source-of-truth contract and release process still live in `soldr` issue #137, `docs/SETUP_SOLDR_PUBLIC_ACTION.md`, and `contracts/zccache-runtime.v1.json`.
 
 ## Usage
 
@@ -108,6 +108,7 @@ jobs:
 - The normal path provisions Rust with `rustup`, bootstrapping `rustup` when it is absent.
 - The action rehydrates `SOLDR_CACHE_DIR`, `CARGO_HOME`, and `RUSTUP_HOME` under the selected cache root.
 - The action restores the Soldr-owned zccache cache root by default so child branches can reuse parent-branch build state.
+- Released archives are validated against the versioned zccache runtime contract before setup-soldr exports `SOLDR_ZCCACHE_LOCAL_DIR`.
 - The default target cache mode is `thin`, which avoids action-owned `target/` snapshots by having soldr pass a bounded Rust artifact plan to zccache. Use `target-cache-mode: full` only for tightly scoped jobs where the whole target directory is known to stay bounded.
 - The action exports `ZCCACHE_CACHE_DIR` to keep managed zccache artifact storage under `SOLDR_CACHE_DIR`.
 - Native C/C++ compiler caching is on by default. Build-script work (bundled SQLite, ring, etc.) runs through zccache without any extra wiring. Set `native-cache: false` to opt out of just the native wrapping while keeping Rust caching intact, or use `soldr --no-cache cargo ...` at command time to disable both layers.

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -122,7 +122,7 @@ def test_setup_soldr_smoke_tests_disable_nested_cache() -> None:
     ).read_text(encoding="utf-8")
 
     assert "Remove-Item Env:ZCCACHE_CACHE_DIR" in workflow
-    assert "soldr --no-cache cargo test -p soldr-cli --test cli --locked" in workflow
+    assert "soldr --no-cache cargo test -p soldr-cli --tests --locked" in workflow
     assert "id: dogfood-build-cache" in workflow
     assert "setup-soldr-dogfood-zccache-v1-" in workflow
     assert "dogfood-build-cache-hit=" in workflow

--- a/tests/test_setup_soldr_ensure_soldr.py
+++ b/tests/test_setup_soldr_ensure_soldr.py
@@ -34,3 +34,49 @@ def test_request_headers_omit_authorization_when_token_missing(monkeypatch) -> N
     headers = module._request_headers()
 
     assert "Authorization" not in headers
+
+
+def test_export_bundle_env_writes_local_dirs_when_bundle_present(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+    github_env = tmp_path / "github.env"
+    suffix = ".exe" if module.os.name == "nt" else ""
+
+    for base in module.ZCCACHE_BUNDLED_BINARIES + (module.CRGX_BUNDLED_BINARY,):
+        install_dir.joinpath(f"{base}{suffix}").write_text("binary", encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_ENV", str(github_env))
+    monkeypatch.delenv(module.ZCCACHE_LOCAL_DIR_ENV, raising=False)
+    monkeypatch.delenv(module.CRGX_LOCAL_DIR_ENV, raising=False)
+
+    module._export_bundle_env(install_dir)
+
+    assert github_env.read_text(encoding="utf-8") == (
+        f"{module.ZCCACHE_LOCAL_DIR_ENV}={install_dir}\n{module.CRGX_LOCAL_DIR_ENV}={install_dir}\n"
+    )
+
+
+def test_export_bundle_env_preserves_explicit_overrides(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+    github_env = tmp_path / "github.env"
+    suffix = ".exe" if module.os.name == "nt" else ""
+
+    for base in module.ZCCACHE_BUNDLED_BINARIES + (module.CRGX_BUNDLED_BINARY,):
+        install_dir.joinpath(f"{base}{suffix}").write_text("binary", encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_ENV", str(github_env))
+    monkeypatch.setenv(module.ZCCACHE_LOCAL_DIR_ENV, str(tmp_path / "zccache-override"))
+    monkeypatch.setenv(module.CRGX_LOCAL_DIR_ENV, str(tmp_path / "crgx-override"))
+
+    module._export_bundle_env(install_dir)
+
+    assert github_env.read_text(encoding="utf-8") == ""

--- a/tests/test_setup_soldr_exporter.py
+++ b/tests/test_setup_soldr_exporter.py
@@ -36,9 +36,11 @@ def test_export_bundle_creates_expected_public_repo_layout(tmp_path: Path) -> No
         ".github/actions/setup-soldr/install_tool_shims.py",
         ".github/actions/setup-soldr/resolve_setup.py",
         ".github/actions/setup-soldr/verify_soldr.py",
+        ".github/actions/setup-soldr/zccache_contract.py",
         "LICENSE",
         "README.md",
         "action.yml",
+        "contracts/zccache-runtime.v1.json",
     ]
 
     assert destination.joinpath("action.yml").read_text(encoding="utf-8") == FIXTURE_DIR.joinpath(

--- a/tests/test_zccache_runtime_contract.py
+++ b/tests/test_zccache_runtime_contract.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = REPO_ROOT / "contracts" / "zccache-runtime.v1.json"
+PY_CONTRACT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "zccache_contract.py"
+
+
+def _load_py_contract():
+    spec = importlib.util.spec_from_file_location("zccache_contract", PY_CONTRACT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _write_manifest_fixture(root: Path, *, windows: bool = False) -> dict[str, object]:
+    module = _load_py_contract()
+    names = module.release_binary_names(windows=windows)
+    payloads: dict[str, bytes] = {}
+    for name in names:
+        payload = f"{name}\n".encode("utf-8")
+        payloads[name] = payload
+        (root / name).write_bytes(payload)
+
+    suffix = ".exe" if windows else ""
+    return {
+        "schema_version": 2,
+        "soldr": {
+            "version": "0.7.39",
+            "target": "x86_64-unknown-linux-gnu",
+            "binary": f"soldr{suffix}",
+            "sha256": _sha256(payloads[f"soldr{suffix}"]),
+            "commit_sha": "abc123",
+        },
+        "zccache": {
+            "version": module.CONTRACT["zccache"]["managed_version"],
+            "target": "x86_64-unknown-linux-musl",
+            "binaries": [
+                {
+                    "name": f"{base}{suffix}",
+                    "sha256": _sha256(payloads[f"{base}{suffix}"]),
+                }
+                for base in module.ZCCACHE_BUNDLED_BINARIES
+            ],
+        },
+        "crgx": {
+            "version": module.CONTRACT["crgx"]["managed_version"],
+            "target": "x86_64-unknown-linux-gnu",
+            "binary": f"crgx{suffix}",
+            "sha256": _sha256(payloads[f"crgx{suffix}"]),
+            "source_commit": "def456",
+        },
+        "archive": {
+            "format": module.ARCHIVE_EXT,
+            "compression_level": module.CONTRACT["release_archive"]["compression_level"],
+        },
+        "built_at": "2026-05-27T00:00:00Z",
+    }
+
+
+def test_contract_json_has_expected_shape() -> None:
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+    assert contract["schema_version"] == 1
+    assert contract["release_archive"]["extension"] == "tar.zst"
+    assert contract["release_archive"]["manifest_min_schema_version"] == 2
+    assert contract["zccache"]["local_dir_env"] == "SOLDR_ZCCACHE_LOCAL_DIR"
+    assert contract["zccache"]["required_binaries"] == [
+        "zccache",
+        "zccache-daemon",
+        "zccache-fp",
+    ]
+    assert contract["crgx"]["local_dir_env"] == "SOLDR_CRGX_LOCAL_DIR"
+    assert contract["crgx"]["required_binaries"] == ["crgx"]
+
+
+def test_python_contract_validates_release_manifest_sha256s(tmp_path: Path) -> None:
+    module = _load_py_contract()
+    manifest = _write_manifest_fixture(tmp_path)
+
+    module.validate_release_manifest(
+        manifest,
+        soldr_target="x86_64-unknown-linux-gnu",
+        windows=False,
+        extract_dir=tmp_path,
+    )
+
+    manifest["zccache"]["binaries"][0]["sha256"] = "0" * 64
+    with pytest.raises(RuntimeError, match="sha256 mismatch"):
+        module.validate_release_manifest(
+            manifest,
+            soldr_target="x86_64-unknown-linux-gnu",
+            windows=False,
+            extract_dir=tmp_path,
+        )
+
+
+def test_python_action_helpers_import_contract_constants() -> None:
+    module = _load_py_contract()
+    ensure_spec = importlib.util.spec_from_file_location(
+        "ensure_soldr",
+        REPO_ROOT / ".github" / "actions" / "setup-soldr" / "ensure_soldr.py",
+    )
+    ensure_soldr = importlib.util.module_from_spec(ensure_spec)
+    assert ensure_spec is not None
+    assert ensure_spec.loader is not None
+    ensure_spec.loader.exec_module(ensure_soldr)
+
+    assert ensure_soldr.ARCHIVE_EXT == module.ARCHIVE_EXT
+    assert ensure_soldr.ZCCACHE_BUNDLED_BINARIES == module.ZCCACHE_BUNDLED_BINARIES
+    assert ensure_soldr.CRGX_BUNDLED_BINARY == module.CRGX_BUNDLED_BINARY
+
+
+def test_release_workflow_and_docs_reference_contract_layout() -> None:
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    release_workflow = (REPO_ROOT / ".github" / "workflows" / "release-auto.yml").read_text(
+        encoding="utf-8"
+    )
+    npm_docs = (REPO_ROOT / "docs" / "NPM_PUBLISHING.md").read_text(encoding="utf-8")
+    runtime_docs = (REPO_ROOT / "docs" / "ZCCACHE_RUNTIME_CONTRACT.md").read_text(encoding="utf-8")
+
+    assert '"schema_version": 2' in release_workflow
+    assert '"format": "tar.zst"' in release_workflow
+    for base in contract["release_archive"]["required_binaries"]:
+        assert base in release_workflow
+        assert base in npm_docs
+    assert "contracts/zccache-runtime.v1.json" in npm_docs
+    assert "contracts/zccache-runtime.v1.json" in runtime_docs
+
+
+def test_npm_package_exports_contract_files() -> None:
+    package = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+
+    assert "contracts/zccache-runtime.v1.json" in package["files"]
+    assert "scripts/zccache-contract.js" in package["files"]


### PR DESCRIPTION
Closes #547.
Part of #543.

## Summary

- Adds `contracts/zccache-runtime.v1.json` as the shared zccache/archive/env contract for Rust, setup-soldr, npm, docs, and public-action export.
- Wires setup-soldr and npm install/launcher paths to contract constants, validates release `manifest.json` sha256 records before staging bundled binaries, and exports local zccache/crgx dirs on warm cached installs when the expected bundle is present.
- Adds Python, Rust, and Node guardrails so release layout, env vars, binary trio, package files, docs, and exporter fixtures stay synchronized.

## Validation

- `soldr cargo fmt --all`
- `soldr cargo check -p soldr-cli --all-targets`
- `soldr cargo test -p soldr-cli fetch::zccache_contract_tests`
- `soldr cargo test -p soldr-cli --lib`
- `soldr cargo clippy -p soldr-cli --all-targets -- -D warnings`
- `uv run ruff check .github/actions/setup-soldr/ensure_soldr.py .github/actions/setup-soldr/zccache_contract.py src/soldr/setup_soldr_exporter.py tests/test_setup_soldr_exporter.py tests/test_setup_soldr_action.py tests/test_setup_soldr_ensure_soldr.py tests/test_zccache_runtime_contract.py`
- `uv run pytest tests/test_zccache_runtime_contract.py tests/test_setup_soldr_exporter.py tests/test_setup_soldr_action.py tests/test_setup_soldr_ensure_soldr.py -q`
- `node scripts/test-npm-package.js`
- `node --check scripts/zccache-contract.js`
- `node --check scripts/install.js`
- `node --check bin/soldr.js`
- `git diff --check`

## Known unrelated local gaps

- Full `uv run pytest -q` currently fails outside this change: cache benchmark report tests require Pillow / have expected-output drift, and `test_workflows_pin_setup_soldr_to_current_v0_sha` reports the checked-in setup-soldr pin differs from the current public `@v0` SHA.