### PR TITLE
perf(bench): add workspace-scale leaf 0006 (crypto/hashing subgraph)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -10,4 +10,5 @@ members = [
     "crates/heavy-leaf-0003",
     "crates/heavy-leaf-0004",
     "crates/heavy-leaf-0005",
+    "crates/heavy-leaf-0006",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0006/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0006/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "heavy-leaf-0006"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust cryptography / hashing subgraph
+# from RustCrypto + dalek: sha2, blake2, blake3, md-5, hmac, hkdf,
+# pbkdf2, argon2, scrypt, aes + aes-gcm, chacha20poly1305,
+# ed25519-dalek + curve25519-dalek + x25519-dalek, signature.
+# Heavy generic + trait machinery; pulls a distinct transitive
+# set from the prior five web / http-client / cli / math / parser
+# subgraphs. No cc-rs build scripts (ring / rusqlite / libpq
+# avoided on purpose).
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+sha2 = "0.10"
+sha3 = "0.10"
+blake2 = "0.10"
+blake3 = "1"
+md-5 = "0.10"
+digest = "0.10"
+hmac = "0.12"
+hkdf = "0.12"
+pbkdf2 = { version = "0.12", features = ["simple"] }
+argon2 = "0.5"
+scrypt = "0.11"
+aes = "0.8"
+aes-gcm = "0.10"
+chacha20poly1305 = "0.10"
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+curve25519-dalek = "4"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+signature = "2"
+rand_core = "0.6"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0006/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0006/README.md
@@ -1,0 +1,10 @@
+# heavy-leaf-0006
+
+Cryptography & hashing subgraph (pure-Rust): `sha2`, `sha3`,
+`blake2`, `blake3`, `md-5`, `hmac`, `hkdf`, `pbkdf2`, `argon2`,
+`scrypt`, `aes` + `aes-gcm`, `chacha20poly1305`, `ed25519-dalek`,
+`curve25519-dalek`, `x25519-dalek`, `signature`, `digest`. No
+`cc-rs` build scripts (ring / rusqlite / libpq avoided on
+purpose). Heavy generic + trait machinery — distinct from the
+prior five leaves' web / http-client / cli / math / parser
+subgraphs. See parent `../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0006/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0006/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0006/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0006/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Sixth sibling leaf with a distinct pure-Rust dep subgraph:
RustCrypto + dalek.

- Hashes & MAC: `sha2`, `sha3`, `blake2`, `blake3`, `md-5`, `hmac`, `hkdf`, `digest`
- Password hashing: `pbkdf2`, `argon2`, `scrypt`
- Symmetric: `aes`, `aes-gcm`, `chacha20poly1305`
- Asymmetric: `ed25519-dalek`, `curve25519-dalek`, `x25519-dalek`, `signature`

Distinct transitive set from the prior five leaves' web / http-client / cli / math / parser subgraphs. No `cc-rs` build scripts (ring / rusqlite / libpq avoided on purpose — same convention as the existing leaves).

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green on the bench workflow
- [ ] Next iteration: monitor next scheduled bench run for any per-leaf failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)