### PR TITLE
fix(daemon): serialize state.redb opens to close LinkZccache race (#608)

### DIFF
--- a/crates/soldr-cli/src/cache_lib/cook_index.rs
+++ b/crates/soldr-cli/src/cache_lib/cook_index.rs
@@ -31,6 +31,7 @@
 //! A future schema change MUST land as `cook_index_v3` rather than
 //! mutating v2 in place.
 
+use crate::cache_lib::redb_lock::{state_db_open_lock, StateDbHandle};
 use crate::cache_lib::target_registry::RegistryError;
 use crate::daemon::protocol::WireDecodeError;
 use crate::daemon::wire::{prost_tagged_bytes, proto, REDB_TAG_PROST};
@@ -79,12 +80,20 @@ fn wire_err(e: WireDecodeError) -> RegistryError {
     RegistryError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
 }
 
-fn open_db(path: &Path) -> Result<Database, RegistryError> {
+/// Acquire the shared [`state_db_open_lock`] and open the redb file
+/// under it. See `cache_lib::redb_lock` for why the handle holds the
+/// lock for the entire lifetime of the [`Database`]: redb refuses
+/// concurrent in-process opens of the same file and would otherwise
+/// race with [`crate::daemon::db`] (issue #608).
+fn open_db(path: &Path) -> Result<StateDbHandle, RegistryError> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    let guard = state_db_open_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let db = Database::builder().create(path)?;
-    Ok(db)
+    Ok(StateDbHandle::new(db, guard))
 }
 
 fn init_v2(db: &Database) -> Result<(), RegistryError> {

--- a/crates/soldr-cli/src/cache_lib/mod.rs
+++ b/crates/soldr-cli/src/cache_lib/mod.rs
@@ -18,6 +18,7 @@ pub mod cook_gc;
 pub mod cook_index;
 pub mod gc;
 pub mod prune_target;
+pub mod redb_lock;
 pub mod save;
 pub mod state_db;
 pub mod strip_target;

--- a/crates/soldr-cli/src/cache_lib/redb_lock.rs
+++ b/crates/soldr-cli/src/cache_lib/redb_lock.rs
@@ -1,0 +1,51 @@
+//! Process-wide serialization for opening the soldr `state.redb` file.
+//!
+//! redb refuses concurrent in-process `Database::open` against the same
+//! file with `Database already open. Cannot acquire lock.`. The daemon's
+//! per-request handlers each call `open_db` on `state.redb`, so two
+//! handlers landing on different tokio worker threads can race and one
+//! of them silently fails — see issue #608 for the regression this
+//! mutex fixes (`db::set_linked_zccache` silently dropped writes when a
+//! concurrent `Status` request had the same file open via
+//! `cook_index::stats`).
+//!
+//! The lock is held for the full lifetime of the redb [`Database`]
+//! handle, not just the open call: the file lock redb holds is released
+//! when the `Database` is dropped, so callers must keep this guard alive
+//! at least that long. The [`StateDbHandle`] wrapper enforces drop order
+//! by declaring `db` before `_guard`.
+
+use redb::Database;
+use std::ops::Deref;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+/// Shared global lock guarding every in-process `Database::open` on
+/// `state.redb`. Both `daemon::db` and `cache_lib::cook_index` go
+/// through this lock — they open the same file.
+pub(crate) fn state_db_open_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Owns a redb [`Database`] handle together with the
+/// [`state_db_open_lock`] guard that gates concurrent opens. Field
+/// order is load-bearing: `db` is declared first so it is dropped
+/// (releasing redb's file lock) before `_guard` is dropped (letting
+/// the next opener proceed).
+pub(crate) struct StateDbHandle {
+    db: Database,
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl StateDbHandle {
+    pub(crate) fn new(db: Database, guard: MutexGuard<'static, ()>) -> Self {
+        Self { db, _guard: guard }
+    }
+}
+
+impl Deref for StateDbHandle {
+    type Target = Database;
+    fn deref(&self) -> &Database {
+        &self.db
+    }
+}

--- a/crates/soldr-cli/src/cache_lib/save.rs
+++ b/crates/soldr-cli/src/cache_lib/save.rs
@@ -1500,7 +1500,7 @@ fn defender_exclusion_guard_for(cache_dir: &Path) -> DefenderExclusionGuard {
     #[cfg(not(target_os = "windows"))]
     {
         let _ = cache_dir;
-        return DefenderExclusionGuard::default();
+        DefenderExclusionGuard::default()
     }
     #[cfg(target_os = "windows")]
     {

--- a/crates/soldr-cli/src/daemon/db.rs
+++ b/crates/soldr-cli/src/daemon/db.rs
@@ -21,6 +21,7 @@
 //! contents on disk are untouched, only the per-build timing snapshots
 //! are dropped.
 
+use crate::cache_lib::redb_lock::{state_db_open_lock, StateDbHandle};
 use crate::cache_lib::target_registry::RegistryError;
 use crate::daemon::protocol::{BuildRecord, WireDecodeError, ZccacheDaemonLink};
 use crate::daemon::wire::{self, prost_tagged_bytes, REDB_TAG_PROST};
@@ -63,12 +64,22 @@ pub struct Event {
     pub exit_code: Option<i32>,
 }
 
-fn open_db(path: &Path) -> Result<Database, RegistryError> {
+/// Acquire the shared [`state_db_open_lock`] and open the redb file
+/// under it. The returned [`StateDbHandle`] derefs to [`Database`] so
+/// existing call sites that just chain `.begin_write()` / `.begin_read()`
+/// keep working. Holding the lock for the full lifetime of the handle
+/// is required: redb's per-file lock is only released on `Database`
+/// drop, so a second opener overlapping us would error out with
+/// `Database already open. Cannot acquire lock.` (#608).
+fn open_db(path: &Path) -> Result<StateDbHandle, RegistryError> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    let guard = state_db_open_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let db = Database::builder().create(path)?;
-    Ok(db)
+    Ok(StateDbHandle::new(db, guard))
 }
 
 fn init_tables(db: &Database) -> Result<(), RegistryError> {

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -105,16 +105,6 @@ struct State {
     /// daemon restarts by design — long-lived totals belong in the
     /// redb `cook_index_v1` table, not in process-local state.
     cook_hits_this_session: AtomicU64,
-    /// Serializes cook_index redb opens within the daemon process.
-    /// redb refuses concurrent in-process `Database::open` for the
-    /// same file with `Database already open. Cannot acquire lock.`
-    /// Each cook_index op (`upsert`, `lookup`, `touch`, `stats`,
-    /// `drift_recipe_hashes`) opens + drops a handle per call so the
-    /// CLI side (`soldr cache stats`, `soldr doctor`) can still
-    /// open `state.redb` between daemon ops. This lock guarantees
-    /// only one daemon worker runs a cook_index op at a time so the
-    /// "already open" error never reaches the wire.
-    cook_index_lock: std::sync::Mutex<()>,
     shutdown: Notify,
 }
 
@@ -131,15 +121,11 @@ impl State {
     }
 
     fn status(&self) -> StatusInfo {
-        // Serialize the redb open behind cook_index_lock — see the
-        // field-level comment for why this matters.
-        let (entries, total_bytes) = {
-            let _guard = self
-                .cook_index_lock
-                .lock()
-                .unwrap_or_else(|p| p.into_inner());
-            cook_index::stats(&self.db_path).unwrap_or((0, 0))
-        };
+        // Serialization of concurrent redb opens against `state.redb`
+        // is handled inside `cook_index::stats` itself via the shared
+        // `redb_lock::state_db_open_lock` (#608) — no extra mutex
+        // needed here.
+        let (entries, total_bytes) = cook_index::stats(&self.db_path).unwrap_or((0, 0));
         StatusInfo {
             version: PROTOCOL_VERSION,
             pid: std::process::id(),
@@ -207,7 +193,6 @@ async fn run_async(opts: ServerOptions) -> Result<(), ServerError> {
         last_activity_ms: AtomicU64::new(0),
         exit_via_idle: AtomicBool::new(false),
         cook_hits_this_session: AtomicU64::new(0),
-        cook_index_lock: std::sync::Mutex::new(()),
         shutdown: Notify::new(),
     });
 
@@ -443,7 +428,13 @@ where
         Request::LinkZccache { link } => {
             // Persist to redb so a restart can still stop the linked
             // daemon, AND cache in-process for fast Status replies.
-            let _ = db::set_linked_zccache(&state.db_path, Some(&link));
+            // Surface persistence errors on stderr — silently dropping
+            // the disk write is exactly what caused the #608 regression
+            // (`stop_linked_zccache` reads from disk on shutdown, not
+            // from this in-memory mutex).
+            if let Err(err) = db::set_linked_zccache(&state.db_path, Some(&link)) {
+                eprintln!("soldr-daemon: failed to persist linked zccache: {err}");
+            }
             if let Ok(mut guard) = state.linked_zccache.lock() {
                 *guard = Some(link);
             }
@@ -463,13 +454,13 @@ where
                 channel,
                 rustc_version,
             };
-            // Hold cook_index_lock for the lookup + drift scan, then
-            // drop before any await — Mutex is sync-only.
+            // The two cook_index calls below each serialize their own
+            // redb open via `redb_lock::state_db_open_lock` (#608), so
+            // no outer mutex is needed. The window between the two
+            // opens admits a concurrent writer; the worst case is a
+            // stale `previous_origin_recipe_hashes` drift list, which
+            // is purely advisory.
             let reply = {
-                let _guard = state
-                    .cook_index_lock
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner());
                 match cook_index::lookup(&state.db_path, &key) {
                     Ok(Some(entry)) => {
                         state.cook_hits_this_session.fetch_add(1, Ordering::Relaxed);
@@ -527,13 +518,7 @@ where
                 origin_url_normalized,
                 cook_cmd_summary,
             };
-            let result = {
-                let _guard = state
-                    .cook_index_lock
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner());
-                cook_index::upsert(&state.db_path, &key, &entry)
-            };
+            let result = cook_index::upsert(&state.db_path, &key, &entry);
             match result {
                 Ok(()) => {
                     let _ = write_frame_async(&mut stream, &Response::Ack).await;
@@ -550,10 +535,6 @@ where
         Request::CookTouch { sha256 } => {
             // Fire-and-forget bump of last_used_unix_ms. Silent on
             // failure — the caller already moved on.
-            let _guard = state
-                .cook_index_lock
-                .lock()
-                .unwrap_or_else(|p| p.into_inner());
             let _ = cook_index::touch(&state.db_path, &sha256, current_unix_ms());
         }
     }

--- a/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
+++ b/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
@@ -166,7 +166,6 @@ impl Drop for EnvScope {
 
 #[cfg(not(windows))]
 #[test]
-#[ignore = "soldr#608: shutdown hook regression — fake zccache never invoked, log empty"]
 fn linked_zccache_is_stopped_on_daemon_shutdown() {
     let cache_root = unique_temp_dir("zccache-link-cache");
     let home_root = unique_temp_dir("zccache-link-home");


### PR DESCRIPTION
## Summary

Fixes the flaky `linked_zccache_is_stopped_on_daemon_shutdown` test (closes #608) and unblocks main CI by fixing a clippy lint that has been failing the Lint job since c50cc98.

## Root cause

`db::set_linked_zccache` (LinkZccache handler) and `cook_index::stats` (the cook stats path inside `Status`) both open the same `state.redb` from different tokio worker threads. redb refuses concurrent in-process `Database::open` (`Database already open. Cannot acquire lock.`); the handler's `let _ = db::set_linked_zccache(...)` swallowed the error. The in-memory mutex was still updated so `Status` returned the link — but the on-disk row was missing, and `stop_linked_zccache` at shutdown early-returned without invoking `zccache stop`.

## Fix

- New `cache_lib::redb_lock` module owning a process-wide `state_db_open_lock` `Mutex<()>` plus a `StateDbHandle` wrapper. Field order is load-bearing: `db` is dropped before `_guard`, so redb's per-file lock is fully released before the next opener proceeds.
- `daemon::db::open_db` and `cache_lib::cook_index::open_db` both go through this lock and return `StateDbHandle` (Deref → `Database`, so call sites that just chain `.begin_write()` keep working).
- Drop the now-redundant `cook_index_lock` `Mutex` from `daemon::server::State` — the global lock subsumes it.
- Surface persistence errors from `LinkZccache` on stderr so a future regression of this kind doesn't silently disappear.
- Re-enable the integration test (remove `#[ignore]`).
- Drive-by: drop a `return` in `cache_lib/save::defender_exclusion_guard_for` that tripped `clippy::needless_return` on the non-Windows build (the unrelated lint that's been failing the Lint job on every main commit since c50cc98).

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean in the cook-dev Docker image.
- [x] `cargo fmt --all -- --check` clean.
- [x] 20/20 passes on the previously-flaky `cargo test -p soldr-cli --test cli_daemon_zccache_link -- linked_zccache_is_stopped_on_daemon_shutdown` (pre-fix repro showed 1/10 fail).
- [ ] CI matrix on push.

Closes #608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)