### PR TITLE
chore(deps): bump running-process 4.3.0 -> 4.4.0 + use Endpoint smart ctors (#726)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,7 +87,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -474,7 +474,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -519,7 +519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1291,7 +1291,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1800,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216d9a8561599e3aeb48477d7fb404fd852f938808e75e8fad3ad9df2d993e5"
+checksum = "e0fed77f3564a9728493f29f3c48ef8a85d76508de94fc2bcb2baaea05b58c23"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1864,7 +1864,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2098,7 +2098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2221,7 +2221,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2765,7 +2765,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -22,7 +22,7 @@ prost14 = { package = "prost", version = "0.14" }
 rayon = { workspace = true }
 redb = { workspace = true }
 reqwest = { workspace = true }
-running-process = { version = "4.3.0", default-features = false, features = ["client"] }
+running-process = { version = "4.4.0", default-features = false, features = ["client"] }
 rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/soldr-cli/src/daemon/backend_handle_adoption.rs
+++ b/crates/soldr-cli/src/daemon/backend_handle_adoption.rs
@@ -36,15 +36,18 @@ pub(crate) const RUNNING_PROCESS_DISABLE_ENV: &str = "RUNNING_PROCESS_DISABLE";
 pub(crate) const RUNNING_PROCESS_BACKEND_HANDLE_STATUS: RunningProcessBackendHandleStatus =
     RunningProcessBackendHandleStatus {
         crate_name: "running-process",
-        dependency_source:
-            "git:https://github.com/zackees/running-process#04f6387c3cf5b2a984cd4bbba8a3e6f177d43a89",
+        // Tracks the published crates.io release the soldr-side adoption is
+        // anchored against. Bumped to 4.4.0 in #726 so the new `backend_sdk`
+        // module (`BackendEndpointMux`, `FrameClient`, identity-file helpers)
+        // is in scope; keep this in lockstep with `Cargo.toml`.
+        dependency_source: "crates.io:running-process@4.4.0",
         required_symbol: "running_process::broker::backend_handle::BackendHandle",
         running_process_issue: "zackees/running-process#232",
         adoption_tracker_issue: "zackees/running-process#242",
         soldr_issue: "zackees/soldr#718",
         active_endpoint_probe: true,
         remaining_gate:
-            "publish running-process with BackendHandle and collect three-OS downstream acceptance",
+            "adopt backend_sdk BackendEndpointMux for the probe handler (soldr#726 follow-up)",
     };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -153,22 +156,30 @@ fn daemon_process_from_pid_file(
 }
 
 fn soldr_daemon_endpoint(paths: &SoldrPaths) -> Endpoint {
-    Endpoint {
-        namespace_id: host_identity::current().namespace_id,
-        path: soldr_daemon_endpoint_path(paths),
+    let namespace_id = host_identity::current().namespace_id;
+    // Use running-process's smart constructors (issue #726): on
+    // Windows `Endpoint::windows_pipe` enforces the bare-pipe-name
+    // invariant (no leading `\\.\pipe\`, never empty), which the
+    // prior manual `Endpoint { path }` literal could silently
+    // violate and address the wrong pipe. `daemon_pipe_name` and
+    // `default_sock_path` are both soldr-controlled producers, so
+    // the smart-constructor errors only fire on a programming bug
+    // — `expect` is correct.
+    #[cfg(windows)]
+    {
+        Endpoint::windows_pipe(namespace_id, crate::cache_lib::daemon_pipe_name(paths))
+            .expect("daemon_pipe_name returns a bare, non-empty pipe name")
     }
-}
-
-#[cfg(unix)]
-fn soldr_daemon_endpoint_path(paths: &SoldrPaths) -> String {
-    client::default_sock_path(paths)
-        .to_string_lossy()
-        .into_owned()
-}
-
-#[cfg(windows)]
-fn soldr_daemon_endpoint_path(paths: &SoldrPaths) -> String {
-    crate::cache_lib::daemon_pipe_name(paths)
+    #[cfg(unix)]
+    {
+        Endpoint::unix_socket(
+            namespace_id,
+            client::default_sock_path(paths)
+                .to_string_lossy()
+                .into_owned(),
+        )
+        .expect("default_sock_path returns a non-empty socket path")
+    }
 }
 
 async fn read_backend_handle_probe_request<S>(stream: &mut S, prefix: &[u8]) -> io::Result<Frame>
@@ -288,7 +299,10 @@ mod tests {
     crate::timed_test!(dependency_status_documents_active_backend_handle_usage, {
         let status = RUNNING_PROCESS_BACKEND_HANDLE_STATUS;
         assert_eq!(status.crate_name, "running-process");
-        assert!(status.dependency_source.contains("04f6387c3cf5b2a984"));
+        // After #726 the dep ships as a published crates.io release rather
+        // than the pre-publication git pin.
+        assert!(status.dependency_source.starts_with("crates.io:"));
+        assert!(status.dependency_source.contains("running-process@"));
         assert_eq!(
             status.required_symbol,
             "running_process::broker::backend_handle::BackendHandle"
@@ -297,7 +311,8 @@ mod tests {
         assert_eq!(status.adoption_tracker_issue, "zackees/running-process#242");
         assert_eq!(status.soldr_issue, "zackees/soldr#718");
         assert!(status.active_endpoint_probe);
-        assert!(status.remaining_gate.contains("three-OS"));
+        // Remaining gate now describes the deferred BackendEndpointMux adoption.
+        assert!(status.remaining_gate.contains("backend_sdk"));
     });
 
     crate::timed_test!(running_process_disable_requires_exact_one, {


### PR DESCRIPTION
## Summary

First slice of #726 — bumps `running-process` to 4.4.0 (the first published release with the new `backend_sdk` module) and replaces the manual `Endpoint { namespace_id, path }` literal with the smart constructors. The bigger `BackendEndpointMux` probe-handler migration is unblocked and tracked as follow-up in the same issue.

Refs #726.

## What landed

- **Dep bump**: `running-process` 4.3.0 → 4.4.0 (`crates/soldr-cli/Cargo.toml` + `Cargo.lock`). 4.3.0 → 4.4.0 is a minor with no breaking changes to soldr's existing imports — compile + tests clean with no other source edits required.
- **`Endpoint::windows_pipe` / `Endpoint::unix_socket`** in `soldr_daemon_endpoint` (`daemon/backend_handle_adoption.rs`). The Windows constructor rejects `\.\pipe\` prefixes — before today, a stray prefix in a future caller would silently address the wrong pipe instead of panicking loudly. Soldr's pipe-name producer is already bare, so the new validation only trips on a programming bug; `expect` is the right discipline. Deletes the platform-split `soldr_daemon_endpoint_path` helpers in the process.
- **Status struct refresh**: `RUNNING_PROCESS_BACKEND_HANDLE_STATUS::dependency_source` was hardcoded to a stale git-commit URL (`04f6387c3cf5b2a984...`); switched to `crates.io:running-process@4.4.0` so the status struct reflects how the dep is actually pulled. Test assertions updated to check the new shape (`starts_with("crates.io:")`, contains `running-process@`) rather than the old commit hash. `remaining_gate` now describes the deferred `BackendEndpointMux` adoption.

## Deferred to follow-up (still under #726)

The probe-server migration — delete soldr's bespoke `is_backend_handle_probe_prefix`, `handle_backend_handle_probe_async`, `read_backend_handle_probe_request`, `validate_backend_handle_probe_request`, `write_backend_handle_probe_response` (~140 LoC in `backend_handle_adoption.rs:118-258`) in favor of `backend_sdk::BackendEndpointMux::poll` — is a structural refactor of `server.rs::handle_connection`: the mux returns a `MuxPoll` verdict (`Legacy`/`ProbeAnswered`/`Payload`/`NeedMoreBytes`) rather than a boolean, and needs a `legacy_detector` closure that classifies soldr's own wire prefix against `ENVELOPE_VERSION`. That's the next PR on #726.

`connect_to_backend` → `FrameClient` adoption is tracked separately as #718.

The issue body's references to `answer_backend_handle_probe` (~line 634) and `write/read/remove_daemon_identity` are stale — those have already been removed from soldr's source; the remaining work is exactly the `BackendEndpointMux` migration above.

## Test plan

- [x] `soldr cargo check -p soldr-cli --bin soldr` — clean
- [x] `soldr cargo test -p soldr-cli --bin soldr daemon::backend_handle_adoption` — 6/6 pass (covers the status-struct assertions + endpoint construction)
- [x] `soldr cargo clippy -p soldr-cli --all-targets -- -D warnings` — clean
- [x] `soldr rustfmt --check --edition 2021 crates/soldr-cli/src/daemon/backend_handle_adoption.rs` — clean on the lines I touched (pre-existing fmt drift on `crate::timed_test!(name, { body })` macros in this file is unrelated to #726 and was left for a separate fmt-only PR)

## Burn-down checklist

Part of the #707 burn-down meta. This unblocks the larger #726 follow-up and lets the dep bump land independently of the probe-handler refactor.