### PR TITLE
chore(release): bump package.json 0.7.51 -> 0.7.52 (follow-up to #678)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.51",
+  "version": "0.7.52",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Follow-up to #678. release-auto failed at the version-bump-detection step with:

    package.json version (0.7.51) must match Cargo.toml (0.7.52)

#678 bumped Cargo.toml but not package.json. This one-line PR fixes the gap so release-auto can cut 0.7.52, which in turn unblocks zackees/setup-soldr#379 and zackees/zccache#662.