### PR TITLE
fix: recover zccache session-start daemon loss

### DIFF
--- a/crates/soldr-cli/src/zccache_lifecycle.rs
+++ b/crates/soldr-cli/src/zccache_lifecycle.rs
@@ -265,9 +265,9 @@ impl ZccacheLifecycle {
             Ok(output) => output,
             Err(err) if zccache_session_start_lost_connection(&err) => {
                 eprintln!(
-                    "soldr: zccache session-start lost connection to daemon; restarting and retrying once"
+                    "soldr: zccache session-start lost connection to daemon; stopping stale state and retrying once"
                 );
-                self.start_with_recovery()?;
+                self.recover_after_session_start_lost_connection()?;
                 self.run_strings(&args).map_err(|retry_err| {
                     SoldrError::Other(format!(
                         "{retry_err}\ninitial zccache session-start failure before retry: {err}"
@@ -297,6 +297,24 @@ impl ZccacheLifecycle {
                 .as_ref()
                 .map(ZccachePrivateDaemonSession::from),
         })
+    }
+
+    fn recover_after_session_start_lost_connection(&mut self) -> Result<(), SoldrError> {
+        let stop = self.stop(false);
+        if let Ok(outcome) = &stop {
+            if let Some(failure) = &outcome.failure {
+                eprintln!(
+                    "soldr: zccache stop during session-start recovery reported: {}",
+                    failure.trim()
+                );
+            }
+        } else if let Err(err) = &stop {
+            eprintln!("soldr: failed to invoke zccache stop during session-start recovery: {err}");
+        }
+        if let Err(message) = remove_stale_zccache_daemon_lock(&self.cache_dir) {
+            eprintln!("soldr: {message}");
+        }
+        self.start_with_recovery()
     }
 
     pub(crate) fn end_session_json(
@@ -873,7 +891,8 @@ fn zccache_session_start_lost_connection(err: &SoldrError) -> bool {
         return false;
     };
     let message = message.to_ascii_lowercase();
-    message.contains("zccache session-start failed")
+    message.contains("zccache session-start")
+        && message.contains("failed")
         && message.contains("lost connection to daemon")
         && (message.contains("no response") || message.contains("no response received"))
 }
@@ -1080,6 +1099,12 @@ mod tests {
             "zccache session-start failed: zccache[err][R]: lost connection to daemon (no response). The daemon may have crashed or been killed mid-request".to_string(),
         );
         assert!(zccache_session_start_lost_connection(&observed));
+
+        let observed_with_args = SoldrError::Other(
+            "zccache session-start --stats --log last-session.log --journal last-session.jsonl failed: zccache[err][R]: lost connection to daemon (no response)"
+                .to_string(),
+        );
+        assert!(zccache_session_start_lost_connection(&observed_with_args));
 
         let unrelated_lost_connection = SoldrError::Other(
             "zccache status failed: zccache[err][R]: lost connection to daemon (no response)"

--- a/crates/soldr-cli/tests/cli_cargo_basic.rs
+++ b/crates/soldr-cli/tests/cli_cargo_basic.rs
@@ -263,6 +263,56 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
 }
 
 #[test]
+fn cargo_front_door_recovers_when_session_start_loses_daemon() {
+    let cache_root = unique_temp_dir("cargo-session-start-lost-daemon");
+    let log_path = cache_root.join("tool.log");
+    let lost_marker = cache_root.join("session-start-lost");
+    let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["cargo", "build"])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("SOLDR_TEST_CARGO_BIN", &cargo)
+        .env("SOLDR_TEST_RUSTC_BIN", &rustc)
+        .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
+        .env("SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE", &lost_marker)
+        .env_remove("SOLDR_TARGET_CACHE_MODE")
+        .env_remove("SOLDR_BUILD_CACHE_MODE")
+        .output()
+        .expect("failed to run soldr cargo build with fake zccache");
+
+    assert!(
+        output.status.success(),
+        "session-start recovery build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
+    let first_session_start = log
+        .find("zccache session-start")
+        .unwrap_or_else(|| panic!("first session-start missing from fake zccache log: {log}"));
+    let stop = log
+        .find("zccache stop")
+        .unwrap_or_else(|| panic!("zccache stop missing from recovery log: {log}"));
+    let second_session_start = log
+        .rfind("zccache session-start")
+        .unwrap_or_else(|| panic!("second session-start missing from fake zccache log: {log}"));
+    let cargo = log
+        .find("cargo wrapper=")
+        .unwrap_or_else(|| panic!("cargo did not run after recovery: {log}"));
+    assert!(
+        first_session_start < stop && stop < second_session_start && second_session_start < cargo,
+        "session-start recovery must stop the stale daemon before retrying: {log}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("session-start lost connection to daemon; stopping stale state"),
+        "expected recovery diagnostic in stderr: {stderr}"
+    );
+}
+
+#[test]
 fn command_lifetime_cache_stops_zccache_after_successful_cargo() {
     let cache_root = unique_temp_dir("cargo-command-lifetime-success");
     let log_path = cache_root.join("tool.log");

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -471,11 +471,18 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
              if \"%~1\"==\"stop\" (\n\
                echo zccache stop cache_dir=%ZCCACHE_CACHE_DIR% daemon_namespace=%ZCCACHE_DAEMON_NAMESPACE%>>\"{0}\"\n\
                if defined SOLDR_TEST_ZCCACHE_STALE_START_ONCE type nul > \"%SOLDR_TEST_ZCCACHE_STALE_START_ONCE%.stopped\"\n\
+               if defined SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE type nul > \"%SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE%.stopped\"\n\
                if defined SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER type nul > \"%SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER%\"\n\
                exit /b 0\n\
              )\n\
               if \"%~1\"==\"session-start\" (\n\
                 echo zccache session-start cache_dir=%ZCCACHE_CACHE_DIR% daemon_namespace=%ZCCACHE_DAEMON_NAMESPACE% args=%*>>\"{0}\"\n\
+                if defined SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE (\n\
+                  if not exist \"%SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE%.stopped\" (\n\
+                    if not exist \"%SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE%.failed\" goto soldr_zccache_session_start_lost_first\n\
+                    goto soldr_zccache_session_start_lost_retry\n\
+                  )\n\
+                )\n\
                 if not \"%~4\"==\"\" type nul > \"%~4\"\n\
                 if not \"%~6\"==\"\" type nul > \"%~6\"\n\
                 echo {{\"session_id\":\"test-session\"}}\n\
@@ -563,7 +570,14 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
              exit /b 2\n\
              :soldr_zccache_flush_no_json\n\
              echo error: unexpected argument '--json' found 1>&2\n\
-             exit /b 2\n",
+             exit /b 2\n\
+             :soldr_zccache_session_start_lost_first\n\
+             type nul > \"%SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE%.failed\"\n\
+             echo zccache lost connection to daemon no response 1>&2\n\
+             exit /b 1\n\
+             :soldr_zccache_session_start_lost_retry\n\
+             echo zccache session-start retried before stop 1>&2\n\
+             exit /b 66\n",
             log_path.display()
         )
     }
@@ -610,6 +624,9 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
                  if [ -n \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE:-}}\" ]; then\n\
                    : > \"${{SOLDR_TEST_ZCCACHE_STALE_START_ONCE}}.stopped\"\n\
                  fi\n\
+                 if [ -n \"${{SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE:-}}\" ]; then\n\
+                   : > \"${{SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE}}.stopped\"\n\
+                 fi\n\
                  if [ -n \"${{SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER:-}}\" ]; then\n\
                    : > \"${{SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER}}\"\n\
                  fi\n\
@@ -617,6 +634,15 @@ pub(crate) fn fake_zccache_script(log_path: &Path) -> String {
                  ;;\n\
                 session-start)\n\
                   echo \"zccache session-start cache_dir=${{ZCCACHE_CACHE_DIR:-}} daemon_namespace=${{ZCCACHE_DAEMON_NAMESPACE:-}} args=$*\" >> \"{0}\"\n\
+                  if [ -n \"${{SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE:-}}\" ] && [ ! -e \"${{SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE}}.stopped\" ]; then\n\
+                    if [ ! -e \"${{SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE}}.failed\" ]; then\n\
+                      : > \"${{SOLDR_TEST_ZCCACHE_SESSION_START_LOST_ONCE}}.failed\"\n\
+                      echo 'zccache[err][R]: lost connection to daemon (no response)' >&2\n\
+                      exit 1\n\
+                    fi\n\
+                    echo 'zccache session-start retried before stop' >&2\n\
+                    exit 66\n\
+                  fi\n\
                   : > \"$4\"\n\
                   : > \"$6\"\n\
                   echo '{{\"session_id\":\"test-session\"}}'\n\


### PR DESCRIPTION
## Summary
- detect real `zccache session-start --stats ... failed` lost-connection errors, not only the abbreviated synthetic form
- stop the same private zccache daemon namespace, clear stale lock state, restart, and retry `session-start` once
- add a fake-zccache regression test that fails unless `stop` happens before the retry

Fixes #749.

## Tests
- `soldr cargo test -p soldr-cli cargo_front_door_recovers_when_session_start_loses_daemon -- --nocapture`
- `soldr cargo test -p soldr-cli session_start_lost_connection_detector_is_narrow -- --nocapture`
- `soldr cargo test -p soldr-cli --test cli_cargo_basic`
- `git diff --check`

Note: `soldr cargo fmt --check` still reports pre-existing formatting drift in unrelated files, so this PR used targeted `soldr rustfmt` on the touched Rust files only.