### PR TITLE
ci: skip expensive workflows for docs-only changes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,6 +9,8 @@ GitHub Actions workflow definitions.
 
 Normal build/test workflows use `zackees/setup-soldr` for Rust build acceleration, excluding `release-auto.yml`. Jobs that build soldr before running soldr self-tests or bootstrap tests stop the setup-soldr builder daemon before the test phase, run the test phase with a fresh `SOLDR_CACHE_DIR` / `ZCCACHE_CACHE_DIR`, and request `SOLDR_CACHE_LIFECYCLE=command` for the isolated test cache when supported by soldr.
 
+Docs-only changes should not trigger expensive build, lint, benchmark, or setup-soldr dogfood workflows. When a workflow needs to ignore Markdown, include both `*.md` and `**/*.md`; the root-only pattern does not cover files under `docs/`, `perf/`, or other subdirectories.
+
 Exceptions:
 
 - **release-auto.yml** remains conservative and keeps its existing release artifact build path.

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - '**/*.md'
 
 concurrency:
   # Only one publish at a time per ref; cancel a stale in-flight when a

--- a/.github/workflows/build-linux-arm64-musl.yml
+++ b/.github/workflows/build-linux-arm64-musl.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "*.md"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "*.md"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-linux-x64-musl.yml
+++ b/.github/workflows/build-linux-x64-musl.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "*.md"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-linux-x64.yml
+++ b/.github/workflows/build-linux-x64.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "*.md"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "*.md"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -7,6 +7,7 @@ on:
       - release
     paths-ignore:
       - "*.md"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "*.md"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-windows-x64.yml
+++ b/.github/workflows/build-windows-x64.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "*.md"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - '*'
     paths-ignore:
       - '*.md'
+      - '**/*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -3,8 +3,6 @@ name: Setup Soldr Action
 on:
   pull_request:
     paths:
-      - README.md
-      - INTEGRATION.md
       - action.yml
       - install.sh
       - rust-toolchain.toml
@@ -21,8 +19,6 @@ on:
     branches:
       - main
     paths:
-      - README.md
-      - INTEGRATION.md
       - action.yml
       - install.sh
       - rust-toolchain.toml


### PR DESCRIPTION
## Summary
- expand Markdown path ignores from root-only \*.md\ to include nested \**/*.md\ for CI and standalone platform build workflows
- skip benchmark-stats on docs-only main pushes
- stop setup-soldr dogfood checks from running for README/INTEGRATION-only edits
- document the docs-only workflow filter convention in .github/workflows/README.md

## Tests
- actionlint
- uv run --no-sync --with pyyaml python - < workflow YAML parse smoke test
- git diff --check