### PR TITLE
feat: install soldr running-process servicedef

### DIFF
--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -421,6 +421,17 @@ pub(crate) enum DaemonSubcommand {
         #[arg(long)]
         json: bool,
     },
+    /// Write soldr-daemon's running-process service definition.
+    #[command(name = "install-servicedef")]
+    InstallServiceDef {
+        /// Override the soldr-daemon binary path. Defaults to a sibling
+        /// of the current soldr executable.
+        #[arg(long, value_name = "PATH")]
+        daemon_binary: Option<std::path::PathBuf>,
+        /// Emit the installed path and deferred broker-adoption items as JSON.
+        #[arg(long)]
+        json: bool,
+    },
     /// Query recorded build sessions.
     Builds {
         #[command(subcommand)]

--- a/crates/soldr-cli/src/daemon/lifecycle.rs
+++ b/crates/soldr-cli/src/daemon/lifecycle.rs
@@ -116,7 +116,7 @@ pub fn append_lifecycle_event(paths: &SoldrPaths, event: &str) {
 /// before the socket is ready.
 pub fn try_spawn_detached() -> Result<(), LifecycleError> {
     let current = std::env::current_exe().map_err(|_| LifecycleError::NoExe)?;
-    let daemon_src = sibling_daemon_binary(&current);
+    let daemon_src = crate::daemon::service_definition::sibling_daemon_binary(&current);
     if !daemon_src.exists() {
         return Err(LifecycleError::NoExe);
     }
@@ -149,6 +149,7 @@ pub fn try_spawn_detached() -> Result<(), LifecycleError> {
         None => daemon_src,
     };
 
+    let _ = crate::daemon::service_definition::install_service_definition(&relocated);
     spawn_detached_inner(&relocated).map_err(LifecycleError::Spawn)
 }
 
@@ -180,18 +181,6 @@ pub(crate) fn acquire_spawn_lock(paths: &SoldrPaths) -> Option<std::fs::File> {
         Ok(()) => Some(file),
         Err(_) => None,
     }
-}
-
-fn sibling_daemon_binary(current: &Path) -> PathBuf {
-    let stem = if cfg!(windows) {
-        "soldr-daemon.exe"
-    } else {
-        "soldr-daemon"
-    };
-    current
-        .parent()
-        .map(|p| p.join(stem))
-        .unwrap_or_else(|| PathBuf::from(stem))
 }
 
 #[cfg(unix)]

--- a/crates/soldr-cli/src/daemon/mod.rs
+++ b/crates/soldr-cli/src/daemon/mod.rs
@@ -26,5 +26,6 @@ pub mod ipc;
 pub mod lifecycle;
 pub mod protocol;
 pub mod server;
+pub mod service_definition;
 pub mod wire;
 pub mod zccache_link;

--- a/crates/soldr-cli/src/daemon/service_definition.rs
+++ b/crates/soldr-cli/src/daemon/service_definition.rs
@@ -1,0 +1,168 @@
+//! Minimal `running-process` service-definition support for soldr-daemon.
+//!
+//! This is the package/discovery slice for zackees/soldr#718. It makes
+//! soldr-daemon discoverable by the shared broker without switching soldr's
+//! own hot path to broker-mediated connects yet.
+
+use crate::daemon::backend_handle_adoption::{
+    SOLDR_DAEMON_SERVICE_NAME, SOLDR_DAEMON_SERVICE_VERSION,
+};
+use prost14::Message as _;
+use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
+use running_process::broker::server::{
+    ensure_service_definition_dir, service_definition_dir, service_definition_path,
+    validate_service_definition_for_service,
+};
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub(crate) const SOLDR_DAEMON_SERVICE_DEF_DEFERRED: &[&str] = &[
+    "broker-client connect_to_backend wiring",
+    "RUNNING_PROCESS_DISABLE escape-hatch enforcement",
+    "default-on rollout and escape-hatch removal",
+];
+
+#[derive(Debug, Clone)]
+pub(crate) struct InstalledServiceDefinition {
+    pub(crate) path: PathBuf,
+    pub(crate) definition: ServiceDefinition,
+}
+
+pub(crate) fn sibling_daemon_binary(current: &Path) -> PathBuf {
+    let stem = if cfg!(windows) {
+        "soldr-daemon.exe"
+    } else {
+        "soldr-daemon"
+    };
+    current
+        .parent()
+        .map(|p| p.join(stem))
+        .unwrap_or_else(|| PathBuf::from(stem))
+}
+
+pub(crate) fn default_daemon_binary() -> io::Result<PathBuf> {
+    let current = std::env::current_exe()?;
+    Ok(sibling_daemon_binary(&current))
+}
+
+pub(crate) fn soldr_daemon_service_definition(
+    daemon_binary: &Path,
+) -> io::Result<ServiceDefinition> {
+    let binary = std::fs::canonicalize(daemon_binary)?;
+    let binary_dir = binary.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "soldr-daemon binary path has no parent directory",
+        )
+    })?;
+
+    let mut labels = HashMap::new();
+    labels.insert("vendor".to_string(), "zackees".to_string());
+    labels.insert("package".to_string(), "soldr".to_string());
+    labels.insert(
+        "running-process-tracker".to_string(),
+        "zackees/soldr#718".to_string(),
+    );
+
+    let definition = ServiceDefinition {
+        service_name: SOLDR_DAEMON_SERVICE_NAME.to_string(),
+        binary_path: binary.display().to_string(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: binary_dir.display().to_string(),
+        min_version: SOLDR_DAEMON_SERVICE_VERSION.to_string(),
+        version_allow_list: vec![SOLDR_DAEMON_SERVICE_VERSION.to_string()],
+        labels,
+    };
+    validate_service_definition_for_service(&definition, SOLDR_DAEMON_SERVICE_NAME)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
+    Ok(definition)
+}
+
+pub(crate) fn install_default_service_definition() -> io::Result<InstalledServiceDefinition> {
+    install_service_definition(&default_daemon_binary()?)
+}
+
+pub(crate) fn install_service_definition(
+    daemon_binary: &Path,
+) -> io::Result<InstalledServiceDefinition> {
+    install_service_definition_to_dir(service_definition_dir(), daemon_binary)
+}
+
+pub(crate) fn install_service_definition_to_dir(
+    service_root: impl AsRef<Path>,
+    daemon_binary: &Path,
+) -> io::Result<InstalledServiceDefinition> {
+    let service_root = service_root.as_ref();
+    ensure_service_definition_dir(service_root).map_err(|err| io::Error::other(err.to_string()))?;
+    let definition = soldr_daemon_service_definition(daemon_binary)?;
+    let path = service_definition_path(service_root, SOLDR_DAEMON_SERVICE_NAME)
+        .map_err(|err| io::Error::other(err.to_string()))?;
+
+    std::fs::write(&path, definition.encode_to_vec())?;
+    Ok(InstalledServiceDefinition { path, definition })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use running_process::broker::server::ServiceDefinitionLoader;
+    use tempfile::TempDir;
+
+    fn fake_daemon_binary(root: &Path) -> PathBuf {
+        let binary = root.join(if cfg!(windows) {
+            "soldr-daemon.exe"
+        } else {
+            "soldr-daemon"
+        });
+        std::fs::write(&binary, b"stub").expect("fake daemon binary");
+        binary
+    }
+
+    #[test]
+    fn service_definition_declares_soldr_daemon_shared_broker() {
+        let temp = TempDir::new().expect("tempdir");
+        let daemon = fake_daemon_binary(temp.path());
+
+        let definition = soldr_daemon_service_definition(&daemon).expect("definition");
+
+        assert_eq!(definition.service_name, "soldr-daemon");
+        assert_eq!(definition.isolation, BrokerIsolation::SharedBroker as i32);
+        assert_eq!(definition.min_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(definition.version_allow_list, [env!("CARGO_PKG_VERSION")]);
+        assert_eq!(
+            definition
+                .labels
+                .get("running-process-tracker")
+                .map(String::as_str),
+            Some("zackees/soldr#718"),
+        );
+    }
+
+    #[test]
+    fn install_service_definition_writes_loader_compatible_protobuf() {
+        let temp = TempDir::new().expect("tempdir");
+        let service_root = temp.path().join("services");
+        let daemon = fake_daemon_binary(temp.path());
+
+        let installed = install_service_definition_to_dir(&service_root, &daemon)
+            .expect("install service definition");
+
+        assert_eq!(installed.path, service_root.join("soldr-daemon.servicedef"));
+        let loaded = ServiceDefinitionLoader::new(&service_root)
+            .load("soldr-daemon")
+            .expect("load service definition");
+        assert_eq!(loaded, installed.definition);
+    }
+
+    #[test]
+    fn deferred_items_document_minimal_slice_boundary() {
+        assert!(SOLDR_DAEMON_SERVICE_DEF_DEFERRED
+            .iter()
+            .any(|item| item.contains("connect_to_backend")));
+        assert!(SOLDR_DAEMON_SERVICE_DEF_DEFERRED
+            .iter()
+            .any(|item| item.contains("escape-hatch")));
+    }
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -1010,6 +1010,35 @@ fn run_daemon_command(command: DaemonSubcommand) -> Result<(), SoldrError> {
             }
             Err(e) => Err(SoldrError::Other(format!("daemon status failed: {e:?}"))),
         },
+        DaemonSubcommand::InstallServiceDef {
+            daemon_binary,
+            json,
+        } => {
+            let installed = match daemon_binary {
+                Some(path) => crate::daemon::service_definition::install_service_definition(&path),
+                None => crate::daemon::service_definition::install_default_service_definition(),
+            }
+            .map_err(|e| SoldrError::Other(format!("failed to install servicedef: {e}")))?;
+            if json {
+                let payload = serde_json::json!({
+                    "path": installed.path,
+                    "service_name": installed.definition.service_name,
+                    "binary_path": installed.definition.binary_path,
+                    "per_version_binary_dir": installed.definition.per_version_binary_dir,
+                    "min_version": installed.definition.min_version,
+                    "version_allow_list": installed.definition.version_allow_list,
+                    "isolation": "SHARED_BROKER",
+                    "deferred": crate::daemon::service_definition::SOLDR_DAEMON_SERVICE_DEF_DEFERRED,
+                });
+                println!("{}", serde_json::to_string(&payload).unwrap_or_default());
+            } else {
+                println!(
+                    "soldr-daemon servicedef installed at {}",
+                    installed.path.display()
+                );
+            }
+            Ok(())
+        }
         DaemonSubcommand::Builds { command } => match command {
             DaemonBuildsSubcommand::List {
                 limit,

--- a/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
+++ b/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::print_stdout)]
 
 use std::ffi::OsString;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -175,4 +176,66 @@ fn status_when_daemon_absent_reports_not_running() {
     );
     let body: Value = serde_json::from_slice(&out.stdout).expect("status json");
     assert_eq!(body["running"].as_bool(), Some(false));
+}
+
+#[test]
+fn install_servicedef_writes_running_process_definition() {
+    let cache_root = unique_temp_dir("daemon-servicedef-cache");
+    let home_root = unique_temp_dir("daemon-servicedef-home");
+    let service_root = unique_temp_dir("daemon-servicedef-services");
+    let daemon_dir = unique_temp_dir("daemon-servicedef-bin");
+    let daemon_binary = daemon_dir.join(if cfg!(windows) {
+        "soldr-daemon.exe"
+    } else {
+        "soldr-daemon"
+    });
+    fs::write(&daemon_binary, b"stub daemon").expect("write fake daemon binary");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_soldr"));
+    cmd.args([
+        "daemon",
+        "install-servicedef",
+        "--daemon-binary",
+        daemon_binary.to_str().expect("utf8 daemon path"),
+        "--json",
+    ]);
+    for (k, v) in isolated_env(&cache_root, &home_root) {
+        cmd.env(k, v);
+    }
+    cmd.env("RUNNING_PROCESS_SERVICE_DEF_DIR", &service_root);
+    cmd.env_remove("RUSTC_WRAPPER");
+    let out = cmd.output().expect("run soldr daemon install-servicedef");
+
+    assert!(
+        out.status.success(),
+        "install-servicedef failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let body: Value = serde_json::from_slice(&out.stdout).expect("servicedef json");
+    assert_eq!(body["service_name"].as_str(), Some("soldr-daemon"));
+    assert!(body["deferred"]
+        .as_array()
+        .expect("deferred array")
+        .iter()
+        .any(|item| item
+            .as_str()
+            .is_some_and(|value| value.contains("connect_to_backend"))));
+
+    let loaded = running_process::broker::server::ServiceDefinitionLoader::new(&service_root)
+        .load("soldr-daemon")
+        .expect("running-process loader validates soldr servicedef");
+    assert_eq!(loaded.service_name, "soldr-daemon");
+    assert_eq!(
+        loaded.isolation,
+        running_process::broker::protocol::BrokerIsolation::SharedBroker as i32,
+    );
+    assert_eq!(
+        loaded.binary_path,
+        fs::canonicalize(&daemon_binary)
+            .unwrap()
+            .display()
+            .to_string()
+    );
+    assert_eq!(loaded.min_version, env!("CARGO_PKG_VERSION"));
 }


### PR DESCRIPTION
## Summary
- add `soldr daemon install-servicedef` to write a prost `soldr-daemon.servicedef` for the running-process broker
- declare soldr-daemon as `SHARED_BROKER` with the current soldr version as the min/version allow-list
- best-effort install the servicedef before direct daemon spawn so the local broker discovery file appears on first daemon start
- keep broker-client `connect_to_backend`, default-on rollout, and escape-hatch removal stubbed/deferred for the next slices

Links: zackees/soldr#718, zackees/running-process#232, zackees/running-process#242, zackees/running-process#228

## Critical Windows checks
- `soldr rustfmt --edition 2021 crates\soldr-cli\src\daemon\service_definition.rs crates\soldr-cli\src\daemon\mod.rs crates\soldr-cli\src\daemon\lifecycle.rs crates\soldr-cli\src\cli_args.rs crates\soldr-cli\src\main.rs crates\soldr-cli\tests\cli_daemon_lifecycle.rs`
- `git diff --check`
- `git diff --cached --check`
- `soldr cargo test -p soldr-cli service_definition -- --nocapture`
- `soldr cargo test -p soldr-cli --test cli_daemon_lifecycle install_servicedef_writes_running_process_definition -- --nocapture`
- `soldr cargo test -p soldr-cli --test cli_daemon_lifecycle start_status_stop_round_trip -- --nocapture`

## Deferred by current scope
- broker-client `running_process::broker::client::connect_to_backend` wiring and direct/broker mode split
- `RUNNING_PROCESS_DISABLE=1` escape hatch enforcement
- default-on rollout, README/doc sweep, escape-hatch removal, and full lint/dylint/CI matrix