### PR TITLE
feat(zccache): use private daemon sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.39"
+version = "0.7.40"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.39"
+version = "0.7.40"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -17,7 +17,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.11.4",
+    "managed_version": "1.11.5",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -17,7 +17,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.11.5",
+    "managed_version": "1.11.6",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/cache/session.rs
+++ b/crates/soldr-cli/src/cache/session.rs
@@ -2,9 +2,11 @@
 //! lifecycle commands for the zccache daemon and its per-session journal.
 
 use crate::core::{SoldrError, SoldrPaths};
+use crate::daemon::db;
 use crate::zccache::managed_zccache_cache_dir;
 use crate::zccache_lifecycle::{
-    ZccacheDaemonExitPollResult, ZccacheLifecycle, ZccacheSessionStartOptions,
+    ZccacheDaemonExitPollResult, ZccacheLifecycle, ZccachePrivateDaemonConfig,
+    ZccacheSessionStartOptions,
 };
 use crate::{cached_active_zccache, fetch_active_zccache, JSON_SCHEMA_VERSION};
 use serde::Serialize;
@@ -276,13 +278,18 @@ pub(crate) async fn run_cache_shutdown_command(
 ) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
     let zccache_dir = managed_zccache_cache_dir(&paths)?;
+    let linked_private = linked_private_zccache_lifecycle(&paths);
+    let active_zccache_dir = linked_private
+        .as_ref()
+        .map(|(_, cache_dir)| cache_dir.clone())
+        .unwrap_or_else(|| zccache_dir.clone());
     let mut notes: Vec<String> = Vec::new();
 
     let fetch = cached_active_zccache(&paths)?;
     let mut output = CacheShutdownOutput {
         schema_version: JSON_SCHEMA_VERSION,
         command: "cache shutdown",
-        cache_dir: zccache_dir.display().to_string(),
+        cache_dir: active_zccache_dir.display().to_string(),
         session_id: None,
         daemon_stopped: false,
         daemon_exited: false,
@@ -294,9 +301,11 @@ pub(crate) async fn run_cache_shutdown_command(
         .ok()
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty());
-    let mut lifecycle = fetch
-        .as_ref()
-        .map(|fetch| ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir));
+    let mut lifecycle = linked_private.map(|(lifecycle, _)| lifecycle).or_else(|| {
+        fetch
+            .as_ref()
+            .map(|fetch| ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir))
+    });
 
     // Step 1: end the active session so zccache flushes the per-session
     // journal before the daemon stops.
