### PR TITLE
feat(bench): workspace-scale leaf 0003 (clap / zstd / tar subgraph)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -7,4 +7,5 @@ resolver = "2"
 members = [
     "crates/heavy-leaf-0001",
     "crates/heavy-leaf-0002",
+    "crates/heavy-leaf-0003",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0003/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0003/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "heavy-leaf-0003"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a CLI / compression / archiver dep subgraph —
+# `clap` (with derive), `zstd`, `tar`, `flate2`, `bytes`. Overlaps
+# heavy-leaf-0001/0002 on serde, tracing, regex, anyhow, but pulls
+# in distinct transitive subgraphs for the archive / compression
+# families that neither sibling exercises.
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+regex = "1"
+clap = { version = "4", features = ["derive", "env", "wrap_help"] }
+clap_complete = "4"
+zstd = "0.13"
+tar = "0.4"
+flate2 = "1"
+bytes = "1"
+indicatif = "0.17"
+crossbeam-channel = "0.5"
+rayon = "1"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0003/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0003/README.md
@@ -1,0 +1,6 @@
+# heavy-leaf-0003
+
+Sibling leaf to `heavy-leaf-0001/` and `heavy-leaf-0002/`. Pulls in
+a CLI / compression / archiver subgraph (`clap` + `zstd` + `tar` +
+`flate2` + `rayon`) that the prior leaves don't exercise. See the
+parent `../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0003/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0003/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0003/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0003/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Sibling to leaves 0001 (axum) and 0002 (reqwest+rustls). Leaf 0003 adds a CLI / compression / archiver subgraph — \`clap\` (derive, env, wrap_help), \`clap_complete\`, \`zstd\`, \`tar\`, \`flate2\`, \`indicatif\`, \`crossbeam-channel\`, \`rayon\`. Overlaps prior leaves on the serde/tracing/regex/anyhow baseline, but the compression and archive families are new to the workspace.

Continues the incremental growth pattern documented in \`benchmarks/workspace-scale/README.md\` and soldr#648 — one leaf per PR, deliberately distinct dep tails so \`target/release\` grows per leaf without doubling the cargo registry baseline.

## Test plan

- [x] Cargo.toml lists three leaves in members[].
- [x] Outside the soldr root workspace; monocrate guard scans only \`crates/*\`.
- [ ] After soldr#657 lands and the fixture is consumed, the cumulative \`target/\` growth per added leaf is measurable in the bench output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)