### PR TITLE
feat(bench): wire ZCCACHE_PROFILE_RUST_MISS for per-phase data collection

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -468,6 +468,12 @@ jobs:
           BENCHMARK_RESULTS_JSON: benchmark-summary/cache-benchmark-results.json
           SCENARIO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scenario || 'all' }}
           THRESHOLD_RATIO: ${{ steps.config.outputs.threshold_ratio }}
+          # Issue #637: emit per-miss phase breakdown to the daemon log so
+          # next-round zccache optimization decisions can be made from data
+          # instead of guesses. The env var is a daemon-side gate
+          # (zccache::daemon::server::handle_compile::pipeline) and is a no-op
+          # when unset, so the cost is borne only here.
+          ZCCACHE_PROFILE_RUST_MISS: "1"
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -702,9 +708,72 @@ jobs:
               print(f"::warning::{failure}")
           PY
 
+      - name: Collect zccache daemon logs (rust miss profile)
+        if: ${{ always() }}
+        shell: bash
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/run-benchmark-zccache
+        run: |
+          set -euo pipefail
+          out_dir=benchmark-summary/zccache-daemon-logs
+          mkdir -p "$out_dir"
+          if [ ! -d "$ZCCACHE_CACHE_DIR" ]; then
+            echo "no cache dir at $ZCCACHE_CACHE_DIR — skipping log collection"
+            exit 0
+          fi
+          # Copy *.log files under the cache dir into the artifact directory,
+          # preserving the relative path so reviewers can correlate cells
+          # with daemon sessions. `find … -type f -name '*.log'` filters out
+          # the multi-MB compile_journal.jsonl payloads, which the rust miss
+          # profile data does not need.
+          (cd "$ZCCACHE_CACHE_DIR" && find . -type f -name '*.log' -print0) \
+            | (cd "$ZCCACHE_CACHE_DIR" && tar --null --files-from=- -cf - 2>/dev/null) \
+            | (cd "$out_dir" && tar -xf - 2>/dev/null) \
+            || echo "no *.log files found under $ZCCACHE_CACHE_DIR"
+          # Extract just the rust_miss_profile lines into a single JSONL so
+          # next-iteration tooling can aggregate without re-parsing the full
+          # daemon log. Each line: a flat {key: value, ...} object keyed on
+          # the space-separated key=value format emitted by
+          # `emit_rust_miss_profile`. Integer values are parsed as ints.
+          jsonl="$out_dir/rust-miss-profile.jsonl"
+          extract_script="$(mktemp)"
+          trap 'rm -f "$extract_script"' EXIT
+          cat >"$extract_script" <<'PY'
+          import json
+          import sys
+
+          for line in sys.stdin:
+              parts = line.strip().split()
+              if not parts or parts[0] != "zccache_rust_miss_profile":
+                  continue
+              row = {}
+              for kv in parts[1:]:
+                  k, _, v = kv.partition("=")
+                  if not k:
+                      continue
+                  try:
+                      row[k] = int(v)
+                  except ValueError:
+                      row[k] = v
+              print(json.dumps(row))
+          PY
+          : > "$jsonl"
+          find "$ZCCACHE_CACHE_DIR" -type f -name '*.log' -print0 \
+            | xargs -0 -I{} grep -h '^zccache_rust_miss_profile ' {} \
+            | python3 "$extract_script" >> "$jsonl" || true
+          echo "rust-miss-profile.jsonl: $(wc -l < "$jsonl") rows"
+
       - name: Cleanup zccache
         if: ${{ always() }}
         uses: ./.github/actions/cache-benchmark-zccache-cleanup
+
+      - name: Upload zccache rust-miss profile artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cache-benchmark-zccache-profile
+          path: benchmark-summary/zccache-daemon-logs
+          if-no-files-found: warn
 
       - name: Upload raw benchmark artifact
         if: ${{ always() }}


### PR DESCRIPTION
## Summary

Closes #637.

After zackees/zccache#630 (parallelize 4+ outputs, merged this loop) and zackees/zccache#635 (move rust miss persist off the daemon critical path, merged this loop), the next-round optimization decision needs **per-phase data** instead of guesses about why the release/lint cells are still ~3-5% behind swatinem.

The data exists already: `RustMissProfile::emit_rust_miss_profile` writes a structured `zccache_rust_miss_profile key=value …` line per miss to the daemon log whenever `ZCCACHE_PROFILE_RUST_MISS` is set. The benchmark workflow just never enabled it.

## Three minimal additions to `cache-benchmark.yml`

1. **Step env**: `ZCCACHE_PROFILE_RUST_MISS: "1"` on the *Run configured benchmarks* step. Daemon-side gate, so the cost is borne only by this workflow.

2. **New step: Collect zccache daemon logs** — walks `${{ runner.temp }}/run-benchmark-zccache` for `*.log` files (skipping the multi-MB `compile_journal.jsonl`), copies them into `benchmark-summary/zccache-daemon-logs/` preserving relative paths, and extracts the `zccache_rust_miss_profile` lines into a single `rust-miss-profile.jsonl` for easy downstream aggregation.

3. **New step: Upload zccache rust-miss profile artifact** — uploads the daemon-logs directory as the new `cache-benchmark-zccache-profile` artifact.

Both new steps run with `if: always()` so a failing benchmark still leaves the diagnostic data behind.

## What this does NOT do (deferred)

- Aggregate phase timings into the rendered HTML report — that needs a decision about which phases to surface and at what aggregation (median? p95?). Leaving the JSONL on disk lets reviewers `jq`/Python on the raw rows in the meantime.
- Add a hard speedup gate on phase metrics — they're informational for now.

## Test plan

- [x] `python -c 'import yaml; yaml.safe_load(open(\".github/workflows/cache-benchmark.yml\"))'` parses cleanly.
- [x] The Python extractor parses a sample `zccache_rust_miss_profile` line into a flat JSON object with integer / string typing.
- [ ] Next scheduled benchmark run on main produces the new artifact at `benchmark-summary/zccache-daemon-logs/`.
- [ ] Per the parent project's \"defer re-testing until next loop\" workflow, surfacing the data in the HTML report is intentionally a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)