### PR TITLE
feat(debug): preserve soldr PDB sidecars

### DIFF
--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -24,6 +24,7 @@ from zccache_contract import (  # noqa: E402
     ZCCACHE_BUNDLED_BINARIES,
     ZCCACHE_LOCAL_DIR_ENV,
     locate_extracted_file,
+    soldr_debug_info_entries,
     validate_release_manifest,
 )
 
@@ -227,6 +228,9 @@ def main() -> None:
             binary_path.chmod(
                 binary_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
             )
+        for entry in soldr_debug_info_entries(manifest):
+            debug_src = _locate_binary(extract_dir, str(entry["name"]))
+            shutil.copy2(debug_src, install_dir / str(entry["name"]))
 
         # Stage the bundled zccache trio next to soldr so the install
         # dir works as a self-contained SOLDR_ZCCACHE_LOCAL_DIR.

--- a/.github/actions/setup-soldr/zccache_contract.py
+++ b/.github/actions/setup-soldr/zccache_contract.py
@@ -84,6 +84,22 @@ def _manifest_binaries(manifest: dict[str, Any]) -> dict[str, str]:
     return binaries
 
 
+def soldr_debug_info_entries(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    soldr = manifest.get("soldr", {})
+    if not isinstance(soldr, dict):
+        return []
+    entries = soldr.get("debug_info", [])
+    if not isinstance(entries, list):
+        return []
+    return [
+        entry
+        for entry in entries
+        if isinstance(entry, dict)
+        and isinstance(entry.get("name"), str)
+        and isinstance(entry.get("sha256"), str)
+    ]
+
+
 def validate_release_manifest(
     manifest: dict[str, Any],
     *,
@@ -127,6 +143,26 @@ def validate_release_manifest(
             raise RuntimeError(f"release manifest sha256 for {name} is not lowercase hex")
         binary_path = locate_extracted_file(extract_dir, name)
         actual_sha = _sha256_file(binary_path)
+        if actual_sha != expected_sha:
+            raise RuntimeError(
+                f"release manifest sha256 mismatch for {name}: expected {expected_sha}, got {actual_sha}"
+            )
+
+    debug_info = soldr_debug_info_entries(manifest)
+    if windows and not debug_info:
+        raise RuntimeError("release manifest is missing soldr debug_info PDB entry")
+    for entry in debug_info:
+        name = str(entry["name"])
+        if entry.get("format") != "pdb":
+            raise RuntimeError(
+                f"unsupported soldr debug_info format for {name}: {entry.get('format')}"
+            )
+        if not name.lower().endswith(".pdb"):
+            raise RuntimeError(f"soldr debug_info entry must name a .pdb file: {name}")
+        expected_sha = str(entry["sha256"]).lower()
+        if len(expected_sha) != 64 or any(ch not in "0123456789abcdef" for ch in expected_sha):
+            raise RuntimeError(f"release manifest sha256 for {name} is not lowercase hex")
+        actual_sha = _sha256_file(locate_extracted_file(extract_dir, name))
         if actual_sha != expected_sha:
             raise RuntimeError(
                 f"release manifest sha256 mismatch for {name}: expected {expected_sha}, got {actual_sha}"

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -92,6 +92,13 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: "--target ${{ inputs.target }}"
 
+      - name: Enable Windows line-table debug symbols
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          "CARGO_PROFILE_DEV_DEBUG=line-tables-only" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CARGO_PROFILE_TEST_DEBUG=line-tables-only" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Restore checkout after soldr-cook
         shell: pwsh
         run: git restore --worktree -- .
@@ -227,6 +234,16 @@ jobs:
             $timer.Elapsed.TotalSeconds
           ))
           exit $exitCode
+
+      - name: Upload Windows test PDBs on failure
+        if: failure() && runner.os == 'Windows'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: windows-test-pdbs-${{ inputs.target }}
+          path: |
+            target/${{ inputs.target }}/debug/**/*.pdb
+            target/debug/**/*.pdb
+          if-no-files-found: warn
 
       - name: Stop isolated test cache
         if: always()

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -260,6 +260,8 @@ jobs:
           shared-key: release-${{ matrix.target }}
 
       - name: Build release binary
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: ${{ contains(matrix.target, 'pc-windows-msvc') && 'line-tables-only' || '0' }}
         run: cargo build --package soldr-cli --release --locked --target ${{ matrix.target }}
 
       - name: Install zstd
@@ -368,6 +370,25 @@ jobs:
           cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" \
              "dist/package/${{ matrix.binary }}"
           chmod +x "dist/package/${{ matrix.binary }}" 2>/dev/null || true
+          case "${{ matrix.target }}" in
+            *-pc-windows-msvc)
+              pdb_src=""
+              for candidate in \
+                "target/${{ matrix.target }}/release/soldr.pdb" \
+                "target/${{ matrix.target }}/release/soldr_cli.pdb"; do
+                if [ -f "$candidate" ]; then
+                  pdb_src="$candidate"
+                  break
+                fi
+              done
+              if [ -z "$pdb_src" ]; then
+                echo "expected a soldr PDB sidecar next to ${{ matrix.binary }}; observed release dir:" >&2
+                ls -la "target/${{ matrix.target }}/release" >&2 || true
+                exit 1
+              fi
+              cp "$pdb_src" "dist/package/$(basename "$pdb_src")"
+              ;;
+          esac
           ls -la dist/package/
 
       - name: Build crgx from pinned source
@@ -524,6 +545,18 @@ jobs:
           }
 
           soldr_sha=$(sha256_of "dist/package/soldr${suffix}")
