### PR TITLE
feat(bench): skeleton workspace-scale fixture (#648)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -1,0 +1,6 @@
+# Skeleton — actual crate graph lands in a follow-up PR (see README).
+# This file exists so the directory has a single-source-of-truth shell
+# and so future PRs can add `members` without re-litigating layout.
+[workspace]
+resolver = "2"
+members = []

--- a/benchmarks/workspace-scale/README.md
+++ b/benchmarks/workspace-scale/README.md
@@ -1,0 +1,48 @@
+# workspace-scale benchmark fixture
+
+Closes #648 (skeleton).
+
+A multi-crate workspace fixture sized so that `cargo build --release`
+produces a `target/` large enough to exceed GitHub Actions' per-repo
+**10 GiB cache size limit**. At that scale `Swatinem/rust-cache`'s
+`actions/cache` save step fails (or, depending on whether the repo
+has prior smaller saves, evicts) — measuring it directly is the
+only way to expose soldr's structural advantage in the published
+benchmark, since the existing `soldr-cli` fixture's `target/` is
+small enough to fit comfortably (~600-800 MiB) and both backends
+restore cleanly.
+
+## Status: SKELETON
+
+This commit lays out the directory + the `[workspace]` `Cargo.toml`
+shell so a follow-up can populate it without re-litigating where it
+lives or how it integrates with `benchmark.toml`. The actual crate
+graph (80-100 dependent crates, each pulling in a different heavy
+dep) lands in a subsequent PR — building 80 crates here without
+their downstream wiring would already be ~600 MiB of registry
+downloads on every soldr CI job, which violates the project's "do
+not blow up the cache budget with few builds" constraint from the
+top of the loop.
+
+## Design constraints
+
+- After the cold-build, `target/release` must be **≥ 12 GiB** to
+  cross the 10 GiB cache limit comfortably.
+- Per-build registry footprint (the part that lands in
+  `$CARGO_HOME/registry`) should stay under ~3 GiB so the
+  cargo baseline doesn't dwarf the per-fixture delta.
+- All deps must be available on crates.io with permissive licences.
+- No build scripts that hit the network or require system libs other
+  than what GHA runners already provide.
+- The workspace must build on all four bench-supported runner OSes
+  (Linux x64/aarch64, macOS, Windows) for the cell to be valid.
+
+## Hooks into the bench harness
+
+When the crate tree is populated, `benchmark.toml` grows a
+`[[fixtures]]` entry pointing here and the workflow Python loop
+becomes a `for fixture in fixtures` over the existing
+profile × mutation matrix. The current single-fixture shape is the
+explicit thing that needs to change next, not the cell structure
+itself — `_backend_cache_roots` already takes the backend identity
+and is agnostic to which workspace it's measuring.


### PR DESCRIPTION
## Summary

Tracks #648. The corrected-data analysis in soldr#639 shows the published soldr-cli benchmark cannot demonstrate a 2x speedup — its `target/` after release-build is only ~600-800 MiB, well under the 10 GiB GHA per-repo cache size limit, so both backends restore cleanly and the warm-time gap is dominated by ±5 % runner noise.

The 2x story lives where the workspace's `target/` **exceeds** the GHA cache cap. There `Swatinem/rust-cache`'s save step fails (or evicts) and soldr's content-addressed cache survives. This PR adds the directory + README + empty `[workspace]` shell for that fixture so a follow-up can populate the crate graph without re-litigating layout.

## Why skeleton-only

Adding 80-100 dependent crates to demonstrate the cliff would land ~600 MiB of registry downloads on every soldr CI job — explicitly against the project's \"don't blow up the cache budget with few builds\" constraint at the top of the loop. The crate graph itself lands once the integration shape against `benchmark.toml` is decided in a follow-up.

## What's here

- `benchmarks/workspace-scale/README.md` — design constraints (≥ 12 GiB `target/`, ≤ 3 GiB registry footprint, builds on all four bench-supported runner OSes, no system-lib deps).
- `benchmarks/workspace-scale/Cargo.toml` — empty `[workspace] members = []` so cargo treats it as a separate workspace (mirrors `benchmarks/sqlite-native/Cargo.toml`'s pattern). The soldr root `Cargo.toml`'s `members` list is `[\"crates/soldr-cli\"]` with no glob, so the new directory is invisible to the workspace and the monocrate guard.

## What this does NOT do

- No crate graph (deferred — see README).
- No `benchmark.toml` wiring (deferred — depends on the harness shape we want for multi-fixture).
- No new bench cells (deferred — same reason).

## Test plan

- [x] `Cargo.toml` validates as a (virtual, empty) workspace shell.
- [x] Soldr root workspace's `members` list unchanged; monocrate guard unaffected (`monocrate_guard.rs` scans `crates/*/Cargo.toml` only).
- [ ] CI build matrix continues to pass on this PR (the new directory is not in the build path).

## Cross-link

- soldr#648 — the proposal.
- soldr#639 — corrected-data analysis + the broader 2x strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)