### PR TITLE
chore(deps): bump managed zccache 1.12.0 -> 1.12.1

### DIFF
--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -18,7 +18,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.12.0",
+    "managed_version": "1.12.1",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.1";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The


### PR DESCRIPTION
## Summary

Picks up [zccache#724](https://github.com/zackees/zccache/issues/724) fix shipped in [zccache#725](https://github.com/zackees/zccache/pull/725) (zccache 1.12.1): `FingerprintManager::on_batch` no longer holds DashMap shard locks across canonicalize + full-file blake3 hashing.

Before this, ESP32/LPC builds with ~400 watch roots wedged the daemon under burst load — one tokio worker spun in `_yield_write_shard` while RPC handlers starved and the client wedge guard tore the daemon down.

## Test plan

- [x] Bumps `MANAGED_ZCCACHE_VERSION` and `contracts/zccache-runtime.v1.json` `managed_version` in lockstep (drift test exists)
- [ ] CI green once zccache 1.12.1 is published to PyPI / crates.io / GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)