### PR TITLE
feat(bench): measure + render per-backend cache directory size

### DIFF
--- a/.github/scripts/cache_benchmark_report.py
+++ b/.github/scripts/cache_benchmark_report.py
@@ -30,6 +30,12 @@ def _read_float(value: Any) -> float | None:
     return float(value)
 
 
+def _read_int(value: Any) -> int | None:
+    if value in ("", None):
+        return None
+    return int(value)
+
+
 def _read_bool(value: Any) -> bool | None:
     if value in ("", None):
         return None
@@ -64,6 +70,23 @@ def _format_ratio(value: float | None) -> str:
 
 def _format_percent(value: float | None) -> str:
     return "n/a" if value is None else f"{value:.2f}%"
+
+
+def _format_bytes(value: int | None) -> str:
+    """Compact human-readable size. Powers of 1024 with two-decimal MiB / GiB.
+
+    Issue #639: the 8 GB cache-size budget the project tracks against
+    real-world workspaces (fastled/fbuild) needs to be visible in the
+    rendered headline alongside the speedup, so the report uses GiB above
+    1 GiB and MiB below — same convention the GitHub Actions cache UI uses.
+    """
+    if value is None:
+        return "n/a"
+    if value < 1024 * 1024:
+        return f"{value / 1024:.1f} KiB"
+    if value < 1024 * 1024 * 1024:
+        return f"{value / (1024 * 1024):.1f} MiB"
+    return f"{value / (1024 * 1024 * 1024):.2f} GiB"
 
 
 def _format_bool(value: bool | None) -> str:
@@ -166,6 +189,7 @@ def _load_results(
                 "speedup_ratio": _round_metric(_read_float(raw_result.get("speedup_ratio"))),
                 "cache_hit": _read_bool(raw_result.get("cache_hit")),
                 "cache_hit_detail": raw_result.get("cache_hit_detail") or None,
+                "cache_dir_bytes": _read_int(raw_result.get("cache_dir_bytes")),
                 "threshold_failed": bool(raw_result.get("threshold_failed", False)),
             }
         )
@@ -371,9 +395,11 @@ def _build_table_rows(report: dict[str, Any]) -> str:
             f"<td>{_format_seconds(soldr.get('cold_seconds'))}</td>"
             f"<td>{_format_seconds(soldr.get('warm_seconds'))}</td>"
             f"<td>{_format_ratio(soldr.get('speedup_ratio'))}</td>"
+            f"<td>{_format_bytes(soldr.get('cache_dir_bytes'))}</td>"
             f"<td>{_format_seconds(swatinem.get('cold_seconds'))}</td>"
             f"<td>{_format_seconds(swatinem.get('warm_seconds'))}</td>"
             f"<td>{_format_ratio(swatinem.get('speedup_ratio'))}</td>"
+            f"<td>{_format_bytes(swatinem.get('cache_dir_bytes'))}</td>"
             f"<td>{_format_percent(row['soldr_vs_base_warm_percent'])}</td>"
             "</tr>"
         )
@@ -581,9 +607,11 @@ def _build_html_page(report: dict[str, Any]) -> str:
               <th>soldr cold</th>
               <th>soldr warm</th>
               <th>soldr speedup</th>
+              <th>soldr cache</th>
               <th>swatinem cold</th>
               <th>swatinem warm</th>
               <th>swatinem speedup</th>
+              <th>swatinem cache</th>
               <th>soldr vs swatinem</th>
             </tr>
           </thead>

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -552,6 +552,45 @@ jobs:
               subprocess.run(command, cwd=repo_root, env=env, check=True)
               return time.perf_counter() - start
 
