### PR TITLE
feat(cook,daemon): add cook_index redb table + CookLookup/CookRecord/CookTouch IPC (#576)

### DIFF
--- a/bench/cook_in_docker.sh
+++ b/bench/cook_in_docker.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# bench/cook_in_docker.sh — build and test the cross-repo cook cache
+# feature inside a Docker container so the host's `~/.soldr/` singleton
+# is never mutated. See docker/cook-shared-cache/Dockerfile for context.
+#
+# Defaults to running the cook-index integration tests added in PR 1
+# (#576 under meta #579). Pass a custom cargo invocation as arguments to
+# override.
+#
+# Usage:
+#   bench/cook_in_docker.sh                       # default: cook-index tests
+#   bench/cook_in_docker.sh cargo test --workspace   # full workspace test
+#   bench/cook_in_docker.sh cargo clippy --workspace # clippy lint
+#
+# Required guarantee per meta #579: the host's `~/.soldr/` directory
+# must be byte-identical before and after this script runs. We mount a
+# named volume (cook-soldr-home) inside the container at /root/.soldr;
+# the host's actual `~/.soldr/` is never bind-mounted.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+IMAGE="soldr-cook-dev"
+VOLUME="cook-soldr-home"
+
+# Build (cached after the first run).
+docker build \
+    -f docker/cook-shared-cache/Dockerfile \
+    -t "$IMAGE" \
+    "$REPO_ROOT"
+
+# Default cargo invocation: run the cook_index integration tests gated
+# on the Docker harness marker.
+if [ "$#" -eq 0 ]; then
+    set -- cargo test --workspace --test daemon_cook_index -- --include-ignored
+fi
+
+# Fresh `~/.soldr/` each time keeps tests deterministic. Remove the
+# volume so the next run starts from empty state; comment out the
+# volume rm if you want to debug across runs.
+docker volume rm --force "$VOLUME" >/dev/null 2>&1 || true
+
+exec docker run \
+    --rm \
+    --init \
+    -v "$REPO_ROOT:/work" \
+    -v "$VOLUME:/root/.soldr" \
+    -e SOLDR_COOK_DOCKER_HARNESS=1 \
+    -w /work \
+    "$IMAGE" \
+    "$@"

--- a/crates/soldr-cli/src/cache_lib/cook_index.rs
+++ b/crates/soldr-cli/src/cache_lib/cook_index.rs
@@ -1,0 +1,441 @@
+//! Cross-repo shared `soldr cook` artifact index (issue #576, meta
+//! #579). PR 1 of 3: the **dormant** index schema and operations.
+//!
+//! This module owns a new redb table inside the shared
+//! `~/.soldr/state.redb` and gives the daemon a per-request-open
+//! surface to look up, record, touch, and stat cook artifacts. Heavy
+//! I/O (tar+zstd:19 packing) lives in the PR 2 `soldr cook` worker;
+//! this module never reads or writes the artifact bytes themselves —
+//! it only tracks where they are and how big they are.
+//!
+//! Key tuple (bincode-serialized blob, used as the redb key):
+//!
+//! ```text
+//! (recipe_hash: [u8; 32], target_triple, profile, channel, rustc_version)
+//! ```
+//!
+//! Cross-target sharing is structurally impossible by including
+//! triple/profile/channel/rustc in the key — there is no code path
+//! that can relax this without changing the schema.
+//!
+//! ## Wire compatibility
+//!
+//! Table name is `cook_index_v1`. A future schema change MUST land as
+//! `cook_index_v2` rather than mutating the v1 table, so old daemons
+//! and old soldr binaries that resume an upgraded state.redb fall
+//! back gracefully.
+
+use crate::cache_lib::target_registry::RegistryError;
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// redb table name. Bumping this for schema breaks (rare) — additive
+/// changes use the existing key/value bincode schema.
+const COOK_INDEX_V1: TableDefinition<&[u8], &[u8]> = TableDefinition::new("cook_index_v1");
+
+/// Lookup key for the cook artifact index. Cross-target sharing is
+/// forbidden by including triple/profile/channel/rustc in the key —
+/// two builds that differ on any of these resolve to different rows
+/// regardless of recipe_hash.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct CookKey {
+    pub recipe_hash: [u8; 32],
+    pub target_triple: String,
+    pub profile: String,
+    pub channel: String,
+    pub rustc_version: String,
+}
+
+/// Stored value for a cook artifact entry. PR 2 writes these via
+/// `CookRecord`; PR 3 reads them via `CookLookup` + `CookTouch`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CookEntry {
+    pub sha256: [u8; 32],
+    pub size_bytes: u64,
+    pub created_unix_ms: u64,
+    pub last_used_unix_ms: u64,
+    /// Best-effort, normalized git remote URL. None when the source
+    /// workspace had no `.git/` at cook time or `git config
+    /// remote.origin.url` was unset.
+    pub origin_url_normalized: Option<String>,
+    /// Human-readable cook command summary stored for diagnostics
+    /// (e.g. shown by `soldr cache stats`).
+    pub cook_cmd_summary: String,
+}
+
+fn bincode_err(e: bincode::Error) -> RegistryError {
+    RegistryError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+fn open_db(path: &Path) -> Result<Database, RegistryError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let db = Database::builder().create(path)?;
+    Ok(db)
+}
+
+fn init_table(db: &Database) -> Result<(), RegistryError> {
+    let txn = db.begin_write()?;
+    {
+        let _ = txn.open_table(COOK_INDEX_V1)?;
+    }
+    txn.commit()?;
+    Ok(())
+}
+
+/// Idempotent: open the `state.redb` file and ensure `cook_index_v1`
+/// exists. Other helpers call this internally; callers (e.g. daemon
+/// startup) can use it to eager-create the table.
+pub fn ensure_initialized(db_path: &Path) -> Result<(), RegistryError> {
+    let db = open_db(db_path)?;
+    init_table(&db)
+}
+
+fn encode_key(key: &CookKey) -> Result<Vec<u8>, RegistryError> {
+    bincode::serialize(key).map_err(bincode_err)
+}
+
+fn decode_entry(bytes: &[u8]) -> Result<CookEntry, RegistryError> {
+    bincode::deserialize(bytes).map_err(bincode_err)
+}
+
+fn encode_entry(entry: &CookEntry) -> Result<Vec<u8>, RegistryError> {
+    bincode::serialize(entry).map_err(bincode_err)
+}
+
+fn decode_key(bytes: &[u8]) -> Result<CookKey, RegistryError> {
+    bincode::deserialize(bytes).map_err(bincode_err)
+}
+
+/// Upsert a cook artifact entry. PR 2's `soldr cook` worker calls
+/// this via the daemon `CookRecord` IPC after the tarball has been
+/// written to `~/.soldr/cache/cook/<sha256>.tar.zst`.
+pub fn upsert(db_path: &Path, key: &CookKey, entry: &CookEntry) -> Result<(), RegistryError> {
+    let db = open_db(db_path)?;
+    init_table(&db)?;
+    let key_bytes = encode_key(key)?;
+    let value_bytes = encode_entry(entry)?;
+    let txn = db.begin_write()?;
+    {
+        let mut table = txn.open_table(COOK_INDEX_V1)?;
+        table.insert(key_bytes.as_slice(), value_bytes.as_slice())?;
+    }
+    txn.commit()?;
+    Ok(())
+}
+
+/// Look up a single entry by the full key tuple. PR 3's cargo-
+/// front-door pre-flight calls this via the daemon `CookLookup` IPC.
+pub fn lookup(db_path: &Path, key: &CookKey) -> Result<Option<CookEntry>, RegistryError> {
+    let db = open_db(db_path)?;
+    init_table(&db)?;
+    let key_bytes = encode_key(key)?;
+    let txn = db.begin_read()?;
+    let table = txn.open_table(COOK_INDEX_V1)?;
+    let Some(row) = table.get(key_bytes.as_slice())? else {
+        return Ok(None);
+    };
+    Ok(Some(decode_entry(row.value())?))
+}
+
+/// Drift diagnostic: given a (missing) lookup key, scan the table for
+/// other rows whose `(origin_url_normalized, target_triple, profile,
+/// channel, rustc_version)` match — but whose `recipe_hash` differs.
+/// Returns up to `limit` previous recipe hashes, useful as the
+/// "previous_origin_recipe_hashes" diagnostic in `CookMiss`.
+///
+/// When `origin_url_normalized` is `None`, drift diagnostic is
+/// skipped (returns empty) — without an origin hint we have no way to
+/// know which other rows "belong to the same repo".
+pub fn drift_recipe_hashes(
+    db_path: &Path,
+    miss_key: &CookKey,
+    origin_url_normalized: Option<&str>,
+    limit: usize,
+) -> Result<Vec<[u8; 32]>, RegistryError> {
+    let Some(origin) = origin_url_normalized else {
+        return Ok(Vec::new());
+    };
+    let db = open_db(db_path)?;
+    init_table(&db)?;
+    let txn = db.begin_read()?;
+    let table = txn.open_table(COOK_INDEX_V1)?;
+    let mut out: Vec<([u8; 32], u64)> = Vec::new();
+    for entry in table.iter()? {
+        let (k_bytes, v_bytes) = entry?;
+        let stored_key = match decode_key(k_bytes.value()) {
+            Ok(k) => k,
+            Err(_) => continue,
+        };
+        if stored_key.recipe_hash == miss_key.recipe_hash {
+            continue;
+        }
+        if stored_key.target_triple != miss_key.target_triple
+            || stored_key.profile != miss_key.profile
+            || stored_key.channel != miss_key.channel
+            || stored_key.rustc_version != miss_key.rustc_version
+        {
+            continue;
+        }
+        let stored_entry = match decode_entry(v_bytes.value()) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if stored_entry.origin_url_normalized.as_deref() != Some(origin) {
+            continue;
+        }
+        out.push((stored_key.recipe_hash, stored_entry.last_used_unix_ms));
+    }
+    out.sort_by(|a, b| b.1.cmp(&a.1));
+    out.truncate(limit);
+    Ok(out.into_iter().map(|(h, _)| h).collect())
+}
+
+/// Bump the `last_used_unix_ms` field for the entry whose
+/// `sha256` matches. Fire-and-forget by PR 3: a touch failure must
+/// never affect callers. Returns `Ok(true)` when a row was bumped,
+/// `Ok(false)` when no matching row exists.
+///
+/// Implementation note: this is O(N) over the index because the
+/// primary key is `CookKey`, not `sha256`. PR 1 ships dormant and PR
+/// 3's pre-flight is the only `CookTouch` caller; a secondary index
+/// can be added later if measurements show it matters.
+pub fn touch(db_path: &Path, sha256: &[u8; 32], now_unix_ms: u64) -> Result<bool, RegistryError> {
+    let db = open_db(db_path)?;
+    init_table(&db)?;
+    let mut updates: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    {
+        let txn = db.begin_read()?;
+        let table = txn.open_table(COOK_INDEX_V1)?;
+        for entry in table.iter()? {
+            let (k_bytes, v_bytes) = entry?;
+            let mut value = match decode_entry(v_bytes.value()) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if &value.sha256 == sha256 {
+                value.last_used_unix_ms = now_unix_ms;
+                let new_v = encode_entry(&value)?;
+                updates.push((k_bytes.value().to_vec(), new_v));
+            }
+        }
+    }
+    if updates.is_empty() {
+        return Ok(false);
+    }
+    let txn = db.begin_write()?;
+    {
+        let mut table = txn.open_table(COOK_INDEX_V1)?;
+        for (k, v) in &updates {
+            table.insert(k.as_slice(), v.as_slice())?;
+        }
+    }
+    txn.commit()?;
+    Ok(true)
+}
+
+/// Aggregate statistics surfaced via `Status` and `soldr daemon
+/// status`: returns `(entry_count, total_size_bytes)`.
+pub fn stats(db_path: &Path) -> Result<(u64, u64), RegistryError> {
+    let db = open_db(db_path)?;
+    init_table(&db)?;
+    let txn = db.begin_read()?;
+    let table = txn.open_table(COOK_INDEX_V1)?;
+    let mut count: u64 = 0;
+    let mut total: u64 = 0;
+    for entry in table.iter()? {
+        let (_, v_bytes) = entry?;
+        if let Ok(decoded) = decode_entry(v_bytes.value()) {
+            count = count.saturating_add(1);
+            total = total.saturating_add(decoded.size_bytes);
+        }
+    }
+    Ok((count, total))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_key(recipe_byte: u8) -> CookKey {
+        CookKey {
+            recipe_hash: [recipe_byte; 32],
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            profile: "release".into(),
+            channel: "1.94.1".into(),
+            rustc_version: "rustc 1.94.1 (abcdef0)".into(),
+        }
+    }
+
+    fn sample_entry(sha_byte: u8, size: u64, origin: Option<&str>) -> CookEntry {
+        CookEntry {
+            sha256: [sha_byte; 32],
+            size_bytes: size,
+            created_unix_ms: 1_700_000_000_000,
+            last_used_unix_ms: 1_700_000_000_000,
+            origin_url_normalized: origin.map(str::to_owned),
+            cook_cmd_summary: "cook --release".into(),
+        }
+    }
+
+    crate::timed_test!(round_trip_upsert_lookup, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        let key = sample_key(1);
+        let entry = sample_entry(0xAA, 1024, Some("https://github.com/zackees/soldr"));
+        upsert(&path, &key, &entry).expect("upsert");
+        let got = lookup(&path, &key).expect("lookup");
+        assert_eq!(got, Some(entry));
+    });
+
+    crate::timed_test!(lookup_returns_none_when_missing, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        let key = sample_key(2);
+        assert_eq!(lookup(&path, &key).expect("lookup"), None);
+    });
+
+    crate::timed_test!(per_target_safety_isolates_rows, {
+        // Same recipe hash, different target triple — must NOT collide.
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        let mut a = sample_key(3);
+        a.target_triple = "x86_64-unknown-linux-gnu".into();
+        let mut b = sample_key(3);
+        b.target_triple = "aarch64-apple-darwin".into();
+        upsert(&path, &a, &sample_entry(0xAA, 100, None)).expect("upsert a");
+        upsert(&path, &b, &sample_entry(0xBB, 200, None)).expect("upsert b");
+        let got_a = lookup(&path, &a).expect("lookup a").expect("hit a");
+        let got_b = lookup(&path, &b).expect("lookup b").expect("hit b");
+        assert_eq!(got_a.sha256, [0xAA; 32]);
+        assert_eq!(got_b.sha256, [0xBB; 32]);
+        assert_eq!(got_a.size_bytes, 100);
+        assert_eq!(got_b.size_bytes, 200);
+    });
+
+    crate::timed_test!(per_profile_safety_isolates_rows, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        let mut release = sample_key(4);
+        release.profile = "release".into();
+        let mut debug = sample_key(4);
+        debug.profile = "dev".into();
+        upsert(&path, &release, &sample_entry(0xCC, 500, None)).expect("upsert rel");
+        upsert(&path, &debug, &sample_entry(0xDD, 600, None)).expect("upsert dev");
+        assert_ne!(
+            lookup(&path, &release).expect("a").expect("hit").sha256,
+            lookup(&path, &debug).expect("b").expect("hit").sha256
+        );
+    });
+
+    crate::timed_test!(
+        drift_collects_other_recipe_hashes_with_same_origin_and_target,
+        {
+            let dir = TempDir::new().expect("tempdir");
+            let path = dir.path().join("state.redb");
+            let origin = "https://github.com/zackees/soldr";
+
+            // Two prior entries, same origin/triple/profile/channel/rustc,
+            // but different recipe hashes.
+            let key_a = sample_key(5);
+            let key_b = sample_key(6);
+            let mut entry_a = sample_entry(0xA1, 10, Some(origin));
+            entry_a.last_used_unix_ms = 100;
+            let mut entry_b = sample_entry(0xB2, 20, Some(origin));
+            entry_b.last_used_unix_ms = 200;
+            upsert(&path, &key_a, &entry_a).expect("upsert a");
+            upsert(&path, &key_b, &entry_b).expect("upsert b");
+
+            // Lookup for a different recipe hash (miss). Drift should
+            // return both prior hashes, newest-first.
+            let miss = sample_key(7);
+            let drift = drift_recipe_hashes(&path, &miss, Some(origin), 10).expect("drift");
+            assert_eq!(drift.len(), 2);
+            assert_eq!(drift[0], [6u8; 32]); // b.last_used=200 → newest first
+            assert_eq!(drift[1], [5u8; 32]);
+        }
+    );
+
+    crate::timed_test!(drift_skips_other_targets_and_other_origins, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        let origin = "https://github.com/zackees/soldr";
+
+        let mut same_origin_diff_triple = sample_key(10);
+        same_origin_diff_triple.target_triple = "aarch64-apple-darwin".into();
+        let same_origin_diff_triple_entry = sample_entry(0x11, 1, Some(origin));
+
+        let mut diff_origin = sample_key(11);
+        diff_origin.target_triple = "x86_64-unknown-linux-gnu".into();
+        let diff_origin_entry = sample_entry(0x22, 1, Some("https://github.com/other/repo"));
+
+        upsert(
+            &path,
+            &same_origin_diff_triple,
+            &same_origin_diff_triple_entry,
+        )
+        .expect("upsert sodt");
+        upsert(&path, &diff_origin, &diff_origin_entry).expect("upsert do");
+
+        let mut miss = sample_key(12);
+        miss.target_triple = "x86_64-unknown-linux-gnu".into();
+        let drift = drift_recipe_hashes(&path, &miss, Some(origin), 10).expect("drift");
+        assert!(drift.is_empty());
+    });
+
+    crate::timed_test!(drift_returns_empty_without_origin_hint, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        upsert(
+            &path,
+            &sample_key(20),
+            &sample_entry(0xEE, 1, Some("https://x")),
+        )
+        .expect("upsert");
+        let miss = sample_key(21);
+        assert!(drift_recipe_hashes(&path, &miss, None, 10)
+            .expect("drift")
+            .is_empty());
+    });
+
+    crate::timed_test!(touch_bumps_last_used_ms, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        let key = sample_key(30);
+        let mut entry = sample_entry(0xFF, 1, None);
+        entry.last_used_unix_ms = 1;
+        upsert(&path, &key, &entry).expect("upsert");
+        assert!(touch(&path, &[0xFF; 32], 9_999).expect("touch"));
+        let got = lookup(&path, &key).expect("lookup").expect("hit");
+        assert_eq!(got.last_used_unix_ms, 9_999);
+    });
+
+    crate::timed_test!(touch_returns_false_when_sha_unknown, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        assert!(!touch(&path, &[0x00; 32], 1).expect("touch"));
+    });
+
+    crate::timed_test!(stats_sums_entries_and_sizes, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        upsert(&path, &sample_key(40), &sample_entry(0x40, 1_024, None)).expect("a");
+        upsert(&path, &sample_key(41), &sample_entry(0x41, 2_048, None)).expect("b");
+        upsert(&path, &sample_key(42), &sample_entry(0x42, 4_096, None)).expect("c");
+        let (count, total) = stats(&path).expect("stats");
+        assert_eq!(count, 3);
+        assert_eq!(total, 1_024 + 2_048 + 4_096);
+    });
+
+    crate::timed_test!(ensure_initialized_is_idempotent, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        ensure_initialized(&path).expect("init 1");
+        ensure_initialized(&path).expect("init 2");
+        let (count, total) = stats(&path).expect("stats");
+        assert_eq!((count, total), (0, 0));
+    });
+}

