### PR TITLE
[codex] Refresh benchmark schedule and badges

### DIFF
--- a/.claude/hooks/tool_guard.py
+++ b/.claude/hooks/tool_guard.py
@@ -250,7 +250,7 @@ def extract_command(data):
 
 def main():
     try:
-        data = json.load(sys.stdin)
+        data = json.loads(sys.stdin.read().lstrip("\ufeff"))
     except json.JSONDecodeError:
         sys.exit(0)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script .claude/hooks/tool_guard.py",
+            "command": "uv run --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
             "timeout": 5
           }
         ]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script .claude/hooks/tool_guard.py",
+            "command": "uv run --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script .claude/hooks/tool_guard.py",
+            "command": "uv run --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
             "timeout": 5
           }
         ]
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script .claude/hooks/tool_guard.py",
+            "command": "uv run --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
             "timeout": 5
           }
         ]

--- a/.github/scripts/cache_benchmark_report.py
+++ b/.github/scripts/cache_benchmark_report.py
@@ -84,6 +84,18 @@ def _generated_at_utc() -> str:
     )
 
 
+def _human_datetime_utc(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return value
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    parsed = parsed.astimezone(timezone.utc)
+    hour = parsed.strftime("%I").lstrip("0") or "0"
+    return f"{parsed.strftime('%B')} {parsed.day}, {parsed.year} at {hour}:{parsed:%M} {parsed:%p} UTC"
+
+
 def _load_config() -> tuple[dict[str, Any], Path]:
     config_path = Path(os.environ.get("BENCHMARK_CONFIG_PATH", DEFAULT_CONFIG_PATH))
     if not config_path.is_absolute():
@@ -290,6 +302,7 @@ def _build_report(
         for profile in profiles
     ]
 
+    generated_at_utc = _generated_at_utc()
     report = {
         "workflow": "cache-benchmark.yml",
         "config_path": str(config_path.relative_to(REPO_ROOT)),
@@ -297,7 +310,8 @@ def _build_report(
         "threshold_ratio": _round_metric(float(os.environ["THRESHOLD_RATIO"])),
         "headline": headline,
         "metadata": {
-            "generated_at_utc": _generated_at_utc(),
+            "generated_at_utc": generated_at_utc,
+            "last_executed_at_human": _human_datetime_utc(generated_at_utc),
             "git_sha": os.environ.get("GITHUB_SHA") or "unknown",
             "github_run_id": os.environ.get("GITHUB_RUN_ID") or "local",
             "runner_os": os.environ.get("RUNNER_OS") or "unknown",
@@ -442,8 +456,9 @@ def _metadata_line(report: dict[str, Any]) -> str:
     metadata = report["metadata"]
     git_sha = metadata["git_sha"]
     short_sha = git_sha[:12] if git_sha != "unknown" else git_sha
+    last_executed = metadata.get("last_executed_at_human") or metadata["generated_at_utc"]
     return (
-        f"Generated {metadata['generated_at_utc']} | "
+        f"Last run {last_executed} | "
         f"SHA {short_sha} | "
         f"{metadata['runner_os']}/{metadata['runner_arch']} | "
         f"Target {metadata['target']}"
@@ -683,10 +698,23 @@ def _write_benchmark_image(report: dict[str, Any], output_path: Path) -> None:
         y += 36
 
     y += 12
+    last_executed = (
+        f"Last run {report['metadata'].get('last_executed_at_human', report['metadata']['generated_at_utc'])}"
+    )
+    draw.text(
+        (x, y),
+        _truncate_text(draw, last_executed, small_font, width - 2 * x),
+        fill=muted,
+        font=small_font,
+    )
+    y += 28
+
     metadata = (
         f"Scenario {report['requested_scenario']} | "
         f"Threshold {report['threshold_ratio']:.2f}x | "
-        f"{_metadata_line(report)}"
+        f"SHA {report['metadata']['git_sha'][:12] if report['metadata']['git_sha'] != 'unknown' else 'unknown'} | "
+        f"{report['metadata']['runner_os']}/{report['metadata']['runner_arch']} | "
+        f"Target {report['metadata']['target']}"
     )
     draw.text(
         (x, y),

--- a/.github/workflows/build-linux-arm64-musl.yml
+++ b/.github/workflows/build-linux-arm64-musl.yml
@@ -1,0 +1,21 @@
+name: Build Linux ARM64 musl
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-musl
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -1,0 +1,21 @@
+name: Build Linux ARM64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-gnu
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-linux-x64-musl.yml
+++ b/.github/workflows/build-linux-x64-musl.yml
@@ -1,0 +1,21 @@
+name: Build Linux x64 musl
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-musl
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-linux-x64.yml
+++ b/.github/workflows/build-linux-x64.yml
@@ -1,0 +1,21 @@
+name: Build Linux x64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-unknown-linux-gnu
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -1,0 +1,21 @@
+name: Build macOS ARM64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15
+      target: aarch64-apple-darwin
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -1,0 +1,22 @@
+name: Build macOS x64
+
+on:
+  push:
+    branches:
+      - main
+      - release
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: macos-15-intel
+      target: x86_64-apple-darwin
+      binary_name: soldr
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -1,0 +1,21 @@
+name: Build Windows ARM64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-11-arm
+      target: aarch64-pc-windows-msvc
+      binary_name: soldr.exe
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -1,0 +1,21 @@
+name: Build Windows x64
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_bootstrap-e2e.yml
+    with:
+      runner: windows-2025
+      target: x86_64-pc-windows-msvc
+      binary_name: soldr.exe
+      source_ref: ${{ github.sha }}

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths-ignore:
       - "*.md"
+  schedule:
+    - cron: "17 9 * * *"
   workflow_dispatch:
     inputs:
       scenario:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ Repository = "https://github.com/zackees/soldr"
 [dependency-groups]
 dev = [
     "maturin>=1.7,<2",
+    "pillow==11.3.0",
     "pytest>=8.0",
     "pytest-xdist>=3.0",
     "ruff>=0.4",

--- a/tests/test_cache_benchmark_report.py
+++ b/tests/test_cache_benchmark_report.py
@@ -247,6 +247,7 @@ def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
             "BENCHMARK_CONFIG_PATH": "benchmark.toml",
             "BENCHMARK_COMMAND_TARGET": "x86_64-unknown-linux-gnu",
             "BENCHMARK_INPUT_JSON": str(input_path),
+            "BENCHMARK_GENERATED_AT_UTC": "2026-06-01T13:45:00Z",
             "BENCHMARK_SUMMARY_JSON": str(json_path),
             "BENCHMARK_SUMMARY_WWW_DIR": str(www_dir),
             "GITHUB_STEP_SUMMARY": str(summary_path),
@@ -259,6 +260,8 @@ def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
     assert report["workflow"] == "cache-benchmark.yml"
     assert report["config_path"] == "benchmark.toml"
     assert report["threshold_ratio"] == 10.0
+    assert report["metadata"]["generated_at_utc"] == "2026-06-01T13:45:00Z"
+    assert report["metadata"]["last_executed_at_human"] == "June 1, 2026 at 1:45 PM UTC"
     assert report["site"]["base_competitor"] == "swatinem"
     assert len(report["profiles"]) == 3
     assert len(report["comparisons"]) == 6
@@ -295,7 +298,9 @@ def test_cache_benchmark_report_writes_json_and_summary(tmp_path: Path) -> None:
     assert "soldr cargo check -p soldr-cli --locked --target x86_64-unknown-linux-gnu" in www_html
     assert "soldr cargo clippy --workspace --all-targets --locked --target x86_64-unknown-linux-gnu -- -D warnings" in www_html
     assert "soldr uses managed zccache internally." in www_html
+    assert "Last run June 1, 2026 at 1:45 PM UTC" in www_html
     assert "latest.json" in www_html
+    assert (www_dir / "benchmark.jpg").exists()
     assert (www_dir / ".nojekyll").exists()
 
 


### PR DESCRIPTION
﻿## Summary

- Run the benchmark workflow on a daily schedule while preserving manual dispatch.
- Add a human-readable last-run timestamp to the benchmark report metadata, HTML, and generated JPEG.
- Restore the eight per-target build workflow entry points used by the README badges.
- Fix the shared PreToolUse hook command so it does not fail under Windows PowerShell, and tolerate BOM-prefixed hook JSON.
- Add Pillow to the dev dependency group because the benchmark report tests generate `benchmark.jpg`.

## Validation

- `uv run --no-project python -m pytest tests/test_cache_benchmark_report.py`
- `uv run --no-project --directory .claude/hooks python -m unittest test_tool_guard`
- `uv run --no-project ruff check .github/scripts/cache_benchmark_report.py tests/test_cache_benchmark_report.py .claude/hooks/tool_guard.py`
- `git diff --check`
- `actionlint`
