### PR TITLE
Fix stale zccache daemon.lock recovery

### DIFF
--- a/crates/soldr-cli/src/zccache_lifecycle.rs
+++ b/crates/soldr-cli/src/zccache_lifecycle.rs
@@ -6,11 +6,14 @@
 
 use crate::core::{suppress_windows_console_window, SoldrError};
 use std::ffi::OsStr;
+use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
 pub(crate) const ZCCACHE_DAEMON_NAMESPACE_ENV_VAR: &str = "ZCCACHE_DAEMON_NAMESPACE";
+const ZCCACHE_DAEMON_LOCK_FILENAME: &str = "daemon.lock";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ZccacheLifecycleState {
@@ -732,6 +735,20 @@ pub(crate) fn start_zccache_with_recovery_for_daemon(
         Ok(stop) => Some(zccache_command_failure_message(&["stop"], &stop)),
         Err(err) => Some(format!("failed to invoke zccache stop: {err}")),
     };
+    let lock_diagnostic = match remove_stale_zccache_daemon_lock(cache_dir) {
+        Ok(Some(lock_path)) => {
+            eprintln!(
+                "soldr: removed stale zccache daemon lock at {} before retry",
+                lock_path.display()
+            );
+            None
+        }
+        Ok(None) => None,
+        Err(message) => {
+            eprintln!("soldr: {message}");
+            Some(message)
+        }
+    };
 
     match run_zccache_start_command(binary, cache_dir, daemon_name) {
         Ok(retry) if retry.status.success() => Ok(()),
@@ -747,6 +764,11 @@ pub(crate) fn start_zccache_with_recovery_for_daemon(
             if let Some(stop_diagnostic) = stop_diagnostic {
                 message.push_str(&format!("\nzccache stop diagnostic: {stop_diagnostic}"));
             }
+            if let Some(lock_diagnostic) = &lock_diagnostic {
+                message.push_str(&format!(
+                    "\nzccache daemon lock diagnostic: {lock_diagnostic}"
+                ));
+            }
             Err(SoldrError::Other(message))
         }
         Err(err) => {
@@ -759,8 +781,25 @@ pub(crate) fn start_zccache_with_recovery_for_daemon(
             if let Some(stop_diagnostic) = stop_diagnostic {
                 message.push_str(&format!("\nzccache stop diagnostic: {stop_diagnostic}"));
             }
+            if let Some(lock_diagnostic) = &lock_diagnostic {
+                message.push_str(&format!(
+                    "\nzccache daemon lock diagnostic: {lock_diagnostic}"
+                ));
+            }
             Err(SoldrError::Other(message))
         }
+    }
+}
+
+fn remove_stale_zccache_daemon_lock(cache_dir: &Path) -> Result<Option<PathBuf>, String> {
+    let lock_path = cache_dir.join(ZCCACHE_DAEMON_LOCK_FILENAME);
+    match fs::remove_file(&lock_path) {
+        Ok(()) => Ok(Some(lock_path)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(format!(
+            "failed to remove stale zccache daemon lock at {}: {err}",
+            lock_path.display()
+        )),
     }
 }
 
@@ -1031,6 +1070,24 @@ mod tests {
         assert!(zccache_flag_unsupported(&out, "--no-depgraph-save"));
         let unrelated = synthetic_output("error: permission denied", 2);
         assert!(!zccache_flag_unsupported(&unrelated, "--no-depgraph-save"));
+    });
+
+    crate::timed_test!(stale_daemon_lock_recovery_removes_daemon_lock, {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let lock_path = temp.path().join(ZCCACHE_DAEMON_LOCK_FILENAME);
+        fs::write(&lock_path, "3197\n").expect("write stale daemon lock");
+
+        let removed =
+            remove_stale_zccache_daemon_lock(temp.path()).expect("remove stale daemon lock");
+        assert_eq!(removed.as_deref(), Some(lock_path.as_path()));
+        assert!(!lock_path.exists());
+    });
+
+    crate::timed_test!(stale_daemon_lock_recovery_ignores_missing_lock, {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let removed =
+            remove_stale_zccache_daemon_lock(temp.path()).expect("ignore missing daemon lock");
+        assert_eq!(removed, None);
     });
 
     crate::timed_test!(output_snippet_omits_empty_output, {

--- a/crates/soldr-cli/tests/cli_rust_plan.rs
+++ b/crates/soldr-cli/tests/cli_rust_plan.rs
@@ -255,3 +255,51 @@ fn cargo_front_door_recovers_from_stale_zccache_daemon_start() {
         "fake zccache should only allow recovery after stop"
     );
 }
+
+#[test]
+fn cargo_front_door_removes_stale_zccache_daemon_lock_before_retry() {
+    let cache_root = unique_temp_dir("cargo-stale-zccache-daemon-lock");
+    let log_path = cache_root.join("tool.log");
+    let stale_marker = cache_root.join("stale-zccache-lock");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_TEST_ZCCACHE_STALE_LOCK_ONCE", &stale_marker)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run soldr cargo build with stale fake zccache lock");
+
+    assert!(
+        output.status.success(),
+        "cache-enabled front door should remove stale zccache daemon.lock before retry\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    assert_eq!(
+        log.matches("zccache start").count(),
+        2,
+        "managed zccache start should be retried once after stale lock detection: {log}"
+    );
+    assert!(
+        log.contains("zccache stop"),
+        "managed zccache should still stop stale daemon state before removing the lock: {log}"
+    );
+    assert!(
+        log.contains("zccache session-start")
+            && log.contains("zccache wrapper")
+            && log.contains("zccache session-end test-session"),
+        "recovered build should still exercise the normal managed zccache path: {log}"
+    );
+    let zccache_cache_dir = discovered_private_zccache_cache_dir(&cache_root);
+    assert!(
+        !zccache_cache_dir.join("daemon.lock").exists(),
+        "soldr should remove stale zccache daemon.lock before retrying start"
+    );
+}

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -508,6 +508,7 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
              exit /b %ERRORLEVEL%\n\
              :soldr_zccache_start\n\
              echo zccache start cache_dir=%ZCCACHE_CACHE_DIR% daemon_namespace=%ZCCACHE_DAEMON_NAMESPACE%>>\"{0}\"\n\
+             if defined SOLDR_TEST_ZCCACHE_STALE_LOCK_ONCE goto soldr_zccache_start_stale_lock\n\
              if not defined SOLDR_TEST_ZCCACHE_STALE_START_ONCE exit /b 0\n\
              if exist \"%SOLDR_TEST_ZCCACHE_STALE_START_ONCE%.stopped\" exit /b 0\n\
              if not exist \"%SOLDR_TEST_ZCCACHE_STALE_START_ONCE%.failed\" (\n\
@@ -517,6 +518,23 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
              )\n\
              echo zccache start retried before stop 1>&2\n\
              exit /b 66\n\
