### PR TITLE
chore(release): bump soldr to 0.7.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.41"
+version = "0.7.42"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/src/cache/report.rs
+++ b/crates/soldr-cli/src/cache/report.rs
@@ -242,8 +242,7 @@ mod tests {
     use crate::daemon::db;
     use crate::daemon::protocol::ZccacheDaemonLink;
 
-    #[test]
-    fn cache_report_follows_linked_private_zccache_dir() {
+    crate::timed_test!(cache_report_follows_linked_private_zccache_dir, {
         let temp = tempfile::tempdir().expect("tempdir");
         let paths = SoldrPaths::with_root(temp.path().join("soldr"));
         let private_dir = paths
@@ -303,5 +302,5 @@ mod tests {
                 .and_then(serde_json::Value::as_u64),
             Some(2)
         );
-    }
+    });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## What changed
- Bump soldr workspace/package version to 0.7.42 so the private zccache perf fix can be released.

## Verification
- `node scripts/test-npm-package.js`
- `rustup run 1.94.1-x86_64-pc-windows-msvc cargo check --locked -p soldr-cli`

After merge, `.github/workflows/release-auto.yml` should publish the GitHub release, PyPI wheels, and npm package from main.