### PR TITLE
feat(ci): cross-compile builders consume the manifest branch (fixes 403)

### DIFF
--- a/.github/scripts/fetch_manifest_asset.sh
+++ b/.github/scripts/fetch_manifest_asset.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Resolve a single asset URL from the public `manifest` branch and curl
+# it to a local path. Replaces the per-lane GitHub Releases API lookup
+# the cross-compile workflow used to do (which 403'd on the
+# unauthenticated 60-req/hour quota when 7 parallel lanes hammered it).
+#
+# Usage:
+#     fetch_manifest_asset.sh <tool> <tag-or-marker> <asset-name> <output-path>
+#
+#   tool          — directory name on the manifest branch (zccache,
+#                   cargo-zigbuild, cargo-xwin, crgx, cargo-chef).
+#   tag-or-marker — exact tag string (e.g. "1.12.9", "v0.23.0"), or
+#                   the literal "latest" / "pinned" — which resolve
+#                   to manifest["latest"] / manifest["pinned"]
+#                   respectively.
+#   asset-name    — release asset filename to download.
+#   output-path   — where to save the asset on disk.
+#
+# Both the per-tool manifest fetch and the asset download go through
+# `raw.githubusercontent.com` (CDN-served, not API-rate-limited).
+#
+# The branch ref is overridable for testing via
+# `SOLDR_MANIFEST_BRANCH_REF` (default: `manifest`); the owner/repo is
+# overridable via `SOLDR_MANIFEST_BRANCH_REPO` (default:
+# `zackees/soldr`). In CI both stay at defaults.
+
+set -euo pipefail
+
+tool="${1:?tool argument required}"
+tag_or_marker="${2:?tag-or-marker argument required}"
+asset_name="${3:?asset-name argument required}"
+output_path="${4:?output-path argument required}"
+
+repo="${SOLDR_MANIFEST_BRANCH_REPO:-zackees/soldr}"
+ref="${SOLDR_MANIFEST_BRANCH_REF:-manifest}"
+base="https://raw.githubusercontent.com/${repo}/${ref}"
+manifest_url="${base}/${tool}/manifest.json"
+
+manifest_tmp="$(mktemp --tmpdir manifest.XXXXXX.json)"
+trap 'rm -f "$manifest_tmp"' EXIT
+
+curl --fail --location --silent --show-error \
+    --retry 6 --retry-delay 5 --retry-all-errors \
+    --output "$manifest_tmp" "$manifest_url"
+
+case "$tag_or_marker" in
+    latest|pinned)
+        tag=$(jq -er --arg key "$tag_or_marker" '.[$key]' "$manifest_tmp")
+        ;;
+    *)
+        tag="$tag_or_marker"
+        ;;
+esac
+
+asset_url=$(jq -er --arg t "$tag" --arg a "$asset_name" \
+    '.releases[$t].assets[$a].url' "$manifest_tmp")
+
+echo "manifest: ${tool} @ ${tag} -> ${asset_name}"
+echo "         ${asset_url}"
+
+mkdir -p "$(dirname "$output_path")"
+curl --fail --location \
+    --retry 6 --retry-delay 5 --retry-all-errors \
+    --output "$output_path" "$asset_url"

--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -157,7 +157,7 @@ jobs:
           cp target/x86_64-unknown-linux-gnu/release/soldr dist/package/soldr
           chmod +x dist/package/soldr
 
-      - name: Fetch matched zccache release for linux-x86
+      - name: Fetch matched zccache release for linux-x86 (from manifest branch)
         run: |
           set -euo pipefail
           zccache_version=$(sed -n 's/.*MANAGED_ZCCACHE_VERSION: &str = "\(.*\)";/\1/p' \
@@ -165,9 +165,8 @@ jobs:
           # Linux gnu rides the musl zccache (statically linked, runs on glibc).
           zccache_target=x86_64-unknown-linux-musl
           asset="zccache-v${zccache_version}-${zccache_target}.tar.gz"
-          url="https://github.com/zackees/zccache/releases/download/${zccache_version}/${asset}"
-          curl --fail --location --retry 6 --retry-delay 5 --retry-all-errors \
-            --output "/tmp/${asset}" "${url}"
+          .github/scripts/fetch_manifest_asset.sh \
+              zccache "${zccache_version}" "${asset}" "/tmp/${asset}"
           tar -xzf "/tmp/${asset}" -C dist/zccache-stage
           for b in zccache zccache-daemon zccache-fp; do
             src=$(find dist/zccache-stage -type f -name "${b}" -print -quit)
@@ -356,6 +355,32 @@ jobs:
           echo "$RUNNER_TEMP/soldr-bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/soldr-bin/soldr" --version
 
+      # Pre-fetch cargo-zigbuild (zigbuild lanes) or cargo-xwin (xwin
+      # lanes) from the public manifest branch and put it on PATH BEFORE
+      # invoking soldr cargo. soldr's cargo front door has a PATH-first
+      # deferral branch (issue #816) that short-circuits its own GitHub
+      # API call when it finds the binary already on PATH — that's how
+      # the parallel matrix avoids fanning out unauthenticated API
+      # requests against the same /releases/latest endpoint and 403-ing.
+      - name: Pre-fetch cargo-${{ matrix.tool }} from manifest -> PATH
+        run: |
+          set -euo pipefail
+          tool="cargo-${{ matrix.tool }}"
+          # Runner host is always linux-x86_64 — the cargo subcommand
+          # itself is a host binary; it drives cargo which then cross-
+          # compiles to ${{ matrix.target }}.
+          asset="${tool}-x86_64-unknown-linux-gnu.tar.xz"
+          dest_dir="${RUNNER_TEMP}/cross-bin"
+          mkdir -p "$dest_dir"
+          .github/scripts/fetch_manifest_asset.sh \
+              "$tool" latest "$asset" "/tmp/${asset}"
+          # cargo-zigbuild / cargo-xwin tar.xz use a per-triple subdir;
+          # --strip-components=1 lands the binary directly in dest_dir.
+          tar -xJf "/tmp/${asset}" -C "$dest_dir" --strip-components=1
+          chmod +x "$dest_dir/$tool"
+          echo "$dest_dir" >> "$GITHUB_PATH"
+          "$dest_dir/$tool" --version || true
+
       - name: Verify zstd present
         run: zstd --version | head -n1
 
@@ -428,7 +453,7 @@ jobs:
           }
           EOF
 
