### PR TITLE
perf(build-then-check): force cargo to invoke rustc by bumping source mtimes

### DIFF
--- a/perf/scenarios/build-then-check/run.sh
+++ b/perf/scenarios/build-then-check/run.sh
@@ -53,13 +53,28 @@ cold_elapsed_ms="$(measure::elapsed_ms "${cold_start_ms}")"
 # Flush so the depgraph snapshot is durable before the cross-verb pass.
 SOLDR_CACHE_DIR="${CACHE}" soldr cache flush --json >/dev/null 2>&1 || true
 
+# Cargo's check fingerprint can short-circuit when it judges build's
+# rmeta as fresh-enough — observed on Linux GHA, NOT on Windows MSVC.
+# A short-circuit means zero rustc invocations and zero zccache hits or
+# misses, which collapses this scenario to "MISSING stats" in the
+# evaluate gate.
+#
+# Advance every source-file mtime (same trick as touch-no-change) so
+# cargo's fingerprint check fails uniformly across platforms and cargo
+# is forced to ask rustc for every unit. Content is unchanged, so this
+# is still an apples-to-apples zccache test: either zccache canonical-
+# izes the cross-verb cache key (the eventual fix) and returns hits, or
+# it recompiles (status quo). Either way the (hits, misses) pair is
+# populated and the gate has a number to compare.
+find "${FIXTURE_DIR}" -name '*.rs' -exec touch {} +
+find "${FIXTURE_DIR}" -name 'Cargo.toml' -exec touch {} +
+find "${FIXTURE_DIR}" -name 'Cargo.lock' -exec touch {} +
+
 # --- Cross-verb check pass -----------------------------------------
-# No source edits, same profile. cargo's own freshness check would
-# accept the rlibs from build, but `cargo check` writes freshness
-# under a different cache key (`-check-*` vs `-build-*`), so cargo
-# re-invokes rustc with `--emit=metadata`. Every such rustc hop hits
-# zccache; this measures whether zccache returns the cached metadata
-# or recompiles.
+# Source mtimes advanced; content identical. cargo refingerprints and
+# re-invokes rustc with `--emit=metadata` per unit. Each hop reaches
+# zccache; this measures whether the cross-verb cache key is canonical-
+# ized (the eventual fix) or split (status quo).
 
 warm_start_ms="$(measure::now_ms)"
 (


### PR DESCRIPTION
## Summary

The first run of `build-then-check` on Linux GHA after #759 produced **0 compilations** (0 hits / 0 misses) because cargo's check-vs-build fingerprint logic short-circuited and accepted build's rmeta as fresh for the `check` verb — **observed on Linux, NOT on Windows MSVC**. The evaluate gate treats empty zccache stats as MISSING and errored on both `medium` and `sqlite-link`:

```
##[error]medium/build-then-check reported warm_hits+warm_misses=0; zccache stats were not captured
##[error]sqlite-link/build-then-check reported warm_hits+warm_misses=0; zccache stats were not captured
```

Mirror the trick `touch-no-change` already uses: advance every `*.rs` / `Cargo.toml` / `Cargo.lock` mtime after the cold build but before the check pass. Content is unchanged, so it's still an apples-to-apples zccache test (canonicalize cross-verb keys → all hits; status quo → all misses), but cargo's fingerprint walk no longer judges check as already-fresh and the `(hits, misses)` pair lands populated on every platform.

## Local smoke after the change (Windows MSVC, fixture `medium`)

```json
{
  "scenario": "build-then-check",
  "cold_ms": 62284,
  "warm_ms": 22407,
  "speedup": 2.78,
  "warm_hits": 0,
  "warm_misses": 107,
  "warm_hit_rate": 0.0
}
```

Unchanged from #759's local numbers (the mtime bump is a no-op on Windows where cargo was already going to invoke rustc).

## Test plan

- [x] Local smoke run on Windows MSVC — stats populated as before
- [ ] Linux CI on the post-merge `main` push will validate the same stats land on Linux

Follow-up to #759. Tracks meta #757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)