### PR TITLE
chore(deps): bump managed zccache 1.12.3 -> 1.12.4

### DIFF
--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -18,7 +18,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.12.3",
+    "managed_version": "1.12.4",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.3";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.4";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The


### PR DESCRIPTION
## Summary

Bumps `MANAGED_ZCCACHE_VERSION` and `contracts/zccache-runtime.v1.json` from 1.12.3 to [1.12.4](https://github.com/zackees/zccache/releases/tag/1.12.4).

## Changes in zccache 1.12.4 (since 1.12.3)

- feat(daemon): auto-install ServiceDefinition at startup ([#720](https://github.com/zackees/zccache/issues/720))
- feat(cli): add `zccache cache list` subcommand ([#695](https://github.com/zackees/zccache/issues/695))
- feat(cli): add `zccache release-handles --path X` ([#694](https://github.com/zackees/zccache/issues/694))
- feat(cli): add `zccache cache size` subcommand ([#695](https://github.com/zackees/zccache/issues/695))
- refactor(wire_frame): port FrameV1 encode/decode onto running-process backend_sdk codecs ([#718](https://github.com/zackees/zccache/issues/718))
- docs(wire): add wire-stability commitment + CI guard ([#693](https://github.com/zackees/zccache/issues/693))
- test(daemon): synthetic spawn-storm reproducer for [#691](https://github.com/zackees/zccache/issues/691)

No wire-breaking changes.

## Test plan

- [ ] CI green (release-auto workflow regenerates managed binary download artifacts at the new version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)