### PR TITLE
docs(readme): replace "Instant warm compiles" with measured 2x claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img width="1536" height="1024" alt="ChatGPT Image Apr 19, 2026, 09_43_32 PM" src="https://github.com/user-attachments/assets/87d94693-3542-4f4f-8b02-600bf0b9810e" />
 
 
-*A tool to download rust tool sets and aggressive cache your build. Instant warm compiles. Gh and local builds. Just add soldr before all your build commands*
+*A tool to download rust tool sets and aggressive cache your build. **2× faster cross-PR builds** via content-addressed caching that swatinem's per-key cache cannot share. GH and local builds. Just add soldr before all your build commands.*
 
 [![Latest soldr benchmark stats](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark.jpg)](https://zackees.github.io/soldr/)
 


### PR DESCRIPTION
## Summary

The published benchmark at https://zackees.github.io/soldr/ has carried the cross-PR 2x clause stably since PR #654 + #656:

> \"...in the cross-PR cache-sharing scenario, soldr is **1.3×-3.4× faster than swatinem (mean 2.15×)**.\"

The README tagline still said \"**Instant warm compiles**\" — which the data doesn't support. Same-job-seed warm time is essentially tied with swatinem (-3% to +2%, within runner noise). The structural 2x is in the cross-PR scenario, where soldr's content-addressed cache hits across PRs that touch different files and swatinem's per-key cache cannot share at all.

This PR brings the README tagline in line with the headline carried by the benchmark page so readers landing on the repo see the same claim on both surfaces.

## Change

```diff
- *A tool to download rust tool sets and aggressive cache your build. Instant warm compiles. Gh and local builds. Just add soldr before all your build commands*
+ *A tool to download rust tool sets and aggressive cache your build. **2× faster cross-PR builds** via content-addressed caching that swatinem's per-key cache cannot share. GH and local builds. Just add soldr before all your build commands.*
```

## What this does NOT do

- Doesn't add a screenshot of the headline (the benchmark.jpg from the stats branch is already embedded).
- Doesn't rewrite the rest of the README — only the lead tagline so the first line a reader sees matches the published number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)