### PR TITLE
fix(load): preserve Unix +x bit on cache-file restore (#587)

### DIFF
--- a/crates/soldr-cli/src/cache_lib/save.rs
+++ b/crates/soldr-cli/src/cache_lib/save.rs
@@ -1082,6 +1082,11 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
             .read_to_end(&mut body)
             .map_err(SaveLoadError::BareIo)?;
         let mtime_secs = entry.header().mtime().ok();
+        // Capture the tar header's Unix mode so the worker can chmod
+        // the file after writing. Without this, executable scripts
+        // and binaries (e.g. cargo `build-script-build`) lose +x on
+        // restore and fail with EACCES — see #587.
+        let mode_bits = entry.header().mode().ok();
 
         // Lazy-start the dispatch on first cache entry.
         let dispatch = extract_dispatch.get_or_insert_with(|| {
@@ -1099,6 +1104,7 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
             entry_type,
             body,
             mtime_secs,
+            mode_bits,
         };
         if dispatch.send(job).is_err() {
             // Receivers are gone — there must be a stored error already.
@@ -1178,6 +1184,11 @@ struct ExtractJob {
     entry_type: tar::EntryType,
     body: Vec<u8>,
     mtime_secs: Option<u64>,
+    /// Unix file mode from the tar header, used to restore the
+    /// executable bit on Unix. None when the header lacked a mode.
+    /// Ignored on Windows (NTFS uses ACLs, not Unix modes; tar
+    /// archives don't carry meaningful NTFS permissions). (#587)
+    mode_bits: Option<u32>,
 }
 
 /// Bounded-channel + worker-thread bundle that owns the parallel extraction
@@ -1290,6 +1301,17 @@ fn extract_one(job: &ExtractJob) -> Result<()> {
     match job.entry_type {
         tar::EntryType::Regular => {
             std::fs::write(&job.dest, &job.body).map_err(|e| io(&job.dest, e))?;
+            // #587: restore +x (and other Unix permission bits) from
+            // the tar header. Without this, cargo build-script-build
+            // binaries restored from cache fail execve with EACCES.
+            // Windows ignores the mode — NTFS uses ACLs, and the tar
+            // header's Unix mode isn't meaningful there.
+            #[cfg(unix)]
+            if let Some(mode) = job.mode_bits {
+                use std::os::unix::fs::PermissionsExt;
+                let perms = std::fs::Permissions::from_mode(mode);
+                std::fs::set_permissions(&job.dest, perms).map_err(|e| io(&job.dest, e))?;
+            }
             if let Some(secs) = job.mtime_secs {
                 let ft = filetime::FileTime::from_unix_time(secs as i64, 0);
                 filetime::set_file_mtime(&job.dest, ft).map_err(|e| io(&job.dest, e))?;

--- a/crates/soldr-cli/tests/save_roundtrip.rs
+++ b/crates/soldr-cli/tests/save_roundtrip.rs
@@ -870,3 +870,51 @@ fn profile_extract_flag_does_not_break_load() {
         b"hello-profile"
     );
 }
+
+/// soldr#587: an executable file (0o755) restored from cache must
+/// still be executable. Without the per-worker chmod that fix
+/// landed, cargo build-script-build files lose +x and fail execve
+/// with EACCES on the next warm build.
+#[cfg(unix)]
+#[test]
+fn load_restores_executable_bit_for_cache_files() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempfile::tempdir().unwrap();
+    let cache = tmp.path().join("cache");
+    fs::create_dir_all(&cache).unwrap();
+    let exe = cache.join("build-script-build");
+    fs::write(&exe, b"#!/bin/sh\necho run\n").unwrap();
+    fs::set_permissions(&exe, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let archive = tmp.path().join("a.tar.zst");
+    let _ = save(&SaveOptions {
+        workspace: None,
+        cache_dir: Some(&cache),
+        out: &archive,
+        zstd_level: 1,
+        threads: None,
+        mtimes_only: false,
+    })
+    .unwrap();
+
+    let restore = tmp.path().join("restore");
+    let _ = load(&LoadOptions {
+        archive: &archive,
+        cache_dir: Some(&restore),
+        workspace: None,
+        threads: None,
+        mtimes_only: false,
+        profile_extract: false,
+        auto_defender_exclude: false,
+    })
+    .unwrap();
+
+    let restored = restore.join("build-script-build");
+    let perms = fs::metadata(&restored).unwrap().permissions();
+    let mode = perms.mode() & 0o777;
+    assert_eq!(
+        mode, 0o755,
+        "restored mode {:o} != 0o755 — +x bit not preserved (regression of #587)",
+        mode
+    );
+}


### PR DESCRIPTION
## Summary

Fix the regression from #581 where \`std::fs::write\` (replacing tar crate's \`entry.unpack()\`) silently dropped the Unix mode bits, so cargo \`build-script-build\` binaries restored from cache failed \`execve\` with EACCES on the next warm build.

Two new things in the worker path:
1. Driver captures \`entry.header().mode().ok()\` into \`ExtractJob::mode_bits\`.
2. After writing the file, \`extract_one\` applies that mode via \`PermissionsExt::from_mode\` on Unix (\`cfg(unix)\`). Windows ignores — NTFS uses ACLs, the tar header's mode isn't meaningful there.

## Test plan

- [x] New \`load_restores_executable_bit_for_cache_files\` test (cfg(unix)) round-trips a 0o755 file and asserts the restored mode is still 0o755. Catches future regressions of the same shape.
- [x] All 15 existing save_roundtrip tests still pass on Windows. (The +x test compile-skips on Windows since the Unix mode model doesn't apply.)
- [ ] CI matrix — the new test runs on the Linux + macOS build jobs.

Fixes: zackees/soldr#587
Refs: zackees/zccache#473, zackees/soldr#575

🤖 Generated with [Claude Code](https://claude.com/claude-code)