### PR TITLE
feat(bench): enable cross-PR scenario on the daily scheduled run

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -507,9 +507,14 @@ jobs:
           # same-job-seed scenario. Defaults off so the scheduled run stays
           # fast; flip via workflow_dispatch when chasing the 2x story.
           INCLUDE_RESTORE_PHASE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.include_restore_phase || 'false' }}
-          # Issue #650: opt-in cross-PR cache sharing measurement. Same gate
-          # shape as INCLUDE_RESTORE_PHASE.
-          INCLUDE_CROSS_PR: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.include_cross_pr || 'false' }}
+          # Issue #650: cross-PR cache sharing measurement. Enabled on the
+          # daily schedule so the published headline at
+          # https://zackees.github.io/soldr/ continues to carry the 1.77x
+          # cross-PR clause without a manual dispatch every cycle. Still
+          # opt-in on workflow_dispatch so ad-hoc runs can chase other
+          # scenarios without paying the ~30 min the cross-PR cells add.
+          # Skipped on push so post-merge feedback stays fast.
+          INCLUDE_CROSS_PR: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.include_cross_pr) || (github.event_name == 'schedule' && 'true') || 'false' }}
         run: |
           set -euo pipefail
           python3 - <<'PY'


### PR DESCRIPTION
## Summary

After PR #651 / #652 measured and surfaced the cross-PR cache sharing speedup (1.77x sum/sum across cells, 2.04-2.79x on the cheap profiles), keeping the result visible on the published page at https://zackees.github.io/soldr/ requires the workflow_dispatch input to be flipped on every cycle. Between dispatches the published headline reverts to \"soldr is X% slower\" without the cross-PR clause.

Wire the daily scheduled cron (`17 9 * * *`) so the cross-PR cells run automatically. workflow_dispatch keeps its existing override for ad-hoc runs.

## Cost / value

- **+30 min per cycle.** Acceptable for once-a-day.
- **Skipped on push.** Post-merge benches stay fast.
- **restore-phase stays dispatch-only.** Its cost (+30 min) and its information value (an upper bound on GHA cache fetch time) don't justify scheduled enablement; the cross-PR scenario carries the 2x narrative on its own.

## Test plan

- [x] YAML parses cleanly.
- [x] Expression validated by inspection: dispatch returns the input, schedule returns 'true', push falls through to 'false'.
- [ ] After merge: next scheduled run at 09:17 UTC publishes a headline that includes the cross-PR 1.77x clause.

## Cross-link

- soldr#650 — cross-PR scenario specification.
- soldr#651 — measurement implementation.
- soldr#652 — headline clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)