### PR TITLE
chore(release): bump soldr to 0.7.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.43"
+version = "0.7.44"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.43",
+  "version": "0.7.44",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Cuts soldr 0.7.44, which includes the cargo-chef cook project-restore fix (#566, merged in #567).

`soldr cook` now snapshots and restores the project's source + crate versions around `cargo chef cook`, so subsequent builds compile the real code at the real version — fixing both the correctness issue (post-cook builds were compiling chef stubs at `0.0.1`) and the first-party compile-cache key churn behind zackees/zccache#448 / zackees/setup-soldr#236.

Bumps `[workspace.package] version`, `package.json`, and the `soldr-cli` `Cargo.lock` entry to `0.7.44`. Merging to `main` triggers `release-auto.yml` to mint `v0.7.44`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)