### PR TITLE
perf(bench): add workspace-scale leaf 0013 (gitoxide + FS tooling)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -17,4 +17,5 @@ members = [
     "crates/heavy-leaf-0010",
     "crates/heavy-leaf-0011",
     "crates/heavy-leaf-0012",
+    "crates/heavy-leaf-0013",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0013/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0013/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "heavy-leaf-0013"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust git (gitoxide) + filesystem
+# tooling subgraph. `gix` is a facade over ~40 sub-crates
+# (gix-config, gix-hash, gix-object, gix-odb, gix-pack,
+# gix-protocol, gix-ref, gix-revwalk, gix-status, gix-worktree,
+# gix-traverse, gix-transport, gix-index, gix-mailmap,
+# gix-features, gix-attributes, gix-pathspec, gix-glob, etc.) —
+# adding one direct dep here pulls a substantial distinct
+# transitive set. Layered on top: `ignore` (gitignore semantics),
+# `walkdir`, `jwalk` (parallel walkdir), `globset`, `fs-err`
+# (better fs::* error wrappers), `tempfile`, `notify` (FS
+# watcher), `dunce` (Windows path canonicalization),
+# `semver` (version parsing), `git-conventional`
+# (Conventional Commits parser). Distinct from the prior twelve
+# leaves' subgraphs. No cc-rs build scripts (libgit2 / git2 / git2-curl
+# avoided to stay pure-Rust).
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+gix = { version = "0.66", default-features = false, features = ["max-performance-safe", "serde", "blob-diff", "blocking-network-client", "revision", "status", "worktree-mutation", "interrupt", "credentials", "command", "parallel"] }
+ignore = "0.4"
+walkdir = "2"
+jwalk = "0.8"
+globset = "0.4"
+fs-err = "3"
+tempfile = "3"
+notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
+dunce = "1"
+semver = { version = "1", features = ["serde"] }
+git-conventional = "0.12"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0013/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0013/README.md
@@ -1,0 +1,14 @@
+# heavy-leaf-0013
+
+Pure-Rust git (gitoxide) + filesystem tooling subgraph: `gix`
+facade pulls ~40 sub-crates (gix-config, gix-hash, gix-object,
+gix-odb, gix-pack, gix-protocol, gix-ref, gix-revwalk,
+gix-status, gix-worktree, gix-traverse, gix-transport,
+gix-index, gix-mailmap, gix-features, gix-attributes,
+gix-pathspec, gix-glob, …). Layered on top: `ignore` (gitignore
+semantics), `walkdir`, `jwalk` (parallel walk), `globset`,
+`fs-err`, `tempfile`, `notify` (FS watcher), `dunce` (Windows
+path canonicalization), `semver`, `git-conventional`. Distinct
+from the prior twelve leaves' subgraphs. No `cc-rs` build scripts
+(libgit2 / git2 avoided to stay pure-Rust). See parent
+`../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0013/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0013/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0013/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0013/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Thirteenth sibling leaf with a distinct pure-Rust dep subgraph.

- **Pure-Rust git:** `gix` facade pulls ~40 sub-crates (`gix-config`, `gix-hash`, `gix-object`, `gix-odb`, `gix-pack`, `gix-protocol`, `gix-ref`, `gix-revwalk`, `gix-status`, `gix-worktree`, `gix-traverse`, `gix-transport`, `gix-index`, `gix-mailmap`, `gix-features`, `gix-attributes`, `gix-pathspec`, `gix-glob`, …)
- **Filesystem tooling:** `ignore` (gitignore semantics), `walkdir`, `jwalk` (parallel walk), `globset`, `fs-err`, `tempfile`, `notify` (FS watcher), `dunce` (Windows path canonicalization)
- **Conventional commits / versions:** `semver`, `git-conventional`

Distinct from the prior twelve leaves' subgraphs (web/http/cli/math/parser/crypto/serialization/storage/text-Unicode/graphics/templating/TUI). No `cc-rs` build scripts (libgit2 / git2 avoided to stay pure-Rust).

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green
- [ ] Next iteration: verify next scheduled bench produces measurable signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)