+             :soldr_zccache_start_stale_lock\n\
+             if not defined ZCCACHE_CACHE_DIR (\n\
+               echo zccache start missing ZCCACHE_CACHE_DIR 1>&2\n\
+               exit /b 67\n\
+             )\n\
+             if not exist \"%SOLDR_TEST_ZCCACHE_STALE_LOCK_ONCE%.failed\" (\n\
+               if not exist \"%ZCCACHE_CACHE_DIR%\" mkdir \"%ZCCACHE_CACHE_DIR%\"\n\
+               echo 3197>\"%ZCCACHE_CACHE_DIR%\\daemon.lock\"\n\
+               type nul > \"%SOLDR_TEST_ZCCACHE_STALE_LOCK_ONCE%.failed\"\n\
+               echo failed to start daemon: daemon started but not accepting connections after 10s 1>&2\n\
+               exit /b 1\n\
+             )\n\
+             if exist \"%ZCCACHE_CACHE_DIR%\\daemon.lock\" (\n\
+               echo zccache start retried while stale daemon.lock remained 1>&2\n\
+               exit /b 66\n\
+             )\n\
+             exit /b 0\n\
              :soldr_zccache_flush\n\
              echo zccache flush args=%* cache_dir=%ZCCACHE_CACHE_DIR%>>\"{0}\"\n\
              if defined SOLDR_TEST_ZCCACHE_FLUSH_UNSUPPORTED goto soldr_zccache_flush_unsupported\n\
@@ -543,6 +561,24 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
              case \"$1\" in\n\
                start)\n\
                  echo \"zccache start cache_dir=${{ZCCACHE_CACHE_DIR:-}} daemon_namespace=${{ZCCACHE_DAEMON_NAMESPACE:-}}\" >> \"{0}\"\n\
+                 if [ -n \"${{SOLDR_TEST_ZCCACHE_STALE_LOCK_ONCE:-}}\" ]; then\n\
+                   if [ -z \"${{ZCCACHE_CACHE_DIR:-}}\" ]; then\n\
+                     echo 'zccache start missing ZCCACHE_CACHE_DIR' >&2\n\
+                     exit 67\n\
+                   fi\n\
+                   lock_path=\"${{ZCCACHE_CACHE_DIR}}/daemon.lock\"\n\
+                   if [ ! -e \"${{SOLDR_TEST_ZCCACHE_STALE_LOCK_ONCE}}.failed\" ]; then\n\
+                     mkdir -p \"${{ZCCACHE_CACHE_DIR}}\"\n\
+                     printf '3197\\n' > \"$lock_path\"\n\
+                     : > \"${{SOLDR_TEST_ZCCACHE_STALE_LOCK_ONCE}}.failed\"\n\
+                     echo 'failed to start daemon: daemon started but not accepting connections after 10s' >&2\n\
+                     exit 1\n\
+                   fi\n\
+                   if [ -e \"$lock_path\" ]; then\n\
+                     echo 'zccache start retried while stale daemon.lock remained' >&2\n\
+                     exit 66\n\
+                   fi\n\
+                 fi\n\
                  if [ -n \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE:-}}\" ]; then\n\
                    if [ ! -e \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE}}.stopped\" ]; then\n\
                      if [ ! -e \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE}}.failed\" ]; then\n\


### PR DESCRIPTION
## Summary
- remove stale `daemon.lock` from the managed zccache cache dir after stale daemon start detection and `zccache stop`
- include lock-removal diagnostics if the recovery retry still fails
- add regression coverage for a stale lock that survives `zccache stop`

Closes #629

## Tests
- `cargo test -p soldr-cli --lib`
- `cargo test -p soldr-cli --test cli_rust_plan`