### PR TITLE
fix(cargo-front-door): defer to cargo-<sub> on PATH (closes #816)

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -810,6 +810,53 @@ fn suggest_cargo_subcommand_typo(sub: &str) -> Option<String> {
     crate::fuzzy_match::suggest_close_match(sub, &known).map(|s| s.to_string())
 }
 
+/// Env var name for the PATH-first override (issue #816). Reads as truthy
+/// when set to any value except an empty string or `0`/`false`/`no`.
+pub(crate) const FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR: &str =
+    "SOLDR_FORCE_MANAGED_CARGO_SUBCOMMANDS";
+
+fn force_managed_cargo_subcommands() -> bool {
+    match std::env::var(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR) {
+        Ok(value) => {
+            let trimmed = value.trim();
+            !matches!(trimmed, "" | "0" | "false" | "no" | "off")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Walk `$PATH` looking for an executable named `tool`. Mirrors the
+/// hand-rolled lookup in `core::toolchain_resolve::path_bin_dir` —
+/// duplicated rather than re-exported to keep the cargo-front-door
+/// independent of `core::toolchain_resolve`'s internals. On Windows the
+/// `PATHEXT` suffix sweep matches what the toolchain resolver does so
+/// `cargo-zigbuild.exe` is found even when the caller typed `cargo-zigbuild`.
+fn find_on_path(tool: &str) -> Option<std::path::PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(tool);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            if std::path::Path::new(tool).extension().is_some() {
+                continue;
+            }
+            let pathext = std::env::var_os("PATHEXT")
+                .and_then(|value| value.into_string().ok())
+                .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string());
+            for suffix in pathext.split(';').map(str::trim).filter(|s| !s.is_empty()) {
+                let suffixed = dir.join(format!("{tool}{suffix}"));
+                if suffixed.is_file() {
+                    return Some(suffixed);
+                }
+            }
+        }
+    }
+    None
+}
+
 async fn ensure_known_subcommand_tool(
     args: &[String],
     paths: &SoldrPaths,
@@ -830,6 +877,31 @@ async fn ensure_known_subcommand_tool(
         }
         return Ok(Vec::new());
     };
+
+    // Issue #816: if `cargo-<sub>` is already on PATH, defer to it instead
+    // of running the managed fetch. This matches the discipline
+    // `ensure_rustup_available` uses for rustup and avoids two failure modes:
+    //   1. The managed fetcher writing an unrunnable artifact (the original
+    //      #816 / #810 cargo-zigbuild bug, now fixed by xz2 extraction —
+    //      but PATH-first is a structural belt-and-suspenders).
+    //   2. Bypassing a user who deliberately installed a specific version
+    //      via `cargo install <name> --locked` or their distro package
+    //      manager. cargo's own external-subcommand dispatch will find the
+    //      PATH binary; soldr returning Ok(empty) here leaves that path
+    //      open without prepending its own bin dir.
+    // Escape hatch: SOLDR_FORCE_MANAGED_CARGO_SUBCOMMANDS=1 forces the
+    // managed fetch even when PATH has the tool — useful for CI runs that
+    // want byte-identical pinned binaries.
+    if !force_managed_cargo_subcommands() {
+        let exe_name = format!("cargo-{sub}");
+        if let Some(path) = find_on_path(&exe_name) {
+            eprintln!(
+                "soldr: deferring to {exe_name} on PATH at {} (set SOLDR_FORCE_MANAGED_CARGO_SUBCOMMANDS=1 to override)",
+                path.display()
+            );
+            return Ok(Vec::new());
+        }
+    }
 
     let version = spec
         .pinned_version

--- a/crates/soldr-cli/src/cargo_front_door/tests.rs
+++ b/crates/soldr-cli/src/cargo_front_door/tests.rs
@@ -503,3 +503,140 @@ fn suggest_cargo_subcommand_typo_returns_none_for_unrelated_input() {
         None,
     );
 }
