### PR TITLE
feat(fetch+pep517): register maturin + expose soldr as PEP 517 build-backend

### DIFF
--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -44,6 +44,13 @@
     ],
     "manifest_block": "cargo_chef"
   },
+  "maturin": {
+    "managed_version": "1.14.1",
+    "required_binaries": [
+      "maturin"
+    ],
+    "manifest_block": "maturin"
+  },
   "setup_action": {
     "cache_root_env": "SOLDR_CACHE_DIR",
     "native_cache_env": "SOLDR_NATIVE_CACHE",

--- a/crates/soldr-cli/src/fetch/known_tools.rs
+++ b/crates/soldr-cli/src/fetch/known_tools.rs
@@ -210,6 +210,22 @@ pub const KNOWN_TOOLS: &[ToolSpec] = &[
         tag_prefix: None,
         pinned_version: None,
     },
+    // `maturin` powers Python+Rust packaging. Two consumers:
+    // 1. `soldr maturin <args>` — direct CLI dispatch for users running
+    //    `soldr maturin develop` / `soldr maturin build` etc.
+    // 2. The PEP 517 build backend in `src/soldr/__init__.py` — when a
+    //    downstream pyproject sets `build-backend = "soldr"`, the shim
+    //    shells out to `soldr maturin pep517 <hook>` for each PEP 517
+    //    entry point. Pinning the version keeps the build backend's
+    //    behavior reproducible across machines and CI runs.
+    ToolSpec {
+        crate_name: "maturin",
+        cargo_subcommand: None,
+        binary_name: "maturin",
+        repo: Some(("PyO3", "maturin")),
+        tag_prefix: None,
+        pinned_version: Some(super::MANAGED_MATURIN_VERSION),
+    },
     // Mindshare top-level tools (issue #598 child). Invoked as
     // `soldr bacon`, `soldr just`, `soldr typos`.
     // `bacon` — https://github.com/Canop/bacon. Tags are `vX.Y.Z`.
@@ -413,12 +429,29 @@ mod tests {
             "wasm-pack",
             "trunk",
             "sccache",
+            "maturin",
         ] {
             let spec = lookup_by_crate(crate_name)
                 .unwrap_or_else(|| panic!("missing registry entry for {crate_name}"));
             assert_eq!(spec.cargo_subcommand, None);
             assert!(spec.repo.is_some());
         }
+    }
+
+    #[test]
+    fn maturin_is_registered_and_pinned_to_managed_version() {
+        // The PEP 517 build backend in src/soldr/__init__.py shells out
+        // to `soldr maturin pep517 <hook>`. If the registry entry drifts
+        // away from MANAGED_MATURIN_VERSION the backend's behavior
+        // changes silently across machines; the pin keeps it reproducible.
+        let spec = lookup_by_crate("maturin").expect("maturin must be registered");
+        assert_eq!(spec.cargo_subcommand, None);
+        assert_eq!(spec.binary_name, "maturin");
+        assert_eq!(spec.repo, Some(("PyO3", "maturin")));
+        assert_eq!(
+            spec.pinned_version,
+            Some(super::super::MANAGED_MATURIN_VERSION)
+        );
     }
 
     #[test]

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -121,6 +121,19 @@ pub const ZCCACHE_LOCAL_DIR_ENV_VAR: &str = "SOLDR_ZCCACHE_LOCAL_DIR";
 /// bundled binary is not available.
 pub const MANAGED_CRGX_VERSION: &str = "0.1.0";
 
+/// Pinned `maturin` release used by both the `soldr maturin <args>`
+/// CLI dispatch and the PEP 517 build backend in `src/soldr/__init__.py`.
+/// Surfaced via `lookup_by_crate("maturin").pinned_version` so every
+/// resolution path lands on the same upstream version — keeping the
+/// Python+Rust packaging behavior reproducible across machines.
+///
+/// Lockstep bookkeeping (per CLAUDE.md "Bumping managed_zccache_version"):
+/// when bumping, also update `contracts/zccache-runtime.v1.json`'s
+/// `maturin.managed_version`; the
+/// `zccache_runtime_contract_matches_rust_constants` test asserts they
+/// match and panics with a directive message if they drift.
+pub const MANAGED_MATURIN_VERSION: &str = "1.14.1";
+
 /// Override the runtime crgx resolution: when set, soldr uses the
 /// `crgx` (or `crgx.exe`) binary in this directory ahead of any
 /// GitHub-Releases / crates.io fetch. The npm shim (`bin/soldr.js`)

