### PR TITLE
fix: overlay warm benchmark bars on cold

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -197,7 +197,7 @@ The manifest points at:
 
 ## README comparison bars (issue #785)
 
-The README uses `benchmark-rust-only.jpg` and `benchmark-rust-c.jpg` for an at-a-glance bare cargo vs sccache vs soldr comparison. The images intentionally match zccache's dark README benchmark style. The historical trend PNG remains published as `benchmark-trend.png`, but it is for the Pages deep-dive rather than the README value proposition.
+The README uses `benchmark-rust-only.jpg` and `benchmark-rust-c.jpg` for an at-a-glance bare cargo vs sccache vs soldr comparison. The images intentionally match zccache's dark README benchmark style: each row draws the cold timing as the back bar and overlays the warm timing in front, normalized to the per-section cold maximum. The historical trend PNG remains published as `benchmark-trend.png`, but it is for the Pages deep-dive rather than the README value proposition.
 
 ### Workloads
 
@@ -223,6 +223,8 @@ The README uses `benchmark-rust-only.jpg` and `benchmark-rust-c.jpg` for an at-a
 | `cold` | Fresh source checkout, fresh target dir, and fresh cache. This should usually be a wash, and it sets honest expectations. | Single sample. |
 | `warm` | Populate the tool cache, run `cargo clean`, then time the rebuild in the same workspace. | Single sample. |
 | `worktree-share` | Build workspace A to populate the cache, then time a sibling workspace B at the same commit. This highlights soldr's `ZCCACHE_PATH_REMAP=auto` parent-child share story. | Single sample. |
+
+The static README renderer combines these rows into two overlay sections: `cold` + `warm`, and `cold` + `worktree-share`. That follows zccache's cold-back/warm-front bar treatment and keeps the image compact.
 
 Each comparison build is bounded by `COMPARISON_BUILD_TIMEOUT_SECONDS` (default: 60). A timed-out cell records `0` and lets the publisher complete so a stuck native compile cannot pin the README workflow for hours.
 

--- a/bench/assemble_benchmark_stats.sh
+++ b/bench/assemble_benchmark_stats.sh
@@ -165,12 +165,12 @@ jq -n \
                 content_type: "image/png"
             },
             comparison_rust: {
-                description: "Dark zccache-style bar chart: bare cargo vs sccache vs soldr on a pure-Rust workload (soldr itself). Embedded in README.",
+                description: "Dark zccache-style overlay chart: bare cargo vs sccache vs soldr on a pure-Rust workload. Cold bars are drawn behind warm overlays. Embedded in README.",
                 url: ($raw_base + "/benchmark-rust-only.jpg"),
                 content_type: "image/jpeg"
             },
             comparison_rust_c: {
-                description: "Dark zccache-style bar chart: bare cargo vs sccache vs soldr on a Rust+C workload (sqlite-link).",
+                description: "Dark zccache-style overlay chart: bare cargo vs sccache vs soldr on a Rust+C workload (sqlite-native). Cold bars are drawn behind warm overlays.",
                 url: ($raw_base + "/benchmark-rust-c.jpg"),
                 content_type: "image/jpeg"
             }

--- a/bench/render_comparison_bars.py
+++ b/bench/render_comparison_bars.py
@@ -33,23 +33,32 @@ BENCHMARKS = {
     },
     "rust-c": {
         "title": "soldr Rust+C benchmarks",
-        "subtitle": "sqlite-link fixture",
+        "subtitle": "sqlite-native fixture",
         "output": "benchmark-rust-c.jpg",
     },
 }
 
-SCENARIO_ORDER = ["cold", "warm", "worktree-share"]
+OVERLAY_SECTIONS = [
+    {
+        "key": "warm",
+        "label": "Warm rebuild (same workspace)",
+        "cold_key": "cold",
+        "warm_key": "warm",
+    },
+    {
+        "key": "worktree-share",
+        "label": "Agent worktree / parent-child share",
+        "cold_key": "cold",
+        "warm_key": "worktree-share",
+    },
+]
 TOOL_ORDER = ["bare", "sccache", "soldr"]
