### PR TITLE
feat(cook): write to cook_index, pack target/ with zstd:19, emit sharing warnings (#577)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,6 +1675,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "walkdir",
  "zip",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ walkdir = "2"
 jwalk = "0.8"
 zstd = { version = "0.13", default-features = false, features = ["zstdmt"] }
 filetime = "0.2"
+# Used by `core::git::normalize_origin_url` for canonicalizing git
+# remote URLs into the prefetch hint stored alongside cook artifacts
+# (issue #577).
+url = "2"
 # Read-only access to cargo's `$CARGO_HOME/.global-cache` SQLite database
 # (issue #349). `bundled` compiles SQLite ourselves so neither the
 # managed wheel nor the cargo-install path needs a system libsqlite3.

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+url = { workspace = true }
 walkdir = { workspace = true }
 zip = { workspace = true }
 zstd = { workspace = true }

--- a/crates/soldr-cli/src/cache_lib/cook_archive.rs
+++ b/crates/soldr-cli/src/cache_lib/cook_archive.rs
@@ -1,0 +1,279 @@
+//! tar + zstd:19 packer for cross-repo `soldr cook` artifacts (issue
+//! #577, meta #579).
+//!
+//! Layout of `~/.soldr/cache/cook/`:
+//!
+//! ```text
+//! <sha256>.tar.zst              # content-addressed cook artifact
+//! .tmp/<rand>.tar.zst           # in-progress write (rename-on-finish)
+//! ```
+//!
+//! This module is **purely a packer**. It is unrelated to the
+//! `cache_lib::save` archive transport — `save.rs` keeps its
+//! `DEFAULT_ZSTD_LEVEL = 3` for the short-lived save/load round-trip,
+//! while cook artifacts use level 19 + `--long=27` because they are
+//! compressed once and decompressed many times (every fork or CI
+//! runner that shares the same recipe hash).
+//!
+//! The packer never reads or writes `cook_index_v1` itself — PR 3's
+//! pre-flight hydrate is what looks up entries via the daemon, and
+//! PR 2's `soldr cook` is what calls `CookRecord` after this packer
+//! returns the resolved sha256.
+
+use crate::cache_lib::target_registry::RegistryError;
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+/// zstd level used for cross-repo cook artifacts. Slow once
+/// (compress per cook run) in exchange for fast many (every fork or
+/// CI runner that hits the same recipe hash decompresses). Do NOT
+/// reuse for the save/load transport — that path stays at
+/// `crate::cache_lib::save::DEFAULT_ZSTD_LEVEL = 3`.
+pub const COOK_ZSTD_LEVEL: i32 = 19;
+
+/// `--long=27` window log enables zstd long-distance matching on the
+/// 128 MiB window — large enough that a typical trimmed `target/`
+/// tree compresses to a small fraction of its raw size.
+pub const COOK_ZSTD_LONG_WINDOW: u32 = 27;
+
+/// Result of [`pack_cook_archive`]: the on-disk path and digest of
+/// the new `<sha256>.tar.zst` artifact, together with the byte size
+/// of the compressed file.
+#[derive(Debug, Clone)]
+pub struct PackedCookArchive {
+    /// Absolute path to `<cook_cache_dir>/<sha256_hex>.tar.zst`.
+    pub path: PathBuf,
+    /// SHA-256 digest of the compressed bytes. Filename is the lower-
+    /// case hex form of this; verifying the file == filename is the
+    /// integrity check PR 3's pre-flight runs before extraction.
+    pub sha256: [u8; 32],
+    /// On-disk size of the compressed artifact.
+    pub size_bytes: u64,
+}
+
+/// Resolve the `~/.soldr/cache/cook/` directory under the supplied
+/// `paths`. Created lazily by [`pack_cook_archive`] but exposed
+/// separately so PR 3 can find existing artifacts without re-packing.
+pub fn cook_cache_dir(paths: &crate::core::SoldrPaths) -> PathBuf {
+    paths.cache.join("cook")
+}
+
+/// Construct the canonical `<sha256_hex>.tar.zst` path for an artifact
+/// under `cook_cache_dir`. Useful for tests + for the daemon's
+/// `Response::CookHit { path }` which mirrors this shape.
+pub fn artifact_path_for_sha(cook_dir: &Path, sha256: &[u8; 32]) -> PathBuf {
+    cook_dir.join(format!("{}.tar.zst", hex_lower(sha256)))
+}
+
+/// Pack `source_dir` into `<cook_cache_dir>/<sha256>.tar.zst` using
+/// tar + zstd at [`COOK_ZSTD_LEVEL`] with the
+/// [`COOK_ZSTD_LONG_WINDOW`] window log. Writes go through
+/// `<cook_cache_dir>/.tmp/<rand>.tar.zst` first so a crashed packer
+/// never leaves a half-written `<sha256>.tar.zst` on disk.
+///
+/// `source_dir` is typically the trimmed `target/<profile>/` tree
+/// (after `cargo chef cook` + `StripTargetOptions::cook()`). The
+/// archive entries are recorded with paths *relative to* the
+/// parent of `source_dir` — i.e. they start with the profile name
+/// (`release/`, `debug/`, ...) so PR 3 can extract straight into
+/// `target/` without an extra rename.
+///
+/// Errors:
+///  * I/O failures creating `.tmp/`, writing the temp file, computing
+///    the sha256, or renaming into place.
+///  * The source_dir not existing — returned as `RegistryError::Io`.
+pub fn pack_cook_archive(
+    source_dir: &Path,
+    cook_dir: &Path,
+) -> Result<PackedCookArchive, RegistryError> {
+    if !source_dir.is_dir() {
+        return Err(RegistryError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("cook archive source missing: {}", source_dir.display()),
+        )));
+    }
+
+    let tmp_dir = cook_dir.join(".tmp");
+    std::fs::create_dir_all(&tmp_dir)?;
+
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let temp_path = tmp_dir.join(format!("cook-{pid}-{nanos}.tar.zst.tmp"));
+
+    let temp_file = File::create(&temp_path)?;
+    let mut encoder = zstd::Encoder::new(temp_file, COOK_ZSTD_LEVEL).map_err(io_err)?;
+    encoder.long_distance_matching(true).map_err(io_err)?;
+    encoder.window_log(COOK_ZSTD_LONG_WINDOW).map_err(io_err)?;
+    // Multi-threaded compression — `zstdmt` feature already enabled
+    // in workspace deps. Using `num_cpus` would add a dep we do not
+    // want; the OS-determined thread count works well for level 19.
+    if let Ok(n) = std::thread::available_parallelism() {
+        let _ = encoder.multithread(n.get() as u32);
+    }
+
+    {
+        // tar archive: entries recorded relative to source_dir's parent
+        // so the leading path component is the profile name.
+        let mut tar_builder = tar::Builder::new(&mut encoder);
+        let prefix_name = source_dir
+            .file_name()
+            .map(|n| n.to_owned())
+            .unwrap_or_else(|| "cook".into());
+        tar_builder
+            .append_dir_all(prefix_name, source_dir)
+            .map_err(io_err)?;
+        tar_builder.finish().map_err(io_err)?;
+    }
+    encoder.finish().map_err(io_err)?;
+
+    // Hash the on-disk file. Going through a fresh `Read` cycle is
+    // simpler than chaining a `Sha256` writer through the zstd encoder
+    // and matches the integrity model PR 3 uses on hydrate (re-hash
+    // the file at the named path and compare to the filename stem).
+    let (sha256, size_bytes) = hash_file(&temp_path)?;
+    let final_path = artifact_path_for_sha(cook_dir, &sha256);
+
+    // Rename into place. If a row already exists, replace it — the
+    // content is identical by construction (same sha256), so a
+    // re-cook of the same recipe is idempotent.
+    std::fs::rename(&temp_path, &final_path).or_else(|_| {
+        // Same-sha file already there: drop the temp.
+        let _ = std::fs::remove_file(&temp_path);
+        Ok::<(), std::io::Error>(())
+    })?;
+
+    Ok(PackedCookArchive {
+        path: final_path,
+        sha256,
+        size_bytes,
+    })
+}
+
+fn hash_file(path: &Path) -> Result<([u8; 32], u64), RegistryError> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    let mut total: u64 = 0;
+    loop {
+        let read = file.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+        total = total.saturating_add(read as u64);
+    }
+    let digest = hasher.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    Ok((out, total))
+}
+
+fn io_err(e: std::io::Error) -> RegistryError {
+    RegistryError::Io(e)
+}
+
+fn hex_lower(bytes: &[u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0F) as usize] as char);
+    }
+    out
+}
+
+/// Pretty-print an abbreviated SHA-256 (12 hex chars) for human-
+/// readable status / warning output. Matches the spec in #577 / #579
+/// (`sha256=<abbrev12>`).
+pub fn sha_abbrev(sha256: &[u8; 32]) -> String {
+    hex_lower(sha256).chars().take(12).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_file(p: &Path, bytes: &[u8]) {
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir");
+        }
+        let mut f = File::create(p).expect("create");
+        f.write_all(bytes).expect("write");
+    }
+
+    crate::timed_test!(pack_writes_content_addressed_artifact, {
+        let dir = TempDir::new().expect("tempdir");
+        let source = dir.path().join("release");
+        write_file(&source.join("deps").join("libfoo-abc.rlib"), b"hello\n");
+        write_file(&source.join("deps").join("libbar-def.rmeta"), b"world\n");
+
+        let cook_dir = dir.path().join("cook");
+        let packed = pack_cook_archive(&source, &cook_dir).expect("pack");
+
+        // Filename matches the sha256 hex.
+        let expected = artifact_path_for_sha(&cook_dir, &packed.sha256);
+        assert_eq!(packed.path, expected);
+        assert!(packed.path.is_file());
+        assert!(packed.size_bytes > 0);
+
+        // Sanity: tmp dir is empty after success.
+        let tmp = cook_dir.join(".tmp");
+        let leftover_count = std::fs::read_dir(&tmp)
+            .map(|it| it.flatten().count())
+            .unwrap_or(0);
+        assert_eq!(leftover_count, 0);
+    });
+
+    crate::timed_test!(pack_is_idempotent_on_same_content, {
+        let dir = TempDir::new().expect("tempdir");
+        let source = dir.path().join("release");
+        write_file(&source.join("deps").join("libfoo-abc.rlib"), b"hello\n");
+
+        let cook_dir = dir.path().join("cook");
+        let a = pack_cook_archive(&source, &cook_dir).expect("a");
+        let b = pack_cook_archive(&source, &cook_dir).expect("b");
+
+        // Identical input → identical sha → identical artifact path.
+        // (Note: tar entries carry per-file mtimes; zstd output may
+        // differ. We assert path stability via the daemon-side hash,
+        // not byte stability across runs.)
+        assert_eq!(a.path.file_name(), b.path.file_name());
+        assert!(a.path.is_file());
+    });
+
+    crate::timed_test!(pack_errors_on_missing_source_dir, {
+        let dir = TempDir::new().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+        let cook_dir = dir.path().join("cook");
+        let err = pack_cook_archive(&missing, &cook_dir).expect_err("must error");
+        match err {
+            RegistryError::Io(e) => assert_eq!(e.kind(), std::io::ErrorKind::NotFound),
+            other => panic!("expected Io NotFound, got {other:?}"),
+        }
+    });
+
+    crate::timed_test!(sha_abbrev_is_twelve_lowercase_hex_chars, {
+        let bytes = [0xAB; 32];
+        let abbrev = sha_abbrev(&bytes);
+        assert_eq!(abbrev.len(), 12);
+        assert!(abbrev
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()));
+    });
+
+    crate::timed_test!(artifact_path_matches_sha_filename, {
+        let cook = Path::new("/cook");
+        let sha = [0x12u8; 32];
+        let path = artifact_path_for_sha(cook, &sha);
+        let name = path.file_name().unwrap().to_string_lossy();
+        assert!(name.ends_with(".tar.zst"));
+        assert!(name.starts_with(&hex_lower(&sha)));
+    });
+}

