### PR TITLE
release(0.7.50): cover TargetRegistry under daemon redb open lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.49"
+version = "0.7.50"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/src/cache_lib/target_registry.rs
+++ b/crates/soldr-cli/src/cache_lib/target_registry.rs
@@ -7,11 +7,13 @@
 //!
 //! The store lives in `~/.soldr/state.redb` alongside other soldr state.
 
+use crate::cache_lib::redb_lock::{state_db_open_lock, StateDbHandle};
 use redb::{
     backends::InMemoryBackend, Database, ReadableDatabase, ReadableTable, ReadableTableMetadata,
     TableDefinition,
 };
 use std::{
+    ops::Deref,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -56,30 +58,67 @@ pub struct TargetRow {
     pub last_used: i64,
 }
 
+/// Internal backing store for [`TargetRegistry`]. File-backed instances
+/// hold the process-wide [`state_db_open_lock`] guard alongside the
+/// redb [`Database`] so concurrent opens against `state.redb` from
+/// other daemon code paths (`daemon::db`, `cache_lib::cook_index`)
+/// serialize safely (#608). In-memory instances bypass the lock —
+/// each is an independent database with no file backing and no
+/// cross-instance contention.
+enum TargetRegistryDb {
+    File(StateDbHandle),
+    InMemory(Database),
+}
+
+impl Deref for TargetRegistryDb {
+    type Target = Database;
+    fn deref(&self) -> &Database {
+        match self {
+            Self::File(h) => h,
+            Self::InMemory(db) => db,
+        }
+    }
+}
+
 /// Redb registry backed by `~/.soldr/state.redb` (or a caller-provided
 /// path).
 pub struct TargetRegistry {
-    db: Database,
+    db: TargetRegistryDb,
 }
 
 impl TargetRegistry {
     /// Open or create the database at the given path. Parent dirs are
-    /// created automatically.
+    /// created automatically. The returned registry holds the
+    /// process-wide [`state_db_open_lock`] guard for its entire
+    /// lifetime so the redb file lock is never contended by another
+    /// in-process opener — the `RecordTargetTouch` handler runs on
+    /// every rustc-wrapper call and would otherwise race with
+    /// `daemon::db` / `cache_lib::cook_index` (#608).
     pub fn open(path: &Path) -> Result<Self, RegistryError> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+        let guard = state_db_open_lock()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let db = Database::builder().create(path)?;
-        Self::init_schema(&db)?;
-        Ok(Self { db })
+        let handle = StateDbHandle::new(db, guard);
+        Self::init_schema(&handle)?;
+        Ok(Self {
+            db: TargetRegistryDb::File(handle),
+        })
     }
 
     /// Open an in-memory database. Useful for tests and for callers
-    /// that want a registry without touching disk.
+    /// that want a registry without touching disk. In-memory instances
+    /// are independent databases (no file backing), so they do not
+    /// acquire [`state_db_open_lock`].
     pub fn open_in_memory() -> Result<Self, RegistryError> {
         let db = Database::builder().create_with_backend(InMemoryBackend::new())?;
         Self::init_schema(&db)?;
-        Ok(Self { db })
+        Ok(Self {
+            db: TargetRegistryDb::InMemory(db),
+        })
     }
 
     fn init_schema(db: &Database) -> Result<(), RegistryError> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.49",
+  "version": "0.7.50",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Two things in one PR (per release publishing rules — a version bump in `Cargo.toml` / `package.json` is what triggers the autonomous release):

1. **Tightens #608's fix.** The `RecordTargetTouch` handler at `daemon/server.rs:333` still opened `TargetRegistry` outside the process-wide `state_db_open_lock` introduced in #608. Under wrapper bursts that handler runs many concurrent opens against `state.redb` and can still race `daemon::db` / `cache_lib::cook_index` — and the handler's `if let Ok(...)` silently drops writes when redb refuses the concurrent open. This PR puts `TargetRegistry`'s file backing through the same lock.
2. **Cuts release 0.7.50** so the previous fix (which landed in 0.7.49 as #616) plus this completing change get shipped together.

## Fix shape

- New `TargetRegistryDb` enum inside `cache_lib::target_registry`: `File(StateDbHandle)` holds the `state_db_open_lock` guard for the registry's lifetime; `InMemory(Database)` keeps the lock-free path used by tests.
- Both arms `Deref<Target = Database>`, so every existing `self.db.*` call site keeps working with no change.
- `TargetRegistry::open(path)` acquires the lock and constructs the file variant; `TargetRegistry::open_in_memory()` is unchanged behaviorally.

State-DB access from outside the daemon (`StateDb::open` in the cargo front door, plus `TargetRegistry::open` from `gc/*` and the wrapper fallback) stays on redb's cross-process file lock — those are separate processes from the daemon, and they each acquire the in-process lock too, just from their own process instance.

## Release diff

- `Cargo.toml` (workspace + soldr-cli): `0.7.49` → `0.7.50`
- `Cargo.lock`: `0.7.49` → `0.7.50`
- `package.json`: `0.7.49` → `0.7.50`

## Test plan

- [x] `cargo build -p soldr-cli --tests --bins` clean in the cook-dev Docker image.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [ ] CI matrix on push.
- [ ] Autonomous release publishes v0.7.50 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)