-TOOL_COLORS = {
-    "bare": "#8b949e",
-    "sccache": "#79c0ff",
-    "soldr": "#f85149",
+TOOL_COLOR_PAIRS = {
+    "bare": {"cold": "#3b4046", "warm": "#8b949e"},
+    "sccache": {"cold": "#1f3a7a", "warm": "#79c0ff"},
+    "soldr": {"cold": "#5b1f1c", "warm": "#f85149"},
 }
-TOOL_DARK_COLORS = {
-    "bare": "#3b4046",
-    "sccache": "#1f3a7a",
-    "soldr": "#5b1f1c",
-}
+WARM_VIOLATION_OUTLINE = "#ffd33d"
 
 
 def load_comparison() -> dict[str, Any]:
@@ -101,17 +110,45 @@ def seconds_label(ms: Any) -> str:
     return f"{seconds:.3f}s"
 
 
-def speedup_label(rows_by_key: dict[tuple[str, str, str], dict[str, Any]], benchmark: str, scenario: str) -> str:
-    sccache = rows_by_key.get((benchmark, scenario, "sccache"), {}).get("wall_ms")
-    soldr = rows_by_key.get((benchmark, scenario, "soldr"), {}).get("wall_ms")
+def overlay_speedup_label(
+    rows_by_key: dict[tuple[str, str, str], dict[str, Any]],
+    benchmark: str,
+    warm_key: str,
+) -> str:
+    sccache = rows_by_key.get((benchmark, warm_key, "sccache"), {}).get("wall_ms")
+    soldr = rows_by_key.get((benchmark, warm_key, "soldr"), {}).get("wall_ms")
     if not isinstance(sccache, (int, float)) or not isinstance(soldr, (int, float)):
         return ""
     if sccache <= 0 or soldr <= 0:
         return ""
     ratio = sccache / soldr
     if ratio >= 1:
-        return f"soldr {ratio:.1f}x faster than sccache"
-    return f"soldr {(1 / ratio):.1f}x slower than sccache"
+        return f"soldr warm {ratio:.1f}x faster than sccache"
+    return f"soldr warm {(1 / ratio):.1f}x slower than sccache"
+
+
+def cold_max_for_section(
+    rows_by_key: dict[tuple[str, str, str], dict[str, Any]],
+    benchmark: str,
+    cold_key: str,
+    warm_key: str,
+) -> tuple[float, str]:
+    cold_values = []
+    for tool in TOOL_ORDER:
+        value = rows_by_key.get((benchmark, cold_key, tool), {}).get("wall_ms")
+        if isinstance(value, (int, float)) and value > 0:
+            cold_values.append(float(value))
+    if cold_values:
+        return max(cold_values), "cold"
+
+    warm_values = []
+    for tool in TOOL_ORDER:
+        value = rows_by_key.get((benchmark, warm_key, tool), {}).get("wall_ms")
+        if isinstance(value, (int, float)) and value > 0:
+            warm_values.append(float(value))
+    if warm_values:
+        return max(warm_values), "warm"
+    return 1.0, "none"
 
 
 def render_benchmark(doc: dict[str, Any], benchmark: str) -> Path:
@@ -120,18 +157,17 @@ def render_benchmark(doc: dict[str, Any], benchmark: str) -> Path:
         (row.get("benchmark"), row.get("scenario_key"), row.get("tool")): row
         for row in rows
     }
-    scenario_labels = {item["key"]: item["label"] for item in doc.get("scenarios", [])}
     tool_labels = {item["key"]: item["label"] for item in doc.get("tools", [])}
 
     scale = 3
     width = 900
     margin = 20
     header_h = 116
-    legend_h = 36
-    scenario_h = 182
-    scenario_gap = 14
+    legend_h = 48
+    section_h = 210
+    section_gap = 16
     footer_h = 50
-    height = header_h + legend_h + (scenario_h + scenario_gap) * len(SCENARIO_ORDER) - scenario_gap + footer_h
+    height = header_h + legend_h + (section_h + section_gap) * len(OVERLAY_SECTIONS) - section_gap + footer_h
 
     image = Image.new("RGB", (width * scale, height * scale), hex_rgb("#0d1117"))
     draw = ImageDraw.Draw(image)
@@ -169,35 +205,63 @@ def render_benchmark(doc: dict[str, Any], benchmark: str) -> Path:
     )
     header_line = f"{meta['subtitle']} | generated {generated}"
     draw.text(xy(margin, 70), truncate(draw, header_line, subtitle_font, (width - margin * 2) * scale), font=subtitle_font, fill=hex_rgb("#8b949e"))
-    draw.text(xy(margin, 92), truncate(draw, versions, subtitle_font, (width - margin * 2) * scale), font=subtitle_font, fill=hex_rgb("#8b949e"))
+    draw.text(
+        xy(margin, 92),
+        truncate(
+            draw,
+            f"{versions} | cold bars in back; warm overlays in front",
+            subtitle_font,
+            (width - margin * 2) * scale,
+        ),
+        font=subtitle_font,
+        fill=hex_rgb("#8b949e"),
+    )
 
     legend_y = header_h + 10
     legend_x = margin
