### PR TITLE
feat: default to fresh soldr workspace env

### DIFF
--- a/bench/run_canaries.sh
+++ b/bench/run_canaries.sh
@@ -32,38 +32,9 @@ trap 'rm -rf "${WORK_DIR}"' EXIT
 
 mkdir -p "${OUT_DIR}"
 
-# Issue #778: setup-soldr exports a fleet of env vars that pin soldr's
-# behavior to the soldr workspace it was set up for
-# (`<runner>/soldr/soldr/soldr`). When the canary script cd's to the
-# medium fixture, those env vars cross-talk:
-#   - ZCCACHE_CACHE_DIR is pinned to setup-soldr's tempdir, but we
-#     override SOLDR_CACHE_DIR below — soldr passes our SOLDR_CACHE_DIR
-#     to zccache while zccache sees the old ZCCACHE_CACHE_DIR and the
-#     two disagree.
-#   - SOLDR_TARGET_CACHE_DIR / _BUNDLE_DIR / _REGISTRY_RECORDED point
-#     at paths under setup-soldr's tempdir; the medium fixture has its
-#     own target/ in a totally unrelated place.
-#   - SETUP_SOLDR_* / SOLDR_BUILD_CACHE_MODE / SOLDR_TARGET_CACHE_MODE
-#     are setup-soldr bookkeeping; safe to strip.
-#
-# KEEP: PATH (soldr lives there), RUSTUP_HOME / RUSTUP_TOOLCHAIN /
-# CARGO_HOME (toolchain), SOLDR_BINARY (alternate binary resolution),
-# SOLDR_LINKER, ZCCACHE_COMPILE_PRIORITY (useful, not workspace-pinned).
-#
-# This keeps setup-soldr's fast-build benefits for the soldr binary
-# itself (which was built earlier in the workflow's setup phase) while
-# letting the canaries run as if from a clean shell.
-unset ZCCACHE_CACHE_DIR \
-      SOLDR_TARGET_CACHE_DIR \
-      SOLDR_TARGET_CACHE_BUNDLE_DIR \
-      SOLDR_TARGET_CACHE_MODE \
-      SOLDR_TARGET_CACHE_PROFILE \
-      SOLDR_TARGET_CACHE_BACKEND \
-      SOLDR_TARGET_CACHE_COMPRESS \
-      SOLDR_TARGET_CACHE_COMPRESS_LEVEL \
-      SOLDR_TARGET_REGISTRY_RECORDED \
-      SOLDR_BUILD_CACHE_MODE \
-      SETUP_SOLDR_BUILD_CACHE_MODE
+# Issue #797: soldr cargo resolves a fresh soldr workspace context by
+# default, so canaries do not maintain their own soldr/zccache env
+# allowlist.
 
 # Single private cache for the whole canary sweep. Every canary writes
 # to the same daemon so warm-cache measurements are meaningful.

--- a/bench/run_comparison.sh
+++ b/bench/run_comparison.sh
@@ -15,22 +15,11 @@ trap 'for wt in "${WORKTREES_TO_REMOVE[@]:-}"; do git -C "${REPO_ROOT}" worktree
 
 mkdir -p "${OUT_DIR}"
 
-# Keep setup-soldr's toolchain/PATH benefits, but remove workspace-pinned
-# cache state so each comparison cell owns its cache and target dirs.
-unset ZCCACHE_CACHE_DIR \
-      SCCACHE_DIR \
+# Keep wrapper-specific env out of the comparison cells. soldr/zccache
+# workspace-state env is handled inside soldr cargo by default (#797).
+unset SCCACHE_DIR \
       RUSTC_WRAPPER \
