### PR TITLE
feat(bench): embed benchmark trend image in README (#771)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -54,6 +54,20 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash bench/assemble_benchmark_stats.sh
 
+      - name: Install matplotlib for trend image
+        # Issue #771: README embeds benchmark-trend.png via raw URL.
+        # python3-matplotlib is the system package (~15s install) and
+        # avoids a venv. Mirrors the python3-pil pattern zccache uses
+        # for the same purpose.
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends python3-matplotlib
+
+      - name: Render benchmark-trend.png
+        working-directory: soldr
+        run: python3 bench/render_benchmark_trend.py
+
       - name: Publish to benchmark-stats branch
         if: ${{ success() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         working-directory: soldr

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Third-party comparison (soldr vs Swatinem/rust-cache vs ...): published from `za
 [![Windows x64](https://github.com/zackees/soldr/actions/workflows/build-windows-x64.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-windows-x64.yml)
 [![Windows ARM64](https://github.com/zackees/soldr/actions/workflows/build-windows-arm64.yml/badge.svg?branch=main)](https://github.com/zackees/soldr/actions/workflows/build-windows-arm64.yml)
 
+## Performance
+
+[![soldr local-build canary trend](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-trend.png)](https://github.com/zackees/soldr/tree/benchmark-stats)
+
+The image is regenerated on every push to `main` by [`.github/workflows/benchmark-stats.yml`](.github/workflows/benchmark-stats.yml). Full data + an interactive Chart.js view are published in the [`benchmark-stats` branch](https://github.com/zackees/soldr/tree/benchmark-stats) and at [zackees.github.io/soldr](https://zackees.github.io/soldr/). The AI-discoverable discovery index is at [`manifest.json`](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/manifest.json). Canary set and methodology: [PERF.md § Per-commit benchmark stats](PERF.md#per-commit-benchmark-stats-issue-768).
+
 **Instant tools. Instant builds. One command.**
 
 soldr = [crgx](https://crgx.dev/) + [zccache](https://github.com/zackees/zccache) in a single tool.

--- a/bench/assemble_benchmark_stats.sh
+++ b/bench/assemble_benchmark_stats.sh
@@ -144,6 +144,11 @@ jq -n \
                 description: "Human-facing rendered view with Chart.js interactive graphs.",
                 url: $pages_url,
                 content_type: "text/html"
+            },
+            readme_image: {
+                description: "Static PNG of the canary trend; embedded in repo README.md and updated on every main-merge (#771).",
+                url: ($raw_base + "/benchmark-trend.png"),
+                content_type: "image/png"
             }
         },
         canaries: {

--- a/bench/render_benchmark_trend.py
+++ b/bench/render_benchmark_trend.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Render the benchmark-stats history.jsonl as a static PNG trend chart
+that the repo README can embed via raw.githubusercontent.com.
+
+Issue #771. Mirrors zccache's `## Performance` README pattern.
+
+Reads:  ./benchmark-stats/history.jsonl
+Writes: ./benchmark-stats/benchmark-trend.png
+
+stdlib + matplotlib only. matplotlib is installed in the workflow via
+`apt-get install -y python3-matplotlib` (small + fast).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+# Match bench/index.html palette so README image and Pages view are
+# visually consistent.
+CANARY_COLORS = {
+    "cargo-build-medium-cold": "#d32f2f",
+    "cargo-build-medium-warm": "#1976d2",
+    "cargo-build-medium-from-warm-zccache": "#388e3c",
+    "cargo-check-medium-cross-verb": "#f57c00",
+    "touch-no-change-medium-warm": "#7b1fa2",
+    "worktree-share-medium-warm": "#00838f",
+}
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HISTORY = REPO_ROOT / "benchmark-stats" / "history.jsonl"
+OUTPUT = REPO_ROOT / "benchmark-stats" / "benchmark-trend.png"
+
+
+def load_history():
+    if not HISTORY.exists():
+        return []
+    rows = []
+    with HISTORY.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as err:
+                print(
+                    f"render: skipping malformed history.jsonl line: {err}",
+                    file=sys.stderr,
+                )
+    return rows
+
+
+def render_empty(reason):
+    fig, ax = plt.subplots(figsize=(8, 4.5))
+    ax.set_axis_off()
+    ax.text(
+        0.5,
+        0.5,
+        f"No benchmark data yet\n({reason})",
+        ha="center",
+        va="center",
+        fontsize=14,
+        color="#656d76",
+        transform=ax.transAxes,
+    )
+    fig.savefig(OUTPUT, dpi=110, bbox_inches="tight")
+    plt.close(fig)
+
+
+def render_trend(rows):
+    canary_names = list(CANARY_COLORS.keys())
+    x = list(range(len(rows)))  # commit index; oldest on left, newest on right
+    fig, ax = plt.subplots(figsize=(8, 4.5))
+    for name in canary_names:
+        ys = [row.get("canaries", {}).get(name) for row in rows]
+        ax.plot(
+            x,
+            ys,
+            marker="o",
+            markersize=2,
+            linewidth=1.2,
+            color=CANARY_COLORS[name],
+            label=name,
+        )
+    ax.set_yscale("log")
+    ax.set_xlabel("main-commit index (older → newer)")
+    ax.set_ylabel("wall time (ms, log scale)")
+    ax.set_title(f"soldr local-build canaries — last {len(rows)} main-commits")
+    ax.grid(True, which="major", linestyle="-", linewidth=0.4, alpha=0.5)
+    ax.grid(True, which="minor", linestyle=":", linewidth=0.3, alpha=0.4)
+    ax.legend(loc="upper left", fontsize=8, frameon=True, ncol=2)
+    fig.tight_layout()
+    fig.savefig(OUTPUT, dpi=110)
+    plt.close(fig)
+
+
+def main():
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    rows = load_history()
+    if not rows:
+        render_empty("history.jsonl missing or empty")
+    else:
+        render_trend(rows)
+    print(f"render: wrote {OUTPUT} ({len(rows)} rows)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements [#771](https://github.com/zackees/soldr/issues/771): embed a dynamic benchmark-trend PNG in `README.md`, mirroring zccache's `## Performance` pattern.

## What lands

| File | Purpose |
|---|---|
| `bench/render_benchmark_trend.py` | matplotlib script; reads `history.jsonl`, plots 6 canaries on log-Y vs commit index, writes `benchmark-trend.png`. Empty-history-safe. |
| `.github/workflows/benchmark-stats.yml` | adds 2 steps: `apt-get install python3-matplotlib` (~15s) + `python3 bench/render_benchmark_trend.py`. Inserted between Assemble and Publish so the PNG ships in the same force-push. |
| `bench/assemble_benchmark_stats.sh` | adds `readme_image` entry under `manifest.json#artifacts` for AI-discoverable URL access. |
| `README.md` | new `## Performance` section right after CI badges, with markdown image embed + links to Pages, manifest.json, and PERF.md. |

Net: +139 / 0.

## Acceptance criteria from #771

- [x] `README.md` has `## Performance` section with markdown image embed
- [ ] First post-merge run of `benchmark-stats.yml` publishes `benchmark-trend.png` to the `benchmark-stats` branch (authoritative CI signal)
- [ ] GitHub renders the embedded image without alt-text fallback
- [x] `manifest.json` lists `readme_image` URL (verified via mock assembler smoke test)
- [x] `render_benchmark_trend.py` invoked from workflow between assemble and publish

## Test plan

- [x] `bash -n bench/assemble_benchmark_stats.sh` — clean
- [x] `python -m py_compile bench/render_benchmark_trend.py` — clean
- [x] Mock assembler run with stub canaries.json produces a `manifest.json` whose `artifacts.readme_image.url` resolves to the expected raw URL.
- [ ] Live workflow: this PR's CI exercises the `build / Build soldr and bootstrap third-party app` matrix only (not benchmark-stats since that's main-only). Authoritative validation is the post-merge run on main.

## Why matplotlib (not Chart.js screenshot or quickchart URL)

- Python + matplotlib is what zccache uses for the same purpose (their workflow installs `python3-pil` for PIL). Keeps the soldr workflow shape recognizable to anyone who's worked on zccache.
- ~15s apt install. No npm chain, no headless browser, no third-party rendering service.
- Output is a self-contained PNG that GitHub caches and serves identically across users.

Closes #771. References #768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)