### PR TITLE
perf(bench): add workspace-scale leaf 0007 (serialization formats + time/ID)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -11,4 +11,5 @@ members = [
     "crates/heavy-leaf-0004",
     "crates/heavy-leaf-0005",
     "crates/heavy-leaf-0006",
+    "crates/heavy-leaf-0007",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0007/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0007/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "heavy-leaf-0007"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust serialization-formats + time/ID
+# subgraph: toml, serde_yaml, quick-xml, roxmltree, csv,
+# ciborium, postcard, rkyv (with `bytecheck` derive macros),
+# rmp-serde, serde_with, time, chrono, jiff, uuid, ulid. Heavy
+# serde-derive expansion and proc-macro surface; distinct from
+# the prior six leaves' web / http-client / cli / math / parser /
+# crypto subgraphs. No cc-rs build scripts.
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+toml = "0.8"
+serde_yaml = "0.9"
+quick-xml = { version = "0.36", features = ["serialize"] }
+roxmltree = "0.20"
+csv = "1"
+ciborium = "0.2"
+postcard = { version = "1", features = ["use-std"] }
+rkyv = { version = "0.7", features = ["validation"] }
+rmp-serde = "1"
+serde_with = { version = "3", features = ["chrono", "json", "macros"] }
+time = { version = "0.3", features = ["serde", "macros", "formatting", "parsing"] }
+chrono = { version = "0.4", features = ["serde"] }
+jiff = { version = "0.1", features = ["serde"] }
+uuid = { version = "1", features = ["v4", "v7", "serde"] }
+ulid = { version = "1", features = ["serde"] }

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0007/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0007/README.md
@@ -1,0 +1,10 @@
+# heavy-leaf-0007
+
+Serialization-formats + time/ID subgraph (pure-Rust): `toml`,
+`serde_yaml`, `quick-xml`, `roxmltree`, `csv`, `ciborium`,
+`postcard`, `rkyv` (with `bytecheck` derive macros), `rmp-serde`,
+`serde_with`, `time`, `chrono`, `jiff`, `uuid`, `ulid`. Heavy
+serde-derive expansion and proc-macro surface — distinct from the
+prior six leaves' web / http-client / cli / math / parser /
+crypto subgraphs. No `cc-rs` build scripts. See parent
+`../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0007/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0007/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0007/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0007/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Seventh sibling leaf with a distinct pure-Rust dep subgraph focused on serialization formats and time/ID handling.

- **Formats:** `toml`, `serde_yaml`, `quick-xml`, `roxmltree`, `csv`, `ciborium`, `postcard`, `rkyv` (with bytecheck derive), `rmp-serde`, `serde_with`
- **Time:** `time`, `chrono`, `jiff`
- **IDs:** `uuid` (v4 + v7), `ulid`

Heavy serde-derive expansion and proc-macro surface — distinct from the prior six leaves' web / http-client / cli / math / parser / crypto subgraphs. No `cc-rs` build scripts.

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green
- [ ] Next iteration: verify next scheduled bench produces measurable signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)