### PR TITLE
docs(bench): note same-job-seed methodology in rendered report

### DIFF
--- a/.github/scripts/cache_benchmark_report.py
+++ b/.github/scripts/cache_benchmark_report.py
@@ -559,6 +559,19 @@ def _build_html_page(report: dict[str, Any]) -> str:
         {escape(soldr_note)} Raw detail is published beside this page as
         <a href="latest.json">latest.json</a>.
       </p>
+      <p class="note">
+        <strong>What "warm" measures here:</strong> every cell runs cold &rarr;
+        warm inside the same CI job, so the warm pass already has a hot
+        <code>target/</code> from the cold seed. swatinem's strength
+        (multi-GB <code>target/</code> restore from a prior job) and soldr's
+        strength (on-demand artifact fetch from a shared
+        <a href="https://github.com/zackees/zccache">zccache</a>) are
+        therefore both invisible &mdash; only the per-rustc wrapper overhead
+        on the few units cargo's mtime fingerprint flags as dirty is on the
+        clock. Treat the headline as a same-job-seed measurement, not a
+        general &ldquo;A is faster than B&rdquo; claim. Tracking under
+        <a href="https://github.com/zackees/soldr/issues/633">soldr#633</a>.
+      </p>
       <div class="table-wrap">
         <table>
           <thead>


### PR DESCRIPTION
## Summary

Adds a second note paragraph to the rendered HTML benchmark report at https://zackees.github.io/soldr/ explaining what "warm" actually measures.

The published page today carries the headline \"Across N configured comparisons, soldr is X% slower on warm time than swatinem and leads K rows.\" That number is correct, but it lands without context — readers see it as a general claim rather than what it actually is: a measurement of the same-job-seed wrapper-overhead scenario, where neither swatinem's real strength (multi-GB \`target/\` restore from a prior job) nor soldr's real strength (on-demand artifact fetch from a shared zccache) is exercised.

This PR adds a caveat paragraph right under the headline so a first-time reader can interpret the numbers correctly.

## What this is NOT

- Not a change to the benchmark scenario itself. Adding cross-job restore would require a second workflow that genuinely transports cache state between jobs — a larger design item that belongs in a separate PR.
- Not a change to the headline calculation. The number is still accurate for what it measures.
- Not a fix for the actual gap. Coordinated upstream work in zackees/zccache#629 / zackees/zccache#630 (merged) addresses the per-MISS persist path.

## Tracks

soldr#633 — keeps the issue open so the eventual cross-job scenario lands as a separate follow-up.

## Test plan

- [x] Diff is purely additive in the HTML template; no behavior change to JSON / metadata / table contents.
- [x] `cache_benchmark_report.py` module imports cleanly.
- [ ] Next run on \`main\` publishes the updated copy to \`benchmark-stats\`; visually inspect at https://zackees.github.io/soldr/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)