### PR TITLE
feat(release): stage Linux .dwp / macOS .dSYM sidecars (#786)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -372,6 +372,8 @@ jobs:
           chmod +x "dist/package/${{ matrix.binary }}" 2>/dev/null || true
           case "${{ matrix.target }}" in
             *-pc-windows-msvc)
+              # Windows MSVC always emits a `.pdb` next to the binary
+              # under the default release profile. Required (#782).
               pdb_src=""
               for candidate in \
                 "target/${{ matrix.target }}/release/soldr.pdb" \
@@ -387,6 +389,39 @@ jobs:
                 exit 1
               fi
               cp "$pdb_src" "dist/package/$(basename "$pdb_src")"
+              ;;
+            *-unknown-linux-*)
+              # Linux split DWARF: only present when the release
+              # profile sets `split-debuginfo = "packed"`. The default
+              # Rust release profile DOES NOT, so a missing `.dwp` is
+              # non-fatal — we stage it opportunistically. Issue #786:
+              # generalize debug-sidecar packaging beyond Windows. The
+              # manifest writer below records whatever ends up in
+              # `dist/package/` under `soldr.debug_info`.
+              for candidate in \
+                "target/${{ matrix.target }}/release/soldr.dwp" \
+                "target/${{ matrix.target }}/release/soldr_cli.dwp"; do
+                if [ -f "$candidate" ]; then
+                  cp "$candidate" "dist/package/$(basename "$candidate")"
+                  echo "staged Linux split-DWARF sidecar: $(basename "$candidate")"
+                  break
+                fi
+              done
+              ;;
+            *-apple-darwin)
+              # macOS dSYM bundle: only present when the release
+              # profile sets `split-debuginfo = "packed"`. The bundle
+              # is a directory tree, NOT a single file — `cp -R`
+              # preserves it. Missing bundle is non-fatal (#786).
+              for candidate in \
+                "target/${{ matrix.target }}/release/soldr.dSYM" \
+                "target/${{ matrix.target }}/release/soldr_cli.dSYM"; do
+                if [ -d "$candidate" ]; then
+                  cp -R "$candidate" "dist/package/$(basename "$candidate")"
+                  echo "staged macOS dSYM sidecar bundle: $(basename "$candidate")"
+                  break
+                fi
+              done
               ;;
           esac
           ls -la dist/package/
@@ -545,7 +580,21 @@ jobs:
           }
 
           soldr_sha=$(sha256_of "dist/package/soldr${suffix}")
-          soldr_debug_info_json="[]"
+          # Build `soldr.debug_info` from every sidecar staged above
+          # (issue #786). Windows .pdb is REQUIRED — its absence fails
+          # the build. Linux .dwp / macOS .dSYM are OPTIONAL — the
+          # default Rust release profile doesn't emit them, so a
+          # missing sidecar is silent and the array stays empty. Format
+          # tags MUST match the constants in
+          # `crates/soldr-cli/src/release_sidecar.rs::DebugSidecarFormat::as_manifest_str`.
+          soldr_debug_info_entries=()
+          add_sidecar_entry() {
+            local path="$1" format="$2"
+            local name sha
+            name=$(basename "$path")
+            sha=$(sha256_of "$path")
+            soldr_debug_info_entries+=("{ \"name\": \"${name}\", \"sha256\": \"${sha}\", \"format\": \"${format}\" }")
+          }
           if [ -n "$suffix" ]; then
             soldr_pdb=$(find dist/package -maxdepth 1 -type f \( -name 'soldr.pdb' -o -name 'soldr_cli.pdb' \) -print -quit)
             if [ -z "$soldr_pdb" ]; then
@@ -553,9 +602,31 @@ jobs:
               ls -la dist/package >&2
               exit 1
             fi
