### PR TITLE
ci: switch Docker /target and CARGO_HOME from bind mounts to named volumes (#593)

### DIFF
--- a/bench/cook_in_docker.sh
+++ b/bench/cook_in_docker.sh
@@ -12,10 +12,37 @@
 #   bench/cook_in_docker.sh cargo test --workspace   # full workspace test
 #   bench/cook_in_docker.sh cargo clippy --workspace # clippy lint
 #
+# ## Volume layout (issue #593)
+#
+# Three named volumes — explicit lifetimes, no host bind mounts of state
+# directories:
+#
+# * `cook-soldr-home` → `/root/.soldr` (test harness state). Wiped per
+#   run for determinism — the cook-index integration tests assert
+#   against a freshly-empty `~/.soldr/`.
+# * `soldr-perf-target` → `/work/target` (cargo build state). Persistent
+#   across runs so cargo's mtime-based fingerprint check actually
+#   succeeds. Without this, Windows + Docker Desktop's WSL2 9P layer
+#   rewrites file mtimes on every container start and cargo rebuilds
+#   the workspace (~6 min on a fresh 21-crate workspace, vs ~1 s when
+#   warm).
+# * `soldr-perf-cargo-home` → `/root/.cargo` (cargo registry index +
+#   downloaded crates). Persistent across runs so the registry index
+#   isn't re-fetched on every container start.
+#
 # Required guarantee per meta #579: the host's `~/.soldr/` directory
-# must be byte-identical before and after this script runs. We mount a
-# named volume (cook-soldr-home) inside the container at /root/.soldr;
-# the host's actual `~/.soldr/` is never bind-mounted.
+# must be byte-identical before and after this script runs. The
+# `cook-soldr-home` volume mount makes that automatic — the host's
+# actual `~/.soldr/` is never bind-mounted.
+#
+# Migration after upgrading to this script: the old host-side `target/`
+# directory under the repo root becomes orphaned (cargo writes into the
+# named volume instead). Reclaim disk with `rm -rf target/`. Wipe the
+# warm volumes explicitly with:
+#
+#   docker volume rm soldr-perf-target soldr-perf-cargo-home
+#
+# if the fingerprint state ever gets corrupted.
 
 set -euo pipefail
 
@@ -23,7 +50,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 IMAGE="soldr-cook-dev"
-VOLUME="cook-soldr-home"
+HARNESS_VOLUME="cook-soldr-home"
+PERSIST_TARGET_VOLUME="soldr-perf-target"
+PERSIST_CARGO_VOLUME="soldr-perf-cargo-home"
 
 # Build (cached after the first run).
 docker build \
@@ -37,16 +66,18 @@ if [ "$#" -eq 0 ]; then
     set -- cargo test --workspace --test daemon_cook_index -- --include-ignored
 fi
 
-# Fresh `~/.soldr/` each time keeps tests deterministic. Remove the
-# volume so the next run starts from empty state; comment out the
-# volume rm if you want to debug across runs.
-docker volume rm --force "$VOLUME" >/dev/null 2>&1 || true
+# Per-run wipe of `cook-soldr-home` keeps the harness-gated tests
+# deterministic. The persistent `soldr-perf-*` volumes are NEVER wiped
+# here — that's the entire point of this script's #593 design.
+docker volume rm --force "$HARNESS_VOLUME" >/dev/null 2>&1 || true
 
 exec docker run \
     --rm \
     --init \
     -v "$REPO_ROOT:/work" \
-    -v "$VOLUME:/root/.soldr" \
+    -v "$HARNESS_VOLUME:/root/.soldr" \
+    -v "$PERSIST_TARGET_VOLUME:/work/target" \
+    -v "$PERSIST_CARGO_VOLUME:/root/.cargo" \
     -e SOLDR_COOK_DOCKER_HARNESS=1 \
     -w /work \
     "$IMAGE" \

--- a/ci/perf_local.py
+++ b/ci/perf_local.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Run arbitrary `cargo` commands against soldr's warmed Docker volumes.
+
+Mirrors the `ci/perf_local.py` pattern in zackees/zccache (zccache PR
+#475). The volumes (`soldr-perf-target`, `soldr-perf-cargo-home`) live
+on Linux-native ext4 inside Docker's VFS so cargo's mtime-based
+fingerprint check actually succeeds — Windows + Docker Desktop's WSL2
+9P bind-mount layer rewrites mtimes on every container start, which
+would otherwise force cargo to rebuild the entire workspace each
+invocation.
+
+Measured on zccache's 21-crate workspace (#593): 6 min no-op rebuild
+with host bind mounts → 1.09 s no-op with named volumes. Same lever
+applies here.
+
+## Usage
+
+    uv run python ci/perf_local.py cargo build --release
+    uv run python ci/perf_local.py cargo test --workspace
+    uv run python ci/perf_local.py cargo clippy --workspace -- -D warnings
+
+Anything after the literal `cargo` token is forwarded verbatim to
+cargo inside the container — `argparse` is intentionally NOT used past
+the `cargo` boundary so flag handling stays unambiguous.
+
+## Volumes
+
+* `soldr-perf-target` → `/work/target` (cargo build state)
+* `soldr-perf-cargo-home` → `/root/.cargo` (cargo registry + downloaded
+  crates)
+* `soldr-perf-soldr-home` → `/root/.soldr` (kept warm; distinct from
+  the test-harness `cook-soldr-home` volume that `bench/cook_in_docker.sh`
+  wipes between runs).
+
+Wipe deliberately if the fingerprint state ever gets corrupted:
+
+    docker volume rm soldr-perf-target soldr-perf-cargo-home soldr-perf-soldr-home
+
+## Migration
+
+Switching to this script orphans the old host-side `target/` directory
+under the repo root. Reclaim disk with:
+
+    rm -rf target/
+
+The first run after the switch is a full cold build (~5-8 min) into
+the fresh volume; subsequent runs are seconds.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+IMAGE = "soldr-cook-dev"
+DOCKERFILE = "docker/cook-shared-cache/Dockerfile"
+VOLUME_TARGET = "soldr-perf-target"
+VOLUME_CARGO_HOME = "soldr-perf-cargo-home"
+VOLUME_SOLDR_HOME = "soldr-perf-soldr-home"
+
+USAGE = """\
+usage: python ci/perf_local.py cargo <args...>
+       python ci/perf_local.py --wipe                # remove the perf volumes
+       python ci/perf_local.py --status              # show volume sizes / existence
+
+Every argument after `cargo` is forwarded verbatim to cargo inside the
+container. See the module docstring for full notes.
+"""
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    os.chdir(repo_root)
+
+    if not shutil.which("docker"):
+        print("error: docker not on PATH", file=sys.stderr)
+        return 2
+
+    if not argv:
+        print(USAGE, file=sys.stderr)
+        return 2
+
+    # Tiny pre-argparse subcommands. Anything else falls through to the
+    # `cargo` forwarder so flags after `cargo` don't get eaten.
+    if argv[0] in ("-h", "--help"):
+        print(USAGE)
+        return 0
+    if argv[0] == "--wipe":
+        return wipe()
+    if argv[0] == "--status":
+        return status()
+    if argv[0] != "cargo":
+        print(
+            f"error: expected `cargo` as the first arg, got {argv[0]!r}\n\n{USAGE}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Build the image (cached; ~5 s when warm).
+    build = subprocess.run(
+        ["docker", "build", "-f", DOCKERFILE, "-t", IMAGE, "."],
+        check=False,
+    )
+    if build.returncode != 0:
+        return build.returncode
+
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "--init",
+        "-v",
+        f"{repo_root}:/work",
+        "-v",
+        f"{VOLUME_SOLDR_HOME}:/root/.soldr",
+        "-v",
+        f"{VOLUME_TARGET}:/work/target",
+        "-v",
+        f"{VOLUME_CARGO_HOME}:/root/.cargo",
+        "-w",
+        "/work",
+        IMAGE,
+        *argv,
+    ]
+    # No `-it` by default. Git Bash / mintty on Windows fools
+    # sys.stdin.isatty() into returning True, which makes `docker run
+    # -it` error with "the input device is not a TTY" because the
+    # underlying console isn't a real ConPTY. Pipes work fine for
+    # `cargo build`/`test`/`clippy` — cargo's progress bar gracefully
+    # downgrades to line-buffered output when stderr is a pipe. Power
+    # users who need a real TTY can set `SOLDR_PERF_LOCAL_TTY=1`.
+    if os.environ.get("SOLDR_PERF_LOCAL_TTY", "").strip() in ("1", "true", "yes"):
+        cmd.insert(2, "-it")
+    completed = subprocess.run(cmd, check=False)
+    return completed.returncode
+
+
+def wipe() -> int:
+    out = subprocess.run(
+        ["docker", "volume", "rm", "--force", VOLUME_TARGET, VOLUME_CARGO_HOME, VOLUME_SOLDR_HOME],
+        check=False,
+    )
+    return out.returncode
+
+
+def status() -> int:
+    rows: list[tuple[str, str]] = []
+    for name in (VOLUME_TARGET, VOLUME_CARGO_HOME, VOLUME_SOLDR_HOME):
+        out = subprocess.run(
+            ["docker", "volume", "inspect", "--format", "{{.Mountpoint}}", name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if out.returncode == 0:
+            rows.append((name, out.stdout.strip() or "(no mountpoint)"))
+        else:
+            rows.append((name, "(absent)"))
+    width = max(len(name) for name, _ in rows)
+    for name, info in rows:
+        print(f"{name:<{width}}  {info}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/docker/cook-shared-cache/Dockerfile
+++ b/docker/cook-shared-cache/Dockerfile
@@ -1,17 +1,31 @@
 # Docker image used to build and test the cross-repo shared `soldr cook`
-# artifact cache feature (issues #576, #577, #578 under meta #579).
+# artifact cache feature (issues #576, #577, #578 under meta #579) and
+# the general perf_local convenience CLI (issue #593).
 #
-# Why Docker is mandatory for this work: PRs 1-3 mutate the soldr daemon
-# protocol, the `~/.soldr/state.redb` schema, and the cargo-front-door
-# hot path. soldr installs as a per-user singleton — running `cargo
-# build` or `cargo test` for these PRs on the host would corrupt the
-# host developer's running daemon and persistent state. Mounting
-# `~/.soldr/` as a container-local volume (tmpfs or named volume — NEVER
-# a bind-mount of the host path) keeps the host singleton intact.
+# Why Docker is mandatory for cook-shared-cache work: PRs 1-3 mutate
+# the soldr daemon protocol, the `~/.soldr/state.redb` schema, and the
+# cargo-front-door hot path. soldr installs as a per-user singleton —
+# running `cargo build` or `cargo test` for these PRs on the host would
+# corrupt the host developer's running daemon and persistent state.
+# Mounting `~/.soldr/` as a container-local volume (tmpfs or named
+# volume — NEVER a bind-mount of the host path) keeps the host
+# singleton intact.
+#
+# Volume layout (issue #593): see `bench/cook_in_docker.sh` and
+# `ci/perf_local.py` for the canonical `docker run -v ...` flags.
+# Summary: `/work/target` and `/root/.cargo` are NAMED VOLUMES (not
+# host bind mounts) so cargo's mtime-based fingerprint check survives
+# container restarts. Without this, Windows + Docker Desktop's WSL2
+# 9P translation layer rewrites mtimes per container start and cargo
+# rebuilds everything (~6 min on a fresh 21-crate workspace, vs ~1 s
+# when warm).
 #
 # Usage (via bench/cook_in_docker.sh):
 #   docker build -f docker/cook-shared-cache/Dockerfile -t soldr-cook-dev .
-#   docker run --rm -v "$(pwd):/work" -v cook-soldr-home:/root/.soldr \
+#   docker run --rm -v "$(pwd):/work" \
+#       -v cook-soldr-home:/root/.soldr \
+#       -v soldr-perf-target:/work/target \
+#       -v soldr-perf-cargo-home:/root/.cargo \
 #       -e SOLDR_COOK_DOCKER_HARNESS=1 -w /work soldr-cook-dev \
 #       cargo test --workspace -- --include-ignored cook_index
 
@@ -34,6 +48,13 @@ RUN apt-get update \
 RUN rustup default 1.94.1 \
     && rustup component add rustfmt clippy
 
+# CARGO_HOME explicit so the `soldr-perf-cargo-home` named volume mount
+# point is unambiguous. Without this the path depends on the base
+# image's $HOME inheritance — `/root/.cargo` happens to be the default
+# for the `rust:bookworm` image but pinning it makes future image
+# migrations safe.
+ENV CARGO_HOME=/root/.cargo
+
 # Source tree is mounted by the runner at /work; no COPY here so each
 # `docker run` reuses the cached image but operates on the live worktree.
 WORKDIR /work
@@ -45,4 +66,4 @@ ENV SOLDR_COOK_DOCKER_HARNESS=1
 
 # Default command is a help message; the runner overrides with the
 # actual `cargo test` invocation.
-CMD ["echo", "soldr-cook-dev image — invoke via bench/cook_in_docker.sh or pass a cargo command"]
+CMD ["echo", "soldr-cook-dev image — invoke via bench/cook_in_docker.sh or ci/perf_local.py"]

--- a/docs/CONTRIBUTING_COOK.md
+++ b/docs/CONTRIBUTING_COOK.md
@@ -44,12 +44,83 @@ run), then runs your command inside a container with:
 - `~/.soldr/` provided by a fresh named volume `cook-soldr-home` at
   `/root/.soldr` inside the container. The host's actual `~/.soldr/`
   is NEVER bind-mounted.
+- `/work/target` provided by the **persistent** named volume
+  `soldr-perf-target` (issue #593). Cargo's build state lives on
+  Linux-native ext4 inside Docker's VFS, not on the host bind mount,
+  so cargo's mtime-based fingerprint check actually succeeds across
+  container restarts.
+- `/root/.cargo` (`CARGO_HOME`) provided by the persistent named
+  volume `soldr-perf-cargo-home`. Registry index + downloaded crates
+  stay warm.
 - `SOLDR_COOK_DOCKER_HARNESS=1` exported so the tests gated on the
   Docker marker run.
 
 The script `docker volume rm`s `cook-soldr-home` at the start of each
-run so the container always starts from an empty soldr state. Comment
-out that line locally if you want to debug across runs.
+run so the container always starts from an empty soldr state. The
+**warm** `soldr-perf-target` and `soldr-perf-cargo-home` volumes are
+NEVER wiped here — that's the entire point of issue #593's design.
+
+## Why named volumes for `target/` and `CARGO_HOME`
+
+Issue #593 fixes a Windows + Docker Desktop performance regression:
+the WSL2 9P translation layer rewrites file mtimes per container
+start. Cargo's mtime-based fingerprint check then decides every
+crate is stale and rebuilds the entire workspace.
+
+Measured on zccache's 21-crate workspace before the fix:
+
+| Scenario                                  | Bind mount | Named volume |
+|---|---|---|
+| `cargo build --release --bin X` (cold)    | ~6 min     | ~4 m 22 s    |
+| Same command, immediate rerun (no-op)     | **6 m 22 s** | **1.09 s**  |
+| `cargo test --lib X` rerun (no source)    | 30+ s      | **1.46 s**   |
+
+The headline win is **6 minutes → 1 second** for no-op rebuilds.
+Linux hosts already see native ext4 on the bind mount so the speedup
+is smaller, but named volumes still beat the bind mount slightly.
+
+### Wiping the warm volumes
+
+If the cargo fingerprint state ever gets corrupted, wipe explicitly:
+
+```bash
+docker volume rm soldr-perf-target soldr-perf-cargo-home
+```
+
+The next run is a full cold build (~5–8 min) into the fresh volume;
+subsequent runs are seconds again.
+
+### Migration from the old layout
+
+After upgrading to this script, the old host-side `target/` directory
+under the repo root becomes orphaned (cargo writes into the named
+volume instead). Reclaim disk with:
+
+```bash
+rm -rf target/
+```
+
+## Arbitrary cargo commands via `ci/perf_local.py`
+
+For day-to-day iteration (not just the cook test harness), use the
+convenience CLI that runs ANY cargo command against the same warm
+volumes:
+
+```bash
+uv run python ci/perf_local.py cargo build --release
+uv run python ci/perf_local.py cargo test --workspace
+uv run python ci/perf_local.py cargo clippy --workspace -- -D warnings
+
+# Volume admin
+uv run python ci/perf_local.py --status   # show volume mount points
+uv run python ci/perf_local.py --wipe     # remove all three perf volumes
+```
+
+`perf_local.py` uses its own `soldr-perf-soldr-home` volume for
+`~/.soldr/` (kept warm, never wiped) so the soldr daemon state and
+caches survive across runs. The cook-test harness uses the separate
+`cook-soldr-home` volume that gets wiped per run for test
+determinism.
 
 ## Acceptance gate (per PR in meta #579)
 
@@ -76,9 +147,14 @@ test` runs are no-ops for these tests, and only `bench/cook_in_docker.sh`
 ## What lives where
 
 - `docker/cook-shared-cache/Dockerfile` — Rust 1.94.1 base image with
-  `pkg-config`, `libssl-dev`, `git`. Marker env var `SOLDR_COOK_DOCKER_HARNESS=1`.
-- `bench/cook_in_docker.sh` — supported runner. Builds the image,
-  mounts the source tree, runs the requested command.
+  `pkg-config`, `libssl-dev`, `git`. Marker env var
+  `SOLDR_COOK_DOCKER_HARNESS=1`. `CARGO_HOME=/root/.cargo` pinned so
+  the named volume mount point is unambiguous.
+- `bench/cook_in_docker.sh` — supported runner for the cook test
+  harness. Builds the image, mounts the source tree + three named
+  volumes, runs the requested command.
+- `ci/perf_local.py` — general-purpose convenience CLI for arbitrary
+  cargo commands against the warm volumes (issue #593).
 - `docs/CONTRIBUTING_COOK.md` — this file.
 
 ## PR scope reminder


### PR DESCRIPTION
Closes #593.

Switches soldr's Docker workflow (`bench/cook_in_docker.sh` + new `ci/perf_local.py`) from host bind mounts to named volumes for `target/` and `CARGO_HOME`. On Windows + Docker Desktop, this turns 6-minute no-op rebuilds into ~1-second no-ops; on Linux/macOS the speedup is smaller but still present.

## Why

Windows + Docker Desktop's WSL2 9P translation layer rewrites file mtimes on every container start. Cargo's mtime-based fingerprint check then decides every crate is stale and rebuilds the workspace. Named volumes live on Linux-native ext4 inside Docker's VFS, so mtimes are stable across container restarts and the fingerprint check actually succeeds.

Measured upstream in zackees/zccache#475 on a 21-crate workspace:

| Scenario                                  | Bind mount | Named volume |
|---|---|---|
| `cargo build --release --bin X` (cold)    | ~6 min     | ~4 m 22 s    |
| Same command, immediate rerun (no-op)     | **6 m 22 s** | **1.09 s**  |
| `cargo test --lib X` rerun (no source)    | 30+ s      | **1.46 s**   |

## What changes

- **`bench/cook_in_docker.sh`** — adds two persistent named volumes to the existing `docker run`: `-v soldr-perf-target:/work/target` and `-v soldr-perf-cargo-home:/root/.cargo`. The existing per-run wipe of `cook-soldr-home` is preserved (the cook-shared-cache harness tests require a fresh `~/.soldr/` for determinism); the new `soldr-perf-*` volumes are NEVER wiped here.
- **`docker/cook-shared-cache/Dockerfile`** — pins `ENV CARGO_HOME=/root/.cargo` so the named-volume mount point is unambiguous and survives future base-image upgrades.
- **`ci/perf_local.py`** (new) — convenience CLI for arbitrary cargo commands against the warm volumes:
  ```
  uv run python ci/perf_local.py cargo build --release
  uv run python ci/perf_local.py cargo test --workspace
  uv run python ci/perf_local.py cargo clippy --workspace -- -D warnings
  uv run python ci/perf_local.py --status   # show volume mount points
  uv run python ci/perf_local.py --wipe     # remove all three perf volumes
  ```
  Uses its own `soldr-perf-soldr-home` volume so soldr daemon state stays warm. `-it` is opt-in via `SOLDR_PERF_LOCAL_TTY=1` because Git Bash on Windows fools `sys.stdin.isatty()` and breaks `docker run -it`.
- **`docs/CONTRIBUTING_COOK.md`** — documents the new layout, the migration step (orphaned host `target/` to remove), and the wipe recipe.

## Verified

- Shell + Python syntax clean (`bash -n`, `ast.parse`).
- `python ci/perf_local.py --help` / `--status` render correctly.
- End-to-end: `python ci/perf_local.py cargo --version` builds the image, runs the container with all three named volumes mounted, and `docker volume inspect` confirms `soldr-perf-target`, `soldr-perf-cargo-home`, `soldr-perf-soldr-home` are all created with valid mountpoints under `/var/lib/docker/volumes/`.

## Migration

After this lands, the old host-side `target/` directory under the repo root becomes orphaned (cargo writes into the named volume). Reclaim disk with:

```bash
rm -rf target/
```

The first run after the switch is a full cold build into the fresh volume; subsequent runs are seconds.

## Test plan

- [x] Shell + Python syntax clean.
- [x] `perf_local.py --help` and `--status` work.
- [x] End-to-end `perf_local.py cargo --version` exercises the full docker build + run + volume mount path.
- [ ] Windows host benchmark on a 21-crate workspace (zccache's measurement methodology) — recommend running locally to confirm the speedup on this codebase too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)