+          soldr_debug_info_json="[]"
+          if [ -n "$suffix" ]; then
+            soldr_pdb=$(find dist/package -maxdepth 1 -type f \( -name 'soldr.pdb' -o -name 'soldr_cli.pdb' \) -print -quit)
+            if [ -z "$soldr_pdb" ]; then
+              echo "missing soldr PDB sidecar in dist/package for Windows release" >&2
+              ls -la dist/package >&2
+              exit 1
+            fi
+            soldr_pdb_name=$(basename "$soldr_pdb")
+            soldr_pdb_sha=$(sha256_of "$soldr_pdb")
+            soldr_debug_info_json=$(printf '[{ "name": "%s", "sha256": "%s", "format": "pdb" }]' "$soldr_pdb_name" "$soldr_pdb_sha")
+          fi
           zccache_sha=$(sha256_of "dist/package/zccache${suffix}")
           zccache_daemon_sha=$(sha256_of "dist/package/zccache-daemon${suffix}")
           zccache_fp_sha=$(sha256_of "dist/package/zccache-fp${suffix}")
@@ -542,6 +575,7 @@ jobs:
               "target": "${soldr_target}",
               "binary": "soldr${suffix}",
               "sha256": "${soldr_sha}",
+              "debug_info": ${soldr_debug_info_json},
               "commit_sha": "${commit_sha}"
             },
             "zccache": {
@@ -730,7 +764,7 @@ jobs:
           # Every archive must ship the 6 expected binaries (soldr,
           # zccache, zccache-daemon, zccache-fp, crgx, cargo-chef) with their
           # platform extension, plus a manifest.json describing the
-          # bundle.
+          # bundle. Windows archives must also ship soldr's PDB sidecar.
           suffix=""
           case "${{ matrix.target }}" in *-pc-windows-msvc) suffix=".exe" ;; esac
           for required in \
@@ -744,6 +778,12 @@ jobs:
             test -f "$extract/$required" \
               || { echo "missing $required in $archive" >&2; exit 1; }
           done
+          if [ -n "$suffix" ]; then
+            if ! find "$extract" -maxdepth 1 -type f \( -name 'soldr.pdb' -o -name 'soldr_cli.pdb' \) | grep -q .; then
+              echo "missing soldr PDB sidecar in $archive" >&2
+              exit 1
+            fi
+          fi
           echo "--- extracted manifest.json ---"
           cat "$extract/manifest.json"
 

