### PR TITLE
chore(deps): bump managed zccache 1.12.4 -> 1.12.7

### DIFF
--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -18,7 +18,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.12.4",
+    "managed_version": "1.12.7",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -87,7 +87,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.4";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.7";
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The


### PR DESCRIPTION
Picks up [zackees/zccache#763](https://github.com/zackees/zccache/pull/763) (version-namespaced cache root, closes the version-shadow chain at zackees/zccache#762) plus intervening 1.12.5/1.12.6 compile-path + observability fixes.