+
+// Issue #816: SOLDR_FORCE_MANAGED_CARGO_SUBCOMMANDS env-var handling.
+// The bool guard parses truthy / falsy values consistently with the
+// pattern other soldr env vars use.
+
+#[test]
+fn force_managed_cargo_subcommands_defaults_to_false_when_unset() {
+    // Serialize on the env mutex used elsewhere in this file so we don't
+    // race against other env-touching tests in the same binary.
+    let _guard = ENV_LOCK.lock().unwrap();
+    let prev = std::env::var_os(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR);
+    // SAFETY: the test acquires ENV_LOCK to serialize against any other
+    // test that mutates process env.
+    unsafe {
+        std::env::remove_var(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR);
+    }
+    assert!(!force_managed_cargo_subcommands());
+    if let Some(value) = prev {
+        unsafe {
+            std::env::set_var(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR, value);
+        }
+    }
+}
+
+#[test]
+fn force_managed_cargo_subcommands_parses_falsey_strings_as_false() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let prev = std::env::var_os(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR);
+    for falsey in ["", " ", "0", "false", "no", "off", "  off  "] {
+        unsafe {
+            std::env::set_var(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR, falsey);
+        }
+        assert!(
+            !force_managed_cargo_subcommands(),
+            "value {falsey:?} should parse as false",
+        );
+    }
+    match prev {
+        Some(value) => unsafe {
+            std::env::set_var(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR, value);
+        },
+        None => unsafe {
+            std::env::remove_var(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR);
+        },
+    }
+}
+
+#[test]
+fn force_managed_cargo_subcommands_parses_truthy_strings_as_true() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let prev = std::env::var_os(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR);
+    for truthy in ["1", "true", "yes", "on", "anything-else"] {
+        unsafe {
+            std::env::set_var(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR, truthy);
+        }
+        assert!(
+            force_managed_cargo_subcommands(),
+            "value {truthy:?} should parse as true",
+        );
+    }
+    match prev {
+        Some(value) => unsafe {
+            std::env::set_var(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR, value);
+        },
+        None => unsafe {
+            std::env::remove_var(FORCE_MANAGED_CARGO_SUBCOMMANDS_ENV_VAR);
+        },
+    }
+}
+
+#[test]
+fn find_on_path_locates_executable_in_a_path_dir() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let exe_name = if cfg!(windows) {
+        "soldr-test-find-on-path-fixture.exe"
+    } else {
+        "soldr-test-find-on-path-fixture"
+    };
+    let exe_path = dir.path().join(exe_name);
+    std::fs::write(&exe_path, b"#!/bin/sh\nexit 0\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&exe_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&exe_path, perms).unwrap();
+    }
+
+    let prev_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut new_path = std::ffi::OsString::from(dir.path());
+    if !prev_path.is_empty() {
+        let sep = if cfg!(windows) { ";" } else { ":" };
+        new_path.push(sep);
+        new_path.push(&prev_path);
+    }
+    unsafe {
+        std::env::set_var("PATH", &new_path);
+    }
+
+    // The probe name is intentionally unsuffixed on both platforms — on
+    // Windows the PATHEXT sweep in find_on_path picks up the `.exe`.
+    let resolved = find_on_path("soldr-test-find-on-path-fixture");
+    unsafe {
+        std::env::set_var("PATH", &prev_path);
+    }
+
+    let resolved_path = resolved.expect("fixture must be found on PATH");
+    assert!(
+        resolved_path.is_file(),
+        "resolved path {resolved_path:?} must exist",
+    );
+    assert!(
+        resolved_path
+            .parent()
+            .map(|p| p == dir.path())
+            .unwrap_or(false),
+        "resolved path {resolved_path:?} must live under the fixture dir {:?}",
+        dir.path(),
+    );
+}
+
+#[test]
+fn find_on_path_returns_none_when_missing() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let prev_path = std::env::var_os("PATH").unwrap_or_default();
+    let new_path: std::ffi::OsString = dir.path().into();
+    unsafe {
+        std::env::set_var("PATH", &new_path);
+    }
+    let resolved = find_on_path("definitely-not-on-path-soldr-test-816");
+    unsafe {
+        std::env::set_var("PATH", &prev_path);
+    }
+    assert_eq!(resolved, None);
+}


### PR DESCRIPTION
## Summary

Closes the second concern raised in #816 — the precedence one. The first concern (managed fetcher writing an unrunnable shim from the raw `.tar.xz` body) was already fixed by [#810](https://github.com/zackees/soldr/pull/810) and shipped in v0.7.57.

The issue body's bullet 2:

> Even when a working `cargo-zigbuild` exists at `$CARGO_HOME/bin/cargo-zigbuild` (here: installed by `soldr cargo install cargo-zigbuild --locked` in the same job, succeeded, on PATH), the managed-fetch path still runs. Either the precedence is wrong or PATH isn't consulted.

is a separate, real bug — `ensure_known_subcommand_tool` jumped straight from `lookup_by_cargo_subcommand` to `fetch_tool_with_paths` without ever consulting `$PATH`.

## Change

`ensure_known_subcommand_tool` now PATH-walks for `cargo-<sub>` before calling the managed fetcher. When the binary is found on PATH:

- Skip the managed fetch entirely.
- Print one stderr line naming the resolved path + the override env var.
- Return `Ok(empty)` so cargo's own external-subcommand dispatch finds the PATH binary (no prepended soldr bin dir needed).

The PATH walker is inlined rather than re-exported from `core::toolchain_resolve` so the cargo-front-door stays independent of that module's internals. The Windows `PATHEXT` suffix sweep matches the existing toolchain_resolve helper exactly.

## Escape hatch

`SOLDR_FORCE_MANAGED_CARGO_SUBCOMMANDS=1` forces the managed fetch even when PATH has the tool. Useful for CI runs that want byte-identical pinned binaries regardless of host state.

Accepts truthy values `1` / `true` / `yes` / `on` (case-sensitive), rejects falsey values `""` / `0` / `false` / `no` / `off`.

## Tests

Five new unit tests in `cargo_front_door::tests`, all using the existing `ENV_LOCK` mutex to serialize against other env-touching tests:

- `force_managed_cargo_subcommands_defaults_to_false_when_unset`
- `force_managed_cargo_subcommands_parses_falsey_strings_as_false`
- `force_managed_cargo_subcommands_parses_truthy_strings_as_true`
- `find_on_path_locates_executable_in_a_path_dir` — writes a fixture executable to a tempdir, prepends it to PATH, verifies `find_on_path` resolves it
- `find_on_path_returns_none_when_missing`

All 60 tests in `cargo_front_door::tests` pass on x86_64-pc-windows-msvc.

## Why mirror toolchain_resolve's pattern instead of using the `which` crate

`which` isn't a workspace dependency and `core::toolchain_resolve::path_bin_dir` / `find_executable_in_dir` already hand-roll the same logic with the right Windows `PATHEXT` semantics. Adding ~25 LOC of duplicated logic beats taking on a new transitive dependency for one call site.

## Test plan

- [x] `cargo build -p soldr-cli` clean on x86_64-pc-windows-msvc
- [x] `cargo test --bin soldr cargo_front_door::` → 60/60 pass (5 new)
- [x] Pre-existing fmt + clippy issues in `tests/cli_zccache_contract_matrix.rs` and `src/save_load.rs` are unaffected by this change (verified failing on `main` independent of this PR)

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)
