### PR TITLE
fix(perf): restore private zccache stats

### DIFF
--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -529,12 +529,24 @@ jobs:
               *) echo "warm_ms" ;;
             esac
           }
+          hits_key_for() {
+            case "$1" in
+              worktree-share) echo "b_hits" ;;
+              *) echo "warm_hits" ;;
+            esac
+          }
+          misses_key_for() {
+            case "$1" in
+              worktree-share) echo "b_misses" ;;
+              *) echo "warm_misses" ;;
+            esac
+          }
 
           {
             echo "## Evaluate ${M_PLATFORM}"
             echo
-            echo "| fixture | scenario | cold ms | warm ms | speedup | threshold | mode | result |"
-            echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+            echo "| fixture | scenario | cold ms | warm ms | speedup | hits/misses | threshold | mode | result |"
+            echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           status=0
@@ -561,10 +573,12 @@ jobs:
               mode="$(mode_for "${scenario}")"
               cold_key="$(cold_key_for "${scenario}")"
               warm_key="$(warm_key_for "${scenario}")"
+              hits_key="$(hits_key_for "${scenario}")"
+              misses_key="$(misses_key_for "${scenario}")"
 
               result_json="$(find "${fixture_root}" -type f -path "*/${scenario}/result.json" | head -n1)"
               if [[ -z "${result_json}" ]]; then
-                echo "| ${fixture} | ${scenario} | - | - | - | >= ${MIN_SPEEDUP}x | ${mode} | MISSING |" >> "$GITHUB_STEP_SUMMARY"
+                echo "| ${fixture} | ${scenario} | - | - | - | - | >= ${MIN_SPEEDUP}x | ${mode} | MISSING |" >> "$GITHUB_STEP_SUMMARY"
                 if [[ "${mode}" == "fail" ]]; then
                   echo "::error::${scenario}/result.json not found in ${fixture} artifact"
                   status=1
@@ -578,7 +592,7 @@ jobs:
               warm_ms="$(jq -r --arg k "${warm_key}" '.[$k] // empty' "${result_json}")"
 
               if [[ -z "${cold_ms}" || -z "${warm_ms}" ]]; then
-                echo "| ${fixture} | ${scenario} | ${cold_ms:--} | ${warm_ms:--} | - | >= ${MIN_SPEEDUP}x | ${mode} | BAD-JSON |" >> "$GITHUB_STEP_SUMMARY"
+                echo "| ${fixture} | ${scenario} | ${cold_ms:--} | ${warm_ms:--} | - | - | >= ${MIN_SPEEDUP}x | ${mode} | BAD-JSON |" >> "$GITHUB_STEP_SUMMARY"
                 if [[ "${mode}" == "fail" ]]; then
                   echo "::error::${fixture}/${scenario} result.json missing ${cold_key}/${warm_key}"
                   status=1
@@ -590,7 +604,7 @@ jobs:
 
               # Treat a 0ms warm build as a measurement bug, not a win.
               if (( warm_ms <= 0 )); then
-                echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | - | >= ${MIN_SPEEDUP}x | ${mode} | BAD-WARM |" >> "$GITHUB_STEP_SUMMARY"
+                echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | - | - | >= ${MIN_SPEEDUP}x | ${mode} | BAD-WARM |" >> "$GITHUB_STEP_SUMMARY"
                 if [[ "${mode}" == "fail" ]]; then
                   echo "::error::${fixture}/${scenario} ${warm_key}=${warm_ms} is non-positive"
                   status=1
@@ -600,19 +614,34 @@ jobs:
                 continue
               fi
 
+              hits="$(jq -r --arg k "${hits_key}" '.[$k] // empty' "${result_json}")"
+              misses="$(jq -r --arg k "${misses_key}" '.[$k] // empty' "${result_json}")"
+              if [[ -z "${hits}" || -z "${misses}" ]]; then
+                echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | - | ${hits:--}/${misses:--} | >= ${MIN_SPEEDUP}x | ${mode} | BAD-STATS |" >> "$GITHUB_STEP_SUMMARY"
+                echo "::error::${fixture}/${scenario} result.json missing ${hits_key}/${misses_key}"
+                status=1
+                continue
+              fi
+              if (( hits + misses <= 0 )); then
+                echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | - | ${hits}/${misses} | >= ${MIN_SPEEDUP}x | ${mode} | BAD-STATS |" >> "$GITHUB_STEP_SUMMARY"
+                echo "::error::${fixture}/${scenario} reported ${hits_key}+${misses_key}=0; zccache stats were not captured"
+                status=1
+                continue
+              fi
+
               speedup="$(awk -v c="${cold_ms}" -v w="${warm_ms}" 'BEGIN { printf "%.2f", c / w }')"
               pass="$(awk -v s="${speedup}" -v t="${MIN_SPEEDUP}" 'BEGIN { print (s >= t) ? "1" : "0" }')"
 
               if [[ "${pass}" == "1" ]]; then
-                echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | >= ${MIN_SPEEDUP}x | ${mode} | PASS |" >> "$GITHUB_STEP_SUMMARY"
+                echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | ${hits}/${misses} | >= ${MIN_SPEEDUP}x | ${mode} | PASS |" >> "$GITHUB_STEP_SUMMARY"
                 echo "${fixture}/${scenario}: ${speedup}x >= ${MIN_SPEEDUP}x — PASS"
               else
                 if [[ "${mode}" == "fail" ]]; then
-                  echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | >= ${MIN_SPEEDUP}x | fail | FAIL |" >> "$GITHUB_STEP_SUMMARY"
+                  echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | ${hits}/${misses} | >= ${MIN_SPEEDUP}x | fail | FAIL |" >> "$GITHUB_STEP_SUMMARY"
                   echo "::error::${fixture}/${scenario} only ${speedup}x faster (need >= ${MIN_SPEEDUP}x)"
                   status=1
                 else
-                  echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | >= ${MIN_SPEEDUP}x | warn | WARN |" >> "$GITHUB_STEP_SUMMARY"
+                  echo "| ${fixture} | ${scenario} | ${cold_ms} | ${warm_ms} | ${speedup}x | ${hits}/${misses} | >= ${MIN_SPEEDUP}x | warn | WARN |" >> "$GITHUB_STEP_SUMMARY"
                   echo "::warning::${fixture}/${scenario} only ${speedup}x faster (need >= ${MIN_SPEEDUP}x); soft gate — not failing today"
                 fi
               fi

--- a/crates/soldr-cli/src/cache/report.rs
+++ b/crates/soldr-cli/src/cache/report.rs
@@ -45,7 +45,18 @@ pub(super) struct CacheReportOutput {
 
 fn collect_cache_report_output() -> Result<CacheReportOutput, SoldrError> {
     let paths = SoldrPaths::new()?;
-    let zccache_dir = managed_zccache_cache_dir(&paths)?;
+    collect_cache_report_output_for_paths(&paths)
+}
+
+fn collect_cache_report_output_for_paths(
+    paths: &SoldrPaths,
+) -> Result<CacheReportOutput, SoldrError> {
+    let default_zccache_dir = managed_zccache_cache_dir(paths)?;
+    let linked_private = super::session::linked_private_zccache_lifecycle(paths);
+    let zccache_dir = linked_private
+        .as_ref()
+        .map(|(_, cache_dir)| cache_dir.clone())
+        .unwrap_or_else(|| default_zccache_dir.clone());
     let session_stats_path = crate::cache_lib::session_stats_path(&zccache_dir);
     let journal_path = crate::cache_lib::session_journal_path(&zccache_dir);
     let session_stats_present = session_stats_path.exists();
@@ -75,14 +86,27 @@ fn collect_cache_report_output() -> Result<CacheReportOutput, SoldrError> {
     };
 
     let rollups = if journal_present {
-        match cached_active_zccache(&paths)? {
-            Some(fetch) => {
-                let journal_arg = journal_path.display().to_string();
-                let result = run_zccache_command_raw_in_cache_dir(
+        let journal_arg = journal_path.display().to_string();
+        let result = if let Some((lifecycle, _)) = linked_private.as_ref() {
+            Some(lifecycle.run_raw(&["analyze", &journal_arg, "--json"])?)
+        } else {
+            match cached_active_zccache(paths)? {
+                Some(fetch) => Some(run_zccache_command_raw_in_cache_dir(
                     &fetch.binary_path,
                     &["analyze", &journal_arg, "--json"],
                     &zccache_dir,
-                )?;
+                )?),
+                None => {
+                    notes.push(
+                        "rollups: managed zccache binary not yet fetched (no builds run yet)"
+                            .to_string(),
+                    );
+                    None
+                }
+            }
+        };
+        match result {
+            Some(result) => {
                 if result.status.success() {
                     let stdout = String::from_utf8_lossy(&result.stdout);
                     match serde_json::from_str::<serde_json::Value>(stdout.trim()) {
@@ -108,13 +132,7 @@ fn collect_cache_report_output() -> Result<CacheReportOutput, SoldrError> {
                     None
                 }
             }
-            None => {
-                notes.push(
-                    "rollups: managed zccache binary not yet fetched (no builds run yet)"
-                        .to_string(),
-                );
-                None
-            }
+            None => None,
         }
     } else {
         notes
@@ -214,5 +232,76 @@ fn print_cache_report_output(output: &CacheReportOutput) {
         for note in &output.notes {
             println!("    - {note}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_cache_report_output_for_paths;
+    use crate::core::SoldrPaths;
+    use crate::daemon::db;
+    use crate::daemon::protocol::ZccacheDaemonLink;
+
+    #[test]
+    fn cache_report_follows_linked_private_zccache_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = SoldrPaths::with_root(temp.path().join("soldr"));
+        let private_dir = paths
+            .cache
+            .join("zccache")
+            .join("private")
+            .join("soldr-dev-test");
+        let stats_path = private_dir.join("logs").join("last-session-stats.json");
+        std::fs::create_dir_all(stats_path.parent().expect("stats parent"))
+            .expect("create private logs");
+        std::fs::write(
+            &stats_path,
+            r#"{"status":"ok","session_id":"private","hits":17,"misses":2,"hit_rate":0.89}"#,
+        )
+        .expect("write stats");
+
+        let fake_zccache = paths.bin.join(if cfg!(windows) {
+            "zccache.exe"
+        } else {
+            "zccache"
+        });
+        std::fs::create_dir_all(fake_zccache.parent().expect("fake parent"))
+            .expect("create fake parent");
+        std::fs::write(&fake_zccache, b"fake").expect("write fake binary");
+
+        db::set_linked_zccache(
+            &db::db_path(&paths),
+            Some(&ZccacheDaemonLink {
+                binary_path: fake_zccache.display().to_string(),
+                cache_dir: private_dir.display().to_string(),
+                session_id: Some("private".into()),
+                source: "managed".into(),
+                private_daemon: true,
+                daemon_name: Some("soldr-dev-test".into()),
+                owner_pid: Some(std::process::id()),
+                private_env_keys: vec!["ZCCACHE_PATH_REMAP".into()],
+            }),
+        )
+        .expect("link private zccache");
+
+        let report = collect_cache_report_output_for_paths(&paths).expect("collect report");
+        assert_eq!(report.session_stats_path, stats_path.display().to_string());
+        assert!(report.session_stats_present);
+        assert_eq!(
+            report
+                .last_session
+                .as_ref()
+                .and_then(|v| v.get("hits"))
+                .and_then(serde_json::Value::as_u64),
+            Some(17)
+        );
+        assert_eq!(
+            report
+                .last_session
+                .as_ref()
+                .and_then(|v| v.get("misses"))
+                .and_then(serde_json::Value::as_u64),
+            Some(2)
+        );
     }
 }

--- a/crates/soldr-cli/src/cache/session.rs
+++ b/crates/soldr-cli/src/cache/session.rs
@@ -549,7 +549,7 @@ pub(crate) async fn run_cache_flush_command(json: bool) -> Result<(), SoldrError
     Ok(())
 }
 
-fn linked_private_zccache_lifecycle(
+pub(super) fn linked_private_zccache_lifecycle(
     paths: &SoldrPaths,
 ) -> Option<(ZccacheLifecycle, std::path::PathBuf)> {
     let link = db::get_linked_zccache(&db::db_path(paths)).ok().flatten()?;

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -676,11 +676,42 @@ pub(crate) fn resolve_private_zccache_daemon_name(
     let mut hasher = blake3::Hasher::new();
     hasher.update(b"soldr-private-zccache-v1\0");
     hash_path_component(&mut hasher, soldr_binary);
-    hash_path_component(&mut hasher, zccache_binary);
-    hash_path_component(&mut hasher, base_cache_dir);
+    let zccache_identity = zccache_binary_identity_path(zccache_binary, base_cache_dir);
+    hash_path_component(&mut hasher, zccache_identity.as_ref());
     let digest = hasher.finalize();
     let hex = digest.to_hex();
     format!("soldr-dev-{}", &hex[..16])
+}
+
+fn zccache_binary_identity_path<'a>(
+    zccache_binary: &'a std::path::Path,
+    base_cache_dir: &'a std::path::Path,
+) -> std::borrow::Cow<'a, std::path::Path> {
+    if let Some(root) = soldr_root_from_zccache_base_dir(base_cache_dir) {
+        if let Ok(relative) = zccache_binary.strip_prefix(&root) {
+            return std::borrow::Cow::Owned(relative.to_path_buf());
+        }
+    }
+    std::borrow::Cow::Borrowed(zccache_binary)
+}
+
+fn soldr_root_from_zccache_base_dir(
+    base_cache_dir: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    if !path_file_name_eq(base_cache_dir, "zccache") {
+        return None;
+    }
+    let cache_dir = base_cache_dir.parent()?;
+    if !path_file_name_eq(cache_dir, "cache") {
+        return None;
+    }
+    cache_dir.parent().map(std::path::Path::to_path_buf)
+}
+
+fn path_file_name_eq(path: &std::path::Path, expected: &str) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case(expected))
 }
 
 fn hash_path_component(hasher: &mut blake3::Hasher, path: &std::path::Path) {
@@ -996,6 +1027,46 @@ mod tests {
                 std::path::Path::new("/repo/target/debug/zccache"),
                 std::path::Path::new("/tmp/cache/zccache"),
             )
+        );
+        assert_eq!(
+            generated,
+            resolve_private_zccache_daemon_name(
+                None,
+                std::path::Path::new("/repo/target/debug/soldr"),
+                std::path::Path::new("/repo/target/debug/zccache"),
+                std::path::Path::new("/tmp/restored-cache/zccache"),
+            ),
+            "save/load restores into a new SOLDR_CACHE_DIR must reuse the same private subtree",
+        );
+        assert_eq!(
+            resolve_private_zccache_daemon_name(
+                None,
+                std::path::Path::new("/repo/target/debug/soldr"),
+                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.11.6/zccache"),
+                std::path::Path::new("/tmp/cache-cold/cache/zccache"),
+            ),
+            resolve_private_zccache_daemon_name(
+                None,
+                std::path::Path::new("/repo/target/debug/soldr"),
+                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.11.6/zccache"),
+                std::path::Path::new("/tmp/cache-warm/cache/zccache"),
+            ),
+            "managed zccache binaries under different SOLDR_CACHE_DIR roots must hash by runtime identity, not absolute path",
+        );
+        assert_ne!(
+            resolve_private_zccache_daemon_name(
+                None,
+                std::path::Path::new("/repo/target/debug/soldr"),
+                std::path::Path::new("/tmp/cache/bin/zccache-local-abc/zccache"),
+                std::path::Path::new("/tmp/cache/cache/zccache"),
+            ),
+            resolve_private_zccache_daemon_name(
+                None,
+                std::path::Path::new("/repo/target/debug/soldr"),
+                std::path::Path::new("/tmp/cache/bin/zccache-local-def/zccache"),
+                std::path::Path::new("/tmp/cache/cache/zccache"),
+            ),
+            "different local zccache runtime labels should still get distinct private daemons",
         );
         assert_eq!(
             resolve_private_zccache_daemon_name(

--- a/perf/lib/common.sh
+++ b/perf/lib/common.sh
@@ -125,6 +125,52 @@ measure::session_end_json() {
     fi
 }
 
+# measure::write_cache_report <cache-root> <json-path>
+#
+# Persist `soldr cache report --json` for <cache-root>. On failure, write
+# an empty object so callers still emit a result.json and the evaluator can
+# fail with BAD-STATS instead of losing the scenario output.
+measure::write_cache_report() {
+    local cache_root="$1"
+    local out="$2"
+    if ! SOLDR_CACHE_DIR="${cache_root}" soldr cache report --json > "${out}" 2>/dev/null; then
+        printf '{}\n' > "${out}"
+    fi
+}
+
+# measure::cache_report_stat <json-path> <stat-key>
+#
+# Read a hit/miss/rate field from `soldr cache report --json`. Supports both
+# direct zccache stats and older nested `{ "stats": ... }` shapes.
+measure::cache_report_stat() {
+    local report="$1"
+    local key="$2"
+    jq -r --arg k "${key}" \
+        '.last_session.stats[$k] // .last_session[$k] // 0' \
+        "${report}" 2>/dev/null || echo 0
+}
+
+# measure::copy_zccache_logs_from_report <json-path> <dest-dir>
+#
+# Copy the authoritative zccache logs directory referenced by a cache report.
+# This follows private-daemon paths such as
+# cache/zccache/private/<daemon>/logs instead of assuming cache/zccache/logs.
+measure::copy_zccache_logs_from_report() {
+    local report="$1"
+    local dest="$2"
+    local stats_path
+    stats_path="$(jq -r '.session_stats_path // empty' "${report}" 2>/dev/null || true)"
+    if [[ -z "${stats_path}" ]]; then
+        return 0
+    fi
+    local logs_dir
+    logs_dir="$(dirname -- "${stats_path}")"
+    if [[ -d "${logs_dir}" ]]; then
+        rm -rf "${dest}"
+        cp -R "${logs_dir}" "${dest}"
+    fi
+}
+
 # --- Wall-time --------------------------------------------------------
 
 # measure::now_ms

--- a/perf/scenarios/cold-tar-untar-warm/run.sh
+++ b/perf/scenarios/cold-tar-untar-warm/run.sh
@@ -49,8 +49,7 @@ cold_elapsed_ms="$(measure::elapsed_ms "${cold_start_ms}")"
 
 # Capture zccache's own cache report for cold side (symmetric with
 # warm) so round 2 can compare entry counts / sizes before flush.
-SOLDR_CACHE_DIR="${CACHE_COLD}" soldr cache report --json \
-    > "${WORKDIR}/cold-cache-report.json" 2>/dev/null || true
+measure::write_cache_report "${CACHE_COLD}" "${WORKDIR}/cold-cache-report.json"
 
 # Flush + shutdown so the depgraph snapshot is durable before tar.
 SOLDR_CACHE_DIR="${CACHE_COLD}" soldr cache flush --json >/dev/null 2>&1 || true
@@ -59,7 +58,9 @@ SOLDR_CACHE_DIR="${CACHE_COLD}" soldr cache shutdown \
 
 # Copy zccache's per-session logs out of the cache tree (daemon is
 # now gone) so the upload-artifact glob picks them up.
-cp -R "${CACHE_COLD}/cache/zccache/logs" "${WORKDIR}/cold-zccache-logs" 2>/dev/null || true
+measure::copy_zccache_logs_from_report \
+    "${WORKDIR}/cold-cache-report.json" \
+    "${WORKDIR}/cold-zccache-logs"
 
 cold_cache_bytes="$(measure::cache_bytes "${CACHE_COLD}")"
 
@@ -108,28 +109,17 @@ warm_elapsed_ms="$(measure::elapsed_ms "${warm_start_ms}")"
 # upload-artifact glob picks them up. We do this for both cold (after
 # cold flush+shutdown above) and warm (here) — round 1 wants ground-
 # truth fingerprint data to drive round 2's hypothesis.
-cp -R "${CACHE_WARM}/cache/zccache/logs" "${WORKDIR}/warm-zccache-logs" 2>/dev/null || true
+measure::write_cache_report "${CACHE_WARM}" "${WORKDIR}/warm-cache-report.json"
+measure::copy_zccache_logs_from_report \
+    "${WORKDIR}/warm-cache-report.json" \
+    "${WORKDIR}/warm-zccache-logs"
 
-# Prefer zccache's authoritative on-disk stats file over `soldr
-# session-end --json`. The latter requires an active session and
-# returns empty after daemon idle-shutdown, which masks real hits/misses
-# as 0/0.
-WARM_STATS_FILE="${CACHE_WARM}/cache/zccache/logs/last-session-stats.json"
-if [[ -s "${WARM_STATS_FILE}" ]]; then
-    warm_hits="$(jq -r '.stats.hits // .hits // 0' "${WARM_STATS_FILE}")"
-    warm_misses="$(jq -r '.stats.misses // .misses // 0' "${WARM_STATS_FILE}")"
-    warm_hit_rate="$(jq -r '.stats.hit_rate // .hit_rate // 0' "${WARM_STATS_FILE}")"
-    warm_stats_source="file"
-else
-    warm_stats="$(SOLDR_CACHE_DIR="${CACHE_WARM}" measure::session_end_json)"
-    warm_hits="$(echo "${warm_stats}" | jq -r '.stats.hits // 0')"
-    warm_misses="$(echo "${warm_stats}" | jq -r '.stats.misses // 0')"
-    warm_hit_rate="$(echo "${warm_stats}" | jq -r '.stats.hit_rate // 0')"
-    warm_stats_source="session-end"
-fi
-
-SOLDR_CACHE_DIR="${CACHE_WARM}" soldr cache report --json \
-    > "${WORKDIR}/warm-cache-report.json" 2>/dev/null || true
+# Pull stats from the cache report instead of `session-end`: the parent shell
+# does not inherit the child build's ZCCACHE_SESSION_ID.
+warm_hits="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hits)"
+warm_misses="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" misses)"
+warm_hit_rate="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hit_rate)"
+warm_stats_source="cache-report"
 
 SOLDR_CACHE_DIR="${CACHE_WARM}" soldr cache shutdown \
     --shutdown-timeout-seconds 30 --json >"${WORKDIR}/warm-shutdown.json" || true

--- a/perf/scenarios/touch-no-change/run.sh
+++ b/perf/scenarios/touch-no-change/run.sh
@@ -61,10 +61,13 @@ warm_start_ms="$(measure::now_ms)"
 )
 warm_elapsed_ms="$(measure::elapsed_ms "${warm_start_ms}")"
 
-warm_stats="$(SOLDR_CACHE_DIR="${CACHE}" measure::session_end_json)"
-warm_hits="$(echo "${warm_stats}" | jq -r '.stats.hits // 0')"
-warm_misses="$(echo "${warm_stats}" | jq -r '.stats.misses // 0')"
-warm_hit_rate="$(echo "${warm_stats}" | jq -r '.stats.hit_rate // 0')"
+measure::write_cache_report "${CACHE}" "${WORKDIR}/warm-cache-report.json"
+measure::copy_zccache_logs_from_report \
+    "${WORKDIR}/warm-cache-report.json" \
+    "${WORKDIR}/warm-zccache-logs"
+warm_hits="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hits)"
+warm_misses="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" misses)"
+warm_hit_rate="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hit_rate)"
 
 SOLDR_CACHE_DIR="${CACHE}" soldr cache shutdown \
     --shutdown-timeout-seconds 30 --json >"${WORKDIR}/touch-shutdown.json" || true

--- a/perf/scenarios/worktree-share/run.sh
+++ b/perf/scenarios/worktree-share/run.sh
@@ -66,10 +66,13 @@ b_start_ms="$(measure::now_ms)"
 )
 b_elapsed_ms="$(measure::elapsed_ms "${b_start_ms}")"
 
-b_stats="$(SOLDR_CACHE_DIR="${CACHE}" measure::session_end_json)"
-b_hits="$(echo "${b_stats}" | jq -r '.stats.hits // 0')"
-b_misses="$(echo "${b_stats}" | jq -r '.stats.misses // 0')"
-b_hit_rate="$(echo "${b_stats}" | jq -r '.stats.hit_rate // 0')"
+measure::write_cache_report "${CACHE}" "${WORKDIR}/warm-cache-report.json"
+measure::copy_zccache_logs_from_report \
+    "${WORKDIR}/warm-cache-report.json" \
+    "${WORKDIR}/warm-zccache-logs"
+b_hits="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hits)"
+b_misses="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" misses)"
+b_hit_rate="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hit_rate)"
 
 SOLDR_CACHE_DIR="${CACHE}" soldr cache shutdown \
     --shutdown-timeout-seconds 30 --json >"${WORKDIR}/worktree-shutdown.json" || true

--- a/tests/test_perf_matrix.py
+++ b/tests/test_perf_matrix.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_perf_matrix_fails_zero_hit_miss_stats() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "perf-matrix.yml").read_text()
+
+    assert "hits_key_for()" in workflow
+    assert "misses_key_for()" in workflow
+    assert "hits + misses <= 0" in workflow
+    assert "BAD-STATS" in workflow
+    assert "zccache stats were not captured" in workflow
+
+
+def test_perf_scenarios_read_stats_from_cache_report() -> None:
+    for rel in [
+        "perf/scenarios/cold-tar-untar-warm/run.sh",
+        "perf/scenarios/worktree-share/run.sh",
+        "perf/scenarios/touch-no-change/run.sh",
+    ]:
+        script = (REPO_ROOT / rel).read_text()
+        assert "measure::write_cache_report" in script
+        assert "measure::cache_report_stat" in script
+        assert "measure::session_end_json" not in script


### PR DESCRIPTION
Closes #560.

## What changed
- Keep generated private zccache daemon names stable across restored `SOLDR_CACHE_DIR` roots so perf save/load restores into the same private cache subtree.
- Make `soldr cache report --json` follow the linked private zccache cache dir before reading session stats/journal.
- Make perf scenarios read hit/miss stats from cache reports instead of parent-shell `session-end`, and upload logs from the reported private logs path.
- Fail perf evaluation when hit/miss fields are missing or `hits + misses == 0`.

## Verification
- `rustup run 1.94.1-x86_64-pc-windows-msvc cargo fmt -- --check`
- `git diff --check`
- `rustup run 1.94.1-x86_64-pc-windows-msvc cargo test -p soldr-cli --bin soldr cache_report_follows_linked_private_zccache_dir`
- `rustup run 1.94.1-x86_64-pc-windows-msvc cargo test -p soldr-cli --bin soldr private_daemon_name_is_stable_sanitized_and_short`
- `rustup run 1.94.1-x86_64-pc-windows-msvc cargo test -p soldr-cli --test cli_cache cache_report_json_surfaces_persisted_session_stats`
- `python -m pytest tests/test_perf_matrix.py -q`