### PR TITLE
chore(release): bump soldr 0.7.48 -> 0.7.49

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.48"
+version = "0.7.49"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.48"
+version = "0.7.49"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.48",
+  "version": "0.7.49",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Cuts a release containing the eight follow-up PRs that landed since v0.7.48.

## Included in v0.7.49

| Issue | PR | Title |
|---|---|---|
| #605 | #607 | ci(release): poll PyPI after publish to close sequential-upload race |
| #602 | #610 | chore(lint): clippy.toml denies new bincode usage |
| #603 | #609 | chore(serialization): drop bincode entirely; gracefully evict pre-#580 redb rows on startup |
| #596 | #611 | feat(load): wire --auto-defender-exclude to Add-MpPreference via shared defender module |
| #589 | #612 | feat(cook): wire [cook] auto-GC eviction pass |
| #574 | #613 | feat(gc): host-volume disk watchdog + soldr gc target reclamation |
| #575 | #614 | feat(load): parallel per-file cache extraction + --profile-extract |
| #598 | #615 | feat(known_tools): register cargo-binstall, cargo-machete, just, bacon, typos |

## Release state check

- ✅ `Cargo.toml` `[workspace.package].version` bumped 0.7.48 → 0.7.49
- ✅ `package.json` `"version"` bumped 0.7.48 → 0.7.49
- ✅ `Cargo.lock` regenerated for the new workspace version
- ✅ PyPI latest is 0.7.48 (0.7.49 is unpublished)
- ✅ npm `@zackees/soldr` latest is 0.7.48 (0.7.49 is unpublished)
- ✅ `git ls-remote --tags origin v0.7.49` returns nothing (tag does not exist)

The Autonomous Release workflow will create the `v0.7.49` tag + GitHub release + PyPI wheels + npm package once this PR merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)