### PR TITLE
perf(matrix): add build-then-check scenario pinning cross-verb cache reuse (#758)

### DIFF
--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -57,6 +57,7 @@ on:
           - cold-tar-untar-warm
           - worktree-share
           - touch-no-change
+          - build-then-check
       # The `debug` input was removed: verbose tracing + raw RSS CSV
       # retention is now always on. The downstream consumer sets
       # SOLDR_DEBUG=1 unconditionally.
@@ -147,11 +148,12 @@ jobs:
                 esac
                 # Scenario token
                 case "${ts}" in
-                  all)      scen="all" ;;
-                  cold)     scen="cold-tar-untar-warm" ;;
-                  worktree) scen="worktree-share" ;;
-                  touch)    scen="touch-no-change" ;;
-                  *)        bad=1 ;;
+                  all)       scen="all" ;;
+                  cold)      scen="cold-tar-untar-warm" ;;
+                  worktree)  scen="worktree-share" ;;
+                  touch)     scen="touch-no-change" ;;
+                  crossverb) scen="build-then-check" ;;
+                  *)         bad=1 ;;
                 esac
                 if [[ -n "${rest}" || "${bad}" == "1" ]]; then
                   echo "::notice::Branch '${REF_NAME}' does not match perf/<plat>-<fix>-<scen>; running full sweep. See PERF.md."
@@ -307,7 +309,7 @@ jobs:
           # are not selected are filtered out of the per-cell loop
           # below, so a cell with zero selected scenarios still skips
           # the rest of the steps but does not consume bench-time.
-          ALL_SCENARIOS="cold-tar-untar-warm worktree-share touch-no-change"
+          ALL_SCENARIOS="cold-tar-untar-warm worktree-share touch-no-change build-then-check"
           selected_scenarios=""
           for s in ${ALL_SCENARIOS}; do
             if in_subset "${REQ_SCENARIOS}" "${s}"; then
@@ -510,7 +512,7 @@ jobs:
           mode_for() {
             case "$1" in
               cold-tar-untar-warm) echo "fail" ;;
-              worktree-share|touch-no-change) echo "warn" ;;
+              worktree-share|touch-no-change|build-then-check) echo "warn" ;;
               *) echo "warn" ;;
             esac
           }
@@ -564,7 +566,7 @@ jobs:
               continue
             fi
 
-            for scenario in cold-tar-untar-warm worktree-share touch-no-change; do
+            for scenario in cold-tar-untar-warm worktree-share touch-no-change build-then-check; do
               if ! in_subset "${REQ_SCENARIOS}" "${scenario}"; then
                 echo "scenario ${scenario} not selected by dispatch input; skipping"
                 continue

