### PR TITLE
ci(release): poll PyPI after publish to close sequential-upload race

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -895,6 +895,43 @@ jobs:
         with:
           packages-dir: dist
 
+      - name: Verify all wheels visible on PyPI
+        # pypa/gh-action-pypi-publish uploads wheels sequentially via twine.
+        # For an N-wheel matrix there is an N x ~2-3s window during which
+        # `https://pypi.org/pypi/<project>/<version>/json` returns a partial
+        # set, and downstream resolvers (e.g. `uv sync`) can cache a
+        # "no compatible wheel" failure for the platforms not yet uploaded.
+        # Poll the JSON endpoint until the full set is visible before the
+        # workflow returns success. See issue #605 for the downstream
+        # breakage that motivated this.
+        shell: bash
+        env:
+          PYPI_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Tag-style version is `vX.Y.Z`; PyPI keys releases by `X.Y.Z`.
+          pypi_version="${PYPI_VERSION#v}"
+          # Expected wheel count == number of non-musl matrix rows in the
+          # `build` job (the musl rows skip wheel build by design). Update
+          # this if the wheel-producing matrix changes.
+          expected=6
+          deadline=$(( $(date +%s) + 300 ))
+          while :; do
+            count="$(curl -fsSL "https://pypi.org/pypi/soldr/${pypi_version}/json" \
+              | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("urls",[])))' 2>/dev/null \
+              || echo 0)"
+            echo "PyPI reports ${count}/${expected} files for soldr==${pypi_version}"
+            if [ "$count" -ge "$expected" ]; then
+              echo "All ${expected} wheels visible on PyPI; verification complete."
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "Timed out waiting for ${expected} wheels for soldr==${pypi_version}" >&2
+              exit 1
+            fi
+            sleep 15
+          done
+
   publish-npm:
     name: Publish npm package
     needs:


### PR DESCRIPTION
Closes #605

## Summary

`pypa/gh-action-pypi-publish` uploads wheels sequentially via twine. For soldr's 6-wheel matrix that opens a ~12-18s window where `https://pypi.org/pypi/soldr/<version>/json` returns a partial set, and downstream resolvers (`uv sync` in particular) can cache a "no compatible wheel for this platform" failure before the missing wheel lands. This actually broke a downstream consumer for `fbuild==2.2.10`; soldr is upstream of every fbuild user's harness so a soldr release with this race risks cascading the same failure mode.

Adds a polling step to the `publish-pypi` job that confirms all 6 wheels are visible on PyPI before the workflow returns success.

## Behaviour

- Step runs after `Publish wheel set to PyPI`.
- Strips the leading `v` from the prepared tag (`vX.Y.Z` → `X.Y.Z`) to match PyPI's release key.
- Polls `https://pypi.org/pypi/soldr/<version>/json` every 15s, parses `urls` length with `python3`.
- Succeeds the first iteration that reports ≥ 6 files; fails hard if the 5-minute deadline elapses first.
- Expected count comment notes the dependency on the non-musl matrix rows so a future matrix change is caught.

## Test plan

- [ ] YAML validates (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-auto.yml'))"`) — already run locally.
- [ ] First post-merge release exercises the new step end-to-end. Expected: step logs `PyPI reports 6/6 files` within a few iterations and succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)