### PR TITLE
perf(bench): add workspace-scale leaf 0014 (OTel + metrics + Sentry)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -18,4 +18,5 @@ members = [
     "crates/heavy-leaf-0011",
     "crates/heavy-leaf-0012",
     "crates/heavy-leaf-0013",
+    "crates/heavy-leaf-0014",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0014/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0014/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "heavy-leaf-0014"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust observability / metrics / tracing
+# subgraph: opentelemetry (with trace, metrics, logs),
+# opentelemetry_sdk (with rt-tokio, trace, metrics, logs),
+# opentelemetry-stdout, opentelemetry-semantic-conventions,
+# tracing-opentelemetry, tracing-tree, tracing-error,
+# tracing-appender (rolling file log appender), metrics,
+# metrics-util, metrics-exporter-prometheus, prometheus,
+# prometheus-client, sentry (with rustls backend — native-tls
+# avoided). Heavy proc-macro graph distinct from the prior
+# thirteen leaves' subgraphs. No cc-rs build scripts (native-tls
+# / openssl avoided).
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+opentelemetry = { version = "0.27", features = ["trace", "metrics", "logs"] }
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "trace", "metrics", "logs", "testing"] }
+opentelemetry-stdout = { version = "0.27", features = ["trace", "metrics", "logs"] }
+opentelemetry-semantic-conventions = "0.27"
+tracing-opentelemetry = "0.28"
+tracing-tree = "0.4"
+tracing-error = "0.2"
+tracing-appender = "0.2"
+metrics = "0.24"
+metrics-util = "0.18"
+metrics-exporter-prometheus = { version = "0.16", default-features = false }
+prometheus = { version = "0.13", default-features = false }
+prometheus-client = "0.22"
+sentry = { version = "0.34", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest"] }

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0014/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0014/README.md
@@ -1,0 +1,13 @@
+# heavy-leaf-0014
+
+Observability / metrics / tracing subgraph (pure-Rust):
+`opentelemetry` (with trace + metrics + logs), `opentelemetry_sdk`
+(with rt-tokio + trace + metrics + logs + testing),
+`opentelemetry-stdout`, `opentelemetry-semantic-conventions`,
+`tracing-opentelemetry`, `tracing-tree`, `tracing-error`,
+`tracing-appender`, `metrics`, `metrics-util`,
+`metrics-exporter-prometheus`, `prometheus`, `prometheus-client`,
+`sentry` (with rustls backend — native-tls avoided). Heavy
+proc-macro graph distinct from the prior thirteen leaves'
+subgraphs. No `cc-rs` build scripts (native-tls / openssl
+avoided). See parent `../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0014/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0014/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0014/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0014/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Fourteenth sibling leaf with a distinct pure-Rust dep subgraph.

- **OpenTelemetry:** `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-stdout`, `opentelemetry-semantic-conventions`
- **Tracing extensions:** `tracing-opentelemetry`, `tracing-tree`, `tracing-error`, `tracing-appender`
- **Metrics:** `metrics`, `metrics-util`, `metrics-exporter-prometheus`, `prometheus`, `prometheus-client`
- **Crash reporting:** `sentry` (rustls backend; native-tls avoided)

Heavy proc-macro graph distinct from the prior thirteen leaves' subgraphs. No `cc-rs` build scripts (native-tls / openssl avoided).

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green
- [ ] Next iteration: verify next scheduled bench produces measurable signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)