### PR TITLE
feat(gc): host-volume disk watchdog + soldr gc target reclamation (#574)

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -381,6 +381,33 @@ pub(crate) async fn run_cargo_front_door(
             .target_dir_for_hooks(args)
             .unwrap_or_else(|| disk::cargo_disk_space_probe_path(args));
         disk::maybe_emit_low_disk_warning(&probe_path);
+        // Issue #574: host-volume disk watchdog. Distinct from the
+        // legacy 2 GiB advisory above — this layer warns at 10 GiB and
+        // aborts at 5 GiB so cross-repo target/ bloat surfaces before
+        // the build sets the disk on fire. Returning Err here lets the
+        // top-level dispatch print the error and exit with a non-zero
+        // code (same path as any other SoldrError from the front door).
+        let watchdog_path = cache_plan
+            .target_dir_for_hooks(args)
+            .unwrap_or_else(|| disk::cargo_disk_space_probe_path(args));
+        match gc::disk::check_disk_or_warn_or_block(&watchdog_path) {
+            gc::disk::DiskCheckOutcome::Disabled | gc::disk::DiskCheckOutcome::Ok { .. } => {}
+            gc::disk::DiskCheckOutcome::Warn {
+                free_bytes,
+                threshold_gib,
+            } => {
+                eprintln!("{}", gc::disk::render_warn_line(free_bytes, threshold_gib));
+            }
+            gc::disk::DiskCheckOutcome::Block {
+                free_bytes,
+                threshold_gib,
+            } => {
+                return Err(SoldrError::Other(gc::disk::render_block_message(
+                    free_bytes,
+                    threshold_gib,
+                )));
+            }
+        }
     }
     cache_plan.restore_rust_artifacts()?;
 

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -635,6 +635,37 @@ pub(crate) enum GcSubcommand {
     /// `clean gc`, then the soldr target purge — and, with
     /// `--aggressive`, a second cargo GC pass with tighter ages.
     Sweep(Box<GcSweepArgs>),
+    /// Walk a configurable root (default `~/dev`, override via `--root`
+    /// or `SOLDR_GC_TARGET_ROOT`) for every workspace with a sibling
+    /// `target/` directory, then either report (default) or purge them
+    /// (issue #574). Designed for cross-repo `target/` reclamation —
+    /// independent of the per-repo `target/` taxonomy walks above.
+    Target(Box<GcTargetArgs>),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct GcTargetArgs {
+    /// Filesystem root to walk. Defaults to the value of
+    /// `$SOLDR_GC_TARGET_ROOT`, falling back to `~/dev`.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) root: Option<std::path::PathBuf>,
+    /// Maximum walk depth.
+    #[arg(long, default_value_t = 4, value_name = "N")]
+    pub(crate) max_depth: usize,
+    /// Report-only (the default).
+    #[arg(long, conflicts_with = "purge")]
+    pub(crate) dry_run: bool,
+    /// Delete every reported `target/` directory after confirming a
+    /// single y/n prompt (skipped when `--yes` is also passed).
+    #[arg(long, conflicts_with = "dry_run")]
+    pub(crate) purge: bool,
+    /// Skip the interactive y/n prompt before purging. Without
+    /// `--purge` this is a no-op.
+    #[arg(long)]
+    pub(crate) yes: bool,
+    /// Emit the stable machine-facing JSON form for this command.
+    #[arg(long)]
+    pub(crate) json: bool,
 }
 
 /// Taxonomy kinds accepted by `gc list --kind` / `gc purge --kind`

--- a/crates/soldr-cli/src/gc/disk.rs
+++ b/crates/soldr-cli/src/gc/disk.rs
@@ -1,0 +1,376 @@
+//! Host-volume disk watchdog (issue #574).
+//!
+//! Probes free space on the volume that hosts the build's `target/` dir
+//! (or CWD if `target/` doesn't exist yet) and either warns or blocks
+//! the cargo invocation when free space drops below configurable
+//! thresholds. Distinct from `cargo_front_door::disk` (which is the
+//! older, narrower "low disk" advisory) — this is the GiB-scale
+//! watchdog tied to cross-repo `target/` reclamation via
+//! `soldr gc target`.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Env-var override for the warn threshold (in GiB).
+pub(crate) const WARN_FREE_GB_ENV_VAR: &str = "SOLDR_TARGET_WARN_FREE_GB";
+/// Env-var override for the block threshold (in GiB).
+pub(crate) const BLOCK_FREE_GB_ENV_VAR: &str = "SOLDR_TARGET_BLOCK_FREE_GB";
+/// Env-var that disables the watchdog entirely when set to a falsy
+/// value (`0` / `false` / `no` / `off`, case-insensitive).
+pub(crate) const AUTO_PRUNE_ENABLED_ENV_VAR: &str = "SOLDR_TARGET_AUTO_PRUNE_ENABLED";
+/// Test seam — when set, overrides the real `fs2::available_space`
+/// probe so unit tests can drive every threshold edge.
+pub(crate) const TEST_DISK_FREE_BYTES_ENV_VAR: &str = "SOLDR_TEST_DISK_FREE_BYTES";
+
+pub(crate) const DEFAULT_WARN_FREE_GB: u64 = 10;
+pub(crate) const DEFAULT_BLOCK_FREE_GB: u64 = 5;
+
+const BYTES_PER_GIB: u64 = 1024 * 1024 * 1024;
+
+/// Outcome of one watchdog check. Caller decides what to do — for
+/// the cargo front door, `Warn` emits a one-line stderr message and
+/// continues, `Block` aborts the invocation with a clear error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DiskCheckOutcome {
+    /// Watchdog disabled via `SOLDR_TARGET_AUTO_PRUNE_ENABLED=0`, or
+    /// the disk probe failed. Either way the caller should proceed.
+    Disabled,
+    /// Free space is healthy.
+    Ok { free_bytes: u64 },
+    /// Free space dropped below the warn threshold but is still above
+    /// the block threshold.
+    Warn { free_bytes: u64, threshold_gib: u64 },
+    /// Free space dropped below the block threshold. Caller MUST abort
+    /// with the rendered suggestion line.
+    Block { free_bytes: u64, threshold_gib: u64 },
+}
+
+/// Resolve free bytes for the disk that holds `path`. Honors
+/// `SOLDR_TEST_DISK_FREE_BYTES` so unit tests can drive every code
+/// path without touching the real filesystem.
+pub(crate) fn free_bytes_for(path: &Path) -> io::Result<u64> {
+    if let Some(raw) = std::env::var_os(TEST_DISK_FREE_BYTES_ENV_VAR) {
+        let raw = raw.to_string_lossy();
+        if raw.eq_ignore_ascii_case("error") {
+            return Err(io::Error::other("test disk-space failure"));
+        }
+        return raw.parse::<u64>().map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid {TEST_DISK_FREE_BYTES_ENV_VAR}: {e}"),
+            )
+        });
+    }
+    let probe = existing_probe_path(path);
+    fs2::available_space(&probe)
+}
+
+/// Resolve the build volume for a cargo invocation. Prefers the
+/// project's `target/` dir when it already exists (cargo will write
+/// into it), falling back to the project's CWD when `target/` hasn't
+/// been created yet. Callers pass `cwd` separately so tests can drive
+/// both branches without changing the process CWD.
+pub(crate) fn build_volume_path(cwd: &Path, target_dir: Option<&Path>) -> PathBuf {
+    if let Some(dir) = target_dir {
+        if dir.exists() {
+            return dir.to_path_buf();
+        }
+    }
+    cwd.to_path_buf()
+}
+
+/// Run the disk watchdog. Returns a [`DiskCheckOutcome`] describing
+/// what (if anything) the caller should do.
+pub(crate) fn check_disk_or_warn_or_block(workdir: &Path) -> DiskCheckOutcome {
+    if !auto_prune_enabled() {
+        return DiskCheckOutcome::Disabled;
+    }
+    let warn_gib = env_u64(WARN_FREE_GB_ENV_VAR).unwrap_or(DEFAULT_WARN_FREE_GB);
+    let block_gib = env_u64(BLOCK_FREE_GB_ENV_VAR).unwrap_or(DEFAULT_BLOCK_FREE_GB);
+
+    // Why: if the user inverts thresholds, prefer "block wins" so the
+    // safety net is conservative rather than silently broken.
+    let (warn_gib, block_gib) = if block_gib > warn_gib {
+        (block_gib, block_gib)
+    } else {
+        (warn_gib, block_gib)
+    };
+
+    let free_bytes = match free_bytes_for(workdir) {
+        Ok(b) => b,
+        Err(_) => return DiskCheckOutcome::Disabled,
+    };
+    classify_outcome(free_bytes, warn_gib, block_gib)
+}
+
+fn classify_outcome(free_bytes: u64, warn_gib: u64, block_gib: u64) -> DiskCheckOutcome {
+    let block_bytes = block_gib.saturating_mul(BYTES_PER_GIB);
+    let warn_bytes = warn_gib.saturating_mul(BYTES_PER_GIB);
+    if free_bytes < block_bytes {
+        DiskCheckOutcome::Block {
+            free_bytes,
+            threshold_gib: block_gib,
+        }
+    } else if free_bytes < warn_bytes {
+        DiskCheckOutcome::Warn {
+            free_bytes,
+            threshold_gib: warn_gib,
+        }
+    } else {
+        DiskCheckOutcome::Ok { free_bytes }
+    }
+}
+
+fn auto_prune_enabled() -> bool {
+    match std::env::var_os(AUTO_PRUNE_ENABLED_ENV_VAR) {
+        None => true,
+        Some(value) => {
+            let s = value.to_string_lossy();
+            let t = s.trim();
+            !(t.eq_ignore_ascii_case("0")
+                || t.eq_ignore_ascii_case("false")
+                || t.eq_ignore_ascii_case("no")
+                || t.eq_ignore_ascii_case("off")
+                || t.is_empty())
+        }
+    }
+}
+
+fn env_u64(name: &str) -> Option<u64> {
+    let raw = std::env::var(name).ok()?;
+    raw.trim().parse::<u64>().ok()
+}
+
+fn existing_probe_path(path: &Path) -> PathBuf {
+    let mut cursor = if path.as_os_str().is_empty() {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    } else {
+        path.to_path_buf()
+    };
+    loop {
+        if cursor.exists() {
+            return cursor;
+        }
+        if !cursor.pop() {
+            return std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        }
+    }
+}
+
+/// Render the one-line stderr warning emitted when the watchdog fires
+/// at the `Warn` tier.
+pub(crate) fn render_warn_line(free_bytes: u64, threshold_gib: u64) -> String {
+    format!(
+        "soldr: warning: build volume has {free} free (< {threshold_gib} GiB threshold). Run `soldr gc target` to find reclaimable `target/` directories under ~/dev.",
+        free = format_bytes(free_bytes),
+    )
+}
+
+/// Render the multi-line stderr error emitted when the watchdog fires
+/// at the `Block` tier. Caller is expected to bail with a non-zero
+/// exit code after printing. Returned without a leading `soldr: `
+/// prefix — the top-level `report_and_exit` helper adds it.
+pub(crate) fn render_block_message(free_bytes: u64, threshold_gib: u64) -> String {
+    format!(
+        "build volume has only {free} free, below the {threshold_gib} GiB block threshold. \
+         Run `soldr gc target --purge` to reclaim space from cross-repo `target/` directories, or set \
+         SOLDR_TARGET_BLOCK_FREE_GB=<lower> / SOLDR_TARGET_AUTO_PRUNE_ENABLED=0 to override.",
+        free = format_bytes(free_bytes),
+    )
+}
+
+fn format_bytes(bytes: u64) -> String {
+    let gib = bytes as f64 / BYTES_PER_GIB as f64;
+    if gib >= 1.0 {
+        format!("{gib:.2} GiB")
+    } else {
+        let mib = bytes as f64 / (1024.0 * 1024.0);
+        format!("{mib:.0} MiB")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timed_test;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    timed_test!(threshold_classifier_returns_ok_above_warn, {
+        let outcome = classify_outcome(
+            20 * BYTES_PER_GIB,
+            DEFAULT_WARN_FREE_GB,
+            DEFAULT_BLOCK_FREE_GB,
+        );
+        assert!(matches!(outcome, DiskCheckOutcome::Ok { .. }));
+    });
+
+    timed_test!(threshold_classifier_returns_warn_between_thresholds, {
+        let outcome = classify_outcome(
+            7 * BYTES_PER_GIB,
+            DEFAULT_WARN_FREE_GB,
+            DEFAULT_BLOCK_FREE_GB,
+        );
+        match outcome {
+            DiskCheckOutcome::Warn {
+                threshold_gib,
+                free_bytes,
+            } => {
+                assert_eq!(threshold_gib, DEFAULT_WARN_FREE_GB);
+                assert_eq!(free_bytes, 7 * BYTES_PER_GIB);
+            }
+            other => panic!("expected Warn, got {other:?}"),
+        }
+    });
+
+    timed_test!(threshold_classifier_returns_block_below_block, {
+        let outcome = classify_outcome(
+            2 * BYTES_PER_GIB,
+            DEFAULT_WARN_FREE_GB,
+            DEFAULT_BLOCK_FREE_GB,
+        );
+        match outcome {
+            DiskCheckOutcome::Block {
+                threshold_gib,
+                free_bytes,
+            } => {
+                assert_eq!(threshold_gib, DEFAULT_BLOCK_FREE_GB);
+                assert_eq!(free_bytes, 2 * BYTES_PER_GIB);
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    });
+
+    timed_test!(threshold_classifier_block_wins_at_block_boundary, {
+        let outcome = classify_outcome(DEFAULT_BLOCK_FREE_GB * BYTES_PER_GIB - 1, 10, 5);
+        assert!(matches!(outcome, DiskCheckOutcome::Block { .. }));
+    });
+
+    timed_test!(check_disk_disabled_via_env_var, {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _disabled = EnvVarGuard::set(AUTO_PRUNE_ENABLED_ENV_VAR, "0");
+        let _free = EnvVarGuard::set(TEST_DISK_FREE_BYTES_ENV_VAR, "0");
+        let outcome = check_disk_or_warn_or_block(std::path::Path::new("."));
+        assert!(matches!(outcome, DiskCheckOutcome::Disabled));
+    });
+
+    timed_test!(check_disk_warns_with_custom_threshold, {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _enabled = EnvVarGuard::remove(AUTO_PRUNE_ENABLED_ENV_VAR);
+        let _warn = EnvVarGuard::set(WARN_FREE_GB_ENV_VAR, "20");
+        let _block = EnvVarGuard::set(BLOCK_FREE_GB_ENV_VAR, "5");
+        let _free = EnvVarGuard::set(
+            TEST_DISK_FREE_BYTES_ENV_VAR,
+            &(15u64 * BYTES_PER_GIB).to_string(),
+        );
+        let outcome = check_disk_or_warn_or_block(std::path::Path::new("."));
+        match outcome {
+            DiskCheckOutcome::Warn { threshold_gib, .. } => assert_eq!(threshold_gib, 20),
+            other => panic!("expected Warn, got {other:?}"),
+        }
+    });
+
+    timed_test!(check_disk_blocks_with_custom_threshold, {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _enabled = EnvVarGuard::remove(AUTO_PRUNE_ENABLED_ENV_VAR);
+        let _warn = EnvVarGuard::set(WARN_FREE_GB_ENV_VAR, "20");
+        let _block = EnvVarGuard::set(BLOCK_FREE_GB_ENV_VAR, "10");
+        let _free = EnvVarGuard::set(
+            TEST_DISK_FREE_BYTES_ENV_VAR,
+            &(3u64 * BYTES_PER_GIB).to_string(),
+        );
+        let outcome = check_disk_or_warn_or_block(std::path::Path::new("."));
+        match outcome {
+            DiskCheckOutcome::Block { threshold_gib, .. } => assert_eq!(threshold_gib, 10),
+            other => panic!("expected Block, got {other:?}"),
+        }
+    });
+
+    timed_test!(check_disk_disabled_when_probe_errors, {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _enabled = EnvVarGuard::remove(AUTO_PRUNE_ENABLED_ENV_VAR);
+        let _free = EnvVarGuard::set(TEST_DISK_FREE_BYTES_ENV_VAR, "error");
+        let outcome = check_disk_or_warn_or_block(std::path::Path::new("."));
+        assert!(matches!(outcome, DiskCheckOutcome::Disabled));
+    });
+
+    timed_test!(inverted_thresholds_collapse_to_block_value, {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _enabled = EnvVarGuard::remove(AUTO_PRUNE_ENABLED_ENV_VAR);
+        // warn=5, block=10 (inverted) — should collapse to a single
+        // block-only check at 10 GiB.
+        let _warn = EnvVarGuard::set(WARN_FREE_GB_ENV_VAR, "5");
+        let _block = EnvVarGuard::set(BLOCK_FREE_GB_ENV_VAR, "10");
+        let _free = EnvVarGuard::set(
+            TEST_DISK_FREE_BYTES_ENV_VAR,
+            &(7u64 * BYTES_PER_GIB).to_string(),
+        );
+        let outcome = check_disk_or_warn_or_block(std::path::Path::new("."));
+        assert!(matches!(outcome, DiskCheckOutcome::Block { .. }));
+    });
+
+    timed_test!(build_volume_path_prefers_target_when_present, {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cwd = tmp.path();
+        let target = cwd.join("target");
+        std::fs::create_dir_all(&target).expect("create target");
+        let resolved = build_volume_path(cwd, Some(&target));
+        assert_eq!(resolved, target);
+    });
+
+    timed_test!(build_volume_path_falls_back_to_cwd_when_target_missing, {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cwd = tmp.path();
+        let target = cwd.join("target");
+        let resolved = build_volume_path(cwd, Some(&target));
+        assert_eq!(resolved, cwd);
+    });
+
+    timed_test!(warn_line_includes_threshold_and_command, {
+        let line = render_warn_line(7 * BYTES_PER_GIB, 10);
+        assert!(line.contains("7.00 GiB"));
+        assert!(line.contains("10 GiB"));
+        assert!(line.contains("soldr gc target"));
+    });
+
+    timed_test!(block_line_directs_user_at_purge, {
+        let msg = render_block_message(2 * BYTES_PER_GIB, 5);
+        assert!(msg.contains("2.00 GiB"));
+        assert!(msg.contains("5 GiB"));
+        assert!(msg.contains("soldr gc target --purge"));
+        assert!(msg.contains("SOLDR_TARGET_BLOCK_FREE_GB"));
+        // Why: `report_and_exit` already prepends "soldr: " — the
+        // rendered message must not double it.
+        assert!(!msg.starts_with("soldr:"));
+    });
+}

--- a/crates/soldr-cli/src/gc/mod.rs
+++ b/crates/soldr-cli/src/gc/mod.rs
@@ -21,7 +21,9 @@ use serde::Serialize;
 
 mod auto;
 mod cargo_native;
+pub(crate) mod disk;
 mod purge;
+pub(crate) mod target_walker;
 mod walks;
 
 // Re-export the public CLI surface so `crate::gc::*` keeps matching
@@ -527,6 +529,217 @@ pub(crate) fn emit_startup_target_warning_if_due() {
         Ok(None) => {}
         Err(_) => {}
     }
+}
+
+// ---------------------------------------------------------------------------
+// soldr gc target — cross-repo target/ reclamation (#574).
+// ---------------------------------------------------------------------------
+
+/// Env-var override for the walk root used by `soldr gc target`.
+pub(crate) const SOLDR_GC_TARGET_ROOT_ENV_VAR: &str = "SOLDR_GC_TARGET_ROOT";
+
+const GC_TARGET_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Serialize)]
+struct GcTargetEntryOutput {
+    workspace_root: String,
+    target_dir: String,
+    size_bytes: u64,
+    size_human: String,
+    file_count: u64,
+    last_modified_ms: i64,
+}
+
+#[derive(Serialize)]
+struct GcTargetOutput {
+    schema_version: u32,
+    command: &'static str,
+    mode: &'static str,
+    root: String,
+    max_depth: usize,
+    entry_count: usize,
+    total_bytes: u64,
+    total_human: String,
+    entries: Vec<GcTargetEntryOutput>,
+    purged_count: usize,
+    failed_count: usize,
+    purged_bytes: u64,
+    purged_human: String,
+    failures: Vec<GcTargetFailure>,
+}
+
+#[derive(Serialize)]
+struct GcTargetFailure {
+    target_dir: String,
+    error: String,
+}
+
+pub(crate) fn run_gc_target_command(args: crate::cli_args::GcTargetArgs) -> Result<(), SoldrError> {
+    use std::io::{IsTerminal, Write};
+    use target_walker::TargetEntry;
+
+    let root = resolve_gc_target_root(args.root.as_deref())?;
+    let mut entries: Vec<TargetEntry> = target_walker::walk(&root, args.max_depth);
+    entries.sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes));
+
+    let total_bytes: u64 = entries.iter().map(|e| e.size_bytes).sum();
+    let mode = if args.purge { "purge" } else { "report" };
+
+    let entry_outputs: Vec<GcTargetEntryOutput> = entries
+        .iter()
+        .map(|e| GcTargetEntryOutput {
+            workspace_root: e.workspace_root.display().to_string(),
+            target_dir: e.target_dir.display().to_string(),
+            size_bytes: e.size_bytes,
+            size_human: crate::cache_lib::target_registry::human_size(e.size_bytes),
+            file_count: e.file_count,
+            last_modified_ms: e.last_modified_ms,
+        })
+        .collect();
+
+    let mut purged_count = 0usize;
+    let mut purged_bytes = 0u64;
+    let mut failures: Vec<GcTargetFailure> = Vec::new();
+
+    if args.purge {
+        // Print human summary to stderr so JSON callers still get clean
+        // stdout. The y/n prompt also lives on stderr/stdin so piping
+        // stdout through `jq` doesn't break confirmation flow.
+        if !args.json {
+            print_target_report(&root, &entries, total_bytes, /*purge_plan=*/ true);
+        }
+
+        let proceed = if args.yes {
+            true
+        } else if !std::io::stdin().is_terminal() {
+            // Why: refuse to silently delete in CI when --yes is missing.
+            // The non-interactive caller must opt in explicitly.
+            eprintln!(
+                "soldr gc target: refusing to purge without --yes on a non-interactive stdin"
+            );
+            return Err(SoldrError::Other(
+                "soldr gc target --purge requires --yes on non-interactive stdin".into(),
+            ));
+        } else {
+            eprint!(
+                "soldr gc target: purge {} target/ director{} totaling {} ? [y/N] ",
+                entries.len(),
+                if entries.len() == 1 { "y" } else { "ies" },
+                crate::cache_lib::target_registry::human_size(total_bytes),
+            );
+            let _ = std::io::stderr().flush();
+            let mut answer = String::new();
+            std::io::stdin()
+                .read_line(&mut answer)
+                .map_err(|e| SoldrError::Other(format!("failed to read prompt answer: {e}")))?;
+            matches!(answer.trim(), "y" | "Y" | "yes" | "Yes" | "YES")
+        };
+
+        if proceed {
+            for entry in &entries {
+                match std::fs::remove_dir_all(&entry.target_dir) {
+                    Ok(()) => {
+                        purged_count += 1;
+                        purged_bytes = purged_bytes.saturating_add(entry.size_bytes);
+                    }
+                    Err(err) => failures.push(GcTargetFailure {
+                        target_dir: entry.target_dir.display().to_string(),
+                        error: err.to_string(),
+                    }),
+                }
+            }
+        } else if !args.json {
+            eprintln!("soldr gc target: aborted; no directories deleted");
+        }
+    } else if !args.json {
+        print_target_report(&root, &entries, total_bytes, /*purge_plan=*/ false);
+    }
+
+    let failed_count = failures.len();
+
+    if args.json {
+        let output = GcTargetOutput {
+            schema_version: GC_TARGET_JSON_SCHEMA_VERSION,
+            command: "gc target",
+            mode,
+            root: root.display().to_string(),
+            max_depth: args.max_depth,
+            entry_count: entries.len(),
+            total_bytes,
+            total_human: crate::cache_lib::target_registry::human_size(total_bytes),
+            entries: entry_outputs,
+            purged_count,
+            failed_count,
+            purged_bytes,
+            purged_human: crate::cache_lib::target_registry::human_size(purged_bytes),
+            failures,
+        };
+        print_json(&output)?;
+    } else if args.purge {
+        eprintln!(
+            "soldr gc target: purged {purged_count} target/ director{} ({}); {} failure{}",
+            if purged_count == 1 { "y" } else { "ies" },
+            crate::cache_lib::target_registry::human_size(purged_bytes),
+            failed_count,
+            if failed_count == 1 { "" } else { "s" },
+        );
+    }
+
+    if args.purge && failed_count > 0 {
+        return Err(SoldrError::Other(format!(
+            "soldr gc target: {failed_count} target/ purge failure{}",
+            if failed_count == 1 { "" } else { "s" }
+        )));
+    }
+    Ok(())
+}
+
+fn print_target_report(
+    root: &std::path::Path,
+    entries: &[target_walker::TargetEntry],
+    total_bytes: u64,
+    purge_plan: bool,
+) {
+    let heading = if purge_plan {
+        "soldr gc target: purge plan"
+    } else {
+        "soldr gc target: report"
+    };
+    println!("{heading}");
+    println!("  root: {}", root.display());
+    println!("  entries: {}", entries.len());
+    println!(
+        "  total: {}",
+        crate::cache_lib::target_registry::human_size(total_bytes)
+    );
+    for entry in entries {
+        println!(
+            "    {}  size={}  files={}  target={}",
+            entry.workspace_root.display(),
+            crate::cache_lib::target_registry::human_size(entry.size_bytes),
+            entry.file_count,
+            entry.target_dir.display(),
+        );
+    }
+    if !purge_plan && !entries.is_empty() {
+        println!("  run with --purge --yes to reclaim these directories");
+    }
+}
+
+fn resolve_gc_target_root(cli: Option<&std::path::Path>) -> Result<std::path::PathBuf, SoldrError> {
+    if let Some(p) = cli {
+        return Ok(p.to_path_buf());
+    }
+    if let Some(raw) = std::env::var_os(SOLDR_GC_TARGET_ROOT_ENV_VAR) {
+        let s = raw.to_string_lossy();
+        let trimmed = s.trim();
+        if !trimmed.is_empty() {
+            return Ok(crate::core::expand_user_home(trimmed));
+        }
+    }
+    let home = crate::core::user_home_dir()
+        .map_err(|e| SoldrError::Other(format!("failed to resolve $HOME: {e}")))?;
+    Ok(home.join("dev"))
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/src/gc/target_walker.rs
+++ b/crates/soldr-cli/src/gc/target_walker.rs
@@ -1,0 +1,216 @@
+//! Cross-repo `target/` walker for `soldr gc target` (issue #574).
+//!
+//! Walks a configurable root (default `~/dev`), finds every directory
+//! containing a `Cargo.toml`, and sums each sibling `target/`'s size.
+//! Returned entries are NOT sorted; sorting is the caller's
+//! responsibility so the CLI handler can choose between size-desc
+//! reports, JSON-stable paths, etc.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use jwalk::WalkDir;
+use serde::Serialize;
+
+use super::walks::fast_directory_size_and_files;
+
+/// One reclaimable workspace `target/` directory.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct TargetEntry {
+    /// Workspace root — the directory containing `Cargo.toml`.
+    pub(crate) workspace_root: PathBuf,
+    /// Sibling `target/` directory we'd actually delete.
+    pub(crate) target_dir: PathBuf,
+    /// Total bytes on disk under `target_dir`.
+    pub(crate) size_bytes: u64,
+    /// Files counted under `target_dir`.
+    pub(crate) file_count: u64,
+    /// Unix-ms mtime of `target_dir` (most-recently-modified entry
+    /// at the top level). Zero when unavailable.
+    pub(crate) last_modified_ms: i64,
+}
+
+/// Walk `root` up to `max_depth` directories deep, collecting every
+/// workspace that has a sibling `target/` directory. Hidden dirs
+/// (leading `.`) are skipped to avoid descending into `.git/` and
+/// similar VCS roots. Symlinks are not followed.
+pub(crate) fn walk(root: &Path, max_depth: usize) -> Vec<TargetEntry> {
+    if !root.is_dir() {
+        return Vec::new();
+    }
+    let mut out: Vec<TargetEntry> = Vec::new();
+    let walker = WalkDir::new(root)
+        .follow_links(false)
+        .max_depth(max_depth)
+        .skip_hidden(true)
+        .process_read_dir(|_depth, _path, _state, children| {
+            // Why: never descend into a `target/` we're about to report
+            // on — saves a huge amount of recursive stat work on big
+            // workspaces and avoids surfacing nested workspace target
+            // dirs as their own entries.
+            children.retain(|entry_result| {
+                let Ok(entry) = entry_result else {
+                    return true;
+                };
+                let name = entry.file_name().to_string_lossy().to_string();
+                name != "target"
+            });
+        });
+
+    for entry in walker.into_iter().flatten() {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.file_name().to_string_lossy() != "Cargo.toml" {
+            continue;
+        }
+        let manifest_path = entry.path();
+        let Some(workspace_root) = manifest_path.parent().map(|p| p.to_path_buf()) else {
+            continue;
+        };
+        let target_dir = workspace_root.join("target");
+        if !target_dir.is_dir() {
+            continue;
+        }
+        let (size_bytes, file_count) = fast_directory_size_and_files(&target_dir);
+        if size_bytes == 0 && file_count == 0 {
+            continue;
+        }
+        let last_modified_ms = directory_mtime_ms(&target_dir);
+        out.push(TargetEntry {
+            workspace_root,
+            target_dir,
+            size_bytes,
+            file_count,
+            last_modified_ms,
+        });
+    }
+    out
+}
+
+fn directory_mtime_ms(path: &Path) -> i64 {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return 0;
+    };
+    let Ok(modified) = meta.modified() else {
+        return 0;
+    };
+    match modified.duration_since(UNIX_EPOCH) {
+        Ok(d) => d.as_millis() as i64,
+        Err(_) => SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timed_test;
+
+    fn seed_workspace(root: &Path, name: &str, target_bytes: usize) -> PathBuf {
+        let workspace = root.join(name);
+        std::fs::create_dir_all(&workspace).expect("create workspace dir");
+        std::fs::write(workspace.join("Cargo.toml"), b"[package]\nname=\"x\"\n")
+            .expect("write Cargo.toml");
+        let target = workspace.join("target");
+        std::fs::create_dir_all(target.join("debug")).expect("create target/debug");
+        std::fs::write(
+            target.join("debug").join("blob.bin"),
+            vec![0u8; target_bytes],
+        )
+        .expect("write blob");
+        workspace
+    }
+
+    timed_test!(walk_finds_workspaces_and_returns_unsorted, {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let small = seed_workspace(root, "small", 1024);
+        let large = seed_workspace(root, "large", 1024 * 1024);
+        let medium = seed_workspace(root, "medium", 64 * 1024);
+
+        let mut entries = walk(root, 4);
+        entries.sort_by_key(|e| e.size_bytes);
+
+        let paths: Vec<&Path> = entries.iter().map(|e| e.workspace_root.as_path()).collect();
+        assert!(paths.contains(&small.as_path()), "found {paths:?}");
+        assert!(paths.contains(&medium.as_path()), "found {paths:?}");
+        assert!(paths.contains(&large.as_path()), "found {paths:?}");
+
+        let large_entry = entries
+            .iter()
+            .find(|e| e.workspace_root == large)
+            .expect("large workspace present");
+        assert!(large_entry.size_bytes >= 1024 * 1024);
+        assert!(large_entry.target_dir.ends_with("target"));
+        assert!(large_entry.file_count >= 1);
+    });
+
+    timed_test!(walk_skips_hidden_directories, {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let _shown = seed_workspace(root, "visible", 1024);
+        let _hidden = seed_workspace(root, ".cache", 1024);
+
+        let entries = walk(root, 4);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].workspace_root.ends_with("visible"));
+    });
+
+    timed_test!(walk_does_not_recurse_into_target_dirs, {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let parent = seed_workspace(root, "outer", 1024);
+
+        // Nested Cargo.toml *inside* the outer target/ — should be
+        // ignored because we prune `target/` from the walk.
+        let nested = parent.join("target").join("nested-project");
+        std::fs::create_dir_all(&nested).expect("nested project dir");
+        std::fs::write(nested.join("Cargo.toml"), b"[package]\nname=\"y\"\n")
+            .expect("write nested Cargo.toml");
+        std::fs::create_dir_all(nested.join("target")).expect("nested target/");
+        std::fs::write(nested.join("target").join("blob.bin"), vec![0u8; 1024])
+            .expect("write nested blob");
+
+        let entries = walk(root, 8);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].workspace_root.ends_with("outer"));
+    });
+
+    timed_test!(walk_respects_max_depth, {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let deep = root.join("a").join("b").join("c").join("project");
+        std::fs::create_dir_all(&deep).expect("deep nested");
+        std::fs::write(deep.join("Cargo.toml"), b"[package]\nname=\"z\"\n")
+            .expect("write deep Cargo.toml");
+        std::fs::create_dir_all(deep.join("target")).expect("deep target/");
+        std::fs::write(deep.join("target").join("blob"), vec![0u8; 1024]).expect("write deep blob");
+
+        // a/b/c/project/Cargo.toml is 5 levels under root — depth 4
+        // misses it, depth 8 finds it.
+        assert!(walk(root, 4).is_empty());
+        assert_eq!(walk(root, 8).len(), 1);
+    });
+
+    timed_test!(walk_skips_workspaces_without_target_dir, {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let no_target = root.join("no-target");
+        std::fs::create_dir_all(&no_target).expect("create dir");
+        std::fs::write(no_target.join("Cargo.toml"), b"[package]\nname=\"w\"\n")
+            .expect("write Cargo.toml");
+
+        let entries = walk(root, 4);
+        assert!(entries.is_empty());
+    });
+
+    timed_test!(walk_returns_empty_when_root_missing, {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bogus = tmp.path().join("does-not-exist");
+        let entries = walk(&bogus, 4);
+        assert!(entries.is_empty());
+    });
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -541,6 +541,10 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                     gc::run_gc_sweep_command(*args)?;
                     return Ok(());
                 }