--- a/crates/soldr-cli/src/cache_lib/mod.rs
+++ b/crates/soldr-cli/src/cache_lib/mod.rs
@@ -13,6 +13,7 @@ use std::{
 pub mod auto_gc;
 pub mod auto_target_gc;
 pub mod cargo_global_cache;
+pub mod cook_index;
 pub mod gc;
 pub mod prune_target;
 pub mod save;

--- a/crates/soldr-cli/src/daemon/client.rs
+++ b/crates/soldr-cli/src/daemon/client.rs
@@ -175,6 +175,120 @@ pub fn link_zccache(paths: &SoldrPaths, link: crate::daemon::protocol::ZccacheDa
     let _ = db::set_linked_zccache(&data_db_path(paths), Some(&link));
 }
 
+/// PR 1 cook-index client surface (#576). PR 2 (`soldr cook`) and PR 3
+/// (cargo-front-door pre-flight) consume these; PR 1 ships dormant so
+/// the helpers here are unused outside integration tests.
+///
+/// The reply is a [`CookLookupOutcome`]:
+/// * `Hit { sha256, path, size_bytes, origin_url_normalized }` — PR 3
+///   verifies `sha256` against the bytes at `path` before extracting.
+/// * `Miss { previous_origin_recipe_hashes }` — used as a drift
+///   diagnostic when the pre-flight misses.
+///
+/// `Err(ClientError::NotRunning)` means the daemon endpoint is not
+/// reachable — caller must NOT treat this as a hard error; the hot
+/// path falls through to a normal cargo run.
+#[allow(clippy::too_many_arguments)]
+pub fn cook_lookup(
+    sock_path: &Path,
+    recipe_hash: [u8; 32],
+    target_triple: String,
+    profile: String,
+    channel: String,
+    rustc_version: String,
+    origin_url_normalized: Option<String>,
+) -> Result<CookLookupOutcome, ClientError> {
+    let req = Request::CookLookup {
+        recipe_hash,
+        target_triple,
+        profile,
+        channel,
+        rustc_version,
+        origin_url_normalized,
+    };
+    match submit_request(sock_path, &req)? {
+        Response::CookHit {
+            sha256,
+            path,
+            size_bytes,
+            origin_url_normalized,
+        } => Ok(CookLookupOutcome::Hit {
+            sha256,
+            path,
+            size_bytes,
+            origin_url_normalized,
+        }),
+        Response::CookMiss {
+            previous_origin_recipe_hashes,
+        } => Ok(CookLookupOutcome::Miss {
+            previous_origin_recipe_hashes,
+        }),
+        Response::Error(msg) => Err(ClientError::Protocol(msg)),
+        other => Err(ClientError::Protocol(format!(
+            "unexpected cook_lookup response: {other:?}"
+        ))),
+    }
+}
+
+/// Strongly-typed reply for [`cook_lookup`] / [`cook_lookup_full`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CookLookupOutcome {
+    Hit {
+        sha256: [u8; 32],
+        path: String,
+        size_bytes: u64,
+        origin_url_normalized: Option<String>,
+    },
+    Miss {
+        previous_origin_recipe_hashes: Vec<[u8; 32]>,
+    },
+}
+
+/// Register a cook artifact with the daemon. PR 2's `soldr cook`
+/// worker calls this after writing `<sha256>.tar.zst` to
+/// `~/.soldr/cache/cook/`. Blocks for the daemon's `Ack` reply
+/// because PR 2 wants to know whether the indexing succeeded before
+/// emitting its `soldr cook: indexed` line.
+#[allow(clippy::too_many_arguments)]
+pub fn cook_record(
+    sock_path: &Path,
+    recipe_hash: [u8; 32],
+    target_triple: String,
+    profile: String,
+    channel: String,
+    rustc_version: String,
+    sha256: [u8; 32],
+    size_bytes: u64,
+    origin_url_normalized: Option<String>,
+    cook_cmd_summary: String,
+) -> Result<(), ClientError> {
+    let req = Request::CookRecord {
+        recipe_hash,
+        target_triple,
+        profile,
+        channel,
+        rustc_version,
+        sha256,
+        size_bytes,
+        origin_url_normalized,
+        cook_cmd_summary,
+    };
+    match submit_request(sock_path, &req)? {
+        Response::Ack => Ok(()),
+        Response::Error(msg) => Err(ClientError::Protocol(msg)),
+        other => Err(ClientError::Protocol(format!(
+            "unexpected cook_record response: {other:?}"
+        ))),
+    }
+}
+
+/// Fire-and-forget bump of `last_used_unix_ms` for the entry whose
+/// sha256 matches. Best-effort by design: a touch failure must never
+/// affect callers (eviction will simply observe stale `last_used`).
+pub fn cook_touch(sock_path: &Path, sha256: [u8; 32]) -> Result<(), ClientError> {
+    submit_fire_and_forget(sock_path, &Request::CookTouch { sha256 })
+}
+
 /// Wrapper-side entry point. Tries the daemon first; on any failure,
 /// upserts the row directly to the redb file. **Never** propagates
 /// errors — a missing daemon must not break a build.

