### PR TITLE
chore(release): bump 0.7.51

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.50"
+version = "0.7.51"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.50",
+  "version": "0.7.51",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Picks up #622 (warm-cook skip; closes #621). Estimated savings: ~5 min on Coverage-shape workloads.