### PR TITLE
fix(test): wrap linked_zccache_is_stopped_on_daemon_shutdown with timed_test!

### DIFF
--- a/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
+++ b/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
@@ -16,6 +16,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use soldr_cli::daemon::{client, db};
+use soldr_cli::timed_test;
 
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -165,8 +166,7 @@ impl Drop for EnvScope {
 }
 
 #[cfg(not(windows))]
-#[test]
-fn linked_zccache_is_stopped_on_daemon_shutdown() {
+timed_test!(linked_zccache_is_stopped_on_daemon_shutdown, Duration::from_secs(60), {
     let cache_root = unique_temp_dir("zccache-link-cache");
     let home_root = unique_temp_dir("zccache-link-home");
     let log_path = unique_temp_dir("zccache-link-log").join("zccache-calls.log");
@@ -262,4 +262,4 @@ fn linked_zccache_is_stopped_on_daemon_shutdown() {
     // And the linked identity must have been cleared on shutdown.
     let link = db::get_linked_zccache(&cache_root.join("state.redb")).expect("get");
     assert_eq!(link, None, "linked zccache must be cleared on shutdown");
-}
+});


### PR DESCRIPTION
## Summary

Lint follow-up for the merge that became #618. When #616 removed the `#[ignore]` after the race was fixed, the test was left as a bare `#[test]`, and `tests/timed_test_lint.rs::every_test_uses_timed_test_macro_or_is_allowlisted` (which I had removed from `LEGACY_ALLOWLIST` in #610 when the test was still ignored) is now failing the Lint job on every main commit since #618.

The corresponding fix-up was in the amended copy of PR #618 but the squash-merge picked up the older, pre-amend SHA — so this never landed.

## Fix

Wrap the test body in `timed_test!(linked_zccache_is_stopped_on_daemon_shutdown, Duration::from_secs(60), { ... })` matching the pattern used in `tests/cli_cargo_native_cc.rs` and elsewhere.

## Test plan

- [x] `cargo test -p soldr-cli --test timed_test_lint` passes (locally in cook-dev Docker).
- [x] `cargo test -p soldr-cli --test cli_daemon_zccache_link` passes.
- [ ] CI matrix on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)