### PR TITLE
chore: gitignore .extern-repos/ and harden hook resolver against subrepo wedge

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
+            "command": "top=$(git rev-parse --show-toplevel 2>/dev/null); while [ -n \"$top\" ] && [ ! -f \"$top/.claude/hooks/tool_guard.py\" ]; do parent=$(dirname \"$top\"); [ \"$parent\" = \"$top\" ] && break; top=$parent; done; if [ -f \"$top/.claude/hooks/tool_guard.py\" ]; then uv run --script \"$top/.claude/hooks/tool_guard.py\"; fi",
             "timeout": 5
           }
         ]

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ uv.lock
 .claude/worktrees/
 .claude/settings.local.json
 .claude/.credentials*
+
+# Dependent-repo checkouts coordinated via the clud-extern-repos convention.
+.extern-repos/


### PR DESCRIPTION
## Summary

Two changes that together make the clud-extern-repos workflow safe to use from inside this repo:

1. **Gitignore `.extern-repos/`** so dependent-repo checkouts (e.g. zackees/zccache for coordinated upstream PRs) don't show up as untracked files in the parent's git status.
2. **Harden the tool_guard hook resolver** so a CWD inside `.extern-repos/<name>/` (which contains its own `.git/`) does not wedge every subsequent shell call.

## The wedge that prompted this

While starting work coordinated with zccache, a `cd .extern-repos/zccache && gh repo clone …` ran inside `.extern-repos/`, producing a nested `.extern-repos/.extern-repos/zccache/` checkout. Bash's persisted CWD ended up there. The hook command then ran:

```
uv run --script "$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py"
```

`git rev-parse --show-toplevel` returned the *nested zccache* repo path, where no hook script exists. uv exited non-zero — and the hook is **PreToolUse**, so its non-zero exit blocked every subsequent shell call. There was no way to `cd` back out.

Once the wedge is in place, the only escape is editing the hook config or hot-patching the missing script path. Both require workarounds that should never be necessary.

## The fix

Replace the literal `$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py` with a walk-up resolver that starts at the nearest git toplevel and walks one directory at a time until it finds a `.claude/hooks/tool_guard.py`. If none is found at any ancestor, the command silently exits 0.

```sh
top=$(git rev-parse --show-toplevel 2>/dev/null)
while [ -n "$top" ] && [ ! -f "$top/.claude/hooks/tool_guard.py" ]; do
  parent=$(dirname "$top")
  [ "$parent" = "$top" ] && break
  top=$parent
done
if [ -f "$top/.claude/hooks/tool_guard.py" ]; then
  uv run --script "$top/.claude/hooks/tool_guard.py"
fi
```

Verified locally from `/c/Users/niteris/dev/soldr/.extern-repos/zccache` (a nested git repo): the resolver resolves to `C:/Users/niteris/dev/soldr/.claude/hooks/tool_guard.py`.

## Trade-off

A workdir with no soldr-rooted ancestor will pass the bare-rust/python check unenforced. That is preferable to the hard-wedge failure mode, and matches reality — the prior behavior already only enforced inside this repo.

## Test plan

- [x] `cd` into `.extern-repos/zccache/` and run a bash command — resolver finds soldr's hook script.
- [x] Pre-fix wedge demonstrated and recovered from in the same session that prompted this PR.
- [ ] Open a fresh session, `cd` into `.extern-repos/zccache/`, and verify the hook enforces the bare-cargo policy correctly (must use `soldr cargo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)