### PR TITLE
fix(wrapper): drop broken ensure_private_zccache_daemon_before_exec (#761)

### DIFF
--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -5,11 +5,11 @@
 
 use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
 use crate::startup_profile::WrapperProfile;
-use crate::zccache_lifecycle::ZCCACHE_DAEMON_NAMESPACE_ENV_VAR;
 #[cfg(not(unix))]
 use crate::zccache_lifecycle::{
     session_start_args, stderr_indicates_unknown_session, ZccacheLifecycle,
     ZccachePrivateDaemonConfig, ZccachePrivateEnv, ZccacheSessionStartOptions,
+    ZCCACHE_DAEMON_NAMESPACE_ENV_VAR,
 };
 use crate::{apply_implicit_toolchain_homes, resolve_toolchain_binary, zccache_binary_override};
 
@@ -236,12 +236,16 @@ fn run_wrapper_through_zccache(
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
-        ensure_private_zccache_daemon_before_exec(zccache)?;
-        // TODO(#265): once exec() replaces this process there is nowhere to
-        // observe zccache's stderr or retry on "unknown session:". The
-        // Windows branch below performs that defensive retry. A Unix port
-        // would need to spawn-with-piped-stderr instead of exec, while still
-        // forwarding the cargo jobserver FDs (see issue #265 for context).
+        // Issue #761: the recovery helper that #747 added here
+        // (`ensure_private_zccache_daemon_before_exec`) probed the
+        // wrong daemon (bare `zccache status` / `zccache start`,
+        // which target the default daemon rather than the inherited
+        // private namespace) and returned Ok(()) without restoring
+        // anything. Net effect was zero recovery, but the function's
+        // mere presence didn't break warm builds — it's just absent
+        // value. Removing it restores the pre-#747 path until a
+        // private-daemon-aware recovery lands. See #761 for the
+        // tracking discussion.
         let err = command.exec();
         Err(SoldrError::Other(format!(
             "failed to exec zccache at {}: {err}",
@@ -253,72 +257,6 @@ fn run_wrapper_through_zccache(
     {
         run_wrapper_through_zccache_windows(raw_args, zccache)
     }
-}
-
-#[cfg(unix)]
-fn ensure_private_zccache_daemon_before_exec(zccache: &std::path::Path) -> Result<(), SoldrError> {
-    let Some(daemon_name) = inherited_private_daemon_name() else {
-        return Ok(());
-    };
-
-    let status = zccache_status(zccache)?;
-    if status.status.success() {
-        return Ok(());
-    }
-    if !zccache_daemon_unavailable(&status.stderr) {
-        return Ok(());
-    }
-
-    eprintln!(
-        "soldr: zccache private daemon {daemon_name} unavailable before rustc exec; restarting"
-    );
-    let start = zccache_command_output(zccache, &["start"])?;
-    if !start.status.success() {
-        return Err(SoldrError::Other(format!(
-            "zccache start failed while recovering private daemon {daemon_name}: {}",
-            String::from_utf8_lossy(&start.stderr).trim()
-        )));
-    }
-
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-    loop {
-        let status = zccache_status(zccache)?;
-        if status.status.success() {
-            return Ok(());
-        }
-        if std::time::Instant::now() >= deadline {
-            return Err(SoldrError::Other(format!(
-                "zccache private daemon {daemon_name} did not become available after restart: {}",
-                String::from_utf8_lossy(&status.stderr).trim()
-            )));
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
-    }
-}
-
-#[cfg(unix)]
-fn zccache_status(zccache: &std::path::Path) -> Result<std::process::Output, SoldrError> {
-    zccache_command_output(zccache, &["status"])
-}
-
-#[cfg(unix)]
-fn zccache_command_output(
-    zccache: &std::path::Path,
-    args: &[&str],
-) -> Result<std::process::Output, SoldrError> {
-    let mut command = std::process::Command::new(zccache);
-    command.args(args);
-    suppress_windows_console_window(&mut command);
-    Ok(command.output()?)
-}
-
-#[cfg(unix)]
-fn zccache_daemon_unavailable(stderr: &[u8]) -> bool {
-    let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
-    stderr.contains("cannot connect to daemon")
-        || stderr.contains("no such file or directory")
-        || stderr.contains("lost connection to daemon")
-        || stderr.contains("not accepting connections")
 }
 
 /// Windows-only wrapper invocation: spawn zccache with its stderr piped so we
@@ -455,6 +393,7 @@ fn allocate_replacement_session(zccache: &std::path::Path) -> Result<String, Sol
     })
 }
 
+#[cfg(not(unix))]
 fn inherited_private_daemon_name() -> Option<String> {
     std::env::var(ZCCACHE_DAEMON_NAMESPACE_ENV_VAR)
         .ok()


### PR DESCRIPTION
## Summary

PR #747's Unix-only \`ensure_private_zccache_daemon_before_exec\` was meant to defensively restart the inherited private zccache daemon if it died between session-start and the rustc-wrapper exec. As written it probes the **default** daemon (\`zccache status\` / \`zccache start\` with no flags), so when the inherited *private* daemon really IS gone it starts the default one, status reports OK against the default, the function returns Ok(()), the exec proceeds, and zccache can't find a matching private daemon to connect to.

In practice this broke every cell of the perf matrix on \`main\` — every (fixture × scenario) went from non-zero hits pre-#747 to \`warm_hits=0, warm_misses=0\` post-#747. Single-commit bisect confirmed it (\`8bfae87\` green → \`f4b8d03\` red, identical zccache binary on both sides).

The minimal-arg attempt to fix this in #762 (thread \`--private-daemon --daemon-name X\` into the existing status/start calls) **broke the Linux build outright**: zccache's \`status\` subcommand does not accept those flags, status fails with an 'unknown argument' stderr that doesn't match \`zccache_daemon_unavailable\`'s patterns, the function bails without recovering, and the exec hits a daemon-less zccache. #762 has been closed.

This PR removes the broken recovery entirely. The pre-#747 code (just \`command.exec()\`) was working correctly on the perf matrix; restoring it is strictly an improvement on today's state. A correct private-daemon-aware recovery needs lifecycle-level state (session-start args, ZCCACHE_CACHE_DIR, owner-pid) that isn't reconstructible from the inherited env alone — left as follow-up.

Closes #761. Tracks meta #757.

## Diff shape

\`crates/soldr-cli/src/wrapper.rs\`:
- Remove \`ensure_private_zccache_daemon_before_exec\` and its three helpers (\`zccache_status\`, \`zccache_command_output\`, \`zccache_daemon_unavailable\`). They had no callers outside the removed function.
- Remove the call to it at line 239.
- Move the \`ZCCACHE_DAEMON_NAMESPACE_ENV_VAR\` import back into the \`#[cfg(not(unix))]\` block (its only remaining caller is the Windows replacement-session path).
- Gate \`inherited_private_daemon_name\` with \`#[cfg(not(unix))]\` for the same reason.
- Leave a TODO-style comment at the removed call site pointing at #761 so the gap is visible.

Net: -73 / +12.

## Test plan

- [x] \`soldr cargo fmt --all -- --check\` — clean
- [x] \`soldr cargo build -p soldr-cli --bin soldr\` — clean on Windows MSVC
- [x] \`soldr cargo clippy -p soldr-cli --bin soldr -- -D warnings\` — clean (no dead-code from the gating)
- [ ] Authoritative validation is the post-merge Linux perf-matrix run on \`main\`. Expected: \`warm_hits\` returns to pre-#747 baseline across all scenarios (\`cold-tar-untar-warm\` ~171 hits on \`medium\`, etc.).

## Trade-off

Removes a defensive recovery that wasn't actually defending anything. The original motivation for #747 commit 4 — "private daemon may die between session-start and rustc exec" — is real but the implementation didn't address it. Until a private-daemon-aware recovery lands, the wrapper exec will fail in that rare scenario the same way it did before #747. That's the pre-#747 behavior the entire perf-matrix history shows is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)