### PR TITLE
feat(load): parallel per-file cache extraction + --profile-extract (#575)

### DIFF
--- a/crates/soldr-cli/src/cache_lib/save.rs
+++ b/crates/soldr-cli/src/cache_lib/save.rs
@@ -997,6 +997,11 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
         None
     };
     let driver_loop_start = std::time::Instant::now();
+    // Cumulative microseconds the driver spent inside `entry.read_to_end`
+    // for cache-file bodies. That call drives the zstd decoder, so this
+    // is the closest cheap approximation of "zstd_decode" wall-clock the
+    // streaming API gives us. tar_parse_us is the loop's remaining time.
+    let mut zstd_decode_us: u64 = 0;
 
     // #575/#596 Defender auto-exclusion (Windows + admin only — never
     // UAC-prompts). The guard removes the exclusion on drop.
@@ -1078,9 +1083,13 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
         // small (<MiB each) and the bounded channel caps how many are
         // resident at once, so memory usage stays bounded.
         let mut body = Vec::new();
+        let body_read_start = opts.profile_extract.then(std::time::Instant::now);
         entry
             .read_to_end(&mut body)
             .map_err(SaveLoadError::BareIo)?;
+        if let Some(t0) = body_read_start {
+            zstd_decode_us = zstd_decode_us.saturating_add(t0.elapsed().as_micros() as u64);
+        }
         let mtime_secs = entry.header().mtime().ok();
         // Capture the tar header's Unix mode so the worker can chmod
         // the file after writing. Without this, executable scripts
@@ -1112,20 +1121,28 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
         }
     }
 
-    let driver_loop_ms = driver_loop_start.elapsed().as_millis() as u64;
+    let driver_loop_us = driver_loop_start.elapsed().as_micros() as u64;
     let workers_drain_start = std::time::Instant::now();
     // Close the dispatch channel and wait for workers to drain. Any error
     // from a worker is surfaced here (first-error-wins).
     if let Some(dispatch) = extract_dispatch {
         dispatch.finish()?;
     }
-    let workers_drain_ms = workers_drain_start.elapsed().as_millis() as u64;
+    let workers_drain_us = workers_drain_start.elapsed().as_micros() as u64;
     if let Some(err) = extract_error.lock().expect("extract_error mutex").take() {
         return Err(err);
     }
     let cache_files_restored = cache_files_counter.load(Ordering::Relaxed);
     if let Some(profile) = profile {
-        profile.emit_to_stderr(driver_loop_ms, workers_drain_ms, cache_files_restored);
+        let phases = ExtractPhaseTimings {
+            zstd_decode_us,
+            // tar_parse_us = driver loop time minus the read_to_end accounting.
+            // Saturates to 0 if profile noise (timer jitter, scheduler) pushed
+            // accumulated zstd_decode_us slightly past driver_loop_us.
+            tar_parse_us: driver_loop_us.saturating_sub(zstd_decode_us),
+            extract_total_us: driver_loop_us.saturating_add(workers_drain_us),
+        };
+        profile.emit_to_stderr(phases, cache_files_restored);
     }
 
     let manifest = match manifest_decoded {
@@ -1335,6 +1352,16 @@ fn extract_one(job: &ExtractJob) -> Result<()> {
     Ok(())
 }
 
+/// Per-phase driver-thread wall-clock collected during a profiled load.
+/// Microsecond precision so `format_profile_line` can emit ms with no
+/// loss at the conversion boundary.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ExtractPhaseTimings {
+    pub zstd_decode_us: u64,
+    pub tar_parse_us: u64,
+    pub extract_total_us: u64,
+}
+
 /// Per-load profiling state collected when `LoadOptions::profile_extract`
 /// is on (#575). Each worker writes into its own slot — no contention.
 /// `emit_to_stderr` formats the summary line at the end of `load()`.
@@ -1365,7 +1392,7 @@ impl ExtractProfile {
         }
     }
 
