### PR TITLE
perf(bench): add workspace-scale leaf 0010 (image/graphics)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -14,4 +14,5 @@ members = [
     "crates/heavy-leaf-0007",
     "crates/heavy-leaf-0008",
     "crates/heavy-leaf-0009",
+    "crates/heavy-leaf-0010",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0010/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0010/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "heavy-leaf-0010"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust image / graphics subgraph:
+# image (with png + jpeg-decoder + gif + tiff), qoi, exr (OpenEXR
+# HDR), ravif + rav1e (AV1 still encoder), imageproc, resvg +
+# tiny-skia + usvg (SVG render to raster), fontdue, palette,
+# color, kurbo, lyon. Heavy mixed compute (proc-macros,
+# generics, large pixel-data routines) distinct from the prior
+# nine leaves' web / http-client / cli / math / parser / crypto /
+# serialization / storage / text-Unicode subgraphs. No cc-rs
+# build scripts (webp / libheif / libwebp avoided to stay
+# pure-Rust).
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "tiff", "bmp", "ico", "qoi", "pnm", "rayon", "serde"] }
+qoi = "0.4"
+exr = "1"
+ravif = "0.11"
+imageproc = "0.25"
+resvg = "0.43"
+tiny-skia = "0.11"
+usvg = "0.43"
+fontdue = "0.9"
+palette = "0.7"
+color = "0.2"
+kurbo = "0.11"
+lyon = "1"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0010/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0010/README.md
@@ -1,0 +1,11 @@
+# heavy-leaf-0010
+
+Image / graphics subgraph (pure-Rust): `image` (with `png`,
+`jpeg-decoder`, `gif`, `tiff`, `bmp`, `ico`, `qoi`, `pnm`), `qoi`,
+`exr` (OpenEXR HDR), `ravif` + `rav1e` (AV1 still encoder),
+`imageproc`, `resvg` + `tiny-skia` + `usvg` (SVG render to
+raster), `fontdue`, `palette`, `color`, `kurbo`, `lyon`. Heavy
+mixed compute (proc-macros, generics, large pixel-data routines)
+distinct from the prior nine leaves' subgraphs. No `cc-rs` build
+scripts (webp / libheif / libwebp avoided to stay pure-Rust).
+See parent `../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0010/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0010/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0010/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0010/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Tenth sibling leaf with a distinct pure-Rust dep subgraph.

- **Raster I/O:** `image` (with png, jpeg-decoder, gif, tiff, bmp, ico, qoi, pnm), `qoi`
- **HDR / advanced codecs:** `exr` (OpenEXR), `ravif` + `rav1e` (AV1)
- **Processing:** `imageproc`
- **Vector & SVG:** `resvg` + `tiny-skia` + `usvg`, `kurbo`, `lyon`
- **Typography:** `fontdue`
- **Color:** `palette`, `color`

Heavy mixed compute (proc-macros, generics, large pixel-data routines) distinct from the prior nine leaves' web / http-client / cli / math / parser / crypto / serialization / storage / text-Unicode subgraphs. No `cc-rs` build scripts (webp / libheif / libwebp avoided to stay pure-Rust).

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green
- [ ] Next iteration: verify next scheduled bench produces measurable signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)