### PR TITLE
test(zccache): add integration guardrails

### DIFF
--- a/contracts/zccache-integration-guardrails.v1.json
+++ b/contracts/zccache-integration-guardrails.v1.json
@@ -1,0 +1,337 @@
+{
+  "schema_version": 1,
+  "name": "soldr-zccache-integration-guardrails",
+  "parent_issue": "https://github.com/zackees/soldr/issues/543",
+  "wave_issue": "https://github.com/zackees/soldr/issues/548",
+  "policy": {
+    "hard_gate": "Must pass before zccache integration refactor waves merge.",
+    "report_only": "Must remain runnable and documented, but does not block every PR unless the refactor touches that path.",
+    "discovery_rule": "If implementation finds a new soldr/zccache refactor area, file a child issue and add it to the parent issue ledger before or alongside the implementation PR."
+  },
+  "validation_commands": [
+    {
+      "id": "rust-contract-matrix",
+      "gate": "hard",
+      "command": "soldr --no-cache cargo test -p soldr-cli --test cli_zccache_contract_matrix --locked"
+    },
+    {
+      "id": "rust-source-resolution",
+      "gate": "hard",
+      "command": "soldr --no-cache cargo test -p soldr-cli --test cli_install_zccache_resolution --locked"
+    },
+    {
+      "id": "rust-wrapper-env",
+      "gate": "hard",
+      "command": "soldr --no-cache cargo test -p soldr-cli --test cli_cargo_wrappers --locked"
+    },
+    {
+      "id": "rust-native-cache-unit",
+      "gate": "hard",
+      "command": "soldr --no-cache cargo test -p soldr-cli --bin soldr --locked native_cc::tests"
+    },
+    {
+      "id": "rust-unknown-session-retry",
+      "gate": "hard",
+      "command": "soldr --no-cache cargo test -p soldr-cli --test cli_unknown_session_retry --locked"
+    },
+    {
+      "id": "rust-native-cache-integration",
+      "gate": "report-only",
+      "command": "soldr --no-cache cargo test -p soldr-cli --test cli_cargo_native_cc --locked"
+    },
+    {
+      "id": "rust-wrapper-perf",
+      "gate": "hard",
+      "command": "soldr --no-cache cargo test -p soldr-cli --test cli_wrapper_perf --locked"
+    },
+    {
+      "id": "rust-watchdog-lint",
+      "gate": "hard",
+      "command": "soldr --no-cache cargo test -p soldr-cli --test timed_test_lint --locked"
+    },
+    {
+      "id": "python-setup-contracts",
+      "gate": "hard",
+      "command": "uv run pytest tests/test_zccache_integration_guardrails.py tests/test_zccache_runtime_contract.py tests/test_setup_soldr_action.py tests/test_setup_soldr_exporter.py tests/test_setup_soldr_ensure_soldr.py -q"
+    },
+    {
+      "id": "node-npm-contract",
+      "gate": "hard",
+      "command": "node scripts/test-npm-package.js"
+    },
+    {
+      "id": "perf-cold-warm",
+      "gate": "report-only",
+      "command": "gh workflow run perf-cold-warm.yml -f run_mode='Purge cache and run cold build before warm build' -f fixture=medium"
+    },
+    {
+      "id": "perf-matrix-worktree-touch",
+      "gate": "report-only",
+      "command": "gh workflow run perf-matrix.yml -f platforms=linux -f fixtures=medium -f scenarios=all"
+    }
+  ],
+  "guardrails": [
+    {
+      "id": "source-precedence",
+      "axis": "source resolution",
+      "gate": "hard",
+      "covers": [
+        "SOLDR_TEST_ZCCACHE_BIN override",
+        "SOLDR_ZCCACHE_LOCAL_DIR override",
+        "pinned managed runtime",
+        "managed cached/runtime fallback",
+        "system fallback diagnostics"
+      ],
+      "test_files": [
+        "crates/soldr-cli/tests/cli_install_zccache_resolution.rs",
+        "crates/soldr-cli/src/fetch/zccache_contract_tests.rs",
+        "tests/test_zccache_runtime_contract.py"
+      ],
+      "validation_command_ids": [
+        "rust-source-resolution",
+        "python-setup-contracts"
+      ]
+    },
+    {
+      "id": "managed-session-env",
+      "axis": "session lifecycle and child env",
+      "gate": "hard",
+      "covers": [
+        "zccache start",
+        "session-start",
+        "ZCCACHE_SESSION_ID propagation",
+        "ZCCACHE_CACHE_DIR propagation",
+        "ZCCACHE_PATH_REMAP propagation",
+        "ZCCACHE_WORKTREE_ROOT propagation",
+        "session-end stats"
+      ],
+      "test_files": [
+        "crates/soldr-cli/tests/cli_zccache_contract_matrix.rs",
+        "crates/soldr-cli/tests/cli_cargo_basic.rs",
+        "crates/soldr-cli/src/cargo_front_door/cache_plan.rs"
+      ],
+      "validation_command_ids": [
+        "rust-contract-matrix",
+        "rust-wrapper-env"
+      ]
+    },
+    {
+      "id": "rust-plan-cache",
+      "axis": "rust artifact plan",
+      "gate": "hard",
+      "covers": [
+        "restore before cargo",
+        "save after cargo",
+        "managed daemon cache dir",
+        "artifact bundle cache dir",
+        "partial restore warning"
+      ],
+      "test_files": [
+        "crates/soldr-cli/tests/cli_zccache_contract_matrix.rs",
+        "crates/soldr-cli/tests/cli_rust_plan.rs",
+        "crates/soldr-cli/src/rust_plan_tests"
+      ],
+      "validation_command_ids": [
+        "rust-contract-matrix"
+      ]
+    },
+    {
+      "id": "disabled-and-non-build",
+      "axis": "cache scoping",
+      "gate": "hard",
+      "covers": [
+        "--no-cache build bypasses managed zccache",
+        "non-build cargo commands bypass managed zccache",
+        "SOLDR_CACHE_ENABLED=0 reaches cargo"
+      ],
+      "test_files": [
+        "crates/soldr-cli/tests/cli_zccache_contract_matrix.rs",
+        "crates/soldr-cli/tests/cli_cargo_wrappers.rs"
+      ],
+      "validation_command_ids": [
+        "rust-contract-matrix",
+        "rust-wrapper-env"
+      ]
+    },
+    {
+      "id": "unknown-session-retry",
+      "axis": "wrapper recovery",
+      "gate": "hard",
+      "platforms": [
+        "windows"
+      ],
+      "covers": [
+        "one retry after zccache unknown session",
+        "fresh session allocation for retry",
+        "non-session errors do not retry"
+      ],
+      "test_files": [
+        "crates/soldr-cli/tests/cli_unknown_session_retry.rs",
+        "crates/soldr-cli/src/wrapper.rs",
+        "crates/soldr-cli/src/zccache_lifecycle.rs"
+      ],
+      "validation_command_ids": [
+        "rust-unknown-session-retry",
+        "rust-watchdog-lint"
+      ]
+    },
+    {
+      "id": "shutdown-scoping",
+      "axis": "daemon shutdown",
+      "gate": "hard",
+      "covers": [
+        "command-lifetime stop after session-end",
+        "failed cargo still shuts down",
+        "shutdown uses soldr-owned cache root",
+        "daemon-down diagnostics"
+      ],
+      "test_files": [
+        "crates/soldr-cli/tests/cli_zccache_contract_matrix.rs",
+        "crates/soldr-cli/tests/cli_cache.rs",
+        "crates/soldr-cli/tests/cli_cargo_basic.rs"
+      ],
+      "validation_command_ids": [
+        "rust-contract-matrix"
+      ]
+    },
+    {
+      "id": "setup-action-outputs",
+      "axis": "setup-soldr action",
+      "gate": "hard",
+      "covers": [
+        "cache-hit output",
+        "build-cache-hit output",
+        "target-cache-hit output",
+        "native-cache-enabled output",
+        "target-cache mode/key policy"
+      ],
+      "test_files": [
+        "action.yml",
+        ".github/actions/setup-soldr/resolve_setup.py",
+        "tests/test_setup_soldr_action.py",
+        "tests/test_setup_soldr_exporter.py"
+      ],
+      "validation_command_ids": [
+        "python-setup-contracts"
+      ]
+    },
+    {
+      "id": "release-npm-staging",
+      "axis": "release and npm staging",
+      "gate": "hard",
+      "covers": [
+        "release archive manifest",
+        "zccache binary trio",
+        "crgx binary",
+        "setup-soldr manifest validation",
+        "npm bundled contract files"
+      ],
+      "test_files": [
+        "contracts/zccache-runtime.v1.json",
+        "contracts/zccache-integration-guardrails.v1.json",
+        ".github/workflows/release-auto.yml",
+        "scripts/zccache-contract.js",
+        "scripts/test-npm-package.js",
+        "tests/test_zccache_runtime_contract.py"
+      ],
+      "validation_command_ids": [
+        "python-setup-contracts",
+        "node-npm-contract"
+      ]
+    },
+    {
+      "id": "perf-cold-warm",
+      "axis": "performance",
+      "gate": "report-only",
+      "covers": [
+        "cold build",
+        "warm build",
+        "flush before save",
+        "hit-rate reporting"
+      ],
+      "test_files": [
+        ".github/workflows/perf-cold-warm.yml",
+        "crates/soldr-cli/tests/cli_cargo_wrappers.rs"
+      ],
+      "validation_command_ids": [
+        "rust-wrapper-env",
+        "perf-cold-warm"
+      ]
+    },
+    {
+      "id": "perf-worktree-share",
+      "axis": "performance",
+      "gate": "report-only",
+      "covers": [
+        "shared cache across worktrees",
+        "branch/worktree target reuse"
+      ],
+      "test_files": [
+        ".github/workflows/perf-matrix.yml",
+        "perf/scenarios/worktree-share/run.sh"
+      ],
+      "validation_command_ids": [
+        "perf-matrix-worktree-touch"
+      ]
+    },
+    {
+      "id": "perf-touch-no-change",
+      "axis": "performance",
+      "gate": "report-only",
+      "covers": [
+        "touch without source change",
+        "Cargo fingerprint churn canary"
+      ],
+      "test_files": [
+        ".github/workflows/perf-matrix.yml",
+        "perf/scenarios/touch-no-change/run.sh"
+      ],
+      "validation_command_ids": [
+        "perf-matrix-worktree-touch"
+      ]
+    },
+    {
+      "id": "native-cc-cache",
+      "axis": "native C/C++ cache",
+      "gate": "hard",
+      "covers": [
+        "CC wrapper injection",
+        "CXX wrapper injection",
+        "CC_KNOWN_WRAPPER_CUSTOM",
+        "SOLDR_NATIVE_CACHE=0 opt-out",
+        "--no-cache disables native cache"
+      ],
+      "test_files": [
+        "crates/soldr-cli/tests/cli_cargo_native_cc.rs",
+        "crates/soldr-cli/src/native_cc_tests.rs",
+        "crates/soldr-cli/src/cargo_front_door/cache_plan.rs"
+      ],
+      "validation_command_ids": [
+        "rust-native-cache-unit",
+        "rust-native-cache-integration"
+      ],
+      "follow_up_issues": [
+        "https://github.com/zackees/soldr/issues/551"
+      ]
+    },
+    {
+      "id": "monolith-migration-ratchet",
+      "axis": "test ownership",
+      "gate": "hard",
+      "covers": [
+        "new zccache integration tests live outside monolithic source modules",
+        "new tests use timed_test watchdog",
+        "wave-specific contract tests remain discoverable"
+      ],
+      "test_files": [
+        "crates/soldr-cli/tests/timed_test_lint.rs",
+        "crates/soldr-cli/src/fetch/zccache_contract_tests.rs",
+        "crates/soldr-cli/src/cargo_front_door/cache_plan.rs",
+        "crates/soldr-cli/src/zccache_lifecycle.rs"
+      ],
+      "validation_command_ids": [
+        "rust-watchdog-lint"
+      ]
+    }
+  ]
+}

