### PR TITLE
test(cli_wrapper): pick MSVC triple based on host arch (Windows ARM64 cell of #692)

### DIFF
--- a/crates/soldr-cli/tests/cli_wrapper.rs
+++ b/crates/soldr-cli/tests/cli_wrapper.rs
@@ -89,8 +89,19 @@ fn cargo_front_door_forces_msvc_target_even_with_polluted_path() {
         String::from_utf8_lossy(&output.stderr)
     );
 
+    // #692: the MSVC target soldr forces is host-arch-dependent
+    // (CLAUDE.md: "Default to `x86_64-pc-windows-msvc` (or aarch64)").
+    // On a Windows ARM64 runner soldr correctly picks
+    // `aarch64-pc-windows-msvc`, so we have to look in the matching
+    // sub-directory under target/. Hardcoding `x86_64-pc-windows-msvc`
+    // broke ci.yml on the Windows ARM64 job.
+    let host_msvc_triple = if cfg!(target_arch = "aarch64") {
+        "aarch64-pc-windows-msvc"
+    } else {
+        "x86_64-pc-windows-msvc"
+    };
     let artifact = target_dir
-        .join("x86_64-pc-windows-msvc")
+        .join(host_msvc_triple)
         .join("debug")
         .join("windows-msvc-default.exe");
     assert!(


### PR DESCRIPTION
Refs #692. Last remaining red cell.

## Failure

After PRs #695 / #696 / #698 cleared the other ci.yml jobs, the Windows ARM64 job still failed:

```
test cargo_front_door_forces_msvc_target_even_with_polluted_path ... FAILED
thread '...' panicked at crates\soldr-cli\tests\cli_wrapper.rs:96:5:
expected MSVC target artifact at .../target/x86_64-pc-windows-msvc/debug/windows-msvc-default.exe
```

## Root cause

The test was written assuming "Windows" implicitly meant x86_64. CLAUDE.md's design rule says: "Default to `x86_64-pc-windows-msvc` (or aarch64)" -- so on a Windows ARM64 runner, soldr correctly picks `aarch64-pc-windows-msvc`, but the test was looking for the x86_64 artifact subdirectory.

## Fix

Match the soldr CLI's host-arch behavior in the test: `cfg!(target_arch = "aarch64")` → `aarch64-pc-windows-msvc`, else `x86_64-pc-windows-msvc`.

## Test plan

- [x] `cargo test --test cli_wrapper` — 3 passed (locally on Windows x64; the new code path triggers on aarch64 runners)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean