### PR TITLE
feat: adopt running-process BackendHandle probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +227,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -277,6 +304,12 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -424,6 +457,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +487,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -475,6 +541,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +582,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -891,6 +980,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "interprocess"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +1070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1117,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1216,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1256,33 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1085,6 +1311,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1126,6 +1358,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1379,27 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1187,7 +1451,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost 0.14.4",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
 ]
 
 [[package]]
@@ -1204,20 +1497,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
+dependencies = [
+ "logos 0.16.1",
+ "miette",
+ "prost 0.14.4",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost 0.14.4",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost 0.14.4",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos 0.15.1",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1238,7 +1592,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1250,7 +1604,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -1329,6 +1683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
 name = "redb"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,8 +1703,48 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1399,12 +1799,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "running-process"
+version = "4.0.3"
+source = "git+https://github.com/zackees/running-process?rev=04f6387c3cf5b2a984cd4bbba8a3e6f177d43a89#04f6387c3cf5b2a984cd4bbba8a3e6f177d43a89"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "clap",
+ "dirs",
+ "getrandom 0.4.2",
+ "interprocess",
+ "libc",
+ "portable-pty",
+ "prost 0.14.4",
+ "prost-build",
+ "prost-types",
+ "protox",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "winapi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1419,12 +1845,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1564,6 +1999,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +2039,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1650,17 +2112,19 @@ dependencies = [
  "hex",
  "jwalk",
  "libc",
- "prost",
+ "prost 0.13.5",
+ "prost 0.14.4",
  "rayon",
  "redb",
  "reqwest",
+ "running-process",
  "rusqlite",
  "serde",
  "serde_json",
  "sha2",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
@@ -1721,6 +2185,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,11 +2225,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1917,7 +2416,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2015,6 +2514,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -2196,7 +2701,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2232,6 +2737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +2774,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2803,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2434,6 +2973,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,7 +3045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -2691,7 +3239,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "xz2",
  "zeroize",

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -18,9 +18,11 @@ fs2 = { workspace = true }
 hex = { workspace = true }
 jwalk = { workspace = true }
 prost = { workspace = true }
+prost14 = { package = "prost", version = "0.14" }
 rayon = { workspace = true }
 redb = { workspace = true }
 reqwest = { workspace = true }
+running-process = { git = "https://github.com/zackees/running-process", rev = "04f6387c3cf5b2a984cd4bbba8a3e6f177d43a89", default-features = false, features = ["client"] }
 rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/soldr-cli/src/cache/release_worktree.rs
+++ b/crates/soldr-cli/src/cache/release_worktree.rs
@@ -76,29 +76,27 @@ pub fn release_worktree(paths: &SoldrPaths, target: &Path) -> Result<ReleaseOutc
 
     // Tier 1.
     match std::fs::remove_dir_all(&canonical_or_self) {
-        Ok(()) => {
-            return Ok(ReleaseOutcome::Removed {
-                path: canonical_or_self,
-            });
-        }
+        Ok(()) => Ok(ReleaseOutcome::Removed {
+            path: canonical_or_self,
+        }),
         Err(err) if is_busy_or_permission_error(&err) => {
             // Fall through to Tier 2.
             let tier1_error = err.to_string();
-            return tier2_rename_to_trash(paths, &canonical_or_self, tier1_error);
+            tier2_rename_to_trash(paths, &canonical_or_self, tier1_error)
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             // Already gone — treat as success, no work needed.
-            return Ok(ReleaseOutcome::Removed {
+            Ok(ReleaseOutcome::Removed {
                 path: canonical_or_self,
-            });
+            })
         }
         Err(err) => {
             // Some other error (read-only fs, broken symlink, etc.) —
             // don't try Tier 2, it'd just fail too. Surface.
-            return Err(SoldrError::Other(format!(
+            Err(SoldrError::Other(format!(
                 "release-worktree: tier-1 remove_dir_all({}) failed: {err}",
                 canonical_or_self.display()
-            )));
+            )))
         }
     }
 }

