### PR TITLE
Redesign soldr root help index

### DIFF
--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -7,18 +7,84 @@
 
 use crate::{optimize, save_load};
 
+const ROOT_LONG_ABOUT: &str = "Instant tools. Instant builds.\n\n\
+soldr wraps cargo and the rustup toolchain so every Rust command goes through a\n\
+managed, content-addressable cache and a repo-pinned toolchain.";
+
+const ROOT_AFTER_HELP: &str = "\
+Examples:\n  \
+soldr cargo build --release   # cached build, pinned toolchain\n  \
+soldr rustfmt --check src     # format check via pinned rustfmt\n  \
+soldr toolchain               # install rust-toolchain.toml\n  \
+soldr cook --release          # prebuild deps as a cache layer\n  \
+soldr status                  # cache health + active toolchain\n\n\
+Run `soldr help <command>` for detailed help on a subcommand,\n\
+including environment variables, exit codes, and on-disk layout.";
+
+const ROOT_BEFORE_HELP: &str = "\
+Common commands:\n  \
+cargo                  Run cargo through soldr (cached, pinned toolchain)\n  \
+rustc                  Compile Rust source via the pinned toolchain\n  \
+rustfmt                Format Rust source via the pinned toolchain\n  \
+clippy-driver          Run the clippy linter via the pinned toolchain\n  \
+rustup                 Drop-in passthrough to the system rustup binary\n\n\
+Less common toolchain commands:\n  \
+rustdoc                Generate Rust documentation\n  \
+rust-analyzer          Run the rust-analyzer language server\n  \
+rust-gdb               Debug with gdb + Rust pretty-printers\n  \
+rust-lldb              Debug with lldb + Rust pretty-printers\n  \
+toolchain              Install the channel declared in rust-toolchain.toml\n  \
+bootstrap              Install rustup itself into soldr's managed bin dir\n  \
+doctor                 Report drift between rust-toolchain.toml and rustup\n  \
+shims                  Install per-version PATH shims for Rust tools\n\n\
+soldr cache & build:\n  \
+cook                   Prebuild dependencies via bundled cargo-chef\n  \
+status                 Show cache status and active toolchain\n  \
+cache                  Inspect compilation cache entries\n  \
+config                 Show or set soldr configuration\n  \
+clean                  Clear the managed zccache build cache\n  \
+purge                  Purge all soldr-managed cache artifacts\n  \
+gc                     Review reclaimable cargo target/ directories\n  \
+save                   Bundle a build cache + source mtimes into a .tar.zst\n  \
+load                   Restore a soldr-save archive on a fresh checkout\n\n\
+soldr ops & infrastructure:\n  \
+daemon                 Manage the long-lived soldr-daemon process\n  \
+session-start          Start a zccache session and print its id\n  \
+session-end            End a zccache session and emit its stats\n  \
+optimize               Apply platform-specific hot-cache tuning\n  \
+defender-exclusions    Manage Windows Defender exclusions for soldr caches\n  \
+install-zccache        Pin local zccache binaries (skip managed fetch)\n\n  \
+help                   Print this message or the help of the given subcommand\n\n";
+
 #[derive(clap::Parser)]
-#[command(name = "soldr", version, about = "Instant tools. Instant builds.")]
+#[command(
+    name = "soldr",
+    version,
+    about = "Instant tools. Instant builds.",
+    long_about = ROOT_LONG_ABOUT,
+    before_help = ROOT_BEFORE_HELP,
+    after_help = ROOT_AFTER_HELP,
+    after_long_help = ROOT_AFTER_HELP,
+    next_line_help = true,
+    help_template = "{about-with-newline}\n{usage-heading} {usage}\n\n{before-help}Options:\n{options}{after-help}",
+    max_term_width = 80
+)]
 pub(crate) struct Cli {
-    /// Disable soldr's compilation cache for this invocation
+    /// Disable soldr's compilation cache for this run
     #[arg(long)]
     pub(crate) no_cache: bool,
-    /// Pick the zccache binary backing the compilation cache.
-    ///
-    /// `managed` (default) fetches the pinned zccache release into
-    /// `~/.soldr/`. `system` uses the `zccache` already on PATH
-    /// (must have `zccache-daemon` and `zccache-fp` as siblings).
-    #[arg(long, value_enum, default_value_t = ZccacheSourceArg::Managed, value_name = "SOURCE")]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = ZccacheSourceArg::Managed,
+        value_name = "SOURCE",
+        hide_possible_values = true,
+        help = "Backing zccache binary",
+        long_help = "Pick the zccache binary backing the compilation cache.\n\n\
+`managed` (default) fetches the pinned release into `~/.soldr/`.\n\
+`system` uses the `zccache` on PATH (with `zccache-daemon` and\n\
+`zccache-fp` as siblings)."
+    )]
     pub(crate) zccache: ZccacheSourceArg,
     #[command(subcommand)]
     pub(crate) command: Commands,