--- a/crates/soldr-cli/src/daemon/protocol.rs
+++ b/crates/soldr-cli/src/daemon/protocol.rs
@@ -10,7 +10,17 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 3;
+/// Protocol version bump rationale:
+///
+/// * v1–v2: pre-PID-file lifecycle.
+/// * v3: target-touch + build-session correlation + linked-zccache.
+/// * v4 (this PR): adds cook-index IPC (CookLookup, CookRecord,
+///   CookTouch) + `cook_stats` on `StatusInfo`. Old clients/daemons
+///   on v3 cannot decode v4 frames and vice versa; the IPC layer
+///   rejects mismatched versions cleanly and the wrapper hot path's
+///   direct-redb fallback keeps builds from breaking during the
+///   short cross-version window after a `soldr` upgrade.
+pub const PROTOCOL_VERSION: u32 = 4;
 
 /// Maximum bincode body size. 64 KiB is comfortably above the largest
 /// realistic record (path strings, a few timestamps). Frames larger than
@@ -67,6 +77,43 @@ pub enum Request {
     /// (explicit RPC, signal, or idle timeout), the daemon issues
     /// `zccache stop` with the recorded cache dir before exiting.
     LinkZccache { link: ZccacheDaemonLink },
+    /// Request-response: probe the cook-artifact index for the given
+    /// `(recipe_hash, target_triple, profile, channel, rustc_version)`
+    /// tuple. On hit returns [`Response::CookHit`]; on miss returns
+    /// [`Response::CookMiss`] with up to N previous recipe hashes
+    /// recorded under the same `(origin, triple, profile, channel,
+    /// rustc)` matrix — used by the consumer (PR 3) as a "recipe
+    /// drift" diagnostic when the cargo-front-door pre-flight misses.
+    /// `origin_url_normalized` is a hint only and never participates
+    /// in the authoritative key.
+    CookLookup {
+        recipe_hash: [u8; 32],
+        target_triple: String,
+        profile: String,
+        channel: String,
+        rustc_version: String,
+        origin_url_normalized: Option<String>,
+    },
+    /// Request-response: register a cook artifact written by PR 2's
+    /// `soldr cook` worker at `~/.soldr/cache/cook/<sha256>.tar.zst`.
+    /// Replies with [`Response::Ack`] on success.
+    CookRecord {
+        recipe_hash: [u8; 32],
+        target_triple: String,
+        profile: String,
+        channel: String,
+        rustc_version: String,
+        sha256: [u8; 32],
+        size_bytes: u64,
+        origin_url_normalized: Option<String>,
+        cook_cmd_summary: String,
+    },
+    /// Fire-and-forget: bump the `last_used_unix_ms` field for the
+    /// row whose `sha256` matches. Sent by PR 3's pre-flight after a
+    /// hit so eviction can prefer rows that are actually serving
+    /// traffic. Failure must never affect the caller — per-call
+    /// 50 ms timeout from the client side.
+    CookTouch { sha256: [u8; 32] },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,6 +122,26 @@ pub enum Response {
     ShuttingDown,
     Builds(Vec<BuildRecord>),
     Error(String),
+    /// Reply to [`Request::CookLookup`] on hit. Carries the on-disk
+    /// path to the `<sha256>.tar.zst` artifact, the recorded sha256
+    /// (PR 3 verifies it before extraction), the byte size for
+    /// hydration reporting, and the recorded origin URL hint.
+    CookHit {
+        sha256: [u8; 32],
+        path: String,
+        size_bytes: u64,
+        origin_url_normalized: Option<String>,
+    },
+    /// Reply to [`Request::CookLookup`] on miss. `previous_origin_recipe_hashes`
+    /// is a diagnostic: at most 8 prior recipe hashes recorded under
+    /// the same `(origin, triple, profile, channel, rustc)` matrix,
+    /// newest-first. Used by PR 3 to print a recipe-drift line.
+    CookMiss {
+        previous_origin_recipe_hashes: Vec<[u8; 32]>,
+    },
+    /// Generic ack for fire-and-forget-style request/response calls
+    /// that don't carry a payload (used by [`Request::CookRecord`]).
+    Ack,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -85,6 +152,36 @@ pub struct StatusInfo {
     pub request_count: u64,
     /// Set by `LinkZccache`; cleared on daemon shutdown.
     pub linked_zccache: Option<ZccacheDaemonLink>,
+    /// Cook-index aggregate stats (issue #576). `None` means "the
+    /// daemon does not expose cook stats" — old v3 daemons can never
+    /// emit this (rejected at the version check), so in practice
+    /// callers should treat `None` as zero. Use
+    /// [`StatusInfo::cook_stats_or_zero`] to get the defaulted view.
+    pub cook_stats: Option<CookStats>,
+}
+
+impl StatusInfo {
+    /// Resolve `cook_stats` to a concrete value, treating `None` as
+    /// the zero state. Reserved for callers that want a fully-
+    /// populated rendering even when the daemon predates the
+    /// cook-index feature.
+    pub fn cook_stats_or_zero(&self) -> CookStats {
+        self.cook_stats.clone().unwrap_or_default()
+    }
+}
+
+/// Aggregate counts for the cook-artifact index. Surfaced through
+/// [`Request::Status`] and rendered by `soldr daemon status` /
+/// `soldr doctor`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CookStats {
+    /// Number of rows currently in `cook_index_v1`.
+    pub entries: u64,
+    /// Sum of `size_bytes` across all rows.
+    pub total_bytes: u64,
+    /// Number of [`Request::CookLookup`] hits served by the running
+    /// daemon since its last startup. Resets across daemon restarts.
+    pub hits_this_session: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -110,4 +207,207 @@ pub struct BuildRecord {
     pub crate_count: u32,
     pub slowest_crate_us: Option<u64>,
     pub slowest_crate_name: Option<String>,
+}
+
+/// Pre-#576 shape of [`StatusInfo`], retained so persisted-state
+/// blobs or pinned-version test fixtures can still be decoded into
+/// the new struct with `cook_stats` defaulting to `None`. The wire
+/// path itself enforces protocol-version equality via
+/// [`crate::daemon::ipc`], so this fallback is a documented "can be"
+/// rather than a "is" — but the unit test in this file exercises it
+/// so the path stays live.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct LegacyStatusInfo {
+    version: u32,
+    pid: u32,
+    uptime_secs: u64,
+    request_count: u64,
+    linked_zccache: Option<ZccacheDaemonLink>,
+}
+
+impl From<LegacyStatusInfo> for StatusInfo {
+    fn from(value: LegacyStatusInfo) -> Self {
+        Self {
+            version: value.version,
+            pid: value.pid,
+            uptime_secs: value.uptime_secs,
+            request_count: value.request_count,
+            linked_zccache: value.linked_zccache,
+            cook_stats: None,
+        }
+    }
+}
+
+/// Decode `bytes` into a [`StatusInfo`]. Tries the current shape
+/// first; on failure falls back to the legacy shape (without
+/// `cook_stats`) and lifts it via [`LegacyStatusInfo::into`]. The
+/// fallback is `pub(crate)` so callers that hold raw [`StatusInfo`]
+/// blobs (tests, future migrations) can use it without poking the
+/// wire path.
+pub(crate) fn decode_status_info_with_legacy_fallback(
+    bytes: &[u8],
+) -> Result<StatusInfo, bincode::Error> {
+    bincode::deserialize::<StatusInfo>(bytes).or_else(|new_err| {
+        bincode::deserialize::<LegacyStatusInfo>(bytes)
+            .map(StatusInfo::from)
+            .map_err(|_| new_err)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_link() -> ZccacheDaemonLink {
+        ZccacheDaemonLink {
+            binary_path: "/tmp/zccache".into(),
+            cache_dir: "/tmp/cache".into(),
+            session_id: Some("session-1".into()),
+            source: "managed".into(),
+            private_daemon: false,
+            daemon_name: None,
+            owner_pid: None,
+            private_env_keys: Vec::new(),
+        }
+    }
+
+    crate::timed_test!(status_info_round_trips_with_cook_stats, {
+        let info = StatusInfo {
+            version: PROTOCOL_VERSION,
+            pid: 4242,
+            uptime_secs: 60,
+            request_count: 17,
+            linked_zccache: Some(sample_link()),
+            cook_stats: Some(CookStats {
+                entries: 3,
+                total_bytes: 9_999,
+                hits_this_session: 1,
+            }),
+        };
+        let bytes = bincode::serialize(&info).expect("serialize");
+        let decoded = decode_status_info_with_legacy_fallback(&bytes).expect("decode");
+        assert_eq!(decoded, info);
+    });
+
+    crate::timed_test!(legacy_status_info_bytes_default_cook_stats_to_none, {
+        let legacy = LegacyStatusInfo {
+            version: 3,
+            pid: 99,
+            uptime_secs: 1,
+            request_count: 0,
+            linked_zccache: None,
+        };
+        let bytes = bincode::serialize(&legacy).expect("serialize legacy");
+        let decoded = decode_status_info_with_legacy_fallback(&bytes).expect("decode");
+        assert_eq!(decoded.version, 3);
+        assert_eq!(decoded.pid, 99);
+        assert_eq!(decoded.uptime_secs, 1);
+        assert_eq!(decoded.request_count, 0);
+        assert!(decoded.linked_zccache.is_none());
+        assert!(
+            decoded.cook_stats.is_none(),
+            "cook_stats must default to None"
+        );
+        // And the helper view defaults to zeroes.
+        assert_eq!(decoded.cook_stats_or_zero(), CookStats::default());
+    });
+
+    crate::timed_test!(cook_lookup_request_round_trips_through_bincode, {
+        let req = Request::CookLookup {
+            recipe_hash: [1u8; 32],
+            target_triple: "x86_64-pc-windows-msvc".into(),
+            profile: "release".into(),
+            channel: "1.94.1".into(),
+            rustc_version: "rustc 1.94.1".into(),
+            origin_url_normalized: Some("https://github.com/zackees/soldr".into()),
+        };
+        let bytes = bincode::serialize(&req).expect("serialize");
+        let decoded: Request = bincode::deserialize(&bytes).expect("deserialize");
+        match decoded {
+            Request::CookLookup {
+                recipe_hash,
+                target_triple,
+                profile,
+                channel,
+                rustc_version,
+                origin_url_normalized,
+            } => {
+                assert_eq!(recipe_hash, [1u8; 32]);
+                assert_eq!(target_triple, "x86_64-pc-windows-msvc");
+                assert_eq!(profile, "release");
+                assert_eq!(channel, "1.94.1");
+                assert_eq!(rustc_version, "rustc 1.94.1");
+                assert_eq!(
+                    origin_url_normalized.as_deref(),
+                    Some("https://github.com/zackees/soldr"),
+                );
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    });
+
+    crate::timed_test!(cook_hit_response_round_trips, {
+        let resp = Response::CookHit {
+            sha256: [0xAA; 32],
+            path: "/home/runner/.soldr/cache/cook/abcd.tar.zst".into(),
+            size_bytes: 4_096,
+            origin_url_normalized: None,
+        };
+        let bytes = bincode::serialize(&resp).expect("serialize");
+        let decoded: Response = bincode::deserialize(&bytes).expect("deserialize");
+        match decoded {
+            Response::CookHit {
+                sha256,
+                path,
+                size_bytes,
+                origin_url_normalized,
+            } => {
+                assert_eq!(sha256, [0xAA; 32]);
+                assert!(path.ends_with(".tar.zst"));
+                assert_eq!(size_bytes, 4_096);
+                assert!(origin_url_normalized.is_none());
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    });
+
+    crate::timed_test!(cook_miss_response_round_trips, {
+        let resp = Response::CookMiss {
+            previous_origin_recipe_hashes: vec![[1u8; 32], [2u8; 32]],
+        };
+        let bytes = bincode::serialize(&resp).expect("serialize");
+        let decoded: Response = bincode::deserialize(&bytes).expect("deserialize");
+        match decoded {
+            Response::CookMiss {
+                previous_origin_recipe_hashes,
+            } => {
+                assert_eq!(previous_origin_recipe_hashes.len(), 2);
+                assert_eq!(previous_origin_recipe_hashes[0], [1u8; 32]);
+                assert_eq!(previous_origin_recipe_hashes[1], [2u8; 32]);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    });
+
+    crate::timed_test!(cook_record_fits_under_max_body_bytes, {
+        // Conservative: long strings still fit comfortably under 64 KiB.
+        let big_string = "x".repeat(1024);
+        let req = Request::CookRecord {
+            recipe_hash: [0; 32],
+            target_triple: big_string.clone(),
+            profile: big_string.clone(),
+            channel: big_string.clone(),
+            rustc_version: big_string.clone(),
+            sha256: [0; 32],
+            size_bytes: u64::MAX,
+            origin_url_normalized: Some(big_string.clone()),
+            cook_cmd_summary: big_string,
+        };
+        let bytes = bincode::serialize(&req).expect("serialize");
+        assert!((bytes.len() as u32) <= MAX_BODY_BYTES);
+    });
+
+    crate::timed_test!(protocol_version_is_v4_after_cook_index, {
+        assert_eq!(PROTOCOL_VERSION, 4);
+    });
 }

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -4,6 +4,7 @@
 //! per-process state (request count, last activity, optional linked
 //! zccache pid placeholder for Phase 3).
 
+use crate::cache_lib::cook_index::{self, CookEntry, CookKey};
 #[cfg(unix)]
 use crate::cache_lib::daemon_sock_path;
 use crate::cache_lib::target_registry::TargetRegistry;
@@ -13,14 +14,20 @@ use crate::daemon::db;
 use crate::daemon::ipc::{read_frame_async, write_frame_async};
 use crate::daemon::lifecycle::{append_lifecycle_event, is_live, remove_pid_file, write_pid_file};
 use crate::daemon::protocol::{
-    BuildRecord, Request, Response, StatusInfo, ZccacheDaemonLink, PROTOCOL_VERSION,
+    BuildRecord, CookStats, Request, Response, StatusInfo, ZccacheDaemonLink, PROTOCOL_VERSION,
 };
 use crate::daemon::zccache_link;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::Notify;
+
+/// Upper bound on the drift diagnostic returned in [`Response::CookMiss`].
+/// Keeps the body well under [`crate::daemon::protocol::MAX_BODY_BYTES`]
+/// and matches PR 3's expectation of "most recent N prior recipe
+/// hashes for this origin+target".
+const COOK_DRIFT_LIMIT: usize = 8;
 
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(1800);
 const IDLE_POLL_INTERVAL: Duration = Duration::from_secs(30);
@@ -78,6 +85,10 @@ struct State {
     /// writer ordering and build-session correlation, not avoiding
     /// the per-write fs::open cost.
     db_path: PathBuf,
+    /// Resolved `~/.soldr/` layout cached for the daemon's lifetime
+    /// so cook-artifact path construction does not need to re-probe
+    /// HOME/SOLDR_CACHE_DIR on every IPC request.
+    paths: SoldrPaths,
     /// Linked zccache runtime kept in memory for fast `Status` replies;
     /// also persisted to redb so a daemon restart can resume shutdown.
     linked_zccache: std::sync::Mutex<Option<ZccacheDaemonLink>>,
@@ -88,6 +99,22 @@ struct State {
     /// task tag the lifecycle event as `died-idle` instead of
     /// `died-shutdown`.
     exit_via_idle: AtomicBool,
+    /// In-process count of [`Request::CookLookup`] hits served since
+    /// this daemon's last startup. Surfaced via [`Request::Status`]
+    /// for `soldr daemon status` and `soldr doctor`. Resets across
+    /// daemon restarts by design — long-lived totals belong in the
+    /// redb `cook_index_v1` table, not in process-local state.
+    cook_hits_this_session: AtomicU64,
+    /// Serializes cook_index redb opens within the daemon process.
+    /// redb refuses concurrent in-process `Database::open` for the
+    /// same file with `Database already open. Cannot acquire lock.`
+    /// Each cook_index op (`upsert`, `lookup`, `touch`, `stats`,
+    /// `drift_recipe_hashes`) opens + drops a handle per call so the
+    /// CLI side (`soldr cache stats`, `soldr doctor`) can still
+    /// open `state.redb` between daemon ops. This lock guarantees
+    /// only one daemon worker runs a cook_index op at a time so the
+    /// "already open" error never reaches the wire.
+    cook_index_lock: std::sync::Mutex<()>,
     shutdown: Notify,
 }
 
@@ -104,6 +131,15 @@ impl State {
     }
 
     fn status(&self) -> StatusInfo {
+        // Serialize the redb open behind cook_index_lock — see the
+        // field-level comment for why this matters.
+        let (entries, total_bytes) = {
+            let _guard = self
+                .cook_index_lock
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            cook_index::stats(&self.db_path).unwrap_or((0, 0))
+        };
         StatusInfo {
             version: PROTOCOL_VERSION,
             pid: std::process::id(),
@@ -114,8 +150,20 @@ impl State {
                 .lock()
                 .unwrap_or_else(|p| p.into_inner())
                 .clone(),
+            cook_stats: Some(CookStats {
+                entries,
+                total_bytes,
+                hits_this_session: self.cook_hits_this_session.load(Ordering::Relaxed),
+            }),
         }
     }
+}
+
+fn current_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 /// Synchronous entry point used by both the `soldr-daemon` bin target
@@ -144,16 +192,22 @@ async fn run_async(opts: ServerOptions) -> Result<(), ServerError> {
     // Initialize the Phase 2 daemon tables (idempotent). Errors here
     // are non-fatal — Phase 1 target tracking still works without them.
     let _ = db::ensure_initialized(&db_path);
+    // Initialize the cook_index_v1 table (issue #576). Idempotent and
+    // non-fatal — old soldr versions ignore this table entirely.
+    let _ = cook_index::ensure_initialized(&db_path);
     // Resume any linked zccache identity persisted across daemon restarts.
     let resumed_link = db::get_linked_zccache(&db_path).ok().flatten();
     let start_instant = Instant::now();
     let state = Arc::new(State {
         db_path,
+        paths: paths.clone(),
         linked_zccache: std::sync::Mutex::new(resumed_link),
         start_instant,
         request_count: AtomicU64::new(0),
         last_activity_ms: AtomicU64::new(0),
         exit_via_idle: AtomicBool::new(false),
+        cook_hits_this_session: AtomicU64::new(0),
+        cook_index_lock: std::sync::Mutex::new(()),
         shutdown: Notify::new(),
     });
 
@@ -394,8 +448,138 @@ where
                 *guard = Some(link);
             }
         }
+        Request::CookLookup {
+            recipe_hash,
+            target_triple,
+            profile,
+            channel,
+            rustc_version,
+            origin_url_normalized,
+        } => {
+            let key = CookKey {
+                recipe_hash,
+                target_triple,
+                profile,
+                channel,
+                rustc_version,
+            };
+            // Hold cook_index_lock for the lookup + drift scan, then
+            // drop before any await — Mutex is sync-only.
+            let reply = {
+                let _guard = state
+                    .cook_index_lock
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner());
+                match cook_index::lookup(&state.db_path, &key) {
+                    Ok(Some(entry)) => {
+                        state.cook_hits_this_session.fetch_add(1, Ordering::Relaxed);
+                        let path = cook_artifact_path(&state.paths, &entry.sha256)
+                            .display()
+                            .to_string();
+                        Response::CookHit {
+                            sha256: entry.sha256,
+                            path,
+                            size_bytes: entry.size_bytes,
+                            origin_url_normalized: entry.origin_url_normalized,
+                        }
+                    }
+                    Ok(None) => {
+                        let previous = cook_index::drift_recipe_hashes(
+                            &state.db_path,
+                            &key,
+                            origin_url_normalized.as_deref(),
+                            COOK_DRIFT_LIMIT,
+                        )
+                        .unwrap_or_default();
+                        Response::CookMiss {
+                            previous_origin_recipe_hashes: previous,
+                        }
+                    }
+                    Err(e) => Response::Error(format!("cook_index lookup failed: {e}")),
+                }
+            };
+            let _ = write_frame_async(&mut stream, &reply).await;
+        }
+        Request::CookRecord {
+            recipe_hash,
+            target_triple,
+            profile,
+            channel,
+            rustc_version,
+            sha256,
+            size_bytes,
+            origin_url_normalized,
+            cook_cmd_summary,
+        } => {
+            let key = CookKey {
+                recipe_hash,
+                target_triple,
+                profile,
+                channel,
+                rustc_version,
+            };
+            let now_ms = current_unix_ms();
+            let entry = CookEntry {
+                sha256,
+                size_bytes,
+                created_unix_ms: now_ms,
+                last_used_unix_ms: now_ms,
+                origin_url_normalized,
+                cook_cmd_summary,
+            };
+            let result = {
+                let _guard = state
+                    .cook_index_lock
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner());
+                cook_index::upsert(&state.db_path, &key, &entry)
+            };
+            match result {
+                Ok(()) => {
+                    let _ = write_frame_async(&mut stream, &Response::Ack).await;
+                }
+                Err(e) => {
+                    let _ = write_frame_async(
+                        &mut stream,
+                        &Response::Error(format!("cook_index upsert failed: {e}")),
+                    )
+                    .await;
+                }
+            }
+        }
+        Request::CookTouch { sha256 } => {
+            // Fire-and-forget bump of last_used_unix_ms. Silent on
+            // failure — the caller already moved on.
+            let _guard = state
+                .cook_index_lock
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let _ = cook_index::touch(&state.db_path, &sha256, current_unix_ms());
+        }
     }
     Ok(())
+}
+
+/// Best-effort resolver for the `~/.soldr/cache/cook/<sha256>.tar.zst`
+/// path. Returns the canonical content-addressed file even when the
+/// file does not yet exist on disk — the path is informational only;
+/// PR 3 (`Response::CookHit` consumer) is responsible for verifying
+/// the sha256 of the bytes it reads.
+fn cook_artifact_path(paths: &SoldrPaths, sha256: &[u8; 32]) -> PathBuf {
+    paths
+        .cache
+        .join("cook")
+        .join(format!("{}.tar.zst", hex_lower(sha256)))
+}
+
+fn hex_lower(bytes: &[u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0F) as usize] as char);
+    }
+    out
 }
 
 async fn run_idle_watchdog(state: Arc<State>, idle_timeout: Duration) {

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -902,6 +902,10 @@ fn run_daemon_command(command: DaemonSubcommand) -> Result<(), SoldrError> {
         },
         DaemonSubcommand::Status { json } => match client::status(&sock) {
             Ok(info) => {
+                // Cook-index aggregate stats (issue #576). Older
+                // daemons would emit `cook_stats: None` — render as
+                // zero so the surface is stable.
+                let cook = info.cook_stats_or_zero();
                 if json {
                     let payload = serde_json::json!({
                         "running": true,
@@ -910,12 +914,21 @@ fn run_daemon_command(command: DaemonSubcommand) -> Result<(), SoldrError> {
                         "uptime_secs": info.uptime_secs,
                         "request_count": info.request_count,
                         "linked_zccache": info.linked_zccache,
+                        "cook": {
+                            "entries": cook.entries,
+                            "total_bytes": cook.total_bytes,
+                            "hits_this_session": cook.hits_this_session,
+                        },
                     });
                     println!("{}", serde_json::to_string(&payload).unwrap_or_default());
                 } else {
                     println!(
                         "soldr-daemon: pid={} uptime={}s requests={} version={}",
                         info.pid, info.uptime_secs, info.request_count, info.version
+                    );
+                    println!(
+                        "  cook: entries={} total_bytes={} hits_this_session={}",
+                        cook.entries, cook.total_bytes, cook.hits_this_session
                     );
                 }
                 Ok(())

--- a/crates/soldr-cli/tests/daemon_cook_index.rs
+++ b/crates/soldr-cli/tests/daemon_cook_index.rs
@@ -1,0 +1,527 @@
+//! Integration tests for the dormant cook-index daemon surface added
+//! in PR 1 of meta issue #579 (sub-issue #576).
+//!
+//! These tests spawn the real `soldr-daemon` binary against a sandboxed
+//! `~/.soldr/` (`SOLDR_CACHE_DIR` + `HOME`/`USERPROFILE` redirect to a
+//! per-test temp dir) and exercise the new `CookLookup`, `CookRecord`,
+//! `CookTouch`, and extended `Status` IPC variants via the public
+//! client helpers.
+//!
+//! ## Docker harness gate
+//!
+//! Every test below short-circuits with a `println!` when
+//! `SOLDR_COOK_DOCKER_HARNESS` is not set to `1`. The meta issue
+//! mandates that PRs 1–3 build and test inside the
+//! `docker/cook-shared-cache/Dockerfile` image so the host developer's
+//! soldr singleton is never mutated. `bench/cook_in_docker.sh` is the
+//! supported runner — it builds the image, mounts the source tree, and
+//! exports the marker. Bare-host `cargo test` invocations skip these
+//! tests, satisfying the "host ~/.soldr/ is byte-identical before and
+//! after the test suite" acceptance gate.
+
+#![allow(clippy::print_stdout)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use soldr_cli::daemon::client::{self, cook_lookup, cook_record, cook_touch, CookLookupOutcome};
+use soldr_cli::daemon::protocol::Response;
+use soldr_cli::timed_test;
+
+const HARNESS_ENV: &str = "SOLDR_COOK_DOCKER_HARNESS";
+
+fn harness_enabled() -> bool {
+    matches!(
+        std::env::var(HARNESS_ENV).ok().as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
+fn skip_unless_in_container(test_name: &str) -> bool {
+    if harness_enabled() {
+        return false;
+    }
+    println!(
+        "{test_name}: skipped — {HARNESS_ENV} not set. \
+         Run via bench/cook_in_docker.sh per meta #579.",
+    );
+    true
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("soldr-cook-{label}-{nanos}"));
+    std::fs::create_dir_all(&dir).expect("failed to create temp dir");
+    dir
+}
+
+fn soldr_daemon_bin() -> PathBuf {
+    let soldr = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let parent = soldr.parent().expect("CARGO_BIN_EXE_soldr has a parent");
+    let stem = if cfg!(windows) {
+        "soldr-daemon.exe"
+    } else {
+        "soldr-daemon"
+    };
+    parent.join(stem)
+}
+
+struct DaemonProc {
+    child: Option<Child>,
+    cache_root: PathBuf,
+}
+
+impl DaemonProc {
+    fn spawn(cache_root: &Path, home_root: &Path) -> Self {
+        let mut cmd = Command::new(soldr_daemon_bin());
+        cmd.args(["--foreground", "--idle-timeout-secs", "60"])
+            .env("SOLDR_CACHE_DIR", cache_root)
+            .env("HOME", home_root)
+            .env("USERPROFILE", home_root)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = cmd.spawn().expect("spawn soldr-daemon");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let pid_path = cache_root
+            .join("cache")
+            .join("soldr-daemon")
+            .join("daemon.pid");
+        while Instant::now() < deadline {
+            if pid_path.exists() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            pid_path.exists(),
+            "soldr-daemon failed to write {} within 5s",
+            pid_path.display()
+        );
+        Self {
+            child: Some(child),
+            cache_root: cache_root.to_path_buf(),
+        }
+    }
+
+    fn sock_path(&self) -> PathBuf {
+        // Construct `SoldrPaths::with_root(...)` directly rather than
+        // mutating `SOLDR_CACHE_DIR` on the process env — these tests
+        // run concurrently under `cargo test` and env mutation is
+        // process-wide, so an EnvScope-based approach races between
+        // tests. `with_root` is the same shape the daemon resolves
+        // to internally (its own SOLDR_CACHE_DIR was set on its
+        // child env at spawn).
+        let paths = soldr_cli::core::SoldrPaths::with_root(self.cache_root.clone());
+        client::default_sock_path(&paths)
+    }
+}
+
+impl Drop for DaemonProc {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let paths = soldr_cli::core::SoldrPaths::with_root(self.cache_root.clone());
+            let _ = client::shutdown(&client::default_sock_path(&paths));
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < deadline {
+                if let Ok(Some(_)) = child.try_wait() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn standard_key_fields() -> (String, String, String, String) {
+    (
+        "x86_64-unknown-linux-gnu".to_string(),
+        "release".to_string(),
+        "1.94.1".to_string(),
+        "rustc 1.94.1 (abcdef0 2026-05-30)".to_string(),
+    )
+}
+
+timed_test!(
+    cook_record_then_lookup_round_trips_through_daemon,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("cook_record_then_lookup_round_trips_through_daemon") {
+            return;
+        }
+        let cache_root = unique_temp_dir("rt-cache");
+        let home_root = unique_temp_dir("rt-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+        let sock = daemon.sock_path();
+
+        let (triple, profile, channel, rustc) = standard_key_fields();
+        cook_record(
+            &sock,
+            [1u8; 32],
+            triple.clone(),
+            profile.clone(),
+            channel.clone(),
+            rustc.clone(),
+            [0xAAu8; 32],
+            4_096,
+            Some("https://github.com/zackees/soldr".to_string()),
+            "cook --release".to_string(),
+        )
+        .expect("CookRecord");
+
+        let outcome = cook_lookup(
+            &sock,
+            [1u8; 32],
+            triple,
+            profile,
+            channel,
+            rustc,
+            Some("https://github.com/zackees/soldr".to_string()),
+        )
+        .expect("CookLookup");
+
+        match outcome {
+            CookLookupOutcome::Hit {
+                sha256,
+                path,
+                size_bytes,
+                origin_url_normalized,
+            } => {
+                assert_eq!(sha256, [0xAAu8; 32]);
+                assert_eq!(size_bytes, 4_096);
+                assert_eq!(
+                    origin_url_normalized.as_deref(),
+                    Some("https://github.com/zackees/soldr")
+                );
+                assert!(
+                    path.ends_with(".tar.zst"),
+                    "expected <sha256>.tar.zst path, got {path}"
+                );
+            }
+            CookLookupOutcome::Miss { .. } => panic!("expected CookHit, got CookMiss"),
+        }
+    }
+);
+
+timed_test!(
+    cook_lookup_miss_reports_drift_recipe_hashes,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("cook_lookup_miss_reports_drift_recipe_hashes") {
+            return;
+        }
+        let cache_root = unique_temp_dir("drift-cache");
+        let home_root = unique_temp_dir("drift-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+        let sock = daemon.sock_path();
+
+        let (triple, profile, channel, rustc) = standard_key_fields();
+        let origin = "https://github.com/zackees/soldr".to_string();
+
+        // Two prior entries with the same origin/triple/profile/channel/rustc
+        // but different recipe hashes.
+        cook_record(
+            &sock,
+            [5u8; 32],
+            triple.clone(),
+            profile.clone(),
+            channel.clone(),
+            rustc.clone(),
+            [0x55u8; 32],
+            1,
+            Some(origin.clone()),
+            "cook a".to_string(),
+        )
+        .expect("CookRecord a");
+        cook_record(
+            &sock,
+            [6u8; 32],
+            triple.clone(),
+            profile.clone(),
+            channel.clone(),
+            rustc.clone(),
+            [0x66u8; 32],
+            2,
+            Some(origin.clone()),
+            "cook b".to_string(),
+        )
+        .expect("CookRecord b");
+
+        // Miss probe for a new (third) recipe hash.
+        let outcome = cook_lookup(
+            &sock,
+            [7u8; 32],
+            triple,
+            profile,
+            channel,
+            rustc,
+            Some(origin),
+        )
+        .expect("CookLookup");
+
+        match outcome {
+            CookLookupOutcome::Miss {
+                previous_origin_recipe_hashes,
+            } => {
+                assert_eq!(previous_origin_recipe_hashes.len(), 2);
+                // newest-first order driven by last_used_unix_ms; the
+                // two records were upserted in (5,6) order so 6 is
+                // most recent and appears first.
+                assert_eq!(previous_origin_recipe_hashes[0], [6u8; 32]);
+                assert_eq!(previous_origin_recipe_hashes[1], [5u8; 32]);
+            }
+            CookLookupOutcome::Hit { .. } => panic!("expected CookMiss, got CookHit"),
+        }
+    }
+);
+
+timed_test!(
+    concurrent_cook_records_all_land_consistently,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("concurrent_cook_records_all_land_consistently") {
+            return;
+        }
+        let cache_root = unique_temp_dir("concur-cache");
+        let home_root = unique_temp_dir("concur-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+        let sock = daemon.sock_path();
+
+        const WORKERS: usize = 8;
+        let mut handles = Vec::with_capacity(WORKERS);
+        for w in 0..WORKERS {
+            let sock = sock.clone();
+            handles.push(std::thread::spawn(move || {
+                let (triple, profile, channel, rustc) = standard_key_fields();
+                let recipe = [w as u8 + 1; 32];
+                let sha = [(w as u8) + 0x80; 32];
+                cook_record(
+                    &sock,
+                    recipe,
+                    triple,
+                    profile,
+                    channel,
+                    rustc,
+                    sha,
+                    1_000 + (w as u64) * 10,
+                    Some("https://github.com/zackees/soldr".to_string()),
+                    format!("cook --worker {w}"),
+                )
+                .expect("CookRecord");
+            }));
+        }
+        for h in handles {
+            h.join().expect("worker join");
+        }
+
+        // Status reports cook_entries == WORKERS and the total bytes
+        // is the sum of all worker payloads.
+        let status = client::status(&sock).expect("status");
+        let cook = status.cook_stats_or_zero();
+        assert_eq!(cook.entries, WORKERS as u64);
+        let expected: u64 = (0..WORKERS).map(|w| 1_000u64 + (w as u64) * 10).sum();
+        assert_eq!(cook.total_bytes, expected);
+    }
+);
+
+timed_test!(
+    per_target_safety_isolates_via_ipc,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("per_target_safety_isolates_via_ipc") {
+            return;
+        }
+        let cache_root = unique_temp_dir("target-cache");
+        let home_root = unique_temp_dir("target-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+        let sock = daemon.sock_path();
+
+        let (_, profile, channel, rustc) = standard_key_fields();
+
+        // Same recipe hash, two different triples — both inserts succeed
+        // and lookups return their respective shas with NO cross-pollination.
+        cook_record(
+            &sock,
+            [0x42u8; 32],
+            "x86_64-unknown-linux-gnu".to_string(),
+            profile.clone(),
+            channel.clone(),
+            rustc.clone(),
+            [0xAAu8; 32],
+            100,
+            None,
+            "cook linux".to_string(),
+        )
+        .expect("linux");
+        cook_record(
+            &sock,
+            [0x42u8; 32],
+            "aarch64-apple-darwin".to_string(),
+            profile.clone(),
+            channel.clone(),
+            rustc.clone(),
+            [0xBBu8; 32],
+            200,
+            None,
+            "cook mac".to_string(),
+        )
+        .expect("mac");
+
+        let linux = cook_lookup(
+            &sock,
+            [0x42u8; 32],
+            "x86_64-unknown-linux-gnu".to_string(),
+            profile.clone(),
+            channel.clone(),
+            rustc.clone(),
+            None,
+        )
+        .expect("lookup linux");
+        let mac = cook_lookup(
+            &sock,
+            [0x42u8; 32],
+            "aarch64-apple-darwin".to_string(),
+            profile,
+            channel,
+            rustc,
+            None,
+        )
+        .expect("lookup mac");
+
+        let CookLookupOutcome::Hit {
+            sha256: linux_sha,
+            size_bytes: linux_size,
+            ..
+        } = linux
+        else {
+            panic!("expected linux hit")
+        };
+        let CookLookupOutcome::Hit {
+            sha256: mac_sha,
+            size_bytes: mac_size,
+            ..
+        } = mac
+        else {
+            panic!("expected mac hit")
+        };
+
+        assert_eq!(linux_sha, [0xAAu8; 32]);
+        assert_eq!(linux_size, 100);
+        assert_eq!(mac_sha, [0xBBu8; 32]);
+        assert_eq!(mac_size, 200);
+
+        // Probing yet a third triple with the same recipe hash → MISS.
+        let other = cook_lookup(
+            &sock,
+            [0x42u8; 32],
+            "x86_64-pc-windows-msvc".to_string(),
+            "release".to_string(),
+            "1.94.1".to_string(),
+            "rustc 1.94.1 (abcdef0 2026-05-30)".to_string(),
+            None,
+        )
+        .expect("lookup other");
+        assert!(matches!(other, CookLookupOutcome::Miss { .. }));
+    }
+);
+
+timed_test!(
+    status_reports_aggregate_cook_metrics,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("status_reports_aggregate_cook_metrics") {
+            return;
+        }
+        let cache_root = unique_temp_dir("status-cache");
+        let home_root = unique_temp_dir("status-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+        let sock = daemon.sock_path();
+
+        // Empty index — cook_stats should be Some(zero).
+        let initial = client::status(&sock).expect("status");
+        let initial_cook = initial.cook_stats_or_zero();
+        assert_eq!(initial_cook.entries, 0);
+        assert_eq!(initial_cook.total_bytes, 0);
+        assert_eq!(initial_cook.hits_this_session, 0);
+
+        let (triple, profile, channel, rustc) = standard_key_fields();
+        for i in 0..3u8 {
+            cook_record(
+                &sock,
+                [i + 1; 32],
+                triple.clone(),
+                profile.clone(),
+                channel.clone(),
+                rustc.clone(),
+                [0xC0 + i; 32],
+                (i as u64 + 1) * 1_024,
+                None,
+                "cook".to_string(),
+            )
+            .expect("record");
+        }
+
+        let after_writes = client::status(&sock).expect("status");
+        let cook = after_writes.cook_stats_or_zero();
+        assert_eq!(cook.entries, 3);
+        assert_eq!(cook.total_bytes, 1_024 + 2_048 + 3_072);
+        // No CookLookup hits yet.
+        assert_eq!(cook.hits_this_session, 0);
+
+        // Drive a hit — Status should now reflect it.
+        let outcome =
+            cook_lookup(&sock, [1u8; 32], triple, profile, channel, rustc, None).expect("lookup");
+        assert!(matches!(outcome, CookLookupOutcome::Hit { .. }));
+
+        let after_hit = client::status(&sock).expect("status");
+        assert_eq!(after_hit.cook_stats_or_zero().hits_this_session, 1);
+    }
+);
+
+timed_test!(
+    cook_touch_is_fire_and_forget_and_silent_on_unknown_sha,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("cook_touch_is_fire_and_forget_and_silent_on_unknown_sha") {
+            return;
+        }
+        let cache_root = unique_temp_dir("touch-cache");
+        let home_root = unique_temp_dir("touch-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+        let sock = daemon.sock_path();
+
+        // Bumping an unknown sha is a no-op success — fire-and-forget
+        // never errors on the caller side.
+        cook_touch(&sock, [0xFEu8; 32]).expect("touch unknown");
+
+        // Daemon still responds to Status normally afterwards.
+        let status = client::status(&sock).expect("status");
+        assert_eq!(status.cook_stats_or_zero().entries, 0);
+    }
+);
+
+// The Status response payload still encodes `Response::Status` cleanly
+// on the wire with the new cook_stats field — guards against an
+// accidental break of the existing variant.
+timed_test!(
+    status_response_decodes_as_expected_variant,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("status_response_decodes_as_expected_variant") {
+            return;
+        }
+        let cache_root = unique_temp_dir("variant-cache");
+        let home_root = unique_temp_dir("variant-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+        let sock = daemon.sock_path();
+        let resp = client::submit_request(&sock, &soldr_cli::daemon::protocol::Request::Status)
+            .expect("submit_request");
+        assert!(matches!(resp, Response::Status(_)));
+    }
+);

--- a/docker/cook-shared-cache/Dockerfile
+++ b/docker/cook-shared-cache/Dockerfile
@@ -1,0 +1,48 @@
+# Docker image used to build and test the cross-repo shared `soldr cook`
+# artifact cache feature (issues #576, #577, #578 under meta #579).
+#
+# Why Docker is mandatory for this work: PRs 1-3 mutate the soldr daemon
+# protocol, the `~/.soldr/state.redb` schema, and the cargo-front-door
+# hot path. soldr installs as a per-user singleton — running `cargo
+# build` or `cargo test` for these PRs on the host would corrupt the
+# host developer's running daemon and persistent state. Mounting
+# `~/.soldr/` as a container-local volume (tmpfs or named volume — NEVER
+# a bind-mount of the host path) keeps the host singleton intact.
+#
+# Usage (via bench/cook_in_docker.sh):
+#   docker build -f docker/cook-shared-cache/Dockerfile -t soldr-cook-dev .
+#   docker run --rm -v "$(pwd):/work" -v cook-soldr-home:/root/.soldr \
+#       -e SOLDR_COOK_DOCKER_HARNESS=1 -w /work soldr-cook-dev \
+#       cargo test --workspace -- --include-ignored cook_index
+
+FROM rust:1.94.1-bookworm
+
+# Build tools needed by the soldr-cli workspace and the integration
+# tests (linker, pkg-config, git for origin-URL probes in PRs 2/3).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential \
+       pkg-config \
+       libssl-dev \
+       git \
+       ca-certificates \
+       curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# soldr's `cargo test` jobs check the system rustc version; pin it here
+# to match `rust-toolchain.toml` (Rust 1.94.1).
+RUN rustup default 1.94.1 \
+    && rustup component add rustfmt clippy
+
+# Source tree is mounted by the runner at /work; no COPY here so each
+# `docker run` reuses the cached image but operates on the live worktree.
+WORKDIR /work
+
+# Marker env var read by tests gated on the Docker harness. Bare-host
+# `cargo test` runs are no-ops for these gated tests; only `docker run`
+# with this image enables them.
+ENV SOLDR_COOK_DOCKER_HARNESS=1
+
+# Default command is a help message; the runner overrides with the
+# actual `cargo test` invocation.
+CMD ["echo", "soldr-cook-dev image — invoke via bench/cook_in_docker.sh or pass a cargo command"]

--- a/docs/CONTRIBUTING_COOK.md
+++ b/docs/CONTRIBUTING_COOK.md
@@ -1,0 +1,96 @@
+# Contributing to the shared `soldr cook` artifact cache
+
+> [!CAUTION]
+> ## Build and test in Docker only
+>
+> **Never run `cargo test` or `cargo build` on the host while working on issues
+> #576, #577, or #578 (meta #579).** These PRs mutate:
+>
+> - The soldr daemon protocol (`crates/soldr-cli/src/daemon/protocol.rs`)
+> - The shared redb schema at `~/.soldr/state.redb` (new `cook_index_v1` table)
+> - The cargo-front-door pre-flight hot path (PR 3)
+>
+> `soldr` installs as a per-user singleton. Host-side `cargo test`
+> for this feature would corrupt the host developer's running daemon,
+> persistent redb state, and (in PR 2/3) the `~/.soldr/cache/cook/`
+> artifact tree. The Docker harness in `docker/cook-shared-cache/`
+> mounts `~/.soldr/` as a container-local named volume so the host
+> singleton stays untouched.
+
+---
+
+## The supported loop
+
+```bash
+# Build + run the dormant cook-index integration tests (PR 1 / #576).
+bench/cook_in_docker.sh
+
+# Run the full workspace test suite in Docker.
+bench/cook_in_docker.sh cargo test --workspace
+
+# Run clippy.
+bench/cook_in_docker.sh cargo clippy --workspace -- -D warnings
+
+# Run a single integration test by name.
+bench/cook_in_docker.sh cargo test --workspace --test daemon_cook_index \
+    -- --include-ignored cook_record_then_lookup_round_trips
+```
+
+`bench/cook_in_docker.sh` builds the
+`docker/cook-shared-cache/Dockerfile` image (cached after the first
+run), then runs your command inside a container with:
+
+- The source tree mounted read-write at `/work`.
+- `~/.soldr/` provided by a fresh named volume `cook-soldr-home` at
+  `/root/.soldr` inside the container. The host's actual `~/.soldr/`
+  is NEVER bind-mounted.
+- `SOLDR_COOK_DOCKER_HARNESS=1` exported so the tests gated on the
+  Docker marker run.
+
+The script `docker volume rm`s `cook-soldr-home` at the start of each
+run so the container always starts from an empty soldr state. Comment
+out that line locally if you want to debug across runs.
+
+## Acceptance gate (per PR in meta #579)
+
+Each PR's CI workflow MUST exercise the Docker harness AND assert
+that the host's `~/.soldr/` is byte-identical before and after the
+suite. The harness mount semantics make this trivial — the host path
+is never touched — but the assertion catches accidental bind-mount
+regressions in future workflow edits.
+
+## The container marker
+
+Every integration test in `tests/daemon_cook_index.rs` (and the
+equivalent tests in PRs 2 and 3) starts with:
+
+```rust
+if skip_unless_in_container("test_name") { return; }
+```
+
+This short-circuits the test with a `println!` when
+`SOLDR_COOK_DOCKER_HARNESS` is not set. Result: bare-host `cargo
+test` runs are no-ops for these tests, and only `bench/cook_in_docker.sh`
+(which exports the marker) actually exercises them.
+
+## What lives where
+
+- `docker/cook-shared-cache/Dockerfile` — Rust 1.94.1 base image with
+  `pkg-config`, `libssl-dev`, `git`. Marker env var `SOLDR_COOK_DOCKER_HARNESS=1`.
+- `bench/cook_in_docker.sh` — supported runner. Builds the image,
+  mounts the source tree, runs the requested command.
+- `docs/CONTRIBUTING_COOK.md` — this file.
+
+## PR scope reminder
+
+- PR 1 (#576) — dormant `cook_index_v1` redb table + new IPC variants
+  + extended `Status` reply. No `soldr cook` changes. No
+  cargo-front-door changes.
+- PR 2 (#577) — `soldr cook` writes `<sha256>.tar.zst` artifacts +
+  registers them via `CookRecord` + emits Cargo.lock-tracked /
+  no-`.git/` / gitignored warnings.
+- PR 3 (#578) — cargo-front-door pre-flight auto-hydrate (default ON,
+  green status line) + opt-out via env var > `rust-toolchain.toml` >
+  `~/.soldr/config.toml`.
+
+See the meta issue for the full design lock-in.


### PR DESCRIPTION
PR 1 of 3 for the cross-repo shared `soldr cook` artifact cache. Tracked under meta issue #579.

Closes #576.

> [!IMPORTANT]
> ## Build and test in Docker only
>
> This PR mutates the daemon protocol (v3 → v4) and the redb schema (`cook_index_v1` table inside `~/.soldr/state.redb`). Per meta #579, all build and test loops MUST execute inside the `docker/cook-shared-cache/Dockerfile` image with `~/.soldr/` mounted as a container-local volume — bare-host `cargo test` would corrupt the host developer's running daemon and persistent state.
>
> Supported loop: `bench/cook_in_docker.sh`.
>
> Tests gated on `SOLDR_COOK_DOCKER_HARNESS=1`; bare-host runs are no-ops.

## What changes

- `crates/soldr-cli/src/cache_lib/cook_index.rs` — new module: `CookKey` (recipe_hash + triple + profile + channel + rustc), `CookEntry`, helpers (`upsert`, `lookup`, `touch`, `stats`, `drift_recipe_hashes`, `ensure_initialized`). Per-call redb open + drop, same pattern as `daemon/db.rs`. Cross-target sharing is structurally forbidden by the key tuple shape.
- `crates/soldr-cli/src/daemon/protocol.rs` — append `Request::CookLookup`, `Request::CookRecord`, `Request::CookTouch` (existing ordinals preserved). Add `Response::CookHit`, `Response::CookMiss`, `Response::Ack`. Extend `StatusInfo` with `cook_stats: Option<CookStats>`. `PROTOCOL_VERSION` bumps 3 → 4. `LegacyStatusInfo` + `decode_status_info_with_legacy_fallback` cover the "backwards-decode of older replies still works (default to 0)" acceptance criterion.
- `crates/soldr-cli/src/daemon/server.rs` — wire handlers for all three new variants. New `cook_index_lock: Mutex<()>` serializes per-call redb opens within the daemon process so the documented "Database already open" error never reaches the wire under concurrent `CookRecord` traffic. `State::status()` reads cook stats with the lock held; `cook_hits_this_session` (AtomicU64) tracks hits since startup.
- `crates/soldr-cli/src/daemon/client.rs` — new `cook_lookup`, `cook_record`, `cook_touch` helpers + `CookLookupOutcome` typed reply.
- `crates/soldr-cli/src/main.rs` — `soldr daemon status` (text + JSON) now reports cook `entries`, `total_bytes`, `hits_this_session`.
- `docker/cook-shared-cache/Dockerfile` + `bench/cook_in_docker.sh` — Docker harness reused by PRs 2 and 3.
- `docs/CONTRIBUTING_COOK.md` — documents the Docker-only loop.

## Hard invariants verified

1. **Cross-target sharing forbidden by construction** — key tuple includes triple/profile/channel/rustc; verified by `per_target_safety_isolates_via_ipc` and unit tests.
2. **Daemon never holds artifact bytes** — IPC payloads carry path strings + sha256, never tarball bytes. Body sizes verified ≤ MAX_BODY_BYTES.
3. **Per-request redb opens** — `cook_index::*` opens + drops per call so the CLI side (`soldr cache stats`, `soldr doctor`) can still open `state.redb` between daemon ops.
4. **Wire compat** — new Request/Response variants appended; existing ordinals preserved. Protocol version 4 enforced by the IPC layer; wrapper hot path's direct-redb fallback keeps builds going during the cross-version window after upgrade.
5. **Backwards-decode** — `LegacyStatusInfo` decode path tested (`legacy_status_info_bytes_default_cook_stats_to_none`).

## Tests

Unit (run anywhere — 254 tests pass):
- `cache_lib::cook_index::tests::*` — round-trip, missing-lookup, per-target safety, per-profile safety, drift collection + scoping, touch by sha, stats aggregate, idempotent init.
- `daemon::protocol::tests::*` — Status round-trip with cook_stats, legacy decode fallback, CookLookup/CookHit/CookMiss wire round-trips, CookRecord body fits under MAX_BODY_BYTES, PROTOCOL_VERSION == 4.

Integration (Docker-only — 7 tests pass):
- `cook_record_then_lookup_round_trips_through_daemon`
- `cook_lookup_miss_reports_drift_recipe_hashes`
- `concurrent_cook_records_all_land_consistently` (8 worker threads)
- `per_target_safety_isolates_via_ipc`
- `status_reports_aggregate_cook_metrics`
- `cook_touch_is_fire_and_forget_and_silent_on_unknown_sha`
- `status_response_decodes_as_expected_variant`

Existing daemon integration tests (lifecycle, target-touch, builds, zccache-link) all still pass — protocol bump did not regress any consumer.

## Test plan

- [x] `bench/cook_in_docker.sh` builds the image and runs the cook-index integration tests green.
- [x] `bench/cook_in_docker.sh cargo test -p soldr-cli --lib` — 254 unit tests pass.
- [x] `bench/cook_in_docker.sh cargo test -p soldr-cli --test cli_daemon_lifecycle --test cli_daemon_target_touch --test cli_daemon_builds --test cli_daemon_zccache_link` — all green.
- [x] `bench/cook_in_docker.sh cargo clippy -p soldr-cli --bins --tests -- -D warnings` clean.
- [x] `bench/cook_in_docker.sh cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)