### PR TITLE
chore(release): bump 0.7.45 -> 0.7.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.45"
+version = "0.7.46"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Cut the 0.7.46 release so setup-soldr#260 can pin to a binary that has #575's parallel-extract path.

Picked up since 0.7.45:
- #581 — parallel per-file extraction inside `soldr load` (the cargo-registry-cache wall-clock win).
- #583 — `--profile-extract` flag for tuning + `--auto-defender-exclude` CLI placeholder (Windows admin-only no-UAC).
- #582 — cook_index daemon foundation (orthogonal but on main).

## Test plan

- [x] `cargo build` clean on workspace (Cargo.lock refreshed via `cargo update -p soldr-cli`).
- [ ] Release CI matrix (build all 8 triples, publish wheels + npm shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)