### PR TITLE
fix(fetch): avoid repo-scoped tokens for cross-repo releases

### DIFF
--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -60,13 +60,28 @@ def _release_url(repo: str, version: str) -> str:
     return f"https://api.github.com/repos/{repo}/releases/latest"
 
 
-def _request_headers() -> dict[str, str]:
+def _auth_token_for_repo(repo: str) -> str:
+    explicit = os.environ.get("SETUP_SOLDR_GITHUB_TOKEN", "").strip()
+    if explicit:
+        return explicit
+
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        return ""
+
+    current_repo = os.environ.get("GITHUB_REPOSITORY", "").strip().lower()
+    if current_repo == repo.strip().lower():
+        return token
+    return ""
+
+
+def _request_headers(repo: str) -> dict[str, str]:
     headers = {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": "setup-soldr-action",
     }
-    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    token = _auth_token_for_repo(repo)
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
@@ -75,7 +90,7 @@ def _request_headers() -> dict[str, str]:
 def _fetch_release(repo: str, version: str) -> dict[str, object]:
     request = urllib.request.Request(
         _release_url(repo, version),
-        headers=_request_headers(),
+        headers=_request_headers(repo),
     )
     with urllib.request.urlopen(request) as response:
         return json.load(response)

--- a/.github/actions/setup-soldr/resolve_setup.py
+++ b/.github/actions/setup-soldr/resolve_setup.py
@@ -152,7 +152,7 @@ def resolve_latest_soldr_release(repo: str) -> str:
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": "setup-soldr-action",
     }
-    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    token = _github_token_for_repo(repo)
     if token:
         headers["Authorization"] = f"Bearer {token}"
     try:
@@ -171,6 +171,21 @@ def resolve_latest_soldr_release(repo: str) -> str:
     if not isinstance(tag, str):
         return ""
     return _normalize_release_tag(tag)
+
+
+def _github_token_for_repo(repo: str) -> str:
+    explicit = os.environ.get("SETUP_SOLDR_GITHUB_TOKEN", "").strip()
+    if explicit:
+        return explicit
+
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        return ""
+
+    current_repo = os.environ.get("GITHUB_REPOSITORY", "").strip().lower()
+    if current_repo == repo.strip().lower():
+        return token
+    return ""
 
 
 def normalize_bool_input(value: str, *, name: str, default: bool) -> bool:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.40"
+version = "0.7.41"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/src/fetch/github.rs
+++ b/crates/soldr-cli/src/fetch/github.rs
@@ -137,7 +137,7 @@ async fn fetch_latest_by_prefix(
         "https://api.github.com/repos/{}/{}/releases?per_page=60",
         repo.owner, repo.repo
     );
-    let resp = github_request(client, &url)
+    let resp = github_request(client, repo, &url)
         .send()
         .await
         .map_err(|e| SoldrError::Network(e.to_string()))?;
