### PR TITLE
feat(bench): opt-in cross-PR cache sharing scenario (#650)

### DIFF
--- a/.github/scripts/cache_benchmark_report.py
+++ b/.github/scripts/cache_benchmark_report.py
@@ -222,6 +222,8 @@ def _load_results(
                 "archive_bytes": _read_int(raw_result.get("archive_bytes")),
                 "restore_seconds": _read_float(raw_result.get("restore_seconds")),
                 "restored_warm_seconds": _read_float(raw_result.get("restored_warm_seconds")),
+                "cross_pr_seed_seconds": _read_float(raw_result.get("cross_pr_seed_seconds")),
+                "cross_pr_build_seconds": _read_float(raw_result.get("cross_pr_build_seconds")),
                 "threshold_failed": bool(raw_result.get("threshold_failed", False)),
             }
         )
@@ -563,6 +565,87 @@ def _build_restore_phase_section(report: dict[str, Any]) -> str:
 """
 
 
+def _cross_pr_rows(report: dict[str, Any]) -> list[tuple[dict[str, Any], dict[str, Any], dict[str, Any]]]:
+    """Yield (row, soldr_result, swatinem_result) when cross-PR data exists.
+
+    Issue #650: only renders when at least one row has the cross-PR fields
+    populated, so scheduled runs are unaffected.
+    """
+    base_competitor_id = report["site"]["base_competitor"]
+    out: list[tuple[dict[str, Any], dict[str, Any], dict[str, Any]]] = []
+    for row in report["comparisons"]:
+        soldr = _comparison_result(row, "soldr") or {}
+        base = _comparison_result(row, base_competitor_id) or {}
+        if any(
+            soldr.get(key) is not None or base.get(key) is not None
+            for key in ("cross_pr_seed_seconds", "cross_pr_build_seconds")
+        ):
+            out.append((row, soldr, base))
+    return out
+
+
+def _build_cross_pr_section(report: dict[str, Any]) -> str:
+    rows = _cross_pr_rows(report)
+    if not rows:
+        return ""
+    table_rows: list[str] = []
+    for row, soldr, base in rows:
+        s_seed = soldr.get("cross_pr_seed_seconds")
+        s_build = soldr.get("cross_pr_build_seconds")
+        b_seed = base.get("cross_pr_seed_seconds")
+        b_build = base.get("cross_pr_build_seconds")
+        speedup = (
+            f"{b_build / s_build:.2f}x"
+            if s_build and b_build and s_build > 0 and b_build > 0
+            else "n/a"
+        )
+        table_rows.append(
+            "<tr>"
+            f"<td>{escape(row['profile_label'])}</td>"
+            f"<td>{escape(row['mutation_label'])}</td>"
+            f"<td>{_format_seconds(s_seed)}</td>"
+            f"<td>{_format_seconds(s_build)}</td>"
+            f"<td>{_format_seconds(b_seed)}</td>"
+            f"<td>{_format_seconds(b_build)}</td>"
+            f"<td>{escape(speedup)}</td>"
+            "</tr>"
+        )
+    return f"""
+      <h2>Cross-PR cache sharing</h2>
+      <p class="meta">
+        Opt-in measurement (workflow_dispatch input
+        <code>include_cross_pr=true</code>). Seeds the backend's cache
+        with mutation A applied (touch
+        <code>crates/soldr-cli/src/fetch/github.rs</code>), switches to
+        mutation B (touch <code>crates/soldr-cli/src/core/git.rs</code>,
+        a deep module in a different subtree), wipes <code>target/</code>
+        so cargo invokes rustc per unit, and times the rebuild. swatinem
+        has no cross-PR cache share so this is effectively a cold rebuild
+        for it; soldr's content-addressed cache serves hits for every
+        unit whose inputs are unchanged across mutations. Tracking under
+        <a href="https://github.com/zackees/soldr/issues/650">soldr#650</a>.
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Profile</th>
+              <th>Change</th>
+              <th>soldr seed (A)</th>
+              <th>soldr build (B)</th>
+              <th>swatinem seed (A)</th>
+              <th>swatinem build (B)</th>
+              <th>soldr speedup vs swatinem</th>
+            </tr>
+          </thead>
+          <tbody>
+            {chr(10).join(table_rows)}
+          </tbody>
+        </table>
+      </div>
+"""
+
+
 def _build_native_sqlite_section(report: dict[str, Any]) -> str:
     native = report.get("native_sqlite")
     if not native or not _native_sqlite_results(report):
@@ -741,6 +824,7 @@ def _build_html_page(report: dict[str, Any]) -> str:
         </table>
       </div>
       {_build_restore_phase_section(report)}
+      {_build_cross_pr_section(report)}
       {_build_native_sqlite_section(report)}
       <h2>Benchmarked Commands</h2>
       <ul>

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -40,6 +40,16 @@ on:
         required: false
         default: false
         type: boolean
+      include_cross_pr:
+        description: >
+          Also measure the cross-PR sharing scenario (#650): seed cache with
+          mutation A, switch to mutation B (different file), wipe target/,
+          rebuild. swatinem has no cross-PR cache share so it pays a full
+          cold-rebuild; soldr's content-addressed cache serves hits for
+          unchanged units. Adds ~3-5 min per cell so it stays opt-in.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -497,6 +507,9 @@ jobs:
           # same-job-seed scenario. Defaults off so the scheduled run stays
           # fast; flip via workflow_dispatch when chasing the 2x story.
           INCLUDE_RESTORE_PHASE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.include_restore_phase || 'false' }}
+          # Issue #650: opt-in cross-PR cache sharing measurement. Same gate
+          # shape as INCLUDE_RESTORE_PHASE.
+          INCLUDE_CROSS_PR: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.include_cross_pr || 'false' }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -708,6 +721,93 @@ jobs:
 
               return phase
 
+          # Issue #650: cross-PR mutation pair. branch-A and branch-B touch
+          # two different deep modules of `soldr-cli`. Both invalidate the
+          # `soldr-cli` crate's compilation but neither invalidates the dep
+          # graph upstream, so a content-addressed cache populated by
+          # branch-A serves hits for every dep when branch-B then builds.
+          # swatinem caches by-key per the PR's commit SHA, so the branch-B
+          # job in real CI has no cache to restore from branch-A — we
+          # simulate that by NOT restoring any backend cache for swatinem.
+          CROSS_PR_BRANCH_A_PATH = "crates/soldr-cli/src/fetch/github.rs"
+          CROSS_PR_BRANCH_B_PATH = "crates/soldr-cli/src/core/git.rs"
+
+          def _apply_mutation_at(path_str, marker):
+              p = repo_root / path_str
+              with p.open("a", encoding="utf-8") as handle:
+                  handle.write(f"\n// cache benchmark mutation: {marker}\n")
+
+          def measure_cross_pr_sharing(profile, backend):
+              """Cross-PR cache-share simulation.
+
+              For soldr the zccache content store is retained between the
+              branch-A seed and the branch-B build (target/ is wiped to
+              force cargo to invoke rustc per unit so the cache is
+              actually consulted). swatinem has no cross-PR mechanism, so
+              its branch-B build is effectively cold (cache + target wiped).
+
+              Returns `{branch_a_seed_seconds, branch_b_seconds}`.
+              """
+              phase = {
+                  "cross_pr_seed_seconds": None,
+                  "cross_pr_build_seconds": None,
+              }
+              # Branch A seed: clean state, apply branch-A mutation, run cargo
+              # with the backend wrapper so the cache populates.
+              clean_workspace()
+              reset_backend(backend)
+              _apply_mutation_at(CROSS_PR_BRANCH_A_PATH, "cross-pr-branch-a")
+              start = time.perf_counter()
+              subprocess.run(
+                  ["cargo", *render_parts(profile["cargo_args"])],
+                  cwd=repo_root,
+                  env=_cargo_env_for(backend),
+                  check=True,
+              )
+              phase["cross_pr_seed_seconds"] = round(time.perf_counter() - start, 2)
+
+              # Switch to branch B: revert the workspace (drops branch-A's
+              # marker), wipe target/ so cargo re-invokes rustc per unit.
+              # For zccache: KEEP the cache (content store), so unchanged
+              # crates serve from cache. For swatinem (no wrapper): there's
+              # no out-of-band cache so the cargo clean is the only state
+              # change — the build is effectively cold.
+              clean_workspace()
+              subprocess.run(
+                  ["cargo", "clean"],
+                  cwd=repo_root,
+                  check=False,
+                  stdout=subprocess.DEVNULL,
+                  stderr=subprocess.DEVNULL,
+              )
+              _apply_mutation_at(CROSS_PR_BRANCH_B_PATH, "cross-pr-branch-b")
+              try:
+                  start = time.perf_counter()
+                  subprocess.run(
+                      ["cargo", *render_parts(profile["cargo_args"])],
+                      cwd=repo_root,
+                      env=_cargo_env_for(backend),
+                      check=True,
+                  )
+                  phase["cross_pr_build_seconds"] = round(time.perf_counter() - start, 2)
+              except subprocess.CalledProcessError:
+                  pass
+              return phase
+
+          def _cargo_env_for(backend):
+              env = os.environ.copy()
+              env["CARGO_TERM_COLOR"] = "never"
+              env.pop("RUSTC_WRAPPER", None)
+              if backend == "zccache":
+                  subprocess.run(
+                      ["zccache", "start"],
+                      check=True,
+                      stdout=subprocess.DEVNULL,
+                      stderr=subprocess.DEVNULL,
+                  )
+                  env["RUSTC_WRAPPER"] = "zccache"
+              return env
+
           results = []
           failures = []
 
@@ -731,6 +831,8 @@ jobs:
                           "archive_bytes": None,
                           "restore_seconds": None,
                           "restored_warm_seconds": None,
+                          "cross_pr_seed_seconds": None,
+                          "cross_pr_build_seconds": None,
                           "threshold_failed": False,
                       }
 
@@ -770,6 +872,14 @@ jobs:
                                         f"{profile['id']}/{mutation['id']}/{competitor['id']}: {exc}")
                               else:
                                   result.update(restore_phase)
+                          if os.environ.get("INCLUDE_CROSS_PR", "").lower() in ("1", "true"):
+                              try:
+                                  cross_pr = measure_cross_pr_sharing(profile, backend)
+                              except Exception as exc:  # noqa: BLE001
+                                  print(f"::warning::cross-pr measurement failed for "
+                                        f"{profile['id']}/{mutation['id']}/{competitor['id']}: {exc}")
+                              else:
+                                  result.update(cross_pr)
                           if result["threshold_failed"]:
                               failures.append(
                                   f"{profile['id']}/{mutation['id']}/{competitor['id']} observed {speedup_ratio:.2f}x, required {threshold:.2f}x"


### PR DESCRIPTION
## Summary

Closes #650. After PR #646 corrected the cache-roots measurement, the data in soldr#639 shows the same-job-seed warm scenario AND the cross-job restore scenario both cannot demonstrate a 2x soldr advantage on this workspace — soldr is competitive (-3 % on warm, 86 % the cache size) but not 2x faster.

The structural lever that genuinely delivers 2x is **cross-PR cache sharing**: swatinem keys its cache by the PR's commit SHA so two PRs touching different files never share artifacts; soldr's content-addressed cache hits regardless of which PR populated it.

## How it measures

Per cell, when `include_cross_pr=true`:

1. **Branch A seed.** Clean workspace + reset backend cache. Apply mutation A (touch `crates/soldr-cli/src/fetch/github.rs`, a deep module). Run cargo with the backend's wrapper so the cache populates. Record `cross_pr_seed_seconds`.

2. **Branch B build.** Revert the workspace (drops A's marker). `cargo clean` to wipe `target/` so cargo has to invoke rustc per unit. Apply mutation B (touch `crates/soldr-cli/src/core/git.rs`, a different deep module in a different subtree). For zccache: keep the cache populated by branch A. For swatinem: no out-of-band cache → effectively cold. Run cargo. Record `cross_pr_build_seconds`.

The B-build numbers expose the structural advantage: soldr's zccache serves hits for every unit whose inputs are unchanged across A and B (everything except soldr-cli's own crate, since both mutations touch a soldr-cli file); swatinem has no cross-PR mechanism so it rebuilds from scratch.

## Report shape

Four fields per row flow through `_load_results`: `cross_pr_seed_seconds`, `cross_pr_build_seconds` (and the swatinem counterparts). The HTML rendering adds a new \"Cross-PR cache sharing\" section with seven columns including a computed `soldr speedup vs swatinem` ratio. Section only emits when at least one row has the data, so scheduled runs are unchanged.

## What this does NOT do

- No two-job CI split — single-job simulation that models swatinem's worst case (no fallback restore-key match).
- No hard gate on the speedup ratio — informational for now.
- README claim untouched. After this scenario produces real numbers, the README can be updated to match.

## Test plan

- [x] Workflow YAML parses cleanly.
- [x] Report script module imports cleanly.
- [x] `_build_cross_pr_section` smoke-tested: returns empty string when no data; with synthetic data (soldr build 38 s, swatinem build 115 s) renders a section containing the expected \"3.03x\" speedup string.
- [ ] Dispatch the workflow with `include_cross_pr=true` and verify the produced `latest.json` populates the four new fields per row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)