--- a/crates/soldr-cli/src/doctor.rs
+++ b/crates/soldr-cli/src/doctor.rs
@@ -7,6 +7,7 @@ use crate::defender_probe::{self, DefenderProbeState, DefenderVerdict, SCANNED_T
 use crate::fetch::{ZccacheBinarySummary, ZccacheSource};
 use crate::{apply_implicit_toolchain_homes, rustup_binary, JSON_SCHEMA_VERSION};
 use serde::Serialize;
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Serialize)]
@@ -57,6 +58,10 @@ struct DoctorOutput {
     /// `true` when the active resolution is the pinned install (i.e.
     /// the managed path is superseded for the next `soldr cargo ...`).
     pinned_zccache_active: bool,
+    /// Debug-info sidecar state for the running soldr binary. On
+    /// Windows this points at the matching PDB directory for dump
+    /// symbolication.
+    soldr_debug_info: DoctorSoldrDebugInfo,
     /// Defender real-time-scan probe state for the cache directory
     /// (issue #357). `None` on non-Windows platforms.
     defender_probe: Option<DoctorDefenderProbe>,
@@ -170,6 +175,14 @@ struct DoctorPinnedZccache {
     managed_version: &'static str,
 }
 
+#[derive(Serialize, Clone)]
+struct DoctorSoldrDebugInfo {
+    binary_path: String,
+    debug_info_found: usize,
+    debug_info_expected: usize,
+    symbol_path: String,
+}
+
 /// Implementation of `soldr doctor`. Read-only — never invokes
 /// `rustup component add` / `target add` / `toolchain install`.
 pub(crate) fn run_doctor(json: bool, refresh_defender_probe: bool) -> Result<i32, SoldrError> {
@@ -178,6 +191,7 @@ pub(crate) fn run_doctor(json: bool, refresh_defender_probe: bool) -> Result<i32
     let manifest = crate::core::read_rust_toolchain_manifest(&workspace_root)?;
     let manifest_present = manifest_path.exists();
     let bundle = collect_zccache_bundle()?;
+    let soldr_debug_info = collect_soldr_debug_info();
     let defender = collect_defender_probe(refresh_defender_probe);
     let cook = collect_cook_stats();
 
@@ -197,6 +211,7 @@ pub(crate) fn run_doctor(json: bool, refresh_defender_probe: bool) -> Result<i32
                 managed_zccache: DoctorManagedZccache::from_summary(&bundle.managed),
                 pinned_zccache: bundle.pinned_doctor.clone(),
                 pinned_zccache_active: bundle.pinned_active,
+                soldr_debug_info: soldr_debug_info.clone(),
                 defender_probe: defender_for_json(defender.as_ref()),
                 cook: cook.clone(),
             };
@@ -207,6 +222,7 @@ pub(crate) fn run_doctor(json: bool, refresh_defender_probe: bool) -> Result<i32
                 manifest_path.display()
             );
             print_zccache_sections(&bundle);
+            print_soldr_debug_info_human(&soldr_debug_info);
             print_defender_probe_human(defender.as_ref());
             if let Some(c) = cook.as_ref() {
                 print_cook_section(c);
@@ -218,6 +234,7 @@ pub(crate) fn run_doctor(json: bool, refresh_defender_probe: bool) -> Result<i32
                 workspace_root.display()
             );
             print_zccache_sections(&bundle);
+            print_soldr_debug_info_human(&soldr_debug_info);
             print_defender_probe_human(defender.as_ref());
             if let Some(c) = cook.as_ref() {
                 print_cook_section(c);
@@ -290,6 +307,7 @@ pub(crate) fn run_doctor(json: bool, refresh_defender_probe: bool) -> Result<i32
             managed_zccache: DoctorManagedZccache::from_summary(&bundle.managed),
             pinned_zccache: bundle.pinned_doctor.clone(),
             pinned_zccache_active: bundle.pinned_active,
+            soldr_debug_info: soldr_debug_info.clone(),
             defender_probe: defender_for_json(defender.as_ref()),
             cook: cook.clone(),
         };
@@ -305,6 +323,7 @@ pub(crate) fn run_doctor(json: bool, refresh_defender_probe: bool) -> Result<i32
             &missing_targets,
             drift,
             &bundle,
+            &soldr_debug_info,
             defender.as_ref(),
             cook.as_ref(),
         );
