### PR TITLE
ci(benchmark-stats): pin Pages actions to commit SHAs

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -79,11 +79,11 @@ jobs:
 
       - name: Configure Pages
         if: ${{ success() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload Pages artifact
         if: ${{ success() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: soldr/benchmark-stats
 
@@ -110,4 +110,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
Follow-up to #770 and #773. The benchmark-stats workflow's Pages actions were pinned to named tags (`@v5`, `@v4`) which soldr's action-pinning policy rejects with `The actions actions/configure-pages@v5 and actions/upload-pages-artifact@v4 are not allowed in zackees/soldr because all actions must be pinned to a full-length commit SHA.`

Pinning all three to their current v5/v4 commit SHAs:
- `actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5`
- `actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4`
- `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4`

Without this, the benchmark-stats workflow can never publish the trend image, and the README embed from #771 will never resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)