### PR TITLE
feat: honor running-process disable for daemon liveness

### DIFF
--- a/crates/soldr-cli/src/daemon/backend_handle_adoption.rs
+++ b/crates/soldr-cli/src/daemon/backend_handle_adoption.rs
@@ -31,6 +31,7 @@ const BACKEND_HANDLE_PROBE_NONCE_BYTES: usize = 32;
 
 pub(crate) const SOLDR_DAEMON_SERVICE_NAME: &str = "soldr-daemon";
 pub(crate) const SOLDR_DAEMON_SERVICE_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const RUNNING_PROCESS_DISABLE_ENV: &str = "RUNNING_PROCESS_DISABLE";
 
 pub(crate) const RUNNING_PROCESS_BACKEND_HANDLE_STATUS: RunningProcessBackendHandleStatus =
     RunningProcessBackendHandleStatus {
@@ -78,6 +79,10 @@ impl SoldrDaemonBackendHandle {
     pub(crate) fn is_alive(&self) -> bool {
         pid_is_alive(self.pid) && pid_exe_stem_matches(self.pid, SOLDR_DAEMON_SERVICE_NAME)
     }
+}
+
+pub(crate) fn running_process_disabled() -> bool {
+    std::env::var(RUNNING_PROCESS_DISABLE_ENV).is_ok_and(|value| value == "1")
 }
 
 pub(crate) fn probe_soldr_daemon(paths: &SoldrPaths) -> Option<SoldrDaemonBackendHandle> {
@@ -294,6 +299,27 @@ mod tests {
         assert_eq!(status.soldr_issue, "zackees/soldr#718");
         assert!(status.active_endpoint_probe);
         assert!(status.remaining_gate.contains("three-OS"));
+    }
+
+    #[test]
+    fn running_process_disable_requires_exact_one() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        let prior = std::env::var_os(RUNNING_PROCESS_DISABLE_ENV);
+
+        std::env::remove_var(RUNNING_PROCESS_DISABLE_ENV);
+        assert!(!running_process_disabled());
+
+        std::env::set_var(RUNNING_PROCESS_DISABLE_ENV, "true");
+        assert!(!running_process_disabled());
+
+        std::env::set_var(RUNNING_PROCESS_DISABLE_ENV, "1");
+        assert!(running_process_disabled());
+
+        match prior {
+            Some(value) => std::env::set_var(RUNNING_PROCESS_DISABLE_ENV, value),
+            None => std::env::remove_var(RUNNING_PROCESS_DISABLE_ENV),
+        }
     }
 
     #[test]

--- a/crates/soldr-cli/src/daemon/lifecycle.rs
+++ b/crates/soldr-cli/src/daemon/lifecycle.rs
@@ -46,7 +46,37 @@ pub fn read_pid_file(paths: &SoldrPaths) -> Option<(u32, PathBuf)> {
 /// running exe stem looks like a soldr-daemon. Returns the PID on
 /// success, None on any mismatch / missing file.
 pub fn is_live(paths: &SoldrPaths) -> Option<u32> {
+    is_live_with_running_process_disabled(
+        paths,
+        crate::daemon::backend_handle_adoption::running_process_disabled(),
+    )
+}
+
+pub(crate) fn is_live_with_running_process_disabled(
+    paths: &SoldrPaths,
+    running_process_disabled: bool,
+) -> Option<u32> {
+    if running_process_disabled {
+        return direct_pid_file_live(paths);
+    }
+
     crate::daemon::backend_handle_adoption::probe_soldr_daemon(paths).map(|handle| handle.pid())
+}
+
+pub(crate) fn direct_pid_file_live(paths: &SoldrPaths) -> Option<u32> {
+    direct_pid_file_live_for_stem(
+        paths,
+        crate::daemon::backend_handle_adoption::SOLDR_DAEMON_SERVICE_NAME,
+    )
+}
+
+fn direct_pid_file_live_for_stem(paths: &SoldrPaths, expected_stem: &str) -> Option<u32> {
+    let (pid, _exe_path) = read_pid_file(paths)?;
+    if pid_is_alive(pid) && pid_exe_stem_matches(pid, expected_stem) {
+        Some(pid)
+    } else {
+        None
+    }
 }
 
 /// Write the PID file for the running daemon. Overwrites any stale
@@ -149,7 +179,9 @@ pub fn try_spawn_detached() -> Result<(), LifecycleError> {
         None => daemon_src,
     };
 
-    let _ = crate::daemon::service_definition::install_service_definition(&relocated);
+    if !crate::daemon::backend_handle_adoption::running_process_disabled() {
+        let _ = crate::daemon::service_definition::install_service_definition(&relocated);
+    }
     spawn_detached_inner(&relocated).map_err(LifecycleError::Spawn)
 }
 
@@ -333,6 +365,29 @@ mod spawn_lock_tests {
         // After release, the next call gets the lock back.
         let third = acquire_spawn_lock(&paths).expect("third acquire after release");
         drop(third);
+    }
+
+    #[test]
+    fn direct_pid_file_live_accepts_expected_process_stem() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = SoldrPaths::with_root(temp.path().to_path_buf());
+        std::fs::create_dir_all(soldr_daemon_dir(&paths)).expect("daemon dir");
+        let current_exe = std::env::current_exe().expect("current exe");
+        let current_stem = current_exe
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .expect("current exe stem")
+            .to_string();
+        std::fs::write(
+            daemon_pid_path(&paths),
+            format!("{}\n{}\n", std::process::id(), current_exe.display()),
+        )
+        .expect("pid file");
+
+        assert_eq!(
+            direct_pid_file_live_for_stem(&paths, &current_stem),
+            Some(std::process::id())
+        );
     }
 
     #[test]

