### PR TITLE
perf(bench): add workspace-scale leaf 0015 (WebAssembly tooling)

### DIFF
--- a/benchmarks/workspace-scale/Cargo.toml
+++ b/benchmarks/workspace-scale/Cargo.toml
@@ -19,4 +19,5 @@ members = [
     "crates/heavy-leaf-0012",
     "crates/heavy-leaf-0013",
     "crates/heavy-leaf-0014",
+    "crates/heavy-leaf-0015",
 ]

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0015/Cargo.toml
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0015/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "heavy-leaf-0015"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+# Sibling leaf with a pure-Rust WebAssembly tooling subgraph:
+# wasmi (pure-Rust interpreter), wasmparser, wat (text → binary
+# assembler), wasmprinter (binary → text), wasm-encoder
+# (builder), wast (full text-format parser), walrus (binary edit
+# library), wasm-smith (test-shape generator), wasm-metadata,
+# leb128 (low-level LEB128 codec). Distinct from the prior
+# fourteen leaves' subgraphs. No cc-rs build scripts (wasmtime
+# / cranelift with cc-rs avoided).
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+thiserror = "2"
+anyhow = "1"
+parking_lot = "0.12"
+once_cell = "1"
+wasmi = { version = "0.40", default-features = false, features = ["std"] }
+wasmparser = "0.218"
+wat = "1"
+wasmprinter = "0.218"
+wasm-encoder = "0.218"
+wast = "218"
+walrus = "0.23"
+wasm-smith = "0.218"
+wasm-metadata = "0.218"
+leb128 = "0.2"

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0015/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0015/README.md
@@ -1,0 +1,10 @@
+# heavy-leaf-0015
+
+WebAssembly tooling subgraph (pure-Rust): `wasmi` (pure-Rust
+interpreter), `wasmparser`, `wat` (text → binary assembler),
+`wasmprinter` (binary → text), `wasm-encoder` (builder), `wast`
+(full text-format parser), `walrus` (binary edit library),
+`wasm-smith` (test-shape generator), `wasm-metadata`, `leb128`.
+Distinct from the prior fourteen leaves' subgraphs. No `cc-rs`
+build scripts (wasmtime / cranelift-with-cc-rs avoided to stay
+pure-Rust). See parent `../README.md` and soldr#648.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0015/src/README.md
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0015/src/README.md
@@ -1,0 +1,4 @@
+# src/
+
+See parent README. Minimal lib body by design — the fixture
+exercises the dep graph in `Cargo.toml`.

--- a/benchmarks/workspace-scale/crates/heavy-leaf-0015/src/lib.rs
+++ b/benchmarks/workspace-scale/crates/heavy-leaf-0015/src/lib.rs
@@ -1,0 +1,5 @@
+//! Sibling leaf — see parent README + soldr#648.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
## Summary

Fifteenth sibling leaf with a distinct pure-Rust dep subgraph.

- **Pure-Rust interpreter:** `wasmi`
- **Parsers / encoders:** `wasmparser`, `wasm-encoder`, `wat`, `wasmprinter`, `wast` (full text-format parser)
- **Binary tooling:** `walrus` (edit library), `wasm-smith` (test-shape generator), `wasm-metadata`
- **Low-level codec:** `leb128`

Distinct from the prior fourteen leaves' subgraphs (web/http/cli/math/parser/crypto/serialization/storage/text/graphics/templating/TUI/git/observability). No `cc-rs` build scripts (wasmtime / cranelift-with-cc-rs avoided to stay pure-Rust).

Continues the incremental growth from #648 toward the workspace size where Swatinem/rust-cache's 10 GiB GHA cap is exceeded and it can no longer save. Cross-PR headline already at mean 2.15× faster than swatinem; this widens the surface that exercises soldr's content-addressed cache.

Refs: #648

## Test plan

- [ ] CI green
- [ ] Next iteration: verify next scheduled bench produces measurable signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)