--- a/crates/soldr-cli/src/daemon/backend_handle_adoption.rs
+++ b/crates/soldr-cli/src/daemon/backend_handle_adoption.rs
@@ -1,46 +1,60 @@
-//! soldr-daemon probe boundary prepared for `running-process` `BackendHandle`.
+//! soldr-daemon integration with `running-process` `BackendHandle`.
 //!
-//! The current crates.io `running-process` release checked for this work is
-//! 4.0.3, which does not expose
-//! `running_process::broker::backend_handle::BackendHandle`. This module keeps
-//! soldr's existing PID-file probe behavior in one place and records the exact
-//! dependency gate for the future migration.
-//!
-//! Once a published `running-process` release contains
-//! zackees/running-process#232, `probe_soldr_daemon` is the call site to replace
-//! with `BackendHandle::probe_with_service`. soldr's IPC
-//! [`crate::daemon::protocol::PROTOCOL_VERSION`] check remains the wire-version
-//! guard after a handle opens a connection.
+//! `running-process` commit 04f6387 added the active endpoint-response probe
+//! required by zackees/running-process#232. soldr now uses that probe at the
+//! old `daemon::lifecycle::is_live` boundary: the PID file is only trusted
+//! after `BackendHandle::probe_with_service` verifies process identity and the
+//! live daemon answers the broker-v1 BackendHandle nonce challenge on its IPC
+//! endpoint.
 
 use crate::cache_lib::daemon_pid_path;
 use crate::core::SoldrPaths;
+#[cfg(unix)]
 use crate::daemon::client;
 use crate::daemon::lifecycle::{pid_exe_stem_matches, pid_is_alive, read_pid_file};
 use crate::daemon::protocol::PROTOCOL_VERSION;
