### PR TITLE
perf(bench): add workspace-scale leaf 0009 (text/Unicode/diff subgraph)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -13,4 +13,5 @@ members = [
     "crates/heavy-leaf-0006",
     "crates/heavy-leaf-0007",
     "crates/heavy-leaf-0008",
+    "crates/heavy-leaf-0009",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0009/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0009/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "heavy-leaf-0009"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust text-processing / Unicode / diff
+# subgraph: aho-corasick + daachorse (multi-pattern), bstr +
+# memchr + memmem (byte search), unicode-segmentation +
+# unicode-normalization + unicode-width + unicode-bidi +
+# unicode-script + unicode-xid + unicode-properties (Unicode
+# tables), icu_collator + icu_normalizer + icu_properties +
+# icu_locid (pure-Rust ICU), similar (diff), strsim,
+# percent-encoding + url + base64 + hex (encoding). Distinct from
+# the prior eight leaves' web / http-client / cli / math /
+# parser / crypto / serialization / storage subgraphs. No cc-rs
+# build scripts.
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+aho-corasick = "1"
+daachorse = "1"
+bstr = { version = "1", features = ["serde"] }
+memchr = "2"
+memmem = "0.1"
+unicode-segmentation = "1"
+unicode-normalization = "0.1"
+unicode-width = "0.2"
+unicode-bidi = "0.3"
+unicode-script = "0.5"
+unicode-xid = "0.2"
+unicode-properties = "0.1"
+icu_collator = "1.5"
+icu_normalizer = "1.5"
+icu_properties = "1.5"
+icu_locid = "1.5"
+icu_segmenter = "1.5"
+similar = { version = "2", features = ["serde"] }
+strsim = "0.11"
+percent-encoding = "2"
+url = "2"
+base64 = "0.22"
+hex = "0.4"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0009/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0009/README.md
@@ -1,0 +1,13 @@
+# heavy-leaf-0009
+
+Text-processing / Unicode / diff subgraph (pure-Rust):
+`aho-corasick`, `daachorse` (multi-pattern), `bstr`, `memchr`,
+`memmem` (byte search), `unicode-segmentation`,
+`unicode-normalization`, `unicode-width`, `unicode-bidi`,
+`unicode-script`, `unicode-xid`, `unicode-properties` (Unicode
+tables), `icu_collator`, `icu_normalizer`, `icu_properties`,
+`icu_locid`, `icu_segmenter` (pure-Rust ICU), `similar` (diff),
+`strsim`, `percent-encoding`, `url`, `base64`, `hex` (encoding).
+Distinct from the prior eight leaves' web / http-client / cli /
+math / parser / crypto / serialization / storage subgraphs. No
+`cc-rs` build scripts. See parent `../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0009/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0009/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0009/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0009/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Ninth sibling leaf with a distinct pure-Rust dep subgraph.

- **Multi-pattern search:** `aho-corasick`, `daachorse`
- **Byte search:** `bstr`, `memchr`, `memmem`
- **Unicode tables:** `unicode-segmentation`, `unicode-normalization`, `unicode-width`, `unicode-bidi`, `unicode-script`, `unicode-xid`, `unicode-properties`
- **ICU (pure-Rust):** `icu_collator`, `icu_normalizer`, `icu_properties`, `icu_locid`, `icu_segmenter`
- **Diff / similarity:** `similar`, `strsim`
- **Encoding:** `percent-encoding`, `url`, `base64`, `hex`

Distinct from the prior eight leaves' web / http-client / cli / math / parser / crypto / serialization / storage subgraphs. No `cc-rs` build scripts.

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green
- [ ] Next iteration: verify next scheduled bench produces measurable signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)