### PR TITLE
fix: align private zccache session endpoint

### DIFF
--- a/crates/soldr-cli/src/zccache_lifecycle.rs
+++ b/crates/soldr-cli/src/zccache_lifecycle.rs
@@ -535,7 +535,7 @@ pub(crate) struct CommandOutput {
 
 pub(crate) fn session_start_args(
     options: &ZccacheSessionStartOptions,
-    cache_dir: &Path,
+    _cache_dir: &Path,
     private_daemon: Option<&ZccachePrivateDaemonConfig>,
 ) -> Vec<String> {
     let mut args = vec![
@@ -554,8 +554,6 @@ pub(crate) fn session_start_args(
         args.push("--private-daemon".to_string());
         args.push("--daemon-name".to_string());
         args.push(private.daemon_name.clone());
-        args.push("--cache-dir".to_string());
-        args.push(cache_dir.display().to_string());
         if let Some(owner_pid) = private.owner_pid {
             args.push("--owner-pid".to_string());
             args.push(owner_pid.to_string());
@@ -1061,9 +1059,10 @@ mod tests {
             assert!(args
                 .windows(2)
                 .any(|w| w[0] == "--daemon-name" && w[1] == "soldr-dev-test"));
-            assert!(args
-                .windows(2)
-                .any(|w| w[0] == "--cache-dir" && w[1] == "/tmp/zccache"));
+            assert!(
+                !args.iter().any(|arg| arg == "--cache-dir"),
+                "private session-start should rely on ZCCACHE_CACHE_DIR instead of --cache-dir: {args:?}"
+            );
             assert!(args
                 .windows(2)
                 .any(|w| w[0] == "--owner-pid" && w[1] == "4242"));


### PR DESCRIPTION
## Summary

- pass the private cache dir to zccache session-start so it resolves the same cache-root-derived endpoint used by the RUSTC_WRAPPER child process
- keep the zccache 1.12.8 effective-root contract intact while preserving private daemon owner/env args
- update the private session-start args regression test

## Tests

- soldr cargo test -p soldr-cli private_session_start_args_include_daemon_owner_cache_and_env -- --nocapture
- soldr cargo test -p soldr-cli session_start_lost_connection_detector_is_narrow -- --nocapture
- soldr cargo test -p soldr-cli --test cli_cargo_basic -- --nocapture
- git diff --check