### PR TITLE
feat(fetch): clearer yellow warning + remediation hint for stale pinned zccache

### DIFF
--- a/crates/soldr-cli/src/fetch/zccache_runtime.rs
+++ b/crates/soldr-cli/src/fetch/zccache_runtime.rs
@@ -393,10 +393,13 @@ impl<'a> ZccacheResolver<'a> {
         if install_zccache::pinned_version_older_than_managed(&pinned.version) {
             if log_stale_pin {
                 eprintln!(
-                    "soldr: ignoring pinned zccache {} at {} because this soldr requires managed zccache {} or newer",
-                    pinned.version,
-                    pinned.runtime_dir.display(),
-                    MANAGED_ZCCACHE_VERSION
+                    "{}",
+                    stale_pin_warning(
+                        &pinned.version,
+                        &pinned.runtime_dir,
+                        MANAGED_ZCCACHE_VERSION,
+                        stderr_should_use_color(),
+                    )
                 );
             }
             return Ok(None);
@@ -407,4 +410,80 @@ impl<'a> ZccacheResolver<'a> {
 
 fn managed_runtime_dir(paths: &SoldrPaths) -> PathBuf {
     paths.bin.join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"))
+}
+
+/// Build the two-line "stale pinned zccache" warning. Pure so the
+/// color-on / color-off forms can be asserted from a unit test;
+/// mirrors `cargo_front_door::disk::low_disk_warning_for_free_bytes`.
+fn stale_pin_warning(
+    pinned_version: &str,
+    pinned_dir: &Path,
+    managed_version: &str,
+    use_color: bool,
+) -> String {
+    let warning = if use_color {
+        "\x1b[33mwarning\x1b[0m"
+    } else {
+        "warning"
+    };
+    format!(
+        "soldr: {warning}: pinned zccache {pinned_version} at {dir} is older than the managed zccache {managed_version} this soldr build requires; falling back to the managed install.\n\
+         soldr: {warning}:   recommendation: run `soldr install-zccache --remove` to purge the stale pin and silence this warning.",
+        dir = pinned_dir.display(),
+    )
+}
+
+fn stderr_should_use_color() -> bool {
+    use std::io::IsTerminal;
+
+    std::env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    crate::timed_test!(stale_pin_warning_colorizes_only_warning_label, {
+        let dir = PathBuf::from("/fake/.soldr/bin/zccache-pinned");
+        let colored = stale_pin_warning("1.8.1", &dir, "1.12.7", true);
+        assert!(
+            colored.contains("\x1b[33mwarning\x1b[0m"),
+            "expected ANSI-yellow warning label, got: {colored}"
+        );
+        assert!(
+            colored.starts_with("soldr: "),
+            "soldr: prefix must remain uncolored for log-grep: {colored}"
+        );
+        assert!(
+            colored.contains("1.8.1"),
+            "pinned version must appear in the message: {colored}"
+        );
+        assert!(
+            colored.contains("1.12.7"),
+            "managed version must appear in the message: {colored}"
+        );
+        assert!(
+            colored.contains("older than the managed zccache"),
+            "diagnostic phrasing missing: {colored}"
+        );
+        assert!(
+            colored.contains("soldr install-zccache --remove"),
+            "remediation recommendation missing: {colored}"
+        );
+    });
+
+    crate::timed_test!(stale_pin_warning_plain_form_drops_ansi, {
+        let dir = PathBuf::from("/fake/.soldr/bin/zccache-pinned");
+        let plain = stale_pin_warning("1.8.1", &dir, "1.12.7", false);
+        assert!(
+            !plain.contains('\x1b'),
+            "plain form must not contain ANSI escapes: {plain:?}"
+        );
+        assert!(plain.contains("warning"), "plain warning token missing");
+        assert!(
+            plain.contains("soldr install-zccache --remove"),
+            "remediation recommendation missing in plain form: {plain}"
+        );
+    });
 }


### PR DESCRIPTION
## Summary

The "soldr is ignoring your pinned zccache" message in `ZccacheResolver::resolve_usable_pinned` (`crates/soldr-cli/src/fetch/zccache_runtime.rs`) read like a debug log and offered no remedy. After several `MANAGED_ZCCACHE_VERSION` bumps (currently `1.12.7`), users with a long-ago `soldr install-zccache` pin (e.g. `1.8.1`) see this on every `soldr cargo` invocation with nothing actionable to do about it.

This PR:

- **Reworks the message into a two-line, user-readable warning** explaining that soldr is *falling back to the managed install* (not silently ignoring), and **explicitly recommends `soldr install-zccache --remove`** to purge the stale pin and silence the warning for good.
- **Colorizes the `warning:` label yellow** on terminals using raw ANSI (`\x1b[33m...\x1b[0m`), gated on `NO_COLOR` + `stderr().is_terminal()` — same pattern as `cargo_front_door::disk::low_disk_warning_for_free_bytes` (`crates/soldr-cli/src/cargo_front_door/disk.rs:33-52`). No new color crate. The `soldr: ` prefix stays uncolored so existing log-grep patterns still match.
- **Extracts the message body into a pure `stale_pin_warning(pinned_version, pinned_dir, managed_version, use_color) -> String`** so the color-on / color-off forms can be unit-tested. Two new `crate::timed_test!` cases sit next to the helper.

Before:
```
soldr: ignoring pinned zccache 1.8.1 at C:\Users\niteris\.soldr\bin\zccache-pinned because this soldr requires managed zccache 1.12.7 or newer
```

After:
```
soldr: warning: pinned zccache 1.8.1 at C:\Users\niteris\.soldr\bin\zccache-pinned is older than the managed zccache 1.12.7 this soldr build requires; falling back to the managed install.
soldr: warning:   recommendation: run `soldr install-zccache --remove` to purge the stale pin and silence this warning.
```
(`warning:` colorized yellow on terminals.)

## Test plan

- [x] `SOLDR_RUSTC_WRAPPER=none soldr cargo test -p soldr-cli --lib -- stale_pin_warning` — the two new unit tests for `stale_pin_warning` (color-on and color-off) pass.
- [x] `SOLDR_RUSTC_WRAPPER=none soldr cargo test -p soldr-cli --test lib_install_zccache --test cli_install_zccache_resolution` — the existing stale-pin integration tests (`known_stale_pinned_zccache_does_not_override_managed_cache`, `zccache_runtime_ignores_stale_pin_for_default_resolution`) still pass; they assert on `runtime.source` / `runtime.runtime_dir`, not on message text, so the wording change is transparent to them.
- [x] `SOLDR_RUSTC_WRAPPER=none soldr cargo clippy -p soldr-cli --lib --all-targets -- -D warnings` clean.
- [x] `soldr rustfmt --check --edition 2021 crates/soldr-cli/src/fetch/zccache_runtime.rs` clean.

## Notes

- No changes to `MANAGED_ZCCACHE_VERSION`, the runtime contract, or the version-comparison logic — this is a message-content change only.
- Pre-existing `cargo fmt --all -- --check` drift on `origin/main` in `crates/soldr-cli/src/daemon/{service_definition,handle_probe}.rs` (introduced by #727 / #734) may cause the CI fmt step to fail; that drift is independent of this PR and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)