--- a/crates/soldr-cli/src/daemon/service_definition.rs
+++ b/crates/soldr-cli/src/daemon/service_definition.rs
@@ -18,8 +18,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 pub(crate) const SOLDR_DAEMON_SERVICE_DEF_DEFERRED: &[&str] = &[
+    "package/postinstall servicedef auto-install coverage",
     "broker-client connect_to_backend wiring",
-    "RUNNING_PROCESS_DISABLE escape-hatch enforcement",
     "default-on rollout and escape-hatch removal",
 ];
 
@@ -161,6 +161,9 @@ mod tests {
         assert!(SOLDR_DAEMON_SERVICE_DEF_DEFERRED
             .iter()
             .any(|item| item.contains("connect_to_backend")));
+        assert!(!SOLDR_DAEMON_SERVICE_DEF_DEFERRED
+            .iter()
+            .any(|item| item.contains("RUNNING_PROCESS_DISABLE")));
         assert!(SOLDR_DAEMON_SERVICE_DEF_DEFERRED
             .iter()
             .any(|item| item.contains("escape-hatch")));

--- a/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
+++ b/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
@@ -9,10 +9,35 @@ use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 use soldr_cli::core::SoldrPaths;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct EnvScope {
+    key: &'static str,
+    prior: Option<OsString>,
+}
+
+impl EnvScope {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, prior }
+    }
+}
+
+impl Drop for EnvScope {
+    fn drop(&mut self) {
+        match &self.prior {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
 
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -162,6 +187,34 @@ fn start_status_stop_round_trip() {
         "pid file left behind at {}",
         pid_path.display()
     );
+}
+
+#[test]
+fn running_process_disable_uses_direct_daemon_liveness() {
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+    let daemon = Daemon::spawn();
+    let cache_root = daemon.cache_root.clone();
+    let home_root = daemon.home_root.clone();
+
+    let status = run_soldr(&["daemon", "status", "--json"], &cache_root, &home_root);
+    assert!(
+        status.status.success(),
+        "soldr daemon status failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let body: Value = serde_json::from_slice(&status.stdout).expect("status json");
+    let pid = body["pid"].as_u64().expect("status carries pid");
+
+    let _env = EnvScope::set("RUNNING_PROCESS_DISABLE", "1");
+    let paths = SoldrPaths::with_root(cache_root);
+    assert_eq!(
+        soldr_cli::daemon::lifecycle::is_live(&paths).map(u64::from),
+        Some(pid),
+        "RUNNING_PROCESS_DISABLE=1 should bypass BackendHandle but keep direct daemon liveness",
+    );
+
+    drop(daemon);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- honor `RUNNING_PROCESS_DISABLE=1` for soldr-daemon liveness by bypassing the running-process BackendHandle probe and using the direct PID/exe check
- skip best-effort running-process servicedef installation when the escape hatch is active
- remove `RUNNING_PROCESS_DISABLE` from the soldr servicedef deferred list while keeping package/postinstall install and broker-client routing stubbed
- add focused coverage for exact env parsing, direct PID helper behavior, service-definition deferred boundaries, and live-daemon direct liveness

## Critical Windows-local checks
- `soldr rustfmt --edition 2021 crates\soldr-cli\src\daemon\backend_handle_adoption.rs crates\soldr-cli\src\daemon\lifecycle.rs crates\soldr-cli\src\daemon\service_definition.rs crates\soldr-cli\tests\cli_daemon_lifecycle.rs`
- `git diff --check`
- `soldr cargo test -p soldr-cli running_process_disable -- --nocapture`
- `soldr cargo test -p soldr-cli direct_pid_file_live -- --nocapture`
- `soldr cargo test -p soldr-cli service_definition -- --nocapture`
- `soldr cargo test -p soldr-cli --test cli_daemon_lifecycle running_process_disable_uses_direct_daemon_liveness -- --nocapture`

## Stubbed / deferred
- package/postinstall servicedef auto-install coverage
- broker-client `connect_to_backend` wiring and direct/broker mode split
- default-on rollout, escape-hatch removal, README/doc sweep, full three-OS acceptance, lint, dylint, and broad CI matrix waiting

Refs zackees/soldr#718.
Refs zackees/running-process#242.
Refs zackees/running-process#228.