### PR TITLE
chore(release): bump 0.7.54 -> 0.7.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.54"
+version = "0.7.55"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.54"
+version = "0.7.55"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Ships [#735](https://github.com/zackees/soldr/pull/735) (managed zccache 1.12.4 → 1.12.7).