### PR TITLE
feat(cook): hydrate from ancestor branch artifacts

### DIFF
--- a/crates/soldr-cli/src/cache_lib/cook_index.rs
+++ b/crates/soldr-cli/src/cache_lib/cook_index.rs
@@ -70,6 +70,9 @@ pub struct CookEntry {
     /// Human-readable cook command summary stored for diagnostics
     /// (e.g. shown by `soldr cache stats`).
     pub cook_cmd_summary: String,
+    /// Best-effort local branch name recorded at cook time. Used only
+    /// to rank same-origin fallback hydration candidates.
+    pub branch_name: Option<String>,
 }
 
 fn prost_decode_err(e: prost::DecodeError) -> RegistryError {
@@ -187,6 +190,7 @@ fn cook_entry_to_wire(entry: &CookEntry) -> proto::WireCookEntry {
         last_used_unix_ms: entry.last_used_unix_ms,
         origin_url_normalized: entry.origin_url_normalized.clone(),
         cook_cmd_summary: entry.cook_cmd_summary.clone(),
+        branch_name: entry.branch_name.clone(),
     }
 }
 
@@ -203,6 +207,7 @@ fn cook_entry_from_wire(wire: proto::WireCookEntry) -> Result<CookEntry, WireDec
         last_used_unix_ms: wire.last_used_unix_ms,
         origin_url_normalized: wire.origin_url_normalized,
         cook_cmd_summary: wire.cook_cmd_summary,
+        branch_name: wire.branch_name,
     })
 }
 
@@ -265,6 +270,67 @@ pub fn lookup(db_path: &Path, key: &CookKey) -> Result<Option<CookEntry>, Regist
         return Ok(None);
     };
     Ok(Some(decode_entry(row.value())?))
+}
+
+/// Best-effort same-origin fallback used when the exact recipe hash
+/// misses. Returns the highest-ranked compatible row and the key it
+/// was stored under.
+pub fn lookup_origin_fallback(
+    db_path: &Path,
+    miss_key: &CookKey,
+    origin_url_normalized: Option<&str>,
+    branch_lineage: &[String],
+) -> Result<Option<(CookKey, CookEntry)>, RegistryError> {
+    let Some(origin) = origin_url_normalized else {
+        return Ok(None);
+    };
+    let db = open_db(db_path)?;
+    init_v2(&db)?;
+    let txn = db.begin_read()?;
+    let table = txn.open_table(COOK_INDEX_V2)?;
+    let mut best: Option<(usize, u64, CookKey, CookEntry)> = None;
+    for entry in table.iter()? {
+        let (k_bytes, v_bytes) = entry?;
+        let Ok(stored_key) = decode_key(k_bytes.value()) else {
+            continue;
+        };
+        if !key_matches_origin_matrix(&stored_key, miss_key) {
+            continue;
+        }
+        let Ok(stored_entry) = decode_entry(v_bytes.value()) else {
+            continue;
+        };
+        if stored_entry.origin_url_normalized.as_deref() != Some(origin) {
+            continue;
+        }
+        let Some(rank) = fallback_branch_rank(stored_entry.branch_name.as_deref(), branch_lineage)
+        else {
+            continue;
+        };
+        let used = stored_entry.last_used_unix_ms;
+        let replace = match &best {
+            None => true,
+            Some((best_rank, best_used, _, _)) => {
+                rank < *best_rank || (rank == *best_rank && used > *best_used)
+            }
+        };
+        if replace {
+            best = Some((rank, used, stored_key, stored_entry));
+        }
+    }
+    Ok(best.map(|(_, _, key, entry)| (key, entry)))
+}
+
+fn fallback_branch_rank(branch_name: Option<&str>, branch_lineage: &[String]) -> Option<usize> {
+    if branch_lineage.is_empty() {
+        return Some(0);
+    }
+    match branch_name {
+        Some(branch) => branch_lineage
+            .iter()
+            .position(|candidate| candidate == branch),
+        None => Some(usize::MAX),
+    }
 }
 
 /// Drift diagnostic: given a (missing) lookup key, scan v2 for other
@@ -452,6 +518,7 @@ mod tests {
             last_used_unix_ms: 1_700_000_000_000,
             origin_url_normalized: origin.map(str::to_owned),
             cook_cmd_summary: "cook --release".into(),
+            branch_name: None,
         }
     }
 