-      SOLDR_RUSTC_WRAPPER \
-      SOLDR_TARGET_CACHE_DIR \
-      SOLDR_TARGET_CACHE_BUNDLE_DIR \
-      SOLDR_TARGET_CACHE_MODE \
-      SOLDR_TARGET_CACHE_PROFILE \
-      SOLDR_TARGET_CACHE_BACKEND \
-      SOLDR_TARGET_CACHE_COMPRESS \
-      SOLDR_TARGET_CACHE_COMPRESS_LEVEL \
-      SOLDR_TARGET_REGISTRY_RECORDED \
-      SOLDR_BUILD_CACHE_MODE \
-      SETUP_SOLDR_BUILD_CACHE_MODE
+      SOLDR_RUSTC_WRAPPER
 
 now_ms() { date +%s%3N; }
 

--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -29,6 +29,7 @@ use crate::zccache::{
     SOLDR_CACHE_LIFECYCLE_ENV_VAR, SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR,
 };
 use crate::{apply_implicit_toolchain_homes, gc, resolve_toolchain_binary, ZccacheSourceArg};
+use std::ffi::OsString;
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -97,6 +98,73 @@ pub(crate) const NO_GC_TARGET_ENV_VAR: &str = "SOLDR_NO_GC_TARGET";
 
 const TEST_FORCE_WORKSPACE_TRAMPOLINE_ENV_VAR: &str = "SOLDR_TEST_FORCE_WORKSPACE_TRAMPOLINE";
 
+const INHERITED_SOLDR_WORKSPACE_ENV_VARS: &[&str] = &[
+    crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR,
+    crate::cache_lib::MANAGED_ZCCACHE_CACHE_DIR_ENV_VAR,
+    crate::cache_lib::ZCCACHE_SESSION_ID_ENV_VAR,
+    crate::wrapper_target::TARGET_REGISTRY_RECORDED_ENV_VAR,
+    crate::TARGET_CACHE_MODE_ENV_VAR,
+    "SOLDR_TARGET_CACHE_DIR",
+    crate::TARGET_CACHE_BUNDLE_DIR_ENV_VAR,
+    crate::TARGET_CACHE_PROFILE_ENV_VAR,
+    crate::TARGET_CACHE_BACKEND_ENV_VAR,
+    crate::TARGET_CACHE_TAR_THREADS_ENV_VAR,
+    "SOLDR_TARGET_CACHE_COMPRESS",
+    "SOLDR_TARGET_CACHE_COMPRESS_LEVEL",
+    "SOLDR_BUILD_CACHE_MODE",
+];
+
+struct EnvRestore {
+    key: OsString,
+    previous: Option<OsString>,
+}
+
+struct FreshSoldrWorkspaceEnvGuard {
+    entries: Vec<EnvRestore>,
+}
+
+impl FreshSoldrWorkspaceEnvGuard {
+    fn apply_unless_trusted(trust_inherited_soldr_env: bool) -> Self {
+        if trust_inherited_soldr_env {
+            return Self {
+                entries: Vec::new(),
+            };
+        }
+
+        let mut keys: Vec<OsString> = INHERITED_SOLDR_WORKSPACE_ENV_VARS
+            .iter()
+            .map(OsString::from)
+            .collect();
+        keys.extend(
+            std::env::vars_os()
+                .map(|(key, _)| key)
+                .filter(|key| key.to_string_lossy().starts_with("SETUP_SOLDR_")),
+        );
+        keys.sort();
+        keys.dedup();
+
+        let mut entries = Vec::new();
+        for key in keys {
+            let previous = std::env::var_os(&key);
+            if previous.is_some() {
+                std::env::remove_var(&key);
+                entries.push(EnvRestore { key, previous });
+            }
+        }
+        Self { entries }
+    }
+}
+
+impl Drop for FreshSoldrWorkspaceEnvGuard {
+    fn drop(&mut self) {
+        for entry in self.entries.iter().rev() {
+            if let Some(value) = &entry.previous {
+                std::env::set_var(&entry.key, value);
+            }
+        }
+    }
+}
+
 /// Outcome of stripping the `--no-gc-target*` flags from a cargo arg
 /// vector. Mirrors the env-var fallback so callers can union all
 /// inputs into a single before/after decision.
