### PR TITLE
chore(deps): bump managed zccache to 1.11.7

### DIFF
--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -18,7 +18,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.11.6",
+    "managed_version": "1.11.7",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.6";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.7";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -1042,13 +1042,13 @@ mod tests {
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.11.6/zccache"),
+                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.11.7/zccache"),
                 std::path::Path::new("/tmp/cache-cold/cache/zccache"),
             ),
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.11.6/zccache"),
+                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.11.7/zccache"),
                 std::path::Path::new("/tmp/cache-warm/cache/zccache"),
             ),
             "managed zccache binaries under different SOLDR_CACHE_DIR roots must hash by runtime identity, not absolute path",

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.11.6");
+    assert_eq!(json["managed_zccache_version"], "1.11.7");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.11.6");
+    assert_eq!(json["managed_zccache_version"], "1.11.7");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.11.6");
+    assert_eq!(json["managed_zccache_version"], "1.11.7");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.11.6");
+    assert_eq!(status_json["managed_version"], "1.11.7");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.11.6");
+    assert_eq!(json["managed_version"], "1.11.7");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Bumps soldr's `MANAGED_ZCCACHE_VERSION` from 1.11.6 to 1.11.7.
- zccache 1.11.7 (https://github.com/zackees/zccache/releases/tag/1.11.7, PyPI: https://pypi.org/project/zccache/1.11.7/) ships the fix for zccache#449 / FastLED#2539: stale `.obj` returned for unity-build TUs after a transitive `.cpp.hpp` change, because the depgraph's read-side `artifact_key` was derived from a stale `resolved_includes` set while the write-side key reflected the fresh post-compile scan. A coincidentally matching older artifact could be served as stale content.
- zccache 1.11.7 treats any hash drift in `last_file_hashes` as `HeadersChanged`, forcing a recompile + re-scan instead of returning a `Hit` with a stale-prediction key. Details: https://github.com/zackees/zccache/pull/450.

## Files touched
- `crates/soldr-cli/src/fetch/mod.rs` — `MANAGED_ZCCACHE_VERSION` constant
- `contracts/zccache-runtime.v1.json` — `managed_version`
- `crates/soldr-cli/src/zccache.rs` — hard-coded test-fixture paths
- `crates/soldr-cli/tests/cli_cache.rs` — 3 assertions
- `crates/soldr-cli/tests/cli_install_zccache.rs` — 2 assertions

## Test plan
- [ ] CI green across all targets.
- [ ] `setup-soldr@v0.9.16+` runners pick up zccache 1.11.7 without manual intervention once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)