### PR TITLE
fix(cargo-front-door): suppress "did you mean?" hint for cargo built-in verbs (#755)

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -694,6 +694,23 @@ fn workspace_trampoline_suppressed_for_tests() -> bool {
         || non_empty(&format!("{}CARGO", crate::REAL_TOOLCHAIN_BINARY_ENV_PREFIX))
 }
 
+/// Decide whether the "did you mean: cargo X?" hint applies to a typed
+/// subcommand that isn't in `known_tools`. Returns `Some(suggestion)`
+/// only when `sub` looks like a typo of a registered cargo subcommand
+/// AND is not itself a legitimate cargo built-in verb.
+///
+/// Issue #755: without the built-in guard, `soldr cargo check` falsely
+/// suggested `cargo chef` (Levenshtein distance 2). Built-in verbs are
+/// routed through the External arm by `cargo` itself; treating them as
+/// typos contradicts the contract documented in `CARGO_BUILTIN_VERBS`.
+fn suggest_cargo_subcommand_typo(sub: &str) -> Option<String> {
+    if crate::cli_args::is_cargo_builtin_verb(sub) {
+        return None;
+    }
+    let known = crate::fetch::known_cargo_subcommands();
+    crate::fuzzy_match::suggest_close_match(sub, &known).map(|s| s.to_string())
+}
+
 async fn ensure_known_subcommand_tool(
     args: &[String],
     paths: &SoldrPaths,
@@ -708,8 +725,7 @@ async fn ensure_known_subcommand_tool(
         // so the underlying cargo invocation continues as today —
         // the suggestion is advisory and cargo's own external-command
         // dispatch may still find the tool on PATH.
-        let known = crate::fetch::known_cargo_subcommands();
-        if let Some(suggestion) = crate::fuzzy_match::suggest_close_match(sub, &known) {
+        if let Some(suggestion) = suggest_cargo_subcommand_typo(sub) {
             eprintln!("soldr: '{sub}' is not a cargo subcommand soldr ships a prebuilt for.");
             eprintln!("soldr: did you mean: cargo {suggestion}?");
         }

--- a/crates/soldr-cli/src/cargo_front_door/tests.rs
+++ b/crates/soldr-cli/src/cargo_front_door/tests.rs
@@ -397,3 +397,38 @@ fn env_disables_target_gc_preserves_explicit_flag_opt_outs() {
     assert!(merged.before);
     assert!(!merged.after);
 }
+
+// Issue #755: cargo built-in verbs must not trigger the fuzzy "did you
+// mean: cargo X?" hint. The External arm hands them straight to cargo;
+// treating them as typos is misleading.
+#[test]
+fn suggest_cargo_subcommand_typo_skips_cargo_builtin_verbs() {
+    for verb in crate::cli_args::CARGO_BUILTIN_VERBS {
+        assert_eq!(
+            suggest_cargo_subcommand_typo(verb),
+            None,
+            "cargo built-in verb {verb:?} must not be suggested as a typo of a known subcommand",
+        );
+    }
+}
+
+#[test]
+fn suggest_cargo_subcommand_typo_still_catches_genuine_typos() {
+    // Regression guard for issue #412: a clear typo of a registered
+    // cargo subcommand (e.g. `ntest` → `nextest`) still gets the hint.
+    assert_eq!(
+        suggest_cargo_subcommand_typo("ntest").as_deref(),
+        Some("nextest"),
+        "fuzzy hint must still fire for genuine typos of known cargo subcommands",
+    );
+}
+
+#[test]
+fn suggest_cargo_subcommand_typo_returns_none_for_unrelated_input() {
+    // Sanity check: random garbage that isn't close to any candidate
+    // gets no suggestion at all.
+    assert_eq!(
+        suggest_cargo_subcommand_typo("completely-made-up-name"),
+        None,
+    );
+}


### PR DESCRIPTION
## Summary

- Guard the cargo-front-door fuzzy "did you mean: cargo X?" hint with `is_cargo_builtin_verb(sub)` so legitimate cargo built-ins (e.g. `check`, `build`, `fix`) never get suggested as typos of registered `known_tools` subcommands. `soldr cargo check` used to emit `did you mean: cargo chef?` — distance 2 from `chef` was tripping the issue #412 typo suggester.
- Extract the suggest-or-skip decision into a small pure helper (`suggest_cargo_subcommand_typo`) so the rule has one home and is unit-testable without spinning up the async fetch path.
- Three unit tests in `cargo_front_door::tests`: (1) every entry in `CARGO_BUILTIN_VERBS` returns `None`, (2) the canonical #412 case (`ntest` → `nextest`) still fires, (3) unrelated input still returns `None`.

Closes #755

## Test plan

- [x] `soldr cargo fmt --all -- --check` — clean
- [x] `soldr cargo test -p soldr-cli --bin soldr cargo_front_door::tests` — 35 passed (incl. 3 new)
- [x] `soldr cargo test -p soldr-cli --bin soldr fuzzy_match::tests` — 13 passed (issue #412 regression guard)
- [x] `soldr cargo clippy -p soldr-cli --bin soldr --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)