### PR TITLE
feat(core): add MANAGED_SHIM_VERSION + SoldrPaths::versioned_root accessors (#743 Phase A)

### DIFF
--- a/crates/soldr-cli/src/core/paths.rs
+++ b/crates/soldr-cli/src/core/paths.rs
@@ -92,6 +92,28 @@ impl SoldrPaths {
         Ok(())
     }
 
+    /// Per-version state root — `<root>/v<MANAGED_SHIM_VERSION>/`.
+    ///
+    /// Reserved for the layout RFC tracked at zackees/soldr#743 (per-soldr-version
+    /// isolation of `shims/`, future `bin/`, `cache/`, `state.redb`, etc.).
+    /// This PR only exposes the accessor; existing top-level subdirs
+    /// (`bin`, `cache`, `config_file`) are NOT migrated here. The first
+    /// real consumer is `versioned_shims_dir` (zackees/soldr#742).
+    pub fn versioned_root(&self) -> PathBuf {
+        self.root
+            .join(format!("v{}", crate::fetch::MANAGED_SHIM_VERSION))
+    }
+
+    /// Per-version shim directory — `<versioned_root>/shims/`.
+    ///
+    /// Owned and populated by the `soldr shims` verb (zackees/soldr#742).
+    /// Holds the native `soldr-shim` install (symlinked/hardlinked under
+    /// each tool name) for THIS soldr version. Multi-version soldr installs
+    /// coexist cleanly because each version has its own subdir.
+    pub fn versioned_shims_dir(&self) -> PathBuf {
+        self.versioned_root().join("shims")
+    }
+
     /// Load the soldr config from `config.toml` if it exists. Missing
     /// or malformed files yield `Default::default()` so callers can
     /// proceed with reasonable defaults.
@@ -429,4 +451,71 @@ min_age_secs = 7200
     fn soldr_root_override_ignores_empty_env() {
         assert!(soldr_root_from_env_var(Some(OsStr::new(""))).is_none());
     }
+
+    // ---------------------------------------------------------------------
+    // Per-version layout helpers (zackees/soldr#743 Phase A).
+    //
+    // These are NEW tests covering only the just-added accessors, so they
+    // use `crate::timed_test!` per the CLAUDE.md "Test Infrastructure"
+    // policy. The legacy bare `#[test]` cases above this block are
+    // grandfathered.
+    // ---------------------------------------------------------------------
+
+    crate::timed_test!(managed_shim_version_matches_cargo_pkg_version, {
+        // The const exists so callers can refer to it without duplicating
+        // the version string. If anyone changes its source away from
+        // `env!("CARGO_PKG_VERSION")`, this guard fires.
+        assert_eq!(
+            crate::fetch::MANAGED_SHIM_VERSION,
+            env!("CARGO_PKG_VERSION"),
+            "MANAGED_SHIM_VERSION must equal the workspace package version"
+        );
+    });
+
+    crate::timed_test!(versioned_root_appends_v_prefix_and_pkg_version, {
+        let root = PathBuf::from("/tmp/synthetic-versioned-root");
+        let paths = SoldrPaths::with_root(root.clone());
+        let v_root = paths.versioned_root();
+
+        let expected_leaf = format!("v{}", crate::fetch::MANAGED_SHIM_VERSION);
+        assert_eq!(
+            v_root,
+            root.join(&expected_leaf),
+            "versioned_root must be <root>/v<MANAGED_SHIM_VERSION>"
+        );
+        assert!(
+            v_root.starts_with(&root),
+            "versioned_root must live under root: {} not under {}",
+            v_root.display(),
+            root.display()
+        );
+        assert_eq!(
+            v_root.file_name().and_then(|s| s.to_str()),
+            Some(expected_leaf.as_str()),
+            "versioned_root leaf must be `v<MANAGED_SHIM_VERSION>`"
+        );
+    });
+
+    crate::timed_test!(versioned_shims_dir_is_under_versioned_root, {
+        let root = PathBuf::from("/tmp/synthetic-versioned-shims");
+        let paths = SoldrPaths::with_root(root.clone());
+
+        let v_root = paths.versioned_root();
+        let shims = paths.versioned_shims_dir();
+
+        assert_eq!(
+            shims.parent(),
+            Some(v_root.as_path()),
+            "versioned_shims_dir parent must be versioned_root"
+        );
+        assert_eq!(
+            shims.file_name().and_then(|s| s.to_str()),
+            Some("shims"),
+            "versioned_shims_dir leaf must be `shims`"
+        );
+        assert!(
+            shims.starts_with(&v_root),
+            "versioned_shims_dir must live under versioned_root"
+        );
+    });
 }

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -88,6 +88,12 @@ pub struct FetchResult {
 }
 
 pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.7";
