### PR TITLE
perf(bench): add workspace-scale leaf 0012 (TUI + syntax highlighting)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -16,4 +16,5 @@ members = [
     "crates/heavy-leaf-0009",
     "crates/heavy-leaf-0010",
     "crates/heavy-leaf-0011",
+    "crates/heavy-leaf-0012",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0012/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0012/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "heavy-leaf-0012"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust TUI + syntax-highlighting
+# subgraph: ratatui (with widgets + crossterm backend),
+# crossterm, tui-textarea, tui-tree-widget, syntect
+# (fancy-regex variant — onig avoided to stay pure-Rust),
+# syntect-tui, termion (alt backend), console, supports-color,
+# supports-hyperlinks, supports-unicode, vt100 (terminal-emulator
+# parser). Heavy regex + finite-state graphs distinct from the
+# prior eleven leaves' subgraphs. No cc-rs build scripts.
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+ratatui = { version = "0.29", features = ["serde", "macros", "all-widgets", "unstable-rendered-line-info"] }
+crossterm = { version = "0.28", features = ["serde", "event-stream"] }
+tui-textarea = "0.7"
+tui-tree-widget = "0.23"
+syntect = { version = "5", default-features = false, features = ["default-fancy"] }
+syntect-tui = "3"
+termion = "4"
+console = "0.15"
+supports-color = "3"
+supports-hyperlinks = "3"
+supports-unicode = "3"
+vt100 = "0.15"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0012/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0012/README.md
@@ -1,0 +1,10 @@
+# heavy-leaf-0012
+
+TUI + syntax-highlighting subgraph (pure-Rust): `ratatui` (with
+widgets + crossterm backend), `crossterm`, `tui-textarea`,
+`tui-tree-widget`, `syntect` (fancy-regex variant — `onig`
+avoided to stay pure-Rust), `syntect-tui`, `termion` (alt
+backend), `console`, `supports-color`, `supports-hyperlinks`,
+`supports-unicode`, `vt100`. Heavy regex + finite-state graphs
+distinct from the prior eleven leaves' subgraphs. No `cc-rs`
+build scripts. See parent `../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0012/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0012/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0012/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0012/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Twelfth sibling leaf with a distinct pure-Rust dep subgraph.

- **TUI:** `ratatui` (with widgets + crossterm backend), `crossterm`, `tui-textarea`, `tui-tree-widget`
- **Syntax highlighting:** `syntect` (fancy-regex variant), `syntect-tui`
- **Terminal abstractions:** `termion`, `console`, `vt100`
- **Capability probes:** `supports-color`, `supports-hyperlinks`, `supports-unicode`

Heavy regex + finite-state graphs distinct from the prior eleven leaves' subgraphs (web/http/cli/math/parser/crypto/serialization/storage/text-Unicode/graphics/templating). No `cc-rs` build scripts (syntect's `onig` variant avoided to stay pure-Rust).

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green
- [ ] Next iteration: verify next scheduled bench produces measurable signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)