### PR TITLE
fix(bench): repoint soldr-core mutation at core/mod.rs after PR #520

### DIFF
--- a/benchmark.toml
+++ b/benchmark.toml
@@ -111,8 +111,11 @@ path = "crates/soldr-cli/src/main.rs"
 [[mutations]]
 id = "soldr-core"
 # Pre-monocrate this was `crates/soldr-core/src/lib.rs` (its own
-# crate). After PR #415 the file moved to
-# `crates/soldr-cli/src/core.rs`. The mutation `id` stays as
-# "soldr-core" so historic benchmark records remain comparable.
+# crate). PR #415 moved it to `crates/soldr-cli/src/core.rs`, and
+# PR #520 split that single file into a `core/` sub-module tree —
+# `core.rs` no longer exists, so the old path silently created a
+# phantom file alongside `core/mod.rs` and rustc errored
+# E0761 (issue #632). The mutation `id` stays as "soldr-core" so
+# historic benchmark records remain comparable.
 label = "Lower-module edit"
-path = "crates/soldr-cli/src/core.rs"
+path = "crates/soldr-cli/src/core/mod.rs"


### PR DESCRIPTION
## Summary

- Closes #632.
- Repoints the `soldr-core` benchmark mutation from `crates/soldr-cli/src/core.rs` (deleted by PR #520) to `crates/soldr-cli/src/core/mod.rs`.
- Refreshes the benchmark.toml comment to capture both moves (#415 and #520) so the next refactor leaves a trail.

The bench workflow's `apply_mutation()` opens the configured path in append mode; on the deleted path it created a phantom `core.rs` next to `core/mod.rs` and rustc errored `E0761` (exit 101). Every `soldr-core` cell in every published run has been failing identically for both backends since #520, hiding a third of the benchmark surface.

## Test plan

- [x] Local: `printf '\n// cache benchmark mutation: soldr-core\n' >> crates/soldr-cli/src/core/mod.rs && soldr cargo check -p soldr-cli --locked` exits 0.
- [x] `git diff` confirms only `benchmark.toml` changed.
- [ ] After merge: next `cache-benchmark.yml` run on `main` populates non-null cold/warm timings for `soldr-core` rows in the rendered report and `latest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)