### PR TITLE
chore(serialization): migrate daemon IPC + redb persistent rows from bincode to Protocol Buffers (#580)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,17 @@ The repo builds itself through soldr so every contributor populates and hits the
 - `.claude/hooks/tool_guard.py` is a `PreToolUse` guard wired in `.claude/settings.json`. It denies bare `cargo`, `rustc`, `rustfmt`, `clippy-driver`, `cargo-clippy`, `cargo-fmt`, `python`, `python3`, `pip`, `pip3` in Claude Code shell tools. Route through `soldr cargo ...` / `uv run ...` / `uv pip ...` to satisfy it.
 - Unit tests for the hook live next to it: `uv run --no-project --directory .claude/hooks python -m unittest test_tool_guard`. The `--directory` flag puts `tool_guard.py` on `sys.path` so the sibling import resolves.
 
+## Serialization (issue #580)
+
+- **Binary transports and persisted-state metadata MUST use Protocol Buffers** (via `prost`), not `bincode` / `rmp-serde` / other schema-less formats. The wire schemas live as hand-written `#[derive(prost::Message)]` types beside a `.proto` file that documents them — see `crates/soldr-cli/src/daemon/wire.rs` + `wire.proto` and `crates/soldr-cli/src/rust_plan_proto.rs` + `rust_plan_manifest.proto` for the existing pattern. The schema file is the source of truth; round-trip unit tests catch drift.
+- **Daemon IPC** (`crates/soldr-cli/src/daemon/{protocol,ipc,wire}.rs`) carries prost-encoded `WireRequest` / `WireResponse` in the frame body. The header is unchanged from prior versions; `PROTOCOL_VERSION` is bumped on every body-format change so peers at different versions error cleanly rather than silently mis-decoding.
+- **Persistent redb rows** added on or after #580 are tagged-byte: `[0x01][prost body]`. Readers classify the leading byte — `0x01` strips and prost-decodes, anything else falls through to a `bincode::deserialize` legacy decoder so rows written by pre-#580 daemons still resolve. The classifier lives in `crate::daemon::wire::classify_redb_row`. The `cook_index` table uses dual versioning (`cook_index_v1` bincode-only, `cook_index_v2` prost-only) instead of tagged-byte; new writes always go to v2, reads consult v2 then v1.
+- **`bincode` is on the way out** but not gone yet. The only acceptable bincode call sites are:
+  1. The redb legacy-fallback decoders that exist solely to read pre-#580 rows (`crate::daemon::db` + `crate::cache_lib::cook_index` v1 fallback paths).
+  2. The `LegacyZccacheDaemonLink` shim in `crate::daemon::db` for the even-older pre-#265 row shape.
+- **Human-edited config (`config.toml`, `rust-toolchain.toml`) stays JSON/TOML.** Protobuf mandate applies only to binary transports + archived metadata.
+- **Lint enforcement** of "no new bincode usage outside the legacy modules" is a follow-up (see the issue tracker). Until that lands, treat the rule above as the convention; new modules that touch persistent storage or IPC must use prost.
+
 ## Test Infrastructure
 
 - **Per-test watchdog (`timed_test!`)**: Tests must be declared with the `timed_test!` macro from `soldr_cli::test_util`. The default deadline is **2 minutes**; pass a `Duration` as the second argument to override (e.g. `timed_test!(name, Duration::from_secs(300), { ... })`). If the body does not return in time the watchdog prints `TEST HUNG (>Ns): <name>` plus a backtrace to stderr and aborts the test binary, guaranteeing a single hung test cannot block the whole suite. Implementation: `crates/soldr-cli/src/test_util.rs`. The self-test feature `test-watchdog-self-test` plus the `#[ignore]`d `deliberate_hang` cases verify the abort path end-to-end.

--- a/crates/soldr-cli/src/cache_lib/cook_index.rs
+++ b/crates/soldr-cli/src/cache_lib/cook_index.rs
@@ -8,7 +8,7 @@
 //! this module never reads or writes the artifact bytes themselves —
 //! it only tracks where they are and how big they are.
 //!
-//! Key tuple (bincode-serialized blob, used as the redb key):
+//! Key tuple (prost-encoded blob, used as the redb key):
 //!
 //! ```text
 //! (recipe_hash: [u8; 32], target_triple, profile, channel, rustc_version)
@@ -18,26 +18,38 @@
 //! triple/profile/channel/rustc in the key — there is no code path
 //! that can relax this without changing the schema.
 //!
-//! ## Wire compatibility
+//! ## Table versioning
 //!
-//! Table name is `cook_index_v1`. A future schema change MUST land as
-//! `cook_index_v2` rather than mutating the v1 table, so old daemons
-//! and old soldr binaries that resume an upgraded state.redb fall
-//! back gracefully.
+//! * `cook_index_v1` — the bincode-formatted table shipped in #582
+//!   (cook-index intro). New writes never land here; reads still
+//!   succeed during the v2 lookup miss fallback so any user who
+//!   indexed a few artifacts pre-#580 still gets cache hits.
+//! * `cook_index_v2` — the prost-formatted table introduced by
+//!   #580. All new writes land here. Keys are bare prost encoding
+//!   (no tag byte — the entire table is one format), values are
+//!   tagged-byte prost (matches the daemon `state.redb` convention).
+//!
+//! A future schema change MUST land as `cook_index_v3` rather than
+//! mutating v2 in place.
 
 use crate::cache_lib::target_registry::RegistryError;
+use crate::daemon::protocol::WireDecodeError;
+use crate::daemon::wire::{classify_redb_row, prost_tagged_bytes, proto, RedbDecode};
+use prost::Message;
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-/// redb table name. Bumping this for schema breaks (rare) — additive
-/// changes use the existing key/value bincode schema.
 const COOK_INDEX_V1: TableDefinition<&[u8], &[u8]> = TableDefinition::new("cook_index_v1");
+const COOK_INDEX_V2: TableDefinition<&[u8], &[u8]> = TableDefinition::new("cook_index_v2");
 
 /// Lookup key for the cook artifact index. Cross-target sharing is
 /// forbidden by including triple/profile/channel/rustc in the key —
 /// two builds that differ on any of these resolve to different rows
 /// regardless of recipe_hash.
+///
+/// Kept `Serialize + Deserialize` so the v1 (bincode) read-fallback
+/// path in [`lookup`] can still decode old keys.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct CookKey {
     pub recipe_hash: [u8; 32],
@@ -68,6 +80,14 @@ fn bincode_err(e: bincode::Error) -> RegistryError {
     RegistryError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
 }
 
+fn prost_decode_err(e: prost::DecodeError) -> RegistryError {
+    RegistryError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+fn wire_err(e: WireDecodeError) -> RegistryError {
+    RegistryError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
 fn open_db(path: &Path) -> Result<Database, RegistryError> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -80,75 +100,168 @@ fn init_table(db: &Database) -> Result<(), RegistryError> {
     let txn = db.begin_write()?;
     {
         let _ = txn.open_table(COOK_INDEX_V1)?;
+        let _ = txn.open_table(COOK_INDEX_V2)?;
     }
     txn.commit()?;
     Ok(())
 }
 
-/// Idempotent: open the `state.redb` file and ensure `cook_index_v1`
-/// exists. Other helpers call this internally; callers (e.g. daemon
-/// startup) can use it to eager-create the table.
+/// Idempotent: open the `state.redb` file and ensure both `cook_index_v1`
+/// and `cook_index_v2` exist. Callers (e.g. daemon startup) can use it
+/// to eager-create the tables.
 pub fn ensure_initialized(db_path: &Path) -> Result<(), RegistryError> {
     let db = open_db(db_path)?;
     init_table(&db)
 }
 
-fn encode_key(key: &CookKey) -> Result<Vec<u8>, RegistryError> {
+// =========================================================================
+// Encoding helpers
+// =========================================================================
+
+fn cook_key_to_wire(key: &CookKey) -> proto::WireCookKey {
+    proto::WireCookKey {
+        recipe_hash: key.recipe_hash.to_vec(),
+        target_triple: key.target_triple.clone(),
+        profile: key.profile.clone(),
+        channel: key.channel.clone(),
+        rustc_version: key.rustc_version.clone(),
+    }
+}
+
+fn cook_key_from_wire(wire: proto::WireCookKey) -> Result<CookKey, WireDecodeError> {
+    if wire.recipe_hash.len() != 32 {
+        return Err(WireDecodeError::InvalidShaLength(wire.recipe_hash.len()));
+    }
+    let mut recipe_hash = [0u8; 32];
+    recipe_hash.copy_from_slice(&wire.recipe_hash);
+    Ok(CookKey {
+        recipe_hash,
+        target_triple: wire.target_triple,
+        profile: wire.profile,
+        channel: wire.channel,
+        rustc_version: wire.rustc_version,
+    })
+}
+
+fn cook_entry_to_wire(entry: &CookEntry) -> proto::WireCookEntry {
+    proto::WireCookEntry {
+        sha256: entry.sha256.to_vec(),
+        size_bytes: entry.size_bytes,
+        created_unix_ms: entry.created_unix_ms,
+        last_used_unix_ms: entry.last_used_unix_ms,
+        origin_url_normalized: entry.origin_url_normalized.clone(),
+        cook_cmd_summary: entry.cook_cmd_summary.clone(),
+    }
+}
+
+fn cook_entry_from_wire(wire: proto::WireCookEntry) -> Result<CookEntry, WireDecodeError> {
+    if wire.sha256.len() != 32 {
+        return Err(WireDecodeError::InvalidShaLength(wire.sha256.len()));
+    }
+    let mut sha256 = [0u8; 32];
+    sha256.copy_from_slice(&wire.sha256);
+    Ok(CookEntry {
+        sha256,
+        size_bytes: wire.size_bytes,
+        created_unix_ms: wire.created_unix_ms,
+        last_used_unix_ms: wire.last_used_unix_ms,
+        origin_url_normalized: wire.origin_url_normalized,
+        cook_cmd_summary: wire.cook_cmd_summary,
+    })
+}
+
+/// Encode a key as bare prost bytes — no tag prefix because the
+/// entire v2 table is one format.
+fn encode_key_v2(key: &CookKey) -> Vec<u8> {
+    let wire = cook_key_to_wire(key);
+    let mut out = Vec::with_capacity(wire.encoded_len());
+    wire.encode(&mut out).expect("Vec write is infallible");
+    out
+}
+
+fn decode_key_v2(bytes: &[u8]) -> Result<CookKey, RegistryError> {
+    let wire = proto::WireCookKey::decode(bytes).map_err(prost_decode_err)?;
+    cook_key_from_wire(wire).map_err(wire_err)
+}
+
+fn decode_entry_tagged(bytes: &[u8]) -> Result<CookEntry, RegistryError> {
+    match classify_redb_row(bytes) {
+        RedbDecode::Prost(rest) => {
+            let wire = proto::WireCookEntry::decode(rest).map_err(prost_decode_err)?;
+            cook_entry_from_wire(wire).map_err(wire_err)
+        }
+        RedbDecode::LegacyBincode(bytes) => {
+            // Shouldn't happen in v2 (we always tag), but if a row was
+            // hand-edited or migrated incorrectly, fall through to the
+            // v1-shape bincode decoder for self-healing.
+            bincode::deserialize::<CookEntry>(bytes).map_err(bincode_err)
+        }
+    }
+}
+
+/// v1 key/value decoders: pure bincode, no tag. Used only by the
+/// migration-fallback read path.
+fn encode_key_v1(key: &CookKey) -> Result<Vec<u8>, RegistryError> {
     bincode::serialize(key).map_err(bincode_err)
 }
 
-fn decode_entry(bytes: &[u8]) -> Result<CookEntry, RegistryError> {
-    bincode::deserialize(bytes).map_err(bincode_err)
+fn decode_key_v1(bytes: &[u8]) -> Result<CookKey, RegistryError> {
+    bincode::deserialize::<CookKey>(bytes).map_err(bincode_err)
 }
 
-fn encode_entry(entry: &CookEntry) -> Result<Vec<u8>, RegistryError> {
-    bincode::serialize(entry).map_err(bincode_err)
+fn decode_entry_v1(bytes: &[u8]) -> Result<CookEntry, RegistryError> {
+    bincode::deserialize::<CookEntry>(bytes).map_err(bincode_err)
 }
 
-fn decode_key(bytes: &[u8]) -> Result<CookKey, RegistryError> {
-    bincode::deserialize(bytes).map_err(bincode_err)
-}
+// =========================================================================
+// Public surface
+// =========================================================================
 
-/// Upsert a cook artifact entry. PR 2's `soldr cook` worker calls
-/// this via the daemon `CookRecord` IPC after the tarball has been
-/// written to `~/.soldr/cache/cook/<sha256>.tar.zst`.
+/// Upsert a cook artifact entry. Always writes to `cook_index_v2`
+/// (prost format).
 pub fn upsert(db_path: &Path, key: &CookKey, entry: &CookEntry) -> Result<(), RegistryError> {
     let db = open_db(db_path)?;
     init_table(&db)?;
-    let key_bytes = encode_key(key)?;
-    let value_bytes = encode_entry(entry)?;
+    let key_bytes = encode_key_v2(key);
+    let value_bytes = prost_tagged_bytes(&cook_entry_to_wire(entry));
     let txn = db.begin_write()?;
     {
-        let mut table = txn.open_table(COOK_INDEX_V1)?;
+        let mut table = txn.open_table(COOK_INDEX_V2)?;
         table.insert(key_bytes.as_slice(), value_bytes.as_slice())?;
     }
     txn.commit()?;
     Ok(())
 }
 
-/// Look up a single entry by the full key tuple. PR 3's cargo-
-/// front-door pre-flight calls this via the daemon `CookLookup` IPC.
+/// Look up a single entry by the full key tuple. Tries `cook_index_v2`
+/// first; on miss, falls back to `cook_index_v1` so rows written by
+/// pre-#580 daemons still resolve. A v1 hit is NOT auto-migrated into
+/// v2 (would require a write transaction on every read) — the next
+/// `upsert` for the key naturally migrates it.
 pub fn lookup(db_path: &Path, key: &CookKey) -> Result<Option<CookEntry>, RegistryError> {
     let db = open_db(db_path)?;
     init_table(&db)?;
-    let key_bytes = encode_key(key)?;
+    let key_v2 = encode_key_v2(key);
     let txn = db.begin_read()?;
+    {
+        let table = txn.open_table(COOK_INDEX_V2)?;
+        if let Some(row) = table.get(key_v2.as_slice())? {
+            return Ok(Some(decode_entry_tagged(row.value())?));
+        }
+    }
+    // v1 fallback.
+    let key_v1 = encode_key_v1(key)?;
     let table = txn.open_table(COOK_INDEX_V1)?;
-    let Some(row) = table.get(key_bytes.as_slice())? else {
+    let Some(row) = table.get(key_v1.as_slice())? else {
         return Ok(None);
     };
-    Ok(Some(decode_entry(row.value())?))
+    Ok(Some(decode_entry_v1(row.value())?))
 }
 
-/// Drift diagnostic: given a (missing) lookup key, scan the table for
-/// other rows whose `(origin_url_normalized, target_triple, profile,
-/// channel, rustc_version)` match — but whose `recipe_hash` differs.
-/// Returns up to `limit` previous recipe hashes, useful as the
-/// "previous_origin_recipe_hashes" diagnostic in `CookMiss`.
-///
-/// When `origin_url_normalized` is `None`, drift diagnostic is
-/// skipped (returns empty) — without an origin hint we have no way to
-/// know which other rows "belong to the same repo".
+/// Drift diagnostic: given a (missing) lookup key, scan v2 then v1
+/// for other rows whose `(origin_url_normalized, target_triple,
+/// profile, channel, rustc_version)` match — but whose `recipe_hash`
+/// differs. Returns up to `limit` previous recipe hashes, newest-first.
 pub fn drift_recipe_hashes(
     db_path: &Path,
     miss_key: &CookKey,
@@ -161,74 +274,115 @@ pub fn drift_recipe_hashes(
     let db = open_db(db_path)?;
     init_table(&db)?;
     let txn = db.begin_read()?;
-    let table = txn.open_table(COOK_INDEX_V1)?;
     let mut out: Vec<([u8; 32], u64)> = Vec::new();
-    for entry in table.iter()? {
-        let (k_bytes, v_bytes) = entry?;
-        let stored_key = match decode_key(k_bytes.value()) {
-            Ok(k) => k,
-            Err(_) => continue,
-        };
-        if stored_key.recipe_hash == miss_key.recipe_hash {
-            continue;
+
+    // v2 scan.
+    {
+        let table = txn.open_table(COOK_INDEX_V2)?;
+        for entry in table.iter()? {
+            let (k_bytes, v_bytes) = entry?;
+            let Ok(stored_key) = decode_key_v2(k_bytes.value()) else {
+                continue;
+            };
+            if !key_matches_origin_matrix(&stored_key, miss_key) {
+                continue;
+            }
+            let Ok(stored_entry) = decode_entry_tagged(v_bytes.value()) else {
+                continue;
+            };
+            if stored_entry.origin_url_normalized.as_deref() != Some(origin) {
+                continue;
+            }
+            out.push((stored_key.recipe_hash, stored_entry.last_used_unix_ms));
         }
-        if stored_key.target_triple != miss_key.target_triple
-            || stored_key.profile != miss_key.profile
-            || stored_key.channel != miss_key.channel
-            || stored_key.rustc_version != miss_key.rustc_version
-        {
-            continue;
-        }
-        let stored_entry = match decode_entry(v_bytes.value()) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        if stored_entry.origin_url_normalized.as_deref() != Some(origin) {
-            continue;
-        }
-        out.push((stored_key.recipe_hash, stored_entry.last_used_unix_ms));
     }
+
+    // v1 scan (pre-#580 rows).
+    {
+        let table = txn.open_table(COOK_INDEX_V1)?;
+        for entry in table.iter()? {
+            let (k_bytes, v_bytes) = entry?;
+            let Ok(stored_key) = decode_key_v1(k_bytes.value()) else {
+                continue;
+            };
+            if !key_matches_origin_matrix(&stored_key, miss_key) {
+                continue;
+            }
+            let Ok(stored_entry) = decode_entry_v1(v_bytes.value()) else {
+                continue;
+            };
+            if stored_entry.origin_url_normalized.as_deref() != Some(origin) {
+                continue;
+            }
+            out.push((stored_key.recipe_hash, stored_entry.last_used_unix_ms));
+        }
+    }
+
     out.sort_by(|a, b| b.1.cmp(&a.1));
     out.truncate(limit);
     Ok(out.into_iter().map(|(h, _)| h).collect())
 }
 
-/// Bump the `last_used_unix_ms` field for the entry whose
-/// `sha256` matches. Fire-and-forget by PR 3: a touch failure must
-/// never affect callers. Returns `Ok(true)` when a row was bumped,
-/// `Ok(false)` when no matching row exists.
-///
-/// Implementation note: this is O(N) over the index because the
-/// primary key is `CookKey`, not `sha256`. PR 1 ships dormant and PR
-/// 3's pre-flight is the only `CookTouch` caller; a secondary index
-/// can be added later if measurements show it matters.
+fn key_matches_origin_matrix(stored: &CookKey, miss: &CookKey) -> bool {
+    if stored.recipe_hash == miss.recipe_hash {
+        return false;
+    }
+    stored.target_triple == miss.target_triple
+        && stored.profile == miss.profile
+        && stored.channel == miss.channel
+        && stored.rustc_version == miss.rustc_version
+}
+
+/// Bump the `last_used_unix_ms` field for the entry whose `sha256`
+/// matches. Scans v2 + v1 and updates whichever table holds the row
+/// (no cross-table migration — see [`lookup`] for the rationale).
 pub fn touch(db_path: &Path, sha256: &[u8; 32], now_unix_ms: u64) -> Result<bool, RegistryError> {
     let db = open_db(db_path)?;
     init_table(&db)?;
-    let mut updates: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let mut v2_updates: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let mut v1_updates: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
     {
         let txn = db.begin_read()?;
-        let table = txn.open_table(COOK_INDEX_V1)?;
+        // v2 scan.
+        let table = txn.open_table(COOK_INDEX_V2)?;
         for entry in table.iter()? {
             let (k_bytes, v_bytes) = entry?;
-            let mut value = match decode_entry(v_bytes.value()) {
-                Ok(v) => v,
-                Err(_) => continue,
+            let Ok(mut value) = decode_entry_tagged(v_bytes.value()) else {
+                continue;
             };
             if &value.sha256 == sha256 {
                 value.last_used_unix_ms = now_unix_ms;
-                let new_v = encode_entry(&value)?;
-                updates.push((k_bytes.value().to_vec(), new_v));
+                let new_v = prost_tagged_bytes(&cook_entry_to_wire(&value));
+                v2_updates.push((k_bytes.value().to_vec(), new_v));
+            }
+        }
+        // v1 scan.
+        let table = txn.open_table(COOK_INDEX_V1)?;
+        for entry in table.iter()? {
+            let (k_bytes, v_bytes) = entry?;
+            let Ok(mut value) = decode_entry_v1(v_bytes.value()) else {
+                continue;
+            };
+            if &value.sha256 == sha256 {
+                value.last_used_unix_ms = now_unix_ms;
+                let new_v = bincode::serialize(&value).map_err(bincode_err)?;
+                v1_updates.push((k_bytes.value().to_vec(), new_v));
             }
         }
     }
-    if updates.is_empty() {
+    if v2_updates.is_empty() && v1_updates.is_empty() {
         return Ok(false);
     }
     let txn = db.begin_write()?;
     {
+        let mut table = txn.open_table(COOK_INDEX_V2)?;
+        for (k, v) in &v2_updates {
+            table.insert(k.as_slice(), v.as_slice())?;
+        }
+    }
+    {
         let mut table = txn.open_table(COOK_INDEX_V1)?;
-        for (k, v) in &updates {
+        for (k, v) in &v1_updates {
             table.insert(k.as_slice(), v.as_slice())?;
         }
     }
@@ -237,19 +391,32 @@ pub fn touch(db_path: &Path, sha256: &[u8; 32], now_unix_ms: u64) -> Result<bool
 }
 
 /// Aggregate statistics surfaced via `Status` and `soldr daemon
-/// status`: returns `(entry_count, total_size_bytes)`.
+/// status`: returns `(entry_count, total_size_bytes)`. Sums both v2
+/// and v1 tables.
 pub fn stats(db_path: &Path) -> Result<(u64, u64), RegistryError> {
     let db = open_db(db_path)?;
     init_table(&db)?;
     let txn = db.begin_read()?;
-    let table = txn.open_table(COOK_INDEX_V1)?;
     let mut count: u64 = 0;
     let mut total: u64 = 0;
-    for entry in table.iter()? {
-        let (_, v_bytes) = entry?;
-        if let Ok(decoded) = decode_entry(v_bytes.value()) {
-            count = count.saturating_add(1);
-            total = total.saturating_add(decoded.size_bytes);
+    {
+        let table = txn.open_table(COOK_INDEX_V2)?;
+        for entry in table.iter()? {
+            let (_, v_bytes) = entry?;
+            if let Ok(decoded) = decode_entry_tagged(v_bytes.value()) {
+                count = count.saturating_add(1);
+                total = total.saturating_add(decoded.size_bytes);
+            }
+        }
+    }
+    {
+        let table = txn.open_table(COOK_INDEX_V1)?;
+        for entry in table.iter()? {
+            let (_, v_bytes) = entry?;
+            if let Ok(decoded) = decode_entry_v1(v_bytes.value()) {
+                count = count.saturating_add(1);
+                total = total.saturating_add(decoded.size_bytes);
+            }
         }
     }
     Ok((count, total))
@@ -299,7 +466,6 @@ mod tests {
     });
 
     crate::timed_test!(per_target_safety_isolates_rows, {
-        // Same recipe hash, different target triple — must NOT collide.
         let dir = TempDir::new().expect("tempdir");
         let path = dir.path().join("state.redb");
         let mut a = sample_key(3);
@@ -337,9 +503,6 @@ mod tests {
             let dir = TempDir::new().expect("tempdir");
             let path = dir.path().join("state.redb");
             let origin = "https://github.com/zackees/soldr";
-
-            // Two prior entries, same origin/triple/profile/channel/rustc,
-            // but different recipe hashes.
             let key_a = sample_key(5);
             let key_b = sample_key(6);
             let mut entry_a = sample_entry(0xA1, 10, Some(origin));
@@ -348,13 +511,10 @@ mod tests {
             entry_b.last_used_unix_ms = 200;
             upsert(&path, &key_a, &entry_a).expect("upsert a");
             upsert(&path, &key_b, &entry_b).expect("upsert b");
-
-            // Lookup for a different recipe hash (miss). Drift should
-            // return both prior hashes, newest-first.
             let miss = sample_key(7);
             let drift = drift_recipe_hashes(&path, &miss, Some(origin), 10).expect("drift");
             assert_eq!(drift.len(), 2);
-            assert_eq!(drift[0], [6u8; 32]); // b.last_used=200 → newest first
+            assert_eq!(drift[0], [6u8; 32]);
             assert_eq!(drift[1], [5u8; 32]);
         }
     );
@@ -363,15 +523,12 @@ mod tests {
         let dir = TempDir::new().expect("tempdir");
         let path = dir.path().join("state.redb");
         let origin = "https://github.com/zackees/soldr";
-
         let mut same_origin_diff_triple = sample_key(10);
         same_origin_diff_triple.target_triple = "aarch64-apple-darwin".into();
         let same_origin_diff_triple_entry = sample_entry(0x11, 1, Some(origin));
-
         let mut diff_origin = sample_key(11);
         diff_origin.target_triple = "x86_64-unknown-linux-gnu".into();
         let diff_origin_entry = sample_entry(0x22, 1, Some("https://github.com/other/repo"));
-
         upsert(
             &path,
             &same_origin_diff_triple,
@@ -379,7 +536,6 @@ mod tests {
         )
         .expect("upsert sodt");
         upsert(&path, &diff_origin, &diff_origin_entry).expect("upsert do");
-
         let mut miss = sample_key(12);
         miss.target_triple = "x86_64-unknown-linux-gnu".into();
         let drift = drift_recipe_hashes(&path, &miss, Some(origin), 10).expect("drift");
@@ -437,5 +593,50 @@ mod tests {
         ensure_initialized(&path).expect("init 2");
         let (count, total) = stats(&path).expect("stats");
         assert_eq!((count, total), (0, 0));
+    });
+
+    /// Write a v1-shaped row directly. Drops the db handle on return
+    /// so the subsequent `lookup` call can open the same file.
+    fn insert_v1_row(path: &Path, key: &CookKey, entry: &CookEntry) {
+        let db = open_db(path).expect("open");
+        init_table(&db).expect("init");
+        let key_v1 = encode_key_v1(key).expect("encode v1 key");
+        let value_v1 = bincode::serialize(entry).expect("serialize v1");
+        let txn = db.begin_write().expect("begin write");
+        {
+            let mut table = txn.open_table(COOK_INDEX_V1).expect("open v1");
+            table
+                .insert(key_v1.as_slice(), value_v1.as_slice())
+                .expect("insert v1");
+        }
+        txn.commit().expect("commit");
+        drop(db);
+    }
+
+    // Reading a pre-#580 row written directly into `cook_index_v1`
+    // with bincode still resolves. Guards the v1 fallback path.
+    crate::timed_test!(v1_bincode_row_still_resolves_via_lookup, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        let key = sample_key(99);
+        let entry = sample_entry(0x99, 7777, Some("https://legacy.example/repo"));
+        insert_v1_row(&path, &key, &entry);
+        let got = lookup(&path, &key).expect("lookup").expect("hit");
+        assert_eq!(got, entry);
+    });
+
+    // Tag-byte hygiene: every v2 value blob starts with 0x01.
+    crate::timed_test!(v2_value_blobs_carry_the_prost_tag, {
+        use crate::daemon::wire::REDB_TAG_PROST;
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        upsert(&path, &sample_key(50), &sample_entry(0x50, 1, None)).expect("upsert");
+        let db = open_db(&path).expect("open");
+        let txn = db.begin_read().expect("read");
+        let table = txn.open_table(COOK_INDEX_V2).expect("v2");
+        for entry in table.iter().expect("iter") {
+            let (_, v) = entry.expect("entry");
+            assert_eq!(v.value()[0], REDB_TAG_PROST);
+        }
     });
 }

--- a/crates/soldr-cli/src/daemon/db.rs
+++ b/crates/soldr-cli/src/daemon/db.rs
@@ -4,16 +4,43 @@
 //! and the wrapper / GC tools open the same file directly.
 //!
 //! Tables live alongside the existing `target_registry_targets`:
-//! - `daemon_builds`  : u64 session_id → bincoded BuildRecord
-//! - `daemon_events`  : u64 event_id   → bincoded Event
+//! - `daemon_builds`  : u64 session_id → tagged-byte BuildRecord
+//! - `daemon_events`  : u64 event_id   → tagged-byte Event
 //! - `daemon_meta`    : `&str` key     → u64 (next event id, ...)
-//! - `daemon_zccache_link` : `&str` key → bincoded ZccacheDaemonLink
+//! - `daemon_zccache_link` : `&str` key → tagged-byte ZccacheDaemonLink
+//!
+//! ## Serialization migration (issue #580)
+//!
+//! Every value written by this module is now `[0x01 tag][prost body]`
+//! (see [`crate::daemon::wire::REDB_TAG_PROST`] +
+//! [`crate::daemon::wire::prost_tagged_bytes`]). Reads classify the
+//! first byte:
+//!
+//! * `0x01` → strip the tag and prost-decode (the new format).
+//! * Anything else → bincode-deserialize the full slice (the legacy
+//!   format that pre-#580 daemons wrote into the same tables).
+//!
+//! The `LegacyZccacheDaemonLink` shim from #265 remains in place as a
+//! second-stage fallback under the bincode branch — it covers the
+//! even-older "before-private-daemon" shape that lacks fields the
+//! current `ZccacheDaemonLink` adds. So a redb row from ANY soldr
+//! version this codebase has ever shipped still decodes.
 
 use crate::cache_lib::target_registry::RegistryError;
-use crate::daemon::protocol::{BuildRecord, ZccacheDaemonLink};
+use crate::daemon::protocol::{BuildRecord, WireDecodeError, ZccacheDaemonLink};
+use crate::daemon::wire::{self, classify_redb_row, prost_tagged_bytes, RedbDecode};
+use prost::Message;
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+
+fn wire_err(e: WireDecodeError) -> RegistryError {
+    RegistryError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+fn prost_decode_err(e: prost::DecodeError) -> RegistryError {
+    RegistryError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
 
 const BUILDS: TableDefinition<u64, &[u8]> = TableDefinition::new("daemon_builds");
 const EVENTS: TableDefinition<u64, &[u8]> = TableDefinition::new("daemon_events");
@@ -115,7 +142,7 @@ pub fn append_event(db_path: &Path, event: &Event) -> Result<(), RegistryError> 
     let db = open_db(db_path)?;
     init_tables(&db)?;
     let id = next_event_id(&db)?;
-    let bytes = bincode::serialize(event).map_err(bincode_err)?;
+    let bytes = prost_tagged_bytes(&wire::event_to_wire(event));
     let txn = db.begin_write()?;
     {
         let mut events = txn.open_table(EVENTS)?;
@@ -128,7 +155,7 @@ pub fn append_event(db_path: &Path, event: &Event) -> Result<(), RegistryError> 
 pub fn upsert_build(db_path: &Path, record: &BuildRecord) -> Result<(), RegistryError> {
     let db = open_db(db_path)?;
     init_tables(&db)?;
-    let bytes = bincode::serialize(record).map_err(bincode_err)?;
+    let bytes = prost_tagged_bytes(&wire::build_record_to_wire(record));
     let txn = db.begin_write()?;
     {
         let mut builds = txn.open_table(BUILDS)?;
@@ -146,8 +173,35 @@ pub fn get_build(db_path: &Path, session_id: u64) -> Result<Option<BuildRecord>,
     let Some(row) = builds.get(session_id)? else {
         return Ok(None);
     };
-    let record: BuildRecord = bincode::deserialize(row.value()).map_err(bincode_err)?;
-    Ok(Some(record))
+    Ok(Some(deserialize_build_record(row.value())?))
+}
+
+/// Read a `BuildRecord` from a redb row, dispatching on the leading
+/// tag byte. New rows (0x01) decode via prost; legacy bytes fall
+/// through to bincode.
+fn deserialize_build_record(bytes: &[u8]) -> Result<BuildRecord, RegistryError> {
+    match classify_redb_row(bytes) {
+        RedbDecode::Prost(rest) => {
+            let wire = wire::proto::WireBuildRecord::decode(rest).map_err(prost_decode_err)?;
+            Ok(wire::build_record_from_wire(wire))
+        }
+        RedbDecode::LegacyBincode(bytes) => {
+            bincode::deserialize::<BuildRecord>(bytes).map_err(bincode_err)
+        }
+    }
+}
+
+/// Read an `Event` from a redb row, with the same tag-byte dispatch.
+fn deserialize_event(bytes: &[u8]) -> Result<Event, RegistryError> {
+    match classify_redb_row(bytes) {
+        RedbDecode::Prost(rest) => {
+            let wire = wire::proto::WireEvent::decode(rest).map_err(prost_decode_err)?;
+            wire::event_from_wire(wire).map_err(wire_err)
+        }
+        RedbDecode::LegacyBincode(bytes) => {
+            bincode::deserialize::<Event>(bytes).map_err(bincode_err)
+        }
+    }
 }
 
 pub fn list_builds(
@@ -162,7 +216,7 @@ pub fn list_builds(
     let mut rows: Vec<BuildRecord> = Vec::new();
     for entry in builds.iter()? {
         let (_, v) = entry?;
-        let record: BuildRecord = bincode::deserialize(v.value()).map_err(bincode_err)?;
+        let record: BuildRecord = deserialize_build_record(v.value())?;
         if let Some(cutoff) = since_ms {
             if record.started_at_ms < cutoff {
                 continue;
@@ -187,7 +241,7 @@ pub fn list_slow_builds(
     let mut rows: Vec<BuildRecord> = Vec::new();
     for entry in builds.iter()? {
         let (_, v) = entry?;
-        let record: BuildRecord = bincode::deserialize(v.value()).map_err(bincode_err)?;
+        let record: BuildRecord = deserialize_build_record(v.value())?;
         if record.total_wall_ms.unwrap_or(0) >= threshold_ms {
             rows.push(record);
         }
@@ -215,7 +269,7 @@ pub fn aggregate_session(
     let mut slowest_name: Option<String> = None;
     for entry in events.iter()? {
         let (_, v) = entry?;
-        let event: Event = bincode::deserialize(v.value()).map_err(bincode_err)?;
+        let event: Event = deserialize_event(v.value())?;
         if event.session_id != Some(session_id) {
             continue;
         }
@@ -244,7 +298,7 @@ pub fn set_linked_zccache(
         let mut table = txn.open_table(ZCCACHE_LINK)?;
         match link {
             Some(link) => {
-                let bytes = bincode::serialize(link).map_err(bincode_err)?;
+                let bytes = prost_tagged_bytes(&wire::zccache_link_to_wire(link));
                 table.insert(LINKED_ZCCACHE_KEY, bytes.as_slice())?;
             }
             None => {
@@ -268,13 +322,28 @@ pub fn get_linked_zccache(db_path: &Path) -> Result<Option<ZccacheDaemonLink>, R
     Ok(Some(link))
 }
 
+/// Three-stage fallback decoder:
+///
+/// 1. `0x01` tag prefix → prost-decode (the #580 format new daemons write).
+/// 2. Bincode current `ZccacheDaemonLink` shape (pre-#580 daemons).
+/// 3. Bincode legacy [`LegacyZccacheDaemonLink`] shape lifted via `From`
+///    (pre-#265 even-older daemons that lacked private-daemon fields).
 fn deserialize_zccache_daemon_link(bytes: &[u8]) -> Result<ZccacheDaemonLink, RegistryError> {
-    match bincode::deserialize::<ZccacheDaemonLink>(bytes) {
-        Ok(link) => Ok(link),
-        Err(new_err) => match bincode::deserialize::<LegacyZccacheDaemonLink>(bytes) {
-            Ok(legacy) => Ok(legacy.into()),
-            Err(_) => Err(bincode_err(new_err)),
-        },
+    match classify_redb_row(bytes) {
+        RedbDecode::Prost(rest) => {
+            let wire =
+                wire::proto::WireZccacheDaemonLink::decode(rest).map_err(prost_decode_err)?;
+            Ok(wire::zccache_link_from_wire(wire))
+        }
+        RedbDecode::LegacyBincode(bytes) => {
+            match bincode::deserialize::<ZccacheDaemonLink>(bytes) {
+                Ok(link) => Ok(link),
+                Err(new_err) => match bincode::deserialize::<LegacyZccacheDaemonLink>(bytes) {
+                    Ok(legacy) => Ok(legacy.into()),
+                    Err(_) => Err(bincode_err(new_err)),
+                },
+            }
+        }
     }
 }
 
@@ -289,7 +358,7 @@ pub fn prune_events_older_than(db_path: &Path, cutoff_ms: i64) -> Result<u64, Re
         let events = txn.open_table(EVENTS)?;
         for entry in events.iter()? {
             let (k, v) = entry?;
-            let event: Event = bincode::deserialize(v.value()).map_err(bincode_err)?;
+            let event = deserialize_event(v.value())?;
             if event.ts_ms < cutoff_ms {
                 to_delete.push(k.value());
             }

--- a/crates/soldr-cli/src/daemon/ipc.rs
+++ b/crates/soldr-cli/src/daemon/ipc.rs
@@ -1,19 +1,61 @@
 //! Frame encoding/decoding for the daemon protocol. The sync helpers
 //! are used by the wrapper-side client (no tokio runtime on the hot
 //! path); the async helpers are used by the server.
+//!
+//! ## Wire shape (issue #580)
+//!
+//! The header is unchanged from prior versions:
+//!
+//! ```text
+//! [u32 LE body_len][u32 LE protocol_version][body]
+//! ```
+//!
+//! What changed in v5 is the **body**: it is now a prost-encoded
+//! `WireRequest` / `WireResponse` (see [`crate::daemon::wire`])
+//! instead of a bincode blob. The header version-check rejects
+//! cross-version traffic cleanly, so a v4 client can never silently
+//! mis-decode a v5 daemon's reply (or vice versa).
 
-use crate::daemon::protocol::{MAX_BODY_BYTES, PROTOCOL_VERSION};
-use serde::{de::DeserializeOwned, Serialize};
+use crate::daemon::protocol::{
+    Request, Response, WireDecodeError, MAX_BODY_BYTES, PROTOCOL_VERSION,
+};
+use crate::daemon::wire;
 use std::io::{self, Read, Write};
 
 const HEADER_BYTES: usize = 8;
 
-fn encoding_error(e: bincode::Error) -> io::Error {
+fn decode_error(e: WireDecodeError) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, e)
 }
 
-pub fn encode_frame<T: Serialize>(msg: &T) -> io::Result<Vec<u8>> {
-    let body = bincode::serialize(msg).map_err(encoding_error)?;
+/// Abstracts over Request/Response so encode/read helpers don't have
+/// to be split into four functions per direction. Each impl plugs in
+/// the appropriate prost encode/decode pair from [`crate::daemon::wire`].
+pub trait WireBody: Sized {
+    fn encode_wire(&self) -> Vec<u8>;
+    fn decode_wire(bytes: &[u8]) -> Result<Self, WireDecodeError>;
+}
+
+impl WireBody for Request {
+    fn encode_wire(&self) -> Vec<u8> {
+        wire::encode_request(self)
+    }
+    fn decode_wire(bytes: &[u8]) -> Result<Self, WireDecodeError> {
+        wire::decode_request(bytes)
+    }
+}
+
+impl WireBody for Response {
+    fn encode_wire(&self) -> Vec<u8> {
+        wire::encode_response(self)
+    }
+    fn decode_wire(bytes: &[u8]) -> Result<Self, WireDecodeError> {
+        wire::decode_response(bytes)
+    }
+}
+
+pub fn encode_frame<T: WireBody>(msg: &T) -> io::Result<Vec<u8>> {
+    let body = msg.encode_wire();
     if body.len() as u32 > MAX_BODY_BYTES {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -27,14 +69,14 @@ pub fn encode_frame<T: Serialize>(msg: &T) -> io::Result<Vec<u8>> {
     Ok(buf)
 }
 
-pub fn write_frame_sync<W: Write, T: Serialize>(w: &mut W, msg: &T) -> io::Result<()> {
+pub fn write_frame_sync<W: Write, T: WireBody>(w: &mut W, msg: &T) -> io::Result<()> {
     let frame = encode_frame(msg)?;
     w.write_all(&frame)?;
     w.flush()?;
     Ok(())
 }
 
-pub fn read_frame_sync<R: Read, T: DeserializeOwned>(r: &mut R) -> io::Result<T> {
+pub fn read_frame_sync<R: Read, T: WireBody>(r: &mut R) -> io::Result<T> {
     let mut header = [0u8; HEADER_BYTES];
     r.read_exact(&mut header)?;
     let body_len = u32::from_le_bytes(header[..4].try_into().expect("4 bytes"));
@@ -53,13 +95,13 @@ pub fn read_frame_sync<R: Read, T: DeserializeOwned>(r: &mut R) -> io::Result<T>
     }
     let mut body = vec![0u8; body_len as usize];
     r.read_exact(&mut body)?;
-    bincode::deserialize(&body).map_err(encoding_error)
+    T::decode_wire(&body).map_err(decode_error)
 }
 
 pub async fn write_frame_async<W, T>(w: &mut W, msg: &T) -> io::Result<()>
 where
     W: tokio::io::AsyncWrite + Unpin,
-    T: Serialize,
+    T: WireBody,
 {
     use tokio::io::AsyncWriteExt;
     let frame = encode_frame(msg)?;
@@ -71,7 +113,7 @@ where
 pub async fn read_frame_async<R, T>(r: &mut R) -> io::Result<T>
 where
     R: tokio::io::AsyncRead + Unpin,
-    T: DeserializeOwned,
+    T: WireBody,
 {
     use tokio::io::AsyncReadExt;
     let mut header = [0u8; HEADER_BYTES];
@@ -92,7 +134,7 @@ where
     }
     let mut body = vec![0u8; body_len as usize];
     r.read_exact(&mut body).await?;
-    bincode::deserialize(&body).map_err(encoding_error)
+    T::decode_wire(&body).map_err(decode_error)
 }
 
 #[cfg(test)]
@@ -130,6 +172,8 @@ mod tests {
 
     #[test]
     fn oversize_body_is_rejected_on_encode() {
+        // A very long path string blows past the 64 KiB body cap once
+        // prost varint-length-prefixes the string field.
         let blob = "x".repeat((MAX_BODY_BYTES + 1) as usize);
         let msg = Request::RecordTargetTouch {
             path: blob,

--- a/crates/soldr-cli/src/daemon/mod.rs
+++ b/crates/soldr-cli/src/daemon/mod.rs
@@ -25,4 +25,5 @@ pub mod ipc;
 pub mod lifecycle;
 pub mod protocol;
 pub mod server;
+pub mod wire;
 pub mod zccache_link;

--- a/crates/soldr-cli/src/daemon/protocol.rs
+++ b/crates/soldr-cli/src/daemon/protocol.rs
@@ -1,26 +1,56 @@
-//! Wire protocol for soldr-daemon — bincode-encoded, length-prefixed
-//! frames. Each frame on the wire is:
+//! Wire protocol for soldr-daemon — prost-encoded (Protocol Buffers),
+//! length-prefixed frames. Each frame on the wire is:
 //!
 //! ```text
-//! [u32 LE body_len][u32 LE protocol_version][bincode body]
+//! [u32 LE body_len][u32 LE protocol_version][prost body]
 //! ```
 //!
 //! `body_len` does NOT include the 4-byte version field. The body is a
-//! bincoded `Request` (client → server) or `Response` (server → client).
+//! prost-encoded `WireRequest` (client → server) or `WireResponse`
+//! (server → client) as defined in [`crate::daemon::wire`].
+//!
+//! The Rust public types in this module ([`Request`], [`Response`],
+//! [`StatusInfo`], ...) keep their existing shape and `serde` derives
+//! so the redb tagged-byte legacy decoder
+//! (`0x00` = bincode, `0x01` = prost — see [`crate::daemon::wire`])
+//! can still read rows written by pre-#580 daemons. The wire path
+//! ALWAYS uses prost; bincode survives only as the persistent-state
+//! fallback.
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// Protocol version bump rationale:
 ///
 /// * v1–v2: pre-PID-file lifecycle.
 /// * v3: target-touch + build-session correlation + linked-zccache.
-/// * v4 (this PR): adds cook-index IPC (CookLookup, CookRecord,
-///   CookTouch) + `cook_stats` on `StatusInfo`. Old clients/daemons
-///   on v3 cannot decode v4 frames and vice versa; the IPC layer
-///   rejects mismatched versions cleanly and the wrapper hot path's
-///   direct-redb fallback keeps builds from breaking during the
-///   short cross-version window after a `soldr` upgrade.
-pub const PROTOCOL_VERSION: u32 = 4;
+/// * v4: cook-index IPC (CookLookup, CookRecord, CookTouch) +
+///   `cook_stats` on `StatusInfo`. Bincode-bodied wire frames.
+/// * v5 (#580): wire body switches from bincode to prost (Protocol
+///   Buffers). The header layout is unchanged so the IPC version
+///   check still triggers on cross-version traffic. Old (v4) clients
+///   trying to talk to a v5 daemon (and vice versa) get a clean
+///   "protocol version mismatch" error rather than silent garbage;
+///   the wrapper hot path's direct-redb fallback keeps builds going
+///   during the cross-version window after a `soldr` upgrade.
+pub const PROTOCOL_VERSION: u32 = 5;
+
+/// Errors surfaced when decoding wire bytes into the public Rust
+/// types. Wraps prost decode failures plus the shape-validation cases
+/// proto3 cannot express (fixed-length byte arrays, non-empty oneofs).
+#[derive(Debug, Error)]
+pub enum WireDecodeError {
+    #[error("prost decode error: {0}")]
+    Prost(#[from] prost::DecodeError),
+    #[error("invalid SHA-256 length on the wire: expected 32 bytes, got {0}")]
+    InvalidShaLength(usize),
+    #[error("empty {0} oneof — payload missing a discriminant")]
+    EmptyOneof(&'static str),
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+    #[error("unknown event kind discriminant: {0}")]
+    UnknownEventKind(u32),
+}
 
 /// Maximum bincode body size. 64 KiB is comfortably above the largest
 /// realistic record (path strings, a few timestamps). Frames larger than
@@ -407,7 +437,7 @@ mod tests {
         assert!((bytes.len() as u32) <= MAX_BODY_BYTES);
     });
 
-    crate::timed_test!(protocol_version_is_v4_after_cook_index, {
-        assert_eq!(PROTOCOL_VERSION, 4);
+    crate::timed_test!(protocol_version_is_v5_after_prost_migration, {
+        assert_eq!(PROTOCOL_VERSION, 5);
     });
 }

--- a/crates/soldr-cli/src/daemon/wire.proto
+++ b/crates/soldr-cli/src/daemon/wire.proto
@@ -1,0 +1,213 @@
+// Wire schema for soldr-daemon IPC + redb-backed persistent state
+// (issue #580). The Rust types in `crates/soldr-cli/src/daemon/wire.rs`
+// are hand-written `#[derive(prost::Message)]` structs that mirror
+// this schema. The .proto file is the documentation source of truth;
+// keep the two in sync.
+//
+// Wire format (issue #580 migration):
+// * IPC frames carry a prost-encoded `WireRequest` or `WireResponse`.
+//   Old bincode frames are rejected by the IPC layer's
+//   `PROTOCOL_VERSION` check (bumped from 4 to 5 when this lands).
+// * redb values are written as `[u8 tag][prost bytes]` where
+//   `tag == 0x01` means "prost-encoded". The read path first tries
+//   to interpret the row as tagged; on tag-byte mismatch it falls
+//   back to the legacy bincode decoder for backwards-compat with
+//   rows written before this migration.
+
+syntax = "proto3";
+
+package soldr.daemon.v1;
+
+// =========================================================================
+// Request (client -> daemon)
+// =========================================================================
+
+message WireRequest {
+  oneof kind {
+    WireRecordTargetTouch record_target_touch = 1;
+    WireUnit status = 2;
+    WireUnit shutdown = 3;
+    WireBuildSessionStart build_session_start = 4;
+    WireBuildSessionEnd build_session_end = 5;
+    WireRecordCompile record_compile = 6;
+    WireListBuilds list_builds = 7;
+    WireListSlowBuilds list_slow_builds = 8;
+    WireLinkZccache link_zccache = 9;
+    WireCookLookup cook_lookup = 10;
+    WireCookRecord cook_record = 11;
+    WireCookTouch cook_touch = 12;
+  }
+}
+
+message WireUnit {}
+
+message WireRecordTargetTouch {
+  string path = 1;
+  int64 unix_seconds = 2;
+}
+
+message WireBuildSessionStart {
+  uint64 session_id = 1;
+  string repo_root = 2;
+  int64 started_at_ms = 3;
+}
+
+message WireBuildSessionEnd {
+  uint64 session_id = 1;
+  int32 exit_code = 2;
+  int64 ended_at_ms = 3;
+}
+
+message WireRecordCompile {
+  uint64 session_id = 1;
+  string crate_name = 2;
+  string target_dir = 3;
+  int64 started_at_ms = 4;
+  // Optional via prost's `optional` keyword (proto3 syntax).
+  optional uint64 duration_us = 5;
+}
+
+message WireListBuilds {
+  uint32 limit = 1;
+  optional int64 since_ms = 2;
+}
+
+message WireListSlowBuilds {
+  uint64 threshold_ms = 1;
+  uint32 limit = 2;
+}
+
+message WireLinkZccache {
+  WireZccacheDaemonLink link = 1;
+}
+
+message WireCookLookup {
+  bytes recipe_hash = 1;  // exactly 32 bytes; validated on decode
+  string target_triple = 2;
+  string profile = 3;
+  string channel = 4;
+  string rustc_version = 5;
+  optional string origin_url_normalized = 6;
+}
+
+message WireCookRecord {
+  bytes recipe_hash = 1;  // exactly 32 bytes
+  string target_triple = 2;
+  string profile = 3;
+  string channel = 4;
+  string rustc_version = 5;
+  bytes sha256 = 6;       // exactly 32 bytes
+  uint64 size_bytes = 7;
+  optional string origin_url_normalized = 8;
+  string cook_cmd_summary = 9;
+}
+
+message WireCookTouch {
+  bytes sha256 = 1;       // exactly 32 bytes
+}
+
+// =========================================================================
+// Response (daemon -> client)
+// =========================================================================
+
+message WireResponse {
+  oneof kind {
+    WireStatusInfo status = 1;
+    WireUnit shutting_down = 2;
+    WireBuilds builds = 3;
+    string error = 4;
+    WireCookHit cook_hit = 5;
+    WireCookMiss cook_miss = 6;
+    WireUnit ack = 7;
+  }
+}
+
+message WireBuilds {
+  repeated WireBuildRecord items = 1;
+}
+
+message WireCookHit {
+  bytes sha256 = 1;
+  string path = 2;
+  uint64 size_bytes = 3;
+  optional string origin_url_normalized = 4;
+}
+
+message WireCookMiss {
+  // Each element is exactly 32 bytes.
+  repeated bytes previous_origin_recipe_hashes = 1;
+}
+
+// =========================================================================
+// Shared persistent + status structures
+// =========================================================================
+
+message WireStatusInfo {
+  uint32 version = 1;
+  uint32 pid = 2;
+  uint64 uptime_secs = 3;
+  uint64 request_count = 4;
+  optional WireZccacheDaemonLink linked_zccache = 5;
+  optional WireCookStats cook_stats = 6;
+}
+
+message WireCookStats {
+  uint64 entries = 1;
+  uint64 total_bytes = 2;
+  uint64 hits_this_session = 3;
+}
+
+message WireZccacheDaemonLink {
+  string binary_path = 1;
+  string cache_dir = 2;
+  optional string session_id = 3;
+  string source = 4;
+  bool private_daemon = 5;
+  optional string daemon_name = 6;
+  optional uint32 owner_pid = 7;
+  repeated string private_env_keys = 8;
+}
+
+message WireBuildRecord {
+  uint64 session_id = 1;
+  string repo_root = 2;
+  int64 started_at_ms = 3;
+  optional int64 ended_at_ms = 4;
+  optional int32 exit_code = 5;
+  optional uint64 total_wall_ms = 6;
+  uint32 crate_count = 7;
+  optional uint64 slowest_crate_us = 8;
+  optional string slowest_crate_name = 9;
+}
+
+// =========================================================================
+// Redb-only persistent rows (issue #580 tagged-byte migration target)
+// =========================================================================
+
+message WireEvent {
+  int64 ts_ms = 1;
+  optional uint64 session_id = 2;
+  // 0=SessionStart, 1=SessionEnd, 2=CompileStart, 3=CompileEnd.
+  uint32 kind = 3;
+  optional string crate_name = 4;
+  optional uint64 duration_us = 5;
+  optional string target_dir = 6;
+  optional int32 exit_code = 7;
+}
+
+message WireCookKey {
+  bytes recipe_hash = 1;  // exactly 32 bytes
+  string target_triple = 2;
+  string profile = 3;
+  string channel = 4;
+  string rustc_version = 5;
+}
+
+message WireCookEntry {
+  bytes sha256 = 1;       // exactly 32 bytes
+  uint64 size_bytes = 2;
+  uint64 created_unix_ms = 3;
+  uint64 last_used_unix_ms = 4;
+  optional string origin_url_normalized = 5;
+  string cook_cmd_summary = 6;
+}

--- a/crates/soldr-cli/src/daemon/wire.rs
+++ b/crates/soldr-cli/src/daemon/wire.rs
@@ -1,0 +1,1091 @@
+//! Hand-written prost types + conversions for the daemon wire schema
+//! (issue #580). The `.proto` schema lives next door as
+//! [`wire.proto`](./wire.proto); keep the two in sync.
+//!
+//! ## Why hand-written instead of `prost-build`
+//!
+//! The repo already uses this pattern in `src/rust_plan_proto.rs`. It
+//! avoids the build.rs / `prost-build` toolchain dep, keeps generated
+//! source out of `OUT_DIR` (CI-visible), and matches the existing
+//! style. The schema is small enough that drift between the .proto
+//! and the .rs is caught by the round-trip unit tests below — every
+//! Rust ↔ wire ↔ Rust conversion is asserted equal.
+//!
+//! ## Backwards compatibility
+//!
+//! * **Wire path**: bumped `PROTOCOL_VERSION` from 4 to 5 in
+//!   [`crate::daemon::protocol`]. Old (v4 / bincode-bodied) frames
+//!   are rejected by the IPC version check before they reach
+//!   bincode-decode, so there is no silent format confusion.
+//! * **Redb path**: the persistent rows added by this issue use a
+//!   one-byte tag prefix — `0x01` means "prost-encoded body
+//!   follows". The read path tries the tagged decode first; on tag
+//!   mismatch (or any decode failure) it falls back to the legacy
+//!   bincode decoder so rows written before this migration still
+//!   round-trip.
+//!
+//! ## Sha32 type-safety
+//!
+//! proto3 has no fixed-length byte arrays — every hash is `bytes` on
+//! the wire and `Vec<u8>` in the generated Rust. The conversion
+//! helpers in this module validate exact-32-byte length on decode and
+//! return [`crate::daemon::protocol::WireDecodeError`] on mismatch,
+//! preserving the `[u8; 32]` type-level guarantee at the public API.
+
+use crate::daemon::db::{Event, EventKind};
+use crate::daemon::protocol::{
+    BuildRecord, CookStats, Request, Response, StatusInfo, WireDecodeError, ZccacheDaemonLink,
+};
+
+pub mod proto {
+    use prost::{Message, Oneof};
+
+    // -- Request ----------------------------------------------------------
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireRequest {
+        #[prost(oneof = "WireRequestKind", tags = "1,2,3,4,5,6,7,8,9,10,11,12")]
+        pub kind: Option<WireRequestKind>,
+    }
+
+    #[derive(Clone, PartialEq, Oneof)]
+    pub enum WireRequestKind {
+        #[prost(message, tag = "1")]
+        RecordTargetTouch(WireRecordTargetTouch),
+        #[prost(message, tag = "2")]
+        Status(WireUnit),
+        #[prost(message, tag = "3")]
+        Shutdown(WireUnit),
+        #[prost(message, tag = "4")]
+        BuildSessionStart(WireBuildSessionStart),
+        #[prost(message, tag = "5")]
+        BuildSessionEnd(WireBuildSessionEnd),
+        #[prost(message, tag = "6")]
+        RecordCompile(WireRecordCompile),
+        #[prost(message, tag = "7")]
+        ListBuilds(WireListBuilds),
+        #[prost(message, tag = "8")]
+        ListSlowBuilds(WireListSlowBuilds),
+        #[prost(message, tag = "9")]
+        LinkZccache(WireLinkZccache),
+        #[prost(message, tag = "10")]
+        CookLookup(WireCookLookup),
+        #[prost(message, tag = "11")]
+        CookRecord(WireCookRecord),
+        #[prost(message, tag = "12")]
+        CookTouch(WireCookTouch),
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireUnit {}
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireRecordTargetTouch {
+        #[prost(string, tag = "1")]
+        pub path: String,
+        #[prost(int64, tag = "2")]
+        pub unix_seconds: i64,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireBuildSessionStart {
+        #[prost(uint64, tag = "1")]
+        pub session_id: u64,
+        #[prost(string, tag = "2")]
+        pub repo_root: String,
+        #[prost(int64, tag = "3")]
+        pub started_at_ms: i64,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireBuildSessionEnd {
+        #[prost(uint64, tag = "1")]
+        pub session_id: u64,
+        #[prost(int32, tag = "2")]
+        pub exit_code: i32,
+        #[prost(int64, tag = "3")]
+        pub ended_at_ms: i64,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireRecordCompile {
+        #[prost(uint64, tag = "1")]
+        pub session_id: u64,
+        #[prost(string, tag = "2")]
+        pub crate_name: String,
+        #[prost(string, tag = "3")]
+        pub target_dir: String,
+        #[prost(int64, tag = "4")]
+        pub started_at_ms: i64,
+        #[prost(uint64, optional, tag = "5")]
+        pub duration_us: Option<u64>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireListBuilds {
+        #[prost(uint32, tag = "1")]
+        pub limit: u32,
+        #[prost(int64, optional, tag = "2")]
+        pub since_ms: Option<i64>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireListSlowBuilds {
+        #[prost(uint64, tag = "1")]
+        pub threshold_ms: u64,
+        #[prost(uint32, tag = "2")]
+        pub limit: u32,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireLinkZccache {
+        #[prost(message, optional, tag = "1")]
+        pub link: Option<WireZccacheDaemonLink>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireCookLookup {
+        #[prost(bytes = "vec", tag = "1")]
+        pub recipe_hash: Vec<u8>,
+        #[prost(string, tag = "2")]
+        pub target_triple: String,
+        #[prost(string, tag = "3")]
+        pub profile: String,
+        #[prost(string, tag = "4")]
+        pub channel: String,
+        #[prost(string, tag = "5")]
+        pub rustc_version: String,
+        #[prost(string, optional, tag = "6")]
+        pub origin_url_normalized: Option<String>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireCookRecord {
+        #[prost(bytes = "vec", tag = "1")]
+        pub recipe_hash: Vec<u8>,
+        #[prost(string, tag = "2")]
+        pub target_triple: String,
+        #[prost(string, tag = "3")]
+        pub profile: String,
+        #[prost(string, tag = "4")]
+        pub channel: String,
+        #[prost(string, tag = "5")]
+        pub rustc_version: String,
+        #[prost(bytes = "vec", tag = "6")]
+        pub sha256: Vec<u8>,
+        #[prost(uint64, tag = "7")]
+        pub size_bytes: u64,
+        #[prost(string, optional, tag = "8")]
+        pub origin_url_normalized: Option<String>,
+        #[prost(string, tag = "9")]
+        pub cook_cmd_summary: String,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireCookTouch {
+        #[prost(bytes = "vec", tag = "1")]
+        pub sha256: Vec<u8>,
+    }
+
+    // -- Response ---------------------------------------------------------
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireResponse {
+        #[prost(oneof = "WireResponseKind", tags = "1,2,3,4,5,6,7")]
+        pub kind: Option<WireResponseKind>,
+    }
+
+    #[derive(Clone, PartialEq, Oneof)]
+    pub enum WireResponseKind {
+        #[prost(message, tag = "1")]
+        Status(WireStatusInfo),
+        #[prost(message, tag = "2")]
+        ShuttingDown(WireUnit),
+        #[prost(message, tag = "3")]
+        Builds(WireBuilds),
+        #[prost(string, tag = "4")]
+        Error(String),
+        #[prost(message, tag = "5")]
+        CookHit(WireCookHit),
+        #[prost(message, tag = "6")]
+        CookMiss(WireCookMiss),
+        #[prost(message, tag = "7")]
+        Ack(WireUnit),
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireBuilds {
+        #[prost(message, repeated, tag = "1")]
+        pub items: Vec<WireBuildRecord>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireCookHit {
+        #[prost(bytes = "vec", tag = "1")]
+        pub sha256: Vec<u8>,
+        #[prost(string, tag = "2")]
+        pub path: String,
+        #[prost(uint64, tag = "3")]
+        pub size_bytes: u64,
+        #[prost(string, optional, tag = "4")]
+        pub origin_url_normalized: Option<String>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireCookMiss {
+        #[prost(bytes = "vec", repeated, tag = "1")]
+        pub previous_origin_recipe_hashes: Vec<Vec<u8>>,
+    }
+
+    // -- Shared / persistent ----------------------------------------------
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireStatusInfo {
+        #[prost(uint32, tag = "1")]
+        pub version: u32,
+        #[prost(uint32, tag = "2")]
+        pub pid: u32,
+        #[prost(uint64, tag = "3")]
+        pub uptime_secs: u64,
+        #[prost(uint64, tag = "4")]
+        pub request_count: u64,
+        #[prost(message, optional, tag = "5")]
+        pub linked_zccache: Option<WireZccacheDaemonLink>,
+        #[prost(message, optional, tag = "6")]
+        pub cook_stats: Option<WireCookStats>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireCookStats {
+        #[prost(uint64, tag = "1")]
+        pub entries: u64,
+        #[prost(uint64, tag = "2")]
+        pub total_bytes: u64,
+        #[prost(uint64, tag = "3")]
+        pub hits_this_session: u64,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireZccacheDaemonLink {
+        #[prost(string, tag = "1")]
+        pub binary_path: String,
+        #[prost(string, tag = "2")]
+        pub cache_dir: String,
+        #[prost(string, optional, tag = "3")]
+        pub session_id: Option<String>,
+        #[prost(string, tag = "4")]
+        pub source: String,
+        #[prost(bool, tag = "5")]
+        pub private_daemon: bool,
+        #[prost(string, optional, tag = "6")]
+        pub daemon_name: Option<String>,
+        #[prost(uint32, optional, tag = "7")]
+        pub owner_pid: Option<u32>,
+        #[prost(string, repeated, tag = "8")]
+        pub private_env_keys: Vec<String>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireBuildRecord {
+        #[prost(uint64, tag = "1")]
+        pub session_id: u64,
+        #[prost(string, tag = "2")]
+        pub repo_root: String,
+        #[prost(int64, tag = "3")]
+        pub started_at_ms: i64,
+        #[prost(int64, optional, tag = "4")]
+        pub ended_at_ms: Option<i64>,
+        #[prost(int32, optional, tag = "5")]
+        pub exit_code: Option<i32>,
+        #[prost(uint64, optional, tag = "6")]
+        pub total_wall_ms: Option<u64>,
+        #[prost(uint32, tag = "7")]
+        pub crate_count: u32,
+        #[prost(uint64, optional, tag = "8")]
+        pub slowest_crate_us: Option<u64>,
+        #[prost(string, optional, tag = "9")]
+        pub slowest_crate_name: Option<String>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireEvent {
+        #[prost(int64, tag = "1")]
+        pub ts_ms: i64,
+        #[prost(uint64, optional, tag = "2")]
+        pub session_id: Option<u64>,
+        #[prost(uint32, tag = "3")]
+        pub kind: u32,
+        #[prost(string, optional, tag = "4")]
+        pub crate_name: Option<String>,
+        #[prost(uint64, optional, tag = "5")]
+        pub duration_us: Option<u64>,
+        #[prost(string, optional, tag = "6")]
+        pub target_dir: Option<String>,
+        #[prost(int32, optional, tag = "7")]
+        pub exit_code: Option<i32>,
+    }
+
+    // -- cook_index persistent rows ---------------------------------------
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireCookKey {
+        #[prost(bytes = "vec", tag = "1")]
+        pub recipe_hash: Vec<u8>,
+        #[prost(string, tag = "2")]
+        pub target_triple: String,
+        #[prost(string, tag = "3")]
+        pub profile: String,
+        #[prost(string, tag = "4")]
+        pub channel: String,
+        #[prost(string, tag = "5")]
+        pub rustc_version: String,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct WireCookEntry {
+        #[prost(bytes = "vec", tag = "1")]
+        pub sha256: Vec<u8>,
+        #[prost(uint64, tag = "2")]
+        pub size_bytes: u64,
+        #[prost(uint64, tag = "3")]
+        pub created_unix_ms: u64,
+        #[prost(uint64, tag = "4")]
+        pub last_used_unix_ms: u64,
+        #[prost(string, optional, tag = "5")]
+        pub origin_url_normalized: Option<String>,
+        #[prost(string, tag = "6")]
+        pub cook_cmd_summary: String,
+    }
+}
+
+use prost::Message as _;
+
+// =========================================================================
+// Sha32 helpers
+// =========================================================================
+
+fn sha_to_vec(sha: &[u8; 32]) -> Vec<u8> {
+    sha.to_vec()
+}
+
+fn vec_to_sha(bytes: &[u8]) -> Result<[u8; 32], WireDecodeError> {
+    if bytes.len() != 32 {
+        return Err(WireDecodeError::InvalidShaLength(bytes.len()));
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(bytes);
+    Ok(out)
+}
+
+// =========================================================================
+// Wire-tagged byte for redb persistent rows
+// =========================================================================
+
+/// The 0x01 byte that prefixes every prost-encoded redb row written
+/// by this codebase. Reads look for it; absence (or any other byte)
+/// triggers the legacy-bincode fallback.
+pub const REDB_TAG_PROST: u8 = 0x01;
+
+/// Prepend [`REDB_TAG_PROST`] to a prost-encoded body. Used by every
+/// writer that lands a row into a redb table participating in the
+/// #580 migration.
+pub fn prost_tagged_bytes<M: prost::Message>(message: &M) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + message.encoded_len());
+    out.push(REDB_TAG_PROST);
+    message.encode(&mut out).expect("Vec write is infallible");
+    out
+}
+
+/// Inverse of [`prost_tagged_bytes`]: when the row starts with the
+/// prost tag, hand the caller the prost payload to decode. When the
+/// row starts with any other byte, hand back the full original slice
+/// so the caller can attempt the legacy bincode decoder.
+pub enum RedbDecode<'a> {
+    Prost(&'a [u8]),
+    LegacyBincode(&'a [u8]),
+}
+
+pub fn classify_redb_row(bytes: &[u8]) -> RedbDecode<'_> {
+    match bytes.split_first() {
+        Some((&REDB_TAG_PROST, rest)) => RedbDecode::Prost(rest),
+        _ => RedbDecode::LegacyBincode(bytes),
+    }
+}
+
+// =========================================================================
+// Encode / decode at the Request + Response boundary (wire framing)
+// =========================================================================
+
+pub fn encode_request(req: &Request) -> Vec<u8> {
+    let wire: proto::WireRequest = req.into();
+    let mut out = Vec::with_capacity(wire.encoded_len());
+    wire.encode(&mut out).expect("Vec write is infallible");
+    out
+}
+
+pub fn decode_request(bytes: &[u8]) -> Result<Request, WireDecodeError> {
+    let wire = proto::WireRequest::decode(bytes).map_err(WireDecodeError::Prost)?;
+    Request::try_from(wire)
+}
+
+pub fn encode_response(resp: &Response) -> Vec<u8> {
+    let wire: proto::WireResponse = resp.into();
+    let mut out = Vec::with_capacity(wire.encoded_len());
+    wire.encode(&mut out).expect("Vec write is infallible");
+    out
+}
+
+pub fn decode_response(bytes: &[u8]) -> Result<Response, WireDecodeError> {
+    let wire = proto::WireResponse::decode(bytes).map_err(WireDecodeError::Prost)?;
+    Response::try_from(wire)
+}
+
+// =========================================================================
+// Conversions: persistent record types
+// =========================================================================
+
+pub fn build_record_to_wire(record: &BuildRecord) -> proto::WireBuildRecord {
+    proto::WireBuildRecord {
+        session_id: record.session_id,
+        repo_root: record.repo_root.clone(),
+        started_at_ms: record.started_at_ms,
+        ended_at_ms: record.ended_at_ms,
+        exit_code: record.exit_code,
+        total_wall_ms: record.total_wall_ms,
+        crate_count: record.crate_count,
+        slowest_crate_us: record.slowest_crate_us,
+        slowest_crate_name: record.slowest_crate_name.clone(),
+    }
+}
+
+pub fn build_record_from_wire(wire: proto::WireBuildRecord) -> BuildRecord {
+    BuildRecord {
+        session_id: wire.session_id,
+        repo_root: wire.repo_root,
+        started_at_ms: wire.started_at_ms,
+        ended_at_ms: wire.ended_at_ms,
+        exit_code: wire.exit_code,
+        total_wall_ms: wire.total_wall_ms,
+        crate_count: wire.crate_count,
+        slowest_crate_us: wire.slowest_crate_us,
+        slowest_crate_name: wire.slowest_crate_name,
+    }
+}
+
+pub fn event_to_wire(event: &Event) -> proto::WireEvent {
+    proto::WireEvent {
+        ts_ms: event.ts_ms,
+        session_id: event.session_id,
+        kind: event_kind_to_u32(&event.kind),
+        crate_name: event.crate_name.clone(),
+        duration_us: event.duration_us,
+        target_dir: event.target_dir.clone(),
+        exit_code: event.exit_code,
+    }
+}
+
+pub fn event_from_wire(wire: proto::WireEvent) -> Result<Event, WireDecodeError> {
+    Ok(Event {
+        ts_ms: wire.ts_ms,
+        session_id: wire.session_id,
+        kind: u32_to_event_kind(wire.kind)?,
+        crate_name: wire.crate_name,
+        duration_us: wire.duration_us,
+        target_dir: wire.target_dir,
+        exit_code: wire.exit_code,
+    })
+}
+
+fn event_kind_to_u32(kind: &EventKind) -> u32 {
+    match kind {
+        EventKind::SessionStart => 0,
+        EventKind::SessionEnd => 1,
+        EventKind::CompileStart => 2,
+        EventKind::CompileEnd => 3,
+    }
+}
+
+fn u32_to_event_kind(n: u32) -> Result<EventKind, WireDecodeError> {
+    match n {
+        0 => Ok(EventKind::SessionStart),
+        1 => Ok(EventKind::SessionEnd),
+        2 => Ok(EventKind::CompileStart),
+        3 => Ok(EventKind::CompileEnd),
+        other => Err(WireDecodeError::UnknownEventKind(other)),
+    }
+}
+
+pub fn zccache_link_to_wire(link: &ZccacheDaemonLink) -> proto::WireZccacheDaemonLink {
+    proto::WireZccacheDaemonLink {
+        binary_path: link.binary_path.clone(),
+        cache_dir: link.cache_dir.clone(),
+        session_id: link.session_id.clone(),
+        source: link.source.clone(),
+        private_daemon: link.private_daemon,
+        daemon_name: link.daemon_name.clone(),
+        owner_pid: link.owner_pid,
+        private_env_keys: link.private_env_keys.clone(),
+    }
+}
+
+pub fn zccache_link_from_wire(wire: proto::WireZccacheDaemonLink) -> ZccacheDaemonLink {
+    ZccacheDaemonLink {
+        binary_path: wire.binary_path,
+        cache_dir: wire.cache_dir,
+        session_id: wire.session_id,
+        source: wire.source,
+        private_daemon: wire.private_daemon,
+        daemon_name: wire.daemon_name,
+        owner_pid: wire.owner_pid,
+        private_env_keys: wire.private_env_keys,
+    }
+}
+
+fn cook_stats_to_wire(stats: &CookStats) -> proto::WireCookStats {
+    proto::WireCookStats {
+        entries: stats.entries,
+        total_bytes: stats.total_bytes,
+        hits_this_session: stats.hits_this_session,
+    }
+}
+
+fn cook_stats_from_wire(wire: proto::WireCookStats) -> CookStats {
+    CookStats {
+        entries: wire.entries,
+        total_bytes: wire.total_bytes,
+        hits_this_session: wire.hits_this_session,
+    }
+}
+
+pub fn status_info_to_wire(info: &StatusInfo) -> proto::WireStatusInfo {
+    proto::WireStatusInfo {
+        version: info.version,
+        pid: info.pid,
+        uptime_secs: info.uptime_secs,
+        request_count: info.request_count,
+        linked_zccache: info.linked_zccache.as_ref().map(zccache_link_to_wire),
+        cook_stats: info.cook_stats.as_ref().map(cook_stats_to_wire),
+    }
+}
+
+pub fn status_info_from_wire(wire: proto::WireStatusInfo) -> StatusInfo {
+    StatusInfo {
+        version: wire.version,
+        pid: wire.pid,
+        uptime_secs: wire.uptime_secs,
+        request_count: wire.request_count,
+        linked_zccache: wire.linked_zccache.map(zccache_link_from_wire),
+        cook_stats: wire.cook_stats.map(cook_stats_from_wire),
+    }
+}
+
+// =========================================================================
+// Conversions: Request
+// =========================================================================
+
+impl From<&Request> for proto::WireRequest {
+    fn from(req: &Request) -> Self {
+        let kind = match req {
+            Request::RecordTargetTouch { path, unix_seconds } => {
+                proto::WireRequestKind::RecordTargetTouch(proto::WireRecordTargetTouch {
+                    path: path.clone(),
+                    unix_seconds: *unix_seconds,
+                })
+            }
+            Request::Status => proto::WireRequestKind::Status(proto::WireUnit {}),
+            Request::Shutdown => proto::WireRequestKind::Shutdown(proto::WireUnit {}),
+            Request::BuildSessionStart {
+                session_id,
+                repo_root,
+                started_at_ms,
+            } => proto::WireRequestKind::BuildSessionStart(proto::WireBuildSessionStart {
+                session_id: *session_id,
+                repo_root: repo_root.clone(),
+                started_at_ms: *started_at_ms,
+            }),
+            Request::BuildSessionEnd {
+                session_id,
+                exit_code,
+                ended_at_ms,
+            } => proto::WireRequestKind::BuildSessionEnd(proto::WireBuildSessionEnd {
+                session_id: *session_id,
+                exit_code: *exit_code,
+                ended_at_ms: *ended_at_ms,
+            }),
+            Request::RecordCompile {
+                session_id,
+                crate_name,
+                target_dir,
+                started_at_ms,
+                duration_us,
+            } => proto::WireRequestKind::RecordCompile(proto::WireRecordCompile {
+                session_id: *session_id,
+                crate_name: crate_name.clone(),
+                target_dir: target_dir.clone(),
+                started_at_ms: *started_at_ms,
+                duration_us: *duration_us,
+            }),
+            Request::ListBuilds { limit, since_ms } => {
+                proto::WireRequestKind::ListBuilds(proto::WireListBuilds {
+                    limit: *limit,
+                    since_ms: *since_ms,
+                })
+            }
+            Request::ListSlowBuilds {
+                threshold_ms,
+                limit,
+            } => proto::WireRequestKind::ListSlowBuilds(proto::WireListSlowBuilds {
+                threshold_ms: *threshold_ms,
+                limit: *limit,
+            }),
+            Request::LinkZccache { link } => {
+                proto::WireRequestKind::LinkZccache(proto::WireLinkZccache {
+                    link: Some(zccache_link_to_wire(link)),
+                })
+            }
+            Request::CookLookup {
+                recipe_hash,
+                target_triple,
+                profile,
+                channel,
+                rustc_version,
+                origin_url_normalized,
+            } => proto::WireRequestKind::CookLookup(proto::WireCookLookup {
+                recipe_hash: sha_to_vec(recipe_hash),
+                target_triple: target_triple.clone(),
+                profile: profile.clone(),
+                channel: channel.clone(),
+                rustc_version: rustc_version.clone(),
+                origin_url_normalized: origin_url_normalized.clone(),
+            }),
+            Request::CookRecord {
+                recipe_hash,
+                target_triple,
+                profile,
+                channel,
+                rustc_version,
+                sha256,
+                size_bytes,
+                origin_url_normalized,
+                cook_cmd_summary,
+            } => proto::WireRequestKind::CookRecord(proto::WireCookRecord {
+                recipe_hash: sha_to_vec(recipe_hash),
+                target_triple: target_triple.clone(),
+                profile: profile.clone(),
+                channel: channel.clone(),
+                rustc_version: rustc_version.clone(),
+                sha256: sha_to_vec(sha256),
+                size_bytes: *size_bytes,
+                origin_url_normalized: origin_url_normalized.clone(),
+                cook_cmd_summary: cook_cmd_summary.clone(),
+            }),
+            Request::CookTouch { sha256 } => {
+                proto::WireRequestKind::CookTouch(proto::WireCookTouch {
+                    sha256: sha_to_vec(sha256),
+                })
+            }
+        };
+        Self { kind: Some(kind) }
+    }
+}
+
+impl TryFrom<proto::WireRequest> for Request {
+    type Error = WireDecodeError;
+
+    fn try_from(wire: proto::WireRequest) -> Result<Self, Self::Error> {
+        let kind = wire.kind.ok_or(WireDecodeError::EmptyOneof("Request"))?;
+        Ok(match kind {
+            proto::WireRequestKind::RecordTargetTouch(m) => Request::RecordTargetTouch {
+                path: m.path,
+                unix_seconds: m.unix_seconds,
+            },
+            proto::WireRequestKind::Status(_) => Request::Status,
+            proto::WireRequestKind::Shutdown(_) => Request::Shutdown,
+            proto::WireRequestKind::BuildSessionStart(m) => Request::BuildSessionStart {
+                session_id: m.session_id,
+                repo_root: m.repo_root,
+                started_at_ms: m.started_at_ms,
+            },
+            proto::WireRequestKind::BuildSessionEnd(m) => Request::BuildSessionEnd {
+                session_id: m.session_id,
+                exit_code: m.exit_code,
+                ended_at_ms: m.ended_at_ms,
+            },
+            proto::WireRequestKind::RecordCompile(m) => Request::RecordCompile {
+                session_id: m.session_id,
+                crate_name: m.crate_name,
+                target_dir: m.target_dir,
+                started_at_ms: m.started_at_ms,
+                duration_us: m.duration_us,
+            },
+            proto::WireRequestKind::ListBuilds(m) => Request::ListBuilds {
+                limit: m.limit,
+                since_ms: m.since_ms,
+            },
+            proto::WireRequestKind::ListSlowBuilds(m) => Request::ListSlowBuilds {
+                threshold_ms: m.threshold_ms,
+                limit: m.limit,
+            },
+            proto::WireRequestKind::LinkZccache(m) => Request::LinkZccache {
+                link: zccache_link_from_wire(
+                    m.link
+                        .ok_or(WireDecodeError::MissingField("LinkZccache.link"))?,
+                ),
+            },
+            proto::WireRequestKind::CookLookup(m) => Request::CookLookup {
+                recipe_hash: vec_to_sha(&m.recipe_hash)?,
+                target_triple: m.target_triple,
+                profile: m.profile,
+                channel: m.channel,
+                rustc_version: m.rustc_version,
+                origin_url_normalized: m.origin_url_normalized,
+            },
+            proto::WireRequestKind::CookRecord(m) => Request::CookRecord {
+                recipe_hash: vec_to_sha(&m.recipe_hash)?,
+                target_triple: m.target_triple,
+                profile: m.profile,
+                channel: m.channel,
+                rustc_version: m.rustc_version,
+                sha256: vec_to_sha(&m.sha256)?,
+                size_bytes: m.size_bytes,
+                origin_url_normalized: m.origin_url_normalized,
+                cook_cmd_summary: m.cook_cmd_summary,
+            },
+            proto::WireRequestKind::CookTouch(m) => Request::CookTouch {
+                sha256: vec_to_sha(&m.sha256)?,
+            },
+        })
+    }
+}
+
+// =========================================================================
+// Conversions: Response
+// =========================================================================
+
+impl From<&Response> for proto::WireResponse {
+    fn from(resp: &Response) -> Self {
+        let kind = match resp {
+            Response::Status(info) => proto::WireResponseKind::Status(status_info_to_wire(info)),
+            Response::ShuttingDown => proto::WireResponseKind::ShuttingDown(proto::WireUnit {}),
+            Response::Builds(rows) => proto::WireResponseKind::Builds(proto::WireBuilds {
+                items: rows.iter().map(build_record_to_wire).collect(),
+            }),
+            Response::Error(msg) => proto::WireResponseKind::Error(msg.clone()),
+            Response::CookHit {
+                sha256,
+                path,
+                size_bytes,
+                origin_url_normalized,
+            } => proto::WireResponseKind::CookHit(proto::WireCookHit {
+                sha256: sha_to_vec(sha256),
+                path: path.clone(),
+                size_bytes: *size_bytes,
+                origin_url_normalized: origin_url_normalized.clone(),
+            }),
+            Response::CookMiss {
+                previous_origin_recipe_hashes,
+            } => proto::WireResponseKind::CookMiss(proto::WireCookMiss {
+                previous_origin_recipe_hashes: previous_origin_recipe_hashes
+                    .iter()
+                    .map(sha_to_vec)
+                    .collect(),
+            }),
+            Response::Ack => proto::WireResponseKind::Ack(proto::WireUnit {}),
+        };
+        Self { kind: Some(kind) }
+    }
+}
+
+impl TryFrom<proto::WireResponse> for Response {
+    type Error = WireDecodeError;
+
+    fn try_from(wire: proto::WireResponse) -> Result<Self, WireDecodeError> {
+        let kind = wire.kind.ok_or(WireDecodeError::EmptyOneof("Response"))?;
+        Ok(match kind {
+            proto::WireResponseKind::Status(m) => Response::Status(status_info_from_wire(m)),
+            proto::WireResponseKind::ShuttingDown(_) => Response::ShuttingDown,
+            proto::WireResponseKind::Builds(m) => {
+                Response::Builds(m.items.into_iter().map(build_record_from_wire).collect())
+            }
+            proto::WireResponseKind::Error(msg) => Response::Error(msg),
+            proto::WireResponseKind::CookHit(m) => Response::CookHit {
+                sha256: vec_to_sha(&m.sha256)?,
+                path: m.path,
+                size_bytes: m.size_bytes,
+                origin_url_normalized: m.origin_url_normalized,
+            },
+            proto::WireResponseKind::CookMiss(m) => {
+                let mut hashes = Vec::with_capacity(m.previous_origin_recipe_hashes.len());
+                for raw in m.previous_origin_recipe_hashes {
+                    hashes.push(vec_to_sha(&raw)?);
+                }
+                Response::CookMiss {
+                    previous_origin_recipe_hashes: hashes,
+                }
+            }
+            proto::WireResponseKind::Ack(_) => Response::Ack,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::protocol::{Response, StatusInfo};
+
+    fn sample_link() -> ZccacheDaemonLink {
+        ZccacheDaemonLink {
+            binary_path: "/tmp/zccache".into(),
+            cache_dir: "/tmp/cache".into(),
+            session_id: Some("session-1".into()),
+            source: "managed".into(),
+            private_daemon: true,
+            daemon_name: Some("soldr-dev".into()),
+            owner_pid: Some(1234),
+            private_env_keys: vec!["ZCCACHE_PATH_REMAP".into()],
+        }
+    }
+
+    crate::timed_test!(record_target_touch_round_trips, {
+        let req = Request::RecordTargetTouch {
+            path: "/tmp/target".into(),
+            unix_seconds: 1_700_000_000,
+        };
+        let bytes = encode_request(&req);
+        let decoded = decode_request(&bytes).expect("decode");
+        assert!(matches!(
+            decoded,
+            Request::RecordTargetTouch { ref path, unix_seconds }
+                if path == "/tmp/target" && unix_seconds == 1_700_000_000
+        ));
+    });
+
+    crate::timed_test!(status_request_round_trips, {
+        let bytes = encode_request(&Request::Status);
+        assert!(matches!(
+            decode_request(&bytes).expect("decode"),
+            Request::Status
+        ));
+    });
+
+    crate::timed_test!(cook_lookup_round_trips_with_all_fields, {
+        let req = Request::CookLookup {
+            recipe_hash: [0x42; 32],
+            target_triple: "x86_64-pc-windows-msvc".into(),
+            profile: "release".into(),
+            channel: "1.94.1".into(),
+            rustc_version: "rustc 1.94.1".into(),
+            origin_url_normalized: Some("https://github.com/zackees/soldr".into()),
+        };
+        let bytes = encode_request(&req);
+        let decoded = decode_request(&bytes).expect("decode");
+        match decoded {
+            Request::CookLookup {
+                recipe_hash,
+                target_triple,
+                profile,
+                channel,
+                rustc_version,
+                origin_url_normalized,
+            } => {
+                assert_eq!(recipe_hash, [0x42; 32]);
+                assert_eq!(target_triple, "x86_64-pc-windows-msvc");
+                assert_eq!(profile, "release");
+                assert_eq!(channel, "1.94.1");
+                assert_eq!(rustc_version, "rustc 1.94.1");
+                assert_eq!(
+                    origin_url_normalized.as_deref(),
+                    Some("https://github.com/zackees/soldr")
+                );
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    });
+
+    crate::timed_test!(cook_record_round_trips_with_sha_validation, {
+        let req = Request::CookRecord {
+            recipe_hash: [0x11; 32],
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            profile: "release".into(),
+            channel: "1.94.1".into(),
+            rustc_version: "rustc 1.94.1".into(),
+            sha256: [0xAA; 32],
+            size_bytes: 4_096,
+            origin_url_normalized: None,
+            cook_cmd_summary: "cook --release".into(),
+        };
+        let bytes = encode_request(&req);
+        let Request::CookRecord {
+            recipe_hash,
+            sha256,
+            size_bytes,
+            ..
+        } = decode_request(&bytes).expect("decode")
+        else {
+            panic!("expected CookRecord");
+        };
+        assert_eq!(recipe_hash, [0x11; 32]);
+        assert_eq!(sha256, [0xAA; 32]);
+        assert_eq!(size_bytes, 4_096);
+    });
+
+    crate::timed_test!(link_zccache_round_trips_with_optional_fields, {
+        let req = Request::LinkZccache {
+            link: sample_link(),
+        };
+        let bytes = encode_request(&req);
+        let decoded = decode_request(&bytes).expect("decode");
+        match decoded {
+            Request::LinkZccache { link } => {
+                assert_eq!(link, sample_link());
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    });
+
+    crate::timed_test!(status_response_round_trips_with_cook_stats, {
+        let info = StatusInfo {
+            version: 5,
+            pid: 4242,
+            uptime_secs: 60,
+            request_count: 17,
+            linked_zccache: Some(sample_link()),
+            cook_stats: Some(CookStats {
+                entries: 3,
+                total_bytes: 9_999,
+                hits_this_session: 1,
+            }),
+        };
+        let resp = Response::Status(info.clone());
+        let bytes = encode_response(&resp);
+        let decoded = decode_response(&bytes).expect("decode");
+        match decoded {
+            Response::Status(decoded_info) => assert_eq!(decoded_info, info),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    });
+
+    crate::timed_test!(cook_hit_response_round_trips, {
+        let resp = Response::CookHit {
+            sha256: [0xCC; 32],
+            path: "/home/runner/.soldr/cache/cook/abcd.tar.zst".into(),
+            size_bytes: 4_096,
+            origin_url_normalized: Some("https://github.com/zackees/soldr".into()),
+        };
+        let bytes = encode_response(&resp);
+        match decode_response(&bytes).expect("decode") {
+            Response::CookHit {
+                sha256,
+                path,
+                size_bytes,
+                origin_url_normalized,
+            } => {
+                assert_eq!(sha256, [0xCC; 32]);
+                assert!(path.ends_with(".tar.zst"));
+                assert_eq!(size_bytes, 4_096);
+                assert_eq!(
+                    origin_url_normalized.as_deref(),
+                    Some("https://github.com/zackees/soldr")
+                );
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    });
+
+    crate::timed_test!(cook_miss_response_round_trips_with_multiple_hashes, {
+        let resp = Response::CookMiss {
+            previous_origin_recipe_hashes: vec![[1u8; 32], [2u8; 32], [3u8; 32]],
+        };
+        let bytes = encode_response(&resp);
+        match decode_response(&bytes).expect("decode") {
+            Response::CookMiss {
+                previous_origin_recipe_hashes,
+            } => {
+                assert_eq!(previous_origin_recipe_hashes.len(), 3);
+                assert_eq!(previous_origin_recipe_hashes[0], [1u8; 32]);
+                assert_eq!(previous_origin_recipe_hashes[1], [2u8; 32]);
+                assert_eq!(previous_origin_recipe_hashes[2], [3u8; 32]);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    });
+
+    crate::timed_test!(builds_response_round_trips_with_all_optional_fields, {
+        let record = BuildRecord {
+            session_id: 42,
+            repo_root: "/r".into(),
+            started_at_ms: 100,
+            ended_at_ms: Some(500),
+            exit_code: Some(0),
+            total_wall_ms: Some(400),
+            crate_count: 7,
+            slowest_crate_us: Some(123_456),
+            slowest_crate_name: Some("zccache".into()),
+        };
+        let resp = Response::Builds(vec![record.clone()]);
+        let bytes = encode_response(&resp);
+        match decode_response(&bytes).expect("decode") {
+            Response::Builds(items) => {
+                assert_eq!(items.len(), 1);
+                assert_eq!(items[0], record);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    });
+
+    crate::timed_test!(invalid_sha_length_is_a_decode_error, {
+        // Build a WireCookTouch by hand with a bogus 16-byte sha.
+        let bad = proto::WireRequest {
+            kind: Some(proto::WireRequestKind::CookTouch(proto::WireCookTouch {
+                sha256: vec![0u8; 16],
+            })),
+        };
+        let mut bytes = Vec::new();
+        prost::Message::encode(&bad, &mut bytes).expect("encode");
+        let err = decode_request(&bytes).expect_err("must error");
+        assert!(matches!(err, WireDecodeError::InvalidShaLength(16)));
+    });
+
+    crate::timed_test!(empty_request_oneof_is_a_decode_error, {
+        let bytes = Vec::new(); // empty WireRequest with no oneof
+        let err = decode_request(&bytes).expect_err("must error");
+        assert!(matches!(err, WireDecodeError::EmptyOneof("Request")));
+    });
+
+    crate::timed_test!(event_kind_round_trips_through_u32, {
+        for kind in [
+            EventKind::SessionStart,
+            EventKind::SessionEnd,
+            EventKind::CompileStart,
+            EventKind::CompileEnd,
+        ] {
+            let n = event_kind_to_u32(&kind);
+            assert_eq!(u32_to_event_kind(n).unwrap(), kind);
+        }
+        assert!(matches!(
+            u32_to_event_kind(99).unwrap_err(),
+            WireDecodeError::UnknownEventKind(99)
+        ));
+    });
+
+    crate::timed_test!(tagged_byte_classifier_routes_correctly, {
+        let prost_body = [0xDE, 0xAD, 0xBE, 0xEF];
+        let mut tagged = vec![REDB_TAG_PROST];
+        tagged.extend_from_slice(&prost_body);
+        match classify_redb_row(&tagged) {
+            RedbDecode::Prost(rest) => assert_eq!(rest, &prost_body),
+            RedbDecode::LegacyBincode(_) => panic!("expected prost classification"),
+        }
+        // Anything else falls through to legacy.
+        let bincode_like = [0x00u8, 0x01, 0x02];
+        match classify_redb_row(&bincode_like) {
+            RedbDecode::Prost(_) => panic!("expected legacy classification"),
+            RedbDecode::LegacyBincode(bytes) => assert_eq!(bytes, &bincode_like),
+        }
+        // Empty falls through to legacy too (bincode will error cleanly).
+        match classify_redb_row(&[]) {
+            RedbDecode::Prost(_) => panic!("expected legacy on empty"),
+            RedbDecode::LegacyBincode(b) => assert!(b.is_empty()),
+        }
+    });
+}


### PR DESCRIPTION
Closes #580.

Migrates every binary transport + persistent metadata blob in the soldr daemon from \`bincode\` to Protocol Buffers (via \`prost\`). Closes the active schema-evolution risk #580 flagged: bincode silently breaks on field add/remove and has no forward-compat story for unknown fields.

## What changes

**Wire (daemon IPC)**
- New \`daemon/wire.{proto,rs}\` — hand-written prost types mirroring a \`.proto\` schema (same pattern as \`src/rust_plan_proto.rs\`). No \`build.rs\` / \`prost-build\` dep needed.
- \`daemon/protocol.rs\` — adds \`WireDecodeError\` for prost+shape failures. Keeps existing public Request/Response/StatusInfo types (with \`serde\` derives for the redb fallback). \`PROTOCOL_VERSION\` bumped 4 → 5 so cross-version IPC errors cleanly.
- \`daemon/ipc.rs\` — new \`WireBody\` trait (impl'd for Request + Response) routes encode/decode through the prost wire layer. Frame header unchanged; only the body bytes are now prost.

**Redb persistent rows (daemon_builds / daemon_events / daemon_zccache_link)**
- Tagged-byte: every value written is now \`[0x01][prost body]\`. Reads classify the leading byte — \`0x01\` strips and prost-decodes, anything else falls through to a \`bincode::deserialize\` fallback so rows from pre-#580 daemons still resolve. \`LegacyZccacheDaemonLink\` (#265) remains as a second-stage fallback for the even-older row shape.

**Redb persistent rows (cook_index)**
- Dual-versioned tables: \`cook_index_v1\` (bincode, read-only fallback) + \`cook_index_v2\` (prost-encoded keys, prost-tagged values). New writes always go to v2. Reads consult v2 then v1.

**Docs**
- New \`CLAUDE.md\` "Serialization" section codifies the policy.

## Backwards compatibility

- **Wire**: a v4 client and a v5 daemon error cleanly with "protocol version mismatch" (existing IPC header check). The wrapper hot path's direct-redb fallback keeps builds going during the cross-version window after a \`soldr\` upgrade.
- **daemon_builds / daemon_events / daemon_zccache_link**: pre-#580 rows still decode via the legacy bincode fallback. New writes always use tagged-byte prost.
- **cook_index**: pre-#580 rows in \`cook_index_v1\` still resolve via the v1 fallback. New writes go to \`cook_index_v2\`.

## Tests (all green in Docker)

- 14 new \`daemon::wire::tests::*\` round-trip tests (Request per variant, Response per variant, SHA-32 length validation, oneof emptiness rejection, EventKind enum round-trip, tagged-byte classifier).
- \`protocol::tests::protocol_version_is_v5_after_prost_migration\`
- \`cook_index::tests::v1_bincode_row_still_resolves_via_lookup\` + \`v2_value_blobs_carry_the_prost_tag\`.
- All existing cook_index tests (round-trip, drift, per-target/profile safety, touch, stats, ensure_initialized) still pass against v2 storage.
- All existing daemon IPC integration tests still pass (\`daemon_cook_index\`, \`cook_writes_index\`, \`cook_hydrate_preflight\`, \`cli_daemon_*\`).
- **688 unit + 7 cook_writes_index + 7 daemon_cook_index + lint, all green.**
- \`clippy -D warnings\` clean. \`cargo fmt --check\` clean.

## Follow-ups (filed separately)

- **#602** — \`clippy.toml\` \`disallowed-methods\` rule banning new bincode usage outside the documented legacy modules.
- **#603** — remove bincode workspace dep + legacy-fallback decoders once a \`soldr daemon clean\` (or equivalent format-version cutoff) has run in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)