### PR TITLE
test: restore zccache contract matrix target-cache planning

### DIFF
--- a/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
+++ b/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
@@ -169,6 +169,7 @@ timed_test!(
             .args(["cargo", "build", "--locked"])
             .env("SOLDR_TEST_CARGO_METADATA_PATH", &fixture.metadata_path)
             .env("SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER", &down_marker)
+            .env("SOLDR_TRUST_INHERITED_ENV", "1")
             .env("SOLDR_TARGET_CACHE_MODE", "thin")
             .env("SOLDR_TARGET_CACHE_BUNDLE_DIR", &fixture.plan_cache)
             .env("SOLDR_CACHE_LIFECYCLE", "command")


### PR DESCRIPTION
## Summary
- Fixes the red Linux/macOS CI smoke test by letting cli_zccache_contract_matrix trust the target-cache env it intentionally injects.
- Without SOLDR_TRUST_INHERITED_ENV=1, the cargo front door strips SOLDR_TARGET_CACHE_MODE / SOLDR_TARGET_CACHE_BUNDLE_DIR before rust-plan setup, so the test never sees zccache rust-plan restore/save.

## Verification
- soldr --no-cache cargo test -p soldr-cli --test cli_zccache_contract_matrix -- --nocapture
- soldr --no-cache cargo fmt --check