### PR TITLE
feat(bench): add README comparison bars

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -25,7 +25,7 @@ jobs:
   benchmark:
     name: Generate + publish benchmark stats
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -44,6 +44,20 @@ jobs:
         working-directory: soldr
         run: bash bench/run_canaries.sh
 
+      - name: Install benchmark rendering and comparison tools
+        # Issue #785: README embeds comparison PNGs that need matplotlib,
+        # and the comparison runner measures a pinned apt sccache package.
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades --no-install-recommends \
+            python3-matplotlib \
+            sccache=0.7.7-2ubuntu0.1
+
+      - name: Run comparison benchmarks
+        working-directory: soldr
+        run: bash bench/run_comparison.sh
+
       - name: Assemble publish dir
         working-directory: soldr
         env:
@@ -54,19 +68,13 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash bench/assemble_benchmark_stats.sh
 
-      - name: Install matplotlib for trend image
-        # Issue #771: README embeds benchmark-trend.png via raw URL.
-        # python3-matplotlib is the system package (~15s install) and
-        # avoids a venv. Mirrors the python3-pil pattern zccache uses
-        # for the same purpose.
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends python3-matplotlib
-
       - name: Render benchmark-trend.png
         working-directory: soldr
         run: python3 bench/render_benchmark_trend.py