-    fn emit_to_stderr(&self, driver_loop_ms: u64, workers_drain_ms: u64, files: u64) {
+    fn emit_to_stderr(&self, phases: ExtractPhaseTimings, files: u64) {
         let mut all_us: Vec<u64> = Vec::new();
         let mut per_worker_counts = Vec::with_capacity(self.per_worker_latencies.len());
         for slot in &self.per_worker_latencies {
@@ -1373,31 +1400,61 @@ impl ExtractProfile {
             per_worker_counts.push(v.len());
             all_us.extend_from_slice(&v);
         }
-        all_us.sort_unstable();
-        let pct = |p: f64| -> u64 {
-            if all_us.is_empty() {
-                return 0;
-            }
-            let idx = ((all_us.len() as f64 - 1.0) * p).round() as usize;
-            all_us[idx.min(all_us.len() - 1)]
-        };
-        let workers_summary: String = per_worker_counts
-            .iter()
-            .enumerate()
-            .map(|(i, n)| format!("{}:n={}", i, n))
-            .collect::<Vec<_>>()
-            .join(", ");
         eprintln!(
-            "soldr load: profile cache_files={} driver_loop_ms={} workers_drain_ms={} workers={{{}}} per_file_p50_us={} p95_us={} p99_us={}",
-            files,
-            driver_loop_ms,
-            workers_drain_ms,
-            workers_summary,
-            pct(0.50),
-            pct(0.95),
-            pct(0.99),
+            "{}",
+            format_profile_line(phases, &per_worker_counts, &all_us, files)
         );
     }
+}
+
+/// Render the documented `soldr load: profile:` line shape (#575). Exposed
+/// at module scope so unit tests can exercise the format independent of a
+/// live extract.
+///
+/// Shape matches the spec in zackees/soldr#575:
+///
+/// ```text
+/// soldr load: profile: zstd_decode=4120ms tar_parse=890ms extract_total=10510ms
+///   workers={0:n=12058, 1:n=12090, 2:n=12053, 3:n=12030}
+///   per_file_p50_us=180 p95_us=450 p99_us=1200 cache_files=48231
+/// ```
+///
+/// Driven by `extract_total_us` instead of summing — that's the only
+/// wall-clock number that includes the workers-drain tail, which is the
+/// number tuning anyone actually cares about. Worker indices are 0-based
+/// to match rayon's convention.
+pub fn format_profile_line(
+    phases: ExtractPhaseTimings,
+    per_worker_counts: &[usize],
+    per_file_latencies_us: &[u64],
+    files: u64,
+) -> String {
+    let mut sorted: Vec<u64> = per_file_latencies_us.to_vec();
+    sorted.sort_unstable();
+    let pct = |p: f64| -> u64 {
+        if sorted.is_empty() {
+            return 0;
+        }
+        let idx = ((sorted.len() as f64 - 1.0) * p).round() as usize;
+        sorted[idx.min(sorted.len() - 1)]
+    };
+    let workers_summary: String = per_worker_counts
+        .iter()
+        .enumerate()
+        .map(|(i, n)| format!("{}:n={}", i, n))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "soldr load: profile: zstd_decode={zstd}ms tar_parse={tar}ms extract_total={total}ms workers={{{workers}}} per_file_p50_us={p50} p95_us={p95} p99_us={p99} cache_files={files}",
+        zstd = phases.zstd_decode_us / 1000,
+        tar = phases.tar_parse_us / 1000,
+        total = phases.extract_total_us / 1000,
+        workers = workers_summary,
+        p50 = pct(0.50),
+        p95 = pct(0.95),
+        p99 = pct(0.99),
+        files = files,
+    )
 }
 
 /// RAII guard for `--auto-defender-exclude` (#596).
