### PR TITLE
[codex] Keep native SQLite report-only failures nonblocking

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -375,7 +375,8 @@ jobs:
               rows = [row]
               write_payload(rows)
               append_summary(rows)
-              sys.exit(exc.returncode or 1)
+              if native_config["mode"] != "report-only":
+                  sys.exit(exc.returncode or 1)
           finally:
               run_quiet(["zccache", "stop"], check=False)
           PY


### PR DESCRIPTION
﻿## Summary

- Keep native SQLite benchmark command failures nonblocking when `benchmark.toml` sets the native SQLite mode to `report-only`.
- Preserve the failure rows/artifacts so the published report still shows Windows native-cache failures instead of hiding them.

## Validation

- `actionlint`
- `git diff --check`
- `uv run --no-project python -m pytest tests/test_cache_benchmark_report.py`
