### PR TITLE
feat(cli): `soldr build` / `soldr test` / etc. — cargo built-in shorthand (phase 2 of #682)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ A single Rust binary with two jobs:
 
 Mode is detected automatically from argv[1]: path-to-rustc → cache mode, built-in command → dispatch, anything else → tool fetch.
 
-**soldr wraps rustc, NOT cargo.** This is the most important design decision. No `soldr build`, `soldr test`, etc. Cargo owns build orchestration; soldr owns per-unit caching. See DESIGN.md "Why no `soldr build`" for rationale.
+**soldr wraps rustc, NOT cargo.** This is the most important design decision: cargo owns build orchestration, soldr owns per-unit caching. See DESIGN.md "Why no `soldr build`" for rationale. As of #685 (phase 2 of #682) `soldr build` / `soldr test` / `soldr clippy` / etc. are accepted as **dispatch shorthand** for `soldr cargo build` / `soldr cargo test` / `soldr cargo clippy` — they route through the cargo front door and do not become soldr-native verbs (the `Commands::Cargo` arm is still where the work happens).
 
 ## Build Commands
 
@@ -99,7 +99,7 @@ Anything not registered falls through the generic External subcommand, which res
 
 ## Key Design Rules
 
-- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`, `rustup`, `toolchain`, `doctor`, `optimize`, `cook` plus the toolchain passthroughs listed above. Never add `build`, `test`, `lint`, `fmt`, `check`, `doc`, `bench`, `publish` — prevents namespace collision with tool names.
+- **Frozen built-in commands**: `status`, `clean`, `config`, `cache`, `version`, `help`, `rustup`, `toolchain`, `doctor`, `optimize`, `cook` plus the toolchain passthroughs listed above. These are clap-captured and must NOT be repurposed. Bare cargo built-in verbs — `build`, `test`, `check`, `run`, `bench`, `doc`, `fmt`, `clippy`, `tree`, `update`, `fix`, `add`, `remove`, `metadata`, `pkgid`, `search`, `vendor`, `yank`, `owner`, `login`, `logout`, `init`, `new`, `generate-lockfile`, `verify-project`, `locate-project`, `report`, `install`, `uninstall`, `publish` — route to `cargo <verb>` via the External arm (see `CARGO_BUILTIN_VERBS` in `cli_args.rs` and the phase-2 hop in `Commands::External` of `main.rs`). They are NOT soldr-native verbs and may not be reused as such; their soldr meaning is "shorthand for `cargo <verb>`."
 - **MSVC on Windows always**: Default to `x86_64-pc-windows-msvc` (or aarch64). Only use GNU if `rust-toolchain.toml` explicitly says so. Target resolved at runtime, not compile-time.
 - **Pre-built first**: Try every binary source before `cargo install`. Resolution order matters.
 - **RUSTC_WRAPPER defaults to zccache**: If `RUSTC_WRAPPER` is not set, soldr defaults to using `zccache` as the wrapper.

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -44,6 +44,63 @@ pub(crate) enum ZccacheSourceArg {
 /// against clap's discovered subcommands and fails when they drift,
 /// so adding a new verb here without updating the enum (or vice
 /// versa) trips the build.
+/// Cargo's own first-party verbs that — when typed bare as
+/// `soldr <verb>` — should be routed through soldr's cargo front
+/// door (`soldr cargo <verb> ...`) instead of falling through
+/// `Commands::External` and attempting a doomed crates.io fetch
+/// for a literally-named crate (`build`, `test`, etc. are not
+/// real crates). Issue #685, phase 2 of #682.
+///
+/// The collision verbs `clean`, `config`, and `version` are
+/// deliberately EXCLUDED — those map to soldr-native built-ins
+/// that clap captures before the External arm runs. `soldr cargo
+/// clean` / `soldr cargo config` continue to work as the explicit
+/// escape hatch. A unit test in `main_tests.rs` asserts the
+/// exclusion stays in place.
+///
+/// The list is intentionally a superset of cargo's own `--list`
+/// output of first-party commands; new cargo verbs (rare) need an
+/// explicit add here.
+pub(crate) const CARGO_BUILTIN_VERBS: &[&str] = &[
+    "build",
+    "test",
+    "check",
+    "run",
+    "bench",
+    "doc",
+    "fmt",
+    "clippy",
+    "tree",
+    "update",
+    "fix",
+    "add",
+    "remove",
+    "metadata",
+    "pkgid",
+    "search",
+    "vendor",
+    "yank",
+    "owner",
+    "login",
+    "logout",
+    "init",
+    "new",
+    "generate-lockfile",
+    "verify-project",
+    "locate-project",
+    "report",
+    "install",
+    "uninstall",
+    "publish",
+];
+
+/// Predicate form of [`CARGO_BUILTIN_VERBS`]. Lives next to the const
+/// so callers (the External arm dispatcher and the tests) share one
+/// source of truth.
+pub(crate) fn is_cargo_builtin_verb(verb: &str) -> bool {
+    CARGO_BUILTIN_VERBS.contains(&verb)
+}
+
 pub(crate) const SOLDR_BUILTIN_VERBS: &[&str] = &[
     "cargo",
     "cook",

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -53,9 +53,10 @@ mod zccache_lifecycle;
 mod test_util;
 
 use cli_args::{
-    CacheSubcommand, Cli, Commands, DaemonBuildsSubcommand, DaemonSubcommand,
-    DefenderExclusionsSubcommand, GcCargoArgs, GcListKind, GcSubcommand, GcSweepArgs,
-    ToolchainSubcommand, TrimProfileArg, ZccacheSourceArg, SOLDR_BUILTIN_VERBS,
+    is_cargo_builtin_verb, CacheSubcommand, Cli, Commands, DaemonBuildsSubcommand,
+    DaemonSubcommand, DefenderExclusionsSubcommand, GcCargoArgs, GcListKind, GcSubcommand,
+    GcSweepArgs, ToolchainSubcommand, TrimProfileArg, ZccacheSourceArg, CARGO_BUILTIN_VERBS,
+    SOLDR_BUILTIN_VERBS,
 };
 
 use crate::core::{suppress_windows_console_window, SoldrError};
@@ -591,6 +592,31 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             if matches!(version, VersionSpec::Latest)
                 && crate::fetch::lookup_by_cargo_subcommand(&crate_name).is_some()
             {
+                let mut cargo_args = Vec::with_capacity(args.len());
+                cargo_args.push(crate_name.clone());
+                cargo_args.extend(tool_args.iter().cloned());
+                std::process::exit(
+                    cargo_front_door::run_cargo_front_door(
+                        &cargo_args,
+                        cache_enabled,
+                        zccache_source,
+                    )
+                    .await?,
+                );
+            }
+
+            // Issue #685 (parent #682, phase 2): bare cargo built-in
+            // shorthand. When the typed verb is one of cargo's own
+            // first-party verbs (`build`, `test`, `check`, `clippy`,
+            // `fmt`, ...), route through the cargo front door —
+            // `soldr build --release` becomes `soldr cargo build
+            // --release`. The collision verbs `clean` / `config` /
+            // `version` are captured by clap before reaching this
+            // arm; see `is_cargo_builtin_verb` for the explicit
+            // exclusion list. Version-pinned forms keep the existing
+            // External fetch path so `soldr build@1.0` parses
+            // exactly like `soldr <unknown-tool>@1.0` does today.
+            if matches!(version, VersionSpec::Latest) && is_cargo_builtin_verb(&crate_name) {
                 let mut cargo_args = Vec::with_capacity(args.len());
                 cargo_args.push(crate_name.clone());
                 cargo_args.extend(tool_args.iter().cloned());

--- a/crates/soldr-cli/src/main_tests.rs
+++ b/crates/soldr-cli/src/main_tests.rs
@@ -381,11 +381,11 @@ fn bare_shorthand_skips_when_user_pinned_a_version() {
 
 #[test]
 fn bare_shorthand_does_not_capture_unrelated_verbs() {
-    // Negative coverage: a verb that ISN'T a cargo subcommand
-    // (top-level fetch tool, made-up name, cargo built-in) must NOT
-    // be routed through the cargo front door by this gate. Top-level
-    // tools already dispatch through External (their own fetch
-    // path); cargo built-ins remain out-of-scope for phase 1.
+    // Negative coverage for the phase-1 (cargo subcommand) hop: a
+    // verb that ISN'T in `KNOWN_TOOLS::cargo_subcommand` must NOT
+    // be matched by `lookup_by_cargo_subcommand`. Top-level fetch
+    // tools (cross, mdbook, bacon) and made-up names go to External;
+    // cargo built-ins (build, test) take the phase-2 hop instead.
     for verb in [
         "cross",
         "mdbook",
@@ -398,6 +398,151 @@ fn bare_shorthand_does_not_capture_unrelated_verbs() {
         assert!(
             crate::fetch::lookup_by_cargo_subcommand(&crate_name).is_none(),
             "verb {verb:?} must NOT be matched as a cargo subcommand in phase 1"
+        );
+    }
+}
+
+/// Issue #685 (parent #682, phase 2): bare cargo-built-in
+/// shorthand. `soldr build` / `soldr test` / `soldr clippy` etc.
+/// must resolve as `soldr cargo <verb>` via the External arm,
+/// NOT fall through to a doomed crates.io fetch. The dispatch
+/// decision keys on `parse_tool_spec` + `is_cargo_builtin_verb`;
+/// these tests exercise that contract directly.
+#[test]
+fn cargo_builtin_shorthand_covers_every_verb_in_the_const() {
+    // Every entry in `CARGO_BUILTIN_VERBS` must round-trip through
+    // `is_cargo_builtin_verb` and through `parse_tool_spec` as a
+    // bare, version-unpinned form. The list is intentionally
+    // hard-coded — adding a new cargo verb to the const without
+    // also adding it here is the kind of drift this test catches.
+    let expected = [
+        "build",
+        "test",
+        "check",
+        "run",
+        "bench",
+        "doc",
+        "fmt",
+        "clippy",
+        "tree",
+        "update",
+        "fix",
+        "add",
+        "remove",
+        "metadata",
+        "pkgid",
+        "search",
+        "vendor",
+        "yank",
+        "owner",
+        "login",
+        "logout",
+        "init",
+        "new",
+        "generate-lockfile",
+        "verify-project",
+        "locate-project",
+        "report",
+        "install",
+        "uninstall",
+        "publish",
+    ];
+    for verb in expected {
+        let (crate_name, version) = parse_tool_spec(verb);
+        assert!(
+            matches!(version, VersionSpec::Latest),
+            "bare verb {verb:?} must parse to VersionSpec::Latest"
+        );
+        assert!(
+            is_cargo_builtin_verb(&crate_name),
+            "bare cargo built-in verb {verb:?} must be matched by is_cargo_builtin_verb"
+        );
+    }
+    // And the reverse: every const entry is in the expected list.
+    // Cheap, but if a future cargo gains a new verb and someone adds
+    // it to the const without updating tests, this fails loudly.
+    for verb in CARGO_BUILTIN_VERBS {
+        assert!(
+            expected.contains(verb),
+            "CARGO_BUILTIN_VERBS gained {verb:?} without a test update"
+        );
+    }
+}
+
+#[test]
+fn cargo_builtin_shorthand_excludes_soldr_native_collision_verbs() {
+    // The three collision verbs (`clean`, `config`, `version`) own
+    // a soldr-native meaning today and MUST NOT be remapped to
+    // cargo by the phase-2 hop. Clap captures them before the
+    // External arm runs, but we also assert the const itself
+    // excludes them — defense in depth + intent documentation.
+    for collision_verb in ["clean", "config", "version"] {
+        assert!(
+            !is_cargo_builtin_verb(collision_verb),
+            "soldr-native verb {collision_verb:?} must NOT be in CARGO_BUILTIN_VERBS"
+        );
+    }
+}
+
+#[test]
+fn cargo_builtin_shorthand_skips_when_user_pinned_a_version() {
+    // `soldr build@1.0` keeps the existing External fetch path —
+    // cargo built-ins have no per-invocation version dimension and
+    // the parse-time `@version` form is reserved for the
+    // crate-fetch path. Same shape as the phase-1
+    // `bare_shorthand_skips_when_user_pinned_a_version` test.
+    let (crate_name, version) = parse_tool_spec("build@1.0");
+    assert_eq!(crate_name, "build");
+    assert!(
+        matches!(version, VersionSpec::Exact(_)),
+        "pinned bare verb must parse to VersionSpec::Exact"
+    );
+    // Sanity: the lookup still matches the verb itself, so the gate
+    // condition `matches!(version, VersionSpec::Latest) && is_…`
+    // depends entirely on the version arm.
+    assert!(is_cargo_builtin_verb(&crate_name));
+}
+
+#[test]
+fn cargo_builtin_shorthand_includes_borderline_install_verb() {
+    // `install` is the borderline case: `soldr install-zccache`
+    // already exists as a soldr built-in (different name, different
+    // verb). Bare `soldr install <crate>` is documented to route to
+    // `cargo install <crate>` because that's the far more common
+    // interpretation. The const-level expectation is asserted here.
+    assert!(
+        is_cargo_builtin_verb("install"),
+        "bare `soldr install` must route to `cargo install` (zccache install is install-zccache)"
+    );
+    // Sanity: the clap built-in keeps its long name and is NOT
+    // remapped.
+    assert!(SOLDR_BUILTIN_VERBS.contains(&"install-zccache"));
+    assert!(!is_cargo_builtin_verb("install-zccache"));
+}
+
+#[test]
+fn cargo_builtin_shorthand_does_not_capture_other_verbs() {
+    // Negative coverage. None of:
+    //   - phase-1 known cargo subcommands (handled by their own hop)
+    //   - top-level fetch tools (cross, mdbook, ...)
+    //   - made-up names
+    //   - soldr-native verbs
+    // should be captured as cargo built-ins.
+    for verb in [
+        "nextest",  // phase-1 known cargo subcommand
+        "zigbuild", // phase-1 known cargo subcommand
+        "cross",    // top-level fetch tool
+        "mdbook",   // top-level fetch tool
+        "bacon",    // top-level fetch tool
+        "completely-made-up-name",
+        "clean",   // soldr-native
+        "config",  // soldr-native
+        "version", // soldr-native
+        "doctor",  // soldr-native
+    ] {
+        assert!(
+            !is_cargo_builtin_verb(verb),
+            "verb {verb:?} must NOT be classified as a cargo built-in"
         );
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 of #682: route bare cargo built-in verbs through the cargo front door.

Closes #685. Builds on #684 (Phase 1).

After this change, the following pairs are equivalent:

| Old                                  | New                          |
|--------------------------------------|------------------------------|
| `soldr cargo build --release`        | `soldr build --release`      |
| `soldr cargo test --workspace`       | `soldr test --workspace`     |
| `soldr cargo clippy -- -D warnings`  | `soldr clippy -- -D warnings`|
| `soldr cargo fmt --all -- --check`   | `soldr fmt --all -- --check` |
| `soldr cargo install ripgrep`        | `soldr install ripgrep`      |

Covers 30 cargo first-party verbs: `build`, `test`, `check`, `run`, `bench`, `doc`, `fmt`, `clippy`, `tree`, `update`, `fix`, `add`, `remove`, `metadata`, `pkgid`, `search`, `vendor`, `yank`, `owner`, `login`, `logout`, `init`, `new`, `generate-lockfile`, `verify-project`, `locate-project`, `report`, `install`, `uninstall`, `publish`.

## Why

- Less typing for the most-common workflow (`soldr build` vs `soldr cargo build`).
- Eliminates the noisy failure where `soldr build` falls through `Commands::External` and tries to fetch a crate literally named `build` (doesn't exist).
- Pure-additive: `soldr cargo <verb>` keeps working forever.

## Collision policy

Three verbs MUST stay anchored to their soldr-native meaning and are explicitly EXCLUDED from the new list:

| Verb       | Stays soldr-native because |
|------------|----------------------------|
| `clean`    | `soldr clean` clears the zccache cache; users expect this. |
| `config`   | `soldr config` shows/sets soldr config; cargo's is unstable. |
| `version`  | `soldr version` prints soldr's version. |

A unit test (`cargo_builtin_shorthand_excludes_soldr_native_collision_verbs`) asserts the exclusion. Clap captures these before the External arm runs anyway, but the explicit assertion is defense in depth.

The borderline `install`: `soldr install ripgrep` routes to `cargo install ripgrep` (the more common interpretation); the zccache install keeps its existing explicit name `install-zccache`. A dedicated unit test (`cargo_builtin_shorthand_includes_borderline_install_verb`) locks in this decision.

## Implementation

- New `CARGO_BUILTIN_VERBS` const + `is_cargo_builtin_verb()` predicate in `crates/soldr-cli/src/cli_args.rs`, declared next to `SOLDR_BUILTIN_VERBS` so the verb taxonomy stays in one place.
- Second dispatch hop in `Commands::External` (`crates/soldr-cli/src/main.rs`) right after the Phase 1 hop. Same gate as Phase 1: `VersionSpec::Latest` + verb match → route through `cargo_front_door::run_cargo_front_door`. `@version` forms fall through to External unchanged.
- `CLAUDE.md` updated:
  - "What is soldr" intro: `soldr build` / `soldr test` / etc. are documented as dispatch shorthand, not native verbs.
  - "Frozen built-in commands" rule: replaces "Never add `build`, `test`, ..." with the explicit list of routed verbs and a "may NOT be repurposed as soldr-native built-ins" note.

## Test plan

- [x] `cargo test --lib -p soldr-cli` — 292 passed
- [x] `cargo test --bin soldr -p soldr-cli` — 727 passed (5 new tests added)
- [x] `cargo test --test cli_dispatch --test cli_cargo_basic --test monocrate_guard --test timed_test_lint` — 17 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

5 new tests in `main_tests.rs`:

- `cargo_builtin_shorthand_covers_every_verb_in_the_const` — every entry in `CARGO_BUILTIN_VERBS` round-trips through `parse_tool_spec` + `is_cargo_builtin_verb`. Drift-guard: adding a verb to the const without updating the test trips the build, and vice versa.
- `cargo_builtin_shorthand_excludes_soldr_native_collision_verbs` — `clean`, `config`, `version` are NOT in `CARGO_BUILTIN_VERBS`.
- `cargo_builtin_shorthand_skips_when_user_pinned_a_version` — `soldr build@1.0` parses to `VersionSpec::Exact(_)`, so the gate skips.
- `cargo_builtin_shorthand_includes_borderline_install_verb` — `install` IS in the list (routes to cargo install); `install-zccache` is NOT (it stays the clap built-in).
- `cargo_builtin_shorthand_does_not_capture_other_verbs` — known cargo subcommands (covered by Phase 1), top-level tools, made-up names, and soldr-native verbs are all rejected by the predicate.

## Out of scope (Phase 3 of #682)

- User-facing documentation in `docs/API.md` + `README.md` covering the new shorthand. Internal `CLAUDE.md` already updated here because the "Frozen built-ins" rule directly contradicts this PR's behavior; deferring would ship internally-inconsistent docs.
