### PR TITLE
feat(bench): optionally build zccache from a git ref for the bench

### DIFF
--- a/.github/actions/cache-benchmark-zccache/action.yml
+++ b/.github/actions/cache-benchmark-zccache/action.yml
@@ -61,6 +61,16 @@ inputs:
       or a specific version like "1.2.5".
     required: false
     default: "latest"
+  zccache-source-ref:
+    description: >
+      Git ref (branch / tag / SHA) of zackees/zccache to build from source.
+      When non-empty, the action runs `cargo install --git … --rev/--branch
+      <ref>` before falling back to the binary install paths. Closes the
+      release-lag gap (soldr#641) so the bench can measure unreleased
+      zccache commits. Empty (default) preserves the pre-#641 behaviour of
+      installing the latest published binary.
+    required: false
+    default: ""
   save-cache:
     description: >
       Whether to save caches at the end. Set to "false" for PR builds
@@ -176,9 +186,38 @@ runs:
       shell: bash
       run: |
         VERSION="${{ inputs.zccache-version }}"
+        SOURCE_REF="${{ inputs.zccache-source-ref }}"
         INSTALLED=false
 
-        if [ "${{ runner.os }}" != "Windows" ]; then
+        # soldr#641: optional from-source install at a specific zccache
+        # git ref. Wins over the binary install paths when the operator
+        # wants to measure an unreleased commit (the binary install paths
+        # only know about published releases). cargo-install spends ~3 min
+        # building zccache-cli on a clean GHA runner, so this path stays
+        # opt-in via a non-empty `zccache-source-ref`.
+        if [ -n "$SOURCE_REF" ]; then
+          SRC_INSTALL_DIR="$HOME/.cargo/bin"
+          # Honour cargo's tooling-toolchain discovery; the bench action
+          # runs after a Rust toolchain is already on PATH so `cargo` is
+          # available. `--locked` keeps the build deterministic.
+          if cargo install \
+              --git https://github.com/zackees/zccache \
+              --rev "$SOURCE_REF" \
+              --locked \
+              --bin zccache \
+              --bin zccache-daemon \
+              --root "$HOME/.cargo" \
+              zccache-cli 2>&1 | tail -20; then
+            echo "$SRC_INSTALL_DIR" >> "$GITHUB_PATH"
+            export PATH="$SRC_INSTALL_DIR:$PATH"
+            INSTALLED=true
+            echo "::notice::zccache built from source at git ref $SOURCE_REF"
+          else
+            echo "::warning::from-source zccache build failed at ref $SOURCE_REF — falling back to binary install"
+          fi
+        fi
+
+        if [ "$INSTALLED" = "false" ] && [ "${{ runner.os }}" != "Windows" ]; then
           INSTALL_DIR="$HOME/.local/bin"
           mkdir -p "$INSTALL_DIR"
           INSTALL_SCRIPT="${{ github.action_path }}/install.sh"

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -24,6 +24,14 @@ on:
         required: true
         default: "10"
         type: string
+      zccache_source_ref:
+        description: >
+          Git ref of zackees/zccache to build from source instead of installing
+          the latest release. Use for measuring unreleased commits (#641).
+          Empty (default) keeps the published-binary path on the scheduled run.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -124,6 +132,7 @@ jobs:
           cache-compilation: "false"
           cache-target: "false"
           save-cache: "false"
+          zccache-source-ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.zccache_source_ref || '' }}
 
       - name: Run native SQLite benchmark
         shell: bash
@@ -459,6 +468,7 @@ jobs:
           cache-dir: ${{ runner.temp }}/run-benchmark-zccache
           cache-target: "false"
           save-cache: "false"
+          zccache-source-ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.zccache_source_ref || '' }}
 
       - name: Run configured benchmarks
         shell: bash


### PR DESCRIPTION
## Summary

Closes #641.

The cache-benchmark workflow installs zccache via the binary install paths in `.github/actions/cache-benchmark-zccache/install.sh`, which download from the latest GitHub release. The bench therefore cannot measure unreleased zccache commits — every soldr benchmark cycle between merge-day on zackees/zccache and the next zccache release measures stale code, no matter how good the commits are.

This PR restores the feedback loop without changing the default behaviour.

## Two coordinated additions

- **Action input `zccache-source-ref`** (default `\"\"`). When non-empty, the action runs `cargo install --git https://github.com/zackees/zccache --rev <ref> --locked --bin zccache --bin zccache-daemon zccache-cli` before falling through to the binary install paths. Empty preserves pre-#641 behaviour for every scheduled run.
- **Workflow `workflow_dispatch` input `zccache_source_ref`** wired into both `Prepare zccache tool` invocations (native-sqlite job + the main config-driven benchmark). Triggering the workflow from the Actions UI now accepts \"build zccache from main HEAD\" or any SHA as a single freeform field.

## What this does NOT do

- Default scheduled run still uses the published binary — keeps the published page stable between intentional re-runs.
- No new gate or warning around the from-source duration (~3 min on a clean runner).
- The cross-job restore scenario (the actual 2x story tracked in #639) is a separate PR.

## Test plan

- [x] Both YAML files parse cleanly under `yaml.safe_load`.
- [x] Diff is purely additive: existing scheduled bench runs unaffected.
- [ ] After merge: dispatch the workflow with `zccache_source_ref` set to the SHA of zackees/zccache main HEAD (currently `25c054b`) and verify the rendered report at https://zackees.github.io/soldr/ now reflects the post-#635 async-persist behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)