+
+      - name: Render comparison bar PNGs
+        working-directory: soldr
+        run: python3 bench/render_comparison_bars.py
 
       - name: Publish to benchmark-stats branch
         if: ${{ success() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -45,13 +45,15 @@ jobs:
         run: bash bench/run_canaries.sh
 
       - name: Install benchmark rendering and comparison tools
-        # Issue #785: README embeds comparison PNGs that need matplotlib,
-        # and the comparison runner measures a pinned apt sccache package.
+        # Issues #785/#790: README embeds zccache-style comparison JPGs
+        # rendered with Pillow, and the comparison runner measures a pinned
+        # apt sccache package.
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --allow-downgrades --no-install-recommends \
             python3-matplotlib \
+            python3-pil \
             sccache=0.7.7-2ubuntu0.1
 
       - name: Run comparison benchmarks
@@ -72,7 +74,7 @@ jobs:
         working-directory: soldr
         run: python3 bench/render_benchmark_trend.py
 
-      - name: Render comparison bar PNGs
+      - name: Render comparison bar JPGs
         working-directory: soldr
         run: python3 bench/render_comparison_bars.py
 

--- a/PERF.md
+++ b/PERF.md
@@ -3,7 +3,7 @@
 soldr has two performance workflows:
 
 1. **`.github/workflows/perf-matrix.yml`** (the "Perf Matrix") — the regression-gate workflow. Push to a branch with a recognized name and the matrix runs the right cells automatically — no manual `workflow_dispatch` needed.
-2. **`.github/workflows/benchmark-stats.yml`** (issue #768) — per-commit trend publishing. Runs on every push to `main`, measures 6 canaries against `perf/fixtures/medium`, and force-publishes to the `benchmark-stats` branch + GitHub Pages.
+2. **`.github/workflows/benchmark-stats.yml`** (issues #768 and #785) — per-commit trend and README comparison publishing. Runs on every push to `main`, measures 6 canaries against `perf/fixtures/medium`, measures bare cargo vs sccache vs soldr comparison bars, and force-publishes to the `benchmark-stats` branch + GitHub Pages.
 
 For the perf-matrix per-scenario design rationale (what each cell proves), see [`perf/README.md`](perf/README.md). For the benchmark-stats canary set + discovery URLs, see the **Per-commit benchmark stats** section near the end of this file.
 
@@ -194,6 +194,45 @@ The manifest points at:
 | `cargo-check-medium-cross-verb` | build → check; pins #758 / [zccache#776](https://github.com/zackees/zccache/issues/776) | 1500 |
 | `touch-no-change-medium-warm` | source mtimes bumped, content unchanged; expect 100% hits | 1500 |
 | `worktree-share-medium-warm` | second fixture extraction, same `SOLDR_CACHE_DIR` | 1500 |
+
+## README comparison bars (issue #785)
+
+The README uses `benchmark-rust-only.png` and `benchmark-rust-c.png` for an at-a-glance bare cargo vs sccache vs soldr comparison. The historical trend PNG remains published as `benchmark-trend.png`, but it is for the Pages deep-dive rather than the README value proposition.
+
+### Workloads
+
+| Benchmark | Fixture | Why |
+|---|---|---|
+| `rust-only` | this `soldr` repository | Real Rust workspace with a meaningful dependency graph; it keeps the headline chart self-contained and current. |
+| `rust-c` | `perf/fixtures/sqlite-link` | Small Rust+C fixture that exercises `cc-rs` / `build.rs` native compilation without adding an external checkout. |
+
+### Tools
+
+| Tool | Command layer | Cache layer |
+|---|---|---|
+| `bare` | `cargo build --release --locked` | None. Universal baseline. |
+| `sccache` | `RUSTC_WRAPPER=sccache cargo build --release --locked` | The common Rust `RUSTC_WRAPPER` alternative. The workflow pins the Ubuntu package and records `sccache --version` in `latest.json#metadata.sccache_version`. |
+| `soldr` | `soldr cargo build --release --locked` | soldr-managed zccache with soldr's wrapper and path-remap defaults. |
+
+`swatinem/rust-cache` is intentionally not a bar. It caches `target/` between GitHub Actions jobs, which is a different layer from a compiler wrapper. `cargo-chef` and linker choices such as `mold` are also different layers, so they are not included in the wrapper comparison.
+
+### Scenarios
+
+| Scenario | What it measures | Samples |
+|---|---|---|
+| `cold` | Fresh source checkout, fresh target dir, and fresh cache. This should usually be a wash, and it sets honest expectations. | Median of 3 per tool/workload cell. |
+| `warm` | Populate the tool cache, run `cargo clean`, then time the rebuild in the same workspace. | Single sample. |
+| `worktree-share` | Build workspace A to populate the cache, then time a sibling workspace B at the same commit. This highlights soldr's `ZCCACHE_PATH_REMAP=auto` parent-child share story. | Single sample. |
+
+### Published data shape
+
+`bench/run_comparison.sh` writes `benchmark-output/comparison.json`; `bench/assemble_benchmark_stats.sh` copies the meaningful parts into `latest.json`:
+
+- `latest.json#metadata.sccache_version` records the pinned sccache binary version alongside soldr and rustc.
+- `latest.json#comparison.scenarios` and `latest.json#comparison.tools` describe chart ordering.
+- `latest.json#results` contains one row per `(benchmark, scenario, tool)` with `command`, `wall_ms`, `mode`, `fixture`, and display labels.
+
+The Pages view renders interactive Chart.js bars from `latest.json#results` above the historical trend charts. The static README PNGs are rendered from the same comparison JSON by `bench/render_comparison_bars.py`.
 
 ### Branch shape
 

--- a/PERF.md
+++ b/PERF.md
@@ -197,7 +197,7 @@ The manifest points at:
 
 ## README comparison bars (issue #785)
 
-The README uses `benchmark-rust-only.png` and `benchmark-rust-c.png` for an at-a-glance bare cargo vs sccache vs soldr comparison. The historical trend PNG remains published as `benchmark-trend.png`, but it is for the Pages deep-dive rather than the README value proposition.
+The README uses `benchmark-rust-only.jpg` and `benchmark-rust-c.jpg` for an at-a-glance bare cargo vs sccache vs soldr comparison. The images intentionally match zccache's dark README benchmark style. The historical trend PNG remains published as `benchmark-trend.png`, but it is for the Pages deep-dive rather than the README value proposition.
 
 ### Workloads
 
@@ -232,7 +232,7 @@ The README uses `benchmark-rust-only.png` and `benchmark-rust-c.png` for an at-a
 - `latest.json#comparison.scenarios` and `latest.json#comparison.tools` describe chart ordering.
 - `latest.json#results` contains one row per `(benchmark, scenario, tool)` with `command`, `wall_ms`, `mode`, `fixture`, and display labels.
 
-The Pages view renders interactive Chart.js bars from `latest.json#results` above the historical trend charts. The static README PNGs are rendered from the same comparison JSON by `bench/render_comparison_bars.py`.
+The Pages view renders interactive Chart.js bars from `latest.json#results` above the historical trend charts. The static README JPGs are rendered from the same comparison JSON by `bench/render_comparison_bars.py`.
 
 ### Branch shape
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Third-party comparison (soldr vs Swatinem/rust-cache vs ...): published from `za
 | [view page](https://zackees.github.io/soldr/) | [json](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/manifest.json) | [view branch](https://github.com/zackees/soldr/tree/benchmark-stats) |
 |---|---|---|
 
-[![soldr vs sccache vs bare cargo - Rust workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-only.png)](https://zackees.github.io/soldr/)
-[![soldr vs sccache vs bare cargo - Rust+C workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-c.png)](https://zackees.github.io/soldr/)
+[![soldr vs sccache vs bare cargo - Rust workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-only.jpg)](https://zackees.github.io/soldr/)
+[![soldr vs sccache vs bare cargo - Rust+C workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-c.jpg)](https://zackees.github.io/soldr/)
 
 Cold builds are a wash; warm and cross-worktree share are where soldr's wrapper architecture pays off. Full historical trend + interactive view: [zackees.github.io/soldr](https://zackees.github.io/soldr/). For the swatinem/rust-cache comparison (GHA target-dir caching, a different layer) see [PERF.md](PERF.md#readme-comparison-bars-issue-785).
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ Third-party comparison (soldr vs Swatinem/rust-cache vs ...): published from `za
 | [view page](https://zackees.github.io/soldr/) | [json](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/manifest.json) | [view branch](https://github.com/zackees/soldr/tree/benchmark-stats) |
 |---|---|---|
 
-[![soldr local-build canary trend](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-trend.png)](https://zackees.github.io/soldr/)
+[![soldr vs sccache vs bare cargo - Rust workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-only.png)](https://zackees.github.io/soldr/)
+[![soldr vs sccache vs bare cargo - Rust+C workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-c.png)](https://zackees.github.io/soldr/)
 
-The image is regenerated on every push to `main` by [`.github/workflows/benchmark-stats.yml`](.github/workflows/benchmark-stats.yml). Canary set and methodology: [PERF.md § Per-commit benchmark stats](PERF.md#per-commit-benchmark-stats-issue-768).
+Cold builds are a wash; warm and cross-worktree share are where soldr's wrapper architecture pays off. Full historical trend + interactive view: [zackees.github.io/soldr](https://zackees.github.io/soldr/). For the swatinem/rust-cache comparison (GHA target-dir caching, a different layer) see [PERF.md](PERF.md#readme-comparison-bars-issue-785).
 
 **Instant tools. Instant builds. One command.**
 

--- a/bench/assemble_benchmark_stats.sh
+++ b/bench/assemble_benchmark_stats.sh
@@ -4,6 +4,7 @@
 #
 # Inputs:
 #   ./benchmark-output/canaries.json   (produced by run_canaries.sh)
+#   ./benchmark-output/comparison.json (produced by run_comparison.sh)
 #   ./bench/index.html                 (static Chart.js page)
 #   ENV REPO_OWNER REPO_NAME REPO_FULL GIT_SHA RUN_URL
 #
@@ -26,6 +27,7 @@ HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${HERE}/.." && pwd)"
 
 IN_FILE="${REPO_ROOT}/benchmark-output/canaries.json"
+COMPARISON_FILE="${REPO_ROOT}/benchmark-output/comparison.json"
 OUT_DIR="${REPO_ROOT}/benchmark-stats"
 RAW_BASE="https://raw.githubusercontent.com/${REPO_FULL}/benchmark-stats"
 PAGES_URL="https://${REPO_OWNER}.github.io/${REPO_NAME}/"
@@ -35,6 +37,11 @@ mkdir -p "${OUT_DIR}"
 
 if [[ ! -f "${IN_FILE}" ]]; then
     echo "assemble: ${IN_FILE} not found; did run_canaries.sh complete?" >&2
+    exit 1
+fi
+
+if [[ ! -f "${COMPARISON_FILE}" ]]; then
+    echo "assemble: ${COMPARISON_FILE} not found; did run_comparison.sh complete?" >&2
     exit 1
 fi
 
@@ -83,6 +90,7 @@ jq -n \
     --arg repository "${REPO_FULL}" \
     --arg run_url "${RUN_URL}" \
     --slurpfile canaries_doc "${IN_FILE}" \
+    --slurpfile comparison_doc "${COMPARISON_FILE}" \
     '{
         schema_version: 1,
         metadata: {
@@ -93,9 +101,15 @@ jq -n \
             run_url: $run_url,
             fixture: "medium",
             soldr_version: $canaries_doc[0].soldr_version,
-            rustc_version: $canaries_doc[0].rustc_version
+            rustc_version: $canaries_doc[0].rustc_version,
+            sccache_version: $comparison_doc[0].sccache_version
         },
-        canaries: $canaries_doc[0].wall_ms
+        canaries: $canaries_doc[0].wall_ms,
+        comparison: {
+            scenarios: $comparison_doc[0].scenarios,
+            tools: $comparison_doc[0].tools
+        },
+        results: $comparison_doc[0].results
     }' >"${OUT_DIR}/latest.json"
 
 echo "assemble: wrote latest.json" >&2
@@ -145,9 +159,19 @@ jq -n \
                 url: $pages_url,
                 content_type: "text/html"
             },
-            readme_image: {
-                description: "Static PNG of the canary trend; embedded in repo README.md and updated on every main-merge (#771).",
+            trend_image: {
+                description: "Static PNG of the canary trend; retained for the Pages historical deep-dive.",
                 url: ($raw_base + "/benchmark-trend.png"),
+                content_type: "image/png"
+            },
+            comparison_rust: {
+                description: "Bar chart: bare cargo vs sccache vs soldr on a pure-Rust workload (soldr itself). Embedded in README.",
+                url: ($raw_base + "/benchmark-rust-only.png"),
+                content_type: "image/png"
+            },
+            comparison_rust_c: {
+                description: "Bar chart: bare cargo vs sccache vs soldr on a Rust+C workload (sqlite-link).",
+                url: ($raw_base + "/benchmark-rust-c.png"),
                 content_type: "image/png"
             }
         },

--- a/bench/assemble_benchmark_stats.sh
+++ b/bench/assemble_benchmark_stats.sh
@@ -165,14 +165,14 @@ jq -n \
                 content_type: "image/png"
             },
             comparison_rust: {
-                description: "Bar chart: bare cargo vs sccache vs soldr on a pure-Rust workload (soldr itself). Embedded in README.",
-                url: ($raw_base + "/benchmark-rust-only.png"),
-                content_type: "image/png"
+                description: "Dark zccache-style bar chart: bare cargo vs sccache vs soldr on a pure-Rust workload (soldr itself). Embedded in README.",
+                url: ($raw_base + "/benchmark-rust-only.jpg"),
+                content_type: "image/jpeg"
             },
             comparison_rust_c: {
-                description: "Bar chart: bare cargo vs sccache vs soldr on a Rust+C workload (sqlite-link).",
-                url: ($raw_base + "/benchmark-rust-c.png"),
-                content_type: "image/png"
+                description: "Dark zccache-style bar chart: bare cargo vs sccache vs soldr on a Rust+C workload (sqlite-link).",
+                url: ($raw_base + "/benchmark-rust-c.jpg"),
+                content_type: "image/jpeg"
             }
         },
         canaries: {

--- a/bench/index.html
+++ b/bench/index.html
@@ -88,8 +88,8 @@
         <a href="manifest.json">manifest.json</a>
         <a href="latest.json">latest.json</a>
         <a href="history.jsonl">history.jsonl</a>
-        <a href="benchmark-rust-only.png">benchmark-rust-only.png</a>
-        <a href="benchmark-rust-c.png">benchmark-rust-c.png</a>
+        <a href="benchmark-rust-only.jpg">benchmark-rust-only.jpg</a>
+        <a href="benchmark-rust-c.jpg">benchmark-rust-c.jpg</a>
         <a href="benchmark-trend.png">benchmark-trend.png</a>
         <a href="https://github.com/zackees/soldr/blob/main/PERF.md#per-commit-benchmark-stats-issue-768">methodology (PERF.md)</a>
     </nav>
@@ -377,7 +377,7 @@
             `# Slim per-commit history (rolling ${manifest.artifacts.history.max_lines} lines)`,
             `curl ${manifest.artifacts.history.url}`,
             ``,
-            `# README comparison PNGs`,
+            `# README comparison JPGs`,
             `curl ${manifest.artifacts.comparison_rust.url}`,
             `curl ${manifest.artifacts.comparison_rust_c.url}`,
         ];

--- a/bench/index.html
+++ b/bench/index.html
@@ -88,10 +88,18 @@
         <a href="manifest.json">manifest.json</a>
         <a href="latest.json">latest.json</a>
         <a href="history.jsonl">history.jsonl</a>
+        <a href="benchmark-rust-only.png">benchmark-rust-only.png</a>
+        <a href="benchmark-rust-c.png">benchmark-rust-c.png</a>
         <a href="benchmark-trend.png">benchmark-trend.png</a>
         <a href="https://github.com/zackees/soldr/blob/main/PERF.md#per-commit-benchmark-stats-issue-768">methodology (PERF.md)</a>
     </nav>
     <div class="meta" id="header-meta">Loading…</div>
+
+    <h2>Latest comparison - Rust workload</h2>
+    <div class="chart-wrap"><canvas id="comparison-rust-only"></canvas></div>
+
+    <h2>Latest comparison - Rust+C workload</h2>
+    <div class="chart-wrap"><canvas id="comparison-rust-c"></canvas></div>
 
     <h2>Latest run — canaries vs theoretical</h2>
     <div class="summary" id="summary">Loading…</div>
@@ -120,6 +128,12 @@
         'cargo-check-medium-cross-verb':        '#f57c00',
         'touch-no-change-medium-warm':          '#7b1fa2',
         'worktree-share-medium-warm':           '#00838f',
+    };
+
+    const TOOL_COLORS = {
+        bare: '#d32f2f',
+        sccache: '#1976d2',
+        soldr: '#2da44e',
     };
 
     async function fetchJson(path) {
@@ -228,6 +242,87 @@
         });
     }
 
+    function renderComparisonChart(canvasId, latest, benchmark) {
+        const canvas = document.getElementById(canvasId);
+        const rows = (latest && latest.results || []).filter(row => row.benchmark === benchmark);
+        if (rows.length === 0) {
+            canvas.replaceWith(Object.assign(document.createElement('div'), {
+                className: 'empty',
+                textContent: 'No comparison rows yet.',
+            }));
+            return null;
+        }
+
+        const scenarioDefs = latest.comparison && latest.comparison.scenarios || [];
+        const toolDefs = latest.comparison && latest.comparison.tools || [];
+        const scenarios = scenarioDefs.map(item => item.key);
+        const tools = toolDefs.map(item => item.key);
+        const scenarioLabels = Object.fromEntries(scenarioDefs.map(item => [item.key, item.label]));
+        const toolLabels = Object.fromEntries(toolDefs.map(item => [item.key, item.label]));
+        const byKey = new Map(rows.map(row => [`${row.scenario_key}:${row.tool}`, row]));
+
+        const datasets = tools.map(tool => ({
+            label: toolLabels[tool] || tool,
+            data: scenarios.map(scenario => {
+                const row = byKey.get(`${scenario}:${tool}`);
+                return row && typeof row.wall_ms === 'number' && row.wall_ms > 0 ? row.wall_ms : null;
+            }),
+            backgroundColor: TOOL_COLORS[tool] || '#656d76',
+            borderColor: TOOL_COLORS[tool] || '#656d76',
+            borderWidth: 1,
+        }));
+
+        return new Chart(canvas.getContext('2d'), {
+            type: 'bar',
+            data: {
+                labels: scenarios.map(key => scenarioLabels[key] || key),
+                datasets,
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                animation: false,
+                interaction: { mode: 'index', intersect: false },
+                scales: {
+                    x: {
+                        title: { display: true, text: 'scenario' },
+                    },
+                    y: {
+                        type: 'logarithmic',
+                        title: { display: true, text: 'wall-time (ms, log scale)' },
+                    },
+                },
+                plugins: {
+                    legend: {
+                        position: 'top',
+                        labels: { boxWidth: 12, font: { size: 11 } },
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: (item) => {
+                                const scenario = scenarios[item.dataIndex];
+                                const tool = tools[item.datasetIndex];
+                                const row = byKey.get(`${scenario}:${tool}`);
+                                if (!row) return `${item.dataset.label}: no data`;
+                                return `${item.dataset.label}: ${row.wall_ms.toLocaleString()} ms - ${row.command}`;
+                            },
+                            afterBody: (items) => {
+                                if (!items.length) return '';
+                                const scenario = scenarios[items[0].dataIndex];
+                                const sccache = byKey.get(`${scenario}:sccache`);
+                                const soldr = byKey.get(`${scenario}:soldr`);
+                                if (!sccache || !soldr || !sccache.wall_ms || !soldr.wall_ms) return '';
+                                const ratio = sccache.wall_ms / soldr.wall_ms;
+                                if (ratio >= 1) return `soldr vs sccache: ${ratio.toFixed(ratio >= 10 ? 0 : 1)}x faster`;
+                                return `soldr vs sccache: ${(1 / ratio).toFixed(1)}x slower`;
+                            },
+                        },
+                    },
+                },
+            },
+        });
+    }
+
     function renderSummary(latest, manifestCanaries) {
         const root = document.getElementById('summary');
         root.innerHTML = '';
@@ -260,11 +355,13 @@
         const runUrl = latest && latest.metadata && latest.metadata.run_url;
         const soldr = latest && latest.metadata && latest.metadata.soldr_version;
         const rustc = latest && latest.metadata && latest.metadata.rustc_version;
+        const sccache = latest && latest.metadata && latest.metadata.sccache_version;
         const parts = [
             `Last run: <code>${shortSha(sha)}</code> at ${generatedAt}`,
         ];
         if (runUrl) parts.push(`<a href="${runUrl}" target="_blank" rel="noopener">workflow run</a>`);
         if (soldr) parts.push(`<code>${soldr}</code>`);
+        if (sccache) parts.push(`<code>${sccache}</code>`);
         if (rustc) parts.push(`<code>${rustc}</code>`);
         document.getElementById('header-meta').innerHTML = parts.join(' · ');
     }
@@ -279,6 +376,10 @@
             ``,
             `# Slim per-commit history (rolling ${manifest.artifacts.history.max_lines} lines)`,
             `curl ${manifest.artifacts.history.url}`,
+            ``,
+            `# README comparison PNGs`,
+            `curl ${manifest.artifacts.comparison_rust.url}`,
+            `curl ${manifest.artifacts.comparison_rust_c.url}`,
         ];
         document.getElementById('how-to-fetch').textContent = lines.join('\n');
     }
