### PR TITLE
chore(release): bump 0.7.52 → 0.7.53 + managed zccache 1.11.14 → 1.11.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.52"
+version = "0.7.53"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.52"
+version = "0.7.53"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -18,7 +18,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.11.14",
+    "managed_version": "1.11.18",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.14";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.18";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -1042,13 +1042,13 @@ mod tests {
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.11.14/zccache"),
+                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.11.18/zccache"),
                 std::path::Path::new("/tmp/cache-cold/cache/zccache"),
             ),
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.11.14/zccache"),
+                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.11.18/zccache"),
                 std::path::Path::new("/tmp/cache-warm/cache/zccache"),
             ),
             "managed zccache binaries under different SOLDR_CACHE_DIR roots must hash by runtime identity, not absolute path",

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.11.14");
+    assert_eq!(json["managed_zccache_version"], "1.11.18");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.11.14");
+    assert_eq!(json["managed_zccache_version"], "1.11.18");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.11.14");
+    assert_eq!(json["managed_zccache_version"], "1.11.18");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.11.14");
+    assert_eq!(status_json["managed_version"], "1.11.18");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.11.14");
+    assert_eq!(json["managed_version"], "1.11.18");
 }
 
 #[test]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.52",
+  "version": "0.7.53",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Triggers an Autonomous Release of soldr 0.7.53. Includes the 4 zccache patches landed since 1.11.14:

- **1.11.15**: NormalizedPath Arc-interning (perf #663); daemon PendingCacheWrite registry scaffolding (#664) and cold-miss persist wiring (#665); cold/warm grouped bar charts on benchmark-stats (#668); **daemon pipe-pool depletion + compile-path wedge recovery (#669)** — this one may also unblock the Windows daemon-stdio-detach hang we worked around in #696 / #701.
- **1.11.16**: adaptive daemon-spawn wait keyed on lockfile PID (#674).
- **1.11.17**: surface `ZCCACHE_PATH_REMAP` in `zccache --help` (#676).
- **1.11.18**: drop misleading "protocol version mismatch" hint from the lost-connection message (#678).

## Files

- `crates/soldr-cli/src/fetch/mod.rs`: `MANAGED_ZCCACHE_VERSION` 1.11.14 → 1.11.18
- `contracts/zccache-runtime.v1.json`: `zccache.managed_version` kept in lockstep (otherwise `zccache_runtime_contract_matches_rust_constants` would trip)
- `crates/soldr-cli/src/zccache.rs`: cosmetic — two test-fixture paths used the literal "1.11.14"; bumped to match
- `Cargo.toml`: workspace version 0.7.52 → 0.7.53 (already published; bump fires release workflow)
- `package.json`: matching version bump
- `Cargo.lock`: regenerated

## Test plan

- [x] `cargo test --bin soldr -p soldr-cli` — 732 passed, 0 failed, 2 ignored
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Release verification

- [x] Cargo.toml = 0.7.53 (not yet on PyPI/npm/git tags)
- [x] package.json = 0.7.53 (matched)
- [x] PyPI `soldr` latest = 0.7.52 (0.7.53 unpublished)
- [x] npm `@zackees/soldr` latest = 0.7.52 (0.7.53 unpublished)
- [x] git tags include v0.7.52 but not v0.7.53 (clean for the release workflow to mint it)