@@ -1606,4 +1663,92 @@ fn num_cpus_for(threads: Option<usize>) -> u32 {
             .map(|n| n.get() as u32)
             .unwrap_or(1)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timed_test;
+
+    timed_test!(profile_line_matches_documented_shape, {
+        // Synthetic per-file latencies: 6 values with known order so the
+        // percentile math is hand-checkable. p50/p95/p99 indices on a
+        // 6-element vec are round((6-1)*p): 3 → 250, 5 → 1200, 5 → 1200.
+        let latencies = vec![100u64, 150, 200, 250, 450, 1200];
+        let per_worker_counts = vec![2usize, 2, 1, 1];
+        let phases = ExtractPhaseTimings {
+            zstd_decode_us: 4_120_000,
+            tar_parse_us: 890_000,
+            extract_total_us: 10_510_000,
+        };
+        let line = format_profile_line(phases, &per_worker_counts, &latencies, 6);
+
+        assert!(
+            line.starts_with("soldr load: profile: "),
+            "missing prefix: {line}"
+        );
+        assert!(
+            line.contains("zstd_decode=4120ms"),
+            "wrong zstd_decode: {line}"
+        );
+        assert!(line.contains("tar_parse=890ms"), "wrong tar_parse: {line}");
+        assert!(
+            line.contains("extract_total=10510ms"),
+            "wrong extract_total: {line}"
+        );
+        assert!(
+            line.contains("workers={0:n=2, 1:n=2, 2:n=1, 3:n=1}"),
+            "wrong workers shape: {line}"
+        );
+        assert!(line.contains("per_file_p50_us=250"), "p50 wrong: {line}");
+        assert!(line.contains("p95_us=1200"), "p95 wrong: {line}");
+        assert!(line.contains("p99_us=1200"), "p99 wrong: {line}");
+        assert!(line.contains("cache_files=6"), "files count wrong: {line}");
+    });
+
+    timed_test!(profile_line_handles_empty_latencies, {
+        // No per-file data (e.g. cache had zero regular entries) — must
+        // still emit a parseable line, with zeros for the percentiles.
+        let line = format_profile_line(
+            ExtractPhaseTimings {
+                zstd_decode_us: 0,
+                tar_parse_us: 0,
+                extract_total_us: 1_000,
+            },
+            &[],
+            &[],
+            0,
+        );
+        assert!(line.contains("per_file_p50_us=0"), "{line}");
+        assert!(line.contains("p95_us=0"), "{line}");
+        assert!(line.contains("p99_us=0"), "{line}");
+        assert!(line.contains("workers={}"), "{line}");
+    });
+
+    // extract_one is the worker entrypoint. Pointing it at a destination
+    // whose parent path conflicts with a pre-existing regular file makes
+    // create_dir_all fail. Gives us a deterministic, OS-agnostic failure
+    // injection without patching production code. The first-error-wins
+    // semantic is exercised end-to-end in tests/save_roundtrip.rs.
+    timed_test!(extract_one_returns_error_with_failing_path, {
+        let tmp = tempfile::tempdir().unwrap();
+        let blocking_file = tmp.path().join("not-a-dir");
+        std::fs::write(&blocking_file, b"i am a file").unwrap();
+
+        // Now try to extract a job whose dest claims the blocking file
+        // is a parent directory. create_dir_all should bail.
+        let job = ExtractJob {
+            dest: blocking_file.join("child.bin"),
+            entry_type: tar::EntryType::Regular,
+            body: b"unused".to_vec(),
+            mtime_secs: None,
+            mode_bits: None,
+        };
+        let err = extract_one(&job).expect_err("worker must surface the IO error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not-a-dir"),
+            "error must mention the offending path: {msg}"
+        );
+    });
 }

--- a/crates/soldr-cli/tests/save_roundtrip.rs
+++ b/crates/soldr-cli/tests/save_roundtrip.rs
@@ -828,6 +828,60 @@ fn parallel_extract_many_small_files() {
     }
 }
 
+/// #575 deterministic-failure semantic: when a worker can't write a
+/// file (here because a path component is occupied by a regular file
+/// that blocks `create_dir_all`), `load()` must return Err and the
+/// error must mention the offending path so operators can repro it.
+/// First-error-wins: subsequent workers are allowed to drain quietly,
+/// but the returned error must come from a real failure, not be
+/// swallowed.
+#[test]
+fn parallel_extract_surfaces_worker_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    let archive = dir.path().join("snap.tar.zst");
+    let restore = dir.path().join("restore");
+
+    // Make an archive that puts files under cache/conflicted/<n>.bin
+    fs::create_dir_all(&cache).unwrap();
+    for n in 0..32u32 {
+        write(&cache.join(format!("conflicted/file{:02}.bin", n)), b"x");
+    }
+
+    save(&SaveOptions {
+        workspace: None,
+        cache_dir: Some(&cache),
+        out: &archive,
+        zstd_level: DEFAULT_ZSTD_LEVEL,
+        threads: None,
+        mtimes_only: false,
+    })
+    .expect("save ok");
+
+    // Pre-create `restore/conflicted` as a REGULAR FILE — any worker that
+    // tries to create_dir_all underneath this path fails deterministically
+    // with NotADirectory / AlreadyExists. The first failure must surface
+    // via load()'s Err return.
+    fs::create_dir_all(&restore).unwrap();
+    fs::write(restore.join("conflicted"), b"blocker").unwrap();
+
+    let err = load(&LoadOptions {
+        archive: &archive,
+        cache_dir: Some(&restore),
+        workspace: None,
+        threads: Some(2),
+        mtimes_only: false,
+        profile_extract: false,
+        auto_defender_exclude: false,
+    })
+    .expect_err("worker failure must propagate up");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("conflicted"),
+        "error must reference the blocking path: {msg}",
+    );
+}
+
 /// `profile_extract: true` is non-fatal and a no-op for correctness:
 /// the load report and file contents must match what a normal load
 /// would produce. We can't easily assert the exact stderr line in this

--- a/docs/API.md
+++ b/docs/API.md
@@ -227,6 +227,52 @@ proposes a GitHub Action that key-tarballs the resulting `target/` by
 action's implementation reduces to: hash `Cargo.lock` → restore tarball
 → on miss, `soldr cook` + tar + save.
 
