### PR TITLE
feat(readme): add links row above performance image + page-side back-link (#776)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ Third-party comparison (soldr vs Swatinem/rust-cache vs ...): published from `za
 
 ## Performance
 
-[![soldr local-build canary trend](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-trend.png)](https://github.com/zackees/soldr/tree/benchmark-stats)
+| [view page](https://zackees.github.io/soldr/) | [json](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/manifest.json) | [view branch](https://github.com/zackees/soldr/tree/benchmark-stats) |
+|---|---|---|
 
-The image is regenerated on every push to `main` by [`.github/workflows/benchmark-stats.yml`](.github/workflows/benchmark-stats.yml). Full data + an interactive Chart.js view are published in the [`benchmark-stats` branch](https://github.com/zackees/soldr/tree/benchmark-stats) and at [zackees.github.io/soldr](https://zackees.github.io/soldr/). The AI-discoverable discovery index is at [`manifest.json`](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/manifest.json). Canary set and methodology: [PERF.md § Per-commit benchmark stats](PERF.md#per-commit-benchmark-stats-issue-768).
+[![soldr local-build canary trend](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-trend.png)](https://zackees.github.io/soldr/)
+
+The image is regenerated on every push to `main` by [`.github/workflows/benchmark-stats.yml`](.github/workflows/benchmark-stats.yml). Canary set and methodology: [PERF.md § Per-commit benchmark stats](PERF.md#per-commit-benchmark-stats-issue-768).
 
 **Instant tools. Instant builds. One command.**
 

--- a/bench/index.html
+++ b/bench/index.html
@@ -24,6 +24,17 @@
             line-height: 1.5;
         }
         h1 { margin: 0 0 4px 0; font-size: 24px; }
+        nav.top-links {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px 14px;
+            margin: 8px 0 16px 0;
+            padding: 8px 12px;
+            background: #f6f8fa;
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            font-size: 13px;
+        }
         h2 { margin: 32px 0 12px 0; font-size: 18px; border-bottom: 1px solid var(--border); padding-bottom: 4px; }
         .meta { color: var(--muted); font-size: 14px; margin-bottom: 8px; }
         .meta code { background: #f6f8fa; padding: 1px 5px; border-radius: 3px; font-size: 12px; }
@@ -72,6 +83,14 @@
 </head>
 <body>
     <h1>soldr benchmark stats</h1>
+    <nav class="top-links" aria-label="Data sources">
+        <a href="https://github.com/zackees/soldr/tree/benchmark-stats">View branch (raw data)</a>
+        <a href="manifest.json">manifest.json</a>
+        <a href="latest.json">latest.json</a>
+        <a href="history.jsonl">history.jsonl</a>
+        <a href="benchmark-trend.png">benchmark-trend.png</a>
+        <a href="https://github.com/zackees/soldr/blob/main/PERF.md#per-commit-benchmark-stats-issue-768">methodology (PERF.md)</a>
+    </nav>
     <div class="meta" id="header-meta">Loading…</div>
 
     <h2>Latest run — canaries vs theoretical</h2>


### PR DESCRIPTION
Closes #776.

README `## Performance`:
- 3-column links row above the image: `view page | json | view branch`
- Image click-through now lands on Pages, not branch tree (image + view-page link are coherent)
- Tightened the explanatory paragraph since the links carry navigation

`bench/index.html`:
- Top `<nav>` row linking to: branch (raw data) / manifest.json / latest.json / history.jsonl / benchmark-trend.png / PERF.md methodology
- Minor CSS for the nav bar (matches the existing summary-bar palette)

🤖 Generated with [Claude Code](https://claude.com/claude-code)