### PR TITLE
fix(wrapper): recover the PRIVATE zccache daemon, not the default one (#761)

### DIFF
--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -261,7 +261,16 @@ fn ensure_private_zccache_daemon_before_exec(zccache: &std::path::Path) -> Resul
         return Ok(());
     };
 
-    let status = zccache_status(zccache)?;
+    // Issue #761: status/start probes here MUST target the same private
+    // daemon namespace the wrapper is about to exec into. Bare
+    // `zccache status` / `zccache start` talk to the *default* daemon —
+    // independent state. If the inherited private daemon is gone and the
+    // recovery starts the default one, the post-exec wrapper still finds
+    // no matching private daemon and serves no cache, which surfaces as
+    // 0% hits across every warm scenario in the perf matrix.
+    let private_args = ["--private-daemon", "--daemon-name", daemon_name.as_str()];
+
+    let status = zccache_private_status(zccache, &private_args)?;
     if status.status.success() {
         return Ok(());
     }
@@ -272,7 +281,9 @@ fn ensure_private_zccache_daemon_before_exec(zccache: &std::path::Path) -> Resul
     eprintln!(
         "soldr: zccache private daemon {daemon_name} unavailable before rustc exec; restarting"
     );
-    let start = zccache_command_output(zccache, &["start"])?;
+    let mut start_args: Vec<&str> = vec!["start"];
+    start_args.extend_from_slice(&private_args);
+    let start = zccache_command_output(zccache, &start_args)?;
     if !start.status.success() {
         return Err(SoldrError::Other(format!(
             "zccache start failed while recovering private daemon {daemon_name}: {}",
@@ -282,7 +293,7 @@ fn ensure_private_zccache_daemon_before_exec(zccache: &std::path::Path) -> Resul
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
     loop {
-        let status = zccache_status(zccache)?;
+        let status = zccache_private_status(zccache, &private_args)?;
         if status.status.success() {
             return Ok(());
         }
@@ -297,8 +308,13 @@ fn ensure_private_zccache_daemon_before_exec(zccache: &std::path::Path) -> Resul
 }
 
 #[cfg(unix)]
-fn zccache_status(zccache: &std::path::Path) -> Result<std::process::Output, SoldrError> {
-    zccache_command_output(zccache, &["status"])
+fn zccache_private_status(
+    zccache: &std::path::Path,
+    private_args: &[&str],
+) -> Result<std::process::Output, SoldrError> {
+    let mut args: Vec<&str> = vec!["status"];
+    args.extend_from_slice(private_args);
+    zccache_command_output(zccache, &args)
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

PR #747's Unix-only \`ensure_private_zccache_daemon_before_exec\` probes \`zccache status\` and starts \`zccache start\` **with no flags**. Both commands target the *default* daemon when the wrapper is about to exec into zccache with \`--private-daemon --daemon-name <name>\` from the inherited env. The recovery starts the wrong daemon; the post-exec wrapper still finds nothing to connect to and serves no cache.

Visible symptom in CI was every (fixture × scenario) cell in the perf matrix reporting \`warm_hits=0, warm_misses=0\` after #747 landed. Bisect was clean: \`8bfae87\` green, \`f4b8d03\` (= #747) red, identical zccache binary on both sides.

This PR threads \`--private-daemon --daemon-name <inherited_name>\` through both the status probe and the start command so the recovery operates on the same namespace the upcoming exec will look for.

Closes #761. Tracks meta #757.

## Diff shape

\`crates/soldr-cli/src/wrapper.rs\`:
- Build a \`private_args\` tuple once from \`inherited_private_daemon_name()\`.
- Replace bare \`zccache status\` / \`zccache start\` with versions that prepend the status/start verb to \`private_args\`.
- Rename the helper from \`zccache_status\` to \`zccache_private_status\` to keep the call sites honest about which daemon is being probed.

## Test plan

- [x] \`soldr cargo fmt --all -- --check\` — clean
- [x] \`soldr cargo build -p soldr-cli --bin soldr\` — native (Windows) build clean
- [x] \`soldr cargo clippy -p soldr-cli --bin soldr -- -D warnings\` — clean
- [ ] Authoritative validation is the post-merge Linux perf-matrix run on \`main\`. Pre-fix: \`warm_hits=0\` across every (fixture, scenario). Post-fix expectation: \`warm_hits>0\` returns to the pre-#747 baseline (\`cold-tar-untar-warm\` ~171 hits on \`medium\`, etc.).

The recovery path is \`#[cfg(unix)]\` and has no existing unit-test coverage in this codebase (the prior PR shipped it untested too). Linux CI is the canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)