### PR TITLE
test: scrub parent-cache env vars in integration test fixtures (Linux/macOS half of #692)

### DIFF
--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -29,7 +29,20 @@ pub(crate) fn scrub_outer_soldr_env(command: &mut Command) -> &mut Command {
         .env_remove("SOLDR_LINKER")
         .env_remove("CARGO_BUILD_TARGET")
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
-        .env_remove("RUSTFLAGS");
+        .env_remove("RUSTFLAGS")
+        // #692: parent-cache-sharing env vars leak from the setup-soldr
+        // action's exported environment ("Parent-cache sharing is
+        // default-on" per CLAUDE.md). They make the test fixture's
+        // child soldr take the "user already set ZCCACHE_PATH_REMAP"
+        // branch and skip the `--private-env` injection that the
+        // contract-matrix test asserts on, breaking
+        // `cli_zccache_contract_matrix` on every Linux/macOS CI run.
+        // Scrub them so soldr always exercises its own injection path
+        // under tests, regardless of the parent process's parent-cache
+        // configuration.
+        .env_remove("ZCCACHE_PATH_REMAP")
+        .env_remove("ZCCACHE_WORKTREE_ROOT")
+        .env_remove("SOLDR_PATH_REMAP");
     for (name, _) in std::env::vars_os() {
         if name
             .to_str()


### PR DESCRIPTION
Refs #692. Fixes the Linux x64 + macOS x64 jobs of the `ci.yml` workflow. The Windows test-hang half is addressed separately.

## Root cause

The \`cli_zccache_contract_matrix\` integration test asserts that the session-start args include \`--private-env ZCCACHE_PATH_REMAP=auto\` and \`--private-env ZCCACHE_WORKTREE_ROOT=…\`. When the test fixture's child soldr inherits a \`ZCCACHE_PATH_REMAP\` already set in the parent environment, soldr's path-remap resolver takes the \"user-already-set, don't overwrite\" branch (Rule 1 in \`resolve_path_remap_env\`) and skips the injection — so the \`--private-env\` flags are never emitted and the assertion fails at \`cli_zccache_contract_matrix.rs:197\`.

The \`setup-soldr\` action exports \`ZCCACHE_PATH_REMAP=auto\` as part of its parent-cache-sharing default-on rollout (CLAUDE.md \"Parent-cache sharing is default-on\"). On every push to main, the Linux x64 and macOS x64 test jobs land in this polluted-env case. Hence the 8+ consecutive ci.yml failures on main.

## Reproduction

Before this PR:
\`\`\`bash
ZCCACHE_PATH_REMAP=auto ZCCACHE_WORKTREE_ROOT=/tmp/foo SOLDR_PATH_REMAP=auto \
  cargo test --test cli_zccache_contract_matrix
# fails at line 197
\`\`\`

After this PR: passes.

## Fix

Extend \`scrub_outer_soldr_env\` in \`crates/soldr-cli/tests/common/mod.rs\` to also remove \`ZCCACHE_PATH_REMAP\`, \`ZCCACHE_WORKTREE_ROOT\`, and \`SOLDR_PATH_REMAP\`. The contract-matrix and similar integration tests now always exercise soldr's own injection path regardless of the runner's parent-cache configuration.

## Test plan

- [x] \`cargo test --test cli_zccache_contract_matrix\` — 2 passed
- [x] \`cargo test --test cli_cargo_basic\` — 11 passed
- [x] \`cargo test --test cli_dispatch\` — 3 passed
- [x] Polluted-env reproduction: \`ZCCACHE_PATH_REMAP=auto ZCCACHE_WORKTREE_ROOT=/tmp/foo SOLDR_PATH_REMAP=auto cargo test --test cli_zccache_contract_matrix\` — 2 passed (previously failed at line 197)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean

## Out of scope

The Windows half of #692 (\`cli_cargo_native_cc\` hang → STATUS_STACK_BUFFER_OVERRUN) is a different failure mode (test-binary teardown vs. test-body assertion) and warrants its own focused PR.