### PR TITLE
perf(cook): skip archive pack when cook index is unavailable

### DIFF
--- a/crates/soldr-cli/src/cook.rs
+++ b/crates/soldr-cli/src/cook.rs
@@ -408,10 +408,10 @@ pub(crate) async fn run_cook(
     let cook_target_dir = resolve_cook_target_dir(&ctx.manifest_dir, &parsed);
     let cook_marker_path = cook_target_dir.join(".soldr-cook-marker.json");
     let expected_marker = compute_cook_marker(&ctx, &parsed);
-    let warm_skip = match (&expected_marker, read_cook_marker(&cook_marker_path)) {
-        (Some(expected), Some(existing)) if existing == *expected => true,
-        _ => false,
-    };
+    let warm_skip = matches!(
+        (&expected_marker, read_cook_marker(&cook_marker_path)),
+        (Some(expected), Some(existing)) if existing == *expected
+    );
     if warm_skip {
         eprintln!(
             "soldr cook: warm-cook detected (recipe + rustc match the prior cook marker at {}) — skipping Phase 2 (cargo chef cook). Estimated savings: ~5 min on Coverage-shape workloads. See soldr#621.",
@@ -672,6 +672,22 @@ fn resolve_target_triple(manifest_dir: &Path, args: &CookArgs) -> Option<String>
 /// artifact with the daemon via `CookRecord`. Best-effort: a failure
 /// here surfaces as a warning but never fails the cook command.
 fn index_cooked_artifact(ctx: &CookContext, args: &CookArgs) -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    index_cooked_artifact_with_packer(ctx, args, &paths, cook_archive::pack_cook_archive)
+}
+
+fn index_cooked_artifact_with_packer<F>(
+    ctx: &CookContext,
+    args: &CookArgs,
+    paths: &SoldrPaths,
+    packer: F,
+) -> Result<(), SoldrError>
+where
+    F: FnOnce(
+        &Path,
+        &Path,
+    ) -> Result<PackedCookArchive, crate::cache_lib::target_registry::RegistryError>,
+{
     // 1. Sharing-eligibility checks.
     let lockfile = ctx.manifest_dir.join("Cargo.lock");
     if !lockfile.is_file() {
@@ -738,8 +754,7 @@ fn index_cooked_artifact(ctx: &CookContext, args: &CookArgs) -> Result<(), Soldr
     let profile = resolve_profile_name(args).to_string();
 
     // 3. Resolve paths under ~/.soldr/.
-    let paths = SoldrPaths::new()?;
-    let cook_dir = cook_cache_dir(&paths);
+    let cook_dir = cook_cache_dir(paths);
     std::fs::create_dir_all(&cook_dir).map_err(|e| {
         SoldrError::Other(format!(
             "soldr cook: failed to create {}: {e}",
@@ -749,9 +764,10 @@ fn index_cooked_artifact(ctx: &CookContext, args: &CookArgs) -> Result<(), Soldr
 
     // 4. Pre-flight CookLookup so we can render a drift diagnostic
     //    when a previous recipe hash exists for this (origin, triple,
-    //    profile, channel, rustc). Best-effort: a daemon hiccup
-    //    falls through silently.
-    let sock = client::default_sock_path(&paths);
+    //    profile, channel, rustc). If this cannot reach the daemon,
+    //    CookRecord cannot be relied on either, so skip the expensive
+    //    archive pack entirely.
+    let sock = client::default_sock_path(paths);
     let prior_drift = match client::cook_lookup(
         &sock,
         recipe_hash,
@@ -774,11 +790,17 @@ fn index_cooked_artifact(ctx: &CookContext, args: &CookArgs) -> Result<(), Soldr
             .first()
             .copied()
             .map(DriftSignal::Drifted),
-        Err(_) => None,
+        Err(e) => {
+            eprintln!(
+                "{} cook index unavailable; skipping shared cook archive pack ({e:?}).",
+                yellow_warning_prefix()
+            );
+            return Ok(());
+        }
     };
 
     // 5. Pack the trimmed target/<profile>/ tree.
-    let packed = cook_archive::pack_cook_archive(&target_dir, &cook_dir)
+    let packed = packer(&target_dir, &cook_dir)
         .map_err(|e| SoldrError::Other(format!("soldr cook: failed to pack cook archive: {e}")))?;
 
     // 6. Register with the daemon. If the daemon is unreachable we

--- a/crates/soldr-cli/src/cook_tests.rs
+++ b/crates/soldr-cli/src/cook_tests.rs
@@ -8,6 +8,36 @@ fn argv(parts: &[&str]) -> Vec<String> {
     parts.iter().map(|s| (*s).to_string()).collect()
 }
 
+fn run_git_in(dir: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}\nstderr: {}",
+        dir.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_git_repo_with_tracked_lock(repo: &Path) {
+    std::fs::create_dir_all(repo).unwrap();
+    run_git_in(repo, &["init", "-q", "-b", "main"]);
+    run_git_in(repo, &["config", "user.email", "cook@example.com"]);
+    run_git_in(repo, &["config", "user.name", "cook test"]);
+    std::fs::write(
+        repo.join("Cargo.toml"),
+        "[package]\nname = \"cook_index_no_daemon\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(repo.join("Cargo.lock"), "# lockfile\n").unwrap();
+    run_git_in(repo, &["add", "Cargo.toml", "Cargo.lock"]);
+    run_git_in(repo, &["commit", "-q", "-m", "init"]);
+}
+
 #[test]
 fn parse_cook_args_recognises_release_and_workspace_flags() {
     let parsed = parse_cook_args(&argv(&["--release", "--workspace"])).unwrap();
@@ -346,6 +376,45 @@ fn sanitize_cargo_chef_recipe_removes_generated_plugin_lines_from_manifests() {
     assert!(!first.contains("plugin = false"));
     assert!(first.contains("proc-macro = false"));
     assert!(second.contains("plugin = \"user-data\""));
+}
+
+#[test]
+fn index_cooked_artifact_skips_archive_pack_when_daemon_unavailable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_git_repo_with_tracked_lock(&repo);
+    let target_debug_deps = repo.join("target").join("debug").join("deps");
+    std::fs::create_dir_all(&target_debug_deps).unwrap();
+    std::fs::write(target_debug_deps.join("libdep.rlib"), b"dep").unwrap();
+
+    let paths = SoldrPaths::with_root(tmp.path().join("soldr-cache"));
+    let ctx = CookContext {
+        manifest_dir: repo,
+        recipe_path: tmp.path().join("recipe.json"),
+        recipe_owned_tempdir: false,
+    };
+    let args = CookArgs {
+        target: Some("x86_64-unknown-linux-gnu".to_string()),
+        ..Default::default()
+    };
+    let mut packer_called = false;
+
+    index_cooked_artifact_with_packer(&ctx, &args, &paths, |_, _| {
+        packer_called = true;
+        panic!("packer must not run when CookLookup cannot reach the daemon")
+    })
+    .unwrap();
+
+    assert!(
+        !packer_called,
+        "daemon-unavailable cook index path must not invoke archive packing"
+    );
+    assert!(
+        !crate::cache_lib::cook_archive::cook_cache_dir(&paths)
+            .join(".tmp")
+            .exists(),
+        "skipping the packer should leave no cook archive temp directory"
+    );
 }
 
 // --- soldr#566: snapshot/restore the project around `cargo chef cook` ---


### PR DESCRIPTION
## Summary

Closes #624.

- Pre-flight `CookLookup` failures now stop cook-index Phase 4 before `pack_cook_archive` runs.
- The skipped path emits a clear warning: `cook index unavailable; skipping shared cook archive pack`.
- The normal daemon-available hit/miss paths still proceed to pack and `CookRecord`.
- Added a regression unit test that injects a packer closure and asserts it is not invoked when the daemon cannot be reached.

## Test Plan

- [x] `soldr cargo test -p soldr-cli index_cooked_artifact_skips_archive_pack_when_daemon_unavailable -- --nocapture`
- [x] `soldr cargo test -p soldr-cli cook::tests -- --nocapture`
- [x] `soldr cargo clippy -p soldr-cli --all-targets -- -D warnings`