### PR TITLE
fix(bench): enable cross-PR scenario on push too (kill publish race)

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -507,14 +507,17 @@ jobs:
           # same-job-seed scenario. Defaults off so the scheduled run stays
           # fast; flip via workflow_dispatch when chasing the 2x story.
           INCLUDE_RESTORE_PHASE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.include_restore_phase || 'false' }}
-          # Issue #650: cross-PR cache sharing measurement. Enabled on the
-          # daily schedule so the published headline at
-          # https://zackees.github.io/soldr/ continues to carry the 1.77x
-          # cross-PR clause without a manual dispatch every cycle. Still
-          # opt-in on workflow_dispatch so ad-hoc runs can chase other
-          # scenarios without paying the ~30 min the cross-PR cells add.
-          # Skipped on push so post-merge feedback stays fast.
-          INCLUDE_CROSS_PR: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.include_cross_pr) || (github.event_name == 'schedule' && 'true') || 'false' }}
+          # Issue #650: cross-PR cache sharing measurement.
+          #
+          # Enabled on **every** event source except a workflow_dispatch
+          # that explicitly opts out. The reason it's always-on is the
+          # publish race: when a push bench finishes after a dispatched
+          # cross-PR bench, the push run's `latest.json` (no
+          # cross_pr_build_seconds fields) overwrites the dispatched
+          # run's, and the rendered headline loses the cross-PR clause.
+          # Paying the +30 min per push bench is worth the guarantee
+          # that the published page reflects the canonical state.
+          INCLUDE_CROSS_PR: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.include_cross_pr == 'false' && 'false') || 'true' }}
         run: |
           set -euo pipefail
           python3 - <<'PY'


### PR DESCRIPTION
## Summary

PR #653 graduated the cross-PR cache-sharing scenario to the daily schedule. That didn't actually solve the publish race identified in iter 22 + iter 24 — push benches still ran without cross-PR and overwrote the dispatched-with-cross-PR run's `latest.json`, stripping the cross-PR clause from the rendered headline for the gap until the next scheduled run fired.

Two iterations in a row I've had to manually cancel the push bench after merging an unrelated PR to keep the cross-PR clause visible. That's not sustainable.

## Change

Switch the gate from \"opt-in on dispatch + scheduled cron\" to **\"always on except explicit opt-out\"**:

```yaml
INCLUDE_CROSS_PR: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.include_cross_pr == 'false' && 'false') || 'true' }}
```

- **push / schedule**: always runs cross-PR.
- **workflow_dispatch**: defaults to running cross-PR; the operator can pass `include_cross_pr=false` to skip when chasing other scenarios.

## Cost / value

- **+30 min per push bench** (~4 push benches/day at peak → +2 hours/day of additional CI time). Worth it for the guarantee that the published page reflects the canonical \"1.5×-2.8× faster\" state without manual intervention.
- `restore-phase` stays opt-in — its value is diagnostic, not headline-grade.

## Test plan

- [x] YAML parses cleanly.
- [x] Expression trace: workflow_dispatch with `include_cross_pr=false` returns `'false'`; everything else returns `'true'`.
- [ ] After merge: next push bench (triggered by this PR's merge) publishes a headline with the cross-PR clause, and the headline stays put through subsequent push benches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)