### PR TITLE
fix(gc): walk .claude/worktrees/ and bump default max_depth to 8

### DIFF
--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -706,8 +706,13 @@ pub(crate) struct GcTargetArgs {
     /// `$SOLDR_GC_TARGET_ROOT`, falling back to `~/dev`.
     #[arg(long, value_name = "PATH")]
     pub(crate) root: Option<std::path::PathBuf>,
-    /// Maximum walk depth.
-    #[arg(long, default_value_t = 4, value_name = "N")]
+    /// Maximum walk depth. Default raised from 4 to 8 in #680 — clud's
+    /// `/clud-pr` worktree layout puts targets at
+    /// `~/dev/<repo>/.claude/worktrees/<branch>/target` (depth 6), and
+    /// workspace-member projects routinely sit one or two levels deeper
+    /// than that. `jwalk` scan time is roughly linear in depth, and a
+    /// shallow `~/dev` adds <1s at depth 8.
+    #[arg(long, default_value_t = 8, value_name = "N")]
     pub(crate) max_depth: usize,
     /// Report-only (the default).
     #[arg(long, conflicts_with = "purge")]

--- a/crates/soldr-cli/src/gc/target_walker.rs
+++ b/crates/soldr-cli/src/gc/target_walker.rs
@@ -31,9 +31,18 @@ pub(crate) struct TargetEntry {
 }
 
 /// Walk `root` up to `max_depth` directories deep, collecting every
-/// workspace that has a sibling `target/` directory. Hidden dirs
-/// (leading `.`) are skipped to avoid descending into `.git/` and
-/// similar VCS roots. Symlinks are not followed.
+/// workspace that has a sibling `target/` directory. VCS metadata
+/// (`.git/`, `.hg/`, `.svn/`, `.jj/`) and `node_modules/` are pruned;
+/// other dot-prefixed dirs (notably `.claude/worktrees/` where clud's
+/// `/clud-pr` skill puts feature-branch workspaces) are descended into
+/// because they routinely contain real Rust build artifacts that
+/// `soldr gc target --purge` should be able to reclaim. Symlinks are
+/// not followed.
+///
+/// Issue #680: the previous `skip_hidden(true)` filter was too
+/// coarse — it conflated "VCS metadata" (skip) with "tool sandboxes
+/// that happen to be dot-prefixed" (don't skip). On the reporter's box
+/// that flipped 9.1 GB of reclaimable space invisible to `gc target`.
 pub(crate) fn walk(root: &Path, max_depth: usize) -> Vec<TargetEntry> {
     if !root.is_dir() {
         return Vec::new();
@@ -42,18 +51,30 @@ pub(crate) fn walk(root: &Path, max_depth: usize) -> Vec<TargetEntry> {
     let walker = WalkDir::new(root)
         .follow_links(false)
         .max_depth(max_depth)
-        .skip_hidden(true)
+        .skip_hidden(false)
         .process_read_dir(|_depth, _path, _state, children| {
             // Why: never descend into a `target/` we're about to report
             // on — saves a huge amount of recursive stat work on big
             // workspaces and avoids surfacing nested workspace target
             // dirs as their own entries.
+            //
+            // Why the explicit deny-list instead of `skip_hidden(true)`:
+            // see #680. We still want to skip VCS metadata roots and
+            // `node_modules` (gigantic, never holds Rust `target/`), but
+            // dot-prefixed tool sandboxes like `.claude/worktrees/` DO
+            // hold real Rust workspaces and must be walked.
             children.retain(|entry_result| {
                 let Ok(entry) = entry_result else {
                     return true;
                 };
                 let name = entry.file_name().to_string_lossy().to_string();
-                name != "target"
+                if name == "target" {
+                    return false;
+                }
+                !matches!(
+                    name.as_str(),
+                    ".git" | ".hg" | ".svn" | ".jj" | "node_modules"
+                )
             });
         });
 
@@ -148,15 +169,51 @@ mod tests {
         assert!(large_entry.file_count >= 1);
     });
 
-    timed_test!(walk_skips_hidden_directories, {
+    timed_test!(walk_descends_into_dot_claude_worktrees, {
+        // Issue #680: clud's `/clud-pr` skill stores every PR's
+        // feature-branch worktree under `.claude/worktrees/<branch>/`
+        // and builds Rust there. The walker MUST descend into
+        // `.claude/` so those targets are reclaimable.
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path();
-        let _shown = seed_workspace(root, "visible", 1024);
-        let _hidden = seed_workspace(root, ".cache", 1024);
+        let worktree_parent = root
+            .join(".claude")
+            .join("worktrees")
+            .join("feat-some-branch");
+        std::fs::create_dir_all(&worktree_parent).expect("create worktree parent");
+        let workspace = seed_workspace(&worktree_parent, "ws", 4096);
 
-        let entries = walk(root, 4);
-        assert_eq!(entries.len(), 1);
-        assert!(entries[0].workspace_root.ends_with("visible"));
+        let entries = walk(root, 8);
+        let paths: Vec<&Path> = entries.iter().map(|e| e.workspace_root.as_path()).collect();
+        assert!(
+            paths.contains(&workspace.as_path()),
+            "expected `.claude/worktrees/...` target to be discovered; got {paths:?}",
+        );
+    });
+
+    timed_test!(walk_still_skips_vcs_metadata_dirs, {
+        // Issue #680: the relaxed hidden-dir filter must NOT cause
+        // VCS metadata roots (`.git/`, `.hg/`, `.svn/`, `.jj/`) or
+        // `node_modules/` to be walked. Cargo-shaped layouts can show
+        // up inside `.git/modules/<sub>/` (git submodules), inside
+        // checked-in fixtures, etc. — none of those are user-managed
+        // build artifacts and must stay invisible to `gc target`.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        for vcs in [".git", ".hg", ".svn", ".jj", "node_modules"] {
+            let _seeded = seed_workspace(&root.join(vcs), "ws", 2048);
+        }
+        // And one positive-control workspace so we know walking happened.
+        let real = seed_workspace(root, "real-project", 1024);
+
+        let entries = walk(root, 8);
+        let paths: Vec<&Path> = entries.iter().map(|e| e.workspace_root.as_path()).collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected only the real workspace; got {paths:?}",
+        );
+        assert!(paths.contains(&real.as_path()));
     });
 
     timed_test!(walk_does_not_recurse_into_target_dirs, {


### PR DESCRIPTION
## Summary

`soldr gc target` missed real Rust `target/` directories that live inside `.claude/worktrees/<branch>/` — exactly where clud's `/clud-pr` skill puts feature-branch workspaces. On the reporter's box (#680) this silently hid **9.1 GB** of reclaimable space even with the disk at 100%.

Two independent causes in `crates/soldr-cli/src/gc/target_walker.rs` + `cli_args.rs`, both addressed here.

Closes #680.

## Root causes and fixes

### (a) `max_depth` default was 4

Worktree-style targets live at depth 6:

```
~/dev/<repo>/.claude/worktrees/<branch>/target
└─1─┘└─2─┘  └──3──┘ └────4───┘ └───5───┘ └─6─┘
```

Workspace members routinely sit one or two levels deeper. **Bumped default to 8.** `jwalk`'s scan time is roughly linear in depth, so a typical `~/dev` adds <1s.

### (b) `skip_hidden(true)` dropped `.claude/`

`skip_hidden(true)` was too coarse — it conflated:
- **VCS metadata roots** (`.git/`, `.hg/`, `.svn/`, `.jj/`) — correctly pruned.
- **Tool sandboxes that happen to be dot-prefixed** (`.claude/worktrees/`) — incorrectly pruned.

Replaced with an explicit deny-list. Dot-prefixed dirs are now walked by default; only `.git`, `.hg`, `.svn`, `.jj`, and `node_modules` are pruned (in addition to the existing `target/` short-circuit).

## Test plan

- [x] `cargo test --bin soldr -p soldr-cli` — **728 passed, 0 failed, 1 ignored** (729 total; 2 new tests, 1 obsolete test replaced)
- [x] `cargo test --bin soldr -p soldr-cli -- gc::target_walker::tests` — 7 passed (5 existing + 2 new)
- [x] `cargo test --test cli_gc_target` — 3 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

New tests in `gc::target_walker::tests`:

- `walk_descends_into_dot_claude_worktrees` — seeds `.claude/worktrees/feat-some-branch/ws/target/` under a tempdir and asserts `walk(root, 8)` finds it. This is the bug from the issue body.
- `walk_still_skips_vcs_metadata_dirs` — seeds `.git/`, `.hg/`, `.svn/`, `.jj/`, and `node_modules/` each holding a cargo-shaped workspace, plus one positive-control workspace. Asserts only the positive control surfaces.

Removed test:
- `walk_skips_hidden_directories` — asserted that `.cache/` was pruned (the old overly-coarse behavior). Replaced by the two above which pin the new fine-grained semantics.

## Out of scope

- #681 (sibling-`Cargo.toml` requirement) is a separate walker bug with an independent fix. Filing as the next loop iteration.
- Changing the `target/` short-circuit in `process_read_dir` (unchanged).
- Adding a `--include-hidden`/`--deny-list` CLI knob — current behavior is now sensible by default; a knob would be premature.