-            soldr_pdb_name=$(basename "$soldr_pdb")
-            soldr_pdb_sha=$(sha256_of "$soldr_pdb")
-            soldr_debug_info_json=$(printf '[{ "name": "%s", "sha256": "%s", "format": "pdb" }]' "$soldr_pdb_name" "$soldr_pdb_sha")
+            add_sidecar_entry "$soldr_pdb" "pdb"
+          fi
+          soldr_dwp=$(find dist/package -maxdepth 1 -type f \( -name 'soldr.dwp' -o -name 'soldr_cli.dwp' \) -print -quit)
+          if [ -n "$soldr_dwp" ]; then
+            add_sidecar_entry "$soldr_dwp" "dwp"
+          fi
+          # macOS dSYM is a directory; sha256 it as a tarball of its
+          # contents so consumers can verify the whole bundle in one
+          # check. The bundle layout itself is preserved on disk.
+          # Pipe through whichever sha256 binary is available — the
+          # `sha256_of` helper above takes a path arg, not stdin.
+          soldr_dsym=$(find dist/package -maxdepth 1 -type d \( -name 'soldr.dSYM' -o -name 'soldr_cli.dSYM' \) -print -quit)
+          if [ -n "$soldr_dsym" ]; then
+            dsym_name=$(basename "$soldr_dsym")
+            if command -v sha256sum >/dev/null 2>&1; then
+              dsym_sha=$(tar -cf - -C "$(dirname "$soldr_dsym")" "$dsym_name" | sha256sum | awk '{print $1}')
+            else
+              dsym_sha=$(tar -cf - -C "$(dirname "$soldr_dsym")" "$dsym_name" | shasum -a 256 | awk '{print $1}')
+            fi
+            soldr_debug_info_entries+=("{ \"name\": \"${dsym_name}\", \"sha256\": \"${dsym_sha}\", \"format\": \"dsym\" }")
+          fi
+          if [ ${#soldr_debug_info_entries[@]} -eq 0 ]; then
+            soldr_debug_info_json="[]"
+          else
+            soldr_debug_info_json=$(printf "[%s]" "$(IFS=,; echo "${soldr_debug_info_entries[*]}")")
           fi
           zccache_sha=$(sha256_of "dist/package/zccache${suffix}")
           zccache_daemon_sha=$(sha256_of "dist/package/zccache-daemon${suffix}")

--- a/crates/soldr-cli/src/lib.rs
+++ b/crates/soldr-cli/src/lib.rs
@@ -19,6 +19,7 @@ pub mod core;
 pub mod daemon;
 pub mod defender;
 pub mod fetch;
+pub mod release_sidecar;
 pub mod self_relocate;
 /// `wrapper_target` holds the wrapper hot-path target-registry routing
 /// extracted out of `wrapper.rs` so integration tests under

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -29,6 +29,7 @@ mod native_cc;
 mod optimize;
 mod optimize_detect;
 mod optimize_windows;
+mod release_sidecar;
 mod rust_plan;
 mod save_load;
 mod self_relocate;

--- a/crates/soldr-cli/src/release_sidecar.rs
+++ b/crates/soldr-cli/src/release_sidecar.rs
@@ -1,0 +1,176 @@
+//! Release-archive debug sidecar classification (issue #786).
+//!
+//! When `release-auto.yml` stages a soldr release archive, it bundles
+//! every debug-symbol sidecar the platform build emits so post-mortem
+//! symbolication works on every target — not just the Windows
+//! `soldr.pdb` case PR #782 covered first. This module is the
+//! platform-independent classifier the manifest writer consults to
+//! tag each staged sidecar with the right `format` field.
+//!
+//! Centralizing the file-suffix → format mapping here lets unit tests
+//! lock the manifest schema even though the actual staging logic
+//! lives in a workflow `bash` step that isn't directly testable.
+//! Anyone touching the YAML can use the same constant strings the
+//! classifier returns, eliminating drift between the workflow's
+//! `format` value and what installers/validators expect.
+
+/// Format tag emitted in `manifest.json` under
+/// `<component>.debug_info[].format`. Versioned implicitly via the
+/// existing `schema_version` field — adding a new variant here is a
+/// schema bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DebugSidecarFormat {
+    /// Windows MSVC program database. Emitted by default on every
+    /// `*-pc-windows-msvc` Rust release build.
+    Pdb,
+    /// macOS DWARF symbol bundle. Emitted only when
+    /// `[profile.release] split-debuginfo = "packed"` (or `"unpacked"`
+    /// for the per-object `.dwo` form). The bundle is a *directory*,
+    /// not a file — workflow archiving must preserve its tree shape.
+    Dsym,
+    /// Linux split DWARF, packed form. Emitted when
+    /// `[profile.release] split-debuginfo = "packed"`.
+    Dwp,
+    /// Linux split DWARF, unpacked per-object form. Emitted when
+    /// `[profile.release] split-debuginfo = "unpacked"`. Most release
+    /// profiles don't use this; included for completeness so the
+    /// manifest tag is stable if a future profile change opts in.
+    Dwo,
+}
+
+impl DebugSidecarFormat {
+    /// The string written into `manifest.json` under
+    /// `<component>.debug_info[].format`. Stable values consumed by
+    /// `scripts/zccache-contract.js` and
+    /// `.github/actions/setup-soldr/zccache_contract.py`.
+    pub fn as_manifest_str(self) -> &'static str {
+        match self {
+            Self::Pdb => "pdb",
+            Self::Dsym => "dsym",
+            Self::Dwp => "dwp",
+            Self::Dwo => "dwo",
+        }
+    }
+}
+
+/// Classify a sidecar by its filename. Accepts both leaf names
+/// (`soldr.pdb`) and paths (`dist/package/soldr.pdb`). The match is
+/// case-insensitive because:
+///
+/// * Windows preserves case in filenames but APIs return them in
+///   whatever case the on-disk record holds — `SOLDR.PDB` is a valid
+///   match;
+/// * `.dSYM` is conventionally upper-S; matching it requires the
+///   tolerant comparison;
+/// * a filesystem with case-folding hardlinks (Windows + WSL2 NTFS)
+///   surfaces both spellings depending on which API enumerated the
+///   tree.
+pub fn classify_sidecar(filename: &str) -> Option<DebugSidecarFormat> {
+    let lower = filename.to_ascii_lowercase();
+    // `.dSYM` is a directory; the workflow may pass either the bundle
+    // root (`soldr.dSYM`) or a path that contains it.
+    if lower.ends_with(".dsym") || lower.contains(".dsym/") || lower.contains(".dsym\\") {
+        return Some(DebugSidecarFormat::Dsym);
+    }
+    if lower.ends_with(".pdb") {
+        return Some(DebugSidecarFormat::Pdb);
+    }
+    if lower.ends_with(".dwp") {
+        return Some(DebugSidecarFormat::Dwp);
+    }
+    if lower.ends_with(".dwo") {
+        return Some(DebugSidecarFormat::Dwo);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(pdb_is_classified_as_pdb, {
+        assert_eq!(classify_sidecar("soldr.pdb"), Some(DebugSidecarFormat::Pdb));
+        assert_eq!(
+            classify_sidecar("soldr_cli.pdb"),
+            Some(DebugSidecarFormat::Pdb),
+        );
+    });
+
+    crate::timed_test!(dsym_bundle_is_classified_as_dsym, {
+        // The macOS dSYM bundle is a directory; the workflow may pass
+        // either form so both must classify cleanly.
+        assert_eq!(
+            classify_sidecar("soldr.dSYM"),
+            Some(DebugSidecarFormat::Dsym),
+        );
+        assert_eq!(
+            classify_sidecar("soldr.dSYM/Contents/Resources/DWARF/soldr"),
+            Some(DebugSidecarFormat::Dsym),
+        );
+    });
+
+    crate::timed_test!(dwp_is_classified_as_dwp, {
+        assert_eq!(classify_sidecar("soldr.dwp"), Some(DebugSidecarFormat::Dwp));
+    });
+
+    crate::timed_test!(dwo_is_classified_as_dwo, {
+        // Unpacked split-debuginfo emits per-object .dwo files. The
+        // classifier supports them so a future profile flip is a
+        // workflow change, not a code change.
+        assert_eq!(
+            classify_sidecar("soldr-abc123.dwo"),
+            Some(DebugSidecarFormat::Dwo),
+        );
+    });
+
+    crate::timed_test!(classifier_is_case_insensitive, {
+        // Windows PDB enumeration can return uppercase; the macOS dSYM
+        // bundle is conventionally upper-S. The tolerant compare keeps
+        // the workflow from having to canonicalize before calling.
+        for name in ["SOLDR.PDB", "Soldr.Pdb", "soldr.DWP", "Soldr.DSYM"] {
+            assert!(
+                classify_sidecar(name).is_some(),
+                "expected {name:?} to classify",
+            );
+        }
+    });
+
+    crate::timed_test!(classifier_returns_none_for_release_binary, {
+        // The release binary itself must NOT classify as a sidecar,
+        // or the manifest writer would double-list it.
+        assert_eq!(classify_sidecar("soldr"), None);
+        assert_eq!(classify_sidecar("soldr.exe"), None);
+        assert_eq!(classify_sidecar("zccache"), None);
+        assert_eq!(classify_sidecar("zccache-daemon"), None);
+    });
+
+    crate::timed_test!(classifier_returns_none_for_unrelated_files, {
+        // Defensive: build artifacts in the same directory must not
+        // be misclassified as sidecars. `dep-info`/`.d`/`.rlib` are the
+        // common confounders.
+        for name in [
+            "soldr.d",
+            "soldr.rlib",
+            "libsoldr.so",
+            "manifest.json",
+            "README.md",
+        ] {
+            assert_eq!(
+                classify_sidecar(name),
+                None,
+                "expected {name:?} to not classify as a sidecar",
+            );
+        }
+    });
+
+    crate::timed_test!(manifest_strings_are_stable, {
+        // Lock the JSON-facing strings. Changing any of these is a
+        // manifest schema break that needs a coordinated bump in
+        // `scripts/zccache-contract.js` and
+        // `.github/actions/setup-soldr/zccache_contract.py`.
+        assert_eq!(DebugSidecarFormat::Pdb.as_manifest_str(), "pdb");
+        assert_eq!(DebugSidecarFormat::Dsym.as_manifest_str(), "dsym");
+        assert_eq!(DebugSidecarFormat::Dwp.as_manifest_str(), "dwp");
+        assert_eq!(DebugSidecarFormat::Dwo.as_manifest_str(), "dwo");
+    });
+}


### PR DESCRIPTION
## Summary

Generalizes release sidecar packaging beyond the Windows \`soldr.pdb\` case PR #782 added first. This PR is the first concrete step toward #786's "all platform debug sidecars" contract.

### Changes

1. **\`release-auto.yml\`** — extend the staging step's \`case "\${{ matrix.target }}"\` block to discover Linux \`.dwp\` and macOS \`.dSYM\` sidecars next to the release binary and copy them into \`dist/package/\`. Missing Linux/macOS sidecars are non-fatal — the default Rust release profile doesn't emit them unless \`[profile.release] split-debuginfo = "packed"\`.
2. **\`release-auto.yml\` manifest writer** — rebuild \`soldr.debug_info\` from EVERY sidecar found in \`dist/package/\` (not just the hardcoded Windows PDB). dSYM is a directory tree, so it's sha256'd via \`tar | sha256sum\` for a single bundle-wide hash.
3. **\`crates/soldr-cli/src/release_sidecar.rs\` (new)** — typed \`DebugSidecarFormat\` enum + \`classify_sidecar(filename)\` so the manifest \`format\` strings (\`pdb\` / \`dsym\` / \`dwp\` / \`dwo\`) have a Rust-side source of truth that downstream contract validators can import.

### Tests (8 new)

\`pdb_is_classified_as_pdb\`, \`dsym_bundle_is_classified_as_dsym\` (file + bundle-tree-path forms), \`dwp_is_classified_as_dwp\`, \`dwo_is_classified_as_dwo\`, \`classifier_is_case_insensitive\`, \`classifier_returns_none_for_release_binary\` (regression: don't double-list the binary), \`classifier_returns_none_for_unrelated_files\` (.d / .rlib / .so / README don't false-positive), \`manifest_strings_are_stable\` (locks the JSON-facing strings against drift).

### Out of scope (deferred to follow-up)

- Updating \`scripts/zccache-contract.js\` and \`.github/actions/setup-soldr/zccache_contract.py\` to validate the new \`debug_info\` entries
- Sidecars for bundled third-party binaries (zccache, crgx, cargo-chef)
- Separate \`soldr-symbols-<target>\` assets for large dSYM bundles

Relates to #786, references #782.

## Test plan

- [x] \`soldr cargo test -p soldr-cli --bin soldr release_sidecar\` — 8 pass
- [x] \`soldr cargo test -p soldr-cli --test timed_test_lint\` — bare-test guard green
- [x] YAML syntax-checked with PyYAML
- [ ] CI green (next release run will exercise the staging branches in practice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)