@@ -319,9 +328,9 @@ pub(crate) async fn run_cache_shutdown_command(
         std::fs::create_dir_all(&target)?;
         let mut copied = 0u32;
         for path in [
-            crate::cache_lib::session_log_path(&zccache_dir),
-            crate::cache_lib::session_journal_path(&zccache_dir),
-            crate::cache_lib::session_stats_path(&zccache_dir),
+            crate::cache_lib::session_log_path(&active_zccache_dir),
+            crate::cache_lib::session_journal_path(&active_zccache_dir),
+            crate::cache_lib::session_stats_path(&active_zccache_dir),
         ] {
             if !path.exists() {
                 continue;
@@ -448,25 +457,35 @@ pub(crate) async fn run_cache_shutdown_command(
 pub(crate) async fn run_cache_flush_command(json: bool) -> Result<(), SoldrError> {
     let paths = SoldrPaths::new()?;
     let zccache_dir = managed_zccache_cache_dir(&paths)?;
+    let linked_private = linked_private_zccache_lifecycle(&paths);
+    let active_zccache_dir = linked_private
+        .as_ref()
+        .map(|(_, cache_dir)| cache_dir.clone())
+        .unwrap_or_else(|| zccache_dir.clone());
     let fetch = cached_active_zccache(&paths)?;
 
     let mut output = CacheFlushOutput {
         schema_version: JSON_SCHEMA_VERSION,
         command: "cache flush",
-        cache_dir: zccache_dir.display().to_string(),
+        cache_dir: active_zccache_dir.display().to_string(),
         flushed: false,
         stats: None,
         notes: Vec::new(),
     };
 
-    if let Some(fetch) = fetch.as_ref() {
+    let mut lifecycle = linked_private.map(|(lifecycle, _)| lifecycle).or_else(|| {
+        fetch
+            .as_ref()
+            .map(|fetch| ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir))
+    });
+
+    if let Some(lifecycle) = lifecycle.as_mut() {
         // soldr#383 contract: ask zccache to fsync its in-memory
         // depgraph (and any other state) to disk and return only once
         // the bytes are durable. Prefer the JSON form so we can
         // re-emit the upstream stats verbatim; fall back to plain
         // `zccache flush` when the build does not yet support
         // `--json`.
-        let mut lifecycle = ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir);
         let result = lifecycle.flush()?;
         output.flushed = result.flushed;
         output.stats = result.stats;
@@ -528,6 +547,26 @@ pub(crate) async fn run_cache_flush_command(json: bool) -> Result<(), SoldrError
         }
     }
     Ok(())
+}
+
+fn linked_private_zccache_lifecycle(
+    paths: &SoldrPaths,
+) -> Option<(ZccacheLifecycle, std::path::PathBuf)> {
+    let link = db::get_linked_zccache(&db::db_path(paths)).ok().flatten()?;
+    if !link.private_daemon {
+        return None;
+    }
+    let daemon_name = link.daemon_name?;
+    let binary_path = std::path::PathBuf::from(link.binary_path);
+    if !binary_path.exists() {
+        return None;
+    }
+    let cache_dir = std::path::PathBuf::from(link.cache_dir);
+    let mut private_daemon = ZccachePrivateDaemonConfig::new(daemon_name);
+    private_daemon.owner_pid = link.owner_pid;
+    let lifecycle =
+        ZccacheLifecycle::new(binary_path, &cache_dir).with_private_daemon(private_daemon);
+    Some((lifecycle, cache_dir))
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/src/cargo_front_door/cache_plan.rs
+++ b/crates/soldr-cli/src/cargo_front_door/cache_plan.rs
@@ -194,17 +194,18 @@ mod tests {
             session_log_path: std::path::PathBuf::from("/tmp/soldr-zccache/log"),
             journal_path: std::path::PathBuf::from("/tmp/soldr-zccache/journal"),
             session_stats_path: std::path::PathBuf::from("/tmp/soldr-zccache/stats.json"),
+            private_daemon: None,
         }
     }
 
     fn managed_wrapper_plan() -> RustcWrapperPlan {
-        RustcWrapperPlan::ManagedZccache(ManagedZccacheWrapperPlan {
+        RustcWrapperPlan::ManagedZccache(Box::new(ManagedZccacheWrapperPlan {
             session: fake_session(),
             child_env: ZccacheChildEnv {
                 path_remap: Some("auto"),
                 worktree_root: Some(std::path::PathBuf::from("/tmp/worktree")),
             },
-        })
+        }))
     }
 
     crate::timed_test!(managed_plan_applies_session_and_path_remap_env, {

--- a/crates/soldr-cli/src/daemon/client.rs
+++ b/crates/soldr-cli/src/daemon/client.rs
@@ -6,6 +6,7 @@
 use crate::cache_lib::target_registry::{current_unix_seconds, TargetRegistry};
 use crate::cache_lib::{daemon_sock_path, data_db_path};
 use crate::core::SoldrPaths;
+use crate::daemon::db;
 use crate::daemon::ipc::{read_frame_sync, write_frame_sync};
 use crate::daemon::protocol::{BuildRecord, Request, Response, StatusInfo};
 use std::path::{Path, PathBuf};
@@ -168,7 +169,10 @@ pub fn record_compile(
 
 pub fn link_zccache(paths: &SoldrPaths, link: crate::daemon::protocol::ZccacheDaemonLink) {
     let sock = default_sock_path(paths);
-    let _ = submit_fire_and_forget(&sock, &Request::LinkZccache { link });
+    if submit_fire_and_forget(&sock, &Request::LinkZccache { link: link.clone() }).is_ok() {
+        return;
+    }
+    let _ = db::set_linked_zccache(&data_db_path(paths), Some(&link));
 }
 
 /// Wrapper-side entry point. Tries the daemon first; on any failure,

--- a/crates/soldr-cli/src/daemon/db.rs
+++ b/crates/soldr-cli/src/daemon/db.rs
@@ -24,6 +24,29 @@ const META_NEXT_EVENT_ID: &str = "next_event_id";
 const LINKED_ZCCACHE_KEY: &str = "active";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct LegacyZccacheDaemonLink {
+    binary_path: String,
+    cache_dir: String,
+    session_id: Option<String>,
+    source: String,
+}
+
+impl From<LegacyZccacheDaemonLink> for ZccacheDaemonLink {
+    fn from(value: LegacyZccacheDaemonLink) -> Self {
+        Self {
+            binary_path: value.binary_path,
+            cache_dir: value.cache_dir,
+            session_id: value.session_id,
+            source: value.source,
+            private_daemon: false,
+            daemon_name: None,
+            owner_pid: None,
+            private_env_keys: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum EventKind {
     SessionStart,
     SessionEnd,
@@ -241,8 +264,18 @@ pub fn get_linked_zccache(db_path: &Path) -> Result<Option<ZccacheDaemonLink>, R
     let Some(row) = table.get(LINKED_ZCCACHE_KEY)? else {
         return Ok(None);
     };
-    let link: ZccacheDaemonLink = bincode::deserialize(row.value()).map_err(bincode_err)?;
+    let link = deserialize_zccache_daemon_link(row.value())?;
     Ok(Some(link))
+}
+
+fn deserialize_zccache_daemon_link(bytes: &[u8]) -> Result<ZccacheDaemonLink, RegistryError> {
+    match bincode::deserialize::<ZccacheDaemonLink>(bytes) {
+        Ok(link) => Ok(link),
+        Err(new_err) => match bincode::deserialize::<LegacyZccacheDaemonLink>(bytes) {
+            Ok(legacy) => Ok(legacy.into()),
+            Err(_) => Err(bincode_err(new_err)),
+        },
+    }
 }
 
 /// Delete `daemon_events` rows older than `cutoff_ms`. Returns the
@@ -423,12 +456,36 @@ mod tests {
             cache_dir: "/tmp/cache".into(),
             session_id: Some("session-1".into()),
             source: "managed".into(),
+            private_daemon: true,
+            daemon_name: Some("soldr-dev-test".into()),
+            owner_pid: Some(1234),
+            private_env_keys: vec!["ZCCACHE_PATH_REMAP".into()],
         };
         assert_eq!(get_linked_zccache(&path).expect("get"), None);
         set_linked_zccache(&path, Some(&link)).expect("set");
         assert_eq!(get_linked_zccache(&path).expect("get"), Some(link));
         set_linked_zccache(&path, None).expect("clear");
         assert_eq!(get_linked_zccache(&path).expect("get"), None);
+    }
+
+    #[test]
+    fn linked_zccache_legacy_identity_decodes_as_shared_daemon() {
+        let legacy = LegacyZccacheDaemonLink {
+            binary_path: "/tmp/zccache".into(),
+            cache_dir: "/tmp/cache".into(),
+            session_id: Some("session-1".into()),
+            source: "managed".into(),
+        };
+        let bytes = bincode::serialize(&legacy).expect("serialize legacy");
+        let decoded = deserialize_zccache_daemon_link(&bytes).expect("decode legacy");
+        assert_eq!(decoded.binary_path, legacy.binary_path);
+        assert_eq!(decoded.cache_dir, legacy.cache_dir);
+        assert_eq!(decoded.session_id, legacy.session_id);
+        assert_eq!(decoded.source, legacy.source);
+        assert!(!decoded.private_daemon);
+        assert_eq!(decoded.daemon_name, None);
+        assert_eq!(decoded.owner_pid, None);
+        assert!(decoded.private_env_keys.is_empty());
     }
 
     #[test]

--- a/crates/soldr-cli/src/daemon/protocol.rs
+++ b/crates/soldr-cli/src/daemon/protocol.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Maximum bincode body size. 64 KiB is comfortably above the largest
 /// realistic record (path strings, a few timestamps). Frames larger than
@@ -93,6 +93,10 @@ pub struct ZccacheDaemonLink {
     pub cache_dir: String,
     pub session_id: Option<String>,
     pub source: String,
+    pub private_daemon: bool,
+    pub daemon_name: Option<String>,
+    pub owner_pid: Option<u32>,
+    pub private_env_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/soldr-cli/src/daemon/zccache_link.rs
+++ b/crates/soldr-cli/src/daemon/zccache_link.rs
@@ -5,7 +5,7 @@
 
 use crate::core::SoldrPaths;
 use crate::daemon::db;
-use crate::zccache_lifecycle::ZccacheLifecycle;
+use crate::zccache_lifecycle::{ZccacheLifecycle, ZccachePrivateDaemonConfig};
 use std::time::Duration;
 
 const STOP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -27,6 +27,15 @@ pub fn stop_linked_zccache(paths: &SoldrPaths) {
     }
 
     let mut lifecycle = ZccacheLifecycle::new(binary_path, cache_dir);
+    if link.private_daemon {
+        let Some(daemon_name) = link.daemon_name.as_deref() else {
+            let _ = db::set_linked_zccache(&db_path, None);
+            return;
+        };
+        let mut private_daemon = ZccachePrivateDaemonConfig::new(daemon_name.to_string());
+        private_daemon.owner_pid = link.owner_pid;
+        lifecycle = lifecycle.with_private_daemon(private_daemon);
+    }
     let _ = lifecycle.stop_best_effort_with_process_timeout(STOP_TIMEOUT);
     let _ = db::set_linked_zccache(&db_path, None);
 }

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.5";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.6";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.4";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.5";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/src/rust_plan.rs
+++ b/crates/soldr-cli/src/rust_plan.rs
@@ -9,8 +9,8 @@ use crate::cargo_front_door::{
 };
 use crate::core::{suppress_windows_console_window, SoldrError};
 use crate::zccache::{
-    command_stderr, normalize_path_for_compare, run_zccache_command_strings_in_cache_dir,
-    ZccacheBuildSession,
+    command_stderr, normalize_path_for_compare,
+    run_zccache_command_strings_in_cache_dir_with_daemon_name, ZccacheBuildSession,
 };
 use crate::{
     apply_implicit_toolchain_homes, non_empty_env_path, SKIP_WARM_RESTORE_ENV_VAR,
@@ -111,6 +111,7 @@ pub(crate) struct RustArtifactPlanContext {
     pub(crate) zccache_binary: std::path::PathBuf,
     pub(crate) cache_dir: std::path::PathBuf,
     pub(crate) zccache_daemon_cache_dir: std::path::PathBuf,
+    pub(crate) zccache_daemon_name: Option<String>,
     pub(crate) session_id: String,
     pub(crate) journal_path: std::path::PathBuf,
     pub(crate) backend: String,
@@ -182,6 +183,10 @@ pub(crate) fn maybe_prepare_rust_artifact_plan(
         zccache_binary: session.binary_path.clone(),
         cache_dir: rust_artifact_plan_cache_dir(session)?,
         zccache_daemon_cache_dir: session.cache_dir.clone(),
+        zccache_daemon_name: session
+            .private_daemon
+            .as_ref()
+            .map(|private| private.daemon_name.clone()),
         session_id: session.session_id.clone(),
         journal_path: session.journal_path.clone(),
         backend: rust_artifact_cache_backend_from_env()?,
@@ -783,10 +788,11 @@ pub(crate) fn run_zccache_rust_plan(
         args.push(plan.session_id.clone());
     }
 
-    let output = run_zccache_command_strings_in_cache_dir(
+    let output = run_zccache_command_strings_in_cache_dir_with_daemon_name(
         &plan.zccache_binary,
         &args,
         &plan.zccache_daemon_cache_dir,
+        plan.zccache_daemon_name.as_deref(),
     )?;
     let stdout = output.stdout.trim();
     if !stdout.is_empty() {

--- a/crates/soldr-cli/src/rust_plan_tests/plan_build.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/plan_build.rs
@@ -64,6 +64,7 @@ fn rust_artifact_plan_selects_external_packages_and_path_exclusions() {
         session_log_path: root.join("cache/logs/last-session.log"),
         journal_path: root.join("cache/logs/last-session.jsonl"),
         session_stats_path: root.join("cache/logs/last-session-stats.json"),
+        private_daemon: None,
     };
     let args = vec![
         "build".to_string(),
@@ -259,6 +260,7 @@ fn rust_artifact_plan_bumps_cache_schema_version_for_thin_v2() {
         session_log_path: root.join("cache/logs/last-session.log"),
         journal_path: root.join("cache/logs/last-session.jsonl"),
         session_stats_path: root.join("cache/logs/last-session-stats.json"),
+        private_daemon: None,
     };
 
     let plan = build_rust_artifact_plan(

--- a/crates/soldr-cli/src/rust_plan_tests/prepopulated_target.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/prepopulated_target.rs
@@ -51,6 +51,7 @@ fn make_plan_ctx(target_dir: &std::path::Path) -> RustArtifactPlanContext {
         zccache_binary: PathBuf::from("/tmp/zccache"),
         cache_dir: PathBuf::from("/tmp/cache"),
         zccache_daemon_cache_dir: PathBuf::from("/tmp/cache"),
+        zccache_daemon_name: None,
         session_id: "session".to_string(),
         journal_path: PathBuf::from("/tmp/journal"),
         backend: "auto".to_string(),

--- a/crates/soldr-cli/src/rust_plan_tests/warm_restore.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/warm_restore.rs
@@ -341,6 +341,7 @@ fn warm_restore_test_context(
         zccache_binary: root.join("zccache"),
         cache_dir: root.join("cache"),
         zccache_daemon_cache_dir: root.join("daemon"),
+        zccache_daemon_name: None,
         session_id: "session-test".to_string(),
         journal_path: root.join("journal"),
         backend: "fs".to_string(),

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -6,7 +6,11 @@
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
 use crate::startup_profile::WrapperProfile;
 #[cfg(not(unix))]
-use crate::zccache_lifecycle::{stderr_indicates_unknown_session, ZccacheLifecycle};
+use crate::zccache_lifecycle::{
+    session_start_args, stderr_indicates_unknown_session, ZccacheLifecycle,
+    ZccachePrivateDaemonConfig, ZccachePrivateEnv, ZccacheSessionStartOptions,
+    ZCCACHE_DAEMON_NAMESPACE_ENV_VAR,
+};
 use crate::{apply_implicit_toolchain_homes, resolve_toolchain_binary, zccache_binary_override};
 
 /// Known toolchain binaries that cargo may invoke through RUSTC_WRAPPER
@@ -359,24 +363,57 @@ fn allocate_replacement_session(zccache: &std::path::Path) -> Result<String, Sol
         })?;
 
     let session_log_path = crate::cache_lib::session_log_path(&cache_dir);
-    let session_log_path_arg = session_log_path.display().to_string();
     let journal_path = crate::cache_lib::session_journal_path(&cache_dir);
-    let journal_path_arg = journal_path.display().to_string();
-    let lifecycle = ZccacheLifecycle::new(zccache, &cache_dir);
-    let session_json = lifecycle.run(&[
-        "session-start",
-        "--stats",
-        "--log",
-        &session_log_path_arg,
-        "--journal",
-        &journal_path_arg,
-    ])?;
+    let session_stats_path = crate::cache_lib::session_stats_path(&cache_dir);
+    let options = ZccacheSessionStartOptions {
+        id: None,
+        session_log_path,
+        journal_path,
+        session_stats_path,
+    };
+    let mut lifecycle = ZccacheLifecycle::new(zccache, &cache_dir);
+    if let Some(daemon_name) = inherited_private_daemon_name() {
+        let private = ZccachePrivateDaemonConfig::new(daemon_name)
+            .with_owner_pid(std::process::id())
+            .with_private_env(inherited_private_zccache_env());
+        lifecycle = lifecycle.with_private_daemon(private);
+    }
+    let args = session_start_args(&options, &cache_dir, lifecycle.private_daemon());
+    let session_json = lifecycle.run_strings(&args)?;
     crate::cache_lib::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
         SoldrError::Other(format!(
             "failed to parse zccache session id from output: {}",
             session_json.stdout.trim()
         ))
     })
+}
+
+#[cfg(not(unix))]
+fn inherited_private_daemon_name() -> Option<String> {
+    std::env::var(ZCCACHE_DAEMON_NAMESPACE_ENV_VAR)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(not(unix))]
+fn inherited_private_zccache_env() -> Vec<ZccachePrivateEnv> {
+    [
+        crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR,
+        crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR,
+    ]
+    .into_iter()
+    .filter_map(|key| {
+        let value = std::env::var_os(key)?;
+        if value.is_empty() {
+            return None;
+        }
+        Some(ZccachePrivateEnv::new(
+            key,
+            value.to_string_lossy().to_string(),
+        ))
+    })
+    .collect()
 }
 
 // Routing logic + `TargetTouchPath` live in `wrapper_target.rs` so the

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -5,7 +5,7 @@ use crate::core::{SoldrError, SoldrPaths};
 use crate::fetch::{ZccacheRuntime, ZccacheRuntimeSource};
 use crate::zccache_lifecycle::{
     zccache_command_failure_message, zccache_json_flag_unsupported, ZccacheLifecycle,
-    ZccacheSessionStartOptions,
+    ZccachePrivateDaemonConfig, ZccachePrivateEnv, ZccacheSessionStartOptions,
 };
 use crate::{
     current_soldr_binary, fetch_active_zccache_runtime, non_empty_env_path, ZccacheSourceArg,
@@ -15,13 +15,17 @@ use std::ffi::OsStr;
 
 pub(crate) use crate::zccache_lifecycle::{
     command_stderr, effective_daemon_rust_log, run_zccache_command_in_cache_dir,
-    run_zccache_command_raw_in_cache_dir, run_zccache_command_strings_in_cache_dir,
-    start_zccache_with_recovery, ZccacheBuildSession, SOLDR_DAEMON_RUST_LOG_ENV_VAR,
+    run_zccache_command_raw_in_cache_dir, run_zccache_command_raw_in_cache_dir_with_daemon_name,
+    run_zccache_command_strings_in_cache_dir,
+    run_zccache_command_strings_in_cache_dir_with_daemon_name, start_zccache_with_recovery,
+    ZccacheBuildSession, SOLDR_DAEMON_RUST_LOG_ENV_VAR, ZCCACHE_DAEMON_NAMESPACE_ENV_VAR,
 };
 
 pub(crate) const SOLDR_CACHE_LIFECYCLE_ENV_VAR: &str = "SOLDR_CACHE_LIFECYCLE";
 pub(crate) const SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR: &str =
     "SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS";
+pub(crate) const SOLDR_ZCCACHE_PRIVATE_DAEMON_NAME_ENV_VAR: &str =
+    "SOLDR_ZCCACHE_PRIVATE_DAEMON_NAME";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CacheLifecycle {
@@ -222,6 +226,23 @@ impl ZccacheChildEnv {
             cargo.env(crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR, root);
         }
     }
+
+    pub(crate) fn private_env_assignments(&self) -> Vec<ZccachePrivateEnv> {
+        let mut entries = Vec::new();
+        if let Some(value) = self.path_remap {
+            entries.push(ZccachePrivateEnv::new(
+                crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR,
+                value,
+            ));
+        }
+        if let Some(root) = self.worktree_root.as_ref() {
+            entries.push(ZccachePrivateEnv::new(
+                crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR,
+                root.display().to_string(),
+            ));
+        }
+        entries
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -232,7 +253,7 @@ pub(crate) struct ManagedZccacheWrapperPlan {
 
 #[derive(Debug, Clone)]
 pub(crate) enum RustcWrapperPlan {
-    ManagedZccache(ManagedZccacheWrapperPlan),
+    ManagedZccache(Box<ManagedZccacheWrapperPlan>),
     Custom {
         wrapper: std::ffi::OsString,
         sccache_dir: Option<std::path::PathBuf>,
@@ -272,6 +293,9 @@ impl RustcWrapperPlan {
                     crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR,
                     &session.session_id,
                 );
+                if let Some(private) = session.private_daemon.as_ref() {
+                    cargo.env(ZCCACHE_DAEMON_NAMESPACE_ENV_VAR, &private.daemon_name);
+                }
                 plan.child_env.apply_to_command(cargo);
             }
             Self::Custom {
@@ -317,7 +341,7 @@ pub(crate) async fn prepare_rustc_wrapper_plan(
     match rustc_wrapper_mode() {
         RustcWrapperMode::ManagedZccache => prepare_zccache_build(paths, zccache_source)
             .await
-            .map(RustcWrapperPlan::ManagedZccache),
+            .map(|plan| RustcWrapperPlan::ManagedZccache(Box::new(plan))),
         RustcWrapperMode::Custom(wrapper) => {
             let sccache_dir =
                 if is_sccache_wrapper(&wrapper) && std::env::var_os("SCCACHE_DIR").is_none() {
@@ -347,9 +371,7 @@ async fn prepare_zccache_build(
     paths: &SoldrPaths,
     zccache_source: ZccacheSourceArg,
 ) -> Result<ManagedZccacheWrapperPlan, SoldrError> {
-    let zccache_dir = managed_zccache_cache_dir(paths)?;
-    std::fs::create_dir_all(&zccache_dir)?;
-    std::fs::create_dir_all(zccache_dir.join("logs"))?;
+    let zccache_base_dir = managed_zccache_cache_dir(paths)?;
     let runtime = match zccache_source {
         ZccacheSourceArg::Managed => fetch_active_zccache_runtime(paths).await?,
         ZccacheSourceArg::System => {
@@ -365,6 +387,22 @@ async fn prepare_zccache_build(
     // source, runtime dir, and version of the binary we just resolved.
     print_zccache_runtime_diagnostic(&runtime);
 
+    let child_env = ZccacheChildEnv::from_current_process()?;
+    let private_daemon_name = resolve_private_zccache_daemon_name(
+        std::env::var(SOLDR_ZCCACHE_PRIVATE_DAEMON_NAME_ENV_VAR)
+            .ok()
+            .as_deref(),
+        &current_soldr_binary()?,
+        &fetch.binary_path,
+        &zccache_base_dir,
+    );
+    let zccache_dir = private_zccache_cache_dir(&zccache_base_dir, &private_daemon_name);
+    std::fs::create_dir_all(&zccache_dir)?;
+    std::fs::create_dir_all(zccache_dir.join("logs"))?;
+    let private_daemon = ZccachePrivateDaemonConfig::new(private_daemon_name.clone())
+        .with_owner_pid(std::process::id())
+        .with_private_env(child_env.private_env_assignments());
+
     // When the resolved zccache CLI binary differs from the one a
     // previous soldr invocation started the daemon with, the live
     // daemon is stale relative to what we just resolved. This matters
@@ -373,12 +411,17 @@ async fn prepare_zccache_build(
     // built daemon, but `zccache start` is a no-op when any daemon
     // is already alive, so a managed daemon from a previous build
     // would keep handling requests. Evict it explicitly here.
-    evict_zccache_daemon_if_binary_changed(&fetch.binary_path, &zccache_dir)?;
+    evict_zccache_daemon_if_binary_changed_scoped(
+        &fetch.binary_path,
+        &zccache_dir,
+        Some(&private_daemon_name),
+    )?;
 
     let session_log_path = crate::cache_lib::session_log_path(&zccache_dir);
     let journal_path = crate::cache_lib::session_journal_path(&zccache_dir);
     let session_stats_path = crate::cache_lib::session_stats_path(&zccache_dir);
-    let mut lifecycle = ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir);
+    let mut lifecycle =
+        ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir).with_private_daemon(private_daemon);
     let session = lifecycle.start_session(ZccacheSessionStartOptions {
         id: None,
         session_log_path,
@@ -395,6 +438,20 @@ async fn prepare_zccache_build(
             cache_dir: session.cache_dir.display().to_string(),
             session_id: Some(session.session_id.clone()),
             source: runtime.source.summary_source().as_str().to_string(),
+            private_daemon: session.private_daemon.is_some(),
+            daemon_name: session
+                .private_daemon
+                .as_ref()
+                .map(|private| private.daemon_name.clone()),
+            owner_pid: session
+                .private_daemon
+                .as_ref()
+                .and_then(|private| private.owner_pid),
+            private_env_keys: session
+                .private_daemon
+                .as_ref()
+                .map(|private| private.private_env_keys.clone())
+                .unwrap_or_default(),
         },
     );
 
@@ -404,7 +461,7 @@ async fn prepare_zccache_build(
         // and a logical worktree root so multiple worktrees of the same repo
         // share zccache hits through normalized keys. Honor user-supplied
         // ZCCACHE_* values, and the SOLDR_PATH_REMAP=off escape hatch.
-        child_env: ZccacheChildEnv::from_current_process()?,
+        child_env,
     })
 }
 
@@ -515,11 +572,8 @@ pub(crate) fn stop_zccache_after_command(
 }
 
 fn finish_zccache_build_text_fallback(session: &ZccacheBuildSession) -> Result<(), SoldrError> {
-    let output = run_zccache_command_in_cache_dir(
-        &session.binary_path,
-        &["session-end", &session.session_id],
-        &session.cache_dir,
-    )?;
+    let lifecycle = ZccacheLifecycle::from_session(session);
+    let output = lifecycle.run(&["session-end", &session.session_id])?;
     let stdout = output.stdout.trim();
     if !stdout.is_empty() {
         eprintln!("soldr: zccache session summary");
@@ -602,6 +656,67 @@ fn json_f64(value: &serde_json::Value, key: &str) -> Option<f64> {
     value.get(key).and_then(serde_json::Value::as_f64)
 }
 
+pub(crate) fn private_zccache_cache_dir(
+    base_dir: &std::path::Path,
+    daemon_name: &str,
+) -> std::path::PathBuf {
+    base_dir.join("private").join(daemon_name)
+}
+
+pub(crate) fn resolve_private_zccache_daemon_name(
+    override_name: Option<&str>,
+    soldr_binary: &std::path::Path,
+    zccache_binary: &std::path::Path,
+    base_cache_dir: &std::path::Path,
+) -> String {
+    if let Some(name) = override_name.and_then(sanitize_zccache_daemon_name) {
+        return name;
+    }
+
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"soldr-private-zccache-v1\0");
+    hash_path_component(&mut hasher, soldr_binary);
+    hash_path_component(&mut hasher, zccache_binary);
+    hash_path_component(&mut hasher, base_cache_dir);
+    let digest = hasher.finalize();
+    let hex = digest.to_hex();
+    format!("soldr-dev-{}", &hex[..16])
+}
+
+fn hash_path_component(hasher: &mut blake3::Hasher, path: &std::path::Path) {
+    let value = path.display().to_string();
+    let value = if cfg!(windows) {
+        value.to_ascii_lowercase()
+    } else {
+        value
+    };
+    hasher.update(value.as_bytes());
+    hasher.update(b"\0");
+}
+
+pub(crate) fn sanitize_zccache_daemon_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let sanitized: String = trimmed
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.len() <= 32 {
+        return Some(sanitized);
+    }
+    let prefix: String = sanitized.chars().take(23).collect();
+    let short = blake3::hash(trimmed.as_bytes()).to_hex();
+    Some(format!("{prefix}-{}", &short[..8]))
+}
+
 pub(crate) fn managed_zccache_cache_dir(
     paths: &SoldrPaths,
 ) -> Result<std::path::PathBuf, SoldrError> {
@@ -667,6 +782,14 @@ pub(crate) fn evict_zccache_daemon_if_binary_changed(
     binary: &std::path::Path,
     cache_dir: &std::path::Path,
 ) -> Result<(), SoldrError> {
+    evict_zccache_daemon_if_binary_changed_scoped(binary, cache_dir, None)
+}
+
+pub(crate) fn evict_zccache_daemon_if_binary_changed_scoped(
+    binary: &std::path::Path,
+    cache_dir: &std::path::Path,
+    daemon_name: Option<&str>,
+) -> Result<(), SoldrError> {
     let sentinel = cache_dir.join(ZCCACHE_LAST_CLI_BINARY_SENTINEL);
     let resolved = binary.display().to_string();
     let prev = std::fs::read_to_string(&sentinel)
@@ -677,7 +800,12 @@ pub(crate) fn evict_zccache_daemon_if_binary_changed(
         eprintln!(
             "soldr: zccache CLI binary changed since last build; stopping stale daemon to force a fresh spawn (issue #365)",
         );
-        if let Err(err) = run_zccache_command_raw_in_cache_dir(binary, &["stop"], cache_dir) {
+        if let Err(err) = run_zccache_command_raw_in_cache_dir_with_daemon_name(
+            binary,
+            &["stop"],
+            cache_dir,
+            daemon_name,
+        ) {
             // Stop failures shouldn't block the build — the start
             // path below has its own stale-daemon recovery.
             eprintln!("soldr: zccache stop reported {err}; continuing");
@@ -830,6 +958,53 @@ mod tests {
         assert_eq!(
             resolve_worktree_root_env(Some(OsStr::new("/custom/root")), cwd),
             None
+        );
+    }
+
+    #[test]
+    fn child_env_private_assignments_match_generated_zccache_env() {
+        let env = ZccacheChildEnv {
+            path_remap: Some("auto"),
+            worktree_root: Some(std::path::PathBuf::from("/repo")),
+        };
+        let entries = env.private_env_assignments();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].key, crate::cache_lib::ZCCACHE_PATH_REMAP_ENV_VAR);
+        assert_eq!(entries[0].value, "auto");
+        assert_eq!(
+            entries[1].key,
+            crate::cache_lib::ZCCACHE_WORKTREE_ROOT_ENV_VAR
+        );
+        assert_eq!(entries[1].value, "/repo");
+    }
+
+    #[test]
+    fn private_daemon_name_is_stable_sanitized_and_short() {
+        let generated = resolve_private_zccache_daemon_name(
+            None,
+            std::path::Path::new("/repo/target/debug/soldr"),
+            std::path::Path::new("/repo/target/debug/zccache"),
+            std::path::Path::new("/tmp/cache/zccache"),
+        );
+        assert!(generated.starts_with("soldr-dev-"));
+        assert!(generated.len() <= 32);
+        assert_eq!(
+            generated,
+            resolve_private_zccache_daemon_name(
+                None,
+                std::path::Path::new("/repo/target/debug/soldr"),
+                std::path::Path::new("/repo/target/debug/zccache"),
+                std::path::Path::new("/tmp/cache/zccache"),
+            )
+        );
+        assert_eq!(
+            resolve_private_zccache_daemon_name(
+                Some(" team/dev soldr "),
+                std::path::Path::new("/ignored/soldr"),
+                std::path::Path::new("/ignored/zccache"),
+                std::path::Path::new("/ignored/cache"),
+            ),
+            "team_dev_soldr"
         );
     }
 

--- a/crates/soldr-cli/src/zccache_lifecycle.rs
+++ b/crates/soldr-cli/src/zccache_lifecycle.rs
@@ -10,6 +10,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
+pub(crate) const ZCCACHE_DAEMON_NAMESPACE_ENV_VAR: &str = "ZCCACHE_DAEMON_NAMESPACE";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ZccacheLifecycleState {
     Ready,
@@ -17,6 +19,76 @@ pub(crate) enum ZccacheLifecycleState {
     SessionActive,
     SessionEnded,
     Stopped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ZccachePrivateEnv {
+    pub(crate) key: String,
+    pub(crate) value: String,
+}
+
+impl ZccachePrivateEnv {
+    pub(crate) fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+
+    fn as_assignment(&self) -> String {
+        format!("{}={}", self.key, self.value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ZccachePrivateDaemonConfig {
+    pub(crate) daemon_name: String,
+    pub(crate) owner_pid: Option<u32>,
+    pub(crate) private_env: Vec<ZccachePrivateEnv>,
+}
+
+impl ZccachePrivateDaemonConfig {
+    pub(crate) fn new(daemon_name: impl Into<String>) -> Self {
+        Self {
+            daemon_name: daemon_name.into(),
+            owner_pid: None,
+            private_env: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_owner_pid(mut self, owner_pid: u32) -> Self {
+        self.owner_pid = Some(owner_pid);
+        self
+    }
+
+    pub(crate) fn with_private_env(mut self, private_env: Vec<ZccachePrivateEnv>) -> Self {
+        self.private_env = private_env;
+        self
+    }
+
+    pub(crate) fn private_env_keys(&self) -> Vec<String> {
+        self.private_env
+            .iter()
+            .map(|entry| entry.key.clone())
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ZccachePrivateDaemonSession {
+    pub(crate) daemon_name: String,
+    pub(crate) owner_pid: Option<u32>,
+    pub(crate) private_env_keys: Vec<String>,
+}
+
+impl From<&ZccachePrivateDaemonConfig> for ZccachePrivateDaemonSession {
+    fn from(config: &ZccachePrivateDaemonConfig) -> Self {
+        Self {
+            daemon_name: config.daemon_name.clone(),
+            owner_pid: config.owner_pid,
+            private_env_keys: config.private_env_keys(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -27,6 +99,7 @@ pub(crate) struct ZccacheBuildSession {
     pub(crate) session_log_path: PathBuf,
     pub(crate) journal_path: PathBuf,
     pub(crate) session_stats_path: PathBuf,
+    pub(crate) private_daemon: Option<ZccachePrivateDaemonSession>,
 }
 
 #[derive(Debug, Clone)]
@@ -117,6 +190,7 @@ pub(crate) struct ZccacheLifecycle {
     binary_path: PathBuf,
     cache_dir: PathBuf,
     state: ZccacheLifecycleState,
+    private_daemon: Option<ZccachePrivateDaemonConfig>,
 }
 
 impl ZccacheLifecycle {
@@ -125,6 +199,7 @@ impl ZccacheLifecycle {
             binary_path: binary_path.into(),
             cache_dir: cache_dir.into(),
             state: ZccacheLifecycleState::Ready,
+            private_daemon: None,
         }
     }
 
@@ -133,7 +208,20 @@ impl ZccacheLifecycle {
             binary_path: session.binary_path.clone(),
             cache_dir: session.cache_dir.clone(),
             state: ZccacheLifecycleState::SessionActive,
+            private_daemon: session.private_daemon.as_ref().map(|private| {
+                let mut config = ZccachePrivateDaemonConfig::new(private.daemon_name.clone());
+                config.owner_pid = private.owner_pid;
+                config
+            }),
         }
+    }
+
+    pub(crate) fn with_private_daemon(
+        mut self,
+        private_daemon: ZccachePrivateDaemonConfig,
+    ) -> Self {
+        self.private_daemon = Some(private_daemon);
+        self
     }
 
     pub(crate) fn binary_path(&self) -> &Path {
@@ -148,8 +236,16 @@ impl ZccacheLifecycle {
         self.state
     }
 
+    pub(crate) fn private_daemon(&self) -> Option<&ZccachePrivateDaemonConfig> {
+        self.private_daemon.as_ref()
+    }
+
     pub(crate) fn start_with_recovery(&mut self) -> Result<(), SoldrError> {
-        start_zccache_with_recovery(&self.binary_path, &self.cache_dir)?;
+        start_zccache_with_recovery_for_daemon(
+            &self.binary_path,
+            &self.cache_dir,
+            self.private_daemon_name(),
+        )?;
         self.state = ZccacheLifecycleState::DaemonStarted;
         Ok(())
     }
@@ -160,22 +256,9 @@ impl ZccacheLifecycle {
     ) -> Result<ZccacheBuildSession, SoldrError> {
         self.start_with_recovery()?;
 
-        let log_arg = options.session_log_path.display().to_string();
-        let journal_arg = options.journal_path.display().to_string();
-        let mut args: Vec<&str> = vec![
-            "session-start",
-            "--stats",
-            "--log",
-            &log_arg,
-            "--journal",
-            &journal_arg,
-        ];
-        if let Some(id) = options.id.as_deref() {
-            args.push("--id");
-            args.push(id);
-        }
+        let args = session_start_args(&options, &self.cache_dir, self.private_daemon.as_ref());
 
-        let session_json = self.run(&args)?;
+        let session_json = self.run_strings(&args)?;
         let session_id = crate::cache_lib::parse_zccache_session_id(&session_json.stdout)
             .ok_or_else(|| {
                 SoldrError::Other(format!(
@@ -192,6 +275,10 @@ impl ZccacheLifecycle {
             session_log_path: options.session_log_path,
             journal_path: options.journal_path,
             session_stats_path: options.session_stats_path,
+            private_daemon: self
+                .private_daemon
+                .as_ref()
+                .map(ZccachePrivateDaemonSession::from),
         })
     }
 
@@ -265,7 +352,12 @@ impl ZccacheLifecycle {
         &mut self,
         timeout: Duration,
     ) -> Result<(), SoldrError> {
-        let mut child = command_with_cache_dir(&self.binary_path, &["stop"], &self.cache_dir);
+        let mut child = command_with_cache_dir_and_daemon_name(
+            &self.binary_path,
+            &["stop"],
+            &self.cache_dir,
+            self.private_daemon_name(),
+        );
         child
             .stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -291,7 +383,12 @@ impl ZccacheLifecycle {
     }
 
     pub(crate) fn poll_daemon_exit(&self, timeout: Duration) -> ZccacheDaemonExitPollResult {
-        poll_zccache_daemon_exit(&self.binary_path, &self.cache_dir, timeout)
+        poll_zccache_daemon_exit_for_daemon(
+            &self.binary_path,
+            &self.cache_dir,
+            self.private_daemon_name(),
+            timeout,
+        )
     }
 
     pub(crate) fn flush(&mut self) -> Result<ZccacheFlushOutcome, SoldrError> {
@@ -364,11 +461,36 @@ impl ZccacheLifecycle {
     }
 
     pub(crate) fn run(&self, args: &[&str]) -> Result<CommandOutput, SoldrError> {
-        run_zccache_command_in_cache_dir(&self.binary_path, args, &self.cache_dir)
+        run_zccache_command_in_cache_dir_with_daemon_name(
+            &self.binary_path,
+            args,
+            &self.cache_dir,
+            self.private_daemon_name(),
+        )
     }
 
     pub(crate) fn run_raw(&self, args: &[&str]) -> Result<Output, SoldrError> {
-        run_zccache_command_raw_in_cache_dir(&self.binary_path, args, &self.cache_dir)
+        run_zccache_command_raw_in_cache_dir_with_daemon_name(
+            &self.binary_path,
+            args,
+            &self.cache_dir,
+            self.private_daemon_name(),
+        )
+    }
+
+    pub(crate) fn run_strings(&self, args: &[String]) -> Result<CommandOutput, SoldrError> {
+        run_zccache_command_strings_in_cache_dir_with_daemon_name(
+            &self.binary_path,
+            args,
+            &self.cache_dir,
+            self.private_daemon_name(),
+        )
+    }
+
+    fn private_daemon_name(&self) -> Option<&str> {
+        self.private_daemon
+            .as_ref()
+            .map(|private| private.daemon_name.as_str())
     }
 }
 
@@ -376,19 +498,57 @@ pub(crate) struct CommandOutput {
     pub(crate) stdout: String,
 }
 
+pub(crate) fn session_start_args(
+    options: &ZccacheSessionStartOptions,
+    cache_dir: &Path,
+    private_daemon: Option<&ZccachePrivateDaemonConfig>,
+) -> Vec<String> {
+    let mut args = vec![
+        "session-start".to_string(),
+        "--stats".to_string(),
+        "--log".to_string(),
+        options.session_log_path.display().to_string(),
+        "--journal".to_string(),
+        options.journal_path.display().to_string(),
+    ];
+    if let Some(id) = options.id.as_deref() {
+        args.push("--id".to_string());
+        args.push(id.to_string());
+    }
+    if let Some(private) = private_daemon {
+        args.push("--private-daemon".to_string());
+        args.push("--daemon-name".to_string());
+        args.push(private.daemon_name.clone());
+        args.push("--cache-dir".to_string());
+        args.push(cache_dir.display().to_string());
+        if let Some(owner_pid) = private.owner_pid {
+            args.push("--owner-pid".to_string());
+            args.push(owner_pid.to_string());
+        }
+        for entry in &private.private_env {
+            args.push("--private-env".to_string());
+            args.push(entry.as_assignment());
+        }
+    }
+    args
+}
+
 pub(crate) fn run_zccache_command_in_cache_dir(
     binary: &Path,
     args: &[&str],
     cache_dir: &Path,
 ) -> Result<CommandOutput, SoldrError> {
-    run_zccache_command_with_env(
-        binary,
-        args,
-        &[(
-            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-            cache_dir.as_os_str(),
-        )],
-    )
+    run_zccache_command_in_cache_dir_with_daemon_name(binary, args, cache_dir, None)
+}
+
+pub(crate) fn run_zccache_command_in_cache_dir_with_daemon_name(
+    binary: &Path,
+    args: &[&str],
+    cache_dir: &Path,
+    daemon_name: Option<&str>,
+) -> Result<CommandOutput, SoldrError> {
+    let envs = cache_dir_envs(cache_dir, daemon_name);
+    run_zccache_command_with_env(binary, args, &envs)
 }
 
 pub(crate) fn run_zccache_command_strings_in_cache_dir(
@@ -396,14 +556,17 @@ pub(crate) fn run_zccache_command_strings_in_cache_dir(
     args: &[String],
     cache_dir: &Path,
 ) -> Result<CommandOutput, SoldrError> {
-    let output = run_zccache_command_raw_strings_with_env(
-        binary,
-        args,
-        &[(
-            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-            cache_dir.as_os_str(),
-        )],
-    )?;
+    run_zccache_command_strings_in_cache_dir_with_daemon_name(binary, args, cache_dir, None)
+}
+
+pub(crate) fn run_zccache_command_strings_in_cache_dir_with_daemon_name(
+    binary: &Path,
+    args: &[String],
+    cache_dir: &Path,
+    daemon_name: Option<&str>,
+) -> Result<CommandOutput, SoldrError> {
+    let envs = cache_dir_envs(cache_dir, daemon_name);
+    let output = run_zccache_command_raw_strings_with_env(binary, args, &envs)?;
     if !output.status.success() {
         return Err(SoldrError::Other(zccache_command_failure_message_strings(
             args, &output,
@@ -420,14 +583,17 @@ pub(crate) fn run_zccache_command_raw_in_cache_dir(
     args: &[&str],
     cache_dir: &Path,
 ) -> Result<Output, SoldrError> {
-    run_zccache_command_raw_with_env(
-        binary,
-        args,
-        &[(
-            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-            cache_dir.as_os_str(),
-        )],
-    )
+    run_zccache_command_raw_in_cache_dir_with_daemon_name(binary, args, cache_dir, None)
+}
+
+pub(crate) fn run_zccache_command_raw_in_cache_dir_with_daemon_name(
+    binary: &Path,
+    args: &[&str],
+    cache_dir: &Path,
+    daemon_name: Option<&str>,
+) -> Result<Output, SoldrError> {
+    let envs = cache_dir_envs(cache_dir, daemon_name);
+    run_zccache_command_raw_with_env(binary, args, &envs)
 }
 
 fn run_zccache_command_with_env(
@@ -470,15 +636,28 @@ fn run_zccache_command_raw_strings_with_env(
     Ok(command.output()?)
 }
 
-fn command_with_cache_dir(binary: &Path, args: &[&str], cache_dir: &Path) -> Command {
-    command_with_env(
-        binary,
-        args,
-        &[(
-            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-            cache_dir.as_os_str(),
-        )],
-    )
+fn command_with_cache_dir_and_daemon_name(
+    binary: &Path,
+    args: &[&str],
+    cache_dir: &Path,
+    daemon_name: Option<&str>,
+) -> Command {
+    let envs = cache_dir_envs(cache_dir, daemon_name);
+    command_with_env(binary, args, &envs)
+}
+
+fn cache_dir_envs<'a>(
+    cache_dir: &'a Path,
+    daemon_name: Option<&'a str>,
+) -> Vec<(&'static str, &'a OsStr)> {
+    let mut envs = vec![(
+        crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+        cache_dir.as_os_str(),
+    )];
+    if let Some(daemon_name) = daemon_name {
+        envs.push((ZCCACHE_DAEMON_NAMESPACE_ENV_VAR, OsStr::new(daemon_name)));
+    }
+    envs
 }
 
 fn command_with_env(binary: &Path, args: &[&str], envs: &[(&str, &OsStr)]) -> Command {
@@ -502,27 +681,32 @@ pub(crate) fn effective_daemon_rust_log(soldr_override: Option<&str>) -> String 
     }
 }
 
-fn run_zccache_start_command(binary: &Path, cache_dir: &Path) -> Result<Output, SoldrError> {
+fn run_zccache_start_command(
+    binary: &Path,
+    cache_dir: &Path,
+    daemon_name: Option<&str>,
+) -> Result<Output, SoldrError> {
     let rust_log =
         effective_daemon_rust_log(std::env::var(SOLDR_DAEMON_RUST_LOG_ENV_VAR).ok().as_deref());
-    run_zccache_command_raw_with_env(
-        binary,
-        &["start"],
-        &[
-            (
-                crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-                cache_dir.as_os_str(),
-            ),
-            ("RUST_LOG", OsStr::new(rust_log.as_str())),
-        ],
-    )
+    let mut command =
+        command_with_cache_dir_and_daemon_name(binary, &["start"], cache_dir, daemon_name);
+    command.env("RUST_LOG", rust_log);
+    Ok(command.output()?)
 }
 
 pub(crate) fn start_zccache_with_recovery(
     binary: &Path,
     cache_dir: &Path,
 ) -> Result<(), SoldrError> {
-    let start = run_zccache_start_command(binary, cache_dir)?;
+    start_zccache_with_recovery_for_daemon(binary, cache_dir, None)
+}
+
+pub(crate) fn start_zccache_with_recovery_for_daemon(
+    binary: &Path,
+    cache_dir: &Path,
+    daemon_name: Option<&str>,
+) -> Result<(), SoldrError> {
+    let start = run_zccache_start_command(binary, cache_dir, daemon_name)?;
     if start.status.success() {
         return Ok(());
     }
@@ -538,13 +722,18 @@ pub(crate) fn start_zccache_with_recovery(
     eprintln!(
         "soldr: zccache start reported an unresponsive daemon; stopping stale state and retrying"
     );
-    let stop_diagnostic = match run_zccache_command_raw_in_cache_dir(binary, &["stop"], cache_dir) {
+    let stop_diagnostic = match run_zccache_command_raw_in_cache_dir_with_daemon_name(
+        binary,
+        &["stop"],
+        cache_dir,
+        daemon_name,
+    ) {
         Ok(stop) if stop.status.success() => None,
         Ok(stop) => Some(zccache_command_failure_message(&["stop"], &stop)),
         Err(err) => Some(format!("failed to invoke zccache stop: {err}")),
     };
 
-    match run_zccache_start_command(binary, cache_dir) {
+    match run_zccache_start_command(binary, cache_dir, daemon_name) {
         Ok(retry) if retry.status.success() => Ok(()),
         Ok(retry) => {
             let mut message = format!(
@@ -586,10 +775,24 @@ pub(crate) fn poll_zccache_daemon_exit(
     cache_dir: &Path,
     timeout: Duration,
 ) -> ZccacheDaemonExitPollResult {
+    poll_zccache_daemon_exit_for_daemon(binary, cache_dir, None, timeout)
+}
+
+pub(crate) fn poll_zccache_daemon_exit_for_daemon(
+    binary: &Path,
+    cache_dir: &Path,
+    daemon_name: Option<&str>,
+    timeout: Duration,
+) -> ZccacheDaemonExitPollResult {
     let deadline = Instant::now() + timeout;
     let poll_interval = Duration::from_millis(100);
     loop {
-        match run_zccache_command_raw_in_cache_dir(binary, &["status"], cache_dir) {
+        match run_zccache_command_raw_in_cache_dir_with_daemon_name(
+            binary,
+            &["status"],
+            cache_dir,
+            daemon_name,
+        ) {
             Ok(output) => {
                 if zccache_daemon_already_stopped(&output) {
                     return ZccacheDaemonExitPollResult::Exited;
@@ -752,6 +955,44 @@ mod tests {
         assert_eq!(lifecycle.binary_path(), Path::new("zccache"));
         assert_eq!(lifecycle.cache_dir(), Path::new("cache"));
     });
+
+    crate::timed_test!(
+        private_session_start_args_include_daemon_owner_cache_and_env,
+        {
+            let options = ZccacheSessionStartOptions {
+                id: Some("session-override".into()),
+                session_log_path: PathBuf::from("/tmp/zccache/log"),
+                journal_path: PathBuf::from("/tmp/zccache/journal"),
+                session_stats_path: PathBuf::from("/tmp/zccache/stats"),
+            };
+            let private = ZccachePrivateDaemonConfig::new("soldr-dev-test")
+                .with_owner_pid(4242)
+                .with_private_env(vec![
+                    ZccachePrivateEnv::new("ZCCACHE_PATH_REMAP", "auto"),
+                    ZccachePrivateEnv::new("ZCCACHE_WORKTREE_ROOT", "/repo"),
+                ]);
+            let args = session_start_args(&options, Path::new("/tmp/zccache"), Some(&private));
+            assert_eq!(args[0], "session-start");
+            assert!(args
+                .windows(2)
+                .any(|w| w[0] == "--id" && w[1] == "session-override"));
+            assert!(args
+                .windows(2)
+                .any(|w| w[0] == "--daemon-name" && w[1] == "soldr-dev-test"));
+            assert!(args
+                .windows(2)
+                .any(|w| w[0] == "--cache-dir" && w[1] == "/tmp/zccache"));
+            assert!(args
+                .windows(2)
+                .any(|w| w[0] == "--owner-pid" && w[1] == "4242"));
+            assert!(args
+                .windows(2)
+                .any(|w| w[0] == "--private-env" && w[1] == "ZCCACHE_PATH_REMAP=auto"));
+            assert!(args
+                .windows(2)
+                .any(|w| w[0] == "--private-env" && w[1] == "ZCCACHE_WORKTREE_ROOT=/repo"));
+        }
+    );
 
     crate::timed_test!(session_already_ended_detects_common_states, {
         for needle in [

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.11.5");
+    assert_eq!(json["managed_zccache_version"], "1.11.6");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.11.5");
+    assert_eq!(json["managed_zccache_version"], "1.11.6");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.11.5");
+    assert_eq!(json["managed_zccache_version"], "1.11.6");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.11.4");
+    assert_eq!(json["managed_zccache_version"], "1.11.5");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.11.4");
+    assert_eq!(json["managed_zccache_version"], "1.11.5");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.11.4");
+    assert_eq!(json["managed_zccache_version"], "1.11.5");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_cargo_basic.rs
+++ b/crates/soldr-cli/tests/cli_cargo_basic.rs
@@ -194,13 +194,17 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         log.contains("cache=1"),
         "cache-enabled front door should propagate cache flag: {log}"
     );
-    let zccache_cache_dir = cache_root.join("cache").join("zccache");
+    let zccache_cache_dir = discovered_private_zccache_cache_dir(&cache_root);
     assert!(
         path_display_variants(&zccache_cache_dir)
             .iter()
             .any(|path| log.contains(&format!("zccache_dir={path}"))
                 && log.contains(&format!("cache_dir={path}"))),
-        "managed zccache commands and cargo wrapper env should use the Soldr-owned cache dir: {log}"
+        "managed zccache commands and cargo wrapper env should use the private Soldr-owned cache dir: {log}"
+    );
+    assert!(
+        log.contains("daemon_namespace=soldr-dev-") && log.contains("--private-daemon"),
+        "managed zccache should use a private daemon namespace: {log}"
     );
     assert!(
         log.contains("zccache start"),
@@ -287,12 +291,12 @@ fn command_lifetime_cache_stops_zccache_after_successful_cargo() {
 
     let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
     assert_command_lifetime_shutdown_order(&log);
-    let zccache_cache_dir = cache_root.join("cache").join("zccache");
+    let zccache_cache_dir = discovered_private_zccache_cache_dir(&cache_root);
     assert!(
         path_display_variants(&zccache_cache_dir)
             .iter()
             .any(|path| log.contains(&format!("zccache stop cache_dir={path}"))),
-        "command-lifetime stop must use the soldr-managed cache root: {log}"
+        "command-lifetime stop must use the private soldr-managed cache root: {log}"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/crates/soldr-cli/tests/cli_cargo_wrappers.rs
+++ b/crates/soldr-cli/tests/cli_cargo_wrappers.rs
@@ -231,7 +231,6 @@ fn nested_soldr_ignores_inherited_managed_zccache_cache_dir() {
     let parent_cache_root = unique_temp_dir("cargo-parent-managed-zccache-dir");
     let child_cache_root = unique_temp_dir("cargo-child-managed-zccache-dir");
     let parent_zccache_dir = parent_cache_root.join("cache").join("zccache");
-    let child_zccache_dir = child_cache_root.join("cache").join("zccache");
     let log_path = child_cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
     let output = isolated_soldr_command()
@@ -255,6 +254,7 @@ fn nested_soldr_ignores_inherited_managed_zccache_cache_dir() {
     );
 
     let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    let child_zccache_dir = discovered_private_zccache_cache_dir(&child_cache_root);
     assert!(
         path_display_variants(&child_zccache_dir)
             .iter()

--- a/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
+++ b/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
@@ -72,7 +72,7 @@ fn install_fake_zccache(cache_root: &Path, log_path: &Path) -> PathBuf {
         use std::os::unix::fs::PermissionsExt;
         let script = format!(
             "#!/bin/sh\n\
-             echo \"zccache $* cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{}\"\n\
+             echo \"zccache $* cache_dir=${{ZCCACHE_CACHE_DIR:-}} daemon_namespace=${{ZCCACHE_DAEMON_NAMESPACE:-}}\" >> \"{}\"\n\
              exit 0\n",
             log_path.display()
         );
@@ -200,6 +200,10 @@ fn linked_zccache_is_stopped_on_daemon_shutdown() {
                     cache_dir: linked_cache_dir.display().to_string(),
                     session_id: Some("linked-session".into()),
                     source: "test".into(),
+                    private_daemon: true,
+                    daemon_name: Some("soldr-dev-link-test".into()),
+                    owner_pid: Some(std::process::id()),
+                    private_env_keys: vec!["ZCCACHE_PATH_REMAP".into()],
                 },
             },
         )
@@ -225,6 +229,12 @@ fn linked_zccache_is_stopped_on_daemon_shutdown() {
     assert_eq!(linked.cache_dir, linked_cache_dir.display().to_string());
     assert_eq!(linked.binary_path, bin.display().to_string());
     assert_eq!(linked.session_id.as_deref(), Some("linked-session"));
+    assert!(linked.private_daemon);
+    assert_eq!(linked.daemon_name.as_deref(), Some("soldr-dev-link-test"));
+    assert_eq!(
+        linked.private_env_keys,
+        vec!["ZCCACHE_PATH_REMAP".to_string()]
+    );
 
     // Trigger shutdown via the explicit RPC.
     client::shutdown(&sock).expect("shutdown");
@@ -235,7 +245,10 @@ fn linked_zccache_is_stopped_on_daemon_shutdown() {
 
     // The fake zccache must have been invoked with `stop`.
     let calls = std::fs::read_to_string(&log_path).unwrap_or_default();
-    let linked_stop = format!("zccache stop cache_dir={}", linked_cache_dir.display());
+    let linked_stop = format!(
+        "zccache stop cache_dir={} daemon_namespace=soldr-dev-link-test",
+        linked_cache_dir.display()
+    );
     assert!(
         calls.lines().any(|l| l.trim() == linked_stop),
         "expected scoped `zccache stop` invocation {linked_stop:?}; log contents:\n{calls}"

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.11.4");
+    assert_eq!(status_json["managed_version"], "1.11.5");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.11.4");
+    assert_eq!(json["managed_version"], "1.11.5");
 }
 
 #[test]

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.11.5");
+    assert_eq!(status_json["managed_version"], "1.11.6");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.11.5");
+    assert_eq!(json["managed_version"], "1.11.6");
 }
 
 #[test]

--- a/crates/soldr-cli/tests/cli_rust_plan.rs
+++ b/crates/soldr-cli/tests/cli_rust_plan.rs
@@ -41,7 +41,6 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
     let cache_root = unique_temp_dir("cargo-rust-plan-cache");
     let workspace = unique_temp_dir("cargo-rust-plan-workspace");
     let plan_cache = cache_root.join("target-artifact-cache");
-    let zccache_cache_dir = cache_root.join("cache").join("zccache");
     let log_path = cache_root.join("tool.log");
     let metadata_path = cache_root.join("metadata.json");
     let target_dir = workspace.join("target");
@@ -96,6 +95,7 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
     );
 
     let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    let zccache_cache_dir = discovered_private_zccache_cache_dir(&cache_root);
     assert!(
         log.contains("zccache rust-plan restore") && log.contains("zccache rust-plan save"),
         "soldr should call zccache rust-plan restore/save when target cache is enabled: {log}"
@@ -119,9 +119,7 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
         "rust-plan restore should run before Cargo and save should run after Cargo: {log}"
     );
 
-    let plan_path = cache_root
-        .join("cache")
-        .join("zccache")
+    let plan_path = zccache_cache_dir
         .join("plans")
         .join("last-rust-artifact-plan.pb");
     let plan_bytes = fs::read(&plan_path).expect("read generated rust plan");

--- a/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
+++ b/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
@@ -23,7 +23,6 @@ struct ContractFixture {
     cache_root: PathBuf,
     workspace: PathBuf,
     plan_cache: PathBuf,
-    zccache_cache_dir: PathBuf,
     log_path: PathBuf,
     metadata_path: PathBuf,
     cargo: PathBuf,
@@ -35,7 +34,6 @@ fn seed_contract_fixture(label: &str) -> ContractFixture {
     let cache_root = unique_temp_dir(&format!("{label}-cache"));
     let workspace = unique_temp_dir(&format!("{label}-workspace"));
     let plan_cache = cache_root.join("target-artifact-cache");
-    let zccache_cache_dir = cache_root.join("cache").join("zccache");
     let log_path = cache_root.join("tool.log");
     let metadata_path = cache_root.join("metadata.json");
     let target_dir = workspace.join("target");
@@ -84,7 +82,6 @@ fn seed_contract_fixture(label: &str) -> ContractFixture {
         cache_root,
         workspace,
         plan_cache,
-        zccache_cache_dir,
         log_path,
         metadata_path,
         cargo,
@@ -191,10 +188,22 @@ timed_test!(
             log.contains("cache=1") && log.contains("session=test-session"),
             "cargo child should receive cache/session env:\n{log}"
         );
+        let zccache_cache_dir = discovered_private_zccache_cache_dir(&fixture.cache_root);
         assert!(
-            log_contains_path(&log, "zccache_dir=", &fixture.zccache_cache_dir)
-                && log_contains_path(&log, "cache_dir=", &fixture.zccache_cache_dir),
-            "cargo and zccache should use the soldr-owned zccache cache dir:\n{log}"
+            log_contains_path(&log, "zccache_dir=", &zccache_cache_dir)
+                && log_contains_path(&log, "cache_dir=", &zccache_cache_dir),
+            "cargo and zccache should use the private soldr-owned zccache cache dir:\n{log}"
+        );
+        assert!(
+            log.contains("daemon_namespace=soldr-dev-")
+                && log.contains("--private-daemon")
+                && log.contains("--daemon-name soldr-dev-")
+                && log.contains("--owner-pid")
+                && (log.contains("--private-env ZCCACHE_PATH_REMAP=auto")
+                    || log.contains("--private-env \"ZCCACHE_PATH_REMAP=auto\""))
+                && (log.contains("--private-env ZCCACHE_WORKTREE_ROOT=")
+                    || log.contains("--private-env \"ZCCACHE_WORKTREE_ROOT=")),
+            "managed zccache should start a private daemon with session-scoped env:\n{log}"
         );
         assert!(
             log.contains("path_remap=auto"),
@@ -209,7 +218,7 @@ timed_test!(
             "rust-plan should receive the target artifact bundle dir:\n{log}"
         );
 
-        let logs_dir = fixture.zccache_cache_dir.join("logs");
+        let logs_dir = zccache_cache_dir.join("logs");
         let session_log = logs_dir.join("last-session.log");
         let journal = logs_dir.join("last-session.jsonl");
         let stats = logs_dir.join("last-session-stats.json");

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -7,11 +7,14 @@
 use serde_json::Value;
 use std::io::Write;
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     fs,
     path::{Path, PathBuf},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+
+static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) fn isolated_soldr_command() -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_soldr"));
@@ -52,7 +55,9 @@ pub(crate) fn unique_temp_dir(label: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("time went backwards")
         .as_nanos();
-    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
+    let counter = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let process_id = std::process::id();
+    let dir = std::env::temp_dir().join(format!("soldr-{label}-{process_id}-{counter}-{nanos}"));
     fs::create_dir_all(&dir).expect("failed to create temp dir");
     dir
 }

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -121,6 +121,24 @@ pub(crate) fn path_display_variants(path: &Path) -> Vec<String> {
     variants
 }
 
+pub(crate) fn discovered_private_zccache_cache_dir(cache_root: &Path) -> PathBuf {
+    let private_root = cache_root.join("cache").join("zccache").join("private");
+    let mut dirs: Vec<PathBuf> = fs::read_dir(&private_root)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", private_root.display()))
+        .map(|entry| entry.expect("read private zccache dir").path())
+        .filter(|path| path.is_dir())
+        .collect();
+    dirs.sort();
+    assert_eq!(
+        dirs.len(),
+        1,
+        "expected one private zccache cache dir under {}, found {:?}",
+        private_root.display(),
+        dirs
+    );
+    dirs.remove(0)
+}
+
 pub(crate) fn logged_cargo_wrapper(log: &str) -> Option<String> {
     log.lines().find_map(|line| {
         let wrapper = line.strip_prefix("cargo wrapper=")?;
@@ -433,20 +451,20 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
             "@echo off\n\
              if \"%~1\"==\"start\" goto soldr_zccache_start\n\
              if \"%~1\"==\"stop\" (\n\
-               echo zccache stop cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+               echo zccache stop cache_dir=%ZCCACHE_CACHE_DIR% daemon_namespace=%ZCCACHE_DAEMON_NAMESPACE%>>\"{0}\"\n\
                if defined SOLDR_TEST_ZCCACHE_STALE_START_ONCE type nul > \"%SOLDR_TEST_ZCCACHE_STALE_START_ONCE%.stopped\"\n\
                if defined SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER type nul > \"%SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER%\"\n\
                exit /b 0\n\
              )\n\
               if \"%~1\"==\"session-start\" (\n\
-                echo zccache session-start cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+                echo zccache session-start cache_dir=%ZCCACHE_CACHE_DIR% daemon_namespace=%ZCCACHE_DAEMON_NAMESPACE% args=%*>>\"{0}\"\n\
                 if not \"%~4\"==\"\" type nul > \"%~4\"\n\
                 if not \"%~6\"==\"\" type nul > \"%~6\"\n\
                 echo {{\"session_id\":\"test-session\"}}\n\
                 exit /b 0\n\
              )\n\
              if \"%~1\"==\"session-end\" (\n\
-               echo zccache session-end %~2 %~3 cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+               echo zccache session-end %~2 %~3 cache_dir=%ZCCACHE_CACHE_DIR% daemon_namespace=%ZCCACHE_DAEMON_NAMESPACE%>>\"{0}\"\n\
                if \"%~3\"==\"--json\" (\n\
                  echo {{\"status\":\"ok\",\"session_id\":\"test-session\",\"duration_ms\":1200,\"compilations\":10,\"hits\":7,\"misses\":3,\"non_cacheable\":2,\"errors\":1,\"time_saved_ms\":900,\"unique_sources\":4,\"bytes_read\":111,\"bytes_written\":222,\"hit_rate\":0.7}}\n\
                ) else (\n\
@@ -480,11 +498,11 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
              )\n\
              set \"rustc=%~1\"\n\
              shift\n\
-             echo zccache wrapper cache_dir=%ZCCACHE_CACHE_DIR% %rustc% %*>>\"{0}\"\n\
+             echo zccache wrapper cache_dir=%ZCCACHE_CACHE_DIR% daemon_namespace=%ZCCACHE_DAEMON_NAMESPACE% %rustc% %*>>\"{0}\"\n\
              call \"%rustc%\" %*\n\
              exit /b %ERRORLEVEL%\n\
              :soldr_zccache_start\n\
-             echo zccache start cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
+             echo zccache start cache_dir=%ZCCACHE_CACHE_DIR% daemon_namespace=%ZCCACHE_DAEMON_NAMESPACE%>>\"{0}\"\n\
              if not defined SOLDR_TEST_ZCCACHE_STALE_START_ONCE exit /b 0\n\
              if exist \"%SOLDR_TEST_ZCCACHE_STALE_START_ONCE%.stopped\" exit /b 0\n\
              if not exist \"%SOLDR_TEST_ZCCACHE_STALE_START_ONCE%.failed\" (\n\
@@ -519,7 +537,7 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
             "#!/bin/sh\n\
              case \"$1\" in\n\
                start)\n\
-                 echo \"zccache start cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+                 echo \"zccache start cache_dir=${{ZCCACHE_CACHE_DIR:-}} daemon_namespace=${{ZCCACHE_DAEMON_NAMESPACE:-}}\" >> \"{0}\"\n\
                  if [ -n \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE:-}}\" ]; then\n\
                    if [ ! -e \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE}}.stopped\" ]; then\n\
                      if [ ! -e \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE}}.failed\" ]; then\n\
@@ -534,7 +552,7 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
                  exit 0\n\
                  ;;\n\
                stop)\n\
-                 echo \"zccache stop cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+                 echo \"zccache stop cache_dir=${{ZCCACHE_CACHE_DIR:-}} daemon_namespace=${{ZCCACHE_DAEMON_NAMESPACE:-}}\" >> \"{0}\"\n\
                  if [ -n \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE:-}}\" ]; then\n\
                    : > \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE}}.stopped\"\n\
                  fi\n\
@@ -544,14 +562,14 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
                  exit 0\n\
                  ;;\n\
                 session-start)\n\
-                  echo \"zccache session-start cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+                  echo \"zccache session-start cache_dir=${{ZCCACHE_CACHE_DIR:-}} daemon_namespace=${{ZCCACHE_DAEMON_NAMESPACE:-}} args=$*\" >> \"{0}\"\n\
                   : > \"$4\"\n\
                   : > \"$6\"\n\
                   echo '{{\"session_id\":\"test-session\"}}'\n\
                   exit 0\n\
                ;;\n\
                session-end)\n\
-                 echo \"zccache session-end $2 $3 cache_dir=${{ZCCACHE_CACHE_DIR:-}}\" >> \"{0}\"\n\
+                 echo \"zccache session-end $2 $3 cache_dir=${{ZCCACHE_CACHE_DIR:-}} daemon_namespace=${{ZCCACHE_DAEMON_NAMESPACE:-}}\" >> \"{0}\"\n\
                  if [ \"${{3:-}}\" = \"--json\" ]; then\n\
                    printf '{{\"status\":\"ok\",\"session_id\":\"test-session\",\"duration_ms\":1200,\"compilations\":10,\"hits\":7,\"misses\":3,\"non_cacheable\":2,\"errors\":1,\"time_saved_ms\":900,\"unique_sources\":4,\"bytes_read\":111,\"bytes_written\":222,\"hit_rate\":0.7}}\\n'\n\
                  else\n\
@@ -611,7 +629,7 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
                fi\n\
                echo \"zccache jobserver fds ok read=$SOLDR_TEST_JOBSERVER_READ_FD write=$SOLDR_TEST_JOBSERVER_WRITE_FD\" >> \"{0}\"\n\
              fi\n\
-             echo \"zccache wrapper cache_dir=${{ZCCACHE_CACHE_DIR:-}} $rustc $*\" >> \"{0}\"\n\
+             echo \"zccache wrapper cache_dir=${{ZCCACHE_CACHE_DIR:-}} daemon_namespace=${{ZCCACHE_DAEMON_NAMESPACE:-}} $rustc $*\" >> \"{0}\"\n\
              \"$rustc\" \"$@\"\n",
             log_path.display()
         )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- Switch managed zccache builds to private daemon sessions with a stable soldr-specific daemon namespace and private cache root.
- Pass owner PID refs and generated private env through `session-start`, then persist private daemon metadata for reconnect, stop, flush, and rust-plan paths.
- Keep manual shutdown from stopping the shared/default zccache daemon when soldr owns only a private dev daemon.
- Pin the managed zccache runtime contract to published zccache 1.11.6, including the private-daemon socket/path fixes from zackees/zccache#433 and the release hardening from zackees/zccache#436.
- Bump soldr to 0.7.40 so main can publish this rollover as a release.

Closes #556.
Part of zackees/zccache#430.

## Verification
- MSVC: `cargo fmt -- --check`
- MSVC: `cargo check -p soldr-cli --all-targets`
- MSVC: `cargo-clippy.exe clippy -p soldr-cli --all-targets -- -D warnings`
- MSVC: `cargo test -p soldr-cli --lib`
- MSVC: `cargo test -p soldr-cli --test cli_zccache_contract_matrix --test cli_cargo_basic --test cli_rust_plan --test cli_cargo_wrappers --test cli_daemon_zccache_link`
- MSVC: `cargo test -p soldr-cli --test cli_cache --test cli_install_zccache`
- MSVC: `cargo test -p soldr-cli zccache_runtime_contract_matches_rust_constants --lib`
- MSVC: `cargo test -p soldr-cli core::tests::test_version --lib`
- `python -m pytest tests/test_zccache_runtime_contract.py -q`
- `git diff --check`

## Latest rollover checks
- MSVC: `rustup run 1.94.1-x86_64-pc-windows-msvc cargo fmt -- --check`
- MSVC with explicit `RUSTC=$(rustup which --toolchain 1.94.1-x86_64-pc-windows-msvc rustc)`: `cargo test -p soldr-cli zccache_runtime_contract_matches_rust_constants --lib`
- MSVC with explicit `RUSTC=$(rustup which --toolchain 1.94.1-x86_64-pc-windows-msvc rustc)`: `cargo test -p soldr-cli --test cli_cache --test cli_install_zccache`
- `python -m pytest tests/test_zccache_runtime_contract.py -q`
- `git diff --check`
