### PR TITLE
style(fmt): reflow long lines flagged by cargo fmt --check

### DIFF
--- a/crates/soldr-cli/src/save_load.rs
+++ b/crates/soldr-cli/src/save_load.rs
@@ -384,8 +384,8 @@ mod private_session_default_tests {
     crate::timed_test!(save_default_preserves_explicit_cache_dir, {
         let mut args = base_save_args();
         args.cache_dir = Some(PathBuf::from("/user/explicit"));
-        let args = apply_private_session_cache_dir_default(args, true, fake_cwd)
-            .expect("apply default");
+        let args =
+            apply_private_session_cache_dir_default(args, true, fake_cwd).expect("apply default");
         assert_eq!(
             args.cache_dir.as_deref(),
             Some(std::path::Path::new("/user/explicit")),
@@ -396,8 +396,8 @@ mod private_session_default_tests {
     crate::timed_test!(save_default_no_op_in_mtimes_only_mode, {
         let mut args = base_save_args();
         args.mtimes_only = true;
-        let args = apply_private_session_cache_dir_default(args, true, fake_cwd)
-            .expect("apply default");
+        let args =
+            apply_private_session_cache_dir_default(args, true, fake_cwd).expect("apply default");
         assert!(
             args.cache_dir.is_none(),
             "mtimes-only forbids --cache-dir; default must not inject one",

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -1379,7 +1379,9 @@ mod tests {
 
     #[test]
     fn private_session_flag_truthy_values() {
-        for v in ["1", "true", "yes", "on", "TRUE", "Yes", "ON", " 1 ", " true "] {
+        for v in [
+            "1", "true", "yes", "on", "TRUE", "Yes", "ON", " 1 ", " true ",
+        ] {
             assert!(
                 parse_private_session_flag(Some(v)),
                 "expected {v:?} to parse truthy",


### PR DESCRIPTION
## Summary

- CI `Lint` job on `main` is red — `soldr cargo fmt --all -- --check` flagged two test bodies for line-reflow
- Pure rustfmt output, no semantic change to either touched function
- Source: failure in https://github.com/zackees/soldr/actions/runs/27870774999 (commit d51fe8e)

## Files

- `crates/soldr-cli/src/save_load.rs` — two `apply_private_session_cache_dir_default(...)` call sites in `mod private_session_default_tests`
- `crates/soldr-cli/src/zccache.rs` — one `for v in [...]` array literal in `private_session_flag_truthy_values`

## Test plan

- [x] `soldr cargo fmt --all -- --check` passes locally
- [ ] CI `Lint` job goes green on this PR