### PR TITLE
fix(wrapper): start the PRIVATE zccache daemon during recovery (#761 part 2)

### DIFF
--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -272,7 +272,19 @@ fn ensure_private_zccache_daemon_before_exec(zccache: &std::path::Path) -> Resul
     eprintln!(
         "soldr: zccache private daemon {daemon_name} unavailable before rustc exec; restarting"
     );
-    let start = zccache_command_output(zccache, &["start"])?;
+    // Issue #761: start the PRIVATE daemon that the wrapper is about
+    // to exec into, NOT the default daemon. Bare `zccache start`
+    // launches the default daemon, leaving the inherited private
+    // namespace empty and the post-exec wrapper unable to connect.
+    // Threading these flags onto the start call is safe — `zccache
+    // start` accepts them (unlike `zccache status`, which is left
+    // bare on the probe above). On a fresh CI runner the typical
+    // sequence is bare-status-fails -> private-start-succeeds ->
+    // private-status-succeeds.
+    let start = zccache_command_output(
+        zccache,
+        &["start", "--private-daemon", "--daemon-name", &daemon_name],
+    )?;
     if !start.status.success() {
         return Err(SoldrError::Other(format!(
             "zccache start failed while recovering private daemon {daemon_name}: {}",


### PR DESCRIPTION
## Summary

Third attempt at the underlying #761 fix. Threads \`--private-daemon --daemon-name <inherited>\` onto the recovery's \`zccache start\` call **only**, leaving the \`zccache status\` probe bare. PR #762 (private flags on both) broke the Linux build because zccache status doesn't accept the flags. PR #763 (clean revert) exposed the underlying race that the broken recovery was at least going through the motions of addressing. This PR threads private flags onto just the recovery target, which is exactly the call shape \`session_start_args\` uses for the non-Unix replacement path — known to work.

On a fresh CI runner the sequence is now:
1. \`zccache status\` (bare) — daemon-less runner, fails with 'cannot connect'
2. \`zccache_daemon_unavailable\` matches → enter recovery
3. \`zccache start --private-daemon --daemon-name <inherited>\` — starts the same private daemon the wrapper is about to exec into
4. Recovery loop polls \`zccache status\` (bare) until it reports OK
5. Wrapper execs into zccache; finds the matching private daemon; serves cache

This addresses BOTH the freshly-built-soldr first-invocation failure (which sank #762 and #763) AND the post-build perf-matrix 0% hits.

Refs #761. Tracks meta #757.

## Test plan

- [x] \`soldr cargo fmt --all -- --check\` — clean
- [x] \`soldr cargo build -p soldr-cli --bin soldr\` — clean (99.7% hits)
- [x] \`soldr cargo clippy -p soldr-cli --bin soldr -- -D warnings\` — clean (100% hits)
- [ ] Authoritative validation is Linux CI on this PR. If the bootstrap-e2e build passes, the recovery actually works on a fresh runner.
- [ ] Post-merge: perf-matrix on \`main\` should show non-zero warm_hits across scenarios (return to pre-#747 baseline).

## Risk

If the daemon-recovery hypothesis is wrong (e.g. the failure is somewhere other than the wrapper recovery path), this PR fails Linux CI the same way #762 / #763 did, and we close it as not-the-fix and re-open #761. The diagnostic value of a CI run with this specific change is high either way — green means the diagnosis was right; red points clearly at the real failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)