### PR TITLE
fix: scrub setup-soldr env in benchmark scripts

### DIFF
--- a/bench/run_canaries.sh
+++ b/bench/run_canaries.sh
@@ -35,6 +35,25 @@ mkdir -p "${OUT_DIR}"
 # Issue #797: soldr cargo resolves a fresh soldr workspace context by
 # default, so canaries do not maintain their own soldr/zccache env
 # allowlist.
+#
+# The workflow itself is bootstrapped by setup-soldr, which exports wrapper
+# and cache variables for the checkout build. Managed soldr invocations reject
+# those inherited values, so each benchmark script boundary starts clean and
+# then chooses its own private cache root below.
+unset ZCCACHE_CACHE_DIR \
+      SCCACHE_DIR \
+      RUSTC_WRAPPER \
+      SOLDR_RUSTC_WRAPPER \
+      SOLDR_CACHE_DIR \
+      SOLDR_TARGET_CACHE_DIR \
+      SOLDR_TARGET_CACHE_BUNDLE_DIR \
+      SOLDR_TARGET_CACHE_MODE \
+      SOLDR_TARGET_CACHE_PROFILE \
+      SOLDR_TARGET_CACHE_BACKEND \
+      SOLDR_TARGET_CACHE_COMPRESS \
+      SOLDR_TARGET_CACHE_COMPRESS_LEVEL \
+      SOLDR_BUILD_CACHE_MODE \
+      SETUP_SOLDR_BUILD_CACHE_MODE
 
 # Single private cache for the whole canary sweep. Every canary writes
 # to the same daemon so warm-cache measurements are meaningful.

--- a/bench/run_comparison.sh
+++ b/bench/run_comparison.sh
@@ -16,11 +16,22 @@ trap 'for wt in "${WORKTREES_TO_REMOVE[@]:-}"; do git -C "${REPO_ROOT}" worktree
 
 mkdir -p "${OUT_DIR}"
 
-# Keep wrapper-specific env out of the comparison cells. soldr/zccache
-# workspace-state env is handled inside soldr cargo by default (#797).
-unset SCCACHE_DIR \
+# Keep setup-soldr's toolchain/PATH benefits, but remove wrapper and cache
+# state so each comparison cell owns its cache and target dirs.
+unset ZCCACHE_CACHE_DIR \
+      SCCACHE_DIR \
       RUSTC_WRAPPER \
-      SOLDR_RUSTC_WRAPPER
+      SOLDR_RUSTC_WRAPPER \
+      SOLDR_CACHE_DIR \
+      SOLDR_TARGET_CACHE_DIR \
+      SOLDR_TARGET_CACHE_BUNDLE_DIR \
+      SOLDR_TARGET_CACHE_MODE \
+      SOLDR_TARGET_CACHE_PROFILE \
+      SOLDR_TARGET_CACHE_BACKEND \
+      SOLDR_TARGET_CACHE_COMPRESS \
+      SOLDR_TARGET_CACHE_COMPRESS_LEVEL \
+      SOLDR_BUILD_CACHE_MODE \
+      SETUP_SOLDR_BUILD_CACHE_MODE
 
 now_ms() { date +%s%3N; }
 


### PR DESCRIPTION
## Summary

Follow-up to #799. The first fast benchmark publish succeeded quickly, but all soldr canary/comparison cells recorded `0` because setup-soldr exports `ZCCACHE_CACHE_DIR` and managed `soldr cargo` now rejects inherited zccache env:

```
soldr: ZCCACHE_CACHE_DIR is managed by soldr for managed zccache builds.
```

This restores an explicit benchmark-script boundary scrub for setup-soldr wrapper/cache vars, then lets the canary sweep and comparison cells choose their own private `SOLDR_CACHE_DIR` values.

## Validation

- `bash -n bench/run_canaries.sh`
- `bash -n bench/run_comparison.sh`
- `git diff --check`