-    for tool in TOOL_ORDER:
-        rect((legend_x, legend_y + 3, legend_x + 28, legend_y + 17), TOOL_COLORS[tool])
-        draw.text(
-            xy(legend_x + 36, legend_y),
-            tool_labels.get(tool, tool),
-            font=small_font,
-            fill=hex_rgb("#c9d1d9"),
-        )
-        legend_x += 170
+    rect((legend_x, legend_y + 2, legend_x + 58, legend_y + 22), TOOL_COLOR_PAIRS["soldr"]["cold"])
+    rect((legend_x, legend_y + 7, legend_x + 26, legend_y + 17), TOOL_COLOR_PAIRS["soldr"]["warm"])
+    draw.text(
+        xy(legend_x + 70, legend_y + 1),
+        "cold (back) + warm (front, overlays cold)",
+        font=small_font,
+        fill=hex_rgb("#c9d1d9"),
+    )
+    violation_x = width - margin - 236
+    rect(
+        (violation_x, legend_y + 7, violation_x + 34, legend_y + 17),
+        TOOL_COLOR_PAIRS["soldr"]["warm"],
+        outline=WARM_VIOLATION_OUTLINE,
+        width_px=2,
+    )
+    draw.text(
+        xy(violation_x + 44, legend_y + 1),
+        "warm > cold",
+        font=small_font,
+        fill=hex_rgb(WARM_VIOLATION_OUTLINE),
+    )
 
     chart_x = margin
     chart_w = width - margin * 2
     label_w = 150
-    value_w = 130
+    value_w = 184
     bar_x0 = chart_x + label_w
     bar_x1 = chart_x + chart_w - value_w
     bar_w = bar_x1 - bar_x0
 
     y = header_h + legend_h
-    for idx, scenario in enumerate(SCENARIO_ORDER):
+    for idx, section in enumerate(OVERLAY_SECTIONS):
         fill = "#0f1620" if idx % 2 == 0 else "#11202d"
-        rect((chart_x, y, chart_x + chart_w, y + scenario_h), fill)
-        title = scenario_labels.get(scenario, scenario)
+        rect((chart_x, y, chart_x + chart_w, y + section_h), fill)
+        title = section["label"]
         draw.text(xy(chart_x + 16, y + 14), title, font=scenario_font, fill=hex_rgb("#f0f6fc"))
-        speedup = speedup_label(rows_by_key, benchmark, scenario)
+        scale_max, scale_source = cold_max_for_section(
+            rows_by_key,
+            benchmark,
+            section["cold_key"],
+            section["warm_key"],
+        )
+        speedup = overlay_speedup_label(rows_by_key, benchmark, section["warm_key"])
         if speedup:
             speedup_w = text_width(draw, speedup, subtitle_font) // scale
             draw.text(
@@ -207,43 +271,69 @@ def render_benchmark(doc: dict[str, Any], benchmark: str) -> Path:
                 fill=hex_rgb("#f85149"),
             )
 
-        values = []
-        for tool in TOOL_ORDER:
-            value = rows_by_key.get((benchmark, scenario, tool), {}).get("wall_ms")
-            if isinstance(value, (int, float)) and value > 0:
-                values.append(float(value))
-        max_value = max(values) if values else 1.0
+        if scale_source == "cold":
+            scale_note = f"100% = cold max {seconds_label(scale_max)}"
+        elif scale_source == "warm":
+            scale_note = f"100% = warm max {seconds_label(scale_max)} (no cold data)"
+        else:
+            scale_note = "no data"
+        draw.text(xy(chart_x + 16, y + 42), scale_note, font=small_font, fill=hex_rgb("#8b949e"))
 
-        row_y = y + 58
+        row_y = y + 76
         for tool in TOOL_ORDER:
-            row = rows_by_key.get((benchmark, scenario, tool), {})
-            value = row.get("wall_ms")
+            cold_value = rows_by_key.get((benchmark, section["cold_key"], tool), {}).get("wall_ms")
+            warm_value = rows_by_key.get((benchmark, section["warm_key"], tool), {}).get("wall_ms")
             label = tool_labels.get(tool, tool)
