### PR TITLE
chore(release): bump 0.7.56 -> 0.7.57 (ships #755/#756 cargo chef fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.56"
+version = "0.7.57"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.56"
+version = "0.7.57"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.56",
+  "version": "0.7.57",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Pure version bump: 0.7.56 → 0.7.57. Ships the **#755/#756 cargo-front-door fix** to released users.

The fix landed on main as `8bfae87` (PR #756) on 2026-06-19, but `v0.7.56` was tagged 2026-06-16 — three days earlier — so users on the latest released soldr still see:

```text
$ soldr cargo check -p zccache --tests
soldr: 'check' is not a cargo subcommand soldr ships a prebuilt for.
soldr: did you mean: cargo chef?
```

Reproduced today on a fresh `0.7.55` install. Upgrading to `0.7.56` doesn't help — the fix isn't in that tag either.

## Files

Three-file lockstep bump per `CLAUDE.md` "Release Publishing Rules":

| File | Before | After |
|---|---|---|
| `Cargo.toml` `[workspace.package].version` | `0.7.56` | `0.7.57` |
| `Cargo.lock` `soldr-cli` package version | `0.7.56` | `0.7.57` |
| `package.json` `"version"` | `0.7.56` | `0.7.57` |

No source code changes.

## Release-state audit (before bumping)

| Surface | Version | Has #756 fix? |
|---|---|---|
| `Cargo.toml` | `0.7.56` | yes (on main, unreleased) |
| `package.json` | `0.7.56` | n/a |
| PyPI `soldr` | `0.7.56` | no |
| npm `@zackees/soldr` | `0.7.56` | no |
| `git ls-remote --tags origin v0.7.57` | (none) | n/a |

`v0.7.57` is not already published — safe target.

## What merging this triggers

The `Autonomous Release` workflow's prepare job will see that `Cargo.toml`'s version differs from the latest published tag, set `should_release=true`, build all three platform matrices, push the `v0.7.57` tag, and publish to PyPI + npm.

## Test plan

- [ ] CI passes on this PR
- [ ] On merge, Autonomous Release publishes `v0.7.57`
- [ ] `pip install soldr==0.7.57` and `npm install @zackees/soldr@0.7.57` resolve
- [ ] `soldr cargo check` on a fresh `pip install soldr==0.7.57` no longer prints the misleading `cargo chef?` hint

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)