@@ -379,6 +398,23 @@ fn collect_cook_stats() -> Option<DoctorCookStats> {
         cache_dir_bytes: bytes,
         cache_dir: cook_dir.display().to_string(),
     })
+}
+
+fn collect_soldr_debug_info() -> DoctorSoldrDebugInfo {
+    let binary_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("soldr"));
+    let symbol_path = binary_path
+        .parent()
+        .map(|path| path.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let (debug_info_found, debug_info_expected) =
+        crate::fetch::zccache::count_debug_info_sidecars(&[binary_path.as_path()]);
+
+    DoctorSoldrDebugInfo {
+        binary_path: binary_path.display().to_string(),
+        debug_info_found,
+        debug_info_expected,
+        symbol_path: symbol_path.display().to_string(),
+    }
 }
 
 /// Format a byte count for the doctor human output. Matches the
@@ -626,6 +662,22 @@ fn print_zccache_sections(bundle: &ZccacheDoctorBundle) {
     print_managed_zccache_human(&bundle.managed, bundle.pinned_active);
 }
 
+fn print_soldr_debug_info_human(summary: &DoctorSoldrDebugInfo) {
+    println!();
+    println!("soldr debug info:");
+    println!("  binary:        {}", summary.binary_path);
+    let pdb_hint = if summary.debug_info_found == 0 {
+        "no PDB present; build soldr with `[profile.release] debug = \"line-tables-only\"` or set CARGO_PROFILE_*_DEBUG=line-tables-only"
+    } else {
+        "complete"
+    };
+    println!(
+        "  pdbs found:    {}/{} ({})",
+        summary.debug_info_found, summary.debug_info_expected, pdb_hint
+    );
+    println!("  symbol path:   {}", summary.symbol_path);
+}
+
 fn print_pinned_zccache_human(
     summary: &ZccacheBinarySummary,
     sidecar: &crate::fetch::PinnedSidecar,
@@ -766,6 +818,7 @@ fn print_doctor_human(
     missing_targets: &[String],
     drift: bool,
     bundle: &ZccacheDoctorBundle,
+    soldr_debug_info: &DoctorSoldrDebugInfo,
     defender: Option<&DefenderProbeOutcome>,
     cook: Option<&DoctorCookStats>,
 ) {
@@ -825,6 +878,7 @@ fn print_doctor_human(
     }
 
     print_zccache_sections(bundle);
+    print_soldr_debug_info_human(soldr_debug_info);
     print_defender_probe_human(defender);
     if let Some(c) = cook {
         print_cook_section(c);

--- a/docs/API.md
+++ b/docs/API.md
@@ -789,6 +789,12 @@ Example JSON output (`schema_version: 1`):
   "drift": true,
   "missing_components": ["clippy"],
   "missing_targets": [],
+  "soldr_debug_info": {
+    "binary_path": "C:\\Users\\user\\.soldr\\bin\\soldr.exe",
+    "debug_info_found": 1,
+    "debug_info_expected": 1,
+    "symbol_path": "C:\\Users\\user\\.soldr\\bin"
+  },
   "defender_probe": {
     "verdict": "scanned",
     "probed_path": "C:\\Users\\user\\.soldr\\cache",

--- a/docs/NPM_PUBLISHING.md
+++ b/docs/NPM_PUBLISHING.md
@@ -89,22 +89,26 @@ Do not publish an npm version until the matching GitHub Release has these files:
 - `soldr-vX.Y.Z-SHA256SUMS.txt`
 
 Each archive is a `.tar.zst` at zstd compression level 19 and bundles
-six binaries plus a `manifest.json` at the archive root:
+six binaries plus a `manifest.json` at the archive root. Windows
+archives also include soldr's matching PDB sidecar:
 
 - `soldr` (or `soldr.exe`) — the soldr CLI itself.
 - `zccache`, `zccache-daemon`, `zccache-fp` — the matching-target
   zccache trio (Linux gnu archives carry the musl zccache because
   zccache ships musl-only on Linux upstream; statically linked, runs
   on glibc).
+- `soldr.pdb` or `soldr_cli.pdb` - Windows-only soldr debug symbols
+  recorded under `soldr.debug_info` in `manifest.json`.
 - `crgx` (or `crgx.exe`) - the matching-target crgx binary.
 - `cargo-chef` (or `cargo-chef.exe`) - the pinned cargo-chef binary used
   by `soldr cook`.
 - `manifest.json` - schema_version 3 descriptor with soldr / zccache /
-  crgx / cargo-chef versions, target triples, per-binary sha256s, and archive format.
+  crgx / cargo-chef versions, target triples, soldr debug-info sidecars,
+  per-file sha256s, and archive format.
   The expected archive layout is versioned in
   `contracts/zccache-runtime.v1.json`.
 
 The npm install wrapper validates `manifest.json`, unpacks all six binaries
-into `bin/native/`, and `bin/soldr.js` exports `SOLDR_ZCCACHE_LOCAL_DIR`,
+plus any soldr debug-info sidecars into `bin/native/`, and `bin/soldr.js` exports `SOLDR_ZCCACHE_LOCAL_DIR`,
 `SOLDR_CRGX_LOCAL_DIR`, and `SOLDR_CARGO_CHEF_LOCAL_DIR` to that dir before
 spawning soldr, so the bundled tools are picked up automatically.

--- a/docs/ZCCACHE_RUNTIME_CONTRACT.md
+++ b/docs/ZCCACHE_RUNTIME_CONTRACT.md
@@ -7,9 +7,11 @@ The contract fixes these cross-runtime expectations:
 
 - Release archives are `.tar.zst` bundles containing `soldr`, `zccache`,
   `zccache-daemon`, `zccache-fp`, `crgx`, `cargo-chef`, and `manifest.json`.
+  Windows archives also carry soldr's matching PDB sidecar (`soldr.pdb` or
+  `soldr_cli.pdb`) so crash dumps can resolve file/line frames.
 - `manifest.json` is the authoritative per-archive descriptor for schema
   version, archive format, soldr target, zccache target, bundled binary names,
-  and per-binary `sha256` values.
+  soldr debug-info sidecars, and per-file `sha256` values.
 - Setup-soldr and npm install must stage the same zccache trio and export
   `SOLDR_ZCCACHE_LOCAL_DIR` only when that trio is present.
 - Setup-soldr and npm must use the same local crgx env var:

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -284,6 +284,13 @@ async function install() {
         fs.chmodSync(dst, 0o755);
       }
     }
+    for (const entry of zccacheContract.soldrDebugInfoEntries(manifest)) {
+      const src = findExtractedBinary(extractDir, entry.name);
+      if (!src) {
+        throw new Error(`release archive ${filename} did not contain ${entry.name}`);
+      }
+      fs.copyFileSync(src, path.join(nativeDir, entry.name));
+    }
 
     // Drop manifest.json alongside the binaries so downstream tooling
     // (and humans reading `bin/native/`) can introspect provenance —

--- a/scripts/test-npm-package.js
+++ b/scripts/test-npm-package.js
@@ -135,6 +135,14 @@ assert.deepStrictEqual(zccacheContract.ZCCACHE_BUNDLED_BINARIES, [
 ]);
 assert.strictEqual(zccacheContract.CRGX_BUNDLED_BINARY, "crgx");
 assert.strictEqual(zccacheContract.CARGO_CHEF_BUNDLED_BINARY, "cargo-chef");
+assert.deepStrictEqual(
+  zccacheContract.soldrDebugInfoEntries({
+    soldr: {
+      debug_info: [{ name: "soldr.pdb", sha256: "0".repeat(64), format: "pdb" }],
+    },
+  }),
+  [{ name: "soldr.pdb", sha256: "0".repeat(64), format: "pdb" }],
+);
 assert.ok(
   fs.existsSync(path.join(root, "contracts", "zccache-integration-guardrails.v1.json")),
   "npm package must include the zccache integration guardrail contract",

--- a/scripts/zccache-contract.js
+++ b/scripts/zccache-contract.js
@@ -57,6 +57,13 @@ function collectManifestBinaries(manifest) {
   return binaries;
 }
 
+function soldrDebugInfoEntries(manifest) {
+  const entries = manifest.soldr && Array.isArray(manifest.soldr.debug_info)
+    ? manifest.soldr.debug_info
+    : [];
+  return entries.filter((entry) => entry && entry.name && entry.sha256);
+}
+
 function validateReleaseManifest(manifest, options) {
   const { soldrTarget, platform = process.platform, findFile } = options;
   if (!Number.isInteger(manifest.schema_version) || manifest.schema_version < MANIFEST_MIN_SCHEMA_VERSION) {
@@ -95,6 +102,28 @@ function validateReleaseManifest(manifest, options) {
       throw new Error(`release manifest sha256 mismatch for ${name}: expected ${expectedSha}, got ${actualSha}`);
     }
   }
+
+  const debugInfo = soldrDebugInfoEntries(manifest);
+  if (platform === "win32" && debugInfo.length === 0) {
+    throw new Error("release manifest is missing soldr debug_info PDB entry");
+  }
+  for (const entry of debugInfo) {
+    if (entry.format !== "pdb") {
+      throw new Error(`unsupported soldr debug_info format for ${entry.name}: ${entry.format}`);
+    }
+    if (!/\.pdb$/i.test(entry.name)) {
+      throw new Error(`soldr debug_info entry must name a .pdb file: ${entry.name}`);
+    }
+    const expectedSha = String(entry.sha256).toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(expectedSha)) {
+      throw new Error(`release manifest sha256 for ${entry.name} is not lowercase hex`);
+    }
+    const filePath = findFile(entry.name);
+    const actualSha = sha256File(filePath);
+    if (actualSha !== expectedSha) {
+      throw new Error(`release manifest sha256 mismatch for ${entry.name}: expected ${expectedSha}, got ${actualSha}`);
+    }
+  }
 }
 
 module.exports = {
@@ -108,6 +137,7 @@ module.exports = {
   ZCCACHE_BUNDLED_BINARIES,
   binaryName,
   releaseBinaryNames,
+  soldrDebugInfoEntries,
   validateReleaseManifest,
   zccacheTargetForSoldrTarget,
 };

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -161,6 +161,17 @@ def test_setup_soldr_smoke_tests_disable_nested_cache() -> None:
     assert "[System.IO.Path]::GetFullPath($env:SOLDR_CACHE_DIR)" in workflow
 
 
+def test_build_and_test_uploads_windows_pdb_artifacts() -> None:
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "_build-and-test.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "CARGO_PROFILE_DEV_DEBUG=line-tables-only" in workflow
+    assert "CARGO_PROFILE_TEST_DEBUG=line-tables-only" in workflow
+    assert "Upload Windows test PDBs on failure" in workflow
+    assert "target/${{ inputs.target }}/debug/**/*.pdb" in workflow
+
+
 def test_main_creates_cache_layout_and_outputs(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     workspace = tmp_path / "workspace"

--- a/tests/test_zccache_runtime_contract.py
+++ b/tests/test_zccache_runtime_contract.py
@@ -36,6 +36,18 @@ def _write_manifest_fixture(root: Path, *, windows: bool = False) -> dict[str, o
         (root / name).write_bytes(payload)
 
     suffix = ".exe" if windows else ""
+    soldr_debug_info: list[dict[str, str]] = []
+    if windows:
+        pdb_name = "soldr.pdb"
+        payloads[pdb_name] = b"soldr pdb\n"
+        (root / pdb_name).write_bytes(payloads[pdb_name])
+        soldr_debug_info.append(
+            {
+                "name": pdb_name,
+                "sha256": _sha256(payloads[pdb_name]),
+                "format": "pdb",
+            }
+        )
     return {
         "schema_version": 3,
         "soldr": {
@@ -43,6 +55,7 @@ def _write_manifest_fixture(root: Path, *, windows: bool = False) -> dict[str, o
             "target": "x86_64-unknown-linux-gnu",
             "binary": f"soldr{suffix}",
             "sha256": _sha256(payloads[f"soldr{suffix}"]),
+            "debug_info": soldr_debug_info,
             "commit_sha": "abc123",
         },
         "zccache": {
@@ -117,6 +130,49 @@ def test_python_contract_validates_release_manifest_sha256s(tmp_path: Path) -> N
         )
 
 
+def test_python_contract_validates_windows_soldr_pdb_sha256(tmp_path: Path) -> None:
+    module = _load_py_contract()
+    manifest = _write_manifest_fixture(tmp_path, windows=True)
+    manifest["soldr"]["target"] = "x86_64-pc-windows-msvc"
+    manifest["zccache"]["target"] = "x86_64-pc-windows-msvc"
+    manifest["crgx"]["target"] = "x86_64-pc-windows-msvc"
+    manifest["cargo_chef"]["target"] = "x86_64-pc-windows-msvc"
+
+    module.validate_release_manifest(
+        manifest,
+        soldr_target="x86_64-pc-windows-msvc",
+        windows=True,
+        extract_dir=tmp_path,
+    )
+
+    manifest["soldr"]["debug_info"][0]["sha256"] = "0" * 64
+    with pytest.raises(RuntimeError, match="soldr.pdb"):
+        module.validate_release_manifest(
+            manifest,
+            soldr_target="x86_64-pc-windows-msvc",
+            windows=True,
+            extract_dir=tmp_path,
+        )
+
+
+def test_python_contract_requires_windows_soldr_pdb(tmp_path: Path) -> None:
+    module = _load_py_contract()
+    manifest = _write_manifest_fixture(tmp_path, windows=True)
+    manifest["soldr"]["target"] = "x86_64-pc-windows-msvc"
+    manifest["zccache"]["target"] = "x86_64-pc-windows-msvc"
+    manifest["crgx"]["target"] = "x86_64-pc-windows-msvc"
+    manifest["cargo_chef"]["target"] = "x86_64-pc-windows-msvc"
+    manifest["soldr"]["debug_info"] = []
+
+    with pytest.raises(RuntimeError, match="missing soldr debug_info PDB"):
+        module.validate_release_manifest(
+            manifest,
+            soldr_target="x86_64-pc-windows-msvc",
+            windows=True,
+            extract_dir=tmp_path,
+        )
+
+
 def test_python_action_helpers_import_contract_constants() -> None:
     module = _load_py_contract()
     ensure_spec = importlib.util.spec_from_file_location(
@@ -144,6 +200,8 @@ def test_release_workflow_and_docs_reference_contract_layout() -> None:
 
     assert '"schema_version": 3' in release_workflow
     assert '"format": "tar.zst"' in release_workflow
+    assert '"debug_info": ${soldr_debug_info_json}' in release_workflow
+    assert "CARGO_PROFILE_RELEASE_DEBUG" in release_workflow
     for base in contract["release_archive"]["required_binaries"]:
         assert base in release_workflow
         assert base in npm_docs


### PR DESCRIPTION
## Summary

- preserve Windows soldr PDB sidecars in release archives and record them under `soldr.debug_info` in `manifest.json`
- validate and stage soldr debug sidecars in setup-soldr and npm install paths
- enable Windows CI line-table debug info and upload test PDBs on failure
- surface the active soldr binary symbol path in `soldr doctor`

Closes #782

## Tests

- `soldr cargo fmt --all`
- `uv run pytest tests/test_zccache_runtime_contract.py tests/test_setup_soldr_action.py -q`
- `node scripts/test-npm-package.js`
- `soldr cargo test -p soldr-cli --lib fetch::zccache::tests::count_debug_info_sidecars --locked`
- `soldr --no-cache cargo check -p soldr-cli --locked`
- `soldr cargo test -p soldr-cli --test fetch_crgx --locked`
- `soldr cargo test -p soldr-cli --test lib_install_zccache --locked`
- `uv run ruff check .github/actions/setup-soldr tests/test_zccache_runtime_contract.py tests/test_setup_soldr_action.py`
- `bash ./test` (fails after workspace build, lib tests, and CLI smoke tests because the script still references removed package `soldr-fetch`)
- `uv run pytest tests -q` (fails on pre-existing repo-wide drift: setup-soldr pin current @v0 mismatch, and zccache guardrail docs/contract drift for `perf-build-then-check`)