+                Some(GcSubcommand::Target(args)) => {
+                    gc::run_gc_target_command(*args)?;
+                    return Ok(());
+                }
                 None => gc::GcInvocation {
                     mode: gc::GcMode::Summary,
                     older_than,

--- a/crates/soldr-cli/tests/cli_gc_target.rs
+++ b/crates/soldr-cli/tests/cli_gc_target.rs
@@ -1,0 +1,144 @@
+//! Integration tests for `soldr gc target` (issue #574).
+//!
+//! Exercises the cross-repo workspace walker, JSON output shape, and
+//! `--purge --yes` deletion path through the real soldr binary.
+
+#![allow(unused_imports)]
+
+use serde_json::Value;
+use soldr_cli::timed_test;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn soldr_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_soldr")
+}
+
+fn seed_workspace(root: &Path, name: &str, target_bytes: usize) -> PathBuf {
+    let workspace = root.join(name);
+    fs::create_dir_all(&workspace).expect("create workspace dir");
+    fs::write(workspace.join("Cargo.toml"), b"[package]\nname=\"x\"\n").expect("Cargo.toml");
+    let target = workspace.join("target").join("debug");
+    fs::create_dir_all(&target).expect("create target/debug");
+    fs::write(target.join("blob.bin"), vec![0u8; target_bytes]).expect("write blob");
+    workspace
+}
+
+timed_test!(gc_target_dry_run_json_shape_is_stable, {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    let small = seed_workspace(root, "small", 4 * 1024);
+    let large = seed_workspace(root, "large", 1024 * 1024);
+
+    let output = Command::new(soldr_bin())
+        .args(["gc", "target", "--root"])
+        .arg(root)
+        .args(["--dry-run", "--json"])
+        .output()
+        .expect("failed to run soldr gc target");
+
+    assert!(
+        output.status.success(),
+        "soldr gc target --dry-run --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        small.join("target").exists(),
+        "dry-run must not delete {}",
+        small.display()
+    );
+    assert!(
+        large.join("target").exists(),
+        "dry-run must not delete {}",
+        large.display()
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("gc target --json must be JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "gc target");
+    assert_eq!(json["mode"], "report");
+    assert_eq!(json["entry_count"], 2);
+    assert_eq!(json["purged_count"], 0);
+    assert_eq!(json["failed_count"], 0);
+    let entries = json["entries"].as_array().expect("entries array");
+    assert_eq!(entries.len(), 2);
+    // entries are sorted size-desc — large should be first.
+    let first_size = entries[0]["size_bytes"].as_u64().unwrap_or(0);
+    let second_size = entries[1]["size_bytes"].as_u64().unwrap_or(0);
+    assert!(
+        first_size >= second_size,
+        "entries should be sorted size-desc: {first_size} vs {second_size}"
+    );
+    assert!(first_size >= 1024 * 1024);
+
+    let total_bytes = json["total_bytes"].as_u64().unwrap_or(0);
+    assert!(total_bytes >= 1024 * 1024 + 4 * 1024);
+});
+
+timed_test!(gc_target_purge_yes_deletes_target_dirs, {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    let alpha = seed_workspace(root, "alpha", 8 * 1024);
+    let beta = seed_workspace(root, "beta", 16 * 1024);
+
+    let output = Command::new(soldr_bin())
+        .args(["gc", "target", "--root"])
+        .arg(root)
+        .args(["--purge", "--yes", "--json"])
+        .output()
+        .expect("failed to run soldr gc target --purge --yes");
+
+    assert!(
+        output.status.success(),
+        "soldr gc target --purge --yes failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !alpha.join("target").exists(),
+        "purge must delete {}",
+        alpha.display()
+    );
+    assert!(
+        !beta.join("target").exists(),
+        "purge must delete {}",
+        beta.display()
+    );
+    // Workspaces themselves stay — only target/ goes away.
+    assert!(alpha.join("Cargo.toml").exists());
+    assert!(beta.join("Cargo.toml").exists());
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("gc target --purge --json must be JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["command"], "gc target");
+    assert_eq!(json["mode"], "purge");
+    assert_eq!(json["entry_count"], 2);
+    assert_eq!(json["purged_count"], 2);
+    assert_eq!(json["failed_count"], 0);
+});
+
+timed_test!(gc_target_empty_root_reports_zero, {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    let output = Command::new(soldr_bin())
+        .args(["gc", "target", "--root"])
+        .arg(root)
+        .args(["--dry-run", "--json"])
+        .output()
+        .expect("failed to run soldr gc target");
+
+    assert!(
+        output.status.success(),
+        "soldr gc target on empty root failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("JSON");
+    assert_eq!(json["entry_count"], 0);
+    assert_eq!(json["total_bytes"], 0);
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -1008,6 +1008,85 @@ Stages, in order:
    `--max-src-age=7days --max-crate-age=14days --max-git-co-age=7days`,
    each clamped to `auto_gc.min_age_secs`.
 
+### `soldr gc target` (issue #574)
+
+Cross-repo `target/` reclamation: walks a configurable root, finds every
+workspace with a sibling `target/` directory, and reports their sizes
+(sorted descending). With `--purge` it deletes them after a single
+confirmation prompt (or `--yes` for non-interactive automation).
+
+```bash
+soldr gc target                                    # report under ~/dev (default)
+soldr gc target --root ~/code --max-depth 6        # custom root and walk depth
+soldr gc target --dry-run --json                   # machine-readable report
+soldr gc target --purge                            # interactive deletion
+soldr gc target --purge --yes                      # non-interactive deletion
+soldr gc target --purge --yes --json               # CI-friendly purge + JSON
+```
+
+Options:
+
+- `--root <PATH>` — walk root. Falls back to `$SOLDR_GC_TARGET_ROOT` then
+  `~/dev`.
+- `--max-depth <N>` — maximum directory depth for the workspace scan
+  (default `4`). Hidden directories (leading `.`) and any directory
+  named `target` are skipped.
+- `--dry-run` — report-only (default).
+- `--purge` — delete every reported `target/` directory.
+- `--yes` — skip the y/n confirmation prompt. Required when stdin is
+  not a terminal (CI).
+- `--json` — emit the stable machine-facing payload (`schema_version: 1`).
+
+JSON shape (stable):
+
+```json
+{
+  "schema_version": 1,
+  "command": "gc target",
+  "mode": "report" | "purge",
+  "root": "/home/me/dev",
+  "max_depth": 4,
+  "entry_count": 0,
+  "total_bytes": 0,
+  "total_human": "0 B",
+  "entries": [
+    {
+      "workspace_root": "/home/me/dev/foo",
+      "target_dir": "/home/me/dev/foo/target",
+      "size_bytes": 0,
+      "size_human": "0 B",
+      "file_count": 0,
+      "last_modified_ms": 0
+    }
+  ],
+  "purged_count": 0,
+  "failed_count": 0,
+  "purged_bytes": 0,
+  "purged_human": "0 B",
+  "failures": []
+}
+```
+
+The walker is independent of the per-repo `gc list` taxonomy above —
+it scans real filesystem trees rather than the soldr registry, so it
+finds workspaces that have never gone through `soldr cargo ...`.
+
+### Host-volume disk watchdog (issue #574)
+
+Before every `soldr cargo ...` build, soldr probes free space on the
+build volume (the disk hosting the project's `target/` dir, or CWD if
+`target/` doesn't exist yet) and either warns or aborts:
+
+- Above `SOLDR_TARGET_WARN_FREE_GB` (default 10 GiB) — silent.
+- Between warn and `SOLDR_TARGET_BLOCK_FREE_GB` (default 5 GiB) —
+  one-line stderr warning pointing at `soldr gc target`.
+- Below the block threshold — cargo is refused with a clear error
+  directing the user at `soldr gc target --purge`.
+
+Set `SOLDR_TARGET_AUTO_PRUNE_ENABLED=0` to disable the watchdog
+entirely. The watchdog is layered on top of the legacy 2 GiB low-disk
+advisory (issue #289) and never replaces it.
+
 ### Automatic GC under disk pressure (issue #323)
 
 soldr's cargo front door triggers a background auto-GC pass when free
@@ -1132,6 +1211,11 @@ Commands:
 | `SOLDR_LINKER` | Pick the linker injected for `soldr cargo ...` builds (issue #285). Accepted values: `default` (no injection — keep the rust-toolchain default), `ld` (system linker — also no injection on every supported platform), `mold` (Linux only; hard error elsewhere), `rust-lld` (Windows MSVC and Linux/MinGW via `clang -fuse-ld=lld`; **no-op on macOS** — see below), `fast` (mold on Linux when present on `PATH`, otherwise rust-lld; rust-lld on Windows MSVC; **no-op on macOS** — see below). The choice resolves to `CARGO_TARGET_<TRIPLE>_LINKER` and `CARGO_TARGET_<TRIPLE>_RUSTFLAGS` injected into the spawned cargo process; the active target is the same one Cargo would pick (`--target` flag, `CARGO_BUILD_TARGET`, or the host triple). A `linker = "..."` field in `~/.soldr/config.toml` is honored when the env var is unset. On macOS targets `rust-lld` and `fast` fall back silently to the platform default linker (issue #509): Apple clang only accepts `-fuse-ld=lld` when the toolchain wires up an `ld64.lld` shim, and stock macOS toolchains do not — injecting it would break even `cc-rs` build-script compilations. | unset |
 | `SOLDR_QUIET_DEFENDER` | Suppress the once-per-day pre-build warning emitted by the cargo front door when Defender is actively scanning the soldr cache directory (issue #358). Truthy values silence the warning; the warning is also automatically suppressed in CI environments. | unset |
 | `SOLDR_OPTIMIZE_HELPER_OUTPUT` | Internal: set by the parent soldr process when it re-launches itself elevated via `--as-elevated-helper`. The elevated child writes its JSON status to this path so the parent can read and propagate it. | unset |
+| `SOLDR_TARGET_WARN_FREE_GB` | Free-space threshold (in GiB) below which the host-volume disk watchdog (issue #574) emits a one-line stderr warning before `soldr cargo ...` dispatches the build. The watchdog probes the disk hosting the project's `target/` dir, falling back to CWD when `target/` doesn't exist yet. | `10` |
+| `SOLDR_TARGET_BLOCK_FREE_GB` | Free-space threshold (in GiB) below which the host-volume disk watchdog (issue #574) refuses to start the build, pointing the user at `soldr gc target --purge`. Always strictly less than `SOLDR_TARGET_WARN_FREE_GB`; inverted thresholds collapse to "block wins". | `5` |
+| `SOLDR_TARGET_AUTO_PRUNE_ENABLED` | Master toggle for the host-volume disk watchdog (issue #574). Falsy values (`0`, `false`, `no`, `off`, empty — case-insensitive) disable the watchdog entirely. | `1` |
+| `SOLDR_GC_TARGET_ROOT` | Default walk root for `soldr gc target` (issue #574). The `--root <PATH>` flag always takes precedence. | `~/dev` |
+| `SOLDR_TEST_DISK_FREE_BYTES` | Test seam for the watchdog: when set to a `u64` byte count (or `error`), overrides the real `fs2::available_space` probe so tests can drive every threshold edge. Internal — never set this in production. | unset |
 
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.


### PR DESCRIPTION
## Summary

Adds the in-tree pieces of issue #574 — a host-volume disk watchdog tied
into the cargo front door, plus a new `soldr gc target` command for
cross-repo `target/` reclamation.

### A) Host-volume disk watchdog (cargo-front-door pre-flight)

Before every build-like `soldr cargo ...` invocation soldr probes free
space on the disk that hosts the project's `target/` dir (or CWD when
`target/` doesn't exist yet) and either warns or aborts:

- `>= SOLDR_TARGET_WARN_FREE_GB` (default 10 GiB) — silent.
- Between warn and `SOLDR_TARGET_BLOCK_FREE_GB` (default 5 GiB) —
  one-line stderr warning pointing at `soldr gc target`.
- `< block` — the invocation is refused with a clear error directing
  the user at `soldr gc target --purge`.

`SOLDR_TARGET_AUTO_PRUNE_ENABLED=0` disables the watchdog entirely.
Inverted thresholds collapse to "block wins" so the safety net is
conservative. Test seam: `SOLDR_TEST_DISK_FREE_BYTES` overrides the
real `fs2::available_space` probe.

### B) `soldr gc target` subcommand

Walks a configurable root (default `~/dev`, override via `--root <PATH>`
or `$SOLDR_GC_TARGET_ROOT`) for every workspace with a sibling
`target/` directory and reports sizes sorted descending. Supports
`--max-depth <N>` (default 4), `--dry-run` (the default), `--purge`
(delete after a single y/n prompt), `--yes` (skip the prompt for
CI/automation), and `--json` (stable `schema_version: 1` payload).

The walker uses `jwalk`, skips hidden directories, and never descends
into `target/` itself.

### C) Settings

Four new env vars documented in `docs/API.md`:
- `SOLDR_TARGET_WARN_FREE_GB` (default `10`)
- `SOLDR_TARGET_BLOCK_FREE_GB` (default `5`)
- `SOLDR_TARGET_AUTO_PRUNE_ENABLED` (default `1`)
- `SOLDR_GC_TARGET_ROOT` (default `~/dev`)

### Decisions made

- Reused the existing top-level `gc` command tree — added `Target` as a
  new `GcSubcommand` variant rather than creating a new top-level verb.
  The `gc` verb is already in `SOLDR_BUILTIN_VERBS` and not on the
  frozen-commands list.
- Watchdog Block returns a `SoldrError` rather than calling
  `std::process::exit` directly so the top-level dispatch handles the
  error consistently with every other front-door failure (proper exit
  code, cache lifecycle finalization, etc.).
- Block message rendered without leading `soldr: ` because
  `report_and_exit` prepends it; a unit test guards that.
- Refuses to purge on non-interactive stdin without `--yes` — CI
  callers must opt in explicitly.

### Out of scope (per issue #574 / agent prompt)

- Foreign-repo cargo routing through soldr (setup-soldr/docs).
- New SQLite registries (#234 covers tracking).
- The `[cook]` auto-GC pass (#589 shipped it).
- The per-checkout `target/` prune hooks (#485 still owns them).

## Test plan

- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo clippy --workspace --bins --tests -- -D warnings`
- [x] `soldr cargo test -p soldr-cli --bin soldr gc::disk` — 13 tests
- [x] `soldr cargo test -p soldr-cli --bin soldr gc::target_walker` — 6 tests
- [x] `soldr cargo test -p soldr-cli --test cli_gc_target` — 3 tests
- [x] `soldr cargo test -p soldr-cli --test timed_test_lint` — passes; all new files use `timed_test!`
- [x] Regression: existing `cli_gc` tests still pass (9/9), `cargo_front_door` unit tests still pass (49/49)
- [x] Manual smoke: real binary report and `--purge --yes` deletion against a tempdir
- [x] Manual smoke: watchdog Warn and Block tiers fire via `SOLDR_TEST_DISK_FREE_BYTES` against `soldr cargo build --help` (exit 0 / exit 1 respectively)

Closes #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)