@@ -547,6 +614,88 @@ mod tests {
         miss.target_triple = "x86_64-unknown-linux-gnu".into();
         let drift = drift_recipe_hashes(&path, &miss, Some(origin), 10).expect("drift");
         assert!(drift.is_empty());
+    });
+
+    crate::timed_test!(
+        fallback_prefers_branch_lineage_before_newer_unrelated_branch,
+        {
+            let dir = TempDir::new().expect("tempdir");
+            let path = dir.path().join("state.redb");
+            let origin = "https://github.com/zackees/soldr";
+
+            let main_key = sample_key(60);
+            let other_key = sample_key(61);
+
+            let mut main_entry = sample_entry(0x60, 10, Some(origin));
+            main_entry.branch_name = Some("main".into());
+            main_entry.last_used_unix_ms = 100;
+            let mut other_entry = sample_entry(0x61, 20, Some(origin));
+            other_entry.branch_name = Some("other".into());
+            other_entry.last_used_unix_ms = 200;
+
+            upsert(&path, &main_key, &main_entry).expect("upsert main");
+            upsert(&path, &other_key, &other_entry).expect("upsert other");
+
+            let miss = sample_key(62);
+            let lineage = vec!["feature/cook".to_string(), "main".to_string()];
+            let (key, entry) = lookup_origin_fallback(&path, &miss, Some(origin), &lineage)
+                .expect("fallback")
+                .expect("hit");
+            assert_eq!(key.recipe_hash, [60u8; 32]);
+            assert_eq!(entry.sha256, [0x60; 32]);
+        }
+    );
+
+    crate::timed_test!(
+        fallback_keeps_legacy_unbranched_entries_when_lineage_is_known,
+        {
+            let dir = TempDir::new().expect("tempdir");
+            let path = dir.path().join("state.redb");
+            let origin = "https://github.com/zackees/soldr";
+
+            let old_key = sample_key(70);
+            let new_key = sample_key(71);
+            let mut old_entry = sample_entry(0x70, 10, Some(origin));
+            old_entry.last_used_unix_ms = 100;
+            let mut new_entry = sample_entry(0x71, 20, Some(origin));
+            new_entry.branch_name = Some("other".into());
+            new_entry.last_used_unix_ms = 200;
+
+            upsert(&path, &old_key, &old_entry).expect("upsert old");
+            upsert(&path, &new_key, &new_entry).expect("upsert new");
+
+            let miss = sample_key(72);
+            let lineage = vec!["feature/cook".to_string(), "main".to_string()];
+            let (key, entry) = lookup_origin_fallback(&path, &miss, Some(origin), &lineage)
+                .expect("fallback")
+                .expect("hit");
+            assert_eq!(key.recipe_hash, [70u8; 32]);
+            assert_eq!(entry.sha256, [0x70; 32]);
+        }
+    );
+
+    crate::timed_test!(fallback_uses_newest_same_origin_when_lineage_is_empty, {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("state.redb");
+        let origin = "https://github.com/zackees/soldr";
+
+        let old_key = sample_key(80);
+        let new_key = sample_key(81);
+        let mut old_entry = sample_entry(0x80, 10, Some(origin));
+        old_entry.last_used_unix_ms = 100;
+        let mut new_entry = sample_entry(0x81, 20, Some(origin));
+        new_entry.branch_name = Some("other".into());
+        new_entry.last_used_unix_ms = 200;
+
+        upsert(&path, &old_key, &old_entry).expect("upsert old");
+        upsert(&path, &new_key, &new_entry).expect("upsert new");
+
+        let miss = sample_key(82);
+        let (key, entry) = lookup_origin_fallback(&path, &miss, Some(origin), &[])
+            .expect("fallback")
+            .expect("hit");
+        assert_eq!(key.recipe_hash, [81u8; 32]);
+        assert_eq!(entry.sha256, [0x81; 32]);
     });
 
     crate::timed_test!(drift_returns_empty_without_origin_hint, {

--- a/crates/soldr-cli/src/cargo_front_door/cook_hydrate.rs
+++ b/crates/soldr-cli/src/cargo_front_door/cook_hydrate.rs
@@ -17,7 +17,7 @@ use crate::cache_lib::cook_archive::{
     self, compute_recipe_hash_proxy, extract_skip_existing, quarantine_artifact, sha_abbrev,
     verify_sha256,
 };
-use crate::core::git::origin_url;
+use crate::core::git::{branch_lineage, origin_url};
 use crate::core::{
     probe_toolchain_binary, read_rust_toolchain_manifest, CookConfig, SoldrConfig, SoldrPaths,
     TargetTriple,
@@ -65,7 +65,8 @@ fn try_hydrate(args: &[String], paths: &SoldrPaths) -> Option<()> {
     let origin = origin_url(&manifest_dir);
 
     let sock = client::default_sock_path(paths);
-    let outcome = client::cook_lookup(
+    let lineage = branch_lineage(&manifest_dir);
+    let outcome = client::cook_lookup_with_branch_lineage(
         &sock,
         recipe_hash,
         triple,
@@ -73,6 +74,7 @@ fn try_hydrate(args: &[String], paths: &SoldrPaths) -> Option<()> {
         channel,
         rustc_version,
         origin,
+        lineage,
     )
     .ok()?;
 
@@ -81,6 +83,9 @@ fn try_hydrate(args: &[String], paths: &SoldrPaths) -> Option<()> {
         path,
         size_bytes,
         origin_url_normalized,
+        matched_recipe_hash,
+        exact_recipe_match,
+        branch_name,
     } = outcome
     else {
         return None;
@@ -123,6 +128,9 @@ fn try_hydrate(args: &[String], paths: &SoldrPaths) -> Option<()> {
         &sha256,
         size_bytes,
         origin_url_normalized.as_deref(),
+        matched_recipe_hash.as_ref(),
+        exact_recipe_match,
+        branch_name.as_deref(),
         &report,
     );
     Some(())
@@ -132,12 +140,24 @@ fn emit_hydrate_line(
     sha256: &[u8; 32],
     size_bytes: u64,
     origin_hint: Option<&str>,
+    matched_recipe_hash: Option<&[u8; 32]>,
+    exact_recipe_match: bool,
+    branch_name: Option<&str>,
     report: &cook_archive::ExtractReport,
 ) {
     let mib = size_bytes as f64 / 1024.0 / 1024.0;
     let origin = origin_hint.unwrap_or("none");
+    let match_kind = if exact_recipe_match {
+        "exact"
+    } else {
+        "fallback"
+    };
+    let matched = matched_recipe_hash
+        .map(sha_abbrev)
+        .unwrap_or_else(|| "unknown".to_string());
+    let branch = branch_name.unwrap_or("unknown");
     eprintln!(
-        "{}  sha256={}  size={mib:.1} MiB  origin-hint={origin}  (files +{} ={})",
+        "{}  sha256={}  size={mib:.1} MiB  origin-hint={origin}  match={match_kind} recipe={matched} branch={branch}  (files +{} ={})",
         green_hydrate_prefix(),
         sha_abbrev(sha256),
         report.files_written,

--- a/crates/soldr-cli/src/cook.rs
+++ b/crates/soldr-cli/src/cook.rs
@@ -19,7 +19,8 @@ use crate::cache_lib::cook_archive::{self, cook_cache_dir, sha_abbrev, PackedCoo
 use crate::cache_lib::strip_target::{strip_target, StripTargetOptions};
 use crate::cargo_front_door;
 use crate::core::git::{
-    cargo_lock_is_gitignored, cargo_lock_is_tracked, find_git_worktree_root, origin_url,
+    cargo_lock_is_gitignored, cargo_lock_is_tracked, current_branch_name, find_git_worktree_root,
+    origin_url,
 };
 use crate::core::{
     probe_toolchain_binary, read_rust_toolchain_manifest, SoldrError, SoldrPaths, TargetTriple,
@@ -751,6 +752,7 @@ where
             )
         })?;
     let origin = origin_url(&ctx.manifest_dir);
+    let branch_name = current_branch_name(&ctx.manifest_dir);
     let profile = resolve_profile_name(args).to_string();
 
     // 3. Resolve paths under ~/.soldr/.
@@ -777,12 +779,21 @@ where
         rustc_version.clone(),
         origin.clone(),
     ) {
-        Ok(CookLookupOutcome::Hit { sha256, .. }) => {
+        Ok(CookLookupOutcome::Hit {
+            sha256,
+            matched_recipe_hash,
+            exact_recipe_match,
+            ..
+        }) => {
             // Already-cached for this exact key. Re-pack + re-record
             // anyway so the artifact bytes match the freshly built
             // target/ — a previous run might have written from a
             // sibling worktree with slightly different mtimes.
-            Some(DriftSignal::AlreadyIndexed(sha256))
+            if exact_recipe_match {
+                Some(DriftSignal::AlreadyIndexed(sha256))
+            } else {
+                matched_recipe_hash.map(DriftSignal::Drifted)
+            }
         }
         Ok(CookLookupOutcome::Miss {
             previous_origin_recipe_hashes,
@@ -807,7 +818,7 @@ where
     //    still keep the on-disk artifact for the next PR-3 hydrate
     //    attempt, but warn so the user knows sharing is one-sided.
     let cook_cmd_summary = build_cook_cmd_summary(args);
-    let register = client::cook_record(
+    let register = client::cook_record_with_branch(
         &sock,
         recipe_hash,
         triple.clone(),
@@ -817,6 +828,7 @@ where
         packed.sha256,
         packed.size_bytes,
         origin.clone(),
+        branch_name,
         cook_cmd_summary,
     );
     if let Err(e) = register {

--- a/crates/soldr-cli/src/core/git.rs
+++ b/crates/soldr-cli/src/core/git.rs
@@ -42,6 +42,46 @@ pub fn origin_url(workspace_root: &Path) -> Option<String> {
     Some(normalize_origin_url(trimmed))
 }
 
+/// Return the current checked-out branch name, or `None` for detached
+/// HEAD / no-git workspaces.
+pub fn current_branch_name(workspace_root: &Path) -> Option<String> {
+    let repo_root = find_git_worktree_root(workspace_root)?;
+    let raw = run_git(&repo_root, ["branch", "--show-current"])?;
+    let branch = raw.trim();
+    if branch.is_empty() || branch == "HEAD" {
+        return None;
+    }
+    Some(branch.to_string())
+}
+
+/// Branch preference list for same-origin cook fallback hydration.
+///
+/// Exact recipe hits do not use this. On a recipe miss, the daemon may
+/// seed `target/` from a compatible same-repo artifact. Ranking prefers
+/// the current branch first, then common mainline branches. This
+/// captures the dominant `main -> feature` flow without network access.
+pub fn branch_lineage(workspace_root: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(branch) = current_branch_name(workspace_root) {
+        push_unique(&mut out, branch);
+    }
+    for branch in ["main", "master", "trunk", "develop"] {
+        push_unique(&mut out, branch.to_string());
+    }
+    out
+}
+
+fn push_unique(out: &mut Vec<String>, value: String) {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    if out.iter().any(|existing| existing == trimmed) {
+        return;
+    }
+    out.push(trimmed.to_string());
+}
+
 /// Canonicalize a git remote URL for use as a cross-repo prefetch
 /// hint. The output is purely a hint — the authoritative cache key
 /// is the recipe hash — so we lean conservative: best-effort lower-
@@ -239,5 +279,21 @@ mod tests {
             normalize_origin_url("file:///srv/git/repo.git"),
             "file:///srv/git/repo"
         );
+    });
+
+    crate::timed_test!(branch_lineage_dedups_current_main, {
+        let dir = tempfile::tempdir().unwrap();
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .args(["init", "-q", "-b", "main"])
+            .status()
+            .expect("git init");
+        assert!(status.success());
+
+        let lineage = branch_lineage(dir.path());
+        assert_eq!(lineage.first().map(String::as_str), Some("main"));
+        assert_eq!(lineage.iter().filter(|b| b.as_str() == "main").count(), 1);
+        assert!(lineage.iter().any(|b| b == "master"));
     });
 }

--- a/crates/soldr-cli/src/daemon/client.rs
+++ b/crates/soldr-cli/src/daemon/client.rs
@@ -198,6 +198,29 @@ pub fn cook_lookup(
     rustc_version: String,
     origin_url_normalized: Option<String>,
 ) -> Result<CookLookupOutcome, ClientError> {
+    cook_lookup_with_branch_lineage(
+        sock_path,
+        recipe_hash,
+        target_triple,
+        profile,
+        channel,
+        rustc_version,
+        origin_url_normalized,
+        Vec::new(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn cook_lookup_with_branch_lineage(
+    sock_path: &Path,
+    recipe_hash: [u8; 32],
+    target_triple: String,
+    profile: String,
+    channel: String,
+    rustc_version: String,
+    origin_url_normalized: Option<String>,
+    branch_lineage: Vec<String>,
+) -> Result<CookLookupOutcome, ClientError> {
     let req = Request::CookLookup {
         recipe_hash,
         target_triple,
@@ -205,6 +228,7 @@ pub fn cook_lookup(
         channel,
         rustc_version,
         origin_url_normalized,
+        branch_lineage,
     };
     match submit_request(sock_path, &req)? {
         Response::CookHit {
@@ -212,11 +236,17 @@ pub fn cook_lookup(
             path,
             size_bytes,
             origin_url_normalized,
+            matched_recipe_hash,
+            exact_recipe_match,
+            branch_name,
         } => Ok(CookLookupOutcome::Hit {
             sha256,
             path,
             size_bytes,
             origin_url_normalized,
+            matched_recipe_hash,
+            exact_recipe_match,
+            branch_name,
         }),
         Response::CookMiss {
             previous_origin_recipe_hashes,
@@ -238,6 +268,9 @@ pub enum CookLookupOutcome {
         path: String,
         size_bytes: u64,
         origin_url_normalized: Option<String>,
+        matched_recipe_hash: Option<[u8; 32]>,
+        exact_recipe_match: bool,
+        branch_name: Option<String>,
     },
     Miss {
         previous_origin_recipe_hashes: Vec<[u8; 32]>,
@@ -262,6 +295,35 @@ pub fn cook_record(
     origin_url_normalized: Option<String>,
     cook_cmd_summary: String,
 ) -> Result<(), ClientError> {
+    cook_record_with_branch(
+        sock_path,
+        recipe_hash,
+        target_triple,
+        profile,
+        channel,
+        rustc_version,
+        sha256,
+        size_bytes,
+        origin_url_normalized,
+        None,
+        cook_cmd_summary,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn cook_record_with_branch(
+    sock_path: &Path,
+    recipe_hash: [u8; 32],
+    target_triple: String,
+    profile: String,
+    channel: String,
+    rustc_version: String,
+    sha256: [u8; 32],
+    size_bytes: u64,
+    origin_url_normalized: Option<String>,
+    branch_name: Option<String>,
+    cook_cmd_summary: String,
+) -> Result<(), ClientError> {
     let req = Request::CookRecord {
         recipe_hash,
         target_triple,
@@ -271,6 +333,7 @@ pub fn cook_record(
         sha256,
         size_bytes,
         origin_url_normalized,
+        branch_name,
         cook_cmd_summary,
     };
     match submit_request(sock_path, &req)? {

--- a/crates/soldr-cli/src/daemon/protocol.rs
+++ b/crates/soldr-cli/src/daemon/protocol.rs
@@ -110,10 +110,10 @@ pub enum Request {
     LinkZccache { link: ZccacheDaemonLink },
     /// Request-response: probe the cook-artifact index for the given
     /// `(recipe_hash, target_triple, profile, channel, rustc_version)`
-    /// tuple. On hit returns [`Response::CookHit`]; on miss returns
-    /// [`Response::CookMiss`] with up to N previous recipe hashes
-    /// recorded under the same `(origin, triple, profile, channel,
-    /// rustc)` matrix.
+    /// tuple. On exact hit returns [`Response::CookHit`] with
+    /// `exact_recipe_match = true`. On exact miss, the daemon may
+    /// return a same-origin fallback [`Response::CookHit`] ranked by
+    /// `branch_lineage`; otherwise it returns [`Response::CookMiss`].
     CookLookup {
         recipe_hash: [u8; 32],
         target_triple: String,
@@ -121,6 +121,7 @@ pub enum Request {
         channel: String,
         rustc_version: String,
         origin_url_normalized: Option<String>,
+        branch_lineage: Vec<String>,
     },
     /// Request-response: register a cook artifact written by PR 2's
     /// `soldr cook` worker at `~/.soldr/cache/cook/<sha256>.tar.zst`.
@@ -134,6 +135,7 @@ pub enum Request {
         sha256: [u8; 32],
         size_bytes: u64,
         origin_url_normalized: Option<String>,
+        branch_name: Option<String>,
         cook_cmd_summary: String,
     },
     /// Fire-and-forget: bump the `last_used_unix_ms` field for the
@@ -150,14 +152,19 @@ pub enum Response {
     /// Reply to [`Request::CookLookup`] on hit. Carries the on-disk
     /// path to the `<sha256>.tar.zst` artifact, the recorded sha256
     /// (PR 3 verifies it before extraction), the byte size for
-    /// hydration reporting, and the recorded origin URL hint.
+    /// hydration reporting, the recorded origin URL hint, and whether
+    /// the hit was exact or a same-origin fallback seed.
     CookHit {
         sha256: [u8; 32],
         path: String,
         size_bytes: u64,
         origin_url_normalized: Option<String>,
+        matched_recipe_hash: Option<[u8; 32]>,
+        exact_recipe_match: bool,
+        branch_name: Option<String>,
     },
-    /// Reply to [`Request::CookLookup`] on miss. `previous_origin_recipe_hashes`
+    /// Reply to [`Request::CookLookup`] when neither an exact nor
+    /// fallback artifact is available. `previous_origin_recipe_hashes`
     /// is a diagnostic: at most 8 prior recipe hashes recorded under
     /// the same `(origin, triple, profile, channel, rustc)` matrix,
     /// newest-first.

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -446,6 +446,7 @@ where
             channel,
             rustc_version,
             origin_url_normalized,
+            branch_lineage,
         } => {
             let key = CookKey {
                 recipe_hash,
@@ -472,18 +473,48 @@ where
                             path,
                             size_bytes: entry.size_bytes,
                             origin_url_normalized: entry.origin_url_normalized,
+                            matched_recipe_hash: Some(recipe_hash),
+                            exact_recipe_match: true,
+                            branch_name: entry.branch_name,
                         }
                     }
                     Ok(None) => {
-                        let previous = cook_index::drift_recipe_hashes(
+                        match cook_index::lookup_origin_fallback(
                             &state.db_path,
                             &key,
                             origin_url_normalized.as_deref(),
-                            COOK_DRIFT_LIMIT,
-                        )
-                        .unwrap_or_default();
-                        Response::CookMiss {
-                            previous_origin_recipe_hashes: previous,
+                            &branch_lineage,
+                        ) {
+                            Ok(Some((matched_key, entry))) => {
+                                state.cook_hits_this_session.fetch_add(1, Ordering::Relaxed);
+                                let path = cook_artifact_path(&state.paths, &entry.sha256)
+                                    .display()
+                                    .to_string();
+                                Response::CookHit {
+                                    sha256: entry.sha256,
+                                    path,
+                                    size_bytes: entry.size_bytes,
+                                    origin_url_normalized: entry.origin_url_normalized,
+                                    matched_recipe_hash: Some(matched_key.recipe_hash),
+                                    exact_recipe_match: false,
+                                    branch_name: entry.branch_name,
+                                }
+                            }
+                            Ok(None) => {
+                                let previous = cook_index::drift_recipe_hashes(
+                                    &state.db_path,
+                                    &key,
+                                    origin_url_normalized.as_deref(),
+                                    COOK_DRIFT_LIMIT,
+                                )
+                                .unwrap_or_default();
+                                Response::CookMiss {
+                                    previous_origin_recipe_hashes: previous,
+                                }
+                            }
+                            Err(e) => {
+                                Response::Error(format!("cook_index fallback lookup failed: {e}"))
+                            }
                         }
                     }
                     Err(e) => Response::Error(format!("cook_index lookup failed: {e}")),
@@ -500,6 +531,7 @@ where
             sha256,
             size_bytes,
             origin_url_normalized,
+            branch_name,
             cook_cmd_summary,
         } => {
             let key = CookKey {
@@ -517,6 +549,7 @@ where
                 last_used_unix_ms: now_ms,
                 origin_url_normalized,
                 cook_cmd_summary,
+                branch_name,
             };
             let result = cook_index::upsert(&state.db_path, &key, &entry);
             match result {

--- a/crates/soldr-cli/src/daemon/wire.proto
+++ b/crates/soldr-cli/src/daemon/wire.proto
@@ -88,6 +88,7 @@ message WireCookLookup {
   string channel = 4;
   string rustc_version = 5;
   optional string origin_url_normalized = 6;
+  repeated string branch_lineage = 7;
 }
 
 message WireCookRecord {
@@ -100,6 +101,7 @@ message WireCookRecord {
   uint64 size_bytes = 7;
   optional string origin_url_normalized = 8;
   string cook_cmd_summary = 9;
+  optional string branch_name = 10;
 }
 
 message WireCookTouch {
@@ -131,6 +133,9 @@ message WireCookHit {
   string path = 2;
   uint64 size_bytes = 3;
   optional string origin_url_normalized = 4;
+  bytes matched_recipe_hash = 5;  // empty when unavailable
+  bool exact_recipe_match = 6;
+  optional string branch_name = 7;
 }
 
 message WireCookMiss {
@@ -210,4 +215,5 @@ message WireCookEntry {
   uint64 last_used_unix_ms = 4;
   optional string origin_url_normalized = 5;
   string cook_cmd_summary = 6;
+  optional string branch_name = 7;
 }

--- a/crates/soldr-cli/src/daemon/wire.rs
+++ b/crates/soldr-cli/src/daemon/wire.rs
@@ -157,6 +157,8 @@ pub mod proto {
         pub rustc_version: String,
         #[prost(string, optional, tag = "6")]
         pub origin_url_normalized: Option<String>,
+        #[prost(string, repeated, tag = "7")]
+        pub branch_lineage: Vec<String>,
     }
 
     #[derive(Clone, PartialEq, Message)]
@@ -179,6 +181,8 @@ pub mod proto {
         pub origin_url_normalized: Option<String>,
         #[prost(string, tag = "9")]
         pub cook_cmd_summary: String,
+        #[prost(string, optional, tag = "10")]
+        pub branch_name: Option<String>,
     }
 
     #[derive(Clone, PartialEq, Message)]
@@ -229,6 +233,12 @@ pub mod proto {
         pub size_bytes: u64,
         #[prost(string, optional, tag = "4")]
         pub origin_url_normalized: Option<String>,
+        #[prost(bytes = "vec", tag = "5")]
+        pub matched_recipe_hash: Vec<u8>,
+        #[prost(bool, tag = "6")]
+        pub exact_recipe_match: bool,
+        #[prost(string, optional, tag = "7")]
+        pub branch_name: Option<String>,
     }
 
     #[derive(Clone, PartialEq, Message)]
@@ -355,6 +365,8 @@ pub mod proto {
         pub origin_url_normalized: Option<String>,
         #[prost(string, tag = "6")]
         pub cook_cmd_summary: String,
+        #[prost(string, optional, tag = "7")]
+        pub branch_name: Option<String>,
     }
 }
 
@@ -375,6 +387,13 @@ fn vec_to_sha(bytes: &[u8]) -> Result<[u8; 32], WireDecodeError> {
     let mut out = [0u8; 32];
     out.copy_from_slice(bytes);
     Ok(out)
+}
+
+fn vec_to_optional_sha(bytes: &[u8]) -> Result<Option<[u8; 32]>, WireDecodeError> {
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    vec_to_sha(bytes).map(Some)
 }
 
 // =========================================================================
@@ -634,6 +653,7 @@ impl From<&Request> for proto::WireRequest {
                 channel,
                 rustc_version,
                 origin_url_normalized,
+                branch_lineage,
             } => proto::WireRequestKind::CookLookup(proto::WireCookLookup {
                 recipe_hash: sha_to_vec(recipe_hash),
                 target_triple: target_triple.clone(),
@@ -641,6 +661,7 @@ impl From<&Request> for proto::WireRequest {
                 channel: channel.clone(),
                 rustc_version: rustc_version.clone(),
                 origin_url_normalized: origin_url_normalized.clone(),
+                branch_lineage: branch_lineage.clone(),
             }),
             Request::CookRecord {
                 recipe_hash,
@@ -651,6 +672,7 @@ impl From<&Request> for proto::WireRequest {
                 sha256,
                 size_bytes,
                 origin_url_normalized,
+                branch_name,
                 cook_cmd_summary,
             } => proto::WireRequestKind::CookRecord(proto::WireCookRecord {
                 recipe_hash: sha_to_vec(recipe_hash),
@@ -662,6 +684,7 @@ impl From<&Request> for proto::WireRequest {
                 size_bytes: *size_bytes,
                 origin_url_normalized: origin_url_normalized.clone(),
                 cook_cmd_summary: cook_cmd_summary.clone(),
+                branch_name: branch_name.clone(),
             }),
             Request::CookTouch { sha256 } => {
                 proto::WireRequestKind::CookTouch(proto::WireCookTouch {
@@ -723,6 +746,7 @@ impl TryFrom<proto::WireRequest> for Request {
                 channel: m.channel,
                 rustc_version: m.rustc_version,
                 origin_url_normalized: m.origin_url_normalized,
+                branch_lineage: m.branch_lineage,
             },
             proto::WireRequestKind::CookRecord(m) => Request::CookRecord {
                 recipe_hash: vec_to_sha(&m.recipe_hash)?,
@@ -733,6 +757,7 @@ impl TryFrom<proto::WireRequest> for Request {
                 sha256: vec_to_sha(&m.sha256)?,
                 size_bytes: m.size_bytes,
                 origin_url_normalized: m.origin_url_normalized,
+                branch_name: m.branch_name,
                 cook_cmd_summary: m.cook_cmd_summary,
             },
             proto::WireRequestKind::CookTouch(m) => Request::CookTouch {
@@ -760,11 +785,20 @@ impl From<&Response> for proto::WireResponse {
                 path,
                 size_bytes,
                 origin_url_normalized,
+                matched_recipe_hash,
+                exact_recipe_match,
+                branch_name,
             } => proto::WireResponseKind::CookHit(proto::WireCookHit {
                 sha256: sha_to_vec(sha256),
                 path: path.clone(),
                 size_bytes: *size_bytes,
                 origin_url_normalized: origin_url_normalized.clone(),
+                matched_recipe_hash: matched_recipe_hash
+                    .as_ref()
+                    .map(sha_to_vec)
+                    .unwrap_or_default(),
+                exact_recipe_match: *exact_recipe_match,
+                branch_name: branch_name.clone(),
             }),
             Response::CookMiss {
                 previous_origin_recipe_hashes,
@@ -797,6 +831,9 @@ impl TryFrom<proto::WireResponse> for Response {
                 path: m.path,
                 size_bytes: m.size_bytes,
                 origin_url_normalized: m.origin_url_normalized,
+                matched_recipe_hash: vec_to_optional_sha(&m.matched_recipe_hash)?,
+                exact_recipe_match: m.exact_recipe_match,
+                branch_name: m.branch_name,
             },
             proto::WireResponseKind::CookMiss(m) => {
                 let mut hashes = Vec::with_capacity(m.previous_origin_recipe_hashes.len());
@@ -860,6 +897,7 @@ mod tests {
             channel: "1.94.1".into(),
             rustc_version: "rustc 1.94.1".into(),
             origin_url_normalized: Some("https://github.com/zackees/soldr".into()),
+            branch_lineage: vec!["feature/cook".into(), "main".into()],
         };
         let bytes = encode_request(&req);
         let decoded = decode_request(&bytes).expect("decode");
@@ -871,6 +909,7 @@ mod tests {
                 channel,
                 rustc_version,
                 origin_url_normalized,
+                branch_lineage,
             } => {
                 assert_eq!(recipe_hash, [0x42; 32]);
                 assert_eq!(target_triple, "x86_64-pc-windows-msvc");
@@ -881,6 +920,7 @@ mod tests {
                     origin_url_normalized.as_deref(),
                     Some("https://github.com/zackees/soldr")
                 );
+                assert_eq!(branch_lineage, vec!["feature/cook", "main"]);
             }
             other => panic!("unexpected variant: {other:?}"),
         }
@@ -896,6 +936,7 @@ mod tests {
             sha256: [0xAA; 32],
             size_bytes: 4_096,
             origin_url_normalized: None,
+            branch_name: Some("main".into()),
             cook_cmd_summary: "cook --release".into(),
         };
         let bytes = encode_request(&req);
@@ -903,6 +944,7 @@ mod tests {
             recipe_hash,
             sha256,
             size_bytes,
+            branch_name,
             ..
         } = decode_request(&bytes).expect("decode")
         else {
@@ -911,6 +953,7 @@ mod tests {
         assert_eq!(recipe_hash, [0x11; 32]);
         assert_eq!(sha256, [0xAA; 32]);
         assert_eq!(size_bytes, 4_096);
+        assert_eq!(branch_name.as_deref(), Some("main"));
     });
 
     crate::timed_test!(link_zccache_round_trips_with_optional_fields, {
@@ -955,6 +998,9 @@ mod tests {
             path: "/home/runner/.soldr/cache/cook/abcd.tar.zst".into(),
             size_bytes: 4_096,
             origin_url_normalized: Some("https://github.com/zackees/soldr".into()),
+            matched_recipe_hash: Some([0x11; 32]),
+            exact_recipe_match: false,
+            branch_name: Some("main".into()),
         };
         let bytes = encode_response(&resp);
         match decode_response(&bytes).expect("decode") {
@@ -963,6 +1009,9 @@ mod tests {
                 path,
                 size_bytes,
                 origin_url_normalized,
+                matched_recipe_hash,
+                exact_recipe_match,
+                branch_name,
             } => {
                 assert_eq!(sha256, [0xCC; 32]);
                 assert!(path.ends_with(".tar.zst"));
@@ -971,6 +1020,9 @@ mod tests {
                     origin_url_normalized.as_deref(),
                     Some("https://github.com/zackees/soldr")
                 );
+                assert_eq!(matched_recipe_hash, Some([0x11; 32]));
+                assert!(!exact_recipe_match);
+                assert_eq!(branch_name.as_deref(), Some("main"));
             }
             other => panic!("unexpected variant: {other:?}"),
         }

--- a/crates/soldr-cli/tests/cook_auto_gc.rs
+++ b/crates/soldr-cli/tests/cook_auto_gc.rs
@@ -47,6 +47,7 @@ fn make_entry(sha_byte: u8, size: u64, last_used: u64, origin: Option<&str>) -> 
         last_used_unix_ms: last_used,
         origin_url_normalized: origin.map(str::to_owned),
         cook_cmd_summary: "cook --release".into(),
+        branch_name: None,
     }
 }
 

--- a/crates/soldr-cli/tests/cook_hydrate_preflight.rs
+++ b/crates/soldr-cli/tests/cook_hydrate_preflight.rs
@@ -22,9 +22,13 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use soldr_cli::cache_lib::cook_archive::{
-    cook_cache_dir, extract_skip_existing, pack_cook_archive, quarantine_artifact, verify_sha256,
+    compute_recipe_hash_proxy, cook_cache_dir, extract_skip_existing, pack_cook_archive,
+    quarantine_artifact, verify_sha256,
 };
-use soldr_cli::daemon::client::{self, cook_lookup, cook_record, CookLookupOutcome};
+use soldr_cli::core::{probe_toolchain_binary, TargetTriple};
+use soldr_cli::daemon::client::{
+    self, cook_lookup, cook_record, cook_record_with_branch, CookLookupOutcome,
+};
 use soldr_cli::timed_test;
 
 const HARNESS_ENV: &str = "SOLDR_COOK_DOCKER_HARNESS";
@@ -71,6 +75,55 @@ fn soldr_daemon_bin() -> PathBuf {
         "soldr-daemon"
     };
     parent.join(stem)
+}
+
+fn soldr_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_soldr"))
+}
+
+fn run_git_in(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}\nstdout:\n{}\nstderr:\n{}",
+        dir.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn run_command_success(mut command: Command, label: &str) {
+    let output = command.output().expect(label);
+    assert!(
+        output.status.success(),
+        "{label} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn rustc_version_string(manifest_dir: &Path) -> String {
+    let rustc = probe_toolchain_binary("rustc", Some(manifest_dir))
+        .unwrap_or_else(|| PathBuf::from("rustc"));
+    let output = Command::new(rustc).arg("-V").output().expect("rustc -V");
+    assert!(
+        output.status.success(),
+        "rustc -V failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout)
+        .expect("rustc -V stdout is UTF-8")
+        .lines()
+        .next()
+        .expect("rustc -V emitted a line")
+        .trim()
+        .to_string()
 }
 
 struct DaemonProc {
@@ -388,5 +441,149 @@ timed_test!(
             })
             .unwrap_or(0);
         assert_eq!(count, 0);
+    }
+);
+
+// A feature branch with a new recipe hash can still hydrate from an
+// ancestor `main` branch artifact when the origin, target, profile,
+// channel, and rustc version are compatible. This exercises the real
+// `soldr cargo build` pre-flight path in a container-local git repo.
+timed_test!(
+    feature_branch_soldr_cargo_build_hydrates_from_main_fallback,
+    Duration::from_secs(120),
+    {
+        if skip_unless_in_container("feature_branch_soldr_cargo_build_hydrates_from_main_fallback")
+        {
+            return;
+        }
+
+        let cache_root = unique_temp_dir("branch-fallback-cache");
+        let home_root = unique_temp_dir("branch-fallback-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+        let sock = daemon.sock_path();
+
+        let origin = "https://github.com/example/branch-fallback-demo";
+        let repo = unique_temp_dir("branch-fallback-repo");
+        run_git_in(&repo, &["init", "-q", "-b", "main"]);
+        run_git_in(&repo, &["config", "user.email", "cook@example.com"]);
+        run_git_in(&repo, &["config", "user.name", "cook test"]);
+        run_git_in(&repo, &["remote", "add", "origin", origin]);
+
+        write_file(
+            &repo.join("Cargo.toml"),
+            br#"[package]
+name = "branch_fallback_demo"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.soldr-test]
+marker = "main"
+"#,
+        );
+        write_file(
+            &repo.join("src").join("main.rs"),
+            b"fn main() { println!(\"branch fallback demo\"); }\n",
+        );
+        let mut generate_lock = Command::new("cargo");
+        generate_lock.arg("generate-lockfile").current_dir(&repo);
+        run_command_success(generate_lock, "cargo generate-lockfile");
+        run_git_in(&repo, &["add", "Cargo.toml", "Cargo.lock", "src/main.rs"]);
+        run_git_in(&repo, &["commit", "-q", "-m", "main"]);
+
+        let main_recipe = compute_recipe_hash_proxy(&repo).expect("main recipe hash");
+        let target_triple = TargetTriple::detect_in_dir(&repo)
+            .expect("target triple")
+            .to_string();
+        let rustc_version = rustc_version_string(&repo);
+        let channel = String::new();
+
+        let paths = soldr_cli::core::SoldrPaths::with_root(cache_root.clone());
+        let cook_dir = cook_cache_dir(&paths);
+        std::fs::create_dir_all(&cook_dir).unwrap();
+        let artifact_root = unique_temp_dir("branch-main-artifact");
+        let debug_dir = artifact_root.join("debug");
+        let sentinel_path = Path::new("debug")
+            .join("deps")
+            .join("soldr-main-seed.rmeta");
+        write_file(
+            &debug_dir.join("deps").join("soldr-main-seed.rmeta"),
+            b"main branch synthetic artifact\n",
+        );
+        let packed = pack_cook_archive(&debug_dir, &cook_dir).expect("pack main artifact");
+
+        cook_record_with_branch(
+            &sock,
+            main_recipe,
+            target_triple,
+            "dev".to_string(),
+            channel,
+            rustc_version,
+            packed.sha256,
+            packed.size_bytes,
+            Some(origin.to_string()),
+            Some("main".to_string()),
+            "synthetic main cook".to_string(),
+        )
+        .expect("record main cook artifact");
+
+        run_git_in(&repo, &["checkout", "-q", "-b", "feature/reuse-main"]);
+        write_file(
+            &repo.join("Cargo.toml"),
+            br#"[package]
+name = "branch_fallback_demo"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.soldr-test]
+marker = "feature"
+"#,
+        );
+        run_git_in(&repo, &["add", "Cargo.toml"]);
+        run_git_in(&repo, &["commit", "-q", "-m", "feature recipe drift"]);
+
+        let feature_recipe = compute_recipe_hash_proxy(&repo).expect("feature recipe hash");
+        assert_ne!(
+            feature_recipe, main_recipe,
+            "feature branch metadata edit must drift the recipe hash"
+        );
+        assert!(
+            !repo.join("target").join(&sentinel_path).exists(),
+            "sentinel should not exist before auto-hydrate"
+        );
+
+        let mut soldr = Command::new(soldr_bin());
+        soldr
+            .current_dir(&repo)
+            .args(["--no-cache", "cargo", "build", "--quiet"])
+            .env("SOLDR_CACHE_DIR", &cache_root)
+            .env("HOME", &home_root)
+            .env("USERPROFILE", &home_root)
+            .env("SOLDR_COOK_AUTO_HYDRATE", "1")
+            .env("SOLDR_NO_GC_TARGET", "1")
+            .env("SOLDR_TEST_FREE_DISK_BYTES", "21474836480")
+            .env("SOLDR_TEST_DISK_FREE_BYTES", "21474836480");
+        let output = soldr.output().expect("soldr cargo build");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "soldr cargo build failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("soldr cook: auto-hydrate activated"),
+            "expected auto-hydrate line\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("match=fallback"),
+            "expected branch fallback hydrate\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("branch=main"),
+            "expected fallback artifact to come from main\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            repo.join("target").join(&sentinel_path).is_file(),
+            "expected sentinel artifact to be extracted into target/"
+        );
     }
 );

--- a/crates/soldr-cli/tests/cook_writes_index.rs
+++ b/crates/soldr-cli/tests/cook_writes_index.rs
@@ -234,6 +234,7 @@ timed_test!(
                 path,
                 size_bytes,
                 origin_url_normalized,
+                ..
             } => {
                 assert_eq!(sha256, packed.sha256);
                 assert_eq!(size_bytes, packed.size_bytes);

--- a/crates/soldr-cli/tests/daemon_cook_index.rs
+++ b/crates/soldr-cli/tests/daemon_cook_index.rs
@@ -192,6 +192,7 @@ timed_test!(
                 path,
                 size_bytes,
                 origin_url_normalized,
+                ..
             } => {
                 assert_eq!(sha256, [0xAAu8; 32]);
                 assert_eq!(size_bytes, 4_096);
@@ -210,10 +211,12 @@ timed_test!(
 );
 
 timed_test!(
-    cook_lookup_miss_reports_drift_recipe_hashes,
+    cook_lookup_recipe_miss_falls_back_to_newest_same_origin_artifact,
     Duration::from_secs(60),
     {
-        if skip_unless_in_container("cook_lookup_miss_reports_drift_recipe_hashes") {
+        if skip_unless_in_container(
+            "cook_lookup_recipe_miss_falls_back_to_newest_same_origin_artifact",
+        ) {
             return;
         }
         let cache_root = unique_temp_dir("drift-cache");
@@ -239,6 +242,7 @@ timed_test!(
             "cook a".to_string(),
         )
         .expect("CookRecord a");
+        std::thread::sleep(Duration::from_millis(2));
         cook_record(
             &sock,
             [6u8; 32],
@@ -266,17 +270,17 @@ timed_test!(
         .expect("CookLookup");
 
         match outcome {
-            CookLookupOutcome::Miss {
-                previous_origin_recipe_hashes,
+            CookLookupOutcome::Hit {
+                sha256,
+                matched_recipe_hash,
+                exact_recipe_match,
+                ..
             } => {
-                assert_eq!(previous_origin_recipe_hashes.len(), 2);
-                // newest-first order driven by last_used_unix_ms; the
-                // two records were upserted in (5,6) order so 6 is
-                // most recent and appears first.
-                assert_eq!(previous_origin_recipe_hashes[0], [6u8; 32]);
-                assert_eq!(previous_origin_recipe_hashes[1], [5u8; 32]);
+                assert_eq!(sha256, [0x66u8; 32]);
+                assert_eq!(matched_recipe_hash, Some([6u8; 32]));
+                assert!(!exact_recipe_match);
             }
-            CookLookupOutcome::Hit { .. } => panic!("expected CookMiss, got CookHit"),
+            CookLookupOutcome::Miss { .. } => panic!("expected fallback CookHit, got CookMiss"),
         }
     }
 );


### PR DESCRIPTION
## Summary
- store cook entries with branch metadata and support origin-compatible fallback lookups by branch lineage
- pass branch lineage through the daemon protocol/client/server and report exact vs fallback hydrate matches
- auto-record the current branch from `soldr cook` and auto-hydrate feature branches from ancestor branch artifacts
- add Docker-gated integration coverage for feature branch hydration from a `main` artifact

## Tests
- Docker: `cargo fmt --all`
- Docker: `cargo test -p soldr-cli --lib fallback_`
- Docker: `cargo test -p soldr-cli --lib branch_lineage_dedups_current_main`
- Docker: `cargo test -p soldr-cli --lib round_trips`
- Docker: `cargo test -p soldr-cli --test daemon_cook_index cook_lookup_recipe_miss_falls_back_to_newest_same_origin_artifact -- --include-ignored`
- Docker: `cargo test -p soldr-cli --test cook_hydrate_preflight -- --include-ignored`
- Docker: `cargo test -p soldr-cli --no-run`