+
+/// The soldr version segment used by per-version `~/.soldr/v<X.Y.Z>/**`
+/// state. Source of truth for `SoldrPaths::versioned_root` and
+/// `SoldrPaths::versioned_shims_dir`. See zackees/soldr#743 for the
+/// layout RFC and zackees/soldr#742 for the first consumer.
+pub const MANAGED_SHIM_VERSION: &str = env!("CARGO_PKG_VERSION");
 // After the Wave 7 monocrate rename in zccache (`zccache-monocrate` -> `zccache`),
 // all three native binaries (`zccache`, `zccache-daemon`, `zccache-fp`) are
 // `[[bin]]` targets inside the umbrella `zccache` crate on crates.io. The


### PR DESCRIPTION
## Summary

Phase A of the per-soldr-version layout RFC tracked at #743. Introduces two new accessors on `SoldrPaths` and the `MANAGED_SHIM_VERSION` const that backs them.

- `crates/soldr-cli/src/fetch/mod.rs` — new `pub const MANAGED_SHIM_VERSION: &str = env!("CARGO_PKG_VERSION")`.
- `crates/soldr-cli/src/core/paths.rs`:
  - `SoldrPaths::versioned_root()` → `<root>/v<MANAGED_SHIM_VERSION>/`.
  - `SoldrPaths::versioned_shims_dir()` → `<versioned_root>/shims/` — the first real consumer (#742).
- Three `crate::timed_test!`-wrapped unit tests covering the const, the root, and the shims-leaf invariants.

**Scope is deliberately tight.** This PR does NOT:
- migrate existing `bin` / `cache` / `config_file` accessors into `versioned_root` (that's the bulk follow-up tracked by #743);
- add `soldr shims` CLI verb or `soldr-shim` bin (that's Phase B / #742);
- touch the daemon or daemon protocol.

The new accessors are only callable from #742's incoming work — they have no other consumers in this PR. That keeps the blast radius zero.

## Test plan

- [x] `SOLDR_RUSTC_WRAPPER=none soldr cargo test -p soldr-cli --lib -- versioned_root versioned_shims_dir managed_shim_version` — three tests pass.
- [x] `SOLDR_RUSTC_WRAPPER=none soldr cargo clippy -p soldr-cli --lib --all-targets -- -D warnings` clean.
- [x] `soldr rustfmt --check --edition 2021` clean on both touched files.

`SOLDR_RUSTC_WRAPPER=none` is the workaround for the unrelated zccache 1.12.7 daemon-mismatch bug tracked at #741 (locally only — CI doesn't need it).

## Notes

- Pre-existing CI failures on `main` (daemon fmt drift + cache-hit-rate gate from prior PRs) are unrelated to this change. PR #740 hit the same wall and merged with main-also-failing classification per /clud-pr-merge.
- Phase B (`soldr shims` CLI + `soldr-shim` native bin with PATH self-strip) lands on top of this.
- Phase C is the consumer in zackees/clud (issue zackees/clud#343).

Refs: #742, #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)