### PR TITLE
chore(release): sync package.json to 0.7.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.54",
+  "version": "0.7.55",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Follow-up to #736 — release-auto requires package.json and Cargo.toml in lockstep.