+### `soldr save` / `soldr load`
+
+Bundle a build-cache directory plus a content-verified snapshot of
+source-file mtimes into a single `.tar.zst` archive (`save`), then
+restore it on a fresh checkout (`load`). Intended for CI cache layers
+that need stable Cargo fingerprints across `actions/checkout` runs
+without resorting to mtime-rewrite tricks.
+
+```bash
+soldr save --cache-dir <dir> --workspace <dir> --out cache.tar.zst
+soldr load --archive cache.tar.zst --cache-dir <dir> --workspace <dir>
+```
+
+Recognised `soldr load` flags (issue #575):
+
+- `--archive <FILE>` — input archive produced by `soldr save`.
+- `--cache-dir <DIR>` — destination cache directory; created if absent.
+- `--workspace <DIR>` — workspace whose source-file mtimes get the
+  content-verified replay. Optional when `--mtimes-only` is unset.
+- `--threads <N>` — parallel-extract worker count. Defaults to
+  rayon's `num_cpus`; capped at the value passed here.
+- `--mtimes-only` — refuse cache entries; apply mtime snapshot only.
+- `--manifest-out <FILE>` — write the archive's protobuf manifest for a
+  later `soldr save --delta-from-manifest`.
+- `--profile-extract` — emit a per-phase profile line to stderr after
+  the load completes. Shape:
+  ```text
+  soldr load: profile: zstd_decode=4120ms tar_parse=890ms extract_total=10510ms \
+    workers={0:n=12058, 1:n=12090, 2:n=12053, 3:n=12030} \
+    per_file_p50_us=180 p95_us=450 p99_us=1200 cache_files=48231
+  ```
+  Also enabled when `SOLDR_PROFILE_EXTRACT=1` is set in the environment.
+  Useful for tuning the parallel-extract worker count against real
+  workloads (issue #575). The line lands on **stderr**; the existing
+  `soldr load:` machine-readable status line on stdout is untouched.
+- `--auto-defender-exclude` — on Windows + admin, briefly add
+  `--cache-dir` to Defender's exclusion list for the duration of the
+  load (issue #596). Never UAC-prompts: no-op on non-Windows or when
+  the current process isn't elevated.
+- `--json` — machine-readable status line on stdout instead of the
+  human-readable summary.
+
+`SOLDR_LOAD_WORKERS=<N>` overrides `--threads` and sizes the rayon
+pool that runs both the per-file extract workers and the
+mtime-replay walk.
+
 ### `soldr status`
 
 Show cache and target information.
@@ -1216,6 +1262,8 @@ Commands:
 | `SOLDR_TARGET_AUTO_PRUNE_ENABLED` | Master toggle for the host-volume disk watchdog (issue #574). Falsy values (`0`, `false`, `no`, `off`, empty — case-insensitive) disable the watchdog entirely. | `1` |
 | `SOLDR_GC_TARGET_ROOT` | Default walk root for `soldr gc target` (issue #574). The `--root <PATH>` flag always takes precedence. | `~/dev` |
 | `SOLDR_TEST_DISK_FREE_BYTES` | Test seam for the watchdog: when set to a `u64` byte count (or `error`), overrides the real `fs2::available_space` probe so tests can drive every threshold edge. Internal — never set this in production. | unset |
+| `SOLDR_PROFILE_EXTRACT` | Env-var equivalent of `soldr load --profile-extract` (issue #575). Any non-empty value other than `0` enables the per-phase profile line on stderr after a load (`zstd_decode`, `tar_parse`, `extract_total`, per-worker job counts, per-file `p50`/`p95`/`p99`). Useful for tuning the parallel-extract worker count against real workloads. | unset |
+| `SOLDR_LOAD_WORKERS` | Cap on the parallel-extract worker pool used by `soldr load` (issue #575). Positive integer; wins over the explicit `--threads` flag. When unset, `--threads` (or rayon's `num_cpus` default) is used. | unset |
 
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.


### PR DESCRIPTION
## Summary

Aligns the on-stderr profile-line shape with the format documented in zackees/soldr#575: `zstd_decode=Nms tar_parse=Nms extract_total=Nms` instead of the prior `driver_loop_ms`/`workers_drain_ms` split. The driver thread accumulates microseconds spent inside the per-entry zstd-fed `read_to_end` so `tar_parse` falls out as the remainder — a cheap, single-threaded measurement that survives the streaming API having no clean boundary between decode and header parse.

The parallel-extraction infrastructure itself shipped in PR #581. This PR finishes the soldr-side scope of #575 by:

- Renaming the emitted phases to the meta-issue spec.
- Pinning the emitted format with unit tests so percentile math, worker-map layout, and phase names stay frozen.
- Adding a load-level test exercising the first-error-wins propagation path through `load()`.
- Documenting `soldr save` / `soldr load` in `docs/API.md` (they had no entry before) and adding `SOLDR_PROFILE_EXTRACT` + `SOLDR_LOAD_WORKERS` to the env-var table.

## What's IN

- Items 1 + 2 of #575 (parallel cache extraction + `--profile-extract` flag), with the format aligned to the meta-issue spec.

## What's OUT

- Item 3 (`--auto-defender-exclude`) already shipped in #596 / PR #611.
- Items 4 + 5 (setup-soldr wiring + local wall-clock measurement on a real Windows runner) are cross-repo / developer-task work tracked under the META.

## Test plan

- [x] `soldr cargo fmt --all -- --check` clean.
- [x] `soldr cargo clippy --workspace --bins --tests -- -D warnings` clean.
- [x] `soldr cargo test -p soldr-cli --lib cache_lib::save::tests` — 3/3 pass (`profile_line_matches_documented_shape`, `profile_line_handles_empty_latencies`, `extract_one_returns_error_with_failing_path`).
- [x] `soldr cargo test -p soldr-cli --test save_roundtrip` — 16/16 pass including the new `parallel_extract_surfaces_worker_errors` and the existing 5k-file `parallel_extract_many_small_files`.
- [x] `soldr cargo test -p soldr-cli --test timed_test_lint` — 1/1 pass; new unit tests use `timed_test!`.
- [ ] CI matrix on push.

Implements soldr-side scope of #575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)