### PR TITLE
feat(bench): workspace-scale leaf 0002 (reqwest/rustls subgraph)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -4,4 +4,7 @@
 # Swatinem/rust-cache can no longer save.
 [workspace]
 resolver = "2"
-members = ["crates/heavy-leaf-0001"]
+members = [
+    "crates/heavy-leaf-0001",
+    "crates/heavy-leaf-0002",
+]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0002/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0002/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "heavy-leaf-0002"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling of heavy-leaf-0001 with a deliberately different dep tail —
+# `reqwest` + `rustls` + `hyper` pull in a different transitive
+# subgraph (rustls webpki + ring, rather than just hyper's existing
+# stack) so the two leaves don't share as much of their compiled
+# output. That widens the workspace-scale `target/` growth per leaf
+# without inflating the cargo registry baseline as fast (because
+# `reqwest` shares many crates with `axum`/`hyper` already pulled in
+# by `heavy-leaf-0001`).
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+regex = "1"
+hyper = { version = "1", features = ["full"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+url = "2"
+futures-util = "0.3"
+bytes = "1"
+async-trait = "0.1"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0002/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0002/README.md
@@ -1,0 +1,8 @@
+# heavy-leaf-0002
+
+Sibling leaf to `heavy-leaf-0001/`. Pulls in `reqwest` (with
+`rustls-tls`) instead of `axum`, so the transitive dep subgraph
+overlaps but isn't identical to leaf 0001 — that grows
+`target/release` per leaf without doubling the cargo registry
+baseline. See the parent `../README.md` for the workspace-scale
+strategy and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0002/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0002/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0002/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0002/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling of `heavy-leaf-0001` — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Sibling leaf to `heavy-leaf-0001/` (#655). Pulls in `reqwest` with `rustls-tls` instead of `axum`, so the transitive subgraph overlaps but isn't identical to leaf 0001. That grows `target/release` per added leaf without doubling the cargo registry baseline, because `reqwest` shares many crates with `hyper`/`tower` already pulled in by leaf 0001.

This is the incremental growth path documented in `benchmarks/workspace-scale/README.md` and at the top of #648 — add one leaf per PR until `target/release` exceeds the GHA 10 GiB cache cap.

## What this does NOT do

- Doesn't wire into `benchmark.toml` (that's #657's harness work).
- Doesn't touch soldr's own CI. `benchmarks/workspace-scale/` is a separate workspace; the monocrate guard at `crates/soldr-cli/tests/monocrate_guard.rs` only scans `crates/*/Cargo.toml`.
- Doesn't change `Cargo.lock` resolution for `crates/soldr-cli`.

## Test plan

- [x] `benchmarks/workspace-scale/Cargo.toml` lists both leaves in `members[]`.
- [x] Each leaf has its own `Cargo.toml`, `README.md`, and `src/lib.rs` (per the directory-must-have-README hook).
- [ ] Once #657's harness PR lands and the fixture is consumed, the workspace-scale `target/` is measurably larger than with a single leaf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)