+          def _dir_size_bytes(path):
+              """Walk path and return total file bytes; None on missing."""
+              if not path or not Path(path).is_dir():
+                  return None
+              total = 0
+              for root, _dirs, files in os.walk(path):
+                  for name in files:
+                      try:
+                          total += (Path(root) / name).stat().st_size
+                      except OSError:
+                          pass
+              return total
+
+          def measure_cache_size_bytes(backend):
+              """Per-backend on-disk cache size *after* the warm run.
+
+              Issue #639: the headline number is silent on the storage cost
+              of each backend, which matters for the 8 GB cache budget claim
+              the project tracks against real-world workspaces (e.g. fbuild).
+
+              - zccache: the cache lives under `$ZCCACHE_CACHE_DIR`. Soldr
+                manages this dir end-to-end so its size is the on-disk cost.
+              - swatinem (no wrapper): the `Cache cargo registry and target`
+                step in `Swatinem/rust-cache` persists `target/` plus the
+                cargo registry. Approximate it with `target/` + `$CARGO_HOME`
+                so the comparison is apples-to-apples — both backends report
+                the bytes they cause to be cached across CI jobs.
+              """
+              if backend == "zccache":
+                  return _dir_size_bytes(os.environ.get("ZCCACHE_CACHE_DIR"))
+              if backend == "swatinem":
+                  total = 0
+                  for sub in (repo_root / "target", Path(os.environ.get("CARGO_HOME") or Path.home() / ".cargo")):
+                      sz = _dir_size_bytes(sub)
+                      if sz is not None:
+                          total += sz
+                  return total or None
+              return None
+
           results = []
           failures = []
 
@@ -570,6 +609,7 @@ jobs:
                           "speedup_ratio": None,
                           "cache_hit": False,
                           "cache_hit_detail": f"backend={backend};same_job_seed=true",
+                          "cache_dir_bytes": None,
                           "threshold_failed": False,
                       }
 
@@ -600,6 +640,7 @@ jobs:
                           result["speedup_ratio"] = round(speedup_ratio, 2)
                           result["cache_hit"] = warm_seconds < cold_seconds
                           result["threshold_failed"] = speedup_ratio < threshold
+                          result["cache_dir_bytes"] = measure_cache_size_bytes(backend)
                           if result["threshold_failed"]:
                               failures.append(
                                   f"{profile['id']}/{mutation['id']}/{competitor['id']} observed {speedup_ratio:.2f}x, required {threshold:.2f}x"


### PR DESCRIPTION
## Summary

Tracks #639. The 2x speedup target needs context — and the context is the on-disk cache budget. The project tracks against real workspaces like [fastled/fbuild](https://github.com/fastled/fbuild) (11 crates, `target/` ~2.3 GiB on disk) where the soldr cache is required to stay under 8 GiB so it can survive on a dev machine without manual GC.

The rendered report at https://zackees.github.io/soldr/ had no way to surface either backend's actual size. This PR adds three small pieces:

- **Workflow Python**: a `measure_cache_size_bytes(backend)` helper called right after each warm pass. zccache reports `$ZCCACHE_CACHE_DIR`; swatinem (no wrapper) reports `target/` + `$CARGO_HOME` — the union of what `Swatinem/rust-cache` actually persists across CI jobs.
- **Report shape**: `cache_dir_bytes` flows through a new `_read_int` helper into per-row JSON.
- **HTML table**: new `soldr cache` / `swatinem cache` columns, formatted via a `_format_bytes` helper (KiB / MiB / GiB, same convention as the GHA cache UI).

## What this does NOT do

- No gate or warn on the 8 GiB cap. Once we have actual values from a real workspace, a gate can land in a follow-up.
- No cross-job restore scenario — that's the actual 2x story, separately tracked under #639.

## Test plan

- [x] `python -m yaml safe_load …` parses the workflow.
- [x] `_format_bytes` smoke-tested: 1024→\"1.0 KiB\", 5 MiB→\"5.0 MiB\", 2.5 GiB→\"2.50 GiB\", None→\"n/a\".
- [x] `_read_int(42)` → 42, `_read_int(None)` → None.
- [ ] Next benchmark run on main publishes `latest.json` with `cache_dir_bytes` populated and the new columns visible on the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)