### PR TITLE
feat(bench): workspace-scale leaf 0005 (parsers / grammar / AST)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -9,4 +9,5 @@ members = [
     "crates/heavy-leaf-0002",
     "crates/heavy-leaf-0003",
     "crates/heavy-leaf-0004",
+    "crates/heavy-leaf-0005",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0005/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0005/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "heavy-leaf-0005"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a parsers / grammar / AST subgraph: nom,
+# winnow, pest + pest_derive, syn + quote + proc-macro2 (heavy
+# proc-macro graph), chumsky. These pull a noticeably different
+# transitive set from the prior four leaves' webframework /
+# compression / math subgraphs. Pure-Rust deps; no cc-rs build
+# scripts.
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+nom = "7"
+winnow = "0.6"
+pest = "2"
+pest_derive = "2"
+syn = { version = "2", features = ["full", "extra-traits", "visit", "visit-mut"] }
+quote = "1"
+proc-macro2 = "1"
+chumsky = "0.9"
+ariadne = "0.5"
+logos = "0.15"
+phf = { version = "0.11", features = ["macros"] }
+strum = { version = "0.27", features = ["derive"] }

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0005/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0005/README.md
@@ -1,0 +1,7 @@
+# heavy-leaf-0005
+
+Parsers / grammar / AST subgraph: `nom`, `winnow`, `pest` +
+`pest_derive`, `syn` + `quote` + `proc-macro2` (heavy proc-macro
+graph), `chumsky`, `ariadne`, `logos`, `phf` + `phf_macros`,
+`strum`. Pure-Rust; no `cc-rs` build scripts. See parent
+`../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0005/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0005/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0005/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0005/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Sibling to leaves 0001 (axum), 0002 (reqwest+rustls), 0003 (clap + compression), 0004 (math + numerical). Leaf 0005 adds a parsers / grammar / AST subgraph:

\`nom\`, \`winnow\`, \`pest\` + \`pest_derive\`, \`syn\` + \`quote\` + \`proc-macro2\` (heavy proc-macro graph), \`chumsky\`, \`ariadne\`, \`logos\`, \`phf\` + \`phf_macros\`, \`strum\`.

Pure-Rust deps; no \`cc-rs\` build scripts so the leaf stays portable across all four bench-supported runner OSes.

## Test plan

- [x] Five leaves now in members[].
- [x] No cc-rs build scripts in the new dep tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)