-            color = TOOL_COLORS[tool]
-            dark = TOOL_DARK_COLORS[tool]
-
-            draw.text(xy(chart_x + 16, row_y + 11), label, font=tool_font, fill=hex_rgb(color))
-            track_y0 = row_y + 14
-            rect((bar_x0, track_y0, bar_x1, track_y0 + 16), "#21262d")
-            if isinstance(value, (int, float)) and value > 0:
-                width_fraction = max(0.015, min(1.0, float(value) / max_value))
-                bar_end = bar_x0 + int(bar_w * width_fraction)
-                rect((bar_x0, track_y0, bar_end, track_y0 + 16), dark)
-                rect((bar_x0, track_y0 + 4, bar_end, track_y0 + 12), color)
-            draw.text(
-                xy(bar_x1 + 12, row_y + 8),
-                seconds_label(value),
-                font=value_font,
-                fill=hex_rgb(color),
+            colors = TOOL_COLOR_PAIRS[tool]
+            warm_violation = (
+                isinstance(cold_value, (int, float))
+                and isinstance(warm_value, (int, float))
+                and cold_value > 0
+                and warm_value > cold_value * 1.10
             )
-            row_y += 36
+
+            draw.text(xy(chart_x + 16, row_y + 14), label, font=tool_font, fill=hex_rgb(colors["warm"]))
+            track_y0 = row_y + 20
+            rect((bar_x0, track_y0 + 10, bar_x1, track_y0 + 14), "#21262d")
+            if isinstance(cold_value, (int, float)) and cold_value > 0:
+                width_fraction = max(0.01, min(1.0, float(cold_value) / scale_max))
+                bar_end = bar_x0 + max(3, int(bar_w * width_fraction))
+                rect((bar_x0, track_y0, bar_end, track_y0 + 24), colors["cold"])
+            if isinstance(warm_value, (int, float)) and warm_value > 0:
+                width_fraction = max(0.01, min(1.0, float(warm_value) / scale_max))
+                bar_end = bar_x0 + max(3, int(bar_w * width_fraction))
+                rect(
+                    (bar_x0, track_y0 + 5, bar_end, track_y0 + 19),
+                    colors["warm"],
+                    outline=WARM_VIOLATION_OUTLINE if warm_violation else None,
+                    width_px=2 if warm_violation else 1,
+                )
+            draw.text(
+                xy(bar_x1 + 12, row_y + 2),
+                f"cold {seconds_label(cold_value)}",
+                font=value_font,
+                fill=hex_rgb(colors["cold"] if isinstance(cold_value, (int, float)) and cold_value > 0 else "#6e7681"),
+            )
+            draw.text(
+                xy(bar_x1 + 12, row_y + 22),
+                f"warm {seconds_label(warm_value)}",
+                font=value_font,
+                fill=hex_rgb(
+                    WARM_VIOLATION_OUTLINE
+                    if warm_violation
+                    else colors["warm"]
+                    if isinstance(warm_value, (int, float)) and warm_value > 0
+                    else "#6e7681"
+                ),
+            )
+            row_y += 44
 
         draw.line(
-            (xy(chart_x + 16, y + scenario_h - 1), xy(chart_x + chart_w - 16, y + scenario_h - 1)),
+            (xy(chart_x + 16, y + section_h - 1), xy(chart_x + chart_w - 16, y + section_h - 1)),
             fill=hex_rgb("#30363d"),
             width=scale,
         )
-        y += scenario_h + scenario_gap
+        y += section_h + section_gap
 
     footer = "Artifacts: latest.json, benchmark-rust-only.jpg, benchmark-rust-c.jpg"
     draw.line((xy(margin, height - 34), xy(width - margin, height - 34)), fill=hex_rgb("#30363d"), width=scale)


### PR DESCRIPTION
## Summary

Matches zccache's README benchmark image style more closely by rendering warm timings over cold timings in the same row:

- cold timing is the back bar
- warm timing is the front overlay
- each section is normalized to its cold max
- right-side labels show both cold and warm values
- warm-slower-than-cold cells get the same warning-outline treatment

For soldr's current comparison data shape, the static README images now combine rows into two compact overlay sections:

- `cold` + `warm`
- `cold` + `worktree-share`

Also updates manifest/docs copy and fixes the stale Rust+C subtitle from `sqlite-link` to `sqlite-native`.

## Zccache reference

Inspected `zackees/zccache/ci/benchmark_stats.py`, specifically `build_combined_image_rows()`, `_normalization_reference()`, and `render_language_jpg()`. zccache merges cold/warm rows per scenario root, normalizes against the cold maximum, draws cold as the back bar, then overlays warm in front.

## Validation

- Generated `benchmark-output/comparison.json` from the latest published benchmark data
- `uv run --no-sync --with pillow python -m py_compile bench/render_comparison_bars.py`
- `uv run --no-sync --with pillow python bench/render_comparison_bars.py`
- `uv run --no-sync --with ruff ruff check bench/render_comparison_bars.py`
- `bash -n bench/assemble_benchmark_stats.sh`
- `git diff --check`
- Visual inspection of generated soldr JPGs against zccache's published `benchmark-rust.jpg`