### PR TITLE
feat(known_tools): register cargo-zigbuild and cargo-xwin for cross-compile docs alignment (refs #598)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Two categories, surfaced as first-class subcommands or via the generic fetch pat
   - `prepare` invokes the cargo binary resolved via `resolve_toolchain_binary("cargo")` directly (NOT through the rustc wrapper) so installs land in soldr-managed `$CARGO_HOME`. The active cargo already obeys `rust-toolchain.toml`, so no channel is threaded through.
 
 **Ecosystem fetches** (registered in `known_tools`, pulled from GitHub Releases):
-- cargo subcommands invoked via `soldr cargo <sub>`: `nextest`, `deny`, `audit`, `llvm-cov`, `udeps`, `semver-checks`, `expand`, `watch`, `chef`.
+- cargo subcommands invoked via `soldr cargo <sub>`: `nextest`, `deny`, `audit`, `llvm-cov`, `udeps`, `semver-checks`, `expand`, `watch`, `chef`, `zigbuild`, `xwin`.
 - top-level tools invoked directly via `soldr <tool>`: `cross`, `mdbook`, `cbindgen`, `wasm-pack`, `trunk`, `sccache`.
 - `cargo-chef` powers the `soldr cook` content-addressable dep-prebuild (issue #359). It is pinned to v0.1.73 — the most recent release that still ships pre-built archives for Windows MSVC and macOS in addition to the Linux assets the newer releases publish.
 

--- a/crates/soldr-cli/src/fetch/known_tools.rs
+++ b/crates/soldr-cli/src/fetch/known_tools.rs
@@ -133,6 +133,28 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
         tag_prefix: None,
         pinned_version: None,
     },
+    // Cross-compile front-ends (issue #598 child). Both are explicitly
+    // documented in `docs/CROSS_COMPILE.md` as the recommended Rust ↔
+    // Windows / Linux cross-compile path, but neither was registered in
+    // this table — so the docs promised auto-fetch behavior the binary
+    // did not actually deliver. `soldr cargo zigbuild build ...` and
+    // `soldr cargo xwin build ...` should now Just Work.
+    ToolSpec {
+        crate_name: "cargo-zigbuild",
+        cargo_subcommand: Some("zigbuild"),
+        binary_name: "cargo-zigbuild",
+        repo: Some(("rust-cross", "cargo-zigbuild")),
+        tag_prefix: None,
+        pinned_version: None,
+    },
+    ToolSpec {
+        crate_name: "cargo-xwin",
+        cargo_subcommand: Some("xwin"),
+        binary_name: "cargo-xwin",
+        repo: Some(("rust-cross", "cargo-xwin")),
+        tag_prefix: None,
+        pinned_version: None,
+    },
     // Phase 5 — web/wasm + cache. Top-level tools invoked directly.
     ToolSpec {
         crate_name: "wasm-pack",
@@ -321,5 +343,35 @@ mod tests {
             assert_eq!(spec.cargo_subcommand, None);
             assert!(spec.repo.is_some());
         }
+    }
+
+    #[test]
+    fn cargo_zigbuild_is_registered_for_cross_compile_docs_alignment() {
+        // docs/CROSS_COMPILE.md names cargo-zigbuild as the recommended
+        // Linux → Windows cross-compile front-end. The promise to auto-
+        // fetch it only holds if the registry has the entry.
+        let spec = lookup_by_crate("cargo-zigbuild").expect("cargo-zigbuild must be registered");
+        assert_eq!(spec.cargo_subcommand, Some("zigbuild"));
+        assert_eq!(spec.binary_name, "cargo-zigbuild");
+        assert_eq!(spec.repo, Some(("rust-cross", "cargo-zigbuild")));
+        assert_eq!(
+            lookup_by_cargo_subcommand("zigbuild").map(|s| s.crate_name),
+            Some("cargo-zigbuild")
+        );
+    }
+
+    #[test]
+    fn cargo_xwin_is_registered_for_cross_compile_docs_alignment() {
+        // docs/CROSS_COMPILE.md names cargo-xwin as the recommended
+        // Linux → Windows MSVC cross-compile front-end. Same docs-
+        // alignment rationale as cargo-zigbuild above.
+        let spec = lookup_by_crate("cargo-xwin").expect("cargo-xwin must be registered");
+        assert_eq!(spec.cargo_subcommand, Some("xwin"));
+        assert_eq!(spec.binary_name, "cargo-xwin");
+        assert_eq!(spec.repo, Some(("rust-cross", "cargo-xwin")));
+        assert_eq!(
+            lookup_by_cargo_subcommand("xwin").map(|s| s.crate_name),
+            Some("cargo-xwin")
+        );
     }
 }


### PR DESCRIPTION
Part of meta #598 — the audit surfaced that `docs/CROSS_COMPILE.md` recommends \`cargo-zigbuild\` and \`cargo-xwin\` but neither was in \`known_tools\`. This PR closes that docs/code inconsistency.

## What changes

- **\`crates/soldr-cli/src/fetch/known_tools.rs\`** — adds two \`ToolSpec\` entries:
  - \`cargo-zigbuild\` → subcommand \`zigbuild\`, repo \`rust-cross/cargo-zigbuild\`
  - \`cargo-xwin\` → subcommand \`xwin\`, repo \`rust-cross/cargo-xwin\`
  Both follow soldr's standard release-asset naming so no tag prefix or version pin is needed.
- **\`CLAUDE.md\`** — updates the "Ecosystem fetches" list to include \`zigbuild\` and \`xwin\` alongside the existing cargo subcommands.

## Effect

- \`soldr cargo zigbuild build --target x86_64-unknown-linux-gnu\` and \`soldr cargo xwin build --target x86_64-pc-windows-msvc\` now follow the explicit registry path (cached crate name → pinned repo → GitHub Releases) instead of the slower crates.io lookup fallback.
- The "tools just work" promise the docs already made now actually holds.

## Tests (10/10 pass)

Two new tests assert the registry contract — crate name, subcommand, binary name, repo override:

- \`cargo_zigbuild_is_registered_for_cross_compile_docs_alignment\`
- \`cargo_xwin_is_registered_for_cross_compile_docs_alignment\`

Plus the existing \`known_tools_are_unique_by_crate_and_subcommand\` regression guard catches collisions.

## Test plan

- [x] \`cargo test -p soldr-cli --bin soldr known_tools\` — 10/10 pass
- [x] \`cargo clippy -p soldr-cli --bins --tests -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test -p soldr-cli --test timed_test_lint\` clean

Refs #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)