### PR TITLE
feat(zccache): use default sessions by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ Anything not registered falls through the generic External subcommand, which res
 - **Pre-built first**: Try every binary source before `cargo install`. Resolution order matters.
 - **RUSTC_WRAPPER defaults to zccache**: If `RUSTC_WRAPPER` is not set, soldr defaults to using `zccache` as the wrapper.
 - **Daemon auto-starts**: First `RUSTC_WRAPPER` call starts the cache daemon transparently. No manual `soldr start`.
+- **Default zccache location stays boring**: Managed `soldr cargo ...` starts and ends zccache sessions without a soldr-private daemon namespace and without setting `ZCCACHE_CACHE_DIR` by default. If the caller sets `ZCCACHE_CACHE_DIR`, soldr forwards it as an explicit zccache override.
 - **Parent-cache sharing is default-on**: For managed-zccache builds soldr seeds `ZCCACHE_PATH_REMAP=auto` on the child cargo (issue #352, Tier L1.x). zccache then normalizes absolute source paths inside compiled artifacts so two git worktrees of the same repo serve each other's cache hits via hardlinks. Escape hatch: `SOLDR_PATH_REMAP=off` suppresses the injection; setting `ZCCACHE_PATH_REMAP` yourself wins. Requires a real `.git/` checkout — tarball/zip checkouts silently fall back to no remap.
 - **Integrity is default**: every fetch records sha256. Pins are opt-in via `SOLDR_CHECKSUMS_FILE`; `SOLDR_TRUST_MODE=strict` refuses unpinned fetches.
 - **Version independence**: Users install once and forget. CI should pin: `pip install soldr==X.Y.Z`.

--- a/crates/soldr-cli/src/cargo_front_door/cache_plan.rs
+++ b/crates/soldr-cli/src/cargo_front_door/cache_plan.rs
@@ -190,6 +190,7 @@ mod tests {
         ZccacheBuildSession {
             binary_path: std::path::PathBuf::from("/tmp/zccache"),
             cache_dir: std::path::PathBuf::from("/tmp/soldr-zccache"),
+            cache_dir_env: true,
             session_id: "session-1".into(),
             session_log_path: std::path::PathBuf::from("/tmp/soldr-zccache/log"),
             journal_path: std::path::PathBuf::from("/tmp/soldr-zccache/journal"),

--- a/crates/soldr-cli/src/rust_plan.rs
+++ b/crates/soldr-cli/src/rust_plan.rs
@@ -111,6 +111,7 @@ pub(crate) struct RustArtifactPlanContext {
     pub(crate) zccache_binary: std::path::PathBuf,
     pub(crate) cache_dir: std::path::PathBuf,
     pub(crate) zccache_daemon_cache_dir: std::path::PathBuf,
+    pub(crate) zccache_daemon_cache_dir_env: bool,
     pub(crate) zccache_daemon_name: Option<String>,
     pub(crate) session_id: String,
     pub(crate) journal_path: std::path::PathBuf,
@@ -183,6 +184,7 @@ pub(crate) fn maybe_prepare_rust_artifact_plan(
         zccache_binary: session.binary_path.clone(),
         cache_dir: rust_artifact_plan_cache_dir(session)?,
         zccache_daemon_cache_dir: session.cache_dir.clone(),
+        zccache_daemon_cache_dir_env: session.cache_dir_env,
         zccache_daemon_name: session
             .private_daemon
             .as_ref()
@@ -792,6 +794,7 @@ pub(crate) fn run_zccache_rust_plan(
         &plan.zccache_binary,
         &args,
         &plan.zccache_daemon_cache_dir,
+        plan.zccache_daemon_cache_dir_env,
         plan.zccache_daemon_name.as_deref(),
     )?;
     let stdout = output.stdout.trim();

--- a/crates/soldr-cli/src/rust_plan_tests/plan_build.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/plan_build.rs
@@ -60,6 +60,7 @@ fn rust_artifact_plan_selects_external_packages_and_path_exclusions() {
     let session = ZccacheBuildSession {
         binary_path: "zccache".into(),
         cache_dir: root.join("cache"),
+        cache_dir_env: true,
         session_id: "session-1".to_string(),
         session_log_path: root.join("cache/logs/last-session.log"),
         journal_path: root.join("cache/logs/last-session.jsonl"),
@@ -256,6 +257,7 @@ fn rust_artifact_plan_bumps_cache_schema_version_for_thin_v2() {
     let session = ZccacheBuildSession {
         binary_path: "zccache".into(),
         cache_dir: root.join("cache"),
+        cache_dir_env: true,
         session_id: "session-thinv2".to_string(),
         session_log_path: root.join("cache/logs/last-session.log"),
         journal_path: root.join("cache/logs/last-session.jsonl"),

--- a/crates/soldr-cli/src/rust_plan_tests/prepopulated_target.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/prepopulated_target.rs
@@ -51,6 +51,7 @@ fn make_plan_ctx(target_dir: &std::path::Path) -> RustArtifactPlanContext {
         zccache_binary: PathBuf::from("/tmp/zccache"),
         cache_dir: PathBuf::from("/tmp/cache"),
         zccache_daemon_cache_dir: PathBuf::from("/tmp/cache"),
+        zccache_daemon_cache_dir_env: true,
         zccache_daemon_name: None,
         session_id: "session".to_string(),
         journal_path: PathBuf::from("/tmp/journal"),

--- a/crates/soldr-cli/src/rust_plan_tests/warm_restore.rs
+++ b/crates/soldr-cli/src/rust_plan_tests/warm_restore.rs
@@ -341,6 +341,7 @@ fn warm_restore_test_context(
         zccache_binary: root.join("zccache"),
         cache_dir: root.join("cache"),
         zccache_daemon_cache_dir: root.join("daemon"),
+        zccache_daemon_cache_dir_env: true,
         zccache_daemon_name: None,
         session_id: "session-test".to_string(),
         journal_path: root.join("journal"),

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -412,7 +412,7 @@ fn run_wrapper_through_zccache_windows(
 }
 
 /// Run `zccache session-start --stats --log <path> --journal <path>` against
-/// the cache dir the wrapper invocation inherits from cargo, and return the
+/// the session directory the wrapper invocation inherits from cargo, and return the
 /// parsed session id. Mirrors the args used by `prepare_zccache_build`.
 ///
 /// Used by the Windows wrapper retry path (issue #265): when the daemon
@@ -420,32 +420,34 @@ fn run_wrapper_through_zccache_windows(
 /// allocates a replacement before retrying the wrapper invocation once.
 #[cfg(not(unix))]
 fn allocate_replacement_session(zccache: &std::path::Path) -> Result<String, SoldrError> {
-    let cache_dir = std::env::var_os(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR)
+    let session_dir = std::env::var_os(crate::zccache::SOLDR_ZCCACHE_SESSION_DIR_ENV_VAR)
         .map(std::path::PathBuf::from)
         .ok_or_else(|| {
             SoldrError::Other(format!(
                 "{} is not set in the wrapper environment; cannot allocate replacement zccache session",
-                crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR
+                crate::zccache::SOLDR_ZCCACHE_SESSION_DIR_ENV_VAR
             ))
         })?;
+    let cache_dir_env = std::env::var_os(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR).is_some();
 
-    let session_log_path = crate::cache_lib::session_log_path(&cache_dir);
-    let journal_path = crate::cache_lib::session_journal_path(&cache_dir);
-    let session_stats_path = crate::cache_lib::session_stats_path(&cache_dir);
+    let session_log_path = crate::cache_lib::session_log_path(&session_dir);
+    let journal_path = crate::cache_lib::session_journal_path(&session_dir);
+    let session_stats_path = crate::cache_lib::session_stats_path(&session_dir);
     let options = ZccacheSessionStartOptions {
         id: None,
         session_log_path,
         journal_path,
         session_stats_path,
     };
-    let mut lifecycle = ZccacheLifecycle::new(zccache, &cache_dir);
+    let mut lifecycle =
+        ZccacheLifecycle::new(zccache, &session_dir).with_cache_dir_env(cache_dir_env);
     if let Some(daemon_name) = inherited_private_daemon_name() {
         let private = ZccachePrivateDaemonConfig::new(daemon_name)
             .with_owner_pid(std::process::id())
             .with_private_env(inherited_private_zccache_env());
         lifecycle = lifecycle.with_private_daemon(private);
     }
-    let args = session_start_args(&options, &cache_dir, lifecycle.private_daemon());
+    let args = session_start_args(&options, &session_dir, lifecycle.private_daemon());
     let session_json = lifecycle.run_strings(&args)?;
     crate::cache_lib::parse_zccache_session_id(&session_json.stdout).ok_or_else(|| {
         SoldrError::Other(format!(

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -5,7 +5,7 @@ use crate::core::{SoldrError, SoldrPaths};
 use crate::fetch::{ZccacheRuntime, ZccacheRuntimeSource};
 use crate::zccache_lifecycle::{
     zccache_command_failure_message, zccache_json_flag_unsupported, ZccacheLifecycle,
-    ZccachePrivateDaemonConfig, ZccachePrivateEnv, ZccacheSessionStartOptions,
+    ZccachePrivateEnv, ZccacheSessionStartOptions,
 };
 use crate::{
     current_soldr_binary, fetch_active_zccache_runtime, non_empty_env_path, ZccacheSourceArg,
@@ -26,6 +26,7 @@ pub(crate) const SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR: &str =
     "SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS";
 pub(crate) const SOLDR_ZCCACHE_PRIVATE_DAEMON_NAME_ENV_VAR: &str =
     "SOLDR_ZCCACHE_PRIVATE_DAEMON_NAME";
+pub(crate) const SOLDR_ZCCACHE_SESSION_DIR_ENV_VAR: &str = "SOLDR_ZCCACHE_SESSION_DIR";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CacheLifecycle {
@@ -281,20 +282,28 @@ impl RustcWrapperPlan {
                     crate::cache_lib::ZCCACHE_BINARY_ENV_VAR,
                     &session.binary_path,
                 );
-                cargo.env(
-                    crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-                    &session.cache_dir,
-                );
-                cargo.env(
-                    crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR,
-                    &session.cache_dir,
-                );
+                cargo.env(SOLDR_ZCCACHE_SESSION_DIR_ENV_VAR, &session.cache_dir);
+                if session.cache_dir_env {
+                    cargo.env(
+                        crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+                        &session.cache_dir,
+                    );
+                    cargo.env(
+                        crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR,
+                        &session.cache_dir,
+                    );
+                } else {
+                    cargo.env_remove(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR);
+                    cargo.env_remove(crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR);
+                }
                 cargo.env(
                     crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR,
                     &session.session_id,
                 );
                 if let Some(private) = session.private_daemon.as_ref() {
                     cargo.env(ZCCACHE_DAEMON_NAMESPACE_ENV_VAR, &private.daemon_name);
+                } else {
+                    cargo.env_remove(ZCCACHE_DAEMON_NAMESPACE_ENV_VAR);
                 }
                 plan.child_env.apply_to_command(cargo);
             }
@@ -388,20 +397,19 @@ async fn prepare_zccache_build(
     print_zccache_runtime_diagnostic(&runtime);
 
     let child_env = ZccacheChildEnv::from_current_process()?;
-    let private_daemon_name = resolve_private_zccache_daemon_name(
-        std::env::var(SOLDR_ZCCACHE_PRIVATE_DAEMON_NAME_ENV_VAR)
-            .ok()
-            .as_deref(),
-        &current_soldr_binary()?,
-        &fetch.binary_path,
-        &zccache_base_dir,
-    );
-    let zccache_dir = private_zccache_cache_dir(&zccache_base_dir, &private_daemon_name);
+    let inherited_soldr_managed_dir =
+        non_empty_env_path(crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR)
+            .map(|path| normalize_path_for_compare(&path))
+            .transpose()?;
+    let explicit_zccache_cache_dir =
+        non_empty_env_path(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR)
+            .map(|path| normalize_path_for_compare(&path))
+            .transpose()?
+            .filter(|path| inherited_soldr_managed_dir.as_ref() != Some(path));
+    let cache_dir_env = explicit_zccache_cache_dir.is_some();
+    let zccache_dir = explicit_zccache_cache_dir.unwrap_or(zccache_base_dir);
     std::fs::create_dir_all(&zccache_dir)?;
     std::fs::create_dir_all(zccache_dir.join("logs"))?;
-    let private_daemon = ZccachePrivateDaemonConfig::new(private_daemon_name.clone())
-        .with_owner_pid(std::process::id())
-        .with_private_env(child_env.private_env_assignments());
 
     // When the resolved zccache CLI binary differs from the one a
     // previous soldr invocation started the daemon with, the live
@@ -414,7 +422,8 @@ async fn prepare_zccache_build(
     evict_zccache_daemon_if_binary_changed_scoped(
         &fetch.binary_path,
         &zccache_dir,
-        Some(&private_daemon_name),
+        cache_dir_env,
+        None,
     )?;
 
     // Refresh stale `runtime-binaries/` from a previous pinned zccache
@@ -427,7 +436,8 @@ async fn prepare_zccache_build(
     refresh_runtime_binaries_if_version_changed_scoped(
         &fetch.binary_path,
         &zccache_dir,
-        Some(&private_daemon_name),
+        cache_dir_env,
+        None,
         &runtime.version,
     )?;
 
@@ -435,7 +445,7 @@ async fn prepare_zccache_build(
     let journal_path = crate::cache_lib::session_journal_path(&zccache_dir);
     let session_stats_path = crate::cache_lib::session_stats_path(&zccache_dir);
     let mut lifecycle =
-        ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir).with_private_daemon(private_daemon);
+        ZccacheLifecycle::new(&fetch.binary_path, &zccache_dir).with_cache_dir_env(cache_dir_env);
     let session = lifecycle.start_session(ZccacheSessionStartOptions {
         id: None,
         session_log_path,
@@ -811,21 +821,7 @@ pub(crate) fn sanitize_zccache_daemon_name(raw: &str) -> Option<String> {
 pub(crate) fn managed_zccache_cache_dir(
     paths: &SoldrPaths,
 ) -> Result<std::path::PathBuf, SoldrError> {
-    let zccache_dir = normalize_path_for_compare(&crate::cache_lib::zccache_dir(paths))?;
-    let inherited_soldr_managed_dir =
-        non_empty_env_path(crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR)
-            .map(|path| normalize_path_for_compare(&path))
-            .transpose()?;
-    if let Some(explicit) = non_empty_env_path(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR) {
-        let explicit = normalize_path_for_compare(&explicit)?;
-        if explicit != zccache_dir && inherited_soldr_managed_dir.as_ref() != Some(&explicit) {
-            return Err(SoldrError::Other(format!(
-                "{} is managed by soldr for managed zccache builds. Unset it, set SOLDR_CACHE_DIR to choose soldr's cache root, or set SOLDR_RUSTC_WRAPPER to use a custom wrapper.",
-                crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR
-            )));
-        }
-    }
-    Ok(zccache_dir)
+    normalize_path_for_compare(&crate::cache_lib::zccache_dir(paths))
 }
 
 pub(crate) fn normalize_path_for_compare(
@@ -873,12 +869,13 @@ pub(crate) fn evict_zccache_daemon_if_binary_changed(
     binary: &std::path::Path,
     cache_dir: &std::path::Path,
 ) -> Result<(), SoldrError> {
-    evict_zccache_daemon_if_binary_changed_scoped(binary, cache_dir, None)
+    evict_zccache_daemon_if_binary_changed_scoped(binary, cache_dir, true, None)
 }
 
 pub(crate) fn evict_zccache_daemon_if_binary_changed_scoped(
     binary: &std::path::Path,
     cache_dir: &std::path::Path,
+    cache_dir_env: bool,
     daemon_name: Option<&str>,
 ) -> Result<(), SoldrError> {
     let sentinel = cache_dir.join(ZCCACHE_LAST_CLI_BINARY_SENTINEL);
@@ -895,6 +892,7 @@ pub(crate) fn evict_zccache_daemon_if_binary_changed_scoped(
             binary,
             &["stop"],
             cache_dir,
+            cache_dir_env,
             daemon_name,
         ) {
             // Stop failures shouldn't block the build — the start
@@ -971,6 +969,7 @@ pub(crate) fn should_refresh_runtime_binaries(
 pub(crate) fn refresh_runtime_binaries_if_version_changed_scoped(
     binary: &std::path::Path,
     cache_dir: &std::path::Path,
+    cache_dir_env: bool,
     daemon_name: Option<&str>,
     current_version: &str,
 ) -> Result<(), SoldrError> {
@@ -989,6 +988,7 @@ pub(crate) fn refresh_runtime_binaries_if_version_changed_scoped(
             binary,
             &["stop"],
             cache_dir,
+            cache_dir_env,
             daemon_name,
         ) {
             // Daemon may already be dead; the subsequent file removal
@@ -1451,6 +1451,7 @@ mod tests {
         refresh_runtime_binaries_if_version_changed_scoped(
             &dummy_binary,
             cache_dir,
+            true,
             Some("soldr-dev-test"),
             "1.12.4",
         )
@@ -1483,6 +1484,7 @@ mod tests {
         refresh_runtime_binaries_if_version_changed_scoped(
             &dummy_binary,
             cache_dir,
+            true,
             Some("soldr-dev-test"),
             "1.12.4",
         )

--- a/crates/soldr-cli/src/zccache_lifecycle.rs
+++ b/crates/soldr-cli/src/zccache_lifecycle.rs
@@ -98,6 +98,7 @@ impl From<&ZccachePrivateDaemonConfig> for ZccachePrivateDaemonSession {
 pub(crate) struct ZccacheBuildSession {
     pub(crate) binary_path: PathBuf,
     pub(crate) cache_dir: PathBuf,
+    pub(crate) cache_dir_env: bool,
     pub(crate) session_id: String,
     pub(crate) session_log_path: PathBuf,
     pub(crate) journal_path: PathBuf,
@@ -192,6 +193,7 @@ pub(crate) enum ZccacheDaemonExitPollResult {
 pub(crate) struct ZccacheLifecycle {
     binary_path: PathBuf,
     cache_dir: PathBuf,
+    cache_dir_env: bool,
     state: ZccacheLifecycleState,
     private_daemon: Option<ZccachePrivateDaemonConfig>,
 }
@@ -201,15 +203,22 @@ impl ZccacheLifecycle {
         Self {
             binary_path: binary_path.into(),
             cache_dir: cache_dir.into(),
+            cache_dir_env: true,
             state: ZccacheLifecycleState::Ready,
             private_daemon: None,
         }
+    }
+
+    pub(crate) fn with_cache_dir_env(mut self, cache_dir_env: bool) -> Self {
+        self.cache_dir_env = cache_dir_env;
+        self
     }
 
     pub(crate) fn from_session(session: &ZccacheBuildSession) -> Self {
         Self {
             binary_path: session.binary_path.clone(),
             cache_dir: session.cache_dir.clone(),
+            cache_dir_env: session.cache_dir_env,
             state: ZccacheLifecycleState::SessionActive,
             private_daemon: session.private_daemon.as_ref().map(|private| {
                 let mut config = ZccachePrivateDaemonConfig::new(private.daemon_name.clone());
@@ -247,6 +256,7 @@ impl ZccacheLifecycle {
         start_zccache_with_recovery_for_daemon(
             &self.binary_path,
             &self.cache_dir,
+            self.cache_dir_env,
             self.private_daemon_name(),
         )?;
         self.state = ZccacheLifecycleState::DaemonStarted;
@@ -288,6 +298,7 @@ impl ZccacheLifecycle {
         Ok(ZccacheBuildSession {
             binary_path: self.binary_path.clone(),
             cache_dir: self.cache_dir.clone(),
+            cache_dir_env: self.cache_dir_env,
             session_id,
             session_log_path: options.session_log_path,
             journal_path: options.journal_path,
@@ -391,6 +402,7 @@ impl ZccacheLifecycle {
             &self.binary_path,
             &["stop"],
             &self.cache_dir,
+            self.cache_dir_env,
             self.private_daemon_name(),
         );
         child
@@ -421,6 +433,7 @@ impl ZccacheLifecycle {
         poll_zccache_daemon_exit_for_daemon(
             &self.binary_path,
             &self.cache_dir,
+            self.cache_dir_env,
             self.private_daemon_name(),
             timeout,
         )
@@ -500,6 +513,7 @@ impl ZccacheLifecycle {
             &self.binary_path,
             args,
             &self.cache_dir,
+            self.cache_dir_env,
             self.private_daemon_name(),
         )
     }
@@ -509,6 +523,7 @@ impl ZccacheLifecycle {
             &self.binary_path,
             args,
             &self.cache_dir,
+            self.cache_dir_env,
             self.private_daemon_name(),
         )
     }
@@ -518,6 +533,7 @@ impl ZccacheLifecycle {
             &self.binary_path,
             args,
             &self.cache_dir,
+            self.cache_dir_env,
             self.private_daemon_name(),
         )
     }
@@ -583,17 +599,28 @@ pub(crate) fn run_zccache_command_in_cache_dir(
     args: &[&str],
     cache_dir: &Path,
 ) -> Result<CommandOutput, SoldrError> {
-    run_zccache_command_in_cache_dir_with_daemon_name(binary, args, cache_dir, None)
+    run_zccache_command_in_cache_dir_with_daemon_name(binary, args, cache_dir, true, None)
 }
 
 pub(crate) fn run_zccache_command_in_cache_dir_with_daemon_name(
     binary: &Path,
     args: &[&str],
     cache_dir: &Path,
+    cache_dir_env: bool,
     daemon_name: Option<&str>,
 ) -> Result<CommandOutput, SoldrError> {
-    let envs = cache_dir_envs(cache_dir, daemon_name);
-    run_zccache_command_with_env(binary, args, &envs)
+    let mut command =
+        command_with_cache_dir_and_daemon_name(binary, args, cache_dir, cache_dir_env, daemon_name);
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(SoldrError::Other(zccache_command_failure_message(
+            args, &output,
+        )));
+    }
+
+    Ok(CommandOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+    })
 }
 
 pub(crate) fn run_zccache_command_strings_in_cache_dir(
@@ -601,17 +628,18 @@ pub(crate) fn run_zccache_command_strings_in_cache_dir(
     args: &[String],
     cache_dir: &Path,
 ) -> Result<CommandOutput, SoldrError> {
-    run_zccache_command_strings_in_cache_dir_with_daemon_name(binary, args, cache_dir, None)
+    run_zccache_command_strings_in_cache_dir_with_daemon_name(binary, args, cache_dir, true, None)
 }
 
 pub(crate) fn run_zccache_command_strings_in_cache_dir_with_daemon_name(
     binary: &Path,
     args: &[String],
     cache_dir: &Path,
+    cache_dir_env: bool,
     daemon_name: Option<&str>,
 ) -> Result<CommandOutput, SoldrError> {
-    let envs = cache_dir_envs(cache_dir, daemon_name);
-    let output = run_zccache_command_raw_strings_with_env(binary, args, &envs)?;
+    let envs = cache_dir_envs(cache_dir, cache_dir_env, daemon_name);
+    let output = run_zccache_command_raw_strings_with_env(binary, args, &envs, cache_dir_env)?;
     if !output.status.success() {
         return Err(SoldrError::Other(zccache_command_failure_message_strings(
             args, &output,
@@ -628,42 +656,18 @@ pub(crate) fn run_zccache_command_raw_in_cache_dir(
     args: &[&str],
     cache_dir: &Path,
 ) -> Result<Output, SoldrError> {
-    run_zccache_command_raw_in_cache_dir_with_daemon_name(binary, args, cache_dir, None)
+    run_zccache_command_raw_in_cache_dir_with_daemon_name(binary, args, cache_dir, true, None)
 }
 
 pub(crate) fn run_zccache_command_raw_in_cache_dir_with_daemon_name(
     binary: &Path,
     args: &[&str],
     cache_dir: &Path,
+    cache_dir_env: bool,
     daemon_name: Option<&str>,
 ) -> Result<Output, SoldrError> {
-    let envs = cache_dir_envs(cache_dir, daemon_name);
-    run_zccache_command_raw_with_env(binary, args, &envs)
-}
-
-fn run_zccache_command_with_env(
-    binary: &Path,
-    args: &[&str],
-    envs: &[(&str, &OsStr)],
-) -> Result<CommandOutput, SoldrError> {
-    let output = run_zccache_command_raw_with_env(binary, args, envs)?;
-    if !output.status.success() {
-        return Err(SoldrError::Other(zccache_command_failure_message(
-            args, &output,
-        )));
-    }
-
-    Ok(CommandOutput {
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-    })
-}
-
-fn run_zccache_command_raw_with_env(
-    binary: &Path,
-    args: &[&str],
-    envs: &[(&str, &OsStr)],
-) -> Result<Output, SoldrError> {
-    let mut command = command_with_env(binary, args, envs);
+    let mut command =
+        command_with_cache_dir_and_daemon_name(binary, args, cache_dir, cache_dir_env, daemon_name);
     Ok(command.output()?)
 }
 
@@ -671,12 +675,14 @@ fn run_zccache_command_raw_strings_with_env(
     binary: &Path,
     args: &[String],
     envs: &[(&str, &OsStr)],
+    cache_dir_env: bool,
 ) -> Result<Output, SoldrError> {
     let mut command = Command::new(binary);
     command.args(args);
     for &(name, value) in envs {
         command.env(name, value);
     }
+    apply_zccache_env_removals(&mut command, cache_dir_env);
     suppress_windows_console_window(&mut command);
     Ok(command.output()?)
 }
@@ -685,20 +691,27 @@ fn command_with_cache_dir_and_daemon_name(
     binary: &Path,
     args: &[&str],
     cache_dir: &Path,
+    cache_dir_env: bool,
     daemon_name: Option<&str>,
 ) -> Command {
-    let envs = cache_dir_envs(cache_dir, daemon_name);
-    command_with_env(binary, args, &envs)
+    let envs = cache_dir_envs(cache_dir, cache_dir_env, daemon_name);
+    let mut command = command_with_env(binary, args, &envs);
+    apply_zccache_env_removals(&mut command, cache_dir_env);
+    command
 }
 
 fn cache_dir_envs<'a>(
     cache_dir: &'a Path,
+    cache_dir_env: bool,
     daemon_name: Option<&'a str>,
 ) -> Vec<(&'static str, &'a OsStr)> {
-    let mut envs = vec![(
-        crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
-        cache_dir.as_os_str(),
-    )];
+    let mut envs = Vec::new();
+    if cache_dir_env {
+        envs.push((
+            crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+            cache_dir.as_os_str(),
+        ));
+    }
     if let Some(daemon_name) = daemon_name {
         envs.push((ZCCACHE_DAEMON_NAMESPACE_ENV_VAR, OsStr::new(daemon_name)));
     }
@@ -715,6 +728,15 @@ fn command_with_env(binary: &Path, args: &[&str], envs: &[(&str, &OsStr)]) -> Co
     command
 }
 
+fn apply_zccache_env_removals(command: &mut Command, cache_dir_env: bool) {
+    if cache_dir_env {
+        return;
+    }
+    command.env_remove(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR);
+    command.env_remove(crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR);
+    command.env_remove(ZCCACHE_DAEMON_NAMESPACE_ENV_VAR);
+}
+
 /// Soldr-side escape hatch for the RUST_LOG value that gets injected into
 /// `zccache start`.
 pub(crate) const SOLDR_DAEMON_RUST_LOG_ENV_VAR: &str = "SOLDR_DAEMON_RUST_LOG";
@@ -729,12 +751,18 @@ pub(crate) fn effective_daemon_rust_log(soldr_override: Option<&str>) -> String 
 fn run_zccache_start_command(
     binary: &Path,
     cache_dir: &Path,
+    cache_dir_env: bool,
     daemon_name: Option<&str>,
 ) -> Result<Output, SoldrError> {
     let rust_log =
         effective_daemon_rust_log(std::env::var(SOLDR_DAEMON_RUST_LOG_ENV_VAR).ok().as_deref());
-    let mut command =
-        command_with_cache_dir_and_daemon_name(binary, &["start"], cache_dir, daemon_name);
+    let mut command = command_with_cache_dir_and_daemon_name(
+        binary,
+        &["start"],
+        cache_dir,
+        cache_dir_env,
+        daemon_name,
+    );
     command.env("RUST_LOG", rust_log);
     Ok(command.output()?)
 }
@@ -743,15 +771,16 @@ pub(crate) fn start_zccache_with_recovery(
     binary: &Path,
     cache_dir: &Path,
 ) -> Result<(), SoldrError> {
-    start_zccache_with_recovery_for_daemon(binary, cache_dir, None)
+    start_zccache_with_recovery_for_daemon(binary, cache_dir, true, None)
 }
 
 pub(crate) fn start_zccache_with_recovery_for_daemon(
     binary: &Path,
     cache_dir: &Path,
+    cache_dir_env: bool,
     daemon_name: Option<&str>,
 ) -> Result<(), SoldrError> {
-    let start = run_zccache_start_command(binary, cache_dir, daemon_name)?;
+    let start = run_zccache_start_command(binary, cache_dir, cache_dir_env, daemon_name)?;
     if start.status.success() {
         return Ok(());
     }
@@ -771,6 +800,7 @@ pub(crate) fn start_zccache_with_recovery_for_daemon(
         binary,
         &["stop"],
         cache_dir,
+        cache_dir_env,
         daemon_name,
     ) {
         Ok(stop) if stop.status.success() => None,
@@ -792,7 +822,7 @@ pub(crate) fn start_zccache_with_recovery_for_daemon(
         }
     };
 
-    match run_zccache_start_command(binary, cache_dir, daemon_name) {
+    match run_zccache_start_command(binary, cache_dir, cache_dir_env, daemon_name) {
         Ok(retry) if retry.status.success() => Ok(()),
         Ok(retry) => {
             let mut message = format!(
@@ -856,12 +886,13 @@ pub(crate) fn poll_zccache_daemon_exit(
     cache_dir: &Path,
     timeout: Duration,
 ) -> ZccacheDaemonExitPollResult {
-    poll_zccache_daemon_exit_for_daemon(binary, cache_dir, None, timeout)
+    poll_zccache_daemon_exit_for_daemon(binary, cache_dir, true, None, timeout)
 }
 
 pub(crate) fn poll_zccache_daemon_exit_for_daemon(
     binary: &Path,
     cache_dir: &Path,
+    cache_dir_env: bool,
     daemon_name: Option<&str>,
     timeout: Duration,
 ) -> ZccacheDaemonExitPollResult {
@@ -872,6 +903,7 @@ pub(crate) fn poll_zccache_daemon_exit_for_daemon(
             binary,
             &["status"],
             cache_dir,
+            cache_dir_env,
             daemon_name,
         ) {
             Ok(output) => {

--- a/crates/soldr-cli/tests/cli_cargo_basic.rs
+++ b/crates/soldr-cli/tests/cli_cargo_basic.rs
@@ -194,17 +194,16 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         log.contains("cache=1"),
         "cache-enabled front door should propagate cache flag: {log}"
     );
-    let zccache_cache_dir = discovered_private_zccache_cache_dir(&cache_root);
+    let zccache_session_dir = cache_root.join("cache").join("zccache");
     assert!(
-        path_display_variants(&zccache_cache_dir)
-            .iter()
-            .any(|path| log.contains(&format!("zccache_dir={path}"))
-                && log.contains(&format!("cache_dir={path}"))),
-        "managed zccache commands and cargo wrapper env should use the private Soldr-owned cache dir: {log}"
+        log.contains("zccache_dir= ") || log.contains("zccache_dir= path_remap="),
+        "default managed cargo env should not force ZCCACHE_CACHE_DIR: {log}"
     );
     assert!(
-        log.contains("daemon_namespace=soldr-dev-") && log.contains("--private-daemon"),
-        "managed zccache should use a private daemon namespace: {log}"
+        !log.contains("daemon_namespace=soldr-dev-")
+            && !log.contains("--private-daemon")
+            && !log.contains("--daemon-name soldr-dev-"),
+        "default managed zccache should not use a private daemon namespace: {log}"
     );
     assert!(
         log.contains("zccache start"),
@@ -237,9 +236,9 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
         "expected zccache hit/miss counts in stderr: {stderr}"
     );
 
-    let journal = zccache_cache_dir.join("logs").join("last-session.jsonl");
-    let session_log = zccache_cache_dir.join("logs").join("last-session.log");
-    let session_stats = zccache_cache_dir
+    let journal = zccache_session_dir.join("logs").join("last-session.jsonl");
+    let session_log = zccache_session_dir.join("logs").join("last-session.log");
+    let session_stats = zccache_session_dir
         .join("logs")
         .join("last-session-stats.json");
     assert!(
@@ -341,12 +340,9 @@ fn command_lifetime_cache_stops_zccache_after_successful_cargo() {
 
     let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
     assert_command_lifetime_shutdown_order(&log);
-    let zccache_cache_dir = discovered_private_zccache_cache_dir(&cache_root);
     assert!(
-        path_display_variants(&zccache_cache_dir)
-            .iter()
-            .any(|path| log.contains(&format!("zccache stop cache_dir={path}"))),
-        "command-lifetime stop must use the private soldr-managed cache root: {log}"
+        log.contains("zccache stop cache_dir=") && !log.contains("daemon_namespace=soldr-dev-"),
+        "command-lifetime stop should target zccache's default daemon without a soldr-private namespace: {log}"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/crates/soldr-cli/tests/cli_cargo_wrappers.rs
+++ b/crates/soldr-cli/tests/cli_cargo_wrappers.rs
@@ -197,32 +197,34 @@ fn cache_enabled_zccache_build_completes_under_20_seconds() {
 }
 
 #[test]
-fn managed_zccache_rejects_conflicting_cache_dir_override() {
-    let cache_root = unique_temp_dir("cargo-conflicting-zccache-dir");
+fn managed_zccache_honors_explicit_cache_dir_override() {
+    let cache_root = unique_temp_dir("cargo-explicit-zccache-dir");
+    let user_zccache_dir = cache_root.join("user-zccache");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
     let output = isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
-        .env("ZCCACHE_CACHE_DIR", cache_root.join("user-zccache"))
+        .env("ZCCACHE_CACHE_DIR", &user_zccache_dir)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
         .output()
-        .expect("failed to run soldr cargo build with conflicting ZCCACHE_CACHE_DIR");
+        .expect("failed to run soldr cargo build with explicit ZCCACHE_CACHE_DIR");
 
     assert!(
-        !output.status.success(),
-        "conflicting ZCCACHE_CACHE_DIR should fail"
+        output.status.success(),
+        "explicit ZCCACHE_CACHE_DIR should be forwarded to zccache\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
     assert!(
-        stderr.contains("ZCCACHE_CACHE_DIR is managed by soldr"),
-        "expected explicit override guidance: {stderr}"
-    );
-    assert!(
-        !log_path.exists(),
-        "zccache should not start after a conflicting cache-dir override"
+        path_display_variants(&user_zccache_dir)
+            .iter()
+            .any(|path| log.contains(&format!("zccache_dir={path}"))
+                && log.contains(&format!("cache_dir={path}"))),
+        "explicit ZCCACHE_CACHE_DIR should reach cargo and zccache commands: {log}"
     );
 }
 
@@ -254,19 +256,12 @@ fn nested_soldr_ignores_inherited_managed_zccache_cache_dir() {
     );
 
     let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
-    let child_zccache_dir = discovered_private_zccache_cache_dir(&child_cache_root);
-    assert!(
-        path_display_variants(&child_zccache_dir)
-            .iter()
-            .any(|path| log.contains(&format!("zccache_dir={path}"))
-                && log.contains(&format!("cache_dir={path}"))),
-        "nested soldr should replace the inherited managed zccache dir with its own cache root: {log}"
-    );
     assert!(
         !path_display_variants(&parent_zccache_dir)
             .iter()
-            .any(|path| log.contains(&format!("cache_dir={path}"))),
-        "nested soldr should not reuse the parent managed zccache dir: {log}"
+            .any(|path| log.contains(&format!("zccache_dir={path}"))
+                || log.contains(&format!("cache_dir={path}"))),
+        "nested soldr should ignore inherited soldr-managed ZCCACHE_CACHE_DIR: {log}"
     );
 }
 

--- a/crates/soldr-cli/tests/cli_rust_plan.rs
+++ b/crates/soldr-cli/tests/cli_rust_plan.rs
@@ -95,16 +95,16 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
     );
 
     let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
-    let zccache_cache_dir = discovered_private_zccache_cache_dir(&cache_root);
+    let zccache_session_dir = cache_root.join("cache").join("zccache");
     assert!(
         log.contains("zccache rust-plan restore") && log.contains("zccache rust-plan save"),
         "soldr should call zccache rust-plan restore/save when target cache is enabled: {log}"
     );
     assert!(
-        path_display_variants(&zccache_cache_dir)
-            .iter()
-            .any(|path| log.contains(&format!("cache_dir={path}"))),
-        "rust-plan calls should query the active managed zccache daemon cache dir: {log}"
+        !log.contains("--private-daemon")
+            && !log.contains("--daemon-name soldr-dev-")
+            && !log.contains("daemon_namespace=soldr-dev-"),
+        "rust-plan calls should use the default zccache daemon/session by default: {log}"
     );
     assert!(
         path_display_variants(&plan_cache).iter().any(|path| {
@@ -119,7 +119,7 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
         "rust-plan restore should run before Cargo and save should run after Cargo: {log}"
     );
 
-    let plan_path = zccache_cache_dir
+    let plan_path = zccache_session_dir
         .join("plans")
         .join("last-rust-artifact-plan.pb");
     let plan_bytes = fs::read(&plan_path).expect("read generated rust plan");
@@ -259,12 +259,14 @@ fn cargo_front_door_recovers_from_stale_zccache_daemon_start() {
 #[test]
 fn cargo_front_door_removes_stale_zccache_daemon_lock_before_retry() {
     let cache_root = unique_temp_dir("cargo-stale-zccache-daemon-lock");
+    let zccache_session_dir = cache_root.join("cache").join("zccache");
     let log_path = cache_root.join("tool.log");
     let stale_marker = cache_root.join("stale-zccache-lock");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
     let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
+        .env("ZCCACHE_CACHE_DIR", &zccache_session_dir)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -297,9 +299,8 @@ fn cargo_front_door_removes_stale_zccache_daemon_lock_before_retry() {
             && log.contains("zccache session-end test-session"),
         "recovered build should still exercise the normal managed zccache path: {log}"
     );
-    let zccache_cache_dir = discovered_private_zccache_cache_dir(&cache_root);
     assert!(
-        !zccache_cache_dir.join("daemon.lock").exists(),
+        !zccache_session_dir.join("daemon.lock").exists(),
         "soldr should remove stale zccache daemon.lock before retrying start"
     );
 }

--- a/crates/soldr-cli/tests/cli_unknown_session_retry.rs
+++ b/crates/soldr-cli/tests/cli_unknown_session_retry.rs
@@ -148,6 +148,7 @@ fn run_soldr_wrapper(label: &str, mode: Option<&str>) -> RetryRun {
     cmd.env("SOLDR_CACHE_ENABLED", "1");
     cmd.env("SOLDR_CACHE_DIR", &cache_root_path);
     cmd.env("SOLDR_TEST_ZCCACHE_BIN", &stub);
+    cmd.env("SOLDR_ZCCACHE_SESSION_DIR", &zccache_cache_dir);
     cmd.env("ZCCACHE_CACHE_DIR", &zccache_cache_dir);
     cmd.env("SOLDR_MANAGED_ZCCACHE_CACHE_DIR", &zccache_cache_dir);
     cmd.env("ZCCACHE_SESSION_ID", "initial-session-from-test");

--- a/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
+++ b/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
@@ -208,22 +208,18 @@ timed_test!(
             log.contains("cache=1") && log.contains("session=test-session"),
             "cargo child should receive cache/session env:\n{log}"
         );
-        let zccache_cache_dir = discovered_private_zccache_cache_dir(&fixture.cache_root);
+        let zccache_session_dir = fixture.cache_root.join("cache").join("zccache");
         assert!(
-            log_contains_path(&log, "zccache_dir=", &zccache_cache_dir)
-                && log_contains_path(&log, "cache_dir=", &zccache_cache_dir),
-            "cargo and zccache should use the private soldr-owned zccache cache dir:\n{log}"
+            log.contains("zccache_dir= ") || log.contains("zccache_dir= path_remap="),
+            "default managed cargo env should not force ZCCACHE_CACHE_DIR:\n{log}"
         );
         assert!(
-            log.contains("daemon_namespace=soldr-dev-")
-                && log.contains("--private-daemon")
-                && log.contains("--daemon-name soldr-dev-")
-                && log.contains("--owner-pid")
-                && (log.contains("--private-env ZCCACHE_PATH_REMAP=auto")
-                    || log.contains("--private-env \"ZCCACHE_PATH_REMAP=auto\""))
-                && (log.contains("--private-env ZCCACHE_WORKTREE_ROOT=")
-                    || log.contains("--private-env \"ZCCACHE_WORKTREE_ROOT=")),
-            "managed zccache should start a private daemon with session-scoped env:\n{log}"
+            !log.contains("daemon_namespace=soldr-dev-")
+                && !log.contains("--private-daemon")
+                && !log.contains("--daemon-name soldr-dev-")
+                && !log.contains("--owner-pid")
+                && !log.contains("--private-env"),
+            "default managed zccache should use zccache's normal daemon/session behavior:\n{log}"
         );
         assert!(
             log.contains("path_remap=auto"),
@@ -238,7 +234,7 @@ timed_test!(
             "rust-plan should receive the target artifact bundle dir:\n{log}"
         );
 
-        let logs_dir = zccache_cache_dir.join("logs");
+        let logs_dir = zccache_session_dir.join("logs");
         let session_log = logs_dir.join("last-session.log");
         let journal = logs_dir.join("last-session.jsonl");
         let stats = logs_dir.join("last-session-stats.json");

--- a/docs/API.md
+++ b/docs/API.md
@@ -49,7 +49,8 @@ Behavior:
 - Fetch a pinned managed `zccache` release when caching is enabled
 - Set `RUSTC_WRAPPER` to the current soldr binary
 - Pass the managed `zccache` binary path into wrapper mode through the environment
-- Start a per-build zccache session under Soldr's owned zccache cache root
+- Start a per-build zccache session while leaving zccache's cache/session
+  location at its normal default unless the caller sets `ZCCACHE_CACHE_DIR`
 - Delegate to Cargo with the exact flags the user passed
 
 Current cache-control behavior:
@@ -59,7 +60,9 @@ Current cache-control behavior:
 - `soldr cargo --no-cache ...` is rejected; `--no-cache` is a top-level soldr flag only
 - `soldr --zccache=system cargo ...` uses the `zccache` already on PATH instead of fetching the pinned managed release. The `zccache-daemon` and `zccache-fp` sibling binaries must live in the same directory as `zccache`. `--zccache=managed` (the default) restores the managed-fetch behavior.
 - zccache integration currently targets Rust builds through the cargo front door
-- managed zccache artifacts and daemon state live under Soldr's cache root through `ZCCACHE_CACHE_DIR`
+- managed zccache session logs, journals, and reports live under Soldr's cache
+  root; zccache cache and daemon state use zccache's normal default location
+  unless the caller sets `ZCCACHE_CACHE_DIR`
 - toolchain binaries (`rustc`, `rustfmt`, `clippy-driver`, etc.) are resolved directly from `RUSTUP_HOME` / `CARGO_HOME` / `PATH` before any `rustup` call; `rustup which` is only used as a fallback when the direct probe fails. The sole exception is when `RUSTUP_TOOLCHAIN` is explicitly set to a non-empty value — in that case soldr skips the direct probe and asks `rustup` for the matching toolchain binary so the pinned channel always wins
 
 This is the normal build entry point.
@@ -861,10 +864,9 @@ The global scope covers:
 - `~/.soldr/bench`
 - `~/.soldr/runtime`
 - `~/.soldr/state.redb`
-- The resolved zccache cache directory (`~/.soldr/cache/zccache`).
-  When `ZCCACHE_CACHE_DIR` is set outside soldr's default, the
-  resolved path is excluded explicitly and a warning suggests
-  unsetting the override.
+- Soldr's managed zccache session/report directory (`~/.soldr/cache/zccache`).
+  When `ZCCACHE_CACHE_DIR` is set, that caller-selected zccache cache root is
+  excluded explicitly.
 
 The project scope covers `<workspace_root>/target/`, where
 `<workspace_root>` is the nearest ancestor of the current directory
@@ -1284,7 +1286,8 @@ Commands:
 | `SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS` | Maximum seconds to wait for command-lifetime zccache shutdown confirmation after `zccache stop`. | `30` |
 | `SOLDR_RELOCATED_EXE` | Internal recursion guard set after Windows self-relocation | unset |
 | `SOLDR_ORIGINAL_EXE` | Internal path to the original executable when Windows self-relocation is active | unset |
-| `ZCCACHE_CACHE_DIR` | zccache cache-root override set by soldr for managed zccache commands | `~/.soldr/cache/zccache` |
+| `SOLDR_ZCCACHE_SESSION_DIR` | Internal session/report directory passed from `soldr cargo ...` into wrapper mode | unset |
+| `ZCCACHE_CACHE_DIR` | Explicit caller override for zccache's cache root; soldr does not set it for default managed zccache builds | unset |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `ZCCACHE_PATH_REMAP` | zccache path-remap mode. soldr seeds `auto` on the child cargo for managed-zccache builds so multiple git worktrees of the same repo share cache hits (issue #352, Tier L1.x). Caller-supplied values are preserved. Requires a real `.git/` checkout — tarball/zip checkouts silently fall back to no remap. | unset (soldr injects `auto`) |
 | `SOLDR_PATH_REMAP` | Escape hatch for the default `ZCCACHE_PATH_REMAP=auto` injection. `off` (case-insensitive) suppresses the injection; any other value, or unset, keeps the default behavior. | unset (`auto`) |
@@ -1307,16 +1310,16 @@ Commands:
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.
 
-When soldr manages zccache itself, a caller-provided `ZCCACHE_CACHE_DIR` must match the cache root derived from `SOLDR_CACHE_DIR`; conflicting values are rejected. Custom wrapper modes leave caller-provided wrapper environment alone — when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has set `SCCACHE_DIR` themselves, soldr forwards their value rather than overriding it.
+When soldr manages zccache itself, it does not set `ZCCACHE_CACHE_DIR` by default; zccache uses its normal effective cache root and daemon/session behavior. A caller-provided `ZCCACHE_CACHE_DIR` is forwarded as an explicit zccache override. Custom wrapper modes leave caller-provided wrapper environment alone — when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has set `SCCACHE_DIR` themselves, soldr forwards their value rather than overriding it.
 
 `soldr cargo ...` only starts the managed build cache for compile-like Cargo subcommands such as `build`, `check`, `test`, `run`, `doc`, `clippy`, and `nextest`. Non-build Cargo commands such as `cargo metadata` and `cargo --version` pass through without starting zccache.
 
 Set `SOLDR_CACHE_LIFECYCLE=command` for self-build jobs that use soldr only as
 the builder and then run tests against zccache or soldr itself. The command
 lifetime mode finalizes zccache session stats first, then runs `zccache stop`
-against soldr's scoped `ZCCACHE_CACHE_DIR` and waits until `zccache status`
-reports that daemon is gone. It does not kill unrelated zccache daemons rooted
-at other cache directories.
+against zccache's active daemon and waits until `zccache status` reports that
+daemon is gone. If `ZCCACHE_CACHE_DIR` was explicitly set, shutdown uses that
+cache root; otherwise it uses zccache's normal default daemon.
 
 On Windows, soldr may copy the running `soldr.exe` into `SOLDR_CACHE_DIR/runtime/soldr-self/<version-and-hash>/soldr.exe` and re-run the command from that relocated copy before build orchestration starts. This keeps disposable worktree builds from repeatedly using the worktree-local `soldr.exe` as `RUSTC_WRAPPER`. The trampoline sets `SOLDR_RELOCATED_EXE=1` and `SOLDR_ORIGINAL_EXE=<original path>` as a recursion guard and preserves argv, inherited environment, stdio, and exit status. Stale relocated copies are purged by a best-effort runtime GC step that runs periodically and skips copies that cannot be removed because they are still locked.
 

--- a/docs/ZCCACHE_INTEGRATION_GUARDRAILS.md
+++ b/docs/ZCCACHE_INTEGRATION_GUARDRAILS.md
@@ -48,11 +48,11 @@ gh workflow run perf-matrix.yml -f platforms=linux -f fixtures=medium -f scenari
   overrides, local development builds, pinned managed runtime, managed cached
   runtime, and system fallback diagnostics.
 - `managed-session-env`: locks managed daemon/session startup and the cargo
-  child environment: `ZCCACHE_SESSION_ID`, `ZCCACHE_CACHE_DIR`,
-  `ZCCACHE_PATH_REMAP`, and `ZCCACHE_WORKTREE_ROOT`.
+  child environment: `ZCCACHE_SESSION_ID`, default absence of
+  `ZCCACHE_CACHE_DIR`, `ZCCACHE_PATH_REMAP`, and `ZCCACHE_WORKTREE_ROOT`.
 - `rust-plan-cache`: locks zccache `rust-plan restore` before Cargo and
-  `rust-plan save` after Cargo, while keeping the managed daemon cache root
-  separate from the target artifact bundle path.
+  `rust-plan save` after Cargo, while keeping zccache's active daemon/cache
+  behavior separate from the target artifact bundle path.
 - `disabled-and-non-build`: locks `--no-cache` and non-build cargo commands so
   they propagate `SOLDR_CACHE_ENABLED=0` and do not start managed zccache.
 - `unknown-session-retry`: locks the Windows wrapper recovery path for


### PR DESCRIPTION
## Summary
- stop the default managed `soldr cargo ...` path from creating soldr-private zccache daemon/session namespaces
- stop forcing `ZCCACHE_CACHE_DIR` by default while preserving explicit caller overrides
- keep session logs/reports under Soldr's cache root and update docs/tests for the new default

Closes #772

## Tests
- `soldr cargo check -p soldr-cli --tests --locked`
- `soldr cargo test -p soldr-cli --test cli_cargo_basic --test cli_cargo_wrappers --test cli_zccache_contract_matrix --test cli_rust_plan --locked`
- `soldr cargo test -p soldr-cli zccache --lib --locked`
- `soldr cargo test -p soldr-cli --lib --locked`
- `soldr cargo test -p soldr-cli --test cli_unknown_session_retry --locked`

## Notes
- `soldr cargo test --workspace --locked` was run twice: the first run completed the lib tests but the test binary exited with transient `STATUS_STACK_BUFFER_OVERRUN`; the immediate `--lib` rerun passed. The second workspace run progressed through the suite and only failed before this fix in `cli_unknown_session_retry`; that test file now passes after adding `SOLDR_ZCCACHE_SESSION_DIR` to its manual wrapper scaffold.