### PR TITLE
docs: fix README performance image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Third-party comparison (soldr vs Swatinem/rust-cache vs ...): published from `za
 
 ## Performance
 
-[![soldr vs sccache vs bare cargo - Rust workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-only.jpg)](https://zackees.github.io/soldr/)
-[![soldr vs sccache vs bare cargo - Rust+C workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-c.jpg)](https://zackees.github.io/soldr/)
+[![soldr local-build canary trend](https://zackees.github.io/soldr/benchmark-trend.png)](https://zackees.github.io/soldr/)
 
 *[performance details](https://zackees.github.io/soldr/)*
 


### PR DESCRIPTION
## Summary

- replace the README performance images that pointed at missing benchmark-stats JPG artifacts
- use the live GitHub Pages-hosted benchmark image URL instead
- keep the image click-through and performance details link pointed at https://zackees.github.io/soldr/

## Validation

- confirmed the old JPG image URLs returned 404
- confirmed https://zackees.github.io/soldr/benchmark-trend.png returns 200 OK as image/png
- ran git diff --check