--- a/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
+++ b/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
@@ -1,0 +1,274 @@
+//! Compact zccache integration contract matrix for issue #548.
+//!
+//! The narrow regression tests still own the details. This file locks the
+//! cross-cutting contract that those details are supposed to compose into:
+//! source resolution, managed daemon/session lifecycle, cargo env propagation,
+//! rust-plan restore/save ordering, and command-lifetime shutdown.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use serde_json::Value;
+use soldr_cli::timed_test;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
+
+struct ContractFixture {
+    cache_root: PathBuf,
+    workspace: PathBuf,
+    plan_cache: PathBuf,
+    zccache_cache_dir: PathBuf,
+    log_path: PathBuf,
+    metadata_path: PathBuf,
+    cargo: PathBuf,
+    rustc: PathBuf,
+    zccache: PathBuf,
+}
+
+fn seed_contract_fixture(label: &str) -> ContractFixture {
+    let cache_root = unique_temp_dir(&format!("{label}-cache"));
+    let workspace = unique_temp_dir(&format!("{label}-workspace"));
+    let plan_cache = cache_root.join("target-artifact-cache");
+    let zccache_cache_dir = cache_root.join("cache").join("zccache");
+    let log_path = cache_root.join("tool.log");
+    let metadata_path = cache_root.join("metadata.json");
+    let target_dir = workspace.join("target");
+
+    fs::create_dir_all(workspace.join(".git")).expect("create fake git root");
+    fs::create_dir_all(workspace.join("app").join("src")).expect("create app source");
+    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::write(workspace.join("Cargo.lock"), "# lock\n").expect("write lockfile");
+    fs::write(
+        workspace.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"app\"]\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(
+        workspace.join("app").join("Cargo.toml"),
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write app manifest");
+    fs::write(
+        workspace.join("app").join("src").join("lib.rs"),
+        "pub fn answer() -> i32 { 42 }\n",
+    )
+    .expect("write app source");
+
+    let metadata = serde_json::json!({
+        "packages": [
+            {
+                "id": "path+file:///repo/app#app@0.1.0",
+                "source": null
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+                "source": "registry+https://github.com/rust-lang/crates.io-index"
+            }
+        ],
+        "workspace_members": ["path+file:///repo/app#app@0.1.0"],
+        "workspace_root": workspace,
+        "target_directory": target_dir
+    });
+    fs::write(&metadata_path, serde_json::to_string(&metadata).unwrap())
+        .expect("write cargo metadata fixture");
+
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+
+    ContractFixture {
+        cache_root,
+        workspace,
+        plan_cache,
+        zccache_cache_dir,
+        log_path,
+        metadata_path,
+        cargo,
+        rustc,
+        zccache,
+    }
+}
+
+fn soldr_with_fake_toolchain(fixture: &ContractFixture) -> Command {
+    let mut command = isolated_soldr_command();
+    command
+        .current_dir(&fixture.workspace)
+        .env("SOLDR_CACHE_DIR", &fixture.cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &fixture.cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &fixture.rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &fixture.zccache)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .env_remove("SOLDR_TARGET_CACHE_PROFILE");
+    command
+}
+
+fn log_contains_path(log: &str, prefix: &str, path: &Path) -> bool {
+    path_display_variants(path)
+        .iter()
+        .any(|variant| log.contains(&format!("{prefix}{variant}")))
+}
+
+fn assert_log_order(log: &str, left: &str, right: &str) {
+    let left_pos = log
+        .find(left)
+        .unwrap_or_else(|| panic!("missing {left:?} in log:\n{log}"));
+    let right_pos = log
+        .find(right)
+        .unwrap_or_else(|| panic!("missing {right:?} in log:\n{log}"));
+    assert!(
+        left_pos < right_pos,
+        "expected {left:?} before {right:?} in log:\n{log}"
+    );
+}
+
+fn assert_no_managed_zccache(log: &str) {
+    for needle in [
+        "zccache start",
+        "zccache session-start",
+        "zccache wrapper",
+        "zccache rust-plan",
+        "zccache session-end",
+        "zccache stop",
+    ] {
+        assert!(
+            !log.contains(needle),
+            "managed zccache should be skipped but found {needle:?} in log:\n{log}"
+        );
+    }
+}
+
+timed_test!(
+    managed_zccache_contract_matrix_covers_session_env_rust_plan_and_shutdown,
+    Duration::from_secs(120),
+    {
+        let fixture = seed_contract_fixture("zccache-contract-matrix");
+        let down_marker = fixture.cache_root.join("zccache-down");
+        let output = soldr_with_fake_toolchain(&fixture)
+            .args(["cargo", "build", "--locked"])
+            .env("SOLDR_TEST_CARGO_METADATA_PATH", &fixture.metadata_path)
+            .env("SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER", &down_marker)
+            .env("SOLDR_TARGET_CACHE_MODE", "thin")
+            .env("SOLDR_TARGET_CACHE_BUNDLE_DIR", &fixture.plan_cache)
+            .env("SOLDR_CACHE_LIFECYCLE", "command")
+            .env("SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS", "5")
+            .output()
+            .expect("run soldr cargo build");
+
+        assert!(
+            output.status.success(),
+            "contract matrix build failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let log = fs::read_to_string(&fixture.log_path).expect("read fake tool log");
+        assert_log_order(&log, "zccache start", "zccache session-start");
+        assert_log_order(&log, "zccache session-start", "zccache rust-plan restore");
+        assert_log_order(&log, "zccache rust-plan restore", "cargo wrapper=");
+        assert_log_order(&log, "cargo wrapper=", "zccache wrapper");
+        assert_log_order(&log, "zccache wrapper", "zccache rust-plan save");
+        assert_log_order(
+            &log,
+            "zccache rust-plan save",
+            "zccache session-end test-session --json",
+        );
+        assert_log_order(
+            &log,
+            "zccache session-end test-session --json",
+            "zccache stop",
+        );
+
+        assert!(
+            log_contains_owned_soldr_wrapper(&log, &fixture.cache_root),
+            "soldr should own RUSTC_WRAPPER in managed mode:\n{log}"
+        );
+        assert!(
+            log.contains("cache=1") && log.contains("session=test-session"),
+            "cargo child should receive cache/session env:\n{log}"
+        );
+        assert!(
+            log_contains_path(&log, "zccache_dir=", &fixture.zccache_cache_dir)
+                && log_contains_path(&log, "cache_dir=", &fixture.zccache_cache_dir),
+            "cargo and zccache should use the soldr-owned zccache cache dir:\n{log}"
+        );
+        assert!(
+            log.contains("path_remap=auto"),
+            "managed zccache should enable normalized path remap:\n{log}"
+        );
+        assert!(
+            log_contains_path(&log, "worktree_root=", &fixture.workspace),
+            "managed zccache should pass the git root as worktree root:\n{log}"
+        );
+        assert!(
+            log_contains_path(&log, "--cache-dir ", &fixture.plan_cache),
+            "rust-plan should receive the target artifact bundle dir:\n{log}"
+        );
+
+        let logs_dir = fixture.zccache_cache_dir.join("logs");
+        let session_log = logs_dir.join("last-session.log");
+        let journal = logs_dir.join("last-session.jsonl");
+        let stats = logs_dir.join("last-session-stats.json");
+        assert!(session_log.exists(), "missing {}", session_log.display());
+        assert!(journal.exists(), "missing {}", journal.display());
+        let stats_json: Value = serde_json::from_str(
+            &fs::read_to_string(&stats)
+                .unwrap_or_else(|err| panic!("failed to read {}: {err}", stats.display())),
+        )
+        .expect("parse session stats");
+        assert_eq!(stats_json["status"], "ok");
+        assert_eq!(stats_json["session_id"], "test-session");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("soldr: zccache session summary"),
+            "session summary should remain visible to users:\n{stderr}"
+        );
+    }
+);
+
+timed_test!(
+    disabled_and_non_build_paths_skip_managed_zccache,
+    Duration::from_secs(120),
+    {
+        let no_cache = seed_contract_fixture("zccache-contract-no-cache");
+        let no_cache_output = soldr_with_fake_toolchain(&no_cache)
+            .args(["--no-cache", "cargo", "build", "--locked"])
+            .output()
+            .expect("run soldr --no-cache cargo build");
+        assert!(
+            no_cache_output.status.success(),
+            "no-cache build failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&no_cache_output.stdout),
+            String::from_utf8_lossy(&no_cache_output.stderr)
+        );
+        let no_cache_log = fs::read_to_string(&no_cache.log_path).expect("read no-cache log");
+        assert!(
+            no_cache_log.contains("cache=0"),
+            "--no-cache should propagate SOLDR_CACHE_ENABLED=0:\n{no_cache_log}"
+        );
+        assert_no_managed_zccache(&no_cache_log);
+
+        let metadata = seed_contract_fixture("zccache-contract-metadata");
+        let metadata_output = soldr_with_fake_toolchain(&metadata)
+            .args(["cargo", "metadata"])
+            .output()
+            .expect("run soldr cargo metadata");
+        assert!(
+            metadata_output.status.success(),
+            "metadata command failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&metadata_output.stdout),
+            String::from_utf8_lossy(&metadata_output.stderr)
+        );
+        let metadata_log = fs::read_to_string(&metadata.log_path).expect("read metadata log");
+        assert!(
+            metadata_log.contains("cache=0"),
+            "non-build cargo should propagate SOLDR_CACHE_ENABLED=0:\n{metadata_log}"
+        );
+        assert_no_managed_zccache(&metadata_log);
+    }
+);

--- a/docs/ZCCACHE_INTEGRATION_GUARDRAILS.md
+++ b/docs/ZCCACHE_INTEGRATION_GUARDRAILS.md
@@ -1,0 +1,80 @@
+# Zccache Integration Guardrails
+
+`contracts/zccache-integration-guardrails.v1.json` is the test and perf
+ledger for the zccache refactor tracked by soldr issue #543. It exists so the
+runtime/source, session, wrapper, setup-soldr, release, npm, and perf contracts
+are visible in one place instead of rediscovered from scattered regression
+tests.
+
+## Gate Policy
+
+Hard gates must pass before a zccache integration refactor wave merges. Report
+only canaries must stay runnable and documented, but they are expected to run on
+manual workflow dispatches or targeted perf branches rather than every PR.
+
+If implementation finds a new soldr/zccache refactor area, file a child issue
+and add it to the parent issue ledger before or alongside the implementation
+PR. Do not fold unrelated refactors into the current wave without recording the
+new work.
+
+## Required Validation Commands
+
+Run these hard gates for zccache integration refactor waves:
+
+```powershell
+soldr --no-cache cargo test -p soldr-cli --test cli_zccache_contract_matrix --locked
+soldr --no-cache cargo test -p soldr-cli --test cli_install_zccache_resolution --locked
+soldr --no-cache cargo test -p soldr-cli --test cli_cargo_wrappers --locked
+soldr --no-cache cargo test -p soldr-cli --bin soldr --locked native_cc::tests
+soldr --no-cache cargo test -p soldr-cli --test cli_unknown_session_retry --locked
+soldr --no-cache cargo test -p soldr-cli --test cli_wrapper_perf --locked
+soldr --no-cache cargo test -p soldr-cli --test timed_test_lint --locked
+uv run pytest tests/test_zccache_integration_guardrails.py tests/test_zccache_runtime_contract.py tests/test_setup_soldr_action.py tests/test_setup_soldr_exporter.py tests/test_setup_soldr_ensure_soldr.py -q
+node scripts/test-npm-package.js
+```
+
+Run these report-only canaries when a wave touches perf-sensitive zccache
+behavior:
+
+```powershell
+gh workflow run perf-cold-warm.yml -f run_mode='Purge cache and run cold build before warm build' -f fixture=medium
+gh workflow run perf-matrix.yml -f platforms=linux -f fixtures=medium -f scenarios=all
+soldr --no-cache cargo test -p soldr-cli --test cli_cargo_native_cc --locked
+```
+
+## Guardrail Axes
+
+- `source-precedence`: locks the zccache source-resolution order across test
+  overrides, local development builds, pinned managed runtime, managed cached
+  runtime, and system fallback diagnostics.
+- `managed-session-env`: locks managed daemon/session startup and the cargo
+  child environment: `ZCCACHE_SESSION_ID`, `ZCCACHE_CACHE_DIR`,
+  `ZCCACHE_PATH_REMAP`, and `ZCCACHE_WORKTREE_ROOT`.
+- `rust-plan-cache`: locks zccache `rust-plan restore` before Cargo and
+  `rust-plan save` after Cargo, while keeping the managed daemon cache root
+  separate from the target artifact bundle path.
+- `disabled-and-non-build`: locks `--no-cache` and non-build cargo commands so
+  they propagate `SOLDR_CACHE_ENABLED=0` and do not start managed zccache.
+- `unknown-session-retry`: locks the Windows wrapper recovery path for
+  `zccache error: unknown session:` so soldr retries once with a fresh session.
+- `shutdown-scoping`: locks command-lifetime shutdown so `session-end` happens
+  before daemon stop and the stop targets the soldr-owned zccache root.
+- `setup-action-outputs`: locks setup-soldr cache outputs, target-cache mode,
+  target-cache keys, and native-cache policy output.
+- `release-npm-staging`: locks release archive manifest validation, bundled
+  zccache/crgx binaries, and npm package contract files.
+- `perf-cold-warm`: keeps the cold/warm build and hit-rate workflow runnable.
+- `perf-worktree-share`: keeps shared-cache worktree reuse measurable.
+- `perf-touch-no-change`: keeps touch-without-change fingerprint churn
+  measurable.
+- `native-cc-cache`: locks native C/C++ env injection and opt-out behavior.
+- `monolith-migration-ratchet`: ensures new zccache integration tests are
+  discoverable outside monolithic source modules and use the `timed_test`
+  watchdog.
+
+## Native Cache Follow-Up
+
+Issue #551 tracks the Windows managed-wrapper build-script hang discovered
+during this refactor. Until that lands, native env shaping is a hard unit/env
+contract, while the real `cli_cargo_native_cc` managed-wrapper integration test
+is a report-only canary and a known follow-up for Windows reliability.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "bin/soldr.js",
+    "contracts/zccache-integration-guardrails.v1.json",
     "contracts/zccache-runtime.v1.json",
     "scripts/install.js",
     "scripts/zccache-contract.js",

--- a/scripts/test-npm-package.js
+++ b/scripts/test-npm-package.js
@@ -67,6 +67,7 @@ assert.strictEqual(pkg.bin.soldr, "bin/soldr.js");
 assert.strictEqual(pkg.repository.url, "git+https://github.com/zackees/soldr.git");
 assert.deepStrictEqual(pkg.files, [
   "bin/soldr.js",
+  "contracts/zccache-integration-guardrails.v1.json",
   "contracts/zccache-runtime.v1.json",
   "scripts/install.js",
   "scripts/zccache-contract.js",
@@ -132,6 +133,10 @@ assert.deepStrictEqual(zccacheContract.ZCCACHE_BUNDLED_BINARIES, [
   "zccache-daemon",
   "zccache-fp",
 ]);
+assert.ok(
+  fs.existsSync(path.join(root, "contracts", "zccache-integration-guardrails.v1.json")),
+  "npm package must include the zccache integration guardrail contract",
+);
 
 // Every TARGETS entry must drop the `archive` field — the combined
 // archive format is fixed (.tar.zst) so the per-target field is dead

--- a/tests/test_zccache_integration_guardrails.py
+++ b/tests/test_zccache_integration_guardrails.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GUARDRAILS_PATH = REPO_ROOT / "contracts" / "zccache-integration-guardrails.v1.json"
+DOCS_PATH = REPO_ROOT / "docs" / "ZCCACHE_INTEGRATION_GUARDRAILS.md"
+
+REQUIRED_GUARDRAIL_IDS = {
+    "source-precedence",
+    "managed-session-env",
+    "rust-plan-cache",
+    "disabled-and-non-build",
+    "unknown-session-retry",
+    "shutdown-scoping",
+    "setup-action-outputs",
+    "release-npm-staging",
+    "perf-cold-warm",
+    "perf-worktree-share",
+    "perf-touch-no-change",
+    "native-cc-cache",
+    "monolith-migration-ratchet",
+}
+
+REQUIRED_COMMAND_IDS = {
+    "rust-contract-matrix",
+    "rust-source-resolution",
+    "rust-wrapper-env",
+    "rust-native-cache-unit",
+    "rust-unknown-session-retry",
+    "rust-native-cache-integration",
+    "rust-wrapper-perf",
+    "rust-watchdog-lint",
+    "python-setup-contracts",
+    "node-npm-contract",
+    "perf-cold-warm",
+    "perf-matrix-worktree-touch",
+}
+
+
+def _guardrails() -> dict[str, object]:
+    return json.loads(GUARDRAILS_PATH.read_text(encoding="utf-8"))
+
+
+def test_guardrail_contract_has_required_axes_and_commands() -> None:
+    contract = _guardrails()
+
+    assert contract["schema_version"] == 1
+    assert contract["parent_issue"] == "https://github.com/zackees/soldr/issues/543"
+    assert contract["wave_issue"] == "https://github.com/zackees/soldr/issues/548"
+
+    commands = contract["validation_commands"]
+    command_ids = {command["id"] for command in commands}
+    assert command_ids == REQUIRED_COMMAND_IDS
+    for command in commands:
+        assert command["gate"] in {"hard", "report-only"}
+        assert command["command"].strip()
+
+    guardrails = contract["guardrails"]
+    guardrail_ids = {guardrail["id"] for guardrail in guardrails}
+    assert guardrail_ids == REQUIRED_GUARDRAIL_IDS
+    for guardrail in guardrails:
+        assert guardrail["gate"] in {"hard", "report-only"}
+        assert guardrail["axis"]
+        assert guardrail["covers"]
+        assert guardrail["validation_command_ids"]
+        assert set(guardrail["validation_command_ids"]).issubset(command_ids)
+
+
+def test_guardrail_test_files_exist() -> None:
+    contract = _guardrails()
+
+    for guardrail in contract["guardrails"]:
+        for rel_path in guardrail["test_files"]:
+            path = REPO_ROOT / rel_path
+            assert path.exists(), f"{guardrail['id']} references missing path: {rel_path}"
+
+
+def test_guardrail_docs_cover_every_id_and_command() -> None:
+    contract = _guardrails()
+    docs = DOCS_PATH.read_text(encoding="utf-8")
+
+    assert "contracts/zccache-integration-guardrails.v1.json" in docs
+    assert "issue #543" in docs
+    for guardrail in contract["guardrails"]:
+        assert f"`{guardrail['id']}`" in docs
+    for command in contract["validation_commands"]:
+        assert command["command"] in docs
+
+
+def test_npm_package_includes_guardrail_contract() -> None:
+    package = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+
+    assert "contracts/zccache-runtime.v1.json" in package["files"]
+    assert "contracts/zccache-integration-guardrails.v1.json" in package["files"]

--- a/tests/test_zccache_runtime_contract.py
+++ b/tests/test_zccache_runtime_contract.py
@@ -145,4 +145,5 @@ def test_npm_package_exports_contract_files() -> None:
     package = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
 
     assert "contracts/zccache-runtime.v1.json" in package["files"]
+    assert "contracts/zccache-integration-guardrails.v1.json" in package["files"]
     assert "scripts/zccache-contract.js" in package["files"]


### PR DESCRIPTION
## Summary

- Adds a versioned zccache integration guardrail manifest covering source resolution, managed session/env, rust-plan, disabled/non-build scope, unknown-session retry, shutdown scoping, setup-soldr outputs, release/npm staging, perf canaries, native CC/CXX cache, and monolith migration.
- Adds `docs/ZCCACHE_INTEGRATION_GUARDRAILS.md` plus parent #543 validation command documentation.
- Adds a compact fake cargo/zccache Rust contract matrix and Python/Node package checks so the guardrail ledger cannot drift.

Closes #548.

## Test plan

- [x] `soldr --no-cache cargo test -p soldr-cli --test cli_zccache_contract_matrix --locked`
- [x] `soldr --no-cache cargo test -p soldr-cli --test cli_install_zccache_resolution --locked`
- [x] `soldr --no-cache cargo test -p soldr-cli --test cli_cargo_wrappers --locked`
- [x] `soldr --no-cache cargo test -p soldr-cli --bin soldr --locked native_cc::tests`
- [x] `soldr --no-cache cargo test -p soldr-cli --test cli_unknown_session_retry --locked`
- [x] `soldr --no-cache cargo test -p soldr-cli --test cli_wrapper_perf --locked`
- [x] `soldr --no-cache cargo test -p soldr-cli --test timed_test_lint --locked`
- [x] `UV_LINK_MODE=copy uv run pytest tests/test_zccache_integration_guardrails.py tests/test_zccache_runtime_contract.py tests/test_setup_soldr_action.py tests/test_setup_soldr_exporter.py tests/test_setup_soldr_ensure_soldr.py -q`
- [x] `node scripts/test-npm-package.js`
- [x] `soldr cargo check -p soldr-cli --all-targets --locked`
- [x] `soldr cargo clippy -p soldr-cli --all-targets --locked -- -D warnings`
- [x] `git diff --check`