@@ -185,7 +185,7 @@ async fn fetch_release_value(
     repo: &RepoInfo,
     url: &str,
 ) -> Result<serde_json::Value, SoldrError> {
-    let resp = github_request(client, url)
+    let resp = github_request(client, repo, url)
         .send()
         .await
         .map_err(|e| SoldrError::Network(e.to_string()))?;
@@ -213,7 +213,7 @@ async fn fetch_release_by_listing(
         "https://api.github.com/repos/{}/{}/releases?per_page=30",
         repo.owner, repo.repo
     );
-    let resp = github_request(client, &url)
+    let resp = github_request(client, repo, &url)
         .send()
         .await
         .map_err(|e| SoldrError::Network(e.to_string()))?;
@@ -305,19 +305,63 @@ fn parse_release_info(
     Ok(ReleaseInfo { version, assets })
 }
 
-fn github_request<'a>(client: &'a reqwest::Client, url: &'a str) -> reqwest::RequestBuilder {
+fn github_request<'a>(
+    client: &'a reqwest::Client,
+    repo: &RepoInfo,
+    url: &'a str,
+) -> reqwest::RequestBuilder {
     let mut request = client
         .get(url)
         .header("Accept", "application/vnd.github+json");
 
-    if let Some(token) = std::env::var("GITHUB_TOKEN")
-        .ok()
-        .or_else(|| std::env::var("GH_TOKEN").ok())
-    {
+    if let Some(token) = github_auth_token_for_repo(repo) {
         request = request.bearer_auth(token);
     }
 
     request
+}
+
+fn github_auth_token_for_repo(repo: &RepoInfo) -> Option<String> {
+    github_auth_token_for_repo_env(
+        repo,
+        std::env::var("SOLDR_GITHUB_TOKEN").ok(),
+        std::env::var("GH_TOKEN").ok(),
+        std::env::var("GITHUB_TOKEN").ok(),
+        std::env::var("GITHUB_REPOSITORY").ok(),
+        std::env::var("GITHUB_ACTIONS").ok(),
+    )
+}
+
+fn github_auth_token_for_repo_env(
+    repo: &RepoInfo,
+    soldr_token: Option<String>,
+    gh_token: Option<String>,
+    github_token: Option<String>,
+    github_repository: Option<String>,
+    github_actions: Option<String>,
+) -> Option<String> {
+    if let Some(token) = soldr_token.filter(|token| !token.is_empty()) {
+        return Some(token);
+    }
+
+    let gh_token = gh_token.filter(|token| !token.is_empty());
+    let github_token = github_token.filter(|token| !token.is_empty());
+    let in_github_actions = github_actions
+        .as_deref()
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"));
+    if !in_github_actions {
+        return gh_token.or(github_token);
+    }
+
+    let requested = format!("{}/{}", repo.owner, repo.repo);
+    let is_actions_repo = github_repository
+        .as_deref()
+        .is_some_and(|current| current.eq_ignore_ascii_case(&requested));
+    if is_actions_repo {
+        gh_token.or(github_token)
+    } else {
+        None
+    }
 }
 
 /// Pick the best asset for our target triple.
@@ -406,6 +450,65 @@ mod tests {
             name: name.to_string(),
             download_url: format!("https://example.com/{name}"),
         }
+    }
+
+    fn repo(owner: &str, name: &str) -> RepoInfo {
+        RepoInfo {
+            owner: owner.to_string(),
+            repo: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn github_auth_prefers_explicit_soldr_github_token() {
+        let token = github_auth_token_for_repo_env(
+            &repo("zackees", "zccache"),
+            Some("soldr-explicit".to_string()),
+            Some("gh-actions".to_string()),
+            Some("actions".to_string()),
+            Some("zackees/soldr".to_string()),
+            Some("true".to_string()),
+        );
+        assert_eq!(token.as_deref(), Some("soldr-explicit"));
+    }
+
+    #[test]
+    fn github_auth_uses_actions_token_only_for_current_repo() {
+        let token = github_auth_token_for_repo_env(
+            &repo("zackees", "soldr"),
+            None,
+            Some("gh-actions".to_string()),
+            Some("actions".to_string()),
+            Some("zackees/soldr".to_string()),
+            Some("true".to_string()),
+        );
+        assert_eq!(token.as_deref(), Some("gh-actions"));
+    }
+
+    #[test]
+    fn github_auth_skips_actions_token_for_cross_repo_release_lookup() {
+        let token = github_auth_token_for_repo_env(
+            &repo("zackees", "zccache"),
+            None,
+            Some("gh-actions".to_string()),
+            Some("actions".to_string()),
+            Some("zackees/soldr".to_string()),
+            Some("true".to_string()),
+        );
+        assert!(token.is_none());
+    }
+
+    #[test]
+    fn github_auth_uses_shell_tokens_outside_actions() {
+        let token = github_auth_token_for_repo_env(
+            &repo("zackees", "zccache"),
+            None,
+            Some("shell-gh".to_string()),
+            Some("shell-github".to_string()),
+            None,
+            None,
+        );
+        assert_eq!(token.as_deref(), Some("shell-gh"));
     }
 
     #[test]

--- a/crates/soldr-cli/tests/cli_cargo_native_cc.rs
+++ b/crates/soldr-cli/tests/cli_cargo_native_cc.rs
@@ -72,6 +72,127 @@ fn soldr_bin() -> &'static str {
     env!("CARGO_BIN_EXE_soldr")
 }
 
+struct FakeZccache {
+    bin: PathBuf,
+    down_marker: PathBuf,
+}
+
+fn fake_script_path(dir: &Path, name: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        dir.join(format!("{name}.cmd"))
+    }
+    #[cfg(not(windows))]
+    {
+        dir.join(name)
+    }
+}
+
+fn write_fake_script(path: &Path, body: &str) {
+    #[cfg(windows)]
+    {
+        fs::write(path, body.replace('\n', "\r\n")).expect("failed to write fake script");
+    }
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::write(path, body).expect("failed to write fake script");
+        let mut perms = fs::metadata(path)
+            .expect("failed to stat fake script")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("failed to chmod fake script");
+    }
+}
+
+fn fake_zccache_script() -> &'static str {
+    #[cfg(windows)]
+    {
+        r#"@echo off
+if "%~1"=="session-start" (
+  echo {"session_id":"test-session"}
+  exit /b 0
+)
+if "%~1"=="start" (
+  exit /b 0
+)
+if "%~1"=="session-end" (
+  echo {"status":"ok","session_id":"test-session","duration_ms":1,"compilations":0,"hits":0,"misses":0}
+  exit /b 0
+)
+if "%~1"=="stop" (
+  if defined SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER type nul > "%SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER%"
+  exit /b 0
+)
+if "%~1"=="status" (
+  if defined SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER if exist "%SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER%" (
+    echo daemon not running 1>&2
+    exit /b 1
+  )
+  echo hits=0
+  exit /b 0
+)
+set "rustc=%~1"
+shift /1
+set "args="
+:args_loop
+if "%~1"=="" goto run_rustc
+set args=%args% "%~1"
+shift /1
+goto args_loop
+:run_rustc
+call "%rustc%" %args%
+exit /b %ERRORLEVEL%
+"#
+    }
+    #[cfg(not(windows))]
+    {
+        r#"#!/bin/sh
+case "$1" in
+  start)
+    exit 0
+    ;;
+  session-start)
+    printf '{"session_id":"test-session"}\n'
+    exit 0
+    ;;
+  session-end)
+    printf '{"status":"ok","session_id":"test-session","duration_ms":1,"compilations":0,"hits":0,"misses":0}\n'
+    exit 0
+    ;;
+  stop)
+    if [ -n "${SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER:-}" ]; then
+      : > "$SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER"
+    fi
+    exit 0
+    ;;
+  status)
+    if [ -n "${SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER:-}" ] && [ -e "$SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER" ]; then
+      echo 'daemon not running' >&2
+      exit 1
+    fi
+    echo 'hits=0'
+    exit 0
+    ;;
+esac
+rustc="$1"
+shift
+exec "$rustc" "$@"
+"#
+    }
+}
+
+fn install_fake_zccache() -> FakeZccache {
+    let dir = unique_temp_dir("native-cc-fake-zccache");
+    let zccache = fake_script_path(&dir, "zccache");
+    write_fake_script(&zccache, fake_zccache_script());
+    FakeZccache {
+        bin: zccache,
+        down_marker: dir.join("daemon-down"),
+    }
+}
+
 fn remove_inherited_native_cache_env(cmd: &mut Command) {
     for key in [
         "CC",
@@ -87,9 +208,13 @@ fn remove_inherited_native_cache_env(cmd: &mut Command) {
         "CXX_x86_64_pc_windows_msvc",
         "CC_aarch64_pc_windows_msvc",
         "CXX_aarch64_pc_windows_msvc",
+        "CARGO_TARGET_DIR",
         "RUSTC_WRAPPER",
         "RUSTC_WORKSPACE_WRAPPER",
         "SOLDR_NATIVE_CACHE",
+        "SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER",
+        "SOLDR_TEST_ZCCACHE_BIN",
+        "SOLDR_ZCCACHE_LOCAL_DIR",
         "ZCCACHE_CACHE_DIR",
     ] {
         cmd.env_remove(key);
@@ -165,6 +290,12 @@ fn run_soldr_cargo_build(project: &Path, env_overrides: &[(&str, &str)]) -> std:
     cmd.env("SOLDR_CACHE_DIR", unique_cache_dir());
     cmd.env("SOLDR_CACHE_LIFECYCLE", "command");
     cmd.env("SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS", "30");
+    let fake_zccache = install_fake_zccache();
+    cmd.env("SOLDR_TEST_ZCCACHE_BIN", &fake_zccache.bin);
+    cmd.env(
+        "SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER",
+        &fake_zccache.down_marker,
+    );
     cmd.env_remove("SOLDR_BUILD_CACHE_MODE");
     cmd.env_remove("SOLDR_TARGET_CACHE_MODE");
     for (k, v) in env_overrides {
@@ -183,6 +314,15 @@ fn parse_captured_env(marker_path: &Path) -> std::collections::HashMap<String, S
             Some((k.to_string(), v.to_string()))
         })
         .collect()
+}
+
+fn assert_command_success(output: &std::process::Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context} failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 timed_test!(
@@ -255,7 +395,7 @@ timed_test!(
     {
         let project = make_env_capture_project("native-cc-disabled");
         let output = run_soldr_cargo_build(&project, &[("SOLDR_NATIVE_CACHE", "0")]);
-        assert!(output.status.success(), "soldr cargo build failed");
+        assert_command_success(&output, "soldr cargo build");
         let env = parse_captured_env(&project.join("env-capture.txt"));
         // CC stays at whatever the build.rs's inherited env had (likely
         // <UNSET> in this test). The critical assertion is the marker:
@@ -293,7 +433,7 @@ timed_test!(
         // into native-cache by setting CC explicitly.
         let project = make_env_capture_project("native-cc-explicit");
         let output = run_soldr_cargo_build(&project, &[("CC", "fake-compiler-doesnt-exist")]);
-        assert!(output.status.success(), "soldr cargo build failed");
+        assert_command_success(&output, "soldr cargo build");
         let env = parse_captured_env(&project.join("env-capture.txt"));
 
         let cc = env.get("CC").cloned().unwrap_or_default();
@@ -320,7 +460,7 @@ timed_test!(
         // CC="sccache clang" → must remain as-is (no double-wrap).
         let project = make_env_capture_project("native-cc-no-double-wrap");
         let output = run_soldr_cargo_build(&project, &[("CC", "sccache clang")]);
-        assert!(output.status.success(), "soldr cargo build failed");
+        assert_command_success(&output, "soldr cargo build");
         let env = parse_captured_env(&project.join("env-capture.txt"));
 
         let cc = env.get("CC").cloned().unwrap_or_default();
@@ -347,10 +487,7 @@ timed_test!(
             cmd.args(["--no-cache", "cargo", "build", "--no-trampoline"]);
             cmd.output().expect("spawn soldr --no-cache cargo build")
         };
-        assert!(
-            output.status.success(),
-            "soldr --no-cache cargo build failed"
-        );
+        assert_command_success(&output, "soldr --no-cache cargo build");
 
         let env = parse_captured_env(&project.join("env-capture.txt"));
         assert_eq!(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.40",
+  "version": "0.7.41",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -20,6 +20,33 @@ def _load_module():
     return module
 
 
+def test_resolve_setup_uses_token_for_current_repo(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("GITHUB_TOKEN", "repo-token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "zackees/soldr")
+    monkeypatch.delenv("SETUP_SOLDR_GITHUB_TOKEN", raising=False)
+
+    assert module._github_token_for_repo("zackees/soldr") == "repo-token"
+
+
+def test_resolve_setup_skips_repo_token_for_cross_repo(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("GITHUB_TOKEN", "repo-token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "caller/app")
+    monkeypatch.delenv("SETUP_SOLDR_GITHUB_TOKEN", raising=False)
+
+    assert module._github_token_for_repo("zackees/soldr") == ""
+
+
+def test_resolve_setup_accepts_explicit_setup_token(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("GITHUB_TOKEN", "repo-token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "caller/app")
+    monkeypatch.setenv("SETUP_SOLDR_GITHUB_TOKEN", "explicit-token")
+
+    assert module._github_token_for_repo("zackees/soldr") == "explicit-token"
+
+
 def test_load_toolchain_spec_reads_rust_toolchain_toml() -> None:
     module = _load_module()
 

--- a/tests/test_setup_soldr_ensure_soldr.py
+++ b/tests/test_setup_soldr_ensure_soldr.py
@@ -20,8 +20,10 @@ def _load_module():
 def test_request_headers_include_github_token_when_present(monkeypatch) -> None:
     module = _load_module()
     monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "zackees/soldr")
+    monkeypatch.delenv("SETUP_SOLDR_GITHUB_TOKEN", raising=False)
 
-    headers = module._request_headers()
+    headers = module._request_headers("zackees/soldr")
 
     assert headers["Authorization"] == "Bearer test-token"
     assert headers["User-Agent"] == "setup-soldr-action"
@@ -30,10 +32,33 @@ def test_request_headers_include_github_token_when_present(monkeypatch) -> None:
 def test_request_headers_omit_authorization_when_token_missing(monkeypatch) -> None:
     module = _load_module()
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("SETUP_SOLDR_GITHUB_TOKEN", raising=False)
 
-    headers = module._request_headers()
+    headers = module._request_headers("zackees/soldr")
 
     assert "Authorization" not in headers
+
+
+def test_request_headers_skip_repo_scoped_token_for_cross_repo(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "caller/app")
+    monkeypatch.delenv("SETUP_SOLDR_GITHUB_TOKEN", raising=False)
+
+    headers = module._request_headers("zackees/soldr")
+
+    assert "Authorization" not in headers
+
+
+def test_request_headers_allow_explicit_setup_token_for_cross_repo(monkeypatch) -> None:
+    module = _load_module()
+    monkeypatch.setenv("GITHUB_TOKEN", "repo-token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "caller/app")
+    monkeypatch.setenv("SETUP_SOLDR_GITHUB_TOKEN", "explicit-token")
+
+    headers = module._request_headers("zackees/soldr")
+
+    assert headers["Authorization"] == "Bearer explicit-token"
 
 
 def test_export_bundle_env_writes_local_dirs_when_bundle_present(


### PR DESCRIPTION
## Summary
- Do not send Actions repo-scoped `GH_TOKEN` / `GITHUB_TOKEN` to cross-repo GitHub release lookups, so managed zccache fetches from `zackees/zccache` use the public release endpoint instead of receiving a misleading 404.
- Add `SOLDR_GITHUB_TOKEN` / `SETUP_SOLDR_GITHUB_TOKEN` as explicit override tokens for callers that really need authenticated cross-repo release access.
- Apply the same repo-scoped-token guard to setup-soldr's Python release lookup helpers.
- Bump soldr to 0.7.41 so the fixed build supersedes the already-published 0.7.40 release.

## Verification
- MSVC with explicit `RUSTC=$(rustup which --toolchain 1.94.1-x86_64-pc-windows-msvc rustc)`: `cargo test -p soldr-cli github_auth_ --lib`
- MSVC with explicit `RUSTC=$(rustup which --toolchain 1.94.1-x86_64-pc-windows-msvc rustc)`: `cargo test -p soldr-cli fetch::github::tests --lib`
- MSVC with explicit `RUSTC=$(rustup which --toolchain 1.94.1-x86_64-pc-windows-msvc rustc)`: `cargo test -p soldr-cli core::tests::test_version --lib`
- MSVC: `cargo fmt -- --check`
- `python -m pytest tests/test_setup_soldr_ensure_soldr.py tests/test_setup_soldr_action.py -q`
- `git diff --check`
- Live smoke: with simulated Actions env and intentionally bad `GH_TOKEN`/`GITHUB_TOKEN`, `soldr session-start --json` fetched zccache 1.11.6 from the GitHub release and `soldr cache shutdown` exited cleanly.

Follow-up to #557 and #556.