### PR TITLE
feat(cli): `soldr <verb>` shorthand for known cargo subcommands (phase 1 of #682)

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -577,6 +577,33 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             let (crate_name, version) = parse_tool_spec(&args[0]);
             let tool_args = &args[1..];
 
+            // Issue #683 (parent #682, phase 1): bare cargo-subcommand
+            // shorthand. When the typed verb (sans `@version`) is one
+            // soldr already prebuilds as a cargo subcommand
+            // (`KNOWN_TOOLS::lookup_by_cargo_subcommand`), route through
+            // the cargo front door — `soldr nextest run` becomes
+            // `soldr cargo nextest run`. This avoids the doomed
+            // crates.io fetch for a literally-named `nextest` crate.
+            // Version-pinned forms (`soldr nextest@0.9.x`) keep the
+            // existing External path; cargo-subcommand pins are
+            // managed in the soldr registry and the front door has no
+            // per-invocation knob.
+            if matches!(version, VersionSpec::Latest)
+                && crate::fetch::lookup_by_cargo_subcommand(&crate_name).is_some()
+            {
+                let mut cargo_args = Vec::with_capacity(args.len());
+                cargo_args.push(crate_name.clone());
+                cargo_args.extend(tool_args.iter().cloned());
+                std::process::exit(
+                    cargo_front_door::run_cargo_front_door(
+                        &cargo_args,
+                        cache_enabled,
+                        zccache_source,
+                    )
+                    .await?,
+                );
+            }
+
             // Issue #412: when the user typed a verb that LOOKS like
             // a typo or a renamed built-in (e.g. `update-zccacheee`,
             // `installzccache`), emit a "did you mean?" hint before

--- a/crates/soldr-cli/src/main_tests.rs
+++ b/crates/soldr-cli/src/main_tests.rs
@@ -315,3 +315,89 @@ fn fuzzy_match_with_soldr_verbs_recognizes_issue_412_examples() {
     // by suggest_close_match returning None on exact match.
     assert_eq!(suggest_close_match("doctor", SOLDR_BUILTIN_VERBS), None);
 }
+
+/// Issue #683 (parent #682, phase 1): bare cargo-subcommand shorthand.
+/// `soldr nextest run` must resolve as `soldr cargo nextest run`, NOT
+/// fall through to a crates.io fetch for a literally-named `nextest`
+/// crate. The dispatch decision in `main.rs` keys on
+/// `parse_tool_spec` + `lookup_by_cargo_subcommand`; these tests
+/// exercise that contract directly so the surface stays observable
+/// without spawning a full `soldr` process.
+#[test]
+fn bare_shorthand_recognizes_every_known_cargo_subcommand() {
+    // Every entry in `KNOWN_TOOLS` with a `cargo_subcommand: Some(_)`
+    // must be reachable via the bare verb (sans `@version`). The
+    // list is intentionally hard-coded — adding a new
+    // `cargo_subcommand` to the registry without also adding it here
+    // is the kind of drift this test exists to catch.
+    let expected = [
+        "nextest",
+        "deny",
+        "audit",
+        "llvm-cov",
+        "udeps",
+        "semver-checks",
+        "expand",
+        "watch",
+        "chef",
+        "zigbuild",
+        "xwin",
+        "binstall",
+        "machete",
+    ];
+    for verb in expected {
+        let (crate_name, version) = parse_tool_spec(verb);
+        assert!(
+            matches!(version, VersionSpec::Latest),
+            "bare verb {verb:?} must parse to VersionSpec::Latest"
+        );
+        assert!(
+            crate::fetch::lookup_by_cargo_subcommand(&crate_name).is_some(),
+            "bare verb {verb:?} must be matched by lookup_by_cargo_subcommand"
+        );
+    }
+}
+
+#[test]
+fn bare_shorthand_skips_when_user_pinned_a_version() {
+    // `soldr nextest@0.9.x` keeps the existing External fetch path
+    // (which today errors with "no crate named nextest"). The
+    // shorthand only fires for unversioned forms because the cargo
+    // front door has no per-invocation version knob — pins are
+    // managed in `KNOWN_TOOLS::pinned_version`.
+    let (crate_name, version) = parse_tool_spec("nextest@0.9.x");
+    assert_eq!(crate_name, "nextest");
+    assert!(
+        matches!(version, VersionSpec::Exact(_)),
+        "pinned bare verb must parse to VersionSpec::Exact"
+    );
+    // Sanity: the lookup still matches the verb itself, so the gate
+    // condition `matches!(version, VersionSpec::Latest) && lookup…`
+    // depends entirely on the version arm. If a future refactor flips
+    // this to use the lookup result alone, this test will surface
+    // that mistake.
+    assert!(crate::fetch::lookup_by_cargo_subcommand(&crate_name).is_some());
+}
+
+#[test]
+fn bare_shorthand_does_not_capture_unrelated_verbs() {
+    // Negative coverage: a verb that ISN'T a cargo subcommand
+    // (top-level fetch tool, made-up name, cargo built-in) must NOT
+    // be routed through the cargo front door by this gate. Top-level
+    // tools already dispatch through External (their own fetch
+    // path); cargo built-ins remain out-of-scope for phase 1.
+    for verb in [
+        "cross",
+        "mdbook",
+        "bacon",
+        "completely-made-up-name",
+        "build",
+        "test",
+    ] {
+        let (crate_name, _) = parse_tool_spec(verb);
+        assert!(
+            crate::fetch::lookup_by_cargo_subcommand(&crate_name).is_none(),
+            "verb {verb:?} must NOT be matched as a cargo subcommand in phase 1"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of #682: drop the `cargo` prefix for the 13 cargo subcommands soldr already prebuilds.

Closes #683.

After this change, the following pairs are equivalent:

| Old                            | New                       |
|--------------------------------|---------------------------|
| `soldr cargo nextest run`      | `soldr nextest run`       |
| `soldr cargo zigbuild build`   | `soldr zigbuild build`    |
| `soldr cargo machete`          | `soldr machete`           |

Every `cargo_subcommand` entry currently registered in `crates/soldr-cli/src/fetch/known_tools.rs` is covered: `nextest`, `deny`, `audit`, `llvm-cov`, `udeps`, `semver-checks`, `expand`, `watch`, `chef`, `zigbuild`, `xwin`, `binstall`, `machete`.

## Why

- Less typing for the common case.
- Eliminates the surprising failure where `soldr nextest` falls through `Commands::External` and tries to fetch a crate literally named `nextest` (which doesn't exist on crates.io).
- Pure-additive: `soldr cargo <verb>` keeps working forever.

## Implementation

One insertion in `Commands::External` (`crates/soldr-cli/src/main.rs`): after `parse_tool_spec(args[0])`, if `version` is `VersionSpec::Latest` and `lookup_by_cargo_subcommand(crate_name)` matches, dispatch through `cargo_front_door::run_cargo_front_door` with the verb prepended to the trailing args. Otherwise the existing External fetch runs unchanged.

`@version` forms keep the existing External path because the cargo front door has no per-invocation version knob — cargo-subcommand pins are managed in `KNOWN_TOOLS::pinned_version`.

## Test plan

- [x] `cargo test --lib -p soldr-cli` — 292 passed, 0 failed
- [x] `cargo test --bins -p soldr-cli` — 722 passed, 0 failed (includes 3 new tests)
- [x] `cargo test --test cli_dispatch --test cli_cargo_basic --test monocrate_guard --test timed_test_lint` — 17 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Full `cargo test --tests` — full integration sweep deferred to CI; the targeted subsets cover the surface this PR touches

New tests in `main_tests.rs`:

- `bare_shorthand_recognizes_every_known_cargo_subcommand` — every one of the 13 verbs round-trips through `parse_tool_spec` + `lookup_by_cargo_subcommand`. Hard-codes the list so adding a new `cargo_subcommand` to the registry without also updating this test trips the build.
- `bare_shorthand_skips_when_user_pinned_a_version` — `soldr nextest@0.9.x` parses to `VersionSpec::Exact(_)`, so the gate skips.
- `bare_shorthand_does_not_capture_unrelated_verbs` — top-level tools, cargo built-ins, and made-up names are not matched.

## Out of scope (later phases of #682)

- Phase 2 — routing cargo's own built-in verbs (`build`, `test`, `check`, `run`, `bench`, `doc`, `fmt`, `clippy`, …) through the cargo front door. Touches the "frozen built-in commands" rule in `CLAUDE.md`.
- Phase 3 — updating `CLAUDE.md` / `docs/API.md` / `README.md` to document the shorthand and loosen the "never add build/test/…" rule.