--- a/crates/soldr-cli/src/fetch/zccache_contract_tests.rs
+++ b/crates/soldr-cli/src/fetch/zccache_contract_tests.rs
@@ -1,7 +1,7 @@
 use super::{
     CARGO_CHEF_LOCAL_DIR_ENV_VAR, CARGO_CHEF_PINNED_VERSION, CRGX_LOCAL_DIR_ENV_VAR,
-    MANAGED_CRGX_VERSION, MANAGED_ZCCACHE_PACKAGES, MANAGED_ZCCACHE_VERSION,
-    ZCCACHE_LOCAL_DIR_ENV_VAR,
+    MANAGED_CRGX_VERSION, MANAGED_MATURIN_VERSION, MANAGED_ZCCACHE_PACKAGES,
+    MANAGED_ZCCACHE_VERSION, ZCCACHE_LOCAL_DIR_ENV_VAR,
 };
 
 // When this test fails, the contributor most likely bumped only one
@@ -63,6 +63,14 @@ crate::timed_test!(zccache_runtime_contract_matches_rust_constants, {
          but CARGO_CHEF_LOCAL_DIR_ENV_VAR in crates/soldr-cli/src/fetch/mod.rs says {:?}. {DRIFT_HINT}",
         contract["cargo_chef"]["local_dir_env"].as_str(),
         CARGO_CHEF_LOCAL_DIR_ENV_VAR,
+    );
+    assert_eq!(
+        contract["maturin"]["managed_version"].as_str(),
+        Some(MANAGED_MATURIN_VERSION),
+        "maturin.managed_version drift: contracts/zccache-runtime.v1.json says {:?} \
+         but MANAGED_MATURIN_VERSION in crates/soldr-cli/src/fetch/mod.rs says {:?}. {DRIFT_HINT}",
+        contract["maturin"]["managed_version"].as_str(),
+        MANAGED_MATURIN_VERSION,
     );
 
     let contract_zccache_bins: Vec<&str> = contract["zccache"]["required_binaries"]

--- a/crates/soldr-cli/src/save_load.rs
+++ b/crates/soldr-cli/src/save_load.rs
@@ -120,7 +120,7 @@ pub fn run_save(args: SaveArgs) -> i32 {
     let args = match apply_private_session_cache_dir_default(
         args,
         crate::zccache::private_session_requested(),
-        || std::env::current_dir(),
+        std::env::current_dir,
     ) {
         Ok(args) => args,
         Err(err) => {
@@ -224,7 +224,7 @@ pub fn run_load(args: LoadArgs) -> i32 {
     let args = match apply_private_session_cache_dir_default_load(
         args,
         crate::zccache::private_session_requested(),
-        || std::env::current_dir(),
+        std::env::current_dir,
     ) {
         Ok(args) => args,
         Err(err) => {

--- a/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
+++ b/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
@@ -328,8 +328,7 @@ timed_test!(
         assert!(
             path_display_variants(&expected_cache_dir)
                 .iter()
-                .any(|variant| log
-                    .contains(&format!("zccache session-start cache_dir={variant}"))),
+                .any(|variant| log.contains(&format!("zccache session-start cache_dir={variant}"))),
             "session-start must inherit ZCCACHE_CACHE_DIR=<{}> so the daemon \
              endpoint matches the cargo child's cache root (regression for \
              PR #751; see #752)\n{log}",
@@ -360,8 +359,7 @@ timed_test!(
         assert!(
             path_display_variants(&expected_cache_dir)
                 .iter()
-                .any(|variant| log
-                    .contains(&format!("zccache wrapper cache_dir={variant}"))),
+                .any(|variant| log.contains(&format!("zccache wrapper cache_dir={variant}"))),
             "wrapper invocation of zccache must inherit cache_dir=<{}> from \
              the cargo child env so the daemon endpoint matches what \
              session-start opened (#752)\n{log}",

--- a/src/soldr/__init__.py
+++ b/src/soldr/__init__.py
@@ -1,1 +1,146 @@
-"""soldr — Instant tools. Instant builds."""
+"""soldr — Instant tools. Instant builds.
+
+PEP 517 build backend that delegates to a managed maturin binary.
+
+Set in your pyproject.toml::
+
+    [build-system]
+    requires = ["soldr"]
+    build-backend = "soldr"
+
+soldr fetches a pinned maturin from GitHub Releases on first build
+(cached under ~/.soldr/bin/) and delegates to it via
+``soldr maturin pep517 <hook>``. Builds run with ``RUSTC_WRAPPER=soldr``
+and ``ZCCACHE_PATH_REMAP=auto`` so rustc invocations are cached and
+git-worktree caches share via path normalization.
+
+``requires = ["soldr"]`` alone is sufficient — there is no separate
+``maturin`` Python dependency to add, because soldr handles maturin
+acquisition itself.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def _prep_env() -> "dict[str, str]":
+    env = os.environ.copy()
+    env.setdefault("RUSTC_WRAPPER", "soldr")
+    env.setdefault("ZCCACHE_PATH_REMAP", "auto")
+    return env
+
+
+def _maturin_pep517(subcommand: str, *args: str) -> None:
+    cmd = ["soldr", "maturin", "pep517", subcommand, *args]
+    subprocess.check_call(cmd, env=_prep_env())
+
+
+def _newest_entry(directory: str, suffix: str, *, want_dir: bool) -> str:
+    entries = []
+    for name in os.listdir(directory):
+        if not name.endswith(suffix):
+            continue
+        path = Path(directory, name)
+        if want_dir and not path.is_dir():
+            continue
+        if not want_dir and not path.is_file():
+            continue
+        entries.append((path.stat().st_mtime, name))
+    if not entries:
+        kind = "directory" if want_dir else "file"
+        raise RuntimeError(
+            f"soldr build backend: no {suffix} {kind} produced in {directory}"
+        )
+    entries.sort(reverse=True)
+    return entries[0][1]
+
+
+# PEP 517 dictates the exact parameter names below; renaming them with
+# `_` prefixes to silence linters would break frontends that call by
+# keyword. `del` after entry preserves the contract while marking each
+# unused arg as intentionally ignored for pylint W0613 / pyright
+# reportUnusedParameter / ruff ARG001.
+
+
+def get_requires_for_build_wheel(config_settings: Optional[dict] = None):
+    del config_settings
+    return []
+
+
+def get_requires_for_build_sdist(config_settings: Optional[dict] = None):
+    del config_settings
+    return []
+
+
+def get_requires_for_build_editable(config_settings: Optional[dict] = None):
+    del config_settings
+    return []
+
+
+def prepare_metadata_for_build_wheel(
+    metadata_directory: str,
+    config_settings: Optional[dict] = None,
+) -> str:
+    del config_settings
+    _maturin_pep517(
+        "write-dist-info",
+        "--metadata-directory",
+        metadata_directory,
+        "--interpreter",
+        sys.executable,
+    )
+    return _newest_entry(metadata_directory, ".dist-info", want_dir=True)
+
+
+prepare_metadata_for_build_editable = prepare_metadata_for_build_wheel
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: Optional[dict] = None,
+    metadata_directory: Optional[str] = None,
+) -> str:
+    # maturin pep517 build-wheel does not accept --metadata-directory;
+    # the dist-info is regenerated, which PEP 517 explicitly permits.
+    del config_settings, metadata_directory
+    _maturin_pep517(
+        "build-wheel",
+        "--interpreter",
+        sys.executable,
+        "--out",
+        wheel_directory,
+    )
+    return _newest_entry(wheel_directory, ".whl", want_dir=False)
+
+
+def build_editable(
+    wheel_directory: str,
+    config_settings: Optional[dict] = None,
+    metadata_directory: Optional[str] = None,
+) -> str:
+    del config_settings, metadata_directory
+    _maturin_pep517(
+        "build-wheel",
+        "--interpreter",
+        sys.executable,
+        "--out",
+        wheel_directory,
+        "--editable",
+    )
+    return _newest_entry(wheel_directory, ".whl", want_dir=False)
+
+
+def build_sdist(
+    sdist_directory: str,
+    config_settings: Optional[dict] = None,
+) -> str:
+    del config_settings
+    _maturin_pep517(
+        "write-sdist",
+        "--sdist-directory",
+        sdist_directory,
+    )
+    return _newest_entry(sdist_directory, ".tar.gz", want_dir=False)

--- a/src/soldr/setup_soldr_exporter.py
+++ b/src/soldr/setup_soldr_exporter.py
@@ -5,7 +5,6 @@ import argparse
 import shutil
 from pathlib import Path
 
-
 HELPER_SCRIPT_PATHS = (
     Path(".github/actions/setup-soldr/resolve_setup.py"),
     Path(".github/actions/setup-soldr/ensure_rust_toolchain.py"),
@@ -212,7 +211,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Export the standalone public setup-soldr action bundle."
     )
     parser.add_argument(
-        "destination", help="Directory to materialize as the future public action repository."
+        "destination",
+        help="Directory to materialize as the future public action repository.",
     )
     parser.add_argument(
         "--source-root",
@@ -224,7 +224,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    destination = export_setup_soldr_bundle(Path(args.source_root), Path(args.destination))
+    destination = export_setup_soldr_bundle(
+        Path(args.source_root), Path(args.destination)
+    )
     print(f"Exported setup-soldr bundle to {destination}")
     return 0
 

--- a/tests/test_bootstrap_act_image.py
+++ b/tests/test_bootstrap_act_image.py
@@ -35,7 +35,6 @@ from pathlib import Path
 
 import pytest
 
-
 ACT_IMAGE = "catthehacker/ubuntu:act-24.04"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -119,7 +118,9 @@ def test_soldr_bootstrap_installs_rustup_on_act_image(tmp_path: Path) -> None:
         "/soldr/bin/rustup --version",
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=600, check=False)
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, timeout=600, check=False
+    )
     assert result.returncode == 0, (
         f"docker run failed (exit {result.returncode})\n"
         f"stdout:\n{result.stdout}\n"
@@ -129,4 +130,6 @@ def test_soldr_bootstrap_installs_rustup_on_act_image(tmp_path: Path) -> None:
     assert '"already_installed": false' in result.stdout, (
         "expected first-run install report; stdout was:\n" + result.stdout
     )
-    assert "rustup" in result.stdout, "expected `rustup --version` output to mention rustup"
+    assert (
+        "rustup" in result.stdout
+    ), "expected `rustup --version` output to mention rustup"

--- a/tests/test_perf_matrix.py
+++ b/tests/test_perf_matrix.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_setup_soldr_action.py
+++ b/tests/test_setup_soldr_action.py
@@ -6,7 +6,6 @@ import json
 import re
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "resolve_setup.py"
 
@@ -162,9 +161,9 @@ def test_setup_soldr_smoke_tests_disable_nested_cache() -> None:
 
 
 def test_build_and_test_uploads_windows_pdb_artifacts() -> None:
-    workflow = (
-        REPO_ROOT / ".github" / "workflows" / "_build-and-test.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (REPO_ROOT / ".github" / "workflows" / "_build-and-test.yml").read_text(
+        encoding="utf-8"
+    )
 
     assert "CARGO_PROFILE_DEV_DEBUG=line-tables-only" in workflow
     assert "CARGO_PROFILE_TEST_DEBUG=line-tables-only" in workflow

--- a/tests/test_setup_soldr_ensure_rust_toolchain.py
+++ b/tests/test_setup_soldr_ensure_rust_toolchain.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-import pytest
-
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SCRIPT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "ensure_rust_toolchain.py"
+SCRIPT_PATH = (
+    REPO_ROOT / ".github" / "actions" / "setup-soldr" / "ensure_rust_toolchain.py"
+)
 
 
 def _load_module():
@@ -59,7 +58,9 @@ def test_main_bootstraps_rustup_when_missing_and_exports_rustup_toolchain(
             "rustc": "C:/tools/rustc.exe",
         }.get(name)
 
-    monkeypatch.setattr(module, "download_rustup_init", lambda _: "C:/tools/rustup-init.exe")
+    monkeypatch.setattr(
+        module, "download_rustup_init", lambda _: "C:/tools/rustup-init.exe"
+    )
     monkeypatch.setattr(module.shutil, "which", fake_which)
 
     def fake_run(command):

--- a/tests/test_setup_soldr_ensure_soldr.py
+++ b/tests/test_setup_soldr_ensure_soldr.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "ensure_soldr.py"
 

--- a/tests/test_setup_soldr_exporter.py
+++ b/tests/test_setup_soldr_exporter.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = REPO_ROOT / "src" / "soldr" / "setup_soldr_exporter.py"
 FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "setup_soldr_exporter"
@@ -43,12 +42,12 @@ def test_export_bundle_creates_expected_public_repo_layout(tmp_path: Path) -> No
         "contracts/zccache-runtime.v1.json",
     ]
 
-    assert destination.joinpath("action.yml").read_text(encoding="utf-8") == FIXTURE_DIR.joinpath(
-        "expected_action.yml"
-    ).read_text(encoding="utf-8")
-    assert destination.joinpath("README.md").read_text(encoding="utf-8") == FIXTURE_DIR.joinpath(
-        "expected_README.md"
-    ).read_text(encoding="utf-8")
+    assert destination.joinpath("action.yml").read_text(
+        encoding="utf-8"
+    ) == FIXTURE_DIR.joinpath("expected_action.yml").read_text(encoding="utf-8")
+    assert destination.joinpath("README.md").read_text(
+        encoding="utf-8"
+    ) == FIXTURE_DIR.joinpath("expected_README.md").read_text(encoding="utf-8")
 
 
 def test_export_bundle_excludes_internal_repo_override_input(tmp_path: Path) -> None:
@@ -60,11 +59,16 @@ def test_export_bundle_excludes_internal_repo_override_input(tmp_path: Path) -> 
     action_yaml = destination.joinpath("action.yml").read_text(encoding="utf-8")
     assert "repo:" not in action_yaml
     assert "INPUT_REPO" not in action_yaml
-    assert "Not part of the intended public setup-soldr@v0 beta contract" not in action_yaml
+    assert (
+        "Not part of the intended public setup-soldr@v0 beta contract"
+        not in action_yaml
+    )
 
 
 def test_export_bundle_refuses_repo_root_as_destination() -> None:
     module = _load_module()
 
-    with pytest.raises(ValueError, match="Destination must not be the source repository root"):
+    with pytest.raises(
+        ValueError, match="Destination must not be the source repository root"
+    ):
         module.export_setup_soldr_bundle(REPO_ROOT, REPO_ROOT)

--- a/tests/test_setup_soldr_install_tool_shims.py
+++ b/tests/test_setup_soldr_install_tool_shims.py
@@ -4,9 +4,10 @@ import importlib.util
 import os
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SCRIPT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "install_tool_shims.py"
+SCRIPT_PATH = (
+    REPO_ROOT / ".github" / "actions" / "setup-soldr" / "install_tool_shims.py"
+)
 
 
 def _load_module():
@@ -40,9 +41,7 @@ def test_tool_env_name_sanitizes_tool_names() -> None:
     assert module.tool_env_name("clippy-driver") == "SOLDR_REAL_CLIPPY_DRIVER"
 
 
-def test_main_writes_cargo_shim_and_real_tool_env(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_main_writes_cargo_shim_and_real_tool_env(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     github_env = tmp_path / "github.env"
     github_path = tmp_path / "github.path"

--- a/tests/test_setup_soldr_pins.py
+++ b/tests/test_setup_soldr_pins.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 VERIFY_SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "verify_setup_soldr_pin.py"
 
@@ -26,26 +25,32 @@ def test_workflows_pin_setup_soldr_to_current_v0_sha() -> None:
 
 
 def test_soldr_self_builds_use_pinned_public_setup_soldr() -> None:
-    bootstrap = (
-        REPO_ROOT / ".github" / "workflows" / "_bootstrap-e2e.yml"
-    ).read_text(encoding="utf-8")
+    bootstrap = (REPO_ROOT / ".github" / "workflows" / "_bootstrap-e2e.yml").read_text(
+        encoding="utf-8"
+    )
 
     assert "uses: ./soldr" not in bootstrap
     assert "uses: zackees/setup-soldr@" in bootstrap
 
 
 def test_ci_resets_restore_key_target_artifacts_before_self_builds() -> None:
-    bootstrap = (
-        REPO_ROOT / ".github" / "workflows" / "_bootstrap-e2e.yml"
-    ).read_text(encoding="utf-8")
+    bootstrap = (REPO_ROOT / ".github" / "workflows" / "_bootstrap-e2e.yml").read_text(
+        encoding="utf-8"
+    )
     build = (REPO_ROOT / ".github" / "workflows" / "_build-and-test.yml").read_text(
         encoding="utf-8"
     )
 
     for workflow in (bootstrap, build):
         assert "id: setup_soldr" in workflow
-        assert "steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'" in workflow
-        assert "steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit'" in workflow
+        assert (
+            "steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'"
+            in workflow
+        )
+        assert (
+            "steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit'"
+            in workflow
+        )
         assert "SOLDR_TARGET_CACHE_MODE=off" in workflow
         assert 'Join-Path "target" "${{ inputs.target }}"' in workflow
         assert 'Join-Path $env:ZCCACHE_CACHE_DIR "artifacts"' in workflow

--- a/tests/test_setup_soldr_verify_soldr.py
+++ b/tests/test_setup_soldr_verify_soldr.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "verify_soldr.py"
 

--- a/tests/test_zccache_integration_guardrails.py
+++ b/tests/test_zccache_integration_guardrails.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GUARDRAILS_PATH = REPO_ROOT / "contracts" / "zccache-integration-guardrails.v1.json"
 DOCS_PATH = REPO_ROOT / "docs" / "ZCCACHE_INTEGRATION_GUARDRAILS.md"
@@ -75,7 +74,9 @@ def test_guardrail_test_files_exist() -> None:
     for guardrail in contract["guardrails"]:
         for rel_path in guardrail["test_files"]:
             path = REPO_ROOT / rel_path
-            assert path.exists(), f"{guardrail['id']} references missing path: {rel_path}"
+            assert (
+                path.exists()
+            ), f"{guardrail['id']} references missing path: {rel_path}"
 
 
 def test_guardrail_docs_cover_every_id_and_command() -> None:

--- a/tests/test_zccache_runtime_contract.py
+++ b/tests/test_zccache_runtime_contract.py
@@ -7,10 +7,11 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_PATH = REPO_ROOT / "contracts" / "zccache-runtime.v1.json"
-PY_CONTRACT_PATH = REPO_ROOT / ".github" / "actions" / "setup-soldr" / "zccache_contract.py"
+PY_CONTRACT_PATH = (
+    REPO_ROOT / ".github" / "actions" / "setup-soldr" / "zccache_contract.py"
+)
 
 
 def _load_py_contract():
@@ -85,7 +86,9 @@ def _write_manifest_fixture(root: Path, *, windows: bool = False) -> dict[str, o
         },
         "archive": {
             "format": module.ARCHIVE_EXT,
-            "compression_level": module.CONTRACT["release_archive"]["compression_level"],
+            "compression_level": module.CONTRACT["release_archive"][
+                "compression_level"
+            ],
         },
         "built_at": "2026-05-27T00:00:00Z",
     }
@@ -192,11 +195,13 @@ def test_python_action_helpers_import_contract_constants() -> None:
 
 def test_release_workflow_and_docs_reference_contract_layout() -> None:
     contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
-    release_workflow = (REPO_ROOT / ".github" / "workflows" / "release-auto.yml").read_text(
+    release_workflow = (
+        REPO_ROOT / ".github" / "workflows" / "release-auto.yml"
+    ).read_text(encoding="utf-8")
+    npm_docs = (REPO_ROOT / "docs" / "NPM_PUBLISHING.md").read_text(encoding="utf-8")
+    runtime_docs = (REPO_ROOT / "docs" / "ZCCACHE_RUNTIME_CONTRACT.md").read_text(
         encoding="utf-8"
     )
-    npm_docs = (REPO_ROOT / "docs" / "NPM_PUBLISHING.md").read_text(encoding="utf-8")
-    runtime_docs = (REPO_ROOT / "docs" / "ZCCACHE_RUNTIME_CONTRACT.md").read_text(encoding="utf-8")
 
     assert '"schema_version": 3' in release_workflow
     assert '"format": "tar.zst"' in release_workflow


### PR DESCRIPTION
## Summary

Closes #821.

- Registers `maturin` in `known_tools` (pinned to v1.14.1 via new `MANAGED_MATURIN_VERSION` constant) so `soldr maturin <args>` auto-fetches and caches the binary on first use.
- Wires the matching `maturin` block into `contracts/zccache-runtime.v1.json` and extends `zccache_runtime_contract_matches_rust_constants` so drift between the Rust constant and the JSON panics with a directive message naming both files (lockstep gate, per CLAUDE.md).
- Replaces the empty `src/soldr/__init__.py` with a **PEP 517 build backend** that delegates to the cached maturin via `soldr maturin pep517 <hook>` CLI subcommands. Each hook pre-sets `RUSTC_WRAPPER=soldr` + `ZCCACHE_PATH_REMAP=auto` so rustc invocations cache and git-worktree caches share via path normalization.

### One-line adoption for downstream Python+Rust projects

```toml
[build-system]
requires = ["soldr"]
build-backend = "soldr"
```

No `maturin` dependency required — soldr handles maturin acquisition itself. This removes the chicken-and-egg with pip's isolated build env that a Python-side `import maturin` would create.

## Design decisions

- **Shell out to `maturin pep517 <hook>`, not `import maturin`.** Keeps the `requires` list to just `["soldr"]` and lets the Rust side own maturin's lifecycle (fetch, cache, version pin). Mirrors how maturin's own backend already shells out internally.
- **`build_wheel` ignores `metadata_directory`.** Matches maturin's CLI surface — `pep517 build-wheel` does not accept `--metadata-directory` and regenerates dist-info. PEP 517 explicitly permits backends to ignore the metadata hint.
- **`del config_settings` instead of underscore rename.** PEP 517 dictates the exact parameter names; renaming to `_config_settings` would break frontends that call by keyword. `del` after entry preserves the contract while silencing pylint W0613 / pyright reportUnusedParameter / ruff ARG001.
- **maturin v1.14.1 pinned.** Verified full platform asset coverage (x86_64/aarch64 windows-msvc, x86_64/aarch64 apple-darwin, x86_64/aarch64 unknown-linux-musl) — no `cargo-chef`-style coverage gap that would force a fallback.

## Validation evidence

End-to-end fetch path proven on Windows:

```
$ cargo run -p soldr-cli --bin soldr -- maturin --version
soldr: fetching maturin...
soldr: trust: unverified maturin v1.14.1 maturin-x86_64-pc-windows-msvc.zip sha256=b560e7a2...
soldr: downloaded maturin v1.14.1
maturin 1.14.1
```

The PEP 517 backend itself will be validated against `~/dev/clud` as the next step after merge (test there: switch `clud`'s pyproject `build-backend` to `soldr` and run `pip install .` from a clean venv).

## Test plan

- [x] `cargo run -p soldr-cli --bin soldr -- maturin --version` returns `maturin 1.14.1` from a clean `~/.soldr/bin/`
- [x] `cargo test -p soldr-cli --lib -- fetch::` (81 tests, all pass) — covers the new `maturin_is_registered_and_pinned_to_managed_version` + extended `top_level_tools_are_registered_without_cargo_subcommand` + `zccache_runtime_contract_matches_rust_constants`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash ./lint` (Python: ruff, black, isort, flake8, pylint, mypy)
- [ ] `pip install .` of a downstream maturin project with `build-backend = "soldr"` — to be done in a follow-up validation against `~/dev/clud`

## Commit layout

Reviewers: the three commits are kept separate so the feature is easy to read in isolation from the drift cleanup.

1. **`feat(fetch+pep517)`** — the actual feature (5 files: known_tools, mod.rs constant, contract JSON, contract test, PEP 517 shim)
2. **`style: pre-existing fmt/clippy/ruff drift`** — `cli_zccache_contract_matrix.rs` (cargo fmt reflow), `save_load.rs` (clippy `redundant_closure`), `test_setup_soldr_ensure_rust_toolchain.py` (ruff F401 + black). All were already on origin/main but the lint gate exposed them.
3. **`style(python): ruff/black/isort auto-fixes`** — 11 unrelated test files reformatted by the project's `./lint` pipeline (purely cosmetic blank-line / line-reflow changes). Bundled so the branch passes CI cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)