### PR TITLE
fix(bench): strip setup-soldr workspace-pinned env vars before canaries (#778)

### DIFF
--- a/bench/run_canaries.sh
+++ b/bench/run_canaries.sh
@@ -32,6 +32,39 @@ trap 'rm -rf "${WORK_DIR}"' EXIT
 
 mkdir -p "${OUT_DIR}"
 
+# Issue #778: setup-soldr exports a fleet of env vars that pin soldr's
+# behavior to the soldr workspace it was set up for
+# (`<runner>/soldr/soldr/soldr`). When the canary script cd's to the
+# medium fixture, those env vars cross-talk:
+#   - ZCCACHE_CACHE_DIR is pinned to setup-soldr's tempdir, but we
+#     override SOLDR_CACHE_DIR below — soldr passes our SOLDR_CACHE_DIR
+#     to zccache while zccache sees the old ZCCACHE_CACHE_DIR and the
+#     two disagree.
+#   - SOLDR_TARGET_CACHE_DIR / _BUNDLE_DIR / _REGISTRY_RECORDED point
+#     at paths under setup-soldr's tempdir; the medium fixture has its
+#     own target/ in a totally unrelated place.
+#   - SETUP_SOLDR_* / SOLDR_BUILD_CACHE_MODE / SOLDR_TARGET_CACHE_MODE
+#     are setup-soldr bookkeeping; safe to strip.
+#
+# KEEP: PATH (soldr lives there), RUSTUP_HOME / RUSTUP_TOOLCHAIN /
+# CARGO_HOME (toolchain), SOLDR_BINARY (alternate binary resolution),
+# SOLDR_LINKER, ZCCACHE_COMPILE_PRIORITY (useful, not workspace-pinned).
+#
+# This keeps setup-soldr's fast-build benefits for the soldr binary
+# itself (which was built earlier in the workflow's setup phase) while
+# letting the canaries run as if from a clean shell.
+unset ZCCACHE_CACHE_DIR \
+      SOLDR_TARGET_CACHE_DIR \
+      SOLDR_TARGET_CACHE_BUNDLE_DIR \
+      SOLDR_TARGET_CACHE_MODE \
+      SOLDR_TARGET_CACHE_PROFILE \
+      SOLDR_TARGET_CACHE_BACKEND \
+      SOLDR_TARGET_CACHE_COMPRESS \
+      SOLDR_TARGET_CACHE_COMPRESS_LEVEL \
+      SOLDR_TARGET_REGISTRY_RECORDED \
+      SOLDR_BUILD_CACHE_MODE \
+      SETUP_SOLDR_BUILD_CACHE_MODE
+
 # Single private cache for the whole canary sweep. Every canary writes
 # to the same daemon so warm-cache measurements are meaningful.
 export SOLDR_CACHE_DIR="${WORK_DIR}/cache"


### PR DESCRIPTION
Closes #778.

## What was wrong

The benchmark-stats workflow's canary step had every canary exit `rc=1` in ~28 ms with no stderr. Defensive `measure()` (#775) recorded 0 ms so the publish step kept running — which is how the README image kept appearing without trend lines.

## Investigation

Reproduced locally on Windows with the **exact same env vars** extracted from the failing CI run (`SOLDR_TARGET_CACHE_DIR`, `SOLDR_TARGET_CACHE_BUNDLE_DIR`, `SOLDR_BUILD_CACHE_MODE`, `ZCCACHE_CACHE_DIR`, `SOLDR_TARGET_REGISTRY_RECORDED`, etc.). Result: `soldr cargo build --release` succeeded in 107 s, 150 compilations. So the env vars themselves aren't fatal — but ONE of them creates cross-talk only on CI's exact configuration (probably the `ZCCACHE_CACHE_DIR` mismatch with my `SOLDR_CACHE_DIR` override).

## What this PR does

Targeted unset of the workspace-pinned env vars before canary runs:

- `ZCCACHE_CACHE_DIR` — setup-soldr pins it; canary script overrides `SOLDR_CACHE_DIR` so this becomes a mismatch source.
- `SOLDR_TARGET_CACHE_DIR` / `_BUNDLE_DIR` / `_REGISTRY_RECORDED` — pinned to the soldr workspace's `target/` and setup-soldr's tempdir, which the medium fixture doesn't use.
- `SOLDR_TARGET_CACHE_MODE` / `_PROFILE` / `_BACKEND` / `_COMPRESS*` — workspace-cache bookkeeping.
- `SOLDR_BUILD_CACHE_MODE` / `SETUP_SOLDR_BUILD_CACHE_MODE` — setup-soldr internal state.

Keeps everything setup-soldr installed for fast soldr-binary cold-restore: `PATH`, `RUSTUP_HOME`, `RUSTUP_TOOLCHAIN`, `CARGO_HOME`, `SOLDR_BINARY`, `SOLDR_LINKER`, `ZCCACHE_COMPILE_PRIORITY`.

Per the issue reporter's constraint: **do not drop setup-soldr** — its fast-build benefit for the soldr binary itself is preserved.

## Test plan

- [x] `bash -n bench/run_canaries.sh` — syntax clean
- [x] Local repro on Windows shows canaries succeed with ALL the env vars present (107 s for cold build), confirming the diagnosis isn't "env vars are universally broken" but "a specific cross-talk only triggers on CI"
- [ ] Post-merge: next benchmark-stats run on `main` should record real wall-times (not 0 ms) for every canary. If it does, the next `history.jsonl` line will have non-zero canaries and the rendered PNG will show actual trend points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)