### PR TITLE
ci(perf-matrix): restore cold-tar-untar-warm hard gate now #761 is fixed

### DIFF
--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -509,19 +509,9 @@ jobs:
           # scenario -> "fail" or "warn". cold-tar-untar-warm is the
           # designed hard gate; the others are soft until their baselines
           # stabilize (see workflow header).
-          #
-          # Issue #761: every scenario currently reports hits+misses=0 on
-          # post-#747 main because a zccache private-daemon lifecycle bug
-          # silently neuters the warm session. The hard gate has been
-          # firing on every push to main for the wrong reason — that
-          # trains people to ignore the alarm and would hide a real
-          # regression when one lands. Temporarily demote cold-tar-untar
-          # -warm to `warn` until #761 lands. The line is one edit to
-          # restore once the lifecycle bug is fixed.
           mode_for() {
             case "$1" in
-              # cold-tar-untar-warm) echo "fail" ;;  # restored once #761 is fixed
-              cold-tar-untar-warm) echo "warn" ;;
+              cold-tar-untar-warm) echo "fail" ;;
               worktree-share|touch-no-change|build-then-check) echo "warn" ;;
               *) echo "warn" ;;
             esac


### PR DESCRIPTION
## Summary

#766 fixed the underlying zccache private-daemon bootstrap by restoring \`--cache-dir\` to \`session_start_args\`. The post-merge perf-matrix run on main (sha \`5fdd4f0\`) confirmed warm_hits returned to the pre-#747 baseline:

| Scenario × Fixture | warm_hits | speedup |
|---|---|---|
| cold-tar-untar-warm × medium | 171 | 26.10× |
| cold-tar-untar-warm × sqlite-link | 44 | 61.06× |
| touch-no-change × medium | 171 | 42.67× |
| touch-no-change × sqlite-link | 44 | 96.36× |

Both \`cold-tar-untar-warm\` cells are well above the 3× threshold the hard gate enforces, so restoring \`cold-tar-untar-warm) echo "fail"\` is safe — and necessary to make the alarm credible again. PR #764's mitigation comment explicitly documented this as a one-line restoration.

## Test plan

- [x] Workflow-only change; no Rust compile to validate.
- [ ] Post-merge perf-matrix on \`main\` should continue to pass with the hard gate engaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)