### PR TITLE
chore(deps): bump managed zccache 1.12.1 -> 1.12.3

### DIFF
--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -18,7 +18,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.12.1",
+    "managed_version": "1.12.3",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.1";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.3";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The


### PR DESCRIPTION
## Summary

Bumps managed zccache 1.12.1 -> 1.12.3 (skipping 1.12.2 — the consumer cascade never ran for 1.12.2; jumping straight to 1.12.3 gets all fixes).

Issues addressed in this jump:

- **#710** (stale clang PCH defeating `#pragma once`) — meson configure snapshot now uses a strict allowlist (`build.ninja`, `compile_commands.json`, `meson-info/`, `meson-private/`, `meson-logs/`). Built `*.pch` / `*.obj` / target subdirs no longer enter the snapshot. KEY_DOMAIN_TAG bumped v2->v3 so poisoned v2 entries on disk miss out. `zccache clear` now also purges `cache_root/meson-configure/`.
- **#726** (daemon murdered by 90s wedge guard under burst link load) — `WEDGE_RECV_DEFAULT_SECS` widened to 180s; `died-shutdown` lifecycle writes CAS-deduped.
- **#728** (`failed to persist artifact output: os error 2` was opaque) — WARN now carries `src=`, `src_exists_now=`, `src_size_now=`, `dst=`, `errno=`, `gap_ms=`.
- **#717** + **#729** (wedge guard regression coverage) — flaky test made deterministic, synthetic 200-way burst-link regression test added under integration suite.

Bumps both `MANAGED_ZCCACHE_VERSION` in `crates/soldr-cli/src/fetch/mod.rs` and `managed_version` in `contracts/zccache-runtime.v1.json` in lockstep (drift test exists).

## Test plan

- [ ] CI green once zccache 1.12.3 is published to PyPI / crates.io / GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)