### PR TITLE
feat(gc): wire sweep_trash into auto-GC throttle window (#710 follow-up)

### DIFF
--- a/crates/soldr-cli/src/cache/mod.rs
+++ b/crates/soldr-cli/src/cache/mod.rs
@@ -24,7 +24,7 @@ pub(super) use crate::zccache_lifecycle::{
 };
 pub(crate) use install::run_install_zccache;
 pub(crate) use release_worktree::{
-    run_cache_release_worktree_command, run_cache_sweep_trash_command,
+    run_cache_release_worktree_command, run_cache_sweep_trash_command, sweep_trash, SweepReport,
 };
 pub(crate) use report::run_cache_report_command;
 pub(crate) use session::{

--- a/crates/soldr-cli/src/gc/auto.rs
+++ b/crates/soldr-cli/src/gc/auto.rs
@@ -146,6 +146,23 @@ fn run_auto_gc_background(paths_root: std::path::PathBuf, log_path: std::path::P
         }
     }
 
+    // `release-worktree` trash sweep (#710 follow-up). Runs every
+    // throttle window so the per-volume `~/.soldr/trash-*/` buckets
+    // get reclaimed without requiring the user to call
+    // `soldr cache sweep-trash` manually. Tolerates per-entry failures
+    // (Windows daemon may still hold handles); retries next pass.
+    if let Ok(report) = crate::cache::sweep_trash(&paths) {
+        if report.removed > 0 || report.retained > 0 {
+            let _ = append_auto_gc_log_line(
+                &log_path,
+                &format!(
+                    "trash-sweep removed={} retained={}",
+                    report.removed, report.retained,
+                ),
+            );
+        }
+    }
+
     if !validated.enabled {
         // Disk-pressure tiers off, but cook-gc above may still have
         // run. Done.


### PR DESCRIPTION
## Summary

Closes the #710 follow-up I scoped out of #711: the per-volume trash buckets created by \`soldr cache release-worktree\` are now reclaimed automatically on every auto-GC throttle window (5-min throttle, same cadence as the \`[cook]\` eviction pass).

Users no longer have to call \`soldr cache sweep-trash\` by hand — it runs transparently from \`run_auto_gc_background\`. Tolerates per-entry failures: a daemon still holding handles into a trashed worktree just falls into \`retained=N\`, retries next throttle window, eventually reclaimed.

## Code shape

Adds one re-export from \`cache/mod.rs\` (\`sweep_trash\` + \`SweepReport\`) and a 12-line block in \`gc/auto.rs::run_auto_gc_background\`, sitting right after the cook-evict pass and following the exact same pattern (run unconditionally, log only when work happened).

```rust
if let Ok(report) = crate::cache::sweep_trash(&paths) {
    if report.removed > 0 || report.retained > 0 {
        let _ = append_auto_gc_log_line(
            &log_path,
            &format!(\"trash-sweep removed={} retained={}\", report.removed, report.retained),
        );
    }
}
```

## Test plan

- [x] \`soldr cargo test --bin soldr -p soldr-cli\` — 744 passed, 0 failed (no test count change; the underlying \`sweep_trash\` was already covered by 5 unit tests in #711)
- [x] \`soldr cargo clippy -p soldr-cli --bin soldr --all-targets -- -D warnings\` — clean
- [x] \`soldr cargo fmt --all -- --check\` — clean

## Why no new tests

\`sweep_trash\` itself has 5 unit tests (#711). The integration is 5 lines of plumbing wrapped in an \`if let Ok(...)\` that already short-circuits on errors. Adding an integration test would require spawning the background auto-GC thread or refactoring \`run_auto_gc_background\` to be unit-testable in pieces — out of proportion to the 17-line change.

Refs #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)