--- a/PERF.md
+++ b/PERF.md
@@ -30,13 +30,14 @@ Branch syntax: **`perf/<plat>-<fix>-<scen>`** with one short token per axis. `al
 | Scenario | `cold` | `cold-tar-untar-warm` |
 | Scenario | `worktree` | `worktree-share` |
 | Scenario | `touch` | `touch-no-change` |
+| Scenario | `crossverb` | `build-then-check` |
 | any axis | `all` | wildcard — run every value on this axis |
 
 Short tokens keep the branch name unambiguous (the real names contain hyphens that would collide with the axis separator).
 
 ### Full scope table
 
-48 hierarchical patterns plus two full-sweep aliases. Anything not in this table (e.g., a developer iteration branch like `perf/cluster-hierarchical-skip`) falls back to a full sweep and emits a `::notice::` so the run is still useful.
+Hierarchical patterns plus two full-sweep aliases. The tables below enumerate `cold` / `worktree` / `touch` for compactness; the `crossverb` scenario follows the same shape — substitute it for the trailing scenario token in any pattern (e.g. `perf/linux-medium-crossverb` is the single cell linux × medium × build-then-check). Anything not in this table (e.g., a developer iteration branch like `perf/cluster-hierarchical-skip`) falls back to a full sweep and emits a `::notice::` so the run is still useful.
 
 #### Aliases — full ride
 
@@ -120,6 +121,7 @@ Short tokens keep the branch name unambiguous (the real names contain hyphens th
 - **Iterating on cache hit-rate fixes that only affect sqlite builds** → `perf/linux-sqlite-cold` (fastest signal: one cell, the hard gate scenario).
 - **Tuning archive fidelity** → `perf/all-all-cold` (sweep cold-tar-untar-warm across everything; fixture variation matters).
 - **Worktree path-remap change** → `perf/linux-all-worktree` (every fixture on linux, worktree scenario only).
+- **Cross-verb cache canonicalization (e.g. `--emit=metadata` ↔ `--emit=metadata,link`)** → `perf/linux-medium-crossverb` (single cell that pins the build→check asymmetry from #758).
 - **Just experimenting / unsure** → `perf/all` or `main` — full sweep; the workflow handles the volume.
 - **Personal feature branch like `perf/wip/foo`** → falls through to full sweep with an `::notice::`. Fine for one-off runs; rename to a canonical pattern when you know what axis you're working on.
 
@@ -128,6 +130,7 @@ Short tokens keep the branch name unambiguous (the real names contain hyphens th
 - **`cold-tar-untar-warm` < 3x** (cold/warm ratio in the Evaluate step) → **fails the workflow**. Hard gate.
 - **`worktree-share` < 3x** → emits `::warning::`, doesn't fail. Soft gate today; promotes to hard once the baseline stabilizes.
 - **`touch-no-change` < 3x** → same as worktree-share, soft today.
+- **`build-then-check` < 3x** → soft warning. The "warm" step is `cargo check` after a warm `cargo build` (same source, same profile); today it returns 0% hits because zccache's cache key splits on the rustc `--emit` flag, so the ratio is close to the threshold. Promotes to hard once zccache canonicalizes `--emit=metadata` against `--emit=metadata,link` keys. Tracks #758.
 
 Threshold lives on the `evaluate` matrix row (`min_speedup: "3.0"`).
 

--- a/contracts/zccache-integration-guardrails.v1.json
+++ b/contracts/zccache-integration-guardrails.v1.json
@@ -291,6 +291,22 @@
       ]
     },
     {
+      "id": "perf-build-then-check",
+      "axis": "performance",
+      "gate": "report-only",
+      "covers": [
+        "cross-verb cache reuse (build -> check)",
+        "rustc --emit canonicalization canary"
+      ],
+      "test_files": [
+        ".github/workflows/perf-matrix.yml",
+        "perf/scenarios/build-then-check/run.sh"
+      ],
+      "validation_command_ids": [
+        "perf-matrix-worktree-touch"
+      ]
+    },
+    {
       "id": "native-cc-cache",
       "axis": "native C/C++ cache",
       "gate": "hard",

--- a/perf/README.md
+++ b/perf/README.md
@@ -25,6 +25,7 @@ matrix cell in this cluster pins a single failure mode:
 | `cold-tar-untar-warm` | cache archive fidelity (tar/untar round-trip)       |
 | `worktree-share`      | `ZCCACHE_PATH_REMAP=auto` injection (issue #352)    |
 | `touch-no-change`     | mtime/content-hash robustness (soldr save/load #377) |
+| `build-then-check`    | cross-verb cache reuse — `--emit=metadata` vs `--emit=metadata,link` (issue #758) |
 
 ## How a worker measures
 

--- a/perf/scenarios/build-then-check/run.sh
+++ b/perf/scenarios/build-then-check/run.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Scenario: cold `cargo build --release`, then immediate `cargo check
+# --release` against an unchanged source tree.
+#
+# What this measures: cross-verb cache reuse. After `build --release`
+# fills zccache with rmeta + rlib for every unit, an immediate `check
+# --release` SHOULD produce ~100% hits because the source, crate
+# versions, and target triple are identical. Today every unit MISSES
+# because zccache's cache key includes the rustc `--emit` flag, and
+# cargo issues `--emit=metadata` for check vs `--emit=metadata,link`
+# for build.
+#
+# Until zccache canonicalizes these keys (`--emit=metadata` is a strict
+# subset of `--emit=metadata,link`), this row is the canary that says
+# how much wall-clock the asymmetry costs.
+#
+# Pinned by issue #758. Soft warning today; promotes to hard fail
+# once the canonicalization lands upstream.
+#
+# Usage: run.sh <fixture-workdir>
+set -euo pipefail
+
+if (( $# != 1 )); then
+    echo "usage: run.sh <fixture-workdir>" >&2
+    exit 2
+fi
+
+FIXTURE_DIR="$1"
+SCENARIO="build-then-check"
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../lib/common.sh
+. "${HERE}/../../lib/common.sh"
+
+WORKDIR="$(cd -- "${FIXTURE_DIR}/.." && pwd)"
+CACHE="${WORKDIR}/cache-build-then-check"
+RSS_CSV="${WORKDIR}/rss-${SCENARIO}.csv"
+
+mkdir -p "${CACHE}"
+
+measure::start_rss_poller "${RSS_CSV}"
+trap 'measure::stop_rss_poller' EXIT
+
+# --- Cold build (populates zccache for the release profile) --------
+
+cold_start_ms="$(measure::now_ms)"
+(
+    cd "${FIXTURE_DIR}"
+    SOLDR_CACHE_DIR="${CACHE}" soldr cargo build --release
+)
+cold_elapsed_ms="$(measure::elapsed_ms "${cold_start_ms}")"
+
+# Flush so the depgraph snapshot is durable before the cross-verb pass.
+SOLDR_CACHE_DIR="${CACHE}" soldr cache flush --json >/dev/null 2>&1 || true
+
+# --- Cross-verb check pass -----------------------------------------
+# No source edits, same profile. cargo's own freshness check would
+# accept the rlibs from build, but `cargo check` writes freshness
+# under a different cache key (`-check-*` vs `-build-*`), so cargo
+# re-invokes rustc with `--emit=metadata`. Every such rustc hop hits
+# zccache; this measures whether zccache returns the cached metadata
+# or recompiles.
+
+warm_start_ms="$(measure::now_ms)"
+(
+    cd "${FIXTURE_DIR}"
+    SOLDR_CACHE_DIR="${CACHE}" soldr cargo check --release
+)
+warm_elapsed_ms="$(measure::elapsed_ms "${warm_start_ms}")"
+
+measure::write_cache_report "${CACHE}" "${WORKDIR}/warm-cache-report.json"
+measure::copy_zccache_logs_from_report \
+    "${WORKDIR}/warm-cache-report.json" \
+    "${WORKDIR}/warm-zccache-logs"
+warm_hits="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hits)"
+warm_misses="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" misses)"
+warm_hit_rate="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hit_rate)"
+
+SOLDR_CACHE_DIR="${CACHE}" soldr cache shutdown \
+    --shutdown-timeout-seconds 30 --json >"${WORKDIR}/build-then-check-shutdown.json" || true
+
+cache_bytes="$(measure::cache_bytes "${CACHE}")"
+
+# --- Measurement teardown ------------------------------------------
+
+measure::stop_rss_poller
+trap - EXIT
+
+peak_daemon_rss="$(measure::peak_daemon_rss_bytes "${RSS_CSV}")"
+peak_compile_rss="$(measure::peak_compile_rss_bytes "${RSS_CSV}")"
+
+# Speedup = cold (build) / warm (check). Today this is ~3x (close to
+# the cold-cache hard-gate threshold) because check forces a full
+# rebuild. Theoretical when keys canonicalize: 20x+ (check is just
+# fingerprint walk + 100% cache lookups).
+if (( warm_elapsed_ms > 0 )); then
+    speedup="$(awk -v c="${cold_elapsed_ms}" -v w="${warm_elapsed_ms}" 'BEGIN { printf "%.2f", c / w }')"
+else
+    speedup="0.00"
+fi
+
+measure::emit_summary_json "${SCENARIO}" \
+    "cold_ms=${cold_elapsed_ms}" \
+    "warm_ms=${warm_elapsed_ms}" \
+    "speedup=${speedup}" \
+    "warm_hits=${warm_hits}" \
+    "warm_misses=${warm_misses}" \
+    "warm_hit_rate=${warm_hit_rate}" \
+    "cache_bytes=${cache_bytes}" \
+    "peak_daemon_rss_bytes=${peak_daemon_rss}" \
+    "peak_compile_rss_bytes=${peak_compile_rss}"
+
+measure::append_summary_md "| ${SCENARIO} | ${cold_elapsed_ms} ms | ${warm_elapsed_ms} ms | ${speedup}x | ${warm_hits}/${warm_misses} | ${warm_hit_rate} | $(( peak_daemon_rss / 1024 / 1024 )) MiB |"


### PR DESCRIPTION
## Summary

- Adds a new perf-matrix scenario `build-then-check` that pins the local-build degeneracy found in #758: warm `cargo build --release` immediately followed by `cargo check --release` returns 0 cache hits because zccache's key includes the rustc `--emit` flag.
- New script `perf/scenarios/build-then-check/run.sh` follows the same shape as `touch-no-change` and emits the canonical `cold_ms` / `warm_ms` / `warm_hits` / `warm_misses` JSON.
- Wiring: `workflow_dispatch` choice list, branch-token `crossverb` → `build-then-check`, `ALL_SCENARIOS`, explicit `mode_for` (soft `warn`), evaluate loop, PERF.md, perf/README.md, contracts.
- Soft gate today. Promotes to hard fail once upstream `zackees/zccache` canonicalizes `--emit=metadata` against `--emit=metadata,link` keys.

Closes #758. Tracks meta #757.

## Local measurement (Windows MSVC, soldr 0.7.55, zccache 1.12.7, fixture: `medium`)

```json
{
  "scenario": "build-then-check",
  "cold_ms": 74090,
  "warm_ms": 29513,
  "speedup": 2.51,
  "warm_hits": 0,
  "warm_misses": 107,
  "warm_hit_rate": 0.0
}
```

2.51× sits below the 3× soft-warning threshold; evaluate will emit `::warning::` on every run until the cache-key canonicalization lands. Theoretical: 20×+ when the cross-verb path goes 100% hits.

## Test plan

- [x] Local end-to-end run of `bash perf/scenarios/build-then-check/run.sh <fixture>` — produces well-formed `result.json` with expected schema.
- [x] `bash -n perf/scenarios/build-then-check/run.sh` — syntax-clean.
- [ ] Normal CI on this PR — perf-matrix does NOT run here (branch is `fix/**`, not `perf/**`); first matrix-side exercise of the new scenario lands on the post-merge `main` push.

## Why a perf-matrix scenario is the right shape for the fix

soldr cannot canonicalize zccache's cache keys — that's a zccache-side concern. What soldr CAN do is establish the baseline so any improvement is visible, and so the asymmetry can't silently regrow on a future cargo or rustc change. This PR is that baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)