### PR TITLE
chore(deps): bump MANAGED_ZCCACHE_VERSION 1.11.8 -> 1.11.14 + release 0.7.52 (closes #677)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.51"
+version = "0.7.52"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.51"
+version = "0.7.52"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -18,7 +18,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.11.8",
+    "managed_version": "1.11.14",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.8";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.14";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -1042,13 +1042,13 @@ mod tests {
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.11.8/zccache"),
+                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.11.14/zccache"),
                 std::path::Path::new("/tmp/cache-cold/cache/zccache"),
             ),
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.11.8/zccache"),
+                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.11.14/zccache"),
                 std::path::Path::new("/tmp/cache-warm/cache/zccache"),
             ),
             "managed zccache binaries under different SOLDR_CACHE_DIR roots must hash by runtime identity, not absolute path",

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.11.8");
+    assert_eq!(json["managed_zccache_version"], "1.11.14");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.11.8");
+    assert_eq!(json["managed_zccache_version"], "1.11.14");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.11.8");
+    assert_eq!(json["managed_zccache_version"], "1.11.14");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.11.8");
+    assert_eq!(status_json["managed_version"], "1.11.14");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.11.8");
+    assert_eq!(json["managed_version"], "1.11.14");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Bumps every codified mention of the managed zccache version from `1.11.8` → `1.11.14`. Closes #677.

Also bumps the soldr workspace version `0.7.51` → `0.7.52` so the `release-auto.yml` workflow cuts a new soldr release when this lands. The downstream setup-soldr issue (zackees/setup-soldr#379) can then pick up the new default `soldr-version`.

## Why now

zccache 1.11.14 ships the `meson configure --no-walk` wrapper (zackees/zccache#660, closes zackees/zccache#659). FastLED measured the end-to-end impact in FastLED/FastLED#2761: cold-with-cache reconfigure dropped from ~5.6s (walked hit, 1.11.13) to **0.62s** (no-walk hit, 1.11.14) — the ~5s difference was the wrapper walking `.venv/` (~100k Python files) on every invocation.

soldr's managed-install path was still resolving to 1.11.8, so any consumer routing through `setup-soldr → soldr → managed-zccache` silently ran an older wrapper than what FastLED's direct PyPI consumers do.

## Notable zccache pickups since 1.11.8

| Pickup | Significance |
|---|---|
| 1.11.11 — depfile-on-cache-hit (zackees/zccache#643) | Without this, `deps = gcc` records `#deps 0` for every cached object → incremental builds produce stale `.obj` files after a git pull that changes transitive headers (symptom: `undefined symbol: ...` link errors hours after the header actually changed). |
| 1.11.12 — `meson configure` wrapper (zackees/zccache#649) | Build-dir-level caching for meson setup. |
| 1.11.13 — `--input-file` (zackees/zccache#655) | Caller-supplied digest sidecar so source globs invalidate the cached configure tree without bypassing the wrapper. |
| 1.11.14 — `--no-walk` (zackees/zccache#660) | Skips the recursive `--source-dir` walk; ~9× cold-with-cache speedup on FastLED's tree. |

## Scope

Mechanical version-string replacements only — no behavior change in soldr code itself.

- `Cargo.toml` — workspace version `0.7.51` → `0.7.52` (drives release-auto)
- `Cargo.lock` — regenerated via `cargo update --workspace`
- `contracts/zccache-runtime.v1.json` — `zccache.managed_version`
- `crates/soldr-cli/src/fetch/mod.rs` — `MANAGED_ZCCACHE_VERSION` const
- `crates/soldr-cli/src/zccache.rs` — 2 test-fixture path strings
- `crates/soldr-cli/tests/cli_cache.rs` — 3 `assert_eq!` strings
- `crates/soldr-cli/tests/cli_install_zccache.rs` — 2 `assert_eq!` strings

## Test plan

- [ ] `cargo test --workspace` passes (version-string assertions now expect 1.11.14)
- [ ] release-auto.yml detects the 0.7.52 bump and publishes a new soldr release
- [ ] Downstream: zackees/setup-soldr#379 picks up the new `soldr-version` default

## Related

- Tracker: zackees/zccache#662
- Source change: zackees/zccache#660 (closes zackees/zccache#659)
- Reference consumer: FastLED/FastLED#2761
- Downstream: zackees/setup-soldr#379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
