### PR TITLE
ci(cook-in-docker): named Docker volumes for /target + CARGO_HOME (closes #593)

### DIFF
--- a/bench/cook_in_docker.sh
+++ b/bench/cook_in_docker.sh
@@ -16,6 +16,14 @@
 # must be byte-identical before and after this script runs. We mount a
 # named volume (cook-soldr-home) inside the container at /root/.soldr;
 # the host's actual `~/.soldr/` is never bind-mounted.
+#
+# Issue #593: cargo's /target and CARGO_HOME live in named Docker
+# volumes (NOT the bind-mounted /work) so cargo's mtime-based
+# fingerprint check actually works on Windows hosts. With bind-mount
+# targets routed through WSL2's 9P translation layer, file mtimes are
+# rewritten per container start and cargo decides everything is
+# stale — measured at 4–6 min per "no-op" rebuild downstream in
+# zccache, fixed to ~1 s by switching to named volumes (zccache #475).
 
 set -euo pipefail
 
@@ -24,6 +32,12 @@ cd "$REPO_ROOT"
 
 IMAGE="soldr-cook-dev"
 VOLUME="cook-soldr-home"
+# Build-state volumes are PERSISTENT (NOT wiped between runs — that
+# would defeat the speedup). Wipe explicitly with
+# `docker volume rm cook-soldr-target cook-soldr-cargo-home` if a stale
+# fingerprint blocks progress.
+TARGET_VOLUME="cook-soldr-target"
+CARGO_HOME_VOLUME="cook-soldr-cargo-home"
 
 # Build (cached after the first run).
 docker build \
@@ -46,7 +60,10 @@ exec docker run \
     --rm \
     --init \
     -v "$REPO_ROOT:/work" \
+    -v "$TARGET_VOLUME:/work/target" \
+    -v "$CARGO_HOME_VOLUME:/cargo-home" \
     -v "$VOLUME:/root/.soldr" \
+    -e CARGO_HOME=/cargo-home \
     -e SOLDR_COOK_DOCKER_HARNESS=1 \
     -w /work \
     "$IMAGE" \

--- a/tests/test_cook_in_docker_volumes.py
+++ b/tests/test_cook_in_docker_volumes.py
@@ -1,0 +1,165 @@
+"""Regression-guard tests for ``bench/cook_in_docker.sh``.
+
+The script bind-mounts the soldr repo at ``/work`` and runs ``cargo`` inside
+the ``soldr-cook-dev`` image. By default that means cargo writes
+``/work/target/`` and re-fetches the registry into a fresh CARGO_HOME on
+every container start, both of which go through Windows + WSL2's 9P
+translation layer that rewrites file mtimes per container start and
+defeats cargo's mtime-based fingerprint check.
+
+zccache filed the upstream issue (zccache #475 fix, soldr #593) and showed
+the bind-mount → named-volume switch turning multi-minute no-op rebuilds
+into ~1 s. This test pins the equivalent invariant for soldr's own
+in-container build/test loop:
+
+1. ``/work/target`` is overlaid by a named Docker volume so cargo's target/
+   lives on Linux-native ext4 inside Docker's VFS.
+2. ``CARGO_HOME`` is set to a path backed by a named Docker volume so the
+   crates-io registry index is reused across container starts.
+
+The tests parse ``bench/cook_in_docker.sh`` as a string — running the
+script for real requires Docker plus several minutes of setup and is
+out of scope for unit-level enforcement.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "bench" / "cook_in_docker.sh"
+
+
+@pytest.fixture(scope="module")
+def script() -> str:
+    assert SCRIPT_PATH.is_file(), f"missing {SCRIPT_PATH}"
+    return SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+def _docker_run_block(script_text: str) -> str:
+    """Return the contiguous slice of the script that contains the
+    final ``docker run`` invocation. Used to assert that the named
+    volumes are wired into the actual run, not just defined in a
+    comment elsewhere."""
+    m = re.search(r"docker run.*?(?=\Z|\n\n)", script_text, re.DOTALL)
+    assert m, "could not locate the `docker run` block in cook_in_docker.sh"
+    return m.group(0)
+
+
+# Mount-source token — either a literal volume name (`cook-soldr-target`)
+# or a bash variable reference (`$TARGET_VOLUME` / `${TARGET_VOLUME}`).
+# Forbids leading `/`, `.`, `~`, `$REPO_ROOT`, `$(pwd)` and other path
+# expressions that would indicate a host bind mount.
+_MOUNT_SOURCE = r"""(?:"?\$\{?[A-Za-z_]\w*\}?"?|"?[A-Za-z][\w\-]*"?)"""
+
+
+def _resolve_variable(script_text: str, name: str) -> str | None:
+    """Find ``NAME=...`` assignment in the script and return its value
+    (stripped of quotes). Returns None if not assigned. Used to verify
+    that a `$VAR_NAME` mount source resolves to a literal volume name
+    rather than a host path."""
+    m = re.search(rf'^\s*{re.escape(name)}=("?)([^"\n#]+)\1\s*$', script_text, re.MULTILINE)
+    if not m:
+        return None
+    return m.group(2).strip()
+
+
+def _mount_source_resolves_to_volume_name(source: str, script_text: str) -> bool:
+    """True if the captured mount source is a named-volume reference
+    (either literal or via a shell variable whose value is a named
+    volume — not a host path)."""
+    source = source.strip().strip('"').strip("'")
+    if source.startswith("$"):
+        var = source.lstrip("$").strip("{}")
+        resolved = _resolve_variable(script_text, var)
+        if resolved is None:
+            return False
+        source = resolved.strip().strip('"').strip("'")
+    # A host path starts with one of these. A named volume is a bare
+    # identifier (alnum + hyphen + underscore), no slashes or `~`.
+    return not source.startswith(("/", ".", "~", "$"))
+
+
+def test_target_dir_is_named_docker_volume(script: str) -> None:
+    """The named volume must be mounted at ``/work/target`` inside the
+    `docker run` invocation — overlaying the bind-mount default so
+    cargo's target/ lives on Linux-native ext4 (fast) instead of the
+    WSL2 9P-translated bind mount (slow)."""
+    block = _docker_run_block(script)
+    target_mount = re.search(
+        rf'-v\s+{_MOUNT_SOURCE}:"?(?:/work/target|/target)"?', block
+    )
+    assert target_mount, (
+        "no named-volume mount found for /work/target or /target in the "
+        "docker run block of bench/cook_in_docker.sh — the bind-mounted "
+        "repo's target/ defeats cargo's incremental on Windows hosts "
+        "(soldr #593 / zccache #475)."
+    )
+    source = target_mount.group(0).split("-v", 1)[1].split(":", 1)[0]
+    assert _mount_source_resolves_to_volume_name(source, script), (
+        f"target/ mount source {source!r} is not a named-volume name — "
+        "it looks like a host path, which puts cargo's target/ back on "
+        "the slow bind-mount layer."
+    )
+
+
+def test_cargo_home_is_named_volume(script: str) -> None:
+    """``CARGO_HOME`` must point at a path backed by a named Docker
+    volume so the cargo registry index is persisted across container
+    starts. Without this, every container re-fetches ~175 MiB.
+
+    Acceptance: either an explicit ``-e CARGO_HOME=...`` env var with a
+    matching ``-v <named-volume>:<path>`` mount, or the volume mounted
+    at ``/root/.cargo`` (cargo's default home) — both forms ensure
+    persistence."""
+    block = _docker_run_block(script)
+
+    cargo_home_envs = re.findall(r"-e\s+CARGO_HOME=([^\s'\"]+)", block)
+    if cargo_home_envs:
+        target_path = cargo_home_envs[0]
+    else:
+        # Default cargo home in the container (`rust:1.94.1-bookworm`
+        # runs as root, so it's /root/.cargo unless overridden).
+        target_path = "/root/.cargo"
+
+    volume_mount = re.search(
+        rf'-v\s+{_MOUNT_SOURCE}:"?{re.escape(target_path)}"?', block
+    )
+    assert volume_mount, (
+        f"no named-volume mount found for CARGO_HOME target ({target_path}) "
+        "in the docker run block of bench/cook_in_docker.sh — every "
+        "container start re-fetches the crates.io registry index "
+        "(~175 MiB) without it."
+    )
+    source = volume_mount.group(0).split("-v", 1)[1].split(":", 1)[0]
+    assert _mount_source_resolves_to_volume_name(source, script), (
+        f"CARGO_HOME mount source {source!r} is not a named-volume name — "
+        "it looks like a host path, which puts the cargo registry back "
+        "on the slow bind-mount layer."
+    )
+
+
+def test_target_and_cargo_volumes_are_not_wiped_each_run(script: str) -> None:
+    """``docker volume rm`` is fine for the ``~/.soldr/`` reset (the
+    cook-shared-cache feature deliberately tests from a clean
+    daemon state), but the target/cargo-home volumes must persist —
+    otherwise we lose the very speedup we're enforcing."""
+    # The existing `~/.soldr/` reset uses `$VOLUME` (singular). Capture
+    # whatever volume names are removed and assert they don't intersect
+    # with the target/cargo-home volume names introduced by the fix.
+    rm_volumes = re.findall(
+        r"docker volume rm[^\n]*\b(\w[\w\-]*)\b", script
+    )
+    rm_names = set(rm_volumes)
+    # Crude but effective: the soldr-home volume's variable is `VOLUME=...`,
+    # so the `docker volume rm "$VOLUME"` line resolves to that name.
+    # We forbid any explicit rm of names containing `target` or `cargo`.
+    bad = {n for n in rm_names if "target" in n.lower() or "cargo" in n.lower()}
+    assert not bad, (
+        f"cook_in_docker.sh removes volumes that hold cargo build state: {bad}. "
+        "These must persist across runs for the named-volume speedup to "
+        "work — only the ~/.soldr/ daemon-state volume should be reset."
+    )


### PR DESCRIPTION
## Summary

\`bench/cook_in_docker.sh\` bind-mounted the soldr repo at \`/work\`, so cargo's \`/work/target/\` and the default CARGO_HOME inside the container both went through the bind-mount layer. On Windows hosts with Docker Desktop's WSL2 backend, that layer rewrites file mtimes per container start and **defeats cargo's mtime-based fingerprint check** — every "no-op" rebuild becomes a full multi-minute one. Downstream zccache (zccache#475) measured the same issue at 4–6 min per no-op rebuild and turned it into **~1 s** by switching to named Docker volumes.

## Changes

- \`bench/cook_in_docker.sh\` — add two persistent named volumes:
  - \`cook-soldr-target\` → \`/work/target\` overlay (cargo target/ lives on Linux-native ext4 inside Docker's VFS, not on the bind-mount layer).
  - \`cook-soldr-cargo-home\` → \`/cargo-home\` + \`CARGO_HOME=/cargo-home\` env so the crates.io registry index (~175 MiB) is reused across container starts instead of refetched.
- \`~/.soldr/\` reset preserved — cook-shared-cache tests deliberately start from clean daemon state. The new volumes are NOT wiped per run (that would defeat the speedup); operators can \`docker volume rm cook-soldr-target cook-soldr-cargo-home\` if a stale fingerprint ever blocks progress.

## TDD RED → GREEN

- New \`tests/test_cook_in_docker_volumes.py\` parses the script and asserts: (a) \`/work/target\` is overlaid by a named volume, (b) \`CARGO_HOME\` points at a named-volume-backed path, (c) build-state volumes are not wiped per run.
- Tests **RED-failed** on the pre-fix script (no \`/work/target\` overlay, no CARGO_HOME volume).
- After the script change, **all 3 tests GREEN**.
- Tests run inside a \`python:3.12-slim\` Docker container per the harness-isolation rule — pytest only parses the script as text, no Rust toolchain is invoked.

## Reference

- zccache PR with measurements: https://github.com/zackees/zccache/pull/475
  - \`cargo build --release\` no-op rerun: **6 m 22 s → 1.09 s** (~350× speedup)
  - \`cargo test --lib\` rerun (no source change): **30+ s → 1.46 s** (~20×)
- soldr issue: #593

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)