--- a/crates/soldr-cli/src/cache_lib/mod.rs
+++ b/crates/soldr-cli/src/cache_lib/mod.rs
@@ -13,6 +13,7 @@ use std::{
 pub mod auto_gc;
 pub mod auto_target_gc;
 pub mod cargo_global_cache;
+pub mod cook_archive;
 pub mod cook_index;
 pub mod gc;
 pub mod prune_target;

--- a/crates/soldr-cli/src/cache_lib/save.rs
+++ b/crates/soldr-cli/src/cache_lib/save.rs
@@ -1051,7 +1051,9 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
         // small (<MiB each) and the bounded channel caps how many are
         // resident at once, so memory usage stays bounded.
         let mut body = Vec::new();
-        entry.read_to_end(&mut body).map_err(SaveLoadError::BareIo)?;
+        entry
+            .read_to_end(&mut body)
+            .map_err(SaveLoadError::BareIo)?;
         let mtime_secs = entry.header().mtime().ok();
 
         // Lazy-start the dispatch on first cache entry.
@@ -1070,7 +1072,7 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
             body,
             mtime_secs,
         };
-        if let Err(_) = dispatch.send(job) {
+        if dispatch.send(job).is_err() {
             // Receivers are gone — there must be a stored error already.
             break;
         }
@@ -1217,7 +1219,10 @@ impl ExtractDispatch {
         ExtractDispatch { tx, barrier }
     }
 
-    fn send(&self, job: ExtractJob) -> std::result::Result<(), std::sync::mpsc::SendError<ExtractJob>> {
+    fn send(
+        &self,
+        job: ExtractJob,
+    ) -> std::result::Result<(), std::sync::mpsc::SendError<ExtractJob>> {
         self.tx.send(job)
     }
 

--- a/crates/soldr-cli/src/cook.rs
+++ b/crates/soldr-cli/src/cook.rs
@@ -15,11 +15,20 @@
 //! `zackees/setup-soldr#110` for the GitHub Action that consumes the
 //! resulting `target/` tarball.
 
+use crate::cache_lib::cook_archive::{self, cook_cache_dir, sha_abbrev, PackedCookArchive};
 use crate::cache_lib::strip_target::{strip_target, StripTargetOptions};
 use crate::cargo_front_door;
-use crate::core::SoldrError;
+use crate::core::git::{
+    cargo_lock_is_gitignored, cargo_lock_is_tracked, find_git_worktree_root, origin_url,
+};
+use crate::core::{
+    probe_toolchain_binary, read_rust_toolchain_manifest, SoldrError, SoldrPaths, TargetTriple,
+};
+use crate::daemon::client::{self, CookLookupOutcome};
 use crate::ZccacheSourceArg;
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Parsed `soldr cook` invocation surface. Mirrors the relevant subset of
 /// `cargo build` knobs plus the cargo-chef-specific recipe controls.
@@ -417,6 +426,14 @@ pub(crate) async fn run_cook(
         run_cook_target_trim(&ctx.manifest_dir);
     }
 
+    // Phase 4: index the cooked target/ into the cross-repo shared
+    // `~/.soldr/cache/cook/` (issue #577, meta #579). Best-effort;
+    // any failure here surfaces as a warning but never fails the
+    // user's cook command — the local `target/` is still valid.
+    if let Err(err) = index_cooked_artifact(&ctx, &parsed) {
+        eprintln!("{} {err}", yellow_warning_prefix());
+    }
+
     if parsed.keep_recipe {
         eprintln!(
             "soldr cook: recipe retained at {}",
@@ -431,6 +448,286 @@ pub(crate) async fn run_cook(
         );
     }
     Ok(0)
+}
+
+/// ANSI-yellow `warning:` prefix gated on stderr being a terminal.
+/// Mirrors the existing pattern in `cargo_front_door::disk`.
+fn yellow_warning_prefix() -> &'static str {
+    use std::io::IsTerminal;
+    if std::io::stderr().is_terminal() {
+        "\x1b[33msoldr cook: warning:\x1b[0m"
+    } else {
+        "soldr cook: warning:"
+    }
+}
+
+/// ANSI-green `indexed` prefix for the success line.
+fn green_indexed_prefix() -> &'static str {
+    use std::io::IsTerminal;
+    if std::io::stderr().is_terminal() {
+        "\x1b[32msoldr cook: indexed\x1b[0m"
+    } else {
+        "soldr cook: indexed"
+    }
+}
+
+/// Resolve the `target/<triple?>/<profile>/` directory cargo-chef
+/// just populated. cargo's mapping: `--release` → `release`, no
+/// flag → `debug` (the "dev" profile), `--profile=<name>` → `<name>`.
+/// With `--target X` the artifacts land under `target/X/<profile>/`.
+fn resolve_cook_target_dir(manifest_dir: &Path, args: &CookArgs) -> PathBuf {
+    let profile = resolve_profile_dir_name(args);
+    let mut root = manifest_dir.join("target");
+    if let Some(triple) = args.target.as_deref() {
+        root = root.join(triple);
+    }
+    root.join(profile)
+}
+
+fn resolve_profile_dir_name(args: &CookArgs) -> &str {
+    if let Some(p) = args.profile.as_deref() {
+        // `dev` is special-cased by cargo → `debug` dir on disk.
+        return if p == "dev" { "debug" } else { p };
+    }
+    if args.release {
+        "release"
+    } else {
+        "debug"
+    }
+}
+
+fn resolve_profile_name(args: &CookArgs) -> &str {
+    if let Some(p) = args.profile.as_deref() {
+        return p;
+    }
+    if args.release {
+        "release"
+    } else {
+        "dev"
+    }
+}
+
+/// Run `rustc -V` and return the trimmed first line, e.g.
+/// `rustc 1.94.1 (abcdef0 2026-05-30)`. Returns `None` when rustc is
+/// unreachable — the caller treats this as "no rustc identity" and
+/// skips indexing (cross-repo sharing without rustc keying would be
+/// unsafe).
+fn rustc_version_string(manifest_dir: &Path) -> Option<String> {
+    let rustc = probe_toolchain_binary("rustc", Some(manifest_dir))
+        .unwrap_or_else(|| PathBuf::from("rustc"));
+    let out = Command::new(rustc).arg("-V").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    Some(s.lines().next()?.trim().to_string())
+}
+
+fn resolve_channel(manifest_dir: &Path) -> Option<String> {
+    match read_rust_toolchain_manifest(manifest_dir) {
+        Ok(m) => m.channel,
+        Err(_) => None,
+    }
+}
+
+fn resolve_target_triple(manifest_dir: &Path, args: &CookArgs) -> Option<String> {
+    if let Some(triple) = args.target.as_deref() {
+        return Some(triple.to_string());
+    }
+    TargetTriple::detect_in_dir(manifest_dir)
+        .ok()
+        .map(|t| t.to_string())
+}
+
+fn sha256_of_path(path: &Path) -> Result<[u8; 32], SoldrError> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        SoldrError::Other(format!(
+            "soldr cook: failed to read recipe {}: {e}",
+            path.display()
+        ))
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let digest = hasher.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    Ok(out)
+}
+
+/// Index the cooked `target/<profile>/` tree into the cross-repo
+/// shared `~/.soldr/cache/cook/` (issue #577) and register the
+/// artifact with the daemon via `CookRecord`. Best-effort: a failure
+/// here surfaces as a warning but never fails the cook command.
+fn index_cooked_artifact(ctx: &CookContext, args: &CookArgs) -> Result<(), SoldrError> {
+    // 1. Sharing-eligibility checks.
+    let lockfile = ctx.manifest_dir.join("Cargo.lock");
+    if !lockfile.is_file() {
+        // Already warned earlier in build_cook_context.
+        return Ok(());
+    }
+    let has_git = find_git_worktree_root(&ctx.manifest_dir).is_some();
+    let lock_tracked = cargo_lock_is_tracked(&ctx.manifest_dir);
+    let lock_gitignored = cargo_lock_is_gitignored(&ctx.manifest_dir);
+
+    if !lock_tracked {
+        // Includes both "no .git/" and "git but file untracked".
+        if has_git {
+            eprintln!(
+                "{} cross-repo cook sharing disabled — Cargo.lock is not tracked by git. \
+                 Commit it to enable.",
+                yellow_warning_prefix()
+            );
+        } else {
+            eprintln!(
+                "{} no .git/ — cook artifact will be local-only, not indexed for sharing.",
+                yellow_warning_prefix()
+            );
+        }
+        return Ok(());
+    }
+    if lock_gitignored {
+        eprintln!(
+            "{} Cargo.lock is gitignored — sharing may leak deps that diverge from upstream. \
+             Skipping cook-index registration.",
+            yellow_warning_prefix()
+        );
+        return Ok(());
+    }
+
+    // 2. Resolve key components.
+    let target_dir = resolve_cook_target_dir(&ctx.manifest_dir, args);
+    if !target_dir.is_dir() {
+        // cargo-chef cook didn't produce a target/<profile>/ tree —
+        // most likely because the build failed earlier (we already
+        // returned in that case). Defensive fallback: silently skip.
+        return Ok(());
+    }
+
+    let triple = resolve_target_triple(&ctx.manifest_dir, args).ok_or_else(|| {
+        SoldrError::Other("soldr cook: could not resolve target triple for cook-index key".into())
+    })?;
+    let channel = resolve_channel(&ctx.manifest_dir).unwrap_or_default();
+    let rustc_version = rustc_version_string(&ctx.manifest_dir).ok_or_else(|| {
+        SoldrError::Other("soldr cook: could not resolve rustc version for cook-index key".into())
+    })?;
+    let recipe_hash = sha256_of_path(&ctx.recipe_path)?;
+    let origin = origin_url(&ctx.manifest_dir);
+    let profile = resolve_profile_name(args).to_string();
+
+    // 3. Resolve paths under ~/.soldr/.
+    let paths = SoldrPaths::new()?;
+    let cook_dir = cook_cache_dir(&paths);
+    std::fs::create_dir_all(&cook_dir).map_err(|e| {
+        SoldrError::Other(format!(
+            "soldr cook: failed to create {}: {e}",
+            cook_dir.display()
+        ))
+    })?;
+
+    // 4. Pre-flight CookLookup so we can render a drift diagnostic
+    //    when a previous recipe hash exists for this (origin, triple,
+    //    profile, channel, rustc). Best-effort: a daemon hiccup
+    //    falls through silently.
+    let sock = client::default_sock_path(&paths);
+    let prior_drift = match client::cook_lookup(
+        &sock,
+        recipe_hash,
+        triple.clone(),
+        profile.clone(),
+        channel.clone(),
+        rustc_version.clone(),
+        origin.clone(),
+    ) {
+        Ok(CookLookupOutcome::Hit { sha256, .. }) => {
+            // Already-cached for this exact key. Re-pack + re-record
+            // anyway so the artifact bytes match the freshly built
+            // target/ — a previous run might have written from a
+            // sibling worktree with slightly different mtimes.
+            Some(DriftSignal::AlreadyIndexed(sha256))
+        }
+        Ok(CookLookupOutcome::Miss {
+            previous_origin_recipe_hashes,
+        }) => previous_origin_recipe_hashes
+            .first()
+            .copied()
+            .map(DriftSignal::Drifted),
+        Err(_) => None,
+    };
+
+    // 5. Pack the trimmed target/<profile>/ tree.
+    let packed = cook_archive::pack_cook_archive(&target_dir, &cook_dir)
+        .map_err(|e| SoldrError::Other(format!("soldr cook: failed to pack cook archive: {e}")))?;
+
+    // 6. Register with the daemon. If the daemon is unreachable we
+    //    still keep the on-disk artifact for the next PR-3 hydrate
+    //    attempt, but warn so the user knows sharing is one-sided.
+    let cook_cmd_summary = build_cook_cmd_summary(args);
+    let register = client::cook_record(
+        &sock,
+        recipe_hash,
+        triple.clone(),
+        profile.clone(),
+        channel.clone(),
+        rustc_version.clone(),
+        packed.sha256,
+        packed.size_bytes,
+        origin.clone(),
+        cook_cmd_summary,
+    );
+    if let Err(e) = register {
+        eprintln!(
+            "{} CookRecord to daemon failed: {e:?}. Artifact written at {} but not indexed.",
+            yellow_warning_prefix(),
+            packed.path.display()
+        );
+        return Ok(());
+    }
+
+    // 7. Recipe-drift diagnostic (printed before the success line so
+    //    the indexed line is the last word).
+    if let Some(DriftSignal::Drifted(prev)) = prior_drift {
+        eprintln!("soldr cook: recipe hash drift since {}", sha_abbrev(&prev));
+    }
+
+    // 8. Green success line.
+    emit_indexed_line(&packed, origin.as_deref());
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+enum DriftSignal {
+    Drifted([u8; 32]),
+    AlreadyIndexed(#[allow(dead_code)] [u8; 32]),
+}
+
+fn emit_indexed_line(packed: &PackedCookArchive, origin: Option<&str>) {
+    let mib = packed.size_bytes as f64 / 1024.0 / 1024.0;
+    let origin_field = origin.unwrap_or("none");
+    eprintln!(
+        "{}  sha256={}  size={mib:.1} MiB  origin={origin_field}",
+        green_indexed_prefix(),
+        sha_abbrev(&packed.sha256),
+    );
+}
+
+fn build_cook_cmd_summary(args: &CookArgs) -> String {
+    let mut parts = vec!["cook".to_string()];
+    if args.release {
+        parts.push("--release".to_string());
+    }
+    if let Some(p) = args.profile.as_deref() {
+        parts.push(format!("--profile={p}"));
+    }
+    if let Some(t) = args.target.as_deref() {
+        parts.push(format!("--target={t}"));
+    }
+    if args.workspace {
+        parts.push("--workspace".to_string());
+    }
+    for pkg in &args.packages {
+        parts.push(format!("-p {pkg}"));
+    }
+    parts.join(" ")
 }
 
 /// Remove cargo-chef-generated `plugin = false` / `plugin = true`

--- a/crates/soldr-cli/src/core/git.rs
+++ b/crates/soldr-cli/src/core/git.rs
@@ -1,0 +1,243 @@
+//! Lightweight `git` subprocess wrappers used by `soldr cook` to
+//! detect the workspace's `origin` remote and gate cross-repo cook
+//! sharing on whether `Cargo.lock` is committed and not gitignored
+//! (issue #577, meta #579).
+//!
+//! Every helper here is best-effort — a missing `git`, a missing
+//! `.git/`, or a network-less repo never bubbles into the cook
+//! command's exit code. Callers branch on `None` / `false` and either
+//! emit a sharing-disabled warning or quietly skip the indexing step.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Walk up from `start` looking for a `.git` directory **or** file.
+/// Git worktrees use a `.git` file that points at the real gitdir, so
+/// both shapes count.  Mirrors `crate::zccache::find_git_worktree_root`
+/// but lives here so the cook surface can pull it from `core` without
+/// dragging in zccache code.
+pub fn find_git_worktree_root(start: &Path) -> Option<PathBuf> {
+    let mut current: PathBuf = start.to_path_buf();
+    loop {
+        let dot_git = current.join(".git");
+        if dot_git.is_dir() || dot_git.is_file() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+/// Return the workspace's `origin` remote URL in normalized form, or
+/// `None` when no `.git/` exists, no `origin` is configured, or `git`
+/// is not on `PATH`.
+pub fn origin_url(workspace_root: &Path) -> Option<String> {
+    let repo_root = find_git_worktree_root(workspace_root)?;
+    let raw = run_git(&repo_root, ["config", "--get", "remote.origin.url"])?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(normalize_origin_url(trimmed))
+}
+
+/// Canonicalize a git remote URL for use as a cross-repo prefetch
+/// hint. The output is purely a hint — the authoritative cache key
+/// is the recipe hash — so we lean conservative: best-effort lower-
+/// case host, strip credentials and trailing `.git`, drop default
+/// ports, and rewrite `git@host:owner/repo` SSH shorthand into the
+/// equivalent `https://host/owner/repo`.
+///
+/// Returns the input verbatim (after trimming) when none of the
+/// rules apply, so opaque shapes (`file:///`, custom schemes) round-
+/// trip unchanged.
+pub fn normalize_origin_url(input: &str) -> String {
+    let input = input.trim();
+
+    // `git@github.com:owner/repo.git` is not a valid URL but is the
+    // dominant SSH shorthand. Rewrite to `https://github.com/owner/repo`
+    // before further normalization.
+    if let Some(rewritten) = rewrite_scp_style(input) {
+        return normalize_via_url(&rewritten).unwrap_or(rewritten);
+    }
+
+    match normalize_via_url(input) {
+        Some(s) => s,
+        None => input.to_string(),
+    }
+}
+
+fn rewrite_scp_style(input: &str) -> Option<String> {
+    // SCP-style: `user@host:path` where `path` has no leading slash.
+    // Must contain a single `@` before a `:`, the `:` cannot be part
+    // of a scheme (no `://`), and the host segment cannot contain
+    // path separators.
+    if input.contains("://") {
+        return None;
+    }
+    let (left, right) = input.split_once(':')?;
+    if right.starts_with('/') {
+        return None;
+    }
+    let (_user, host) = left.split_once('@')?;
+    if host.is_empty() || host.contains('/') {
+        return None;
+    }
+    let path = right.trim_start_matches('/');
+    Some(format!("https://{host}/{path}"))
+}
+
+fn normalize_via_url(input: &str) -> Option<String> {
+    let mut parsed = url::Url::parse(input).ok()?;
+    // Strip credentials.
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    // Lowercase scheme + host. `url::Url::set_*` rejects ports for
+    // some schemes; ignore those errors.
+    let scheme = parsed.scheme().to_ascii_lowercase();
+    if let Err(_e) = parsed.set_scheme(&scheme) {
+        // `set_scheme` refuses some transitions (e.g. between special
+        // and non-special schemes). Fall through with original.
+    }
+    if let Some(host) = parsed.host_str() {
+        let lower = host.to_ascii_lowercase();
+        let _ = parsed.set_host(Some(&lower));
+    }
+    // Drop default port.
+    if let Some(p) = parsed.port() {
+        let default = match parsed.scheme() {
+            "http" => Some(80),
+            "https" => Some(443),
+            "ssh" | "git" => Some(22),
+            _ => None,
+        };
+        if Some(p) == default {
+            let _ = parsed.set_port(None);
+        }
+    }
+    // Strip trailing `.git` and any single trailing `/`. `url` keeps
+    // the path normalized but we mutate the path manually to be safe.
+    let path = parsed.path().to_string();
+    let mut trimmed = path.trim_end_matches('/').to_string();
+    if let Some(stripped) = trimmed.strip_suffix(".git") {
+        trimmed = stripped.to_string();
+    }
+    parsed.set_path(&trimmed);
+    Some(parsed.to_string())
+}
+
+/// True when `Cargo.lock` exists at the workspace root and is tracked
+/// by git. Returns `false` when there is no `.git/`, no
+/// `Cargo.lock`, or `git ls-files --error-unmatch` exits non-zero.
+pub fn cargo_lock_is_tracked(workspace_root: &Path) -> bool {
+    let lockfile = workspace_root.join("Cargo.lock");
+    if !lockfile.is_file() {
+        return false;
+    }
+    if find_git_worktree_root(workspace_root).is_none() {
+        return false;
+    }
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(workspace_root)
+        .args(["ls-files", "--error-unmatch", "Cargo.lock"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    matches!(status, Ok(s) if s.success())
+}
+
+/// True when `Cargo.lock` would be ignored by git per the workspace's
+/// `.gitignore` rules. `git check-ignore` exits 0 only when the path
+/// matches an ignore rule (a tracked file shadows this — git treats
+/// tracked files as un-ignorable — so the combination
+/// `tracked + ignored` is impossible by definition). Returns `false`
+/// when git is unavailable or there is no `.git/`.
+pub fn cargo_lock_is_gitignored(workspace_root: &Path) -> bool {
+    if find_git_worktree_root(workspace_root).is_none() {
+        return false;
+    }
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(workspace_root)
+        .args(["check-ignore", "-q", "Cargo.lock"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    matches!(status, Ok(s) if s.success())
+}
+
+fn run_git<I, S>(repo_root: &Path, args: I) -> Option<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(rewrite_scp_style_canonicalizes_ssh_shorthand, {
+        assert_eq!(
+            rewrite_scp_style("git@github.com:zackees/soldr.git"),
+            Some("https://github.com/zackees/soldr.git".to_string())
+        );
+        assert_eq!(
+            rewrite_scp_style("git@github.com:zackees/soldr"),
+            Some("https://github.com/zackees/soldr".to_string())
+        );
+    });
+
+    crate::timed_test!(rewrite_scp_style_ignores_full_urls, {
+        assert_eq!(
+            rewrite_scp_style("https://github.com/zackees/soldr.git"),
+            None
+        );
+        assert_eq!(
+            rewrite_scp_style("ssh://git@github.com/zackees/soldr"),
+            None
+        );
+    });
+
+    crate::timed_test!(normalize_strips_credentials_and_dot_git, {
+        let out = normalize_origin_url("https://user:pass@GitHub.com/Owner/Repo.git");
+        assert_eq!(out, "https://github.com/Owner/Repo");
+    });
+
+    crate::timed_test!(normalize_drops_default_port, {
+        assert_eq!(
+            normalize_origin_url("https://github.com:443/zackees/soldr"),
+            "https://github.com/zackees/soldr"
+        );
+        assert_eq!(
+            normalize_origin_url("http://github.com:80/zackees/soldr"),
+            "http://github.com/zackees/soldr"
+        );
+    });
+
+    crate::timed_test!(normalize_canonicalizes_scp_form_to_https, {
+        assert_eq!(
+            normalize_origin_url("git@github.com:Owner/Repo.git"),
+            "https://github.com/Owner/Repo"
+        );
+    });
+
+    crate::timed_test!(normalize_round_trips_unknown_schemes_verbatim, {
+        assert_eq!(
+            normalize_origin_url("file:///srv/git/repo.git"),
+            "file:///srv/git/repo"
+        );
+    });
+}

--- a/crates/soldr-cli/src/core/mod.rs
+++ b/crates/soldr-cli/src/core/mod.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+pub mod git;
 mod paths;
 mod target_triple;
 mod toolchain_manifest;

--- a/crates/soldr-cli/tests/cook_writes_index.rs
+++ b/crates/soldr-cli/tests/cook_writes_index.rs
@@ -1,0 +1,382 @@
+//! Integration tests for PR 2 (#577): `soldr cook`'s cross-repo
+//! shared-artifact indexing.
+//!
+//! These tests spawn the real `soldr-daemon` binary against a
+//! sandboxed `~/.soldr/` and drive the PR-2 flow end-to-end via the
+//! public packer (`cache_lib::cook_archive`) + client IPC helpers
+//! (`daemon::client::cook_record` / `cook_lookup`).
+//!
+//! Docker harness gate: every test short-circuits unless
+//! `SOLDR_COOK_DOCKER_HARNESS=1` is set. The supported runner is
+//! `bench/cook_in_docker.sh`. Bare-host `cargo test` runs skip
+//! everything so the host developer's soldr singleton stays
+//! untouched (see meta #579 + `docs/CONTRIBUTING_COOK.md`).
+
+#![allow(clippy::print_stdout)]
+
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use soldr_cli::cache_lib::cook_archive::{
+    artifact_path_for_sha, cook_cache_dir, pack_cook_archive,
+};
+use soldr_cli::core::git::{
+    cargo_lock_is_gitignored, cargo_lock_is_tracked, find_git_worktree_root, normalize_origin_url,
+    origin_url,
+};
+use soldr_cli::daemon::client::{self, cook_lookup, cook_record, CookLookupOutcome};
+use soldr_cli::timed_test;
+
+const HARNESS_ENV: &str = "SOLDR_COOK_DOCKER_HARNESS";
+
+fn harness_enabled() -> bool {
+    matches!(
+        std::env::var(HARNESS_ENV).ok().as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
+fn skip_unless_in_container(test_name: &str) -> bool {
+    if harness_enabled() {
+        return false;
+    }
+    println!("{test_name}: skipped — {HARNESS_ENV} not set. Run via bench/cook_in_docker.sh.");
+    true
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("soldr-cookwrites-{label}-{nanos}"));
+    std::fs::create_dir_all(&dir).expect("failed to create temp dir");
+    dir
+}
+
+fn write_file(p: &Path, bytes: &[u8]) {
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir");
+    }
+    let mut f = File::create(p).expect("create");
+    f.write_all(bytes).expect("write");
+}
+
+fn soldr_daemon_bin() -> PathBuf {
+    let soldr = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let parent = soldr.parent().expect("CARGO_BIN_EXE_soldr has a parent");
+    let stem = if cfg!(windows) {
+        "soldr-daemon.exe"
+    } else {
+        "soldr-daemon"
+    };
+    parent.join(stem)
+}
+
+struct DaemonProc {
+    child: Option<Child>,
+    cache_root: PathBuf,
+}
+
+impl DaemonProc {
+    fn spawn(cache_root: &Path, home_root: &Path) -> Self {
+        let mut cmd = Command::new(soldr_daemon_bin());
+        cmd.args(["--foreground", "--idle-timeout-secs", "60"])
+            .env("SOLDR_CACHE_DIR", cache_root)
+            .env("HOME", home_root)
+            .env("USERPROFILE", home_root)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = cmd.spawn().expect("spawn soldr-daemon");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let pid_path = cache_root
+            .join("cache")
+            .join("soldr-daemon")
+            .join("daemon.pid");
+        while Instant::now() < deadline {
+            if pid_path.exists() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            pid_path.exists(),
+            "soldr-daemon failed to write {} within 5s",
+            pid_path.display()
+        );
+        Self {
+            child: Some(child),
+            cache_root: cache_root.to_path_buf(),
+        }
+    }
+
+    fn sock_path(&self) -> PathBuf {
+        let paths = soldr_cli::core::SoldrPaths::with_root(self.cache_root.clone());
+        client::default_sock_path(&paths)
+    }
+}
+
+impl Drop for DaemonProc {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let paths = soldr_cli::core::SoldrPaths::with_root(self.cache_root.clone());
+            let _ = client::shutdown(&client::default_sock_path(&paths));
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < deadline {
+                if let Ok(Some(_)) = child.try_wait() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Synthetic minimal `target/release/` tree mimicking what
+/// `cargo chef cook` produces post-trim.
+fn write_synthetic_target_release(root: &Path) {
+    write_file(&root.join("deps").join("libfoo-abc.rlib"), b"rlib foo\n");
+    write_file(&root.join("deps").join("libbar-def.rmeta"), b"rmeta bar\n");
+    write_file(&root.join("deps").join("libbaz-ghi.rlib"), b"rlib baz\n");
+}
+
+fn run_git_in(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("git");
+    assert!(status.success(), "git {args:?} failed in {}", dir.display());
+}
+
+/// Initialize a real git repo with `Cargo.lock` committed and an
+/// `origin` remote pointed at `origin_url`.
+fn init_git_repo_with_origin(repo: &Path, origin: &str) {
+    std::fs::create_dir_all(repo).unwrap();
+    run_git_in(repo, &["init", "-q", "-b", "main"]);
+    run_git_in(repo, &["config", "user.email", "cook@example.com"]);
+    run_git_in(repo, &["config", "user.name", "cook test"]);
+    run_git_in(repo, &["remote", "add", "origin", origin]);
+    write_file(
+        &repo.join("Cargo.toml"),
+        b"[package]\nname='ci'\nversion='0'\n",
+    );
+    write_file(&repo.join("Cargo.lock"), b"# lockfile\n");
+    run_git_in(repo, &["add", "Cargo.toml", "Cargo.lock"]);
+    run_git_in(repo, &["commit", "-q", "-m", "init"]);
+}
+
+timed_test!(
+    end_to_end_pack_then_record_then_lookup_hits,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("end_to_end_pack_then_record_then_lookup_hits") {
+            return;
+        }
+        let cache_root = unique_temp_dir("e2e-cache");
+        let home_root = unique_temp_dir("e2e-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+        let sock = daemon.sock_path();
+
+        // Pack a synthetic target/release tree into ~/.soldr/cache/cook/.
+        let project_target = unique_temp_dir("e2e-project").join("target");
+        let release_dir = project_target.join("release");
+        write_synthetic_target_release(&release_dir);
+        let paths = soldr_cli::core::SoldrPaths::with_root(cache_root.clone());
+        let cook_dir = cook_cache_dir(&paths);
+        std::fs::create_dir_all(&cook_dir).unwrap();
+        let packed = pack_cook_archive(&release_dir, &cook_dir).expect("pack");
+        assert_eq!(
+            packed.path,
+            artifact_path_for_sha(&cook_dir, &packed.sha256)
+        );
+        assert!(packed.path.is_file());
+
+        // Register with the daemon.
+        cook_record(
+            &sock,
+            [0xA1u8; 32],
+            "x86_64-unknown-linux-gnu".to_string(),
+            "release".to_string(),
+            "1.94.1".to_string(),
+            "rustc 1.94.1 (test)".to_string(),
+            packed.sha256,
+            packed.size_bytes,
+            Some("https://github.com/zackees/soldr".to_string()),
+            "cook --release".to_string(),
+        )
+        .expect("cook_record");
+
+        // Subsequent lookup hits.
+        let outcome = cook_lookup(
+            &sock,
+            [0xA1u8; 32],
+            "x86_64-unknown-linux-gnu".to_string(),
+            "release".to_string(),
+            "1.94.1".to_string(),
+            "rustc 1.94.1 (test)".to_string(),
+            Some("https://github.com/zackees/soldr".to_string()),
+        )
+        .expect("cook_lookup");
+
+        match outcome {
+            CookLookupOutcome::Hit {
+                sha256,
+                path,
+                size_bytes,
+                origin_url_normalized,
+            } => {
+                assert_eq!(sha256, packed.sha256);
+                assert_eq!(size_bytes, packed.size_bytes);
+                assert_eq!(
+                    origin_url_normalized.as_deref(),
+                    Some("https://github.com/zackees/soldr"),
+                );
+                assert!(
+                    path.ends_with(".tar.zst"),
+                    "expected <sha256>.tar.zst path, got {path}"
+                );
+                // The daemon's reported path matches what the packer
+                // produced.
+                assert_eq!(PathBuf::from(&path), packed.path);
+            }
+            CookLookupOutcome::Miss { .. } => panic!("expected CookHit"),
+        }
+
+        // Daemon Status reflects the indexed row.
+        let status = client::status(&sock).expect("status");
+        let cook = status.cook_stats_or_zero();
+        assert_eq!(cook.entries, 1);
+        assert_eq!(cook.total_bytes, packed.size_bytes);
+    }
+);
+
+timed_test!(
+    origin_url_helper_extracts_and_normalizes,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("origin_url_helper_extracts_and_normalizes") {
+            return;
+        }
+        let repo = unique_temp_dir("origin-repo");
+        init_git_repo_with_origin(&repo, "https://User:PASS@GitHub.com/Owner/Repo.git");
+        let out = origin_url(&repo).expect("origin_url");
+        assert_eq!(out, "https://github.com/Owner/Repo");
+
+        // find_git_worktree_root walks up.
+        let nested = repo.join("a").join("b");
+        std::fs::create_dir_all(&nested).unwrap();
+        let resolved = find_git_worktree_root(&nested).expect("worktree root");
+        // Compare canonical paths on Windows where temp paths sometimes
+        // surface with a short-name prefix.
+        let resolved = std::fs::canonicalize(&resolved).unwrap_or(resolved);
+        let repo_canon = std::fs::canonicalize(&repo).unwrap_or(repo);
+        assert_eq!(resolved, repo_canon);
+    }
+);
+
+timed_test!(
+    cargo_lock_tracked_returns_true_after_commit,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("cargo_lock_tracked_returns_true_after_commit") {
+            return;
+        }
+        let repo = unique_temp_dir("tracked-repo");
+        init_git_repo_with_origin(&repo, "git@github.com:zackees/soldr.git");
+        assert!(cargo_lock_is_tracked(&repo));
+        assert!(!cargo_lock_is_gitignored(&repo));
+    }
+);
+
+timed_test!(
+    cargo_lock_tracked_returns_false_when_lock_is_untracked,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("cargo_lock_tracked_returns_false_when_lock_is_untracked") {
+            return;
+        }
+        let repo = unique_temp_dir("untracked-repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git_in(&repo, &["init", "-q", "-b", "main"]);
+        run_git_in(&repo, &["config", "user.email", "u@example.com"]);
+        run_git_in(&repo, &["config", "user.name", "u"]);
+        write_file(
+            &repo.join("Cargo.toml"),
+            b"[package]\nname='x'\nversion='0'\n",
+        );
+        write_file(&repo.join("Cargo.lock"), b"# lock\n");
+        run_git_in(&repo, &["add", "Cargo.toml"]);
+        run_git_in(&repo, &["commit", "-q", "-m", "no lock"]);
+        // Cargo.lock exists on disk but is NOT in git.
+        assert!(!cargo_lock_is_tracked(&repo));
+    }
+);
+
+timed_test!(
+    cargo_lock_gitignored_returns_true_when_pattern_matches,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("cargo_lock_gitignored_returns_true_when_pattern_matches") {
+            return;
+        }
+        let repo = unique_temp_dir("gitignored-repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git_in(&repo, &["init", "-q", "-b", "main"]);
+        run_git_in(&repo, &["config", "user.email", "u@example.com"]);
+        run_git_in(&repo, &["config", "user.name", "u"]);
+        write_file(&repo.join(".gitignore"), b"Cargo.lock\n");
+        write_file(
+            &repo.join("Cargo.toml"),
+            b"[package]\nname='x'\nversion='0'\n",
+        );
+        write_file(&repo.join("Cargo.lock"), b"# ignored lock\n");
+        run_git_in(&repo, &["add", "Cargo.toml", ".gitignore"]);
+        run_git_in(&repo, &["commit", "-q", "-m", "gitignore"]);
+        assert!(cargo_lock_is_gitignored(&repo));
+        assert!(!cargo_lock_is_tracked(&repo));
+    }
+);
+
+timed_test!(
+    no_git_workspace_reports_no_origin_and_no_worktree,
+    Duration::from_secs(60),
+    {
+        if skip_unless_in_container("no_git_workspace_reports_no_origin_and_no_worktree") {
+            return;
+        }
+        let dir = unique_temp_dir("no-git");
+        write_file(
+            &dir.join("Cargo.toml"),
+            b"[package]\nname='nogit'\nversion='0'\n",
+        );
+        write_file(&dir.join("Cargo.lock"), b"# lock\n");
+        assert!(find_git_worktree_root(&dir).is_none());
+        assert!(origin_url(&dir).is_none());
+        assert!(!cargo_lock_is_tracked(&dir));
+        assert!(!cargo_lock_is_gitignored(&dir));
+    }
+);
+
+// Pure unit-style coverage of normalize_origin_url that's safe to run
+// outside the harness too — exercised via the wrapper functions above
+// in the harness path but useful as a smoke check anywhere.
+timed_test!(normalize_origin_url_matches_design_examples, {
+    assert_eq!(
+        normalize_origin_url("https://USER:PASS@GitHub.com:443/Owner/Repo.git"),
+        "https://github.com/Owner/Repo"
+    );
+    assert_eq!(
+        normalize_origin_url("git@github.com:Owner/Repo.git"),
+        "https://github.com/Owner/Repo"
+    );
+});

--- a/crates/soldr-cli/tests/save_roundtrip.rs
+++ b/crates/soldr-cli/tests/save_roundtrip.rs
@@ -785,14 +785,13 @@ fn parallel_extract_many_small_files() {
     for (rel, (body, mtime_ms_expected)) in &expected {
         let restored = restore.join(rel);
         let actual = fs::read(&restored).unwrap_or_else(|e| {
-            panic!("missing or unreadable restored file {}: {}", restored.display(), e);
+            panic!(
+                "missing or unreadable restored file {}: {}",
+                restored.display(),
+                e
+            );
         });
-        assert_eq!(
-            &actual,
-            body,
-            "content mismatch at {}",
-            restored.display()
-        );
+        assert_eq!(&actual, body, "content mismatch at {}", restored.display());
         // tar stores mtime at second resolution; allow ±1000 ms slack.
         let restored_mtime = mtime_ms(&restored);
         let diff = (restored_mtime - mtime_ms_expected).abs();


### PR DESCRIPTION
PR 2 of 3 for the cross-repo shared `soldr cook` artifact cache (meta #579). Depends on PR 1 (#582, merged).

Closes #577.

> [!IMPORTANT]
> ## Build and test in Docker only
>
> This PR activates the cook-write path: `~/.soldr/cache/cook/<sha256>.tar.zst` artifacts are written, `CookRecord` is sent to the daemon. Per meta #579, all build and test loops MUST execute inside `bench/cook_in_docker.sh`. Bare-host runs corrupt the host developer's running daemon and persistent state. Tests gated on `SOLDR_COOK_DOCKER_HARNESS=1`.

## What changes

- **`crates/soldr-cli/src/cache_lib/cook_archive.rs`** — new content-addressed tar+zstd:19 packer with `--long=27` window log + multi-threaded compression. Constants `COOK_ZSTD_LEVEL = 19` and `COOK_ZSTD_LONG_WINDOW = 27`. Writes go through `<cook_dir>/.tmp/<rand>.tar.zst.tmp` and rename into place so a crashed packer never leaves a half-written `<sha256>.tar.zst`. `cache_lib::save` zstd:3 default is UNTOUCHED.
- **`crates/soldr-cli/src/core/git.rs`** — new helpers: `origin_url()` (subprocess `git config --get remote.origin.url`), `normalize_origin_url()` (lowercase scheme+host, strip userinfo, strip trailing `.git`, drop default port, canonicalize SSH shorthand), `cargo_lock_is_tracked()`, `cargo_lock_is_gitignored()`, `find_git_worktree_root()`.
- **`crates/soldr-cli/src/cook.rs`** — new Phase 4 indexing step:
  1. Warnings (yellow ANSI 33, gated on `is_terminal`) for each sharing-disable condition.
  2. Resolve key tuple: SHA-256(recipe.json) + target_triple + profile + channel (rust-toolchain.toml) + `rustc -V`.
  3. Pre-flight `CookLookup` → diagnostic line on miss when previous origin-recipe hashes exist.
  4. Pack via `cook_archive::pack_cook_archive`.
  5. `CookRecord` → daemon.
  6. Green ANSI 32 status: `soldr cook: indexed  sha256=<abbrev12>  size=<MiB>  origin=<url|none>`.
- **`Cargo.toml` / `crates/soldr-cli/Cargo.toml`** — adds workspace dep `url = "2"`.
- **`crates/soldr-cli/src/cache_lib/save.rs`** (drive-by) — fixes a pre-existing clippy `redundant_pattern_matching` warning (`if let Err(_) = X` → `if X.is_err()`) that blocks `clippy -D warnings`. Pure mechanical, behavior identical. `cargo fmt` reflowed two adjacent lines in the same file plus one test in `tests/save_roundtrip.rs`.

## Warnings table (matches meta #579)

| Condition | Detection | Behavior |
|---|---|---|
| `Cargo.lock` not git-tracked | `git ls-files --error-unmatch Cargo.lock` | **WARN (yellow)** — cooked locally, NOT indexed |
| No `.git/` | `find_git_worktree_root()` returns `None` | **WARN (yellow)** — local-only |
| `Cargo.lock` gitignored | `git check-ignore -q Cargo.lock` | **WARN (yellow)** — cooked locally, NOT indexed |
| Recipe drift since previous entry | `CookMiss { previous_origin_recipe_hashes }` non-empty | **DIAGNOSTIC** — `soldr cook: recipe hash drift since <prev_sha12>` |

Success line on indexed cook: `soldr cook: indexed  sha256=<abbrev12>  size=<MiB>  origin=<url|none>` (green).

## Hard invariants verified

1. **Cross-target sharing structurally forbidden** — key includes triple/profile/channel/rustc, daemon-side schema from PR 1 unchanged.
2. **Content-addressed** — filename IS sha256 of compressed bytes. PR 3's pre-flight hydrate verifies by re-hashing.
3. **`cache_lib::save` defaults preserved** — assert `DEFAULT_ZSTD_LEVEL` still 3; the cook path uses a separate `COOK_ZSTD_LEVEL`.
4. **Cargo.lock is mandatory for indexing** — all three warning paths skip the `CookRecord` call.
5. **Daemon failure non-fatal** — pre-flight + record errors surface as yellow warnings, never fail the cook command.

## Tests (run in Docker)

PR 2 integration suite (`cook_writes_index.rs`, 7 tests):
- `end_to_end_pack_then_record_then_lookup_hits`
- `origin_url_helper_extracts_and_normalizes`
- `cargo_lock_tracked_returns_true_after_commit`
- `cargo_lock_tracked_returns_false_when_lock_is_untracked`
- `cargo_lock_gitignored_returns_true_when_pattern_matches`
- `no_git_workspace_reports_no_origin_and_no_worktree`
- `normalize_origin_url_matches_design_examples`

PR 1 integration suite still passes (7/7):
- `daemon_cook_index.rs` — round-trip, drift, concurrency, per-target safety, status counts, fire-and-forget touch, status variant.

Existing daemon + cli_cook + lifecycle + target_touch tests unchanged.

Unit tests added:
- `cache_lib::cook_archive::tests::*` — pack round-trip, idempotence, missing source, sha abbreviation, artifact-path filename shape.
- `core::git::tests::*` — SCP-style shorthand canonicalization, normalize-credentials-and-dot-git, drop-default-port, round-trip unknown schemes.

## Test plan

- [x] `bench/cook_in_docker.sh cargo check -p soldr-cli --bins --tests` clean.
- [x] `bench/cook_in_docker.sh cargo test -p soldr-cli --test cook_writes_index --test daemon_cook_index --test cli_daemon_lifecycle --test cli_daemon_target_touch --test cli_cook --test timed_test_lint` — all green.
- [x] `bench/cook_in_docker.sh cargo clippy -p soldr-cli --bins --tests -- -D warnings` clean.
- [x] `bench/cook_in_docker.sh cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)