### PR TITLE
chore(release): bump 0.7.44 -> 0.7.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.44"
+version = "0.7.45"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.44",
+  "version": "0.7.45",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary
- Ships #569: managed zccache pinned to 1.11.7, which closes zccache#449 / FastLED#2539 (stale `.obj` for unity-build TUs after a transitive `.cpp.hpp` change).
- `release-auto.yml` detects the `[workspace.package].version` change on push-to-main and publishes the new soldr release.

## Test plan
- [x] CI on #569 was green across all 13 checks.
- [ ] CI on this release PR confirms `Cargo.lock` is in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)