### PR TITLE
feat(bench): workspace-scale leaf 0004 (math / numerical subgraph)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -8,4 +8,5 @@ members = [
     "crates/heavy-leaf-0001",
     "crates/heavy-leaf-0002",
     "crates/heavy-leaf-0003",
+    "crates/heavy-leaf-0004",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0004/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0004/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "heavy-leaf-0004"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a math / numerical / sampling subgraph that the
+# prior leaves don't pull in: ndarray (with rayon + serde features),
+# nalgebra, statrs, rand + rand_distr + rand_chacha. No cc-rs build
+# scripts in the tail, so the leaf stays portable across the four
+# bench-supported runner OSes per the parent README's design
+# constraint.
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+ndarray = { version = "0.16", features = ["rayon", "serde"] }
+nalgebra = { version = "0.33", features = ["serde-serialize"] }
+statrs = "0.18"
+rand = "0.9"
+rand_distr = "0.5"
+rand_chacha = "0.9"
+num-traits = "0.2"
+num-complex = "0.4"
+rayon = "1"
+itertools = "0.13"
+smallvec = "1"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0004/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0004/README.md
@@ -1,0 +1,7 @@
+# heavy-leaf-0004
+
+Math / numerical / sampling subgraph: `ndarray` (rayon + serde),
+`nalgebra`, `statrs`, `rand` + `rand_distr` + `rand_chacha`,
+`num-traits`, `num-complex`, `itertools`, `smallvec`. Pure-Rust
+deps — no `cc-rs` build scripts, so the leaf stays portable across
+all four bench-supported runner OSes. See parent README + soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0004/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0004/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0004/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0004/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Sibling to leaves 0001 (axum), 0002 (reqwest+rustls), 0003 (clap + compression). Leaf 0004 adds a math / numerical / sampling subgraph: \`ndarray\` (rayon + serde), \`nalgebra\`, \`statrs\`, \`rand\` + \`rand_distr\` + \`rand_chacha\`, \`num-traits\`, \`num-complex\`, \`itertools\`, \`smallvec\`.

Pure-Rust deps — no \`cc-rs\` build scripts, so the leaf stays portable across all four bench-supported runner OSes per the design constraint documented in \`benchmarks/workspace-scale/README.md\`.

## Test plan

- [x] Four leaves now in members[].
- [x] No cc-rs build scripts in the new dep tail.
- [ ] After #657's harness PR lands and the fixture is consumed, cumulative target/ growth is measurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)