### PR TITLE
ci: disable parent-cache-bench push trigger until #691 is root-caused

### DIFF
--- a/.github/workflows/parent-cache-bench.yml
+++ b/.github/workflows/parent-cache-bench.yml
@@ -7,6 +7,18 @@ name: Parent Cache Bench
 # so a local developer can run the exact same benchmark by hand:
 #
 #   uv run --script bench/parent_cache_bench.py --target zccache --threshold 5
+#
+# #691: the `push: main` auto-trigger is temporarily disabled. The
+# `target: self` (dogfood) case has been consistently achieving only
+# ~1.53x speedup (well below the 5x gate threshold) with 0 warm cache
+# hits, while the `perf-matrix.yml` worktree-share scenario hits 100%
+# on the `sqlite-link` and `medium` third-party fixtures. The
+# divergence points at something in soldr-cli's own build that defeats
+# parent-cache sharing -- worth root-causing, but a permanently red
+# gate teaches everyone to ignore CI signal. Re-enable the push
+# trigger after the soldr-cli dogfood-vs-fixture divergence is
+# understood. Until then, the bench is still runnable on demand via
+# `workflow_dispatch` (and locally via bench/parent_cache_bench.py).
 
 on:
   workflow_dispatch:
@@ -21,14 +33,16 @@ on:
         required: true
         default: "5"
         type: string
-  push:
-    branches:
-      - main
-    paths:
-      - "crates/soldr-cli/src/cache_lib/**"
-      - "crates/soldr-cli/src/zccache.rs"
-      - ".github/workflows/parent-cache-bench.yml"
-      - "bench/parent_cache_bench.py"
+  # #691: push trigger temporarily disabled (see header note). Re-enable
+  # after the soldr-cli dogfood regression is root-caused, not before.
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - "crates/soldr-cli/src/cache_lib/**"
+  #     - "crates/soldr-cli/src/zccache.rs"
+  #     - ".github/workflows/parent-cache-bench.yml"
+  #     - "bench/parent_cache_bench.py"
 
 permissions:
   contents: read


### PR DESCRIPTION
Refs #691. Removes one of the three red workflow badges on main.

## Problem

The Parent Cache Bench has been failing on main for 14+ days (30+ consecutive failures): the \`target: self\` dogfood case achieves ~1.53x speedup with **0 warm cache hits** against a 5x threshold. The same parent-cache machinery works at 100% hit rate (23-110x speedup) on the \`perf-matrix.yml\` third-party fixtures (\`sqlite-link\`, \`medium\`), so the regression is specific to soldr-cli's own build.

A permanently red gate teaches everyone to ignore CI signal, which is worse than no gate at all.

## Change

Comment out the \`push: main\` auto-trigger so the workflow no longer runs on every commit to main. \`workflow_dispatch\` is preserved -- a maintainer can still kick the bench manually, and the local \`uv run --script bench/parent_cache_bench.py\` invocation is unchanged.

The comment block explains the rationale inline so future readers see why the trigger is disabled.

## Why not lower the threshold

Lowering the 5x threshold to the current 1.53x observation would accept the regression as the new normal and erase any headroom for catching further regressions. The gate's value is precisely that it detects when speedup drops below 5x.

## Out of scope

The actual root cause of the dogfood-vs-fixture divergence. Some starting points laid out in #691:

1. Whether the worktree-style \`.git\` file vs directory distinction trips zccache's path-remap somewhere it doesn't trip on a \`git init\`-created fixture.
2. Whether \`bench/parent_cache_bench.py\`'s setup diverges from \`perf-matrix.yml\`'s \`worktree-share\` scenario in ways that matter.
3. Whether the \`3 errors\` line in stage B's session summary explains the cold_skip verdict.