+use prost14::Message as _;
+use running_process::broker::backend_handle::{BackendHandle, DaemonProcess};
+use running_process::broker::backend_lifecycle::identity::IdentityError;
+use running_process::broker::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
+use running_process::broker::host_identity;
+use running_process::broker::protocol::{
+    Endpoint, Frame, FrameKind, PayloadEncoding, ENVELOPE_VERSION, MAX_FRAME_BYTES,
+};
+use sha2::{Digest, Sha256};
+use std::io;
 use std::path::{Path, PathBuf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+const BACKEND_HANDLE_PROBE_PREFIX_BYTES: usize = 5;
+const BACKEND_HANDLE_PROBE_NONCE_BYTES: usize = 32;
 
 pub(crate) const SOLDR_DAEMON_SERVICE_NAME: &str = "soldr-daemon";
 pub(crate) const SOLDR_DAEMON_SERVICE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub(crate) const RUNNING_PROCESS_BACKEND_HANDLE_GATE: RunningProcessBackendHandleGate =
-    RunningProcessBackendHandleGate {
+pub(crate) const RUNNING_PROCESS_BACKEND_HANDLE_STATUS: RunningProcessBackendHandleStatus =
+    RunningProcessBackendHandleStatus {
         crate_name: "running-process",
-        checked_published_version: "4.0.3",
+        dependency_source:
+            "git:https://github.com/zackees/running-process#04f6387c3cf5b2a984cd4bbba8a3e6f177d43a89",
         required_symbol: "running_process::broker::backend_handle::BackendHandle",
         running_process_issue: "zackees/running-process#232",
+        adoption_tracker_issue: "zackees/running-process#242",
         soldr_issue: "zackees/soldr#718",
+        active_endpoint_probe: true,
         remaining_gate:
-            "publish a running-process release that exposes BackendHandle, then replace this \
-             PID-file adapter with BackendHandle::probe_with_service",
+            "publish running-process with BackendHandle and collect three-OS downstream acceptance",
     };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct RunningProcessBackendHandleGate {
+pub(crate) struct RunningProcessBackendHandleStatus {
     pub(crate) crate_name: &'static str,
-    pub(crate) checked_published_version: &'static str,
+    pub(crate) dependency_source: &'static str,
     pub(crate) required_symbol: &'static str,
     pub(crate) running_process_issue: &'static str,
+    pub(crate) adoption_tracker_issue: &'static str,
     pub(crate) soldr_issue: &'static str,
+    pub(crate) active_endpoint_probe: bool,
     pub(crate) remaining_gate: &'static str,
 }
 
@@ -53,7 +67,7 @@ pub(crate) struct SoldrDaemonBackendHandle {
     pub(crate) exe_path: PathBuf,
     pub(crate) endpoint: PathBuf,
     pub(crate) pid_file: PathBuf,
-    pub(crate) adoption_gate: RunningProcessBackendHandleGate,
+    pub(crate) adoption_status: RunningProcessBackendHandleStatus,
 }
 
 impl SoldrDaemonBackendHandle {
@@ -67,27 +81,188 @@ impl SoldrDaemonBackendHandle {
 }
 
 pub(crate) fn probe_soldr_daemon(paths: &SoldrPaths) -> Option<SoldrDaemonBackendHandle> {
-    probe_daemon_with_expected_stem(paths, SOLDR_DAEMON_SERVICE_NAME)
-}
-
-fn probe_daemon_with_expected_stem(
-    paths: &SoldrPaths,
-    expected_stem: &str,
-) -> Option<SoldrDaemonBackendHandle> {
     let (pid, exe_path) = read_pid_file(paths)?;
-    if !(pid_is_alive(pid) && pid_exe_stem_matches(pid, expected_stem)) {
-        return None;
-    }
+    let expected = daemon_process_from_pid_file(paths, pid, exe_path)?;
+    let handle = BackendHandle::probe_with_service(
+        SOLDR_DAEMON_SERVICE_NAME,
+        SOLDR_DAEMON_SERVICE_VERSION,
+        &expected.ipc_endpoint,
+        &expected,
+    )
+    .ok()?;
+
     Some(SoldrDaemonBackendHandle {
         service_name: SOLDR_DAEMON_SERVICE_NAME,
         service_version: SOLDR_DAEMON_SERVICE_VERSION,
         protocol_version: PROTOCOL_VERSION,
-        pid,
-        exe_path,
-        endpoint: client::default_sock_path(paths),
+        pid: handle.daemon_process.pid,
+        exe_path: handle.daemon_process.exe_path,
+        endpoint: PathBuf::from(handle.daemon_process.ipc_endpoint.path),
         pid_file: daemon_pid_path(paths),
-        adoption_gate: RUNNING_PROCESS_BACKEND_HANDLE_GATE,
+        adoption_status: RUNNING_PROCESS_BACKEND_HANDLE_STATUS,
     })
+}
+
+pub(crate) fn current_daemon_process(
+    paths: &SoldrPaths,
+    idle_timeout_secs: Option<u32>,
+) -> Result<DaemonProcess, IdentityError> {
+    DaemonProcess::current_process(soldr_daemon_endpoint(paths), idle_timeout_secs)
+}
+
+pub(crate) fn is_backend_handle_probe_prefix(prefix: &[u8]) -> bool {
+    if prefix.len() != BACKEND_HANDLE_PROBE_PREFIX_BYTES || prefix[0] != ENVELOPE_VERSION {
+        return false;
+    }
+    let body_len = u32::from_le_bytes([prefix[1], prefix[2], prefix[3], prefix[4]]) as usize;
+    body_len <= MAX_FRAME_BYTES
+}
+
+pub(crate) async fn handle_backend_handle_probe_async<S>(
+    stream: &mut S,
+    prefix: &[u8],
+    daemon: &DaemonProcess,
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let request_frame = read_backend_handle_probe_request(stream, prefix).await?;
+    let nonce = validate_backend_handle_probe_request(&request_frame)?;
+    write_backend_handle_probe_response(stream, &request_frame, &nonce, daemon).await
+}
+
+fn daemon_process_from_pid_file(
+    paths: &SoldrPaths,
+    pid: u32,
+    exe_path: PathBuf,
+) -> Option<DaemonProcess> {
+    Some(DaemonProcess {
+        pid,
+        exe_sha256: sha256_file(&exe_path).ok()?,
+        exe_path,
+        boot_id: host_identity::current().boot_id,
+        ipc_endpoint: soldr_daemon_endpoint(paths),
+        started_at_unix_ms: 0,
+        idle_timeout_secs: None,
+    })
+}
+
+fn soldr_daemon_endpoint(paths: &SoldrPaths) -> Endpoint {
+    Endpoint {
+        namespace_id: host_identity::current().namespace_id,
+        path: soldr_daemon_endpoint_path(paths),
+    }
+}
+
+#[cfg(unix)]
+fn soldr_daemon_endpoint_path(paths: &SoldrPaths) -> String {
+    client::default_sock_path(paths)
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(windows)]
+fn soldr_daemon_endpoint_path(paths: &SoldrPaths) -> String {
+    crate::cache_lib::daemon_pipe_name(paths)
+}
+
+async fn read_backend_handle_probe_request<S>(stream: &mut S, prefix: &[u8]) -> io::Result<Frame>
+where
+    S: AsyncRead + Unpin,
+{
+    if !is_backend_handle_probe_prefix(prefix) {
+        return Err(invalid_data(
+            "not a running-process BackendHandle probe frame",
+        ));
+    }
+    let body_len = u32::from_le_bytes([prefix[1], prefix[2], prefix[3], prefix[4]]) as usize;
+    let mut body = vec![0_u8; body_len];
+    if body_len > 0 {
+        stream.read_exact(&mut body).await?;
+    }
+    Frame::decode(body.as_slice()).map_err(|err| invalid_data(err.to_string()))
+}
+
+fn validate_backend_handle_probe_request(frame: &Frame) -> io::Result<[u8; 32]> {
+    if frame.envelope_version != ENVELOPE_VERSION as u32 {
+        return Err(invalid_data(
+            "BackendHandle probe envelope_version is not v1",
+        ));
+    }
+    if FrameKind::try_from(frame.kind) != Ok(FrameKind::Request) {
+        return Err(invalid_data("BackendHandle probe kind is not REQUEST"));
+    }
+    if frame.payload_protocol != BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL {
+        return Err(invalid_data(
+            "BackendHandle probe payload_protocol does not match",
+        ));
+    }
+    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
+        return Err(invalid_data("BackendHandle probe payload is compressed"));
+    }
+    frame
+        .payload
+        .as_slice()
+        .try_into()
+        .map_err(|_| invalid_data("BackendHandle probe nonce must be 32 bytes"))
+}
+
+async fn write_backend_handle_probe_response<S>(
+    stream: &mut S,
+    request_frame: &Frame,
+    nonce: &[u8; 32],
+    daemon: &DaemonProcess,
+) -> io::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let mut payload = Vec::with_capacity(BACKEND_HANDLE_PROBE_NONCE_BYTES + 256);
+    payload.extend_from_slice(nonce);
+    daemon
+        .to_proto()
+        .encode(&mut payload)
+        .map_err(|err| invalid_data(err.to_string()))?;
+
+    let response = Frame {
+        envelope_version: ENVELOPE_VERSION as u32,
+        kind: FrameKind::Response as i32,
+        payload_protocol: BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
+        payload,
+        request_id: request_frame.request_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: request_frame.traceparent.clone(),
+        tracestate: request_frame.tracestate.clone(),
+    };
+
+    let mut body = Vec::with_capacity(response.encoded_len());
+    response
+        .encode(&mut body)
+        .map_err(|err| invalid_data(err.to_string()))?;
+    if body.len() > MAX_FRAME_BYTES {
+        return Err(invalid_data(
+            "BackendHandle probe response exceeds frame cap",
+        ));
+    }
+
+    let mut wire = Vec::with_capacity(BACKEND_HANDLE_PROBE_PREFIX_BYTES + body.len());
+    wire.push(ENVELOPE_VERSION);
+    wire.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    wire.extend_from_slice(&body);
+    stream.write_all(&wire).await?;
+    stream.flush().await
+}
+
+fn sha256_file(path: &Path) -> io::Result<[u8; 32]> {
+    let bytes = std::fs::read(path)?;
+    let digest = Sha256::digest(&bytes);
+    let mut out = [0_u8; 32];
+    out.copy_from_slice(&digest);
+    Ok(out)
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
 }
 
 #[cfg(test)]
@@ -106,19 +281,19 @@ mod tests {
     }
 
     #[test]
-    fn dependency_gate_documents_published_backend_handle_blocker() {
-        let gate = RUNNING_PROCESS_BACKEND_HANDLE_GATE;
-        assert_eq!(gate.crate_name, "running-process");
-        assert_eq!(gate.checked_published_version, "4.0.3");
+    fn dependency_status_documents_active_backend_handle_usage() {
+        let status = RUNNING_PROCESS_BACKEND_HANDLE_STATUS;
+        assert_eq!(status.crate_name, "running-process");
+        assert!(status.dependency_source.contains("04f6387c3cf5b2a984"));
         assert_eq!(
-            gate.required_symbol,
+            status.required_symbol,
             "running_process::broker::backend_handle::BackendHandle"
         );
-        assert_eq!(gate.running_process_issue, "zackees/running-process#232");
-        assert_eq!(gate.soldr_issue, "zackees/soldr#718");
-        assert!(gate
-            .remaining_gate
-            .contains("publish a running-process release"));
+        assert_eq!(status.running_process_issue, "zackees/running-process#232");
+        assert_eq!(status.adoption_tracker_issue, "zackees/running-process#242");
+        assert_eq!(status.soldr_issue, "zackees/soldr#718");
+        assert!(status.active_endpoint_probe);
+        assert!(status.remaining_gate.contains("three-OS"));
     }
 
     #[test]
@@ -139,23 +314,32 @@ mod tests {
     }
 
     #[test]
-    fn probe_current_process_records_backend_handle_shape() {
+    fn pid_file_identity_records_running_process_backend_handle_shape() {
         let temp = TempDir::new().expect("tempdir");
         let paths = SoldrPaths::with_root(temp.path().to_path_buf());
         let current_exe = std::env::current_exe().expect("current exe");
-        let current_stem = current_exe.file_stem().and_then(|s| s.to_str()).unwrap();
-        write_pid_file(&paths, std::process::id(), &current_exe);
 
-        let handle = probe_daemon_with_expected_stem(&paths, current_stem)
-            .expect("current test process should probe");
+        let identity =
+            daemon_process_from_pid_file(&paths, std::process::id(), current_exe.clone())
+                .expect("identity");
 
-        assert_eq!(handle.service_name, SOLDR_DAEMON_SERVICE_NAME);
-        assert_eq!(handle.service_version, SOLDR_DAEMON_SERVICE_VERSION);
-        assert_eq!(handle.protocol_version, PROTOCOL_VERSION);
-        assert_eq!(handle.pid(), std::process::id());
-        assert_eq!(handle.exe_path, current_exe);
-        assert_eq!(handle.endpoint, client::default_sock_path(&paths));
-        assert_eq!(handle.pid_file, daemon_pid_path(&paths));
-        assert_eq!(handle.adoption_gate, RUNNING_PROCESS_BACKEND_HANDLE_GATE);
+        assert_eq!(identity.pid, std::process::id());
+        assert_eq!(identity.exe_path, current_exe);
+        assert_eq!(identity.ipc_endpoint, soldr_daemon_endpoint(&paths));
+        assert_eq!(identity.exe_sha256, sha256_file(&current_exe).unwrap());
+        assert!(!identity.boot_id.is_empty());
+    }
+
+    #[test]
+    fn backend_handle_probe_prefix_classifies_broker_v1_only() {
+        let mut running_process_prefix = [0_u8; BACKEND_HANDLE_PROBE_PREFIX_BYTES];
+        running_process_prefix[0] = ENVELOPE_VERSION;
+        running_process_prefix[1..].copy_from_slice(&16_u32.to_le_bytes());
+        assert!(is_backend_handle_probe_prefix(&running_process_prefix));
+
+        let mut soldr_prefix = [0_u8; BACKEND_HANDLE_PROBE_PREFIX_BYTES];
+        soldr_prefix[..4].copy_from_slice(&1_u32.to_le_bytes());
+        soldr_prefix[4] = PROTOCOL_VERSION as u8;
+        assert!(!is_backend_handle_probe_prefix(&soldr_prefix));
     }
 }

--- a/crates/soldr-cli/src/daemon/ipc.rs
+++ b/crates/soldr-cli/src/daemon/ipc.rs
@@ -115,9 +115,26 @@ where
     R: tokio::io::AsyncRead + Unpin,
     T: WireBody,
 {
+    read_frame_async_with_prefix(r, &[]).await
+}
+
+pub async fn read_frame_async_with_prefix<R, T>(r: &mut R, prefix: &[u8]) -> io::Result<T>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    T: WireBody,
+{
     use tokio::io::AsyncReadExt;
+    if prefix.len() > HEADER_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "frame prefix exceeds header length",
+        ));
+    }
     let mut header = [0u8; HEADER_BYTES];
-    r.read_exact(&mut header).await?;
+    header[..prefix.len()].copy_from_slice(prefix);
+    if prefix.len() < HEADER_BYTES {
+        r.read_exact(&mut header[prefix.len()..]).await?;
+    }
     let body_len = u32::from_le_bytes(header[..4].try_into().expect("4 bytes"));
     let version = u32::from_le_bytes(header[4..].try_into().expect("4 bytes"));
     if version != PROTOCOL_VERSION {

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -10,8 +10,11 @@ use crate::cache_lib::daemon_sock_path;
 use crate::cache_lib::target_registry::TargetRegistry;
 use crate::cache_lib::{data_db_path, soldr_daemon_dir};
 use crate::core::SoldrPaths;
+use crate::daemon::backend_handle_adoption::{
+    current_daemon_process, handle_backend_handle_probe_async, is_backend_handle_probe_prefix,
+};
 use crate::daemon::db;
-use crate::daemon::ipc::{read_frame_async, write_frame_async};
+use crate::daemon::ipc::{read_frame_async_with_prefix, write_frame_async};
 use crate::daemon::lifecycle::{append_lifecycle_event, is_live, remove_pid_file, write_pid_file};
 use crate::daemon::protocol::{
     BuildRecord, CookStats, Request, Response, StatusInfo, ZccacheDaemonLink, PROTOCOL_VERSION,
@@ -89,6 +92,10 @@ struct State {
     /// so cook-artifact path construction does not need to re-probe
     /// HOME/SOLDR_CACHE_DIR on every IPC request.
     paths: SoldrPaths,
+    /// Identity returned to `running-process` BackendHandle endpoint
+    /// probes. The client-side liveness check only trusts the PID
+    /// file after this endpoint response matches.
+    daemon_identity: running_process::broker::backend_handle::DaemonProcess,
     /// Linked zccache runtime kept in memory for fast `Status` replies;
     /// also persisted to redb so a daemon restart can resume shutdown.
     linked_zccache: std::sync::Mutex<Option<ZccacheDaemonLink>>,
@@ -184,9 +191,13 @@ async fn run_async(opts: ServerOptions) -> Result<(), ServerError> {
     // Resume any linked zccache identity persisted across daemon restarts.
     let resumed_link = db::get_linked_zccache(&db_path).ok().flatten();
     let start_instant = Instant::now();
+    let idle_timeout_secs = u32::try_from(opts.idle_timeout.as_secs()).ok();
+    let daemon_identity = current_daemon_process(&paths, idle_timeout_secs)
+        .map_err(|err| ServerError::Io(std::io::Error::other(err.to_string())))?;
     let state = Arc::new(State {
         db_path,
         paths: paths.clone(),
+        daemon_identity,
         linked_zccache: std::sync::Mutex::new(resumed_link),
         start_instant,
         request_count: AtomicU64::new(0),
@@ -303,7 +314,19 @@ async fn handle_connection<S>(mut stream: S, state: Arc<State>) -> std::io::Resu
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
-    let req: Request = match read_frame_async(&mut stream).await {
+    use tokio::io::AsyncReadExt;
+
+    let mut prefix = [0_u8; 5];
+    if stream.read_exact(&mut prefix).await.is_err() {
+        return Ok(());
+    }
+    if is_backend_handle_probe_prefix(&prefix) {
+        let _ =
+            handle_backend_handle_probe_async(&mut stream, &prefix, &state.daemon_identity).await;
+        return Ok(());
+    }
+
+    let req: Request = match read_frame_async_with_prefix(&mut stream, &prefix).await {
         Ok(r) => r,
         Err(_) => return Ok(()),
     };

--- a/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
+++ b/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
@@ -11,6 +11,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
+use soldr_cli::core::SoldrPaths;
 
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -136,6 +137,12 @@ fn start_status_stop_round_trip() {
     assert_eq!(body["running"].as_bool(), Some(true));
     let pid = body["pid"].as_u64().expect("status carries pid");
     assert!(pid > 0);
+    let paths = SoldrPaths::with_root(cache_root.clone());
+    assert_eq!(
+        soldr_cli::daemon::lifecycle::is_live(&paths).map(u64::from),
+        Some(pid),
+        "lifecycle::is_live must verify the daemon through running-process BackendHandle",
+    );
 
     let stop = run_soldr(&["daemon", "stop"], &cache_root, &home_root);
     assert!(stop.status.success(), "stop failed: {stop:?}");


### PR DESCRIPTION
## Summary

- Pin `running-process` to zackees/running-process PR #350 merge commit and use `running_process::broker::backend_handle::BackendHandle` for soldr-daemon liveness.
- Teach soldr-daemon to answer the upstream broker-v1 BackendHandle endpoint probe on its existing IPC endpoint while preserving the current soldr prost-v5 request path.
- Add Windows-local lifecycle coverage that `lifecycle::is_live` verifies the spawned daemon through BackendHandle; clean an existing `release_worktree` clippy blocker so all-targets lint is green.

Refs zackees/running-process#232
Refs zackees/running-process#242
Refs zackees/running-process#228
Refs zackees/soldr#718

## Validation

- `soldr cargo check -p soldr-cli`
- `soldr cargo test -p soldr-cli backend_handle_adoption -- --nocapture`
- `soldr cargo test -p soldr-cli --test cli_daemon_lifecycle -- --nocapture`
- `soldr cargo test -p soldr-cli --test cli_daemon_target_touch -- --nocapture`
- `soldr cargo clippy -p soldr-cli --lib -- -D warnings`
- `soldr cargo clippy -p soldr-cli --test cli_daemon_lifecycle --test cli_daemon_target_touch -- -D warnings`
- `soldr cargo clippy -p soldr-cli --all-targets -- -D warnings`
- `soldr cargo test -p soldr-cli release_worktree -- --nocapture`
- `soldr cargo fmt -- --check`
- `git diff --check`