@@ -299,6 +400,8 @@
 
         const canaryNames = Object.keys(manifest.canaries);
         renderHeader(manifest, latest);
+        renderComparisonChart('comparison-rust-only', latest, 'rust-only');
+        renderComparisonChart('comparison-rust-c', latest, 'rust-c');
         renderSummary(latest, manifest.canaries);
         renderHowToFetch(manifest);
 

--- a/bench/render_comparison_bars.py
+++ b/bench/render_comparison_bars.py
@@ -1,151 +1,270 @@
 #!/usr/bin/env python3
-"""Render README-facing comparison bar charts from comparison.json.
+"""Render zccache-style dark README comparison charts.
 
 Reads:  ./benchmark-output/comparison.json
-Writes: ./benchmark-stats/benchmark-rust-only.png
-        ./benchmark-stats/benchmark-rust-c.png
+Writes: ./benchmark-stats/benchmark-rust-only.jpg
+        ./benchmark-stats/benchmark-rust-c.jpg
 """
 
+from __future__ import annotations
+
 import json
-import math
 import sys
-from collections import defaultdict
 from pathlib import Path
+from typing import Any
 
-import matplotlib
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError as exc:  # pragma: no cover - exercised in workflow setup
+    raise SystemExit(
+        "Pillow is required to render benchmark JPGs. Install python3-pil."
+    ) from exc
 
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INPUT = REPO_ROOT / "benchmark-output" / "comparison.json"
 OUT_DIR = REPO_ROOT / "benchmark-stats"
 
-TOOL_COLORS = {
-    "bare": "#d32f2f",
-    "sccache": "#1976d2",
-    "soldr": "#2da44e",
-}
-
 BENCHMARKS = {
     "rust-only": {
-        "title": "soldr vs sccache vs bare cargo - Rust workload",
-        "output": "benchmark-rust-only.png",
+        "title": "soldr Rust benchmarks",
+        "subtitle": "bare cargo vs sccache vs soldr",
+        "output": "benchmark-rust-only.jpg",
     },
     "rust-c": {
-        "title": "soldr vs sccache vs bare cargo - Rust+C workload",
-        "output": "benchmark-rust-c.png",
+        "title": "soldr Rust+C benchmarks",
+        "subtitle": "sqlite-link fixture",
+        "output": "benchmark-rust-c.jpg",
     },
 }
 
 SCENARIO_ORDER = ["cold", "warm", "worktree-share"]
 TOOL_ORDER = ["bare", "sccache", "soldr"]
+TOOL_COLORS = {
+    "bare": "#8b949e",
+    "sccache": "#79c0ff",
+    "soldr": "#f85149",
+}
+TOOL_DARK_COLORS = {
+    "bare": "#3b4046",
+    "sccache": "#1f3a7a",
+    "soldr": "#5b1f1c",
+}
 
 
-def load_comparison():
+def load_comparison() -> dict[str, Any]:
     with INPUT.open("r", encoding="utf-8-sig") as f:
         return json.load(f)
 
 
-def by_benchmark(rows):
-    grouped = defaultdict(dict)
-    for row in rows:
-        key = (row.get("benchmark"), row.get("scenario_key"), row.get("tool"))
-        grouped[key] = row
-    return grouped
+def font(size: int, bold: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    names = (
+        ("DejaVuSans-Bold.ttf", "Arial Bold.ttf") if bold else ("DejaVuSans.ttf", "Arial.ttf")
+    )
+    for name in names:
+        try:
+            return ImageFont.truetype(name, size)
+        except OSError:
+            pass
+    return ImageFont.load_default()
 
 
-def positive_or_none(value):
-    if isinstance(value, (int, float)) and value > 0:
+def hex_rgb(value: str) -> tuple[int, int, int]:
+    value = value.lstrip("#")
+    return tuple(int(value[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def text_width(draw: ImageDraw.ImageDraw, value: str, fnt: Any) -> int:
+    box = draw.textbbox((0, 0), value, font=fnt)
+    return int(box[2] - box[0])
+
+
+def truncate(draw: ImageDraw.ImageDraw, value: str, fnt: Any, max_width: int) -> str:
+    if text_width(draw, value, fnt) <= max_width:
         return value
-    return None
+    suffix = "..."
+    available = max(0, max_width - text_width(draw, suffix, fnt))
+    out = ""
+    for char in value:
+        if text_width(draw, out + char, fnt) > available:
+            break
+        out += char
+    return out.rstrip() + suffix
 
 
-def ratio_text(sccache_ms, soldr_ms):
-    sccache_ms = positive_or_none(sccache_ms)
-    soldr_ms = positive_or_none(soldr_ms)
-    if not sccache_ms or not soldr_ms:
-        return None
-    ratio = sccache_ms / soldr_ms
-    if ratio < 1:
-        return f"{1 / ratio:.1f}x slower"
-    if ratio >= 10:
-        return f"{ratio:.0f}x faster"
-    return f"{ratio:.1f}x faster"
+def seconds_label(ms: Any) -> str:
+    if not isinstance(ms, (int, float)) or ms <= 0:
+        return "n/a"
+    seconds = ms / 1000.0
+    if seconds < 1:
+        return f"{ms:.0f}ms"
+    return f"{seconds:.3f}s"
 
 
-def render_chart(doc, benchmark, grouped):
-    meta = BENCHMARKS[benchmark]
-    scenarios = {item["key"]: item["label"] for item in doc.get("scenarios", [])}
-    tools = {item["key"]: item["label"] for item in doc.get("tools", [])}
+def speedup_label(rows_by_key: dict[tuple[str, str, str], dict[str, Any]], benchmark: str, scenario: str) -> str:
+    sccache = rows_by_key.get((benchmark, scenario, "sccache"), {}).get("wall_ms")
+    soldr = rows_by_key.get((benchmark, scenario, "soldr"), {}).get("wall_ms")
+    if not isinstance(sccache, (int, float)) or not isinstance(soldr, (int, float)):
+        return ""
+    if sccache <= 0 or soldr <= 0:
+        return ""
+    ratio = sccache / soldr
+    if ratio >= 1:
+        return f"soldr {ratio:.1f}x faster than sccache"
+    return f"soldr {(1 / ratio):.1f}x slower than sccache"
 
-    fig, ax = plt.subplots(figsize=(9.2, 4.8))
-    group_width = 0.72
-    bar_width = group_width / len(TOOL_ORDER)
-    x_positions = list(range(len(SCENARIO_ORDER)))
 
-    max_y = 1
-    for tool_idx, tool in enumerate(TOOL_ORDER):
-        xs = [x - group_width / 2 + bar_width / 2 + tool_idx * bar_width for x in x_positions]
-        ys = []
-        for scenario in SCENARIO_ORDER:
-            row = grouped.get((benchmark, scenario, tool), {})
-            value = positive_or_none(row.get("wall_ms"))
-            ys.append(value)
-            if value:
-                max_y = max(max_y, value)
-        ax.bar(
-            xs,
-            [value or math.nan for value in ys],
-            width=bar_width * 0.92,
-            label=tools.get(tool, tool),
-            color=TOOL_COLORS.get(tool, "#656d76"),
+def render_benchmark(doc: dict[str, Any], benchmark: str) -> Path:
+    rows = [row for row in doc.get("results", []) if row.get("benchmark") == benchmark]
+    rows_by_key = {
+        (row.get("benchmark"), row.get("scenario_key"), row.get("tool")): row
+        for row in rows
+    }
+    scenario_labels = {item["key"]: item["label"] for item in doc.get("scenarios", [])}
+    tool_labels = {item["key"]: item["label"] for item in doc.get("tools", [])}
+
+    scale = 3
+    width = 900
+    margin = 20
+    header_h = 116
+    legend_h = 36
+    scenario_h = 182
+    scenario_gap = 14
+    footer_h = 50
+    height = header_h + legend_h + (scenario_h + scenario_gap) * len(SCENARIO_ORDER) - scenario_gap + footer_h
+
+    image = Image.new("RGB", (width * scale, height * scale), hex_rgb("#0d1117"))
+    draw = ImageDraw.Draw(image)
+
+    title_font = font(32 * scale, bold=True)
+    subtitle_font = font(14 * scale)
+    scenario_font = font(20 * scale, bold=True)
+    tool_font = font(16 * scale, bold=True)
+    value_font = font(15 * scale, bold=True)
+    small_font = font(13 * scale)
+
+    def xy(x: int, y: int) -> tuple[int, int]:
+        return x * scale, y * scale
+
+    def rect(values: tuple[int, int, int, int], fill: str, outline: str | None = None, width_px: int = 1) -> None:
+        draw.rectangle(
+            tuple(v * scale for v in values),
+            fill=hex_rgb(fill),
+            outline=hex_rgb(outline) if outline else None,
+            width=width_px * scale,
         )
 
+    meta = BENCHMARKS[benchmark]
+    rect((0, 0, width, header_h), "#161b22")
+    draw.text(xy(margin, 22), meta["title"], font=title_font, fill=hex_rgb("#f0f6fc"))
+    generated = doc.get("ran_at", "unknown")
+    versions = " | ".join(
+        part
+        for part in (
+            doc.get("soldr_version"),
+            doc.get("sccache_version"),
+            doc.get("rustc_version"),
+        )
+        if part
+    )
+    header_line = f"{meta['subtitle']} | generated {generated}"
+    draw.text(xy(margin, 70), truncate(draw, header_line, subtitle_font, (width - margin * 2) * scale), font=subtitle_font, fill=hex_rgb("#8b949e"))
+    draw.text(xy(margin, 92), truncate(draw, versions, subtitle_font, (width - margin * 2) * scale), font=subtitle_font, fill=hex_rgb("#8b949e"))
+
+    legend_y = header_h + 10
+    legend_x = margin
+    for tool in TOOL_ORDER:
+        rect((legend_x, legend_y + 3, legend_x + 28, legend_y + 17), TOOL_COLORS[tool])
+        draw.text(
+            xy(legend_x + 36, legend_y),
+            tool_labels.get(tool, tool),
+            font=small_font,
+            fill=hex_rgb("#c9d1d9"),
+        )
+        legend_x += 170
+
+    chart_x = margin
+    chart_w = width - margin * 2
+    label_w = 150
+    value_w = 130
+    bar_x0 = chart_x + label_w
+    bar_x1 = chart_x + chart_w - value_w
+    bar_w = bar_x1 - bar_x0
+
+    y = header_h + legend_h
     for idx, scenario in enumerate(SCENARIO_ORDER):
-        sccache = grouped.get((benchmark, scenario, "sccache"), {}).get("wall_ms")
-        soldr = grouped.get((benchmark, scenario, "soldr"), {}).get("wall_ms")
-        label = ratio_text(sccache, soldr)
-        soldr_value = positive_or_none(soldr)
-        if label and soldr_value:
-            soldr_x = idx - group_width / 2 + bar_width / 2 + TOOL_ORDER.index("soldr") * bar_width
-            ax.annotate(
-                label,
-                xy=(soldr_x, soldr_value),
-                xytext=(0, 7),
-                textcoords="offset points",
-                ha="center",
-                va="bottom",
-                fontsize=8,
-                color=TOOL_COLORS["soldr"],
-                fontweight="bold",
+        fill = "#0f1620" if idx % 2 == 0 else "#11202d"
+        rect((chart_x, y, chart_x + chart_w, y + scenario_h), fill)
+        title = scenario_labels.get(scenario, scenario)
+        draw.text(xy(chart_x + 16, y + 14), title, font=scenario_font, fill=hex_rgb("#f0f6fc"))
+        speedup = speedup_label(rows_by_key, benchmark, scenario)
+        if speedup:
+            speedup_w = text_width(draw, speedup, subtitle_font) // scale
+            draw.text(
+                xy(chart_x + chart_w - 16 - speedup_w, y + 20),
+                speedup,
+                font=subtitle_font,
+                fill=hex_rgb("#f85149"),
             )
 
-    ax.set_yscale("log")
-    ax.set_ylabel("wall time (ms, log scale)")
-    ax.set_title(meta["title"])
-    ax.set_xticks(x_positions)
-    ax.set_xticklabels([scenarios.get(key, key) for key in SCENARIO_ORDER], rotation=8, ha="right")
-    ax.grid(True, which="major", axis="y", linestyle="-", linewidth=0.4, alpha=0.45)
-    ax.grid(True, which="minor", axis="y", linestyle=":", linewidth=0.3, alpha=0.35)
-    ax.legend(loc="upper right", fontsize=9)
-    ax.set_ylim(bottom=1, top=max_y * 5)
-    fig.tight_layout()
-    output = OUT_DIR / meta["output"]
-    fig.savefig(output, dpi=130)
-    plt.close(fig)
-    print(f"render: wrote {output}", file=sys.stderr)
+        values = []
+        for tool in TOOL_ORDER:
+            value = rows_by_key.get((benchmark, scenario, tool), {}).get("wall_ms")
+            if isinstance(value, (int, float)) and value > 0:
+                values.append(float(value))
+        max_value = max(values) if values else 1.0
 
+        row_y = y + 58
+        for tool in TOOL_ORDER:
+            row = rows_by_key.get((benchmark, scenario, tool), {})
+            value = row.get("wall_ms")
+            label = tool_labels.get(tool, tool)
+            color = TOOL_COLORS[tool]
+            dark = TOOL_DARK_COLORS[tool]
 
-def main():
+            draw.text(xy(chart_x + 16, row_y + 11), label, font=tool_font, fill=hex_rgb(color))
+            track_y0 = row_y + 14
+            rect((bar_x0, track_y0, bar_x1, track_y0 + 16), "#21262d")
+            if isinstance(value, (int, float)) and value > 0:
+                width_fraction = max(0.015, min(1.0, float(value) / max_value))
+                bar_end = bar_x0 + int(bar_w * width_fraction)
+                rect((bar_x0, track_y0, bar_end, track_y0 + 16), dark)
+                rect((bar_x0, track_y0 + 4, bar_end, track_y0 + 12), color)
+            draw.text(
+                xy(bar_x1 + 12, row_y + 8),
+                seconds_label(value),
+                font=value_font,
+                fill=hex_rgb(color),
+            )
+            row_y += 36
+
+        draw.line(
+            (xy(chart_x + 16, y + scenario_h - 1), xy(chart_x + chart_w - 16, y + scenario_h - 1)),
+            fill=hex_rgb("#30363d"),
+            width=scale,
+        )
+        y += scenario_h + scenario_gap
+
+    footer = "Artifacts: latest.json, benchmark-rust-only.jpg, benchmark-rust-c.jpg"
+    draw.line((xy(margin, height - 34), xy(width - margin, height - 34)), fill=hex_rgb("#30363d"), width=scale)
+    draw.text(xy(margin, height - 25), footer, font=small_font, fill=hex_rgb("#8b949e"))
+
+    resampling = getattr(Image, "Resampling", Image).LANCZOS
+    image = image.resize((width, height), resampling)
     OUT_DIR.mkdir(parents=True, exist_ok=True)
+    output = OUT_DIR / meta["output"]
+    image.save(output, format="JPEG", quality=90, optimize=True)
+    return output
+
+
+def main() -> int:
     if not INPUT.exists():
         print(f"render: missing {INPUT}", file=sys.stderr)
         return 1
     doc = load_comparison()
-    grouped = by_benchmark(doc.get("results", []))
     for benchmark in BENCHMARKS:
-        render_chart(doc, benchmark, grouped)
+        output = render_benchmark(doc, benchmark)
+        print(f"render: wrote {output}", file=sys.stderr)
     return 0
 
 

--- a/bench/render_comparison_bars.py
+++ b/bench/render_comparison_bars.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Render README-facing comparison bar charts from comparison.json.
+
+Reads:  ./benchmark-output/comparison.json
+Writes: ./benchmark-stats/benchmark-rust-only.png
+        ./benchmark-stats/benchmark-rust-c.png
+"""
+
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INPUT = REPO_ROOT / "benchmark-output" / "comparison.json"
+OUT_DIR = REPO_ROOT / "benchmark-stats"
+
+TOOL_COLORS = {
+    "bare": "#d32f2f",
+    "sccache": "#1976d2",
+    "soldr": "#2da44e",
+}
+
+BENCHMARKS = {
+    "rust-only": {
+        "title": "soldr vs sccache vs bare cargo - Rust workload",
+        "output": "benchmark-rust-only.png",
+    },
+    "rust-c": {
+        "title": "soldr vs sccache vs bare cargo - Rust+C workload",
+        "output": "benchmark-rust-c.png",
+    },
+}
+
+SCENARIO_ORDER = ["cold", "warm", "worktree-share"]
+TOOL_ORDER = ["bare", "sccache", "soldr"]
+
+
+def load_comparison():
+    with INPUT.open("r", encoding="utf-8-sig") as f:
+        return json.load(f)
+
+
+def by_benchmark(rows):
+    grouped = defaultdict(dict)
+    for row in rows:
+        key = (row.get("benchmark"), row.get("scenario_key"), row.get("tool"))
+        grouped[key] = row
+    return grouped
+
+
+def positive_or_none(value):
+    if isinstance(value, (int, float)) and value > 0:
+        return value
+    return None
+
+
+def ratio_text(sccache_ms, soldr_ms):
+    sccache_ms = positive_or_none(sccache_ms)
+    soldr_ms = positive_or_none(soldr_ms)
+    if not sccache_ms or not soldr_ms:
+        return None
+    ratio = sccache_ms / soldr_ms
+    if ratio < 1:
+        return f"{1 / ratio:.1f}x slower"
+    if ratio >= 10:
+        return f"{ratio:.0f}x faster"
+    return f"{ratio:.1f}x faster"
+
+
+def render_chart(doc, benchmark, grouped):
+    meta = BENCHMARKS[benchmark]
+    scenarios = {item["key"]: item["label"] for item in doc.get("scenarios", [])}
+    tools = {item["key"]: item["label"] for item in doc.get("tools", [])}
+
+    fig, ax = plt.subplots(figsize=(9.2, 4.8))
+    group_width = 0.72
+    bar_width = group_width / len(TOOL_ORDER)
+    x_positions = list(range(len(SCENARIO_ORDER)))
+
+    max_y = 1
+    for tool_idx, tool in enumerate(TOOL_ORDER):
+        xs = [x - group_width / 2 + bar_width / 2 + tool_idx * bar_width for x in x_positions]
+        ys = []
+        for scenario in SCENARIO_ORDER:
+            row = grouped.get((benchmark, scenario, tool), {})
+            value = positive_or_none(row.get("wall_ms"))
+            ys.append(value)
+            if value:
+                max_y = max(max_y, value)
+        ax.bar(
+            xs,
+            [value or math.nan for value in ys],
+            width=bar_width * 0.92,
+            label=tools.get(tool, tool),
+            color=TOOL_COLORS.get(tool, "#656d76"),
+        )
+
+    for idx, scenario in enumerate(SCENARIO_ORDER):
+        sccache = grouped.get((benchmark, scenario, "sccache"), {}).get("wall_ms")
+        soldr = grouped.get((benchmark, scenario, "soldr"), {}).get("wall_ms")
+        label = ratio_text(sccache, soldr)
+        soldr_value = positive_or_none(soldr)
+        if label and soldr_value:
+            soldr_x = idx - group_width / 2 + bar_width / 2 + TOOL_ORDER.index("soldr") * bar_width
+            ax.annotate(
+                label,
+                xy=(soldr_x, soldr_value),
+                xytext=(0, 7),
+                textcoords="offset points",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color=TOOL_COLORS["soldr"],
+                fontweight="bold",
+            )
+
+    ax.set_yscale("log")
+    ax.set_ylabel("wall time (ms, log scale)")
+    ax.set_title(meta["title"])
+    ax.set_xticks(x_positions)
+    ax.set_xticklabels([scenarios.get(key, key) for key in SCENARIO_ORDER], rotation=8, ha="right")
+    ax.grid(True, which="major", axis="y", linestyle="-", linewidth=0.4, alpha=0.45)
+    ax.grid(True, which="minor", axis="y", linestyle=":", linewidth=0.3, alpha=0.35)
+    ax.legend(loc="upper right", fontsize=9)
+    ax.set_ylim(bottom=1, top=max_y * 5)
+    fig.tight_layout()
+    output = OUT_DIR / meta["output"]
+    fig.savefig(output, dpi=130)
+    plt.close(fig)
+    print(f"render: wrote {output}", file=sys.stderr)
+
+
+def main():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    if not INPUT.exists():
+        print(f"render: missing {INPUT}", file=sys.stderr)
+        return 1
+    doc = load_comparison()
+    grouped = by_benchmark(doc.get("results", []))
+    for benchmark in BENCHMARKS:
+        render_chart(doc, benchmark, grouped)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/run_comparison.sh
+++ b/bench/run_comparison.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Runs the README-facing bare cargo vs sccache vs soldr comparison
+# benchmarks and emits benchmark-output/comparison.json.
+
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${HERE}/.." && pwd)"
+
+OUT_DIR="${REPO_ROOT}/benchmark-output"
+WORK_DIR="$(mktemp -d)"
+WORKTREES_TO_REMOVE=()
+CREATED_PROJECT=""
+trap 'for wt in "${WORKTREES_TO_REMOVE[@]:-}"; do git -C "${REPO_ROOT}" worktree remove --force "$wt" >/dev/null 2>&1 || true; done; rm -rf "${WORK_DIR}"' EXIT
+
+mkdir -p "${OUT_DIR}"
+
+# Keep setup-soldr's toolchain/PATH benefits, but remove workspace-pinned
+# cache state so each comparison cell owns its cache and target dirs.
+unset ZCCACHE_CACHE_DIR \
+      SCCACHE_DIR \
+      RUSTC_WRAPPER \
+      SOLDR_RUSTC_WRAPPER \
+      SOLDR_TARGET_CACHE_DIR \
+      SOLDR_TARGET_CACHE_BUNDLE_DIR \
+      SOLDR_TARGET_CACHE_MODE \
+      SOLDR_TARGET_CACHE_PROFILE \
+      SOLDR_TARGET_CACHE_BACKEND \
+      SOLDR_TARGET_CACHE_COMPRESS \
+      SOLDR_TARGET_CACHE_COMPRESS_LEVEL \
+      SOLDR_TARGET_REGISTRY_RECORDED \
+      SOLDR_BUILD_CACHE_MODE \
+      SETUP_SOLDR_BUILD_CACHE_MODE
+
+now_ms() { date +%s%3N; }
+
+elapsed_ms() {
+    local start="$1"
+    local end
+    end="$(now_ms)"
+    echo "$(( end - start ))"
+}
+
+json_escape() {
+    jq -Rn --arg v "$1" '$v'
+}
+
+append_result() {
+    local benchmark="$1"
+    local fixture="$2"
+    local scenario_key="$3"
+    local scenario="$4"
+    local mode="$5"
+    local tool="$6"
+    local tool_label="$7"
+    local command_text="$8"
+    local wall_ms="$9"
+    local project_path="${10}"
+
+    cat >>"${RESULTS_JSONL}" <<EOF
+{"benchmark":$(json_escape "$benchmark"),"fixture":$(json_escape "$fixture"),"scenario_key":$(json_escape "$scenario_key"),"scenario":$(json_escape "$scenario"),"mode":$(json_escape "$mode"),"tool":$(json_escape "$tool"),"tool_label":$(json_escape "$tool_label"),"command":$(json_escape "$command_text"),"wall_ms":${wall_ms},"project_path":$(json_escape "$project_path")}
+EOF
+}
+
+run_logged() {
+    local label="$1"
+    shift
+    echo "+ $label" >&2
+    "$@" >&2
+}
+
+measure_command() {
+    local label="$1"
+    shift
+    local t0 rc elapsed
+    echo "::group::comparison ${label}" >&2
+    echo "+ $*" >&2
+    t0="$(now_ms)"
+    set +e
+    "$@" >&2
+    rc=$?
+    set -e
+    elapsed="$(elapsed_ms "${t0}")"
+    if (( rc == 0 )); then
+        echo "comparison ${label}: ok (${elapsed} ms)" >&2
+        echo "::endgroup::" >&2
+        echo "${elapsed}"
+    else
+        echo "comparison ${label}: FAILED (rc=${rc}, ${elapsed} ms) - recording 0" >&2
+        echo "::endgroup::" >&2
+        echo "0"
+    fi
+}
+
+median_ms() {
+    printf '%s\n' "$@" | sort -n | awk 'NF { values[NR] = $1 } END { if (NR == 0) print 0; else print values[int((NR + 1) / 2)] }'
+}
+
+make_fixture_project() {
+    local fixture="$1"
+    local dest="$2"
+    mkdir -p "${dest}"
+    if [[ "${fixture}" == "soldr" ]]; then
+        git -C "${REPO_ROOT}" worktree add --detach "${dest}/soldr" HEAD >/dev/null
+        WORKTREES_TO_REMOVE+=("${dest}/soldr")
+        CREATED_PROJECT="${dest}/soldr"
+    else
+        bash "${REPO_ROOT}/perf/lib/extract.sh" "${fixture}" "${dest}" >/dev/null
+        CREATED_PROJECT="${dest}/${fixture}"
+    fi
+}
+
+tool_label() {
+    case "$1" in
+        bare) echo "Bare cargo" ;;
+        sccache) echo "sccache" ;;
+        soldr) echo "soldr" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+command_text() {
+    case "$1" in
+        bare) echo "cargo build --release --locked" ;;
+        sccache) echo "RUSTC_WRAPPER=sccache cargo build --release --locked" ;;
+        soldr) echo "soldr cargo build --release --locked" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+run_build() {
+    local tool="$1"
+    local project="$2"
+    local cache_dir="$3"
+    local target_dir="$4"
+    case "${tool}" in
+        bare)
+            (cd "${project}" && CARGO_TARGET_DIR="${target_dir}" cargo build --release --locked)
+            ;;
+        sccache)
+            mkdir -p "${cache_dir}"
+            (cd "${project}" && SCCACHE_DIR="${cache_dir}" RUSTC_WRAPPER=sccache CARGO_TARGET_DIR="${target_dir}" cargo build --release --locked)
+            ;;
+        soldr)
+            mkdir -p "${cache_dir}"
+            (cd "${project}" && SOLDR_CACHE_DIR="${cache_dir}" CARGO_TARGET_DIR="${target_dir}" soldr cargo build --release --locked)
+            ;;
+        *)
+            echo "unknown tool: ${tool}" >&2
+            return 2
+            ;;
+    esac
+}
+
+clean_project() {
+    local project="$1"
+    local target_dir="$2"
+    (cd "${project}" && CARGO_TARGET_DIR="${target_dir}" cargo clean >/dev/null 2>&1 || true)
+    rm -rf "${target_dir}"
+}
+
+measure_cold() {
+    local benchmark="$1"
+    local fixture="$2"
+    local tool="$3"
+    local samples=()
+    for idx in 1 2 3; do
+        local cell="${WORK_DIR}/${benchmark}/cold/${tool}/${idx}"
+        local project cache target ms
+        make_fixture_project "${fixture}" "${cell}/src"
+        project="${CREATED_PROJECT}"
+        cache="${cell}/cache"
+        target="${cell}/target"
+        ms="$(measure_command "${benchmark} cold ${tool} sample ${idx}" run_build "${tool}" "${project}" "${cache}" "${target}")"
+        samples+=("${ms}")
+    done
+    median_ms "${samples[@]}"
+}
+
+measure_warm() {
+    local benchmark="$1"
+    local fixture="$2"
+    local tool="$3"
+    local cell="${WORK_DIR}/${benchmark}/warm/${tool}"
+    local project cache target
+    make_fixture_project "${fixture}" "${cell}/src"
+    project="${CREATED_PROJECT}"
+    cache="${cell}/cache"
+    target="${cell}/target"
+    run_logged "${benchmark} warm ${tool} populate" run_build "${tool}" "${project}" "${cache}" "${target}"
+    clean_project "${project}" "${target}"
+    measure_command "${benchmark} warm ${tool}" run_build "${tool}" "${project}" "${cache}" "${target}"
+}
+
+measure_worktree_share() {
+    local benchmark="$1"
+    local fixture="$2"
+    local tool="$3"
+    local cell="${WORK_DIR}/${benchmark}/worktree-share/${tool}"
+    local project_a project_b cache target_a target_b
+    make_fixture_project "${fixture}" "${cell}/src-a"
+    project_a="${CREATED_PROJECT}"
+    make_fixture_project "${fixture}" "${cell}/src-b"
+    project_b="${CREATED_PROJECT}"
+    cache="${cell}/cache"
+    target_a="${cell}/target-a"
+    target_b="${cell}/target-b"
+    run_logged "${benchmark} worktree-share ${tool} populate A" run_build "${tool}" "${project_a}" "${cache}" "${target_a}"
+    measure_command "${benchmark} worktree-share ${tool} build B" run_build "${tool}" "${project_b}" "${cache}" "${target_b}"
+}
+
+RESULTS_JSONL="${WORK_DIR}/comparison-results.jsonl"
+: >"${RESULTS_JSONL}"
+
+declare -A FIXTURES=(
+    ["rust-only"]="soldr"
+    ["rust-c"]="sqlite-link"
+)
+
+for benchmark in rust-only rust-c; do
+    fixture="${FIXTURES[${benchmark}]}"
+    for tool in bare sccache soldr; do
+        label="$(tool_label "${tool}")"
+        command="$(command_text "${tool}")"
+
+        ms="$(measure_cold "${benchmark}" "${fixture}" "${tool}")"
+        append_result "${benchmark}" "${fixture}" "cold" "Cold build" "cold" "${tool}" "${label}" "${command}" "${ms}" "median-of-3"
+
+        ms="$(measure_warm "${benchmark}" "${fixture}" "${tool}")"
+        append_result "${benchmark}" "${fixture}" "warm" "Warm rebuild (same workspace)" "warm" "${tool}" "${label}" "${command}" "${ms}" "single-sample"
+
+        ms="$(measure_worktree_share "${benchmark}" "${fixture}" "${tool}")"
+        append_result "${benchmark}" "${fixture}" "worktree-share" "Agent worktree / parent-child share" "worktree-share" "${tool}" "${label}" "${command}" "${ms}" "single-sample"
+    done
+done
+
+ran_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+soldr_version="$(soldr --version 2>/dev/null || echo unknown)"
+rustc_version="$(rustc --version 2>/dev/null || echo unknown)"
+sccache_version="$(sccache --version 2>/dev/null || echo unknown)"
+
+jq -s \
+    --arg ran_at "${ran_at}" \
+    --arg soldr_version "${soldr_version}" \
+    --arg rustc_version "${rustc_version}" \
+    --arg sccache_version "${sccache_version}" \
+    '{
+        ran_at: $ran_at,
+        soldr_version: $soldr_version,
+        rustc_version: $rustc_version,
+        sccache_version: $sccache_version,
+        schema_version: 1,
+        scenarios: [
+            {key: "cold", label: "Cold build", samples: 3},
+            {key: "warm", label: "Warm rebuild (same workspace)", samples: 1},
+            {key: "worktree-share", label: "Agent worktree / parent-child share", samples: 1}
+        ],
+        tools: [
+            {key: "bare", label: "Bare cargo"},
+            {key: "sccache", label: "sccache"},
+            {key: "soldr", label: "soldr"}
+        ],
+        results: .
+    }' "${RESULTS_JSONL}" >"${OUT_DIR}/comparison.json"
+
+echo "comparison.json written to ${OUT_DIR}/comparison.json" >&2
+cat "${OUT_DIR}/comparison.json" >&2


### PR DESCRIPTION
## Summary
- add a benchmark comparison runner for bare cargo vs sccache vs soldr across rust-only and Rust+C workloads
- publish comparison rows into latest.json, expose comparison JPGs in manifest.json, and render zccache-style dark README benchmark images
- update README, PERF.md, and Pages to show comparison bars above the historical trend view while keeping the trend artifact for deep-dive use

Closes #785
Closes #790

## Tests
- bash -n bench/run_comparison.sh; bash -n bench/assemble_benchmark_stats.sh; bash -n bench/run_canaries.sh
- uv run --no-sync --with pillow python -m py_compile bench/render_comparison_bars.py
- git diff --check
- synthetic benchmark-output assemble/render smoke test for latest.json, manifest.json, and comparison JPG generation
- visual inspection of synthetic benchmark-rust-only.jpg