### PR TITLE
feat(ci): prefetch release-manifest in stage 1 to dodge GitHub API rate limits

### DIFF
--- a/.github/scripts/build_release_manifest.py
+++ b/.github/scripts/build_release_manifest.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Pre-fetch all third-party tool release URLs into a single manifest.
+
+Why this exists: every parallel cross-compile lane in
+`cross-compile-all-targets.yml` used to independently resolve tool
+download URLs against the GitHub REST API (60 req/hour unauthenticated).
+With 7 lanes × 5 tools that adds up to a burst of >35 API calls, which
+on a busy runner IP routinely hits the 403 rate-limit cap. Centralizing
+the resolution into a single Stage 1 step (which DOES use
+`$GITHUB_TOKEN` — authenticated rate limit is 1000 req/hour, plenty of
+headroom) means Stage 2 lanes never touch the API; they curl public
+`https://github.com/.../releases/download/...` URLs straight from the
+manifest. Those public URLs are CDN-backed and aren't subject to the
+API rate limit.
+
+The manifest is uploaded as an artifact AND saved to actions/cache with
+a day-keyed key so re-runs within the same UTC day skip the API round
+trip entirely.
+
+Schema (`release-manifest.json`):
+
+    {
+      "schema_version": 1,
+      "generated_at": "2026-06-21T05:30:00Z",
+      "tools": {
+        "<tool-name>": {
+          "version": "1.12.9",
+          "tag": "1.12.9",
+          "release_html_url": "https://github.com/.../releases/tag/1.12.9",
+          "assets": {
+            "<asset-filename>": {
+              "url":  "https://github.com/.../releases/download/<tag>/<filename>",
+              "size": 12345678
+            }
+          }
+        }
+      }
+    }
+
+`url` is always the public `browser_download_url` (NOT the API
+`api.github.com/.../releases/assets/<id>` URL — that one IS rate-limited
+and counts against the consumer's quota).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def read_constant(path: Path, name: str) -> str:
+    """Pull a `const NAME: &str = "value";` out of a Rust source file."""
+    text = path.read_text(encoding="utf-8")
+    m = re.search(rf'{re.escape(name)}\s*:\s*&str\s*=\s*"([^"]+)"', text)
+    if not m:
+        raise RuntimeError(f"could not find {name} in {path}")
+    return m.group(1)
+
+
+def gh_request(url: str, token: str | None) -> Any:
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "soldr-release-manifest-builder")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    last_exc: Exception | None = None
+    for attempt in range(5):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            last_exc = exc
+            # 403 + secondary-rate-limit headers → back off and retry.
+            if exc.code in (403, 429):
+                wait = 2 ** attempt
+                print(
+                    f"  github API returned {exc.code}; sleeping {wait}s before retry",
+                    file=sys.stderr,
+                )
+                time.sleep(wait)
+                continue
+            raise
+        except urllib.error.URLError as exc:
+            last_exc = exc
+            wait = 2 ** attempt
+            time.sleep(wait)
+    raise RuntimeError(f"github API failed after retries: {last_exc}")
+
+
+def resolve_release(owner: str, repo: str, tag: str | None, token: str | None) -> dict[str, Any]:
+    """Fetch a release by tag, or `latest` when tag is None.
+
+    `tag` is the literal git tag (e.g. `1.12.9` for zccache, `v0.23.0`
+    for cargo-zigbuild). Callers pass the exact pinned tag — there's no
+    semver resolution here.
+    """
+    if tag is None:
+        url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
+    else:
+        url = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}"
+    return gh_request(url, token)
+
+
+def build_tool_entry(
+    name: str,
+    owner: str,
+    repo: str,
+    tag: str | None,
+    token: str | None,
+) -> dict[str, Any]:
+    print(f"resolving {name} @ {tag or 'latest'} ({owner}/{repo})...", file=sys.stderr)
+    release = resolve_release(owner, repo, tag, token)
+    resolved_tag: str = release["tag_name"]
+    # The version commonly drops the leading `v` for human display, but
+    # we keep both shapes available for consumers that prefer one or
+    # the other.
+    version = resolved_tag[1:] if resolved_tag.startswith("v") else resolved_tag
+
+    assets: dict[str, dict[str, Any]] = {}
+    for asset in release.get("assets", []):
+        # `browser_download_url` is the public CDN-backed URL that does
+        # NOT count against the consumer's API rate limit. That's the
+        # entire point of generating this manifest centrally.
+        assets[asset["name"]] = {
+            "url": asset["browser_download_url"],
+            "size": asset.get("size"),
+        }
+    return {
+        "version": version,
+        "tag": resolved_tag,
+        "release_html_url": release.get("html_url"),
+        "assets": assets,
+    }
+
+
+def main() -> int:
+    out_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("release-manifest.json")
+    token = os.environ.get("GITHUB_TOKEN") or None
+
+    # Resolve pinned versions from soldr's source so the manifest stays
+    # in lockstep with what the cross builders actually consume.
+    fetch_mod = REPO_ROOT / "crates" / "soldr-cli" / "src" / "fetch" / "mod.rs"
+    known_tools = REPO_ROOT / "crates" / "soldr-cli" / "src" / "fetch" / "known_tools.rs"
+
+    zccache_version = read_constant(fetch_mod, "MANAGED_ZCCACHE_VERSION")
+    crgx_version = read_constant(fetch_mod, "MANAGED_CRGX_VERSION")
+    cargo_chef_version = read_constant(known_tools, "CARGO_CHEF_PINNED_VERSION")
+
+    # Each (owner, repo, tag) below maps to one GitHub release lookup.
+    # cargo-zigbuild / cargo-xwin are unpinned in known_tools (latest at
+    # `soldr cargo zigbuild` invocation time), so we resolve `latest`
+    # here and the consumer-side soldr binary picks the same version up
+    # off PATH before it would have called the API itself.
+    tools = [
+        ("zccache",        "zackees",         "zccache",        zccache_version),
+        ("crgx",           "yfedoseev",       "crgx",           f"v{crgx_version}"),
+        ("cargo-chef",     "LukeMathWalker",  "cargo-chef",     f"v{cargo_chef_version}"),
+        ("cargo-zigbuild", "rust-cross",      "cargo-zigbuild", None),
+        ("cargo-xwin",     "rust-cross",      "cargo-xwin",     None),
+    ]
+
+    out = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "tools": {},
+    }
+
+    for name, owner, repo, tag in tools:
+        out["tools"][name] = build_tool_entry(name, owner, repo, tag, token)
+
+    out_path.write_text(json.dumps(out, indent=2) + "\n", encoding="utf-8")
+    total_assets = sum(len(t["assets"]) for t in out["tools"].values())
+    print(
+        f"wrote {out_path} ({len(out['tools'])} tools, {total_assets} assets)",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -24,6 +24,20 @@ name: Cross-compile soldr (bootstrap + all targets, single linux-x86_64 runner f
 # `cargo build -p soldr-cli` is the single source of truth for what
 # the cross jobs use.
 #
+# GitHub API rate-limit avoidance (`release-manifest`):
+#   Stage 1 also runs `.github/scripts/build_release_manifest.py` once,
+#   which hits the GitHub Releases API (authenticated via the workflow's
+#   $GITHUB_TOKEN — 5000 req/hour limit) for zccache + crgx + cargo-chef
+#   + cargo-zigbuild + cargo-xwin and writes every asset's public
+#   `browser_download_url` to `release-manifest.json`. That manifest is
+#   uploaded as an artifact (consumed by Stage 2 lanes) AND saved to
+#   actions/cache keyed on the UTC date, so re-runs within the same day
+#   skip the API round trip entirely. Stage 2 lanes then curl from those
+#   pre-resolved public URLs (CDN-backed, NOT API-rate-limited) and
+#   pre-extract cargo-zigbuild / cargo-xwin onto PATH so soldr's own
+#   fetch dispatcher defers to the PATH binary without calling the
+#   unauthenticated GitHub API itself.
+#
 # Trigger: workflow_dispatch only.
 
 on:
@@ -64,6 +78,69 @@ jobs:
       - name: Verify zstd present
         shell: bash
         run: zstd --version | head -n1
+
+      # Pre-compute today's release manifest cache key so the cache
+      # restore step can hit on UTC-date granularity. `step.outputs.key`
+      # is consumed by both the cache step and the upload-artifact
+      # naming downstream.
+      - name: Compute release-manifest cache key
+        id: manifest_key
+        shell: bash
+        run: |
+          set -euo pipefail
+          today=$(date -u +%Y-%m-%d)
+          # Schema version bump if build_release_manifest.py changes shape.
+          echo "key=release-manifest-v1-${today}" >> "$GITHUB_OUTPUT"
+          echo "Cache key: release-manifest-v1-${today}"
+
+      - name: Restore release-manifest cache
+        id: manifest_cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: release-manifest.json
+          key: ${{ steps.manifest_key.outputs.key }}
+
+      # On cache miss, query GitHub Releases (authenticated, 5000 rq/hr)
+      # for every third-party tool used by the cross-compile lanes and
+      # write `release-manifest.json` mapping each tool/asset to its
+      # public `browser_download_url`. Stage 2 lanes consume the manifest
+      # via artifact download and curl those URLs directly — no API
+      # calls fan out across the matrix.
+      - name: Build release-manifest.json (on cache miss)
+        if: steps.manifest_cache.outputs.cache-hit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/build_release_manifest.py release-manifest.json
+          echo "--- manifest summary ---"
+          python3 -c "
+          import json
+          m = json.load(open('release-manifest.json'))
+          for name, t in m['tools'].items():
+              print(f'  {name}: tag={t[\"tag\"]} assets={len(t[\"assets\"])}')
+          "
+
+      - name: Show release-manifest cache status
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.manifest_cache.outputs.cache-hit }}" = "true" ]; then
+            echo "release-manifest cache HIT — skipped GitHub API"
+          else
+            echo "release-manifest cache MISS — generated fresh, saved under key ${{ steps.manifest_key.outputs.key }}"
+          fi
+          ls -la release-manifest.json
+
+      - name: Upload release-manifest artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-manifest
+          path: release-manifest.json
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
 
       # Bare cargo here — soldr isn't built yet. This is the ONLY job
       # in the workflow that runs cargo without going through soldr.
@@ -132,7 +209,7 @@ jobs:
           cp target/x86_64-unknown-linux-gnu/release/soldr dist/package/soldr
           chmod +x dist/package/soldr
 
-      - name: Fetch matched zccache release for linux-x86
+      - name: Fetch matched zccache release for linux-x86 (from manifest)
         shell: bash
         run: |
           set -euo pipefail
@@ -141,7 +218,11 @@ jobs:
           # Linux gnu rides the musl zccache (statically linked, runs on glibc).
           zccache_target=x86_64-unknown-linux-musl
           asset="zccache-v${zccache_version}-${zccache_target}.tar.gz"
-          url="https://github.com/zackees/zccache/releases/download/${zccache_version}/${asset}"
+          # Lookup URL from the prefetched manifest instead of hitting the
+          # GitHub API again. `jq -e` exits non-zero if the path is null,
+          # so a missing asset fails the step loudly.
+          url=$(jq -er --arg a "$asset" '.tools.zccache.assets[$a].url' release-manifest.json)
+          echo "manifest URL: ${url}"
           curl --fail --location --retry 6 --retry-delay 5 --retry-all-errors \
             --output "/tmp/${asset}" "${url}"
           tar -xzf "/tmp/${asset}" -C dist/zccache-stage
@@ -322,6 +403,53 @@ jobs:
           echo "$RUNNER_TEMP/soldr-bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/soldr-bin/soldr" --version
 
+      # Download the prefetched release-manifest from Stage 1. The lane
+      # uses `jq` over this JSON to look up direct download URLs for
+      # zccache + cargo-zigbuild + cargo-xwin, avoiding the soldr
+      # binary's unauthenticated GitHub API calls (60 req/hr per IP)
+      # that were 403-ing across the parallel matrix.
+      - name: Download release-manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-manifest
+          path: .
+
+      # Pre-fetch cargo-zigbuild (zigbuild lanes) or cargo-xwin (xwin
+      # lanes) from the manifest's public URL and put it on PATH BEFORE
+      # invoking soldr cargo. The soldr front door's PATH-first deferral
+      # branch then short-circuits its own GitHub API call (issue #816),
+      # so the matrix doesn't fan out 7× unauthenticated API requests
+      # to the same /releases/latest endpoint.
+      - name: Pre-fetch cargo subcommand binary (manifest → PATH)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The runner host is linux-x86_64 — cargo subcommand binaries
+          # themselves are host binaries (they drive cargo, which then
+          # cross-compiles to ${{ matrix.target }}). So we always grab
+          # the x86_64-unknown-linux-gnu asset regardless of the lane's
+          # target triple.
+          tool="cargo-${{ matrix.tool }}"
+          host_triple="x86_64-unknown-linux-gnu"
+          asset="${tool}-${host_triple}.tar.xz"
+          url=$(jq -er --arg t "$tool" --arg a "$asset" \
+            '.tools[$t].assets[$a].url' release-manifest.json)
+          version=$(jq -r --arg t "$tool" '.tools[$t].version' release-manifest.json)
+          echo "Pre-fetching ${tool} v${version} from manifest"
+          echo "  URL: ${url}"
+          dest_dir="${RUNNER_TEMP}/cross-bin"
+          mkdir -p "$dest_dir"
+          curl --fail --location --retry 6 --retry-delay 5 --retry-all-errors \
+            --output "/tmp/${asset}" "${url}"
+          # cargo-zigbuild / cargo-xwin tar.xz archives use the per-triple
+          # layout `<asset-stem>/<binary>`. Extract directly into dest_dir
+          # with --strip-components=1 so we end up with $dest_dir/cargo-<tool>.
+          tar -xJf "/tmp/${asset}" -C "$dest_dir" --strip-components=1
+          chmod +x "$dest_dir/$tool"
+          echo "$dest_dir" >> "$GITHUB_PATH"
+          ls -la "$dest_dir/$tool"
+          "$dest_dir/$tool" --version || true
+
       - name: Verify zstd present
         shell: bash
         run: zstd --version | head -n1
@@ -402,7 +530,7 @@ jobs:
           }
           EOF
 
-      - name: Fetch matched zccache release
+      - name: Fetch matched zccache release (from manifest)
         shell: bash
         run: |
           set -euo pipefail
@@ -420,7 +548,10 @@ jobs:
             *) echo "no zccache mapping" >&2; exit 1 ;;
           esac
           asset="zccache-v${zccache_version}-${zccache_target}.${ext}"
-          url="https://github.com/zackees/zccache/releases/download/${zccache_version}/${asset}"
+          # Lookup URL from the prefetched manifest instead of hitting
+          # the GitHub API directly across the matrix.
+          url=$(jq -er --arg a "$asset" '.tools.zccache.assets[$a].url' release-manifest.json)
+          echo "manifest URL: ${url}"
           curl --fail --location --retry 6 --retry-delay 5 --retry-all-errors \
             --output "/tmp/${asset}" "${url}"
           case "$ext" in


### PR DESCRIPTION
## Problem

With 7 parallel cross-compile matrix lanes each independently hitting the GitHub Releases API, runs were 403-ing on the secondary rate limit. soldr's own fetch path makes those API calls **unauthenticated** (`http_client()` in `crates/soldr-cli/src/fetch/github.rs:27` adds no `Authorization` header), so they share the **60-req/hour anonymous quota** on the runner IP.

Symptom observed: cross-compile run 27894154592 immediately after #841 merged.

## Fix

Stage 1 makes the API calls **once, authenticated** (via `$GITHUB_TOKEN`, raising the limit to 5000 req/hour) and writes every asset's public `browser_download_url` into `release-manifest.json`. Stage 2 lanes consume that manifest and curl direct public URLs — those CDN-backed download URLs are **not** API-rate-limited; only the lookup is.

## What ships

- **`.github/scripts/build_release_manifest.py`** — queries `/releases/tags/<tag>` (or `/releases/latest`) for zccache + crgx + cargo-chef + cargo-zigbuild + cargo-xwin. Reads pinned versions out of soldr's own `MANAGED_ZCCACHE_VERSION` / `MANAGED_CRGX_VERSION` / `CARGO_CHEF_PINNED_VERSION` constants so the manifest stays in lockstep with what soldr would have fetched.

- **Stage 1**:
  - `actions/cache` keyed on UTC date (`release-manifest-v1-YYYY-MM-DD`) — effective ~24h expiration; re-runs same day skip the API call entirely.
  - Generation step runs only on cache miss.
  - Upload as `release-manifest` artifact (`retention-days: 1`).
  - The existing linux-x86 zccache fetch step now reads its URL from the manifest too — single source of truth.

- **Stage 2 every lane**:
  - Downloads the `release-manifest` artifact.
  - **Pre-fetches `cargo-<matrix.tool>` for `x86_64-unknown-linux-gnu`** (the runner host) from the manifest URL, extracts onto `PATH` **before** invoking `soldr cargo`. soldr's PATH-first deferral branch (issue #816 lineage — when `SOLDR_FORCE_MANAGED_CARGO_SUBCOMMANDS=0`, default) short-circuits its own API call when the binary's already on PATH.
  - Looks up zccache URLs via `jq` from the manifest instead of constructing them.

## API call count, before vs after

| | Before | After |
|---|---|---|
| Per Stage 2 lane | 1 unauthenticated `cargo-zigbuild`/`cargo-xwin` lookup inside soldr + curl construction | 0 — pure manifest lookup |
| Stage 1 | 0 | 5 authenticated calls |
| Total per run | 7+ unauthenticated (≈11% of anon quota) | 5 authenticated (0.1% of authed quota) |

## Follow-up (out of scope here)

soldr's own `fetch::github::http_client` should learn to read `Authorization: Bearer $GITHUB_TOKEN` from env so even non-pre-fetched paths benefit. Tracked separately.

## Test plan

- [x] YAML parses cleanly
- [x] `ruff check` clean on `build_release_manifest.py`
- [x] Live API test against `rust-cross/cargo-zigbuild` returned 20 assets with correct `browser_download_url` shapes
- [ ] Live workflow run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)