### PR TITLE
chore(release): bump 0.7.53 -> 0.7.54 + running-process git -> crates.io 4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,8 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.0.3"
-source = "git+https://github.com/zackees/running-process?rev=04f6387c3cf5b2a984cd4bbba8a3e6f177d43a89#04f6387c3cf5b2a984cd4bbba8a3e6f177d43a89"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b463aaf22bc2a27eb0b7bf347c4aa315075796908f859fbd8bcd469041cfc940"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2102,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.53"
+version = "0.7.54"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.53"
+version = "0.7.54"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -22,7 +22,7 @@ prost14 = { package = "prost", version = "0.14" }
 rayon = { workspace = true }
 redb = { workspace = true }
 reqwest = { workspace = true }
-running-process = { git = "https://github.com/zackees/running-process", rev = "04f6387c3cf5b2a984cd4bbba8a3e6f177d43a89", default-features = false, features = ["client"] }
+running-process = { version = "4.1.0", default-features = false, features = ["client"] }
 rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.53",
+  "version": "0.7.54",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

- Flip `crates/soldr-cli/Cargo.toml`'s `running-process` dep from the pinned git rev (`04f6387c3cf5b2a984cd4bbba8a3e6f177d43a89`, v4.0.3) to crates.io `version = "4.1.0"`. `default-features = false, features = ["client"]` preserved verbatim — no API delta.
- Regenerated `Cargo.lock` via `cargo update -p running-process` (now `source = "registry+https://github.com/rust-lang/crates.io-index"` with checksum).
- Bump workspace version 0.7.53 → 0.7.54 (`Cargo.toml`, `package.json`) so the Autonomous Release workflow (`release-auto.yml`) publishes the new crate-source pin to PyPI/npm.

## Context

The staged `feat/720-backend-handle-adoption` branch (tracking running-process#382 / soldr#720) is now mostly redundant: main independently merged

- #721 — BackendHandle probe adoption
- #723 — honor `RUNNING_PROCESS_DISABLE` for daemon liveness
- #724 — retry zccache session-start after daemon loss

Those PRs consumed the running-process 4.1.0 `BackendHandle` surface while still depending on the git rev. The only remaining loose end is to flip the dep source to the published crate and cut the release that ships it. This PR is exactly that.

Dead-code check on the two files the old branch deleted (`crates/soldr-cli/src/daemon/service_definition.rs`, `crates/soldr-cli/tests/cli_daemon_lifecycle.rs`): both are still actively referenced on origin/main — `service_definition` is used by `daemon/lifecycle.rs`, `daemon/mod.rs`, and `main.rs`; `cli_daemon_lifecycle.rs` is a live integration test. Not deleted.

Refs zackees/running-process#382

## Test plan

- [x] `soldr cargo build --workspace --locked` — clean
- [x] `soldr cargo fmt --all -- --check` — clean
- [x] `soldr cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `soldr cargo test --workspace --lib --locked` — 307 passed, 1 ignored
- [x] `soldr cargo test -p soldr-cli --test cli_daemon_lifecycle --test monocrate_guard --locked` — 6 passed (4 lifecycle + 2 monocrate guard)
- [ ] CI workflows on this PR (full sweep)