@@ -123,6 +189,7 @@ pub(crate) const SOLDR_BUILTIN_VERBS: &[&str] = &[
     "toolchain",
     "bootstrap",
     "doctor",
+    "shims",
     "optimize",
     "defender-exclusions",
     "session-start",
@@ -136,80 +203,117 @@ pub(crate) const SOLDR_BUILTIN_VERBS: &[&str] = &[
 
 #[derive(clap::Subcommand)]
 pub(crate) enum Commands {
-    /// Run Cargo through soldr's front door
+    /// Run cargo through soldr (cached, pinned toolchain)
     Cargo {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Content-addressable dep prebuild via the bundled `cargo-chef`
-    /// (issue #359). Splits a project build into a recipe phase
-    /// (`cargo chef prepare`) and a stub-project compile phase
-    /// (`cargo chef cook`) so the dep set can be cached as an output
-    /// layer (Docker), a tarball (CI), or just a warm `target/` (local
-    /// dev) that survives source-code commits. Routes both phases
-    /// through the cargo front door so zccache, `ZCCACHE_PATH_REMAP=auto`,
-    /// and the soldr-managed toolchain homes all apply.
-    ///
-    /// Recognised flags (everything else: pass after `--`):
-    /// `--release`, `--target <triple>`, `--workspace`, `--profile <name>`,
-    /// `-p`/`--package <name>` (repeatable), `--recipe-path <path>`,
-    /// `--keep-recipe`, `--prepare-only`, `--cook-only`.
-    Cook {
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
-    /// Run rustc from the active toolchain
+    /// Compile Rust source via the pinned toolchain
     Rustc {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Run rustfmt from the active toolchain
+    /// Format Rust source via the pinned toolchain
     Rustfmt {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Run clippy-driver from the active toolchain
+    /// Run the clippy linter via the pinned toolchain
     #[command(name = "clippy-driver")]
     ClippyDriver {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Run rustdoc from the active toolchain
+    /// Drop-in passthrough to the system rustup binary
+    ///
+    /// When the first non-flag positional argument is `target` or
+    /// `component` and `rust-toolchain.toml` declares a `channel`,
+    /// soldr automatically inserts `--toolchain <channel>` after the
+    /// subcommand (unless the user already passed `--toolchain`).
+    /// Every other invocation is forwarded verbatim.
+    Rustup {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Generate Rust documentation
     Rustdoc {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Run rust-gdb from the active toolchain
-    #[command(name = "rust-gdb")]
-    RustGdb {
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
-    /// Run rust-lldb from the active toolchain
-    #[command(name = "rust-lldb")]
-    RustLldb {
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
-    /// Run rust-analyzer from the active toolchain
+    /// Run the rust-analyzer language server
     #[command(name = "rust-analyzer")]
     RustAnalyzer {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Show cache status and tool info
+    /// Debug with gdb + Rust pretty-printers
+    #[command(name = "rust-gdb")]
+    RustGdb {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Debug with lldb + Rust pretty-printers
+    #[command(name = "rust-lldb")]
+    RustLldb {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Install the channel declared in rust-toolchain.toml
+    Toolchain {
+        #[command(subcommand)]
+        subcommand: ToolchainSubcommand,
+    },
+    /// Install rustup itself into soldr's managed bin dir
+    #[command(
+        long_about = "Install `rustup` itself into the soldr-managed bin dir when the host has no system-managed toolchain manager. Idempotent: a re-run with rustup already present prints the resolved path and exits 0.\n\nFetches `rustup-init` from `https://static.rust-lang.org/rustup/dist/<host-triple>/` under the same `SOLDR_TRUST_MODE` / `SOLDR_CHECKSUMS_FILE` policy as every other soldr-fetched binary. Set `SOLDR_NO_BOOTSTRAP=1` to disable the implicit auto-install that runs from `soldr cargo` / `soldr rustup ...` when rustup is missing."
+    )]
+    Bootstrap {
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Report drift between rust-toolchain.toml and rustup
+    #[command(
+        long_about = "Diagnose drift between `rust-toolchain.toml` and the currently installed rustup state. Read-only: never mutates rustup. Exit code is `1` when drift is detected, `0` otherwise."
+    )]
+    Doctor {
+        /// Emit the stable machine-facing JSON form for this command.
+        #[arg(long)]
+        json: bool,
+        /// Force a fresh Defender real-time-scan probe of the soldr
+        /// cache directory, ignoring the cached result. No-op outside
+        /// Windows. Issue #357.
+        #[arg(long)]
+        refresh_defender_probe: bool,
+    },
+    /// Install per-version PATH shims for Rust tools
+    ///
+    /// Writes `cargo`, `rustc`, `rustfmt`, `clippy-driver`, and
+    /// `rustdoc` shims under `~/.soldr/v<MANAGED_SHIM_VERSION>/shims/`
+    /// and emits stable JSON describing where they live.
+    Shims {
+        /// Emit the stable machine-facing JSON form
+        /// (`schema_version: 1`).
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Prebuild dependencies via bundled cargo-chef
+    #[command(
+        long_about = "Content-addressable dependency prebuild via the bundled `cargo-chef`. Splits a project build into a recipe phase (`cargo chef prepare`) and a stub-project compile phase (`cargo chef cook`) so the dep set can be cached as an output layer (Docker), a tarball (CI), or just a warm `target/` (local dev) that survives source-code commits.\n\nRoutes both phases through the cargo front door so zccache, `ZCCACHE_PATH_REMAP=auto`, and the soldr-managed toolchain homes all apply.\n\nRecognised flags (everything else: pass after `--`): `--release`, `--target <triple>`, `--workspace`, `--profile <name>`, `-p`/`--package <name>` (repeatable), `--recipe-path <path>`, `--keep-recipe`, `--prepare-only`, `--cook-only`."
+    )]
+    Cook {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Show cache status and active toolchain
     Status {
         /// Emit the stable machine-facing JSON form for this command
         #[arg(long)]
         json: bool,
     },
-    /// Clear the managed zccache build cache
-    Clean,
-    /// Purge all soldr-managed cache artifacts
-    Purge,
-    /// Show or set configuration
-    Config,
-    /// Inspect the compilation cache
+    /// Inspect compilation cache entries
     Cache {
         /// Emit the stable machine-facing JSON form for this command
         #[arg(long)]
@@ -217,17 +321,17 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: Option<CacheSubcommand>,
     },
-    /// Show version
-    Version {
-        /// Emit the stable machine-facing JSON form for this command
-        #[arg(long)]
-        json: bool,
-    },
-    /// Review reclaimable Cargo `target/` directories tracked by
-    /// the soldr registry (`~/.soldr/state.redb`).
+    /// Show or set soldr configuration
+    Config,
+    /// Clear the managed zccache build cache
+    Clean,
+    /// Purge all soldr-managed cache artifacts
+    Purge,
+    /// Review reclaimable cargo target/ directories
     ///
     /// Aliases: `purge-targets` (matches issue #234's `soldr --purge`
-    /// wording).
+    /// wording). Uses the soldr registry (`~/.soldr/state.redb`) to
+    /// discover tracked Cargo `target/` directories.
     #[command(alias = "purge-targets")]
     Gc {
         /// Deprecated: `soldr gc` is already a non-destructive summary.
@@ -250,84 +354,23 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: Option<GcSubcommand>,
     },
-    /// Drop-in passthrough to the system `rustup` binary.
-    ///
-    /// When the first non-flag positional argument is `target` or
-    /// `component` and `rust-toolchain.toml` declares a `channel`,
-    /// soldr automatically inserts `--toolchain <channel>` after the
-    /// subcommand (unless the user already passed `--toolchain`).
-    /// Every other invocation is forwarded verbatim.
-    Rustup {
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
-    /// Read `rust-toolchain.toml` and install the declared channel /
-    /// components / targets via `rustup`.
-    Toolchain {
+    /// Bundle a build cache + source mtimes into a .tar.zst
+    #[command(
+        long_about = "Bundle a build-cache directory plus a content-verified snapshot of source-file mtimes into a single `.tar.zst` archive. The output is consumed by `soldr load` to restore both the cache and Cargo-friendly source mtimes on a fresh checkout."
+    )]
+    Save(save_load::SaveArgs),
+    /// Restore a soldr-save archive on a fresh checkout
+    #[command(
+        long_about = "Restore an archive produced by `soldr save`: unpack the cache to the destination directory and replay each source-file mtime, but only when the current file's size and BLAKE3 hash still match the snapshot so soldr cannot underbuild after a real source change."
+    )]
+    Load(save_load::LoadArgs),
+
+    /// Manage the long-lived soldr-daemon process
+    Daemon {
         #[command(subcommand)]
-        subcommand: ToolchainSubcommand,
+        command: DaemonSubcommand,
     },
-    /// Install `rustup` itself into the soldr-managed bin dir when the
-    /// host has no system-managed toolchain manager. Idempotent — a
-    /// re-run with rustup already present prints the resolved path and
-    /// exits 0. Fetches `rustup-init` from
-    /// `https://static.rust-lang.org/rustup/dist/<host-triple>/` under
-    /// the same `SOLDR_TRUST_MODE` / `SOLDR_CHECKSUMS_FILE` policy as
-    /// every other soldr-fetched binary. Set `SOLDR_NO_BOOTSTRAP=1` to
-    /// disable the implicit auto-install that runs from
-    /// `soldr cargo` / `soldr rustup ...` when rustup is missing.
-    Bootstrap {
-        /// Emit the stable machine-facing JSON form for this command.
-        #[arg(long)]
-        json: bool,
-    },
-    /// Diagnose drift between `rust-toolchain.toml` and the
-    /// currently installed rustup state. Read-only — never mutates
-    /// rustup. Exit code is `1` when drift is detected, `0` otherwise.
-    Doctor {
-        /// Emit the stable machine-facing JSON form for this command.
-        #[arg(long)]
-        json: bool,
-        /// Force a fresh Defender real-time-scan probe of the soldr
-        /// cache directory, ignoring the cached result. No-op outside
-        /// Windows. Issue #357.
-        #[arg(long)]
-        refresh_defender_probe: bool,
-    },
-    /// Install per-version shims (`cargo`, `rustc`, `rustfmt`,
-    /// `clippy-driver`, `rustdoc`) under
-    /// `~/.soldr/v<MANAGED_SHIM_VERSION>/shims/` and emit a stable JSON
-    /// describing where they live. Consumers (e.g.
-    /// [`clud`](https://github.com/zackees/clud/issues/343)) prepend
-    /// `path_entry` from the JSON to their session `PATH` to route
-    /// Rust toolchain calls through soldr.
-    ///
-    /// Idempotent: re-runs no-op when the on-disk shims still match the
-    /// soldr-shim source binary (blake3 content-hash check). The
-    /// installed shim is a copy of the sibling `soldr-shim` binary
-    /// that ships in the same release tarball. See zackees/soldr#742.
-    Shims {
-        /// Emit the stable machine-facing JSON form
-        /// (`schema_version: 1`).
-        #[arg(long)]
-        json: bool,
-    },
-    /// Apply platform-specific hot-cache optimizations (Windows
-    /// Defender exclusions today; future platforms TBD). Auto-skips on
-    /// CI. See `docs/API.md` for the full matrix.
-    Optimize(optimize::OptimizeArgs),
-    /// First-class surface for managing Windows Defender real-time-scan
-    /// exclusions on soldr's hot cache directories (issue #355).
-    ///
-    /// Self-documenting verbs (`check` / `add` / `remove`) over the same
-    /// Defender machinery `soldr optimize` already exposes. Windows-only;
-    /// no-op with a clear message on macOS / Linux.
-    #[command(name = "defender-exclusions")]
-    DefenderExclusions {
-        #[command(subcommand)]
-        subcommand: DefenderExclusionsSubcommand,
-    },
-    /// Start a zccache session and return its identifier.
+    /// Start a zccache session and print its id
     ///
     /// Idempotent: when `ZCCACHE_SESSION_ID` is already set in the
     /// environment (and `--id` is not), emits the existing session
@@ -351,7 +394,7 @@ pub(crate) enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// End a zccache session and emit its finalized stats.
+    /// End a zccache session and emit its stats
     ///
     /// Idempotent: a second call against an already-finalized session
     /// reports the prior stats (or notes that the session is gone)
@@ -369,17 +412,27 @@ pub(crate) enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Install zccache binaries into soldr's private dir so soldr stops
-    /// fetching the managed GitHub release. Pins a user-supplied set of
-    /// three zccache binaries (zccache, zccache-daemon, zccache-fp) into
-    /// `<SoldrPaths::bin>/zccache-pinned/`. Subsequent `soldr cargo ...`
-    /// invocations resolve the pinned binaries automatically.
+    /// Apply platform-specific hot-cache tuning
+    #[command(
+        long_about = "Apply platform-specific hot-cache optimizations (Windows Defender exclusions today; future platforms TBD). Auto-skips on CI. See `docs/API.md` for the full matrix."
+    )]
+    Optimize(optimize::OptimizeArgs),
+    /// Manage Windows Defender exclusions for soldr caches
     ///
-    /// Exactly one of `<source>`, `--remove`, or `--status` must be
-    /// provided. `<source>` accepts `system`, a directory or archive
-    /// path (`.zip` / `.tar.gz` / `.tar.zst`), or an `http(s)://` URL
-    /// pointing at such an archive.
-    #[command(name = "install-zccache", alias = "update-zccache")]
+    /// Self-documenting verbs (`check` / `add` / `remove`) over the same
+    /// Defender machinery `soldr optimize` already exposes. Windows-only;
+    /// no-op with a clear message on macOS / Linux.
+    #[command(name = "defender-exclusions")]
+    DefenderExclusions {
+        #[command(subcommand)]
+        subcommand: DefenderExclusionsSubcommand,
+    },
+    /// Pin local zccache binaries (skip managed fetch)
+    #[command(
+        name = "install-zccache",
+        alias = "update-zccache",
+        long_about = "Install zccache binaries into soldr's private dir so soldr stops fetching the managed GitHub release. Pins a user-supplied set of three zccache binaries (`zccache`, `zccache-daemon`, `zccache-fp`) into `<SoldrPaths::bin>/zccache-pinned/`. Subsequent `soldr cargo ...` invocations resolve the pinned binaries automatically.\n\nExactly one of `<source>`, `--remove`, or `--status` must be provided. `<source>` accepts `system`, a directory or archive path (`.zip` / `.tar.gz` / `.tar.zst`), or an `http(s)://` URL pointing at such an archive."
+    )]
     InstallZccache {
         /// Source for the three zccache binaries. Mutually exclusive
         /// with `--remove` / `--status`.
@@ -397,23 +450,13 @@ pub(crate) enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Bundle a build-cache directory plus a content-verified
-    /// snapshot of source-file mtimes into a single `.tar.zst`
-    /// archive. The output is consumed by `soldr load` to restore
-    /// both the cache and Cargo-friendly source mtimes on a fresh
-    /// checkout.
-    Save(save_load::SaveArgs),
-    /// Restore an archive produced by `soldr save`: unpack the cache
-    /// to the destination directory and replay each source-file
-    /// mtime, but only when the current file's size and BLAKE3 hash
-    /// still match the snapshot (so we cannot underbuild after a
-    /// real source change).
-    Load(save_load::LoadArgs),
-    /// Manage the long-lived `soldr-daemon` companion process that owns
-    /// target/ tracking. Phase 1 — `start`, `stop`, `status` only.
-    Daemon {
-        #[command(subcommand)]
-        command: DaemonSubcommand,
+
+    /// Show version
+    #[command(hide = true)]
+    Version {
+        /// Emit the stable machine-facing JSON form for this command
+        #[arg(long)]
+        json: bool,
     },
     /// Anything else is a tool to fetch and run
     #[command(external_subcommand)]

--- a/crates/soldr-cli/src/main_tests.rs
+++ b/crates/soldr-cli/src/main_tests.rs
@@ -4,7 +4,7 @@
 //! `#[path]` so `main.rs` stays comfortably under the 1000-LOC ceiling.
 
 use super::*;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use std::ffi::{OsStr, OsString};
 use std::sync::Mutex;
 
@@ -158,6 +158,63 @@ fn cli_parses_zccache_flag_values() {
 
     let invalid = Cli::try_parse_from(["soldr", "--zccache=bogus", "cargo", "build"]);
     assert!(invalid.is_err(), "unknown zccache source must fail clap");
+}
+
+#[test]
+fn root_help_groups_commands_and_keeps_lines_short() {
+    let help = Cli::command().render_help().to_string();
+
+    let common = help.find("Common commands:").unwrap();
+    let less_common = help.find("Less common toolchain commands:").unwrap();
+    let cache = help.find("soldr cache & build:").unwrap();
+    let ops = help.find("soldr ops & infrastructure:").unwrap();
+    assert!(
+        common < less_common && less_common < cache && cache < ops,
+        "command groups should render in familiarity order:\n{help}"
+    );
+
+    assert!(help.contains("  cargo                  Run cargo through soldr"));
+    assert!(help.contains("  cook                   Prebuild dependencies"));
+    assert!(help.contains("Examples:\n  soldr cargo build --release"));
+    assert!(
+        !help.contains("\nCommands:\n"),
+        "flat command list returned:\n{help}"
+    );
+    assert!(
+        !help.contains("\n  version"),
+        "version subcommand should be hidden from the index:\n{help}"
+    );
+
+    let long_lines: Vec<_> = help.lines().filter(|line| line.len() > 80).collect();
+    assert!(
+        long_lines.is_empty(),
+        "root help lines should fit 80 columns: {long_lines:?}\n{help}"
+    );
+}
+
+#[test]
+fn long_root_help_expands_intro_and_zccache_details() {
+    let help = Cli::command().render_long_help().to_string();
+
+    assert!(help.contains("soldr wraps cargo and the rustup toolchain"));
+    assert!(help.contains("Pick the zccache binary backing the compilation cache."));
+    assert!(help.contains("`managed` (default) fetches the pinned release"));
+    assert!(help.contains("`system` uses the `zccache` on PATH"));
+}
+
+#[test]
+fn verbose_command_details_live_on_subcommand_help() {
+    let root = Cli::command().render_help().to_string();
+    assert!(!root.contains("https://static.rust-lang.org/rustup/dist"));
+    assert!(!root.contains("SOLDR_NO_BOOTSTRAP"));
+
+    let mut cmd = Cli::command();
+    let bootstrap = cmd
+        .find_subcommand_mut("bootstrap")
+        .expect("bootstrap subcommand should exist");
+    let help = bootstrap.render_long_help().to_string();
+    assert!(help.contains("https://static.rust-lang.org/rustup/dist"));
+    assert!(help.contains("SOLDR_NO_BOOTSTRAP"));
 }
 
 #[test]

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -5,11 +5,11 @@
 
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
 use crate::startup_profile::WrapperProfile;
+use crate::zccache_lifecycle::ZCCACHE_DAEMON_NAMESPACE_ENV_VAR;
 #[cfg(not(unix))]
 use crate::zccache_lifecycle::{
     session_start_args, stderr_indicates_unknown_session, ZccacheLifecycle,
     ZccachePrivateDaemonConfig, ZccachePrivateEnv, ZccacheSessionStartOptions,
-    ZCCACHE_DAEMON_NAMESPACE_ENV_VAR,
 };
 use crate::{apply_implicit_toolchain_homes, resolve_toolchain_binary, zccache_binary_override};
 
@@ -236,6 +236,7 @@ fn run_wrapper_through_zccache(
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
+        ensure_private_zccache_daemon_before_exec(zccache)?;
         // TODO(#265): once exec() replaces this process there is nowhere to
         // observe zccache's stderr or retry on "unknown session:". The
         // Windows branch below performs that defensive retry. A Unix port
@@ -252,6 +253,72 @@ fn run_wrapper_through_zccache(
     {
         run_wrapper_through_zccache_windows(raw_args, zccache)
     }
+}
+
+#[cfg(unix)]
+fn ensure_private_zccache_daemon_before_exec(zccache: &std::path::Path) -> Result<(), SoldrError> {
+    let Some(daemon_name) = inherited_private_daemon_name() else {
+        return Ok(());
+    };
+
+    let status = zccache_status(zccache)?;
+    if status.status.success() {
+        return Ok(());
+    }
+    if !zccache_daemon_unavailable(&status.stderr) {
+        return Ok(());
+    }
+
+    eprintln!(
+        "soldr: zccache private daemon {daemon_name} unavailable before rustc exec; restarting"
+    );
+    let start = zccache_command_output(zccache, &["start"])?;
+    if !start.status.success() {
+        return Err(SoldrError::Other(format!(
+            "zccache start failed while recovering private daemon {daemon_name}: {}",
+            String::from_utf8_lossy(&start.stderr).trim()
+        )));
+    }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let status = zccache_status(zccache)?;
+        if status.status.success() {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(SoldrError::Other(format!(
+                "zccache private daemon {daemon_name} did not become available after restart: {}",
+                String::from_utf8_lossy(&status.stderr).trim()
+            )));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+#[cfg(unix)]
+fn zccache_status(zccache: &std::path::Path) -> Result<std::process::Output, SoldrError> {
+    zccache_command_output(zccache, &["status"])
+}
+
+#[cfg(unix)]
+fn zccache_command_output(
+    zccache: &std::path::Path,
+    args: &[&str],
+) -> Result<std::process::Output, SoldrError> {
+    let mut command = std::process::Command::new(zccache);
+    command.args(args);
+    suppress_windows_console_window(&mut command);
+    Ok(command.output()?)
+}
+
+#[cfg(unix)]
+fn zccache_daemon_unavailable(stderr: &[u8]) -> bool {
+    let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    stderr.contains("cannot connect to daemon")
+        || stderr.contains("no such file or directory")
+        || stderr.contains("lost connection to daemon")
+        || stderr.contains("not accepting connections")
 }
 
 /// Windows-only wrapper invocation: spawn zccache with its stderr piped so we
@@ -388,7 +455,6 @@ fn allocate_replacement_session(zccache: &std::path::Path) -> Result<String, Sol
     })
 }
 
-#[cfg(not(unix))]
 fn inherited_private_daemon_name() -> Option<String> {
     std::env::var(ZCCACHE_DAEMON_NAMESPACE_ENV_VAR)
         .ok()

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -396,7 +396,8 @@ async fn prepare_zccache_build(
         &fetch.binary_path,
         &zccache_base_dir,
     );
-    let zccache_dir = private_zccache_cache_dir(&zccache_base_dir, &private_daemon_name);
+    let zccache_dir =
+        private_zccache_cache_dir(&zccache_base_dir, &private_daemon_name, &runtime.version);
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
     let private_daemon = ZccachePrivateDaemonConfig::new(private_daemon_name.clone())
@@ -719,8 +720,12 @@ fn print_wasted_depgraph_hits_if_any(session_log_path: &std::path::Path) {
 pub(crate) fn private_zccache_cache_dir(
     base_dir: &std::path::Path,
     daemon_name: &str,
+    zccache_version: &str,
 ) -> std::path::PathBuf {
-    base_dir.join("private").join(daemon_name)
+    base_dir
+        .join("private")
+        .join(daemon_name)
+        .join(format!("v{zccache_version}"))
 }
 
 pub(crate) fn resolve_private_zccache_daemon_name(
@@ -1322,6 +1327,22 @@ mod tests {
                 std::path::Path::new("/ignored/cache"),
             ),
             "team_dev_soldr"
+        );
+    }
+
+    #[test]
+    fn private_zccache_cache_dir_is_version_scoped() {
+        let dir = private_zccache_cache_dir(
+            std::path::Path::new("/tmp/cache/zccache"),
+            "soldr-dev-abc",
+            "1.12.7",
+        );
+        assert_eq!(
+            dir,
+            std::path::Path::new("/tmp/cache/zccache")
+                .join("private")
+                .join("soldr-dev-abc")
+                .join("v1.12.7")
         );
     }
 

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -396,12 +396,13 @@ async fn prepare_zccache_build(
         &fetch.binary_path,
         &zccache_base_dir,
     );
-    let zccache_dir =
-        private_zccache_cache_dir(&zccache_base_dir, &private_daemon_name, &runtime.version);
+    let zccache_dir = private_zccache_cache_dir(&zccache_base_dir, &private_daemon_name);
+    let zccache_cache_dir_arg = private_zccache_cache_dir_arg(&zccache_dir, &runtime.version);
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
     let private_daemon = ZccachePrivateDaemonConfig::new(private_daemon_name.clone())
         .with_owner_pid(std::process::id())
+        .with_cache_dir_arg(zccache_cache_dir_arg)
         .with_private_env(child_env.private_env_assignments());
 
     // When the resolved zccache CLI binary differs from the one a
@@ -720,12 +721,15 @@ fn print_wasted_depgraph_hits_if_any(session_log_path: &std::path::Path) {
 pub(crate) fn private_zccache_cache_dir(
     base_dir: &std::path::Path,
     daemon_name: &str,
+) -> std::path::PathBuf {
+    base_dir.join("private").join(daemon_name)
+}
+
+pub(crate) fn private_zccache_cache_dir_arg(
+    cache_dir: &std::path::Path,
     zccache_version: &str,
 ) -> std::path::PathBuf {
-    base_dir
-        .join("private")
-        .join(daemon_name)
-        .join(format!("v{zccache_version}"))
+    cache_dir.join(format!("v{zccache_version}"))
 }
 
 pub(crate) fn resolve_private_zccache_daemon_name(
@@ -1331,10 +1335,9 @@ mod tests {
     }
 
     #[test]
-    fn private_zccache_cache_dir_is_version_scoped() {
-        let dir = private_zccache_cache_dir(
-            std::path::Path::new("/tmp/cache/zccache"),
-            "soldr-dev-abc",
+    fn private_zccache_cache_dir_arg_is_version_scoped() {
+        let dir = private_zccache_cache_dir_arg(
+            &private_zccache_cache_dir(std::path::Path::new("/tmp/cache/zccache"), "soldr-dev-abc"),
             "1.12.7",
         );
         assert_eq!(

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -397,12 +397,10 @@ async fn prepare_zccache_build(
         &zccache_base_dir,
     );
     let zccache_dir = private_zccache_cache_dir(&zccache_base_dir, &private_daemon_name);
-    let zccache_cache_dir_arg = private_zccache_cache_dir_arg(&zccache_dir, &runtime.version);
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
     let private_daemon = ZccachePrivateDaemonConfig::new(private_daemon_name.clone())
         .with_owner_pid(std::process::id())
-        .with_cache_dir_arg(zccache_cache_dir_arg)
         .with_private_env(child_env.private_env_assignments());
 
     // When the resolved zccache CLI binary differs from the one a
@@ -723,13 +721,6 @@ pub(crate) fn private_zccache_cache_dir(
     daemon_name: &str,
 ) -> std::path::PathBuf {
     base_dir.join("private").join(daemon_name)
-}
-
-pub(crate) fn private_zccache_cache_dir_arg(
-    cache_dir: &std::path::Path,
-    zccache_version: &str,
-) -> std::path::PathBuf {
-    cache_dir.join(format!("v{zccache_version}"))
 }
 
 pub(crate) fn resolve_private_zccache_daemon_name(
@@ -1331,21 +1322,6 @@ mod tests {
                 std::path::Path::new("/ignored/cache"),
             ),
             "team_dev_soldr"
-        );
-    }
-
-    #[test]
-    fn private_zccache_cache_dir_arg_is_version_scoped() {
-        let dir = private_zccache_cache_dir_arg(
-            &private_zccache_cache_dir(std::path::Path::new("/tmp/cache/zccache"), "soldr-dev-abc"),
-            "1.12.7",
-        );
-        assert_eq!(
-            dir,
-            std::path::Path::new("/tmp/cache/zccache")
-                .join("private")
-                .join("soldr-dev-abc")
-                .join("v1.12.7")
         );
     }
 

--- a/crates/soldr-cli/src/zccache_lifecycle.rs
+++ b/crates/soldr-cli/src/zccache_lifecycle.rs
@@ -48,6 +48,7 @@ pub(crate) struct ZccachePrivateDaemonConfig {
     pub(crate) daemon_name: String,
     pub(crate) owner_pid: Option<u32>,
     pub(crate) private_env: Vec<ZccachePrivateEnv>,
+    pub(crate) cache_dir_arg: Option<PathBuf>,
 }
 
 impl ZccachePrivateDaemonConfig {
@@ -56,6 +57,7 @@ impl ZccachePrivateDaemonConfig {
             daemon_name: daemon_name.into(),
             owner_pid: None,
             private_env: Vec::new(),
+            cache_dir_arg: None,
         }
     }
 
@@ -66,6 +68,11 @@ impl ZccachePrivateDaemonConfig {
 
     pub(crate) fn with_private_env(mut self, private_env: Vec<ZccachePrivateEnv>) -> Self {
         self.private_env = private_env;
+        self
+    }
+
+    pub(crate) fn with_cache_dir_arg(mut self, cache_dir_arg: PathBuf) -> Self {
+        self.cache_dir_arg = Some(cache_dir_arg);
         self
     }
 
@@ -537,7 +544,14 @@ pub(crate) fn session_start_args(
         args.push("--daemon-name".to_string());
         args.push(private.daemon_name.clone());
         args.push("--cache-dir".to_string());
-        args.push(cache_dir.display().to_string());
+        args.push(
+            private
+                .cache_dir_arg
+                .as_deref()
+                .unwrap_or(cache_dir)
+                .display()
+                .to_string(),
+        );
         if let Some(owner_pid) = private.owner_pid {
             args.push("--owner-pid".to_string());
             args.push(owner_pid.to_string());
@@ -1056,6 +1070,21 @@ mod tests {
                 .any(|w| w[0] == "--private-env" && w[1] == "ZCCACHE_WORKTREE_ROOT=/repo"));
         }
     );
+
+    crate::timed_test!(private_session_start_args_can_override_cache_dir_arg, {
+        let options = ZccacheSessionStartOptions {
+            id: None,
+            session_log_path: PathBuf::from("/tmp/zccache/log"),
+            journal_path: PathBuf::from("/tmp/zccache/journal"),
+            session_stats_path: PathBuf::from("/tmp/zccache/stats"),
+        };
+        let private = ZccachePrivateDaemonConfig::new("soldr-dev-test")
+            .with_cache_dir_arg(PathBuf::from("/tmp/zccache/v1.12.7"));
+        let args = session_start_args(&options, Path::new("/tmp/zccache"), Some(&private));
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "--cache-dir" && w[1] == "/tmp/zccache/v1.12.7"));
+    });
 
     crate::timed_test!(session_already_ended_detects_common_states, {
         for needle in [

--- a/crates/soldr-cli/src/zccache_lifecycle.rs
+++ b/crates/soldr-cli/src/zccache_lifecycle.rs
@@ -48,7 +48,6 @@ pub(crate) struct ZccachePrivateDaemonConfig {
     pub(crate) daemon_name: String,
     pub(crate) owner_pid: Option<u32>,
     pub(crate) private_env: Vec<ZccachePrivateEnv>,
-    pub(crate) cache_dir_arg: Option<PathBuf>,
 }
 
 impl ZccachePrivateDaemonConfig {
@@ -57,7 +56,6 @@ impl ZccachePrivateDaemonConfig {
             daemon_name: daemon_name.into(),
             owner_pid: None,
             private_env: Vec::new(),
-            cache_dir_arg: None,
         }
     }
 
@@ -68,11 +66,6 @@ impl ZccachePrivateDaemonConfig {
 
     pub(crate) fn with_private_env(mut self, private_env: Vec<ZccachePrivateEnv>) -> Self {
         self.private_env = private_env;
-        self
-    }
-
-    pub(crate) fn with_cache_dir_arg(mut self, cache_dir_arg: PathBuf) -> Self {
-        self.cache_dir_arg = Some(cache_dir_arg);
         self
     }
 
@@ -524,7 +517,7 @@ pub(crate) struct CommandOutput {
 
 pub(crate) fn session_start_args(
     options: &ZccacheSessionStartOptions,
-    cache_dir: &Path,
+    _cache_dir: &Path,
     private_daemon: Option<&ZccachePrivateDaemonConfig>,
 ) -> Vec<String> {
     let mut args = vec![
@@ -543,15 +536,6 @@ pub(crate) fn session_start_args(
         args.push("--private-daemon".to_string());
         args.push("--daemon-name".to_string());
         args.push(private.daemon_name.clone());
-        args.push("--cache-dir".to_string());
-        args.push(
-            private
-                .cache_dir_arg
-                .as_deref()
-                .unwrap_or(cache_dir)
-                .display()
-                .to_string(),
-        );
         if let Some(owner_pid) = private.owner_pid {
             args.push("--owner-pid".to_string());
             args.push(owner_pid.to_string());
@@ -1056,9 +1040,10 @@ mod tests {
             assert!(args
                 .windows(2)
                 .any(|w| w[0] == "--daemon-name" && w[1] == "soldr-dev-test"));
-            assert!(args
-                .windows(2)
-                .any(|w| w[0] == "--cache-dir" && w[1] == "/tmp/zccache"));
+            assert!(
+                !args.iter().any(|arg| arg == "--cache-dir"),
+                "private session-start should rely on ZCCACHE_CACHE_DIR instead of --cache-dir: {args:?}"
+            );
             assert!(args
                 .windows(2)
                 .any(|w| w[0] == "--owner-pid" && w[1] == "4242"));
@@ -1070,21 +1055,6 @@ mod tests {
                 .any(|w| w[0] == "--private-env" && w[1] == "ZCCACHE_WORKTREE_ROOT=/repo"));
         }
     );
-
-    crate::timed_test!(private_session_start_args_can_override_cache_dir_arg, {
-        let options = ZccacheSessionStartOptions {
-            id: None,
-            session_log_path: PathBuf::from("/tmp/zccache/log"),
-            journal_path: PathBuf::from("/tmp/zccache/journal"),
-            session_stats_path: PathBuf::from("/tmp/zccache/stats"),
-        };
-        let private = ZccachePrivateDaemonConfig::new("soldr-dev-test")
-            .with_cache_dir_arg(PathBuf::from("/tmp/zccache/v1.12.7"));
-        let args = session_start_args(&options, Path::new("/tmp/zccache"), Some(&private));
-        assert!(args
-            .windows(2)
-            .any(|w| w[0] == "--cache-dir" && w[1] == "/tmp/zccache/v1.12.7"));
-    });
 
     crate::timed_test!(session_already_ended_detects_common_states, {
         for needle in [

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -154,7 +154,23 @@ pub(crate) fn discovered_private_zccache_cache_dir(cache_root: &Path) -> PathBuf
         private_root.display(),
         dirs
     );
-    dirs.remove(0)
+    let namespace_dir = dirs.remove(0);
+    let mut version_dirs: Vec<PathBuf> = fs::read_dir(&namespace_dir)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", namespace_dir.display()))
+        .map(|entry| entry.expect("read private zccache version dir").path())
+        .filter(|path| {
+            path.is_dir()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with('v'))
+        })
+        .collect();
+    version_dirs.sort();
+    if version_dirs.len() == 1 {
+        return version_dirs.remove(0);
+    }
+    namespace_dir
 }
 
 pub(crate) fn logged_cargo_wrapper(log: &str) -> Option<String> {


### PR DESCRIPTION
## Summary
- replace the flat root help command list with grouped command sections ordered by familiarity
- shorten root command descriptions and move verbose bootstrap/cook/cache details to subcommand long help
- add root examples plus clap-generated help tests for grouping, line width, and long-help placement

Closes #745

## Tests
- soldr cargo check -p soldr-cli
- soldr cargo test -p soldr-cli root_help_groups_commands_and_keeps_lines_short
- soldr cargo test -p soldr-cli long_root_help_expands_intro_and_zccache_details
- soldr cargo test -p soldr-cli verbose_command_details_live_on_subcommand_help
- .\\target\\x86_64-pc-windows-msvc\\debug\\soldr.exe -h line-width check

Note: soldr cargo test -p soldr-cli currently fails in existing cli_cache tests because this machine has pinned zccache 1.12.7 while those assertions expect 1.12.0.