### PR TITLE
ci: authenticate managed zccache release lookup

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -51,6 +51,11 @@ jobs:
       CXX_x86_64_unknown_linux_musl: musl-g++
       CC_aarch64_unknown_linux_musl: musl-gcc
       CXX_aarch64_unknown_linux_musl: musl-g++
+      # Managed zccache is fetched from zackees/zccache, which is a
+      # cross-repo GitHub Releases lookup from this workflow. Use soldr's
+      # explicit opt-in token env so release metadata requests are
+      # authenticated without weakening the generic GITHUB_TOKEN guard.
+      SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -63,6 +63,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     env:
       GH_TOKEN: ${{ github.token }}
+      # Managed zccache is fetched from zackees/zccache, which is a
+      # cross-repo GitHub Releases lookup from this workflow. Use soldr's
+      # explicit opt-in token env so release metadata requests are
+      # authenticated without weakening the generic GITHUB_TOKEN guard.
+      SOLDR_GITHUB_TOKEN: ${{ github.token }}
       RUST_BACKTRACE: "1"
       CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ permissions:
 
 env:
   RUST_BACKTRACE: "1"
+  # Direct CI jobs may resolve managed zccache from zackees/zccache.
+  # Use soldr's explicit opt-in token env for authenticated release
+  # metadata requests without weakening generic cross-repo GITHUB_TOKEN use.
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
   lint:

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -39,6 +39,12 @@ jobs:
   smoke:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    env:
+      # Managed zccache is fetched from zackees/zccache, which is a
+      # cross-repo GitHub Releases lookup from this workflow. Use soldr's
+      # explicit opt-in token env so release metadata requests are
+      # authenticated without weakening the generic GITHUB_TOKEN guard.
+      SOLDR_GITHUB_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
       matrix:
@@ -166,16 +172,6 @@ jobs:
         shell: pwsh
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-build-under-test
-          # Network-touching tests (e.g. `fetch_crgx_and_run`) hit the
-          # GitHub Releases API. Without a token the rate limit is
-          # 60/hr per runner IP and gets exhausted quickly when several
-          # workflows run on the same shared macOS / Linux pool.
-          # Authenticating bumps the limit to 5000/hr and turns the
-          # flake into a non-issue. Pair the env var with the inner
-          # retry budget in fetch_repo_binary_with_paths (#432) — the
-          # token covers rate-limit class failures, the retry covers
-          # transient release-propagation 404s.
-          SOLDR_GITHUB_TOKEN: ${{ github.token }}
         run: |
           Remove-Item Env:ZCCACHE_CACHE_DIR -ErrorAction SilentlyContinue
           $timer = [Diagnostics.Stopwatch]::StartNew()


### PR DESCRIPTION
## Summary

- set `SOLDR_GITHUB_TOKEN` from `github.token` in CI paths that may resolve managed zccache from `zackees/zccache`
- keep soldr's generic cross-repo `GITHUB_TOKEN` guard intact by using the existing explicit opt-in env var
- move the setup-soldr smoke workflow token from one test step to job scope so the dogfood build path is covered too

Closes #753.

## Tests

- `git diff --check`
- parsed changed workflow YAML files with PyYAML