### PR TITLE
test(fetch_crgx): skip on Windows ARM64 (no upstream asset, last cell of #692)

### DIFF
--- a/crates/soldr-cli/tests/fetch_crgx.rs
+++ b/crates/soldr-cli/tests/fetch_crgx.rs
@@ -13,6 +13,19 @@ use soldr_cli::fetch::{fetch_tool, VersionSpec};
 async fn fetch_crgx_and_run() {
     const CRGX_VERSION: &str = "0.1.0";
 
+    // #692: upstream crgx 0.1.0 publishes Linux x64/aarch64/musl,
+    // macOS x64/aarch64, and Windows x64 assets -- but NOT a Windows
+    // ARM64 (aarch64-pc-windows-msvc) asset. The failing run logs the
+    // full asset list. Skip on Windows ARM64 until upstream ships one;
+    // the rest of the matrix still exercises the fetch chain.
+    if cfg!(all(target_os = "windows", target_arch = "aarch64")) {
+        eprintln!(
+            "skipping fetch_crgx_and_run on aarch64-pc-windows-msvc: \
+             upstream crgx {CRGX_VERSION} has no Windows ARM64 asset (see #692)"
+        );
+        return;
+    }
+
     // Fetch a pinned crgx release for the current platform.
     let result = fetch_tool("crgx", &VersionSpec::Exact(CRGX_VERSION.into()))
         .await


### PR DESCRIPTION
Refs #692. Last red cell I can find.

## Failure

```
test fetch_crgx_and_run ... FAILED
thread 'fetch_crgx_and_run' panicked at fetch_crgx.rs:19:10:
failed to fetch crgx: UnsupportedPlatform("asset matching failed for yfedoseev/crgx version 0.1.0 target aarch64-pc-windows-msvc:
  asset matching failed: no asset matches target aarch64-pc-windows-msvc;
  available assets:
    crgx-linux-aarch64-0.1.0.tar.gz, crgx-linux-x86_64-0.1.0.tar.gz, crgx-linux-x86_64-musl-0.1.0.tar.gz,
    crgx-macos-aarch64-0.1.0.tar.gz, crgx-macos-x86_64-0.1.0.tar.gz,
    crgx-windows-x86_64-0.1.0.zip")
```

Upstream legitimately doesn't ship Windows aarch64 yet.

## Fix

Skip the test on Windows ARM64 via `cfg!(all(target_os = "windows", target_arch = "aarch64"))`. Restore when upstream publishes the asset.

## Test plan

- [x] `cargo test --test fetch_crgx` — 1 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean