### PR TITLE
fix(fetch): auto-bootstrap zig so soldr cargo zigbuild Just Works

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -949,6 +949,8 @@ async fn ensure_known_subcommand_tool(
     // Escape hatch: SOLDR_FORCE_MANAGED_CARGO_SUBCOMMANDS=1 forces the
     // managed fetch even when PATH has the tool — useful for CI runs that
     // want byte-identical pinned binaries.
+    let mut extra_bin_dirs: Vec<std::path::PathBuf> = Vec::new();
+
     if !force_managed_cargo_subcommands() {
         let exe_name = format!("cargo-{sub}");
         if let Some(path) = find_on_path(&exe_name) {
@@ -956,7 +958,12 @@ async fn ensure_known_subcommand_tool(
                 "soldr: deferring to {exe_name} on PATH at {} (set SOLDR_FORCE_MANAGED_CARGO_SUBCOMMANDS=1 to override)",
                 path.display()
             );
-            return Ok(Vec::new());
+            // Even when cargo-zigbuild is provided by the host, it
+            // still shells out to `zig`. Run the transitive bootstrap
+            // before returning so the deferred-on-PATH branch doesn't
+            // silently regress.
+            append_subcommand_transitive_bin_dirs(sub, paths, &mut extra_bin_dirs).await?;
+            return Ok(extra_bin_dirs);
         }
     }
 
@@ -987,7 +994,29 @@ async fn ensure_known_subcommand_tool(
             ))
         })?
         .to_path_buf();
-    Ok(vec![dir])
+    extra_bin_dirs.push(dir);
+    append_subcommand_transitive_bin_dirs(sub, paths, &mut extra_bin_dirs).await?;
+    Ok(extra_bin_dirs)
+}
+
+/// Resolve transitive runtime dependencies for `cargo-<sub>` and append
+/// their bin directories to `extra_bin_dirs`.
+///
+/// Today the only registered transitive bootstrap is `zig` for
+/// `cargo-zigbuild`. cargo-zigbuild shells out to a `zig` binary to do
+/// the cross-link step; without this, `soldr cargo zigbuild ...` on a
+/// fresh runner explodes with `Error: Failed to find zig` even though
+/// soldr happily fetched cargo-zigbuild itself.
+async fn append_subcommand_transitive_bin_dirs(
+    sub: &str,
+    paths: &SoldrPaths,
+    extra_bin_dirs: &mut Vec<std::path::PathBuf>,
+) -> Result<(), SoldrError> {
+    if sub == "zigbuild" {
+        let zig_dir = crate::fetch::ensure_zig(paths).await?;
+        extra_bin_dirs.push(zig_dir);
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -42,6 +42,9 @@ pub mod github;
 pub mod zccache;
 pub mod zccache_install;
 pub mod zccache_runtime;
+pub mod zig;
+
+pub use zig::{ensure_zig, MANAGED_ZIG_VERSION};
 
 #[cfg(test)]
 mod zccache_contract_tests;

--- a/crates/soldr-cli/src/fetch/zig.rs
+++ b/crates/soldr-cli/src/fetch/zig.rs
@@ -1,0 +1,265 @@
+//! Auto-bootstrap a `zig` binary for `cargo zigbuild` to consume.
+//!
+//! cargo-zigbuild shells out to a `zig` executable to do the cross-link
+//! step. Until this module existed, `soldr cargo zigbuild ...` would
+//! fetch `cargo-zigbuild` from `known_tools` but leave zig itself
+//! missing — every cross-compile lane on a fresh runner exploded with
+//! `Error: Failed to find zig / cannot find binary path` (observed in
+//! `cross-compile-all-targets.yml` run 27893281530). The fix lives in
+//! soldr, not the workflow, because soldr advertises itself as the
+//! bootstrapper for cross builds (CLAUDE.md "Pre-built first") and
+//! every consumer of `soldr cargo zigbuild` benefits.
+//!
+//! Resolution order, mirroring cargo-zigbuild's own logic:
+//!   1. `ZIG` env var pointing at an existing file → use it.
+//!   2. `zig` (or `zig.exe`) already on `PATH` → use it.
+//!   3. Managed fetch from `https://ziglang.org/download/...`, cached
+//!      at `~/.soldr/bin/zig-<MANAGED_ZIG_VERSION>/`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{SoldrError, SoldrPaths};
+
+use super::github::http_client;
+use super::trust;
+
+/// Zig version that ships in soldr's managed bootstrap.
+/// 0.13.0 is the long-tested LTS release of zig (June 2024) and is the
+/// floor that cargo-zigbuild 0.20+ depends on. Bumping is a one-line
+/// change here, but keep the major.minor stable between consumer
+/// releases — cargo-zigbuild itself is sensitive to zig API breakage.
+pub const MANAGED_ZIG_VERSION: &str = "0.13.0";
+
+const ZIG_ENV_VAR: &str = "ZIG";
+
+/// Ensure a zig binary is available for cargo-zigbuild. Returns the
+/// **directory** holding the binary so the caller can prepend it to
+/// `PATH` (matching how `ensure_known_subcommand_tool` already wires
+/// `cargo-zigbuild` into the child cargo's environment).
+pub async fn ensure_zig(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
+    if let Some(dir) = zig_dir_from_env_var() {
+        return Ok(dir);
+    }
+    if let Some(dir) = zig_dir_from_path() {
+        return Ok(dir);
+    }
+
+    paths.ensure_dirs()?;
+
+    let install_dir = paths.bin.join(format!("zig-{MANAGED_ZIG_VERSION}"));
+    let stamp = install_dir.join(".complete");
+    let cached_bin = managed_zig_binary_path(&install_dir);
+    if stamp.is_file() && cached_bin.is_file() {
+        if let Some(parent) = cached_bin.parent() {
+            return Ok(parent.to_path_buf());
+        }
+    }
+
+    let (asset, url) = zig_download_url(MANAGED_ZIG_VERSION)?;
+    eprintln!("soldr: fetching zig v{MANAGED_ZIG_VERSION} ({asset})...");
+
+    let client = http_client()?;
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(SoldrError::Network(format!(
+            "zig download {url} failed: HTTP {}",
+            resp.status()
+        )));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    let digest = trust::sha256_of(&bytes);
+    let store = trust::PinnedChecksumStore::from_env()?;
+    let mode = trust::TrustMode::from_env();
+    match trust::verify_download("zig", MANAGED_ZIG_VERSION, &asset, &digest, &store, mode)? {
+        trust::VerifyOutcome::Verified { sha256 } => {
+            eprintln!("soldr: trust: verified zig v{MANAGED_ZIG_VERSION} {asset} sha256={sha256}");
+        }
+        trust::VerifyOutcome::Unverified { sha256 } => {
+            eprintln!(
+                "soldr: trust: unverified zig v{MANAGED_ZIG_VERSION} {asset} sha256={sha256} (set {} to pin; run with {}=strict to require pins)",
+                trust::CHECKSUMS_FILE_ENV_VAR,
+                trust::TRUST_MODE_ENV_VAR
+            );
+        }
+    }
+
+    if install_dir.exists() {
+        std::fs::remove_dir_all(&install_dir)?;
+    }
+    std::fs::create_dir_all(&install_dir)?;
+
+    if asset.ends_with(".zip") {
+        extract_zip_tree(&bytes, &install_dir)?;
+    } else {
+        extract_tar_xz_tree(&bytes, &install_dir)?;
+    }
+
+    let resolved = managed_zig_binary_path(&install_dir);
+    if !resolved.is_file() {
+        return Err(SoldrError::Archive(format!(
+            "zig binary not found after extract at {}",
+            resolved.display()
+        )));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&resolved)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&resolved, perms)?;
+    }
+
+    std::fs::write(&stamp, MANAGED_ZIG_VERSION)?;
+    eprintln!("soldr: downloaded zig v{MANAGED_ZIG_VERSION}");
+
+    resolved
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| SoldrError::Other("zig binary has no parent directory".into()))
+}
+
+fn zig_dir_from_env_var() -> Option<PathBuf> {
+    let value = std::env::var_os(ZIG_ENV_VAR)?;
+    let p = PathBuf::from(value);
+    if p.is_file() {
+        p.parent().map(Path::to_path_buf)
+    } else {
+        None
+    }
+}
+
+fn zig_dir_from_path() -> Option<PathBuf> {
+    let exe = zig_binary_filename();
+    let path_env = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_env) {
+        let candidate = dir.join(exe);
+        if candidate.is_file() {
+            return Some(dir);
+        }
+    }
+    None
+}
+
+fn zig_binary_filename() -> &'static str {
+    if cfg!(windows) {
+        "zig.exe"
+    } else {
+        "zig"
+    }
+}
+
+fn managed_zig_binary_path(install_dir: &Path) -> PathBuf {
+    install_dir
+        .join(managed_zig_archive_root())
+        .join(zig_binary_filename())
+}
+
+/// The official zig tarballs / zips unpack to a single top-level
+/// directory `zig-<os>-<arch>-<version>` (the 0.13.x naming
+/// convention). Mirror that so we know exactly where to find the
+/// extracted binary without scanning.
+fn managed_zig_archive_root() -> String {
+    let (os, arch) = host_zig_os_arch().unwrap_or(("linux", "x86_64"));
+    format!("zig-{os}-{arch}-{MANAGED_ZIG_VERSION}")
+}
+
+fn host_zig_os_arch() -> Option<(&'static str, &'static str)> {
+    let arch = if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        return None;
+    };
+    let os = if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        return None;
+    };
+    Some((os, arch))
+}
+
+fn zig_download_url(version: &str) -> Result<(String, String), SoldrError> {
+    let Some((os, arch)) = host_zig_os_arch() else {
+        return Err(SoldrError::Other(format!(
+            "unsupported host for zig bootstrap: arch={} os={}",
+            std::env::consts::ARCH,
+            std::env::consts::OS,
+        )));
+    };
+    let ext = if os == "windows" { "zip" } else { "tar.xz" };
+    let asset = format!("zig-{os}-{arch}-{version}.{ext}");
+    let url = format!("https://ziglang.org/download/{version}/{asset}");
+    Ok((asset, url))
+}
+
+fn extract_tar_xz_tree(data: &[u8], dest: &Path) -> Result<(), SoldrError> {
+    let reader = std::io::Cursor::new(data);
+    let xz = xz2::read::XzDecoder::new(reader);
+    let mut archive = tar::Archive::new(xz);
+    archive
+        .unpack(dest)
+        .map_err(|e| SoldrError::Archive(e.to_string()))?;
+    Ok(())
+}
+
+fn extract_zip_tree(data: &[u8], dest: &Path) -> Result<(), SoldrError> {
+    let reader = std::io::Cursor::new(data);
+    let mut archive =
+        zip::ZipArchive::new(reader).map_err(|e| SoldrError::Archive(e.to_string()))?;
+    archive
+        .extract(dest)
+        .map_err(|e| SoldrError::Archive(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(zig_download_url_known_targets, {
+        // Smoke: we don't hit the network in unit tests, just verify the
+        // URL builder formats the asset name as `zig-<os>-<arch>-<ver>.<ext>`.
+        let (asset, url) =
+            zig_download_url("0.13.0").expect("host should resolve in unit-test env");
+        assert!(
+            asset.starts_with("zig-") && asset.contains("-0.13.0."),
+            "asset name should embed version: {asset}",
+        );
+        assert!(
+            url.starts_with("https://ziglang.org/download/0.13.0/"),
+            "url should target ziglang.org/download/<ver>/: {url}",
+        );
+        assert!(
+            asset.ends_with(".tar.xz") || asset.ends_with(".zip"),
+            "asset extension should match the OS family: {asset}",
+        );
+    });
+
+    crate::timed_test!(env_var_overrides_path_and_managed_install, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let exe = tmp.path().join(zig_binary_filename());
+        std::fs::write(&exe, b"#!/bin/sh\necho fake-zig\n").expect("write");
+        let prev = std::env::var_os(ZIG_ENV_VAR);
+        std::env::set_var(ZIG_ENV_VAR, &exe);
+        let resolved = zig_dir_from_env_var();
+        match prev {
+            Some(v) => std::env::set_var(ZIG_ENV_VAR, v),
+            None => std::env::remove_var(ZIG_ENV_VAR),
+        }
+        assert_eq!(resolved.as_deref(), exe.parent());
+    });
+}


### PR DESCRIPTION
## Summary

cargo-zigbuild shells out to a `zig` binary for the cross-link step. Until now, `soldr cargo zigbuild ...` fetched cargo-zigbuild from `known_tools` but left zig itself missing — every cross-compile lane in `cross-compile-all-targets.yml` run [27893281530](https://github.com/zackees/soldr/actions/runs/27893281530) (the first run after #840 merged) exploded with:

```
Error: Failed to find zig
Caused by:
    cannot find binary path
```

Per `CLAUDE.md` ("Pre-built first" + "soldr is designed to be a bootstrapper"), the fix belongs in soldr itself, not in every consuming GitHub Action or Dockerfile that has to remember to apt-install zig.

## What this adds

**`crates/soldr-cli/src/fetch/zig.rs`** — new module with `ensure_zig`. Resolution order mirrors cargo-zigbuild's own:

1. `ZIG` env var pointing at an existing file → use it.
2. `zig` (or `zig.exe`) already on `PATH` → use it.
3. Managed fetch from `https://ziglang.org/download/<ver>/`, cached at `~/.soldr/bin/zig-<MANAGED_ZIG_VERSION>/`.

Honors `SOLDR_TRUST_MODE` / `SOLDR_CHECKSUMS_FILE` like every other fetch path. Pinned to **zig 0.13.0** — the LTS-shaped release that cargo-zigbuild 0.20+ targets.

**`cargo_front_door::ensure_known_subcommand_tool`** — when the resolved subcommand is `zigbuild`, also call `ensure_zig` and append its bin dir to the extra-PATH dirs prepended to the child cargo. The bootstrap also runs when cargo-zigbuild itself is already on PATH (the `SOLDR_FORCE_MANAGED_CARGO_SUBCOMMANDS=0` deferral branch) — a host-provided cargo-zigbuild still needs zig.

## Why pin zig in soldr instead of leaving it to setup scripts

Same answer as cargo-zigbuild itself. The setup-soldr action, every cross-compile workflow downstream, and any docker base image used for builds would all need their own zig install step otherwise. Pinning here means `soldr cargo zigbuild` on a fresh `ubuntu-24.04` runner Just Works.

## Test plan

- [x] `cargo build -p soldr-cli` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p soldr-cli fetch::zig` — both new unit tests pass
- [x] `cargo test -p soldr-cli cargo_front_door` — all pass
- [ ] Live cross-compile lane (linux-arm via `soldr cargo zigbuild`) — verified by re-dispatching `cross-compile-all-targets` against this branch once merged.

## Pre-existing test note

The integration test `cargo_front_door_does_not_start_cache_for_non_build_subcommands` panics on `main` as of `7a701f7` and continues to panic on this branch — verified by stashing my diff and re-running. Not addressed here; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)