### PR TITLE
docs: document the cargo verb shorthand (phase 3 of #682)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ soldr purge
 SOLDR_RUSTC_WRAPPER=sccache soldr cargo build
 SOLDR_RUSTC_WRAPPER=none soldr cargo build
 
+# Shorthand: drop the `cargo` prefix for cargo's built-in verbs and for
+# any cargo subcommand soldr already prebuilds. `soldr cargo <verb>` is
+# preserved as the explicit escape hatch (always works), and the
+# collision verbs `clean`, `config`, and `version` keep their
+# soldr-native meaning. See docs/API.md "Cargo Verb Shorthand" for the
+# full list.
+soldr build --release          # == soldr cargo build --release
+soldr test --workspace         # == soldr cargo test --workspace
+soldr clippy -- -D warnings    # == soldr cargo clippy -- -D warnings
+soldr nextest run              # == soldr cargo nextest run
+
 # Fetch and run any Rust tool instantly:
 soldr maturin build --release
 soldr cargo-dylint check

--- a/docs/API.md
+++ b/docs/API.md
@@ -81,13 +81,52 @@ soldr maturin@1.7.0 build
 
 Resolution order:
 
-1. Local cache in `~/.soldr/bin/`
-2. crates.io repository lookup
-3. GitHub Releases for that repository
+1. **Cargo verb shorthand** — if `<tool>` (with no `@<version>` suffix) is either a cargo subcommand soldr already prebuilds (`nextest`, `deny`, `audit`, ...) OR one of cargo's own first-party verbs (`build`, `test`, `clippy`, ...), the invocation is rewritten as `soldr cargo <tool> [args...]` and dispatched through the cargo front door. See [Cargo Verb Shorthand](#cargo-verb-shorthand) below for the full list.
+2. Local cache in `~/.soldr/bin/`
+3. crates.io repository lookup
+4. GitHub Releases for that repository
 
 Current implementation note:
 
 - the broader binstall/QuickInstall/`cargo install` fallback chain is planned behavior, not the current shipped fetch path
+
+#### Cargo Verb Shorthand
+
+When `soldr <verb> [args...]` is invoked and `<verb>` is not a frozen soldr built-in, the External arm rewrites the invocation as `soldr cargo <verb> [args...]` whenever `<verb>` matches one of two lists. The long form `soldr cargo <verb>` continues to work — the shorthand is purely additive.
+
+**Routed cargo subcommands** (soldr prebuilds these via `KNOWN_TOOLS`):
+
+`nextest`, `deny`, `audit`, `llvm-cov`, `udeps`, `semver-checks`, `expand`, `watch`, `chef`, `zigbuild`, `xwin`, `binstall`, `machete`
+
+**Routed cargo built-in verbs** (cargo's first-party commands):
+
+`build`, `test`, `check`, `run`, `bench`, `doc`, `fmt`, `clippy`, `tree`, `update`, `fix`, `add`, `remove`, `metadata`, `pkgid`, `search`, `vendor`, `yank`, `owner`, `login`, `logout`, `init`, `new`, `generate-lockfile`, `verify-project`, `locate-project`, `report`, `install`, `uninstall`, `publish`
+
+**Collision policy.** These three verbs MUST stay anchored to their soldr-native meaning and are explicitly excluded from the shorthand:
+
+| Verb       | soldr-native meaning                              | Cargo equivalent (use long form) |
+|------------|---------------------------------------------------|-----------------------------------|
+| `clean`    | Clear the managed zccache build cache             | `soldr cargo clean`               |
+| `config`   | Show or set soldr configuration                   | `soldr cargo config` (unstable)   |
+| `version`  | Print soldr's version                             | `soldr cargo --version`           |
+
+The borderline case `install`: bare `soldr install <crate>` routes to `cargo install <crate>` (the far more common interpretation). The zccache install keeps its existing explicit name `soldr install-zccache`.
+
+**Version pinning skips the shorthand.** Cargo built-in verbs and registered cargo subcommands cannot be version-pinned via the bare `@<version>` form — the cargo front door has no per-invocation version knob. `soldr build@1.0` keeps the existing External fetch path (and errors with "no crate named build"), and so do the registered subcommands (`soldr nextest@0.9.x` falls through to External). For pinned cargo-subcommand versions, use the soldr registry (`KNOWN_TOOLS::pinned_version` in source); for pinned tool fetches, use the External path for crates that actually exist.
+
+```bash
+# Shorthand
+soldr build --release          # == soldr cargo build --release
+soldr test --workspace         # == soldr cargo test --workspace
+soldr clippy -- -D warnings    # == soldr cargo clippy -- -D warnings
+soldr fmt --all -- --check     # == soldr cargo fmt --all -- --check
+soldr nextest run              # == soldr cargo nextest run
+soldr zigbuild build --target ...  # == soldr cargo zigbuild build --target ...
+
+# Long form (always works as the escape hatch)
+soldr cargo clean              # explicitly route `clean` to cargo (NOT soldr's cache clean)
+soldr cargo config get profile.dev
+```
 
 ### Mode 3: Internal Wrapper Mode
 
@@ -116,7 +155,7 @@ When soldr starts, it decides its mode in this order:
 1. If `argv[1]` looks like `rustc` or a path to `rustc`, enter wrapper mode.
 2. Otherwise, parse CLI commands with Clap.
 3. `cargo` is a first-class built-in subcommand.
-4. Any unknown first argument is treated as a tool name to fetch and run.
+4. Any other first argument falls through to the External arm, which itself tries dispatch in order: cargo verb shorthand (see [Cargo Verb Shorthand](#cargo-verb-shorthand)) first; if no match, treat the argument as a tool name to fetch and run.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 3 of #682: user-facing documentation for the cargo verb shorthand.

Closes #687. Builds on #684 (Phase 1) and #686 (Phase 2). Closes the parent #682.

## Changes

### `docs/API.md`

- New **Cargo Verb Shorthand** subsection under Mode 2 (Tool Fetcher) documenting:
  - The 13 routed cargo subcommands (`nextest`, `deny`, `audit`, ...).
  - The 30 routed cargo built-in verbs (`build`, `test`, `clippy`, `fmt`, ...).
  - The `clean` / `config` / `version` collision policy, with a table mapping each to its long-form cargo equivalent.
  - The `install` borderline-case decision (routes to `cargo install`; zccache install keeps its explicit `install-zccache` name).
  - The `@<version>` skip-the-shorthand behavior, with the rationale (no per-invocation knob in the cargo front door).
  - A concrete worked-example block contrasting shorthand vs long form.
- Resolution-order list under Mode 2 picks up the new shorthand hop as step 1.
- Mode Detection list (step 4) now references the External arm's internal dispatch order.

### `README.md`

- Adds a short "Shorthand" callout in the existing `soldr cargo build` / `soldr cargo test` example block, with three concrete one-liners and a pointer at `docs/API.md` for the full table.

## Test plan

- [x] `git diff --stat` — only `README.md` and `docs/API.md` modified (no source / test / Cargo.toml).
- [x] Manual read-through of both files to confirm the rendered sections flow naturally with surrounding text.
- [ ] CI — docs-only, expected no-op for build/test workflows.

## Out of scope

- Behavior changes (those shipped in #684 / #686).
- `CLAUDE.md` updates (already in #686 because the "Frozen built-ins" rule directly contradicted Phase 2 behavior).
- `INTEGRATION.md` / setup-soldr docs — the action's own README is the canonical place for CI shorthand examples; left for setup-soldr#TBD.
