### PR TITLE
fix: restore README benchmark snapshots

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -82,7 +82,7 @@ jobs:
         run: python3 bench/render_comparison_bars.py
 
       - name: Publish to benchmark-stats branch
-        if: ${{ success() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        if: ${{ success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         working-directory: soldr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -91,11 +91,11 @@ jobs:
         run: bash bench/publish_benchmark_stats.sh
 
       - name: Configure Pages
-        if: ${{ success() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        if: ${{ success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload Pages artifact
-        if: ${{ success() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        if: ${{ success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: soldr/benchmark-stats
@@ -112,7 +112,7 @@ jobs:
   deploy-pages:
     name: Deploy benchmark page
     needs: benchmark
-    if: ${{ needs.benchmark.result == 'success' && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    if: ${{ needs.benchmark.result == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-24.04
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Third-party comparison (soldr vs Swatinem/rust-cache vs ...): published from `za
 
 ## Performance
 
-[![soldr local-build canary trend](https://zackees.github.io/soldr/benchmark-trend.png)](https://zackees.github.io/soldr/)
+[![soldr vs sccache vs bare cargo - Rust workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-only.jpg)](https://zackees.github.io/soldr/)
+[![soldr vs sccache vs bare cargo - Rust+C workload](https://raw.githubusercontent.com/zackees/soldr/benchmark-stats/benchmark-rust-c.jpg)](https://zackees.github.io/soldr/)
 
 *[performance details](https://zackees.github.io/soldr/)*
 


### PR DESCRIPTION
## Summary

- restore README embeds for the two zccache-style benchmark snapshot JPGs
- keep both image click targets pointed at https://zackees.github.io/soldr/
- allow benchmark-stats workflow_dispatch runs on main to publish benchmark-stats and deploy Pages, so the public orphan branch can be repopulated on demand

Closes #794

## Validation

- actionlint .github/workflows/benchmark-stats.yml
- python -m py_compile bench/render_comparison_bars.py
- python bench/render_comparison_bars.py with synthetic comparison.json, producing benchmark-rust-only.jpg and benchmark-rust-c.jpg
- bash -n bench/run_comparison.sh
- bash -n bench/assemble_benchmark_stats.sh
- bash -n bench/publish_benchmark_stats.sh
- git diff --check