### PR TITLE
perf(bench): add workspace-scale leaf 0011 (templating + markdown)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -15,4 +15,5 @@ members = [
     "crates/heavy-leaf-0008",
     "crates/heavy-leaf-0009",
     "crates/heavy-leaf-0010",
+    "crates/heavy-leaf-0011",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0011/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0011/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "heavy-leaf-0011"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust templating + markdown subgraph:
+# handlebars, tera, askama + askama_derive, minijinja (with
+# loader + json + macros), ramhorns + ramhorns-derive,
+# pulldown-cmark (markdown), comrak (alternate markdown with
+# extensions + footnotes + table + tasklist), html5ever
+# (HTML5 parser), markup5ever. Heavy proc-macro graph
+# distinct from the prior ten leaves' web / http-client / cli /
+# math / parser / crypto / serialization / storage /
+# text-Unicode / graphics subgraphs. No cc-rs build scripts.
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+handlebars = "6"
+tera = "1"
+askama = "0.12"
+askama_derive = "0.12"
+minijinja = { version = "2", features = ["loader", "json", "macros", "multi_template", "internal_debug"] }
+ramhorns = "1"
+ramhorns-derive = "1"
+pulldown-cmark = "0.12"
+comrak = { version = "0.31", features = ["shortcodes"] }
+html5ever = "0.29"
+markup5ever = "0.14"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0011/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0011/README.md
@@ -1,0 +1,9 @@
+# heavy-leaf-0011
+
+Templating + markdown subgraph (pure-Rust): `handlebars`, `tera`,
+`askama` + `askama_derive`, `minijinja` (with `loader`, `json`,
+`macros`, `multi_template`, `internal_debug`), `ramhorns` +
+`ramhorns-derive`, `pulldown-cmark`, `comrak` (alternate markdown
+with `shortcodes`), `html5ever`, `markup5ever`. Heavy proc-macro
+graph distinct from the prior ten leaves' subgraphs. No `cc-rs`
+build scripts. See parent `../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0011/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0011/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0011/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0011/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Eleventh sibling leaf with a distinct pure-Rust dep subgraph.

- **Templating engines:** `handlebars`, `tera`, `askama` + `askama_derive`, `minijinja` (with loader/json/macros/multi_template), `ramhorns` + `ramhorns-derive`
- **Markdown:** `pulldown-cmark`, `comrak` (with shortcodes)
- **HTML5:** `html5ever`, `markup5ever`

Heavy proc-macro graph distinct from the prior ten leaves' subgraphs (web/http/cli/math/parser/crypto/serialization/storage/text-Unicode/graphics). No `cc-rs` build scripts.

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green
- [ ] Next iteration: verify next scheduled bench produces measurable signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)