### PR TITLE
chore: bump managed zccache 1.11.18 -> 1.11.20

### DIFF
--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -18,7 +18,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.11.18",
+    "managed_version": "1.11.20",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.18";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.11.20";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -1140,13 +1140,13 @@ mod tests {
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.11.18/zccache"),
+                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.11.20/zccache"),
                 std::path::Path::new("/tmp/cache-cold/cache/zccache"),
             ),
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.11.18/zccache"),
+                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.11.20/zccache"),
                 std::path::Path::new("/tmp/cache-warm/cache/zccache"),
             ),
             "managed zccache binaries under different SOLDR_CACHE_DIR roots must hash by runtime identity, not absolute path",

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -78,7 +78,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.11.18");
+    assert_eq!(json["managed_zccache_version"], "1.11.20");
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +235,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.11.18");
+    assert_eq!(json["managed_zccache_version"], "1.11.20");
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +287,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.11.18");
+    assert_eq!(json["managed_zccache_version"], "1.11.20");
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -135,7 +135,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.11.18");
+    assert_eq!(status_json["managed_version"], "1.11.20");
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +186,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.11.18");
+    assert_eq!(json["managed_version"], "1.11.20");
 }
 
 #[test]


### PR DESCRIPTION
Lift soldr's managed zccache pin to pick up the two new patch releases.

## What's in 1.11.19 + 1.11.20

- **1.11.19** — #678 (CLI lost-connection message cleanup), #679 (docs for cached-stderr cross-worktree leak, closes zackees/zccache#672), **#681 (depgraph eviction fix, closes zackees/zccache#680)**, #686 (`ZCCACHE_DIAG_CWD` diagnostic, closes zackees/zccache#683), #670 (application-layer back-pressure groundwork).
- **1.11.20** — #684 (auto-generated zccache vs sccache feature comparison matrix, closes zackees/zccache#682).

The headline fix is **zackees/zccache#681**: depgraph contexts pointing at disk-evicted artifacts no longer surface as wasted `Hit` followed by `artifact_not_found` and a forced recompile. On the **soldr-cli dogfood reproducer** in zackees/soldr#704, the real hit rate jumps from 15.7 % back to ~99 % — exactly the regression filed as zackees/zccache#680.

## Touched files

| File | What changed |
|---|---|
| `contracts/zccache-runtime.v1.json` | `managed_version` field |
| `crates/soldr-cli/src/fetch/mod.rs` | `MANAGED_ZCCACHE_VERSION` const |
| `crates/soldr-cli/src/zccache.rs` | two test path strings (`zccache-1.11.18` → `zccache-1.11.20`) |
| `crates/soldr-cli/tests/cli_cache.rs` | three managed-version assertions |
| `crates/soldr-cli/tests/cli_install_zccache.rs` | two managed-version assertions |

## Verification

- `soldr cargo check -p soldr-cli` green against the bumped manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)