-      - name: Fetch matched zccache release
+      - name: Fetch matched zccache release (from manifest branch)
         run: |
           set -euo pipefail
           zccache_version=$(sed -n 's/.*MANAGED_ZCCACHE_VERSION: &str = "\(.*\)";/\1/p' \
@@ -445,9 +470,8 @@ jobs:
             *) echo "no zccache mapping" >&2; exit 1 ;;
           esac
           asset="zccache-v${zccache_version}-${zccache_target}.${ext}"
-          url="https://github.com/zackees/zccache/releases/download/${zccache_version}/${asset}"
-          curl --fail --location --retry 6 --retry-delay 5 --retry-all-errors \
-            --output "/tmp/${asset}" "${url}"
+          .github/scripts/fetch_manifest_asset.sh \
+              zccache "${zccache_version}" "${asset}" "/tmp/${asset}"
           case "$ext" in
             tar.gz) tar -xzf "/tmp/${asset}" -C dist/zccache-stage ;;
             zip)    sudo apt-get install -y --no-install-recommends unzip


### PR DESCRIPTION
## Summary

The cross-compile workflow now sources all third-party tool URLs from the public \`manifest\` branch (\`https://raw.githubusercontent.com/zackees/soldr/manifest/...\`) instead of hitting the GitHub Releases API per-lane. That endpoint is CDN-served and **not** rate-limited.

## What changes

### Stage 1 (\`bootstrap-and-linux-x86\`)
- zccache fetch step now resolves its URL via the new \`fetch_manifest_asset.sh\` helper instead of building \`https://github.com/.../releases/download/...\` from a hardcoded template. Same single download, manifest-driven URL.

### Stage 2 (every cross matrix lane)
- **NEW step**: pre-fetch \`cargo-\${matrix.tool}\` (cargo-zigbuild or cargo-xwin) for the linux-x86_64 host directly from the manifest, extract onto \`PATH\` **before** invoking \`soldr cargo\`. soldr's cargo front door defers to a PATH binary when present (issue #816 lineage), so \`soldr cargo zigbuild build ...\` no longer fans out 7× unauthenticated \`/releases/latest\` API lookups.
- zccache fetch reuses the same helper.

### \`.github/scripts/fetch_manifest_asset.sh\`
Tiny shell wrapper:
\`\`\`
fetch_manifest_asset.sh <tool> <tag-or-marker> <asset-name> <output-path>
\`\`\`
\`tag-or-marker\` is a literal tag, or the strings \`latest\` / \`pinned\` (jq-resolved against the per-tool manifest's top-level \`latest\` / \`pinned\` fields). Both the manifest read and the asset download go through raw.githubusercontent.com.

## API call count

| | Before | After |
|---|---|---|
| Stage 1 zccache | 0 API (direct URL) | 0 API |
| Stage 2 per lane: cargo subcommand | 1 unauthenticated \`/releases/latest\` inside soldr | 0 — PATH deferral kicks in |
| Stage 2 per lane: zccache | 0 API (direct URL) | 0 API |
| **Total API per workflow run** | **7+ unauthenticated** | **0** |

The remaining 5 API calls (one per tool to keep the manifest fresh) are made **once daily** by the \`refresh-manifest\` workflow, authenticated against the 5000 req/hour bucket.

## Test plan

- [x] YAML parses
- [x] \`bash -n\` on the helper script
- [ ] Live run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)