### PR TITLE
test(fetch): directive panic messages for contract-drift assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,16 @@ Anything not registered falls through the generic External subcommand, which res
 - uv for Python dependency management
 - Workspace dependencies shared in root `Cargo.toml`
 
+## Bumping managed_zccache_version
+
+When pulling in a new managed zccache release, **three files must be updated in lockstep** or `zccache_runtime_contract_matches_rust_constants` (or a `./test` run) will fail:
+
+1. `crates/soldr-cli/src/fetch/mod.rs` — bump `MANAGED_ZCCACHE_VERSION`.
+2. `contracts/zccache-runtime.v1.json` — bump `zccache.managed_version` to the same value.
+3. `crates/soldr-cli/src/zccache.rs` — bump the two cosmetic test-fixture paths that embed the version (won't break the contract test, but drifts if not updated).
+
+If you bump only #1, the contract test now panics with a directive message naming both files. Same procedure applies for `MANAGED_CRGX_VERSION` and `CARGO_CHEF_PINNED_VERSION` — see the matching `crgx.managed_version` / `cargo_chef.managed_version` entries in the contract.
+
 ## Reference Docs
 
 - **`PERF.md` — Performance testing. Read this BEFORE running any perf work. See callout at the top of this file.**

--- a/crates/soldr-cli/src/fetch/zccache_contract_tests.rs
+++ b/crates/soldr-cli/src/fetch/zccache_contract_tests.rs
@@ -4,6 +4,12 @@ use super::{
     ZCCACHE_LOCAL_DIR_ENV_VAR,
 };
 
+// When this test fails, the contributor most likely bumped only one
+// side — the panic message names BOTH files so the fix-on-the-spot is
+// obvious. See #703.
+const DRIFT_HINT: &str =
+    "Bump both in lockstep. See \"Bumping managed_zccache_version\" in CLAUDE.md.";
+
 crate::timed_test!(zccache_runtime_contract_matches_rust_constants, {
     let contract: serde_json::Value = serde_json::from_str(include_str!(
         "../../../../contracts/zccache-runtime.v1.json"
@@ -12,27 +18,51 @@ crate::timed_test!(zccache_runtime_contract_matches_rust_constants, {
 
     assert_eq!(
         contract["zccache"]["managed_version"].as_str(),
-        Some(MANAGED_ZCCACHE_VERSION)
+        Some(MANAGED_ZCCACHE_VERSION),
+        "zccache.managed_version drift: contracts/zccache-runtime.v1.json says {:?} \
+         but MANAGED_ZCCACHE_VERSION in crates/soldr-cli/src/fetch/mod.rs says {:?}. {DRIFT_HINT}",
+        contract["zccache"]["managed_version"].as_str(),
+        MANAGED_ZCCACHE_VERSION,
     );
     assert_eq!(
         contract["zccache"]["local_dir_env"].as_str(),
-        Some(ZCCACHE_LOCAL_DIR_ENV_VAR)
+        Some(ZCCACHE_LOCAL_DIR_ENV_VAR),
+        "zccache.local_dir_env drift: contracts/zccache-runtime.v1.json says {:?} \
+         but ZCCACHE_LOCAL_DIR_ENV_VAR in crates/soldr-cli/src/fetch/mod.rs says {:?}. {DRIFT_HINT}",
+        contract["zccache"]["local_dir_env"].as_str(),
+        ZCCACHE_LOCAL_DIR_ENV_VAR,
     );
     assert_eq!(
         contract["crgx"]["managed_version"].as_str(),
-        Some(MANAGED_CRGX_VERSION)
+        Some(MANAGED_CRGX_VERSION),
+        "crgx.managed_version drift: contracts/zccache-runtime.v1.json says {:?} \
+         but MANAGED_CRGX_VERSION in crates/soldr-cli/src/fetch/mod.rs says {:?}. {DRIFT_HINT}",
+        contract["crgx"]["managed_version"].as_str(),
+        MANAGED_CRGX_VERSION,
     );
     assert_eq!(
         contract["crgx"]["local_dir_env"].as_str(),
-        Some(CRGX_LOCAL_DIR_ENV_VAR)
+        Some(CRGX_LOCAL_DIR_ENV_VAR),
+        "crgx.local_dir_env drift: contracts/zccache-runtime.v1.json says {:?} \
+         but CRGX_LOCAL_DIR_ENV_VAR in crates/soldr-cli/src/fetch/mod.rs says {:?}. {DRIFT_HINT}",
+        contract["crgx"]["local_dir_env"].as_str(),
+        CRGX_LOCAL_DIR_ENV_VAR,
     );
     assert_eq!(
         contract["cargo_chef"]["managed_version"].as_str(),
-        Some(CARGO_CHEF_PINNED_VERSION)
+        Some(CARGO_CHEF_PINNED_VERSION),
+        "cargo_chef.managed_version drift: contracts/zccache-runtime.v1.json says {:?} \
+         but CARGO_CHEF_PINNED_VERSION in crates/soldr-cli/src/fetch/mod.rs says {:?}. {DRIFT_HINT}",
+        contract["cargo_chef"]["managed_version"].as_str(),
+        CARGO_CHEF_PINNED_VERSION,
     );
     assert_eq!(
         contract["cargo_chef"]["local_dir_env"].as_str(),
-        Some(CARGO_CHEF_LOCAL_DIR_ENV_VAR)
+        Some(CARGO_CHEF_LOCAL_DIR_ENV_VAR),
+        "cargo_chef.local_dir_env drift: contracts/zccache-runtime.v1.json says {:?} \
+         but CARGO_CHEF_LOCAL_DIR_ENV_VAR in crates/soldr-cli/src/fetch/mod.rs says {:?}. {DRIFT_HINT}",
+        contract["cargo_chef"]["local_dir_env"].as_str(),
+        CARGO_CHEF_LOCAL_DIR_ENV_VAR,
     );
 
     let contract_zccache_bins: Vec<&str> = contract["zccache"]["required_binaries"]
@@ -45,7 +75,12 @@ crate::timed_test!(zccache_runtime_contract_matches_rust_constants, {
         .iter()
         .map(|(_, binary)| *binary)
         .collect();
-    assert_eq!(contract_zccache_bins, rust_zccache_bins);
+    assert_eq!(
+        contract_zccache_bins, rust_zccache_bins,
+        "zccache.required_binaries drift: contracts/zccache-runtime.v1.json says {contract_zccache_bins:?} \
+         but MANAGED_ZCCACHE_PACKAGES in crates/soldr-cli/src/fetch/mod.rs yields {rust_zccache_bins:?}. \
+         {DRIFT_HINT}",
+    );
 
     let release_bins: Vec<&str> = contract["release_archive"]["required_binaries"]
         .as_array()
@@ -53,15 +88,19 @@ crate::timed_test!(zccache_runtime_contract_matches_rust_constants, {
         .iter()
         .map(|value| value.as_str().expect("binary name should be a string"))
         .collect();
+    let expected_release_bins = vec![
+        "soldr",
+        "zccache",
+        "zccache-daemon",
+        "zccache-fp",
+        "crgx",
+        "cargo-chef",
+    ];
     assert_eq!(
-        release_bins,
-        vec![
-            "soldr",
-            "zccache",
-            "zccache-daemon",
-            "zccache-fp",
-            "crgx",
-            "cargo-chef"
-        ]
+        release_bins, expected_release_bins,
+        "release_archive.required_binaries drift: contracts/zccache-runtime.v1.json says \
+         {release_bins:?} but the hard-coded expectation in this test says \
+         {expected_release_bins:?}. Update both in lockstep when adding or removing a \
+         packaged binary.",
     );
 });


### PR DESCRIPTION
## Summary

Bare `assert_eq!`s in `zccache_contract_tests.rs` told contributors *that* the runtime contract drifted but not *where* the two sides live. When bumping `MANAGED_ZCCACHE_VERSION` in PR #702, that meant a 5-minute debug session to find `contracts/zccache-runtime.v1.json`.

Each assertion now panics with a directive message naming both file paths and the drifted values, plus a pointer to a new \"Bumping managed_zccache_version\" section in `CLAUDE.md` that lists every file (`mod.rs` constant, contract JSON, and the two cosmetic fixture paths in `zccache.rs`) that must be updated in lockstep. Same treatment applied to the `crgx` and `cargo_chef` assertions for consistency.

## Example new error

```
zccache.managed_version drift: contracts/zccache-runtime.v1.json says Some(\"1.11.18\") \
but MANAGED_ZCCACHE_VERSION in crates/soldr-cli/src/fetch/mod.rs says \"9.9.9-drift-smoke-test\". \
Bump both in lockstep. See \"Bumping managed_zccache_version\" in CLAUDE.md.
```

## Test plan

- [x] Smoke-tested by deliberately drifting `MANAGED_ZCCACHE_VERSION` to a sentinel and confirming the new panic message names both files (reverted before commit).
- [x] `soldr cargo test --bin soldr -p soldr-cli zccache_runtime_contract_matches_rust_constants` — passes
- [x] `soldr cargo test --bin soldr -p soldr-cli` — 732 passed, 0 failed
- [x] `soldr cargo clippy -p soldr-cli --bin soldr --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all -- --check` — clean

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)