@@ -118,6 +186,16 @@ impl GcTargetOptOut {
 
 fn env_disables_target_gc() -> bool {
     std::env::var_os(NO_GC_TARGET_ENV_VAR)
+        .map(|v| {
+            let s = v.to_string_lossy();
+            let t = s.trim();
+            !t.is_empty() && !t.eq_ignore_ascii_case("0") && !t.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
+fn env_flag_truthy(key: &str) -> bool {
+    std::env::var_os(key)
         .map(|v| {
             let s = v.to_string_lossy();
             let t = s.trim();
@@ -191,16 +269,34 @@ fn scrub_soldr_cache_lifecycle_env_for_child_cargo(command: &mut std::process::C
     command.env_remove(SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS_ENV_VAR);
 }
 
+fn scrub_inherited_soldr_workspace_env_for_child_cargo(command: &mut std::process::Command) {
+    for key in INHERITED_SOLDR_WORKSPACE_ENV_VARS {
+        command.env_remove(key);
+    }
+    for key in std::env::vars_os()
+        .map(|(key, _)| key)
+        .filter(|key| key.to_string_lossy().starts_with("SETUP_SOLDR_"))
+    {
+        command.env_remove(key);
+    }
+}
+
 pub(crate) async fn run_cargo_front_door(
     args: &[String],
     cache_enabled: bool,
     zccache_source: ZccacheSourceArg,
+    trust_inherited_soldr_env: bool,
 ) -> Result<i32, SoldrError> {
     if cargo_args_use_reserved_no_cache(args) {
         return Err(SoldrError::Other(
             "`--no-cache` must appear before `cargo`, as in `soldr --no-cache cargo build`".into(),
         ));
     }
+
+    let trust_inherited_soldr_env =
+        trust_inherited_soldr_env || env_flag_truthy(crate::TRUST_INHERITED_SOLDR_ENV_VAR);
+    let _fresh_workspace_env =
+        FreshSoldrWorkspaceEnvGuard::apply_unless_trusted(trust_inherited_soldr_env);
 
     let cache_lifecycle = cache_lifecycle_from_env()?;
     let command_lifetime_shutdown_timeout = if cache_lifecycle == CacheLifecycle::Command {
@@ -294,6 +390,9 @@ pub(crate) async fn run_cargo_front_door(
     // process. Letting cargo inherit them leaks daemon lifecycle policy
     // into build scripts and test binaries that may spawn nested soldr.
     scrub_soldr_cache_lifecycle_env_for_child_cargo(&mut command);
+    if !trust_inherited_soldr_env {
+        scrub_inherited_soldr_workspace_env_for_child_cargo(&mut command);
+    }
     // soldr cargo is the top of the invocation tree, so any inherited
     // MAKEFLAGS/CARGO_MAKEFLAGS points at jobserver fds that aren't open in
     // our process. Stripping them lets cargo start a fresh jobserver instead

--- a/crates/soldr-cli/src/cargo_front_door/tests.rs
+++ b/crates/soldr-cli/src/cargo_front_door/tests.rs
@@ -70,6 +70,77 @@ fn child_cargo_scrubs_soldr_cache_lifecycle_controls() {
 }
 
 #[test]
+fn fresh_workspace_env_guard_removes_and_restores_soldr_workspace_state() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _zccache = EnvVarGuard::set(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR, "/old/zccache");
+    let _target_bundle = EnvVarGuard::set(crate::TARGET_CACHE_BUNDLE_DIR_ENV_VAR, "/old/bundle");
+    let _setup = EnvVarGuard::set("SETUP_SOLDR_WORKSPACE", "/old/workspace");
+    let _cache_dir = EnvVarGuard::set("SOLDR_CACHE_DIR", "/intentional/cache");
+
+    {
+        let _guard = FreshSoldrWorkspaceEnvGuard::apply_unless_trusted(false);
+
+        assert!(std::env::var_os(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR).is_none());
+        assert!(std::env::var_os(crate::TARGET_CACHE_BUNDLE_DIR_ENV_VAR).is_none());
+        assert!(std::env::var_os("SETUP_SOLDR_WORKSPACE").is_none());
+        assert_eq!(
+            std::env::var_os("SOLDR_CACHE_DIR"),
+            Some(OsString::from("/intentional/cache"))
+        );
+    }
+
+    assert_eq!(
+        std::env::var_os(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR),
+        Some(OsString::from("/old/zccache"))
+    );
+    assert_eq!(
+        std::env::var_os(crate::TARGET_CACHE_BUNDLE_DIR_ENV_VAR),
+        Some(OsString::from("/old/bundle"))
+    );
+    assert_eq!(
+        std::env::var_os("SETUP_SOLDR_WORKSPACE"),
+        Some(OsString::from("/old/workspace"))
+    );
+}
+
+#[test]
+fn trusted_workspace_env_guard_leaves_inherited_soldr_state_available() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _zccache = EnvVarGuard::set(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR, "/old/zccache");
+
+    let _guard = FreshSoldrWorkspaceEnvGuard::apply_unless_trusted(true);
+
+    assert_eq!(
+        std::env::var_os(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR),
+        Some(OsString::from("/old/zccache"))
+    );
+}
+
+#[test]
+fn child_cargo_scrubs_inherited_soldr_workspace_state() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _setup = EnvVarGuard::set("SETUP_SOLDR_WORKSPACE", "/old/workspace");
+    let mut command = std::process::Command::new("cargo");
+    command.env(crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR, "/old/zccache");
+    command.env(crate::TARGET_CACHE_BUNDLE_DIR_ENV_VAR, "/old/bundle");
+
+    scrub_inherited_soldr_workspace_env_for_child_cargo(&mut command);
+
+    assert_eq!(
+        command_env_override(&command, crate::cache_lib::ZCCACHE_CACHE_DIR_ENV_VAR),
+        Some(None)
+    );
+    assert_eq!(
+        command_env_override(&command, crate::TARGET_CACHE_BUNDLE_DIR_ENV_VAR),
+        Some(None)
+    );
+    assert_eq!(
+        command_env_override(&command, "SETUP_SOLDR_WORKSPACE"),
+        Some(None)
+    );
+}
+
+#[test]
 fn low_disk_warning_formats_yellow_below_threshold() {
     let message = low_disk_warning_for_free_bytes(1536 * 1024 * 1024, true)
         .expect("expected low-disk warning below threshold");

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -73,6 +73,14 @@ pub(crate) struct Cli {
     /// Disable soldr's compilation cache for this run
     #[arg(long)]
     pub(crate) no_cache: bool,
+    /// Trust inherited soldr/zccache workspace environment for cargo runs
+    #[arg(
+        long,
+        help = "Trust inherited soldr/zccache workspace env for cargo runs",
+        long_help = "Trust inherited soldr/zccache workspace environment for cargo runs.\n\n\
+By default, `soldr cargo ...` resolves a fresh soldr workspace context from the current cwd/manifest while preserving normal OS, Cargo, Rust, proxy, cert, and CI environment. This flag is an advanced escape hatch for CI/action workflows that intentionally inject soldr/zccache workspace state."
+    )]
+    pub(crate) trust_inherited_soldr_env: bool,
     #[arg(
         long,
         value_enum,

--- a/crates/soldr-cli/src/cook.rs
+++ b/crates/soldr-cli/src/cook.rs
@@ -364,9 +364,13 @@ pub(crate) async fn run_cook(
     // Phase 1: prepare. Cheap, deterministic, reads only the manifest tree.
     if !parsed.cook_only {
         let prepare_args = build_chef_prepare_args(&ctx);
-        let code =
-            cargo_front_door::run_cargo_front_door(&prepare_args, cache_enabled, zccache_source)
-                .await?;
+        let code = cargo_front_door::run_cargo_front_door(
+            &prepare_args,
+            cache_enabled,
+            zccache_source,
+            false,
+        )
+        .await?;
         if code != 0 {
             return Ok(code);
         }
@@ -434,7 +438,8 @@ pub(crate) async fn run_cook(
     // project. Output lands in `target/`.
     let cook_args = build_chef_cook_args(&ctx, &parsed);
     let cook_result =
-        cargo_front_door::run_cargo_front_door(&cook_args, cache_enabled, zccache_source).await;
+        cargo_front_door::run_cargo_front_door(&cook_args, cache_enabled, zccache_source, false)
+            .await;
 
     // Restore the project to its pre-cook state regardless of how cook exited,
     // so the tree is pristine for every subsequent build step (#566).

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -122,6 +122,9 @@ pub(crate) const THIN_MANIFEST_FILENAME: &str = "manifest.v2.json";
 /// value (`0` / `false` / `no` / `off` / empty, case-insensitive) to opt out;
 /// unset or any other value keeps the short-circuit enabled.
 pub(crate) const SKIP_WARM_RESTORE_ENV_VAR: &str = "SOLDR_RUST_PLAN_SKIP_WARM_RESTORE";
+/// Opt-in escape hatch for advanced workflows that intentionally inject
+/// soldr/zccache workspace-pinned state into `soldr cargo ...`.
+pub(crate) const TRUST_INHERITED_SOLDR_ENV_VAR: &str = "SOLDR_TRUST_INHERITED_ENV";
 /// Filename of the sentinel written next to the thin-slice bundle root after
 /// a successful `rust-plan save`. Read on the next invocation by
 /// `should_skip_warm_restore` to decide whether `rust-plan restore` would be
@@ -231,12 +234,18 @@ async fn run_with_args(prog: &str, args: &[String]) -> Result<i32, SoldrError> {
 async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
     let cache_enabled = !cli.no_cache;
     let zccache_source = cli.zccache;
+    let trust_inherited_soldr_env = cli.trust_inherited_soldr_env;
 
     match cli.command {
         Commands::Cargo { args } => {
             std::process::exit(
-                cargo_front_door::run_cargo_front_door(&args, cache_enabled, zccache_source)
-                    .await?,
+                cargo_front_door::run_cargo_front_door(
+                    &args,
+                    cache_enabled,
+                    zccache_source,
+                    trust_inherited_soldr_env,
+                )
+                .await?,
             );
         }
         Commands::Cook { args } => {
@@ -614,6 +623,7 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                         &cargo_args,
                         cache_enabled,
                         zccache_source,
+                        trust_inherited_soldr_env,
                     )
                     .await?,
                 );
@@ -639,6 +649,7 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                         &cargo_args,
                         cache_enabled,
                         zccache_source,
+                        trust_inherited_soldr_env,
                     )
                     .await?,
                 );

--- a/crates/soldr-cli/src/main_tests.rs
+++ b/crates/soldr-cli/src/main_tests.rs
@@ -161,6 +161,16 @@ fn cli_parses_zccache_flag_values() {
 }
 
 #[test]
+fn cli_parses_trust_inherited_soldr_env_flag() {
+    let default = Cli::try_parse_from(["soldr", "cargo", "build"]).unwrap();
+    assert!(!default.trust_inherited_soldr_env);
+
+    let trusted =
+        Cli::try_parse_from(["soldr", "--trust-inherited-soldr-env", "cargo", "build"]).unwrap();
+    assert!(trusted.trust_inherited_soldr_env);
+}
+
+#[test]
 fn root_help_groups_commands_and_keeps_lines_short() {
     let help = Cli::command().render_help().to_string();
 

--- a/crates/soldr-cli/tests/cli_cargo_wrappers.rs
+++ b/crates/soldr-cli/tests/cli_cargo_wrappers.rs
@@ -197,7 +197,7 @@ fn cache_enabled_zccache_build_completes_under_20_seconds() {
 }
 
 #[test]
-fn managed_zccache_honors_explicit_cache_dir_override() {
+fn managed_zccache_honors_explicit_cache_dir_override_when_trusted() {
     let cache_root = unique_temp_dir("cargo-explicit-zccache-dir");
     let user_zccache_dir = cache_root.join("user-zccache");
     let log_path = cache_root.join("tool.log");
@@ -206,6 +206,7 @@ fn managed_zccache_honors_explicit_cache_dir_override() {
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("ZCCACHE_CACHE_DIR", &user_zccache_dir)
+        .env("SOLDR_TRUST_INHERITED_ENV", "1")
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)

--- a/crates/soldr-cli/tests/cli_rust_plan.rs
+++ b/crates/soldr-cli/tests/cli_rust_plan.rs
@@ -78,6 +78,7 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
         .env("SOLDR_TEST_CARGO_METADATA_PATH", &metadata_path)
+        .env("SOLDR_TRUST_INHERITED_ENV", "1")
         .env("SOLDR_TARGET_CACHE_MODE", "thin")
         .env("SOLDR_TARGET_CACHE_BUNDLE_DIR", &plan_cache)
         // setup-soldr exports SOLDR_TARGET_CACHE_PROFILE=thin-v1 today; this
@@ -181,6 +182,7 @@ fn cargo_front_door_warns_when_rust_plan_restore_is_partial() {
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
         .env("SOLDR_TEST_CARGO_METADATA_PATH", &metadata_path)
+        .env("SOLDR_TRUST_INHERITED_ENV", "1")
         .env("SOLDR_TARGET_CACHE_MODE", "thin")
         .env("SOLDR_TARGET_CACHE_BUNDLE_DIR", &plan_cache)
         .env("SOLDR_TEST_RUST_PLAN_STALE", "1")
@@ -267,6 +269,7 @@ fn cargo_front_door_removes_stale_zccache_daemon_lock_before_retry() {
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("ZCCACHE_CACHE_DIR", &zccache_session_dir)
+        .env("SOLDR_TRUST_INHERITED_ENV", "1")
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
         .env("SOLDR_TEST_RUSTC_BIN", &rustc)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1290,10 +1290,11 @@ Commands:
 | `SOLDR_CACHE_DIR` | Override cache directory | `~/.soldr` |
 | `SOLDR_CACHE_LIFECYCLE` | zccache daemon lifetime for `soldr cargo ...`. `job` keeps the scoped daemon alive for later soldr invocations in the same job. `command` ends the zccache session and stops the scoped daemon before `soldr cargo ...` exits; intended for self-build CI where later tests must not inherit the builder daemon. | `job` |
 | `SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS` | Maximum seconds to wait for command-lifetime zccache shutdown confirmation after `zccache stop`. | `30` |
+| `SOLDR_TRUST_INHERITED_ENV` | Advanced escape hatch for CI/action workflows that intentionally inject soldr/zccache workspace-pinned env into `soldr cargo ...`. Truthy values are equivalent to `--trust-inherited-soldr-env`; unset/default means `soldr cargo ...` derives a fresh soldr workspace context from the current cwd/manifest while preserving normal OS, Cargo, Rust, proxy, cert, and CI env. | unset |
 | `SOLDR_RELOCATED_EXE` | Internal recursion guard set after Windows self-relocation | unset |
 | `SOLDR_ORIGINAL_EXE` | Internal path to the original executable when Windows self-relocation is active | unset |
 | `SOLDR_ZCCACHE_SESSION_DIR` | Internal session/report directory passed from `soldr cargo ...` into wrapper mode | unset |
-| `ZCCACHE_CACHE_DIR` | Explicit caller override for zccache's cache root; soldr does not set it for default managed zccache builds | unset |
+| `ZCCACHE_CACHE_DIR` | zccache cache-root override. `soldr cargo ...` ignores inherited values by default so stale workspace state from setup/action wrappers cannot bleed across projects; pass `--trust-inherited-soldr-env` or set `SOLDR_TRUST_INHERITED_ENV=1` only when intentionally injecting this state. | unset |
 | `ZCCACHE_SESSION_ID` | Per-build zccache session identifier set by soldr | unset |
 | `ZCCACHE_PATH_REMAP` | zccache path-remap mode. soldr seeds `auto` on the child cargo for managed-zccache builds so multiple git worktrees of the same repo share cache hits (issue #352, Tier L1.x). Caller-supplied values are preserved. Requires a real `.git/` checkout — tarball/zip checkouts silently fall back to no remap. | unset (soldr injects `auto`) |
 | `SOLDR_PATH_REMAP` | Escape hatch for the default `ZCCACHE_PATH_REMAP=auto` injection. `off` (case-insensitive) suppresses the injection; any other value, or unset, keeps the default behavior. | unset (`auto`) |
@@ -1316,7 +1317,7 @@ Commands:
 `RUSTC_WRAPPER=soldr cargo build` remains a valid low-level passthrough path, but it is no longer the preferred user-facing workflow.
 When `SOLDR_RUSTC_WRAPPER` is set to a non-empty value such as `sccache`, soldr puts that binary in the wrapper slot instead of its managed zccache. If it is set to `none` or an empty string, soldr leaves `RUSTC_WRAPPER` unset for that build.
 
-When soldr manages zccache itself, it does not set `ZCCACHE_CACHE_DIR` by default; zccache uses its normal effective cache root and daemon/session behavior. A caller-provided `ZCCACHE_CACHE_DIR` is forwarded as an explicit zccache override. Custom wrapper modes leave caller-provided wrapper environment alone — when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has set `SCCACHE_DIR` themselves, soldr forwards their value rather than overriding it.
+When soldr manages zccache itself, `soldr cargo ...` resolves a fresh soldr workspace context by default. It preserves normal process environment used by Cargo, Rust, proxies, certificates, CI, and platform SDKs, but ignores inherited soldr/zccache workspace-pinned state such as `ZCCACHE_CACHE_DIR`, `SOLDR_TARGET_CACHE_*`, `SOLDR_TARGET_REGISTRY_RECORDED`, and `SETUP_SOLDR_*`. Pass `--trust-inherited-soldr-env` or set `SOLDR_TRUST_INHERITED_ENV=1` only for advanced workflows that intentionally inject those values. Custom wrapper modes leave caller-provided wrapper environment alone; when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has set `SCCACHE_DIR` themselves, soldr forwards their value rather than overriding it.
 
 `soldr cargo ...` only starts the managed build cache for compile-like Cargo subcommands such as `build`, `check`, `test`, `run`, `doc`, `clippy`, and `nextest`. Non-build Cargo commands such as `cargo metadata` and `cargo --version` pass through without starting zccache.
 


### PR DESCRIPTION
## Summary

- make `soldr cargo ...` default to a fresh soldr workspace context by scrubbing inherited soldr/zccache workspace-pinned env unless explicitly trusted
- add `--trust-inherited-soldr-env` / `SOLDR_TRUST_INHERITED_ENV=1` as the escape hatch for intentional injected state
- remove benchmark-script soldr/zccache env allowlists and document the new env contract

Closes #797

## Tests

- `soldr cargo fmt --all`
- `soldr --no-cache cargo test -p soldr-cli cargo_front_door`
- `soldr --no-cache cargo test -p soldr-cli cli_parses_trust_inherited_soldr_env_flag`
- `soldr --no-cache cargo test -p soldr-cli --test cli_cargo_wrappers`
- `soldr --no-cache cargo check -p soldr-cli`
- `soldr --no-cache cargo clippy -p soldr-cli --all-targets -- -D warnings`
- `soldr --no-cache cargo test -p soldr-cli`