### PR TITLE
perf(bench): add workspace-scale leaf 0008 (embedded storage + concurrent collections)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -12,4 +12,5 @@ members = [
     "crates/heavy-leaf-0005",
     "crates/heavy-leaf-0006",
     "crates/heavy-leaf-0007",
+    "crates/heavy-leaf-0008",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0008/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0008/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "heavy-leaf-0008"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust embedded-storage + concurrent
+# collections subgraph: redb (embedded KV), moka (TinyLFU cache),
+# lru, schnellru, dashmap + scc (concurrent maps), indexmap +
+# slotmap + slab (indexed collections), petgraph (graphs),
+# rangemap + intervaltree, fst (finite state transducer),
+# growable-bloom-filter. Distinct from the prior seven leaves'
+# web / http-client / cli / math / parser / crypto / serialization
+# subgraphs. No cc-rs build scripts (sled / rocksdb avoided to
+# stay pure-Rust).
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+redb = "2"
+moka = { version = "0.12", features = ["future", "sync"] }
+lru = "0.12"
+schnellru = "0.2"
+dashmap = "6"
+scc = "2"
+indexmap = { version = "2", features = ["serde"] }
+slotmap = { version = "1", features = ["serde"] }
+slab = "0.4"
+petgraph = "0.6"
+rangemap = "1"
+fst = "0.4"
+growable-bloom-filter = "2"
+ahash = "0.8"
+foldhash = "0.1"
+hashbrown = { version = "0.15", features = ["serde", "rayon"] }

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0008/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0008/README.md
@@ -1,0 +1,12 @@
+# heavy-leaf-0008
+
+Embedded-storage + concurrent collections subgraph (pure-Rust):
+`redb` (embedded KV), `moka` (TinyLFU cache), `lru`, `schnellru`,
+`dashmap` + `scc` (concurrent maps), `indexmap` + `slotmap` +
+`slab` (indexed collections), `petgraph` (graphs), `rangemap`,
+`fst` (finite state transducer), `growable-bloom-filter`,
+`ahash` + `foldhash` + `hashbrown`. Distinct from the prior seven
+leaves' web / http-client / cli / math / parser / crypto /
+serialization subgraphs. No `cc-rs` build scripts (sled /
+rocksdb avoided to stay pure-Rust). See parent `../README.md`
+and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0008/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0008/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0008/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0008/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Eighth sibling leaf with a distinct pure-Rust dep subgraph.

- **Storage:** `redb` (embedded KV)
- **Caches:** `moka` (TinyLFU), `lru`, `schnellru`
- **Concurrent maps:** `dashmap`, `scc`
- **Indexed collections:** `indexmap`, `slotmap`, `slab`
- **Graphs / ranges:** `petgraph`, `rangemap`
- **Probabilistic / search:** `fst`, `growable-bloom-filter`
- **Hashers:** `ahash`, `foldhash`, `hashbrown`

Distinct from the prior seven leaves' web / http-client / cli / math / parser / crypto / serialization subgraphs. No `cc-rs` build scripts (sled / rocksdb avoided to stay pure-Rust).

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green
- [ ] Next iteration: verify next scheduled bench produces measurable signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)