### PR TITLE
fix(cargo): inject CC_<triple>=clang-cl for soldr cargo xwin build *-pc-windows-msvc (closes #838)

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -381,6 +381,12 @@ pub(crate) async fn run_cargo_front_door(
     // fetch the corresponding `cargo-<sub>` binary and prepend its directory to
     // PATH so cargo's subcommand dispatch finds it.
     let extra_bin_dirs = ensure_known_subcommand_tool(args, &paths).await?;
+    // Compute env-var overrides keyed off the subcommand + its
+    // --target argument. Today this fixes ring's build.rs on
+    // `cargo xwin build --target *-pc-windows-msvc` by routing cc-rs
+    // to `clang-cl` instead of the GNU-flavoured `clang`. See
+    // `compute_subcommand_env_overrides` for the full rule set.
+    let subcommand_env_overrides = compute_subcommand_env_overrides(args);
 
     let mut command = std::process::Command::new(&cargo);
     command.args(args);
@@ -436,6 +442,16 @@ pub(crate) async fn run_cargo_front_door(
                     command.env("RUSTUP_TOOLCHAIN", channel);
                 }
             }
+        }
+    }
+
+    // Apply subcommand-derived env overrides (e.g. CC_<triple>=clang-cl
+    // for `cargo xwin build --target *-pc-windows-msvc`). Honor a
+    // caller-set value — don't clobber if the user already exported
+    // their own CC / CXX / AR.
+    for (key, value) in &subcommand_env_overrides {
+        if std::env::var_os(key).is_none() {
+            command.env(key, value);
         }
     }
 
@@ -1017,6 +1033,84 @@ async fn append_subcommand_transitive_bin_dirs(
         extra_bin_dirs.push(zig_dir);
     }
     Ok(())
+}
+
+/// Compute environment-variable overrides for the child cargo invocation
+/// based on the subcommand and its `--target` argument.
+///
+/// The only rule today: `cargo xwin build --target <triple>` for any
+/// `<triple>` ending in `-pc-windows-msvc` injects
+///
+///   CC_<triple-underscored>  = clang-cl
+///   CXX_<triple-underscored> = clang-cl
+///   AR_<triple-underscored>  = llvm-lib
+///
+/// Why: cc-rs (used by ring, blake3, and other C-FFI crates) detects
+/// `target=*-pc-windows-msvc` and formats include flags MSVC-style
+/// (`/imsvc <path>`). But cc-rs's default driver for that triple,
+/// when `cl.exe` isn't on PATH (typical on Linux cross-compile hosts),
+/// is the GNU-flavoured `clang` driver — which interprets `/imsvc`
+/// as a literal filename. The result is the build.rs error
+///   `clang: error: no such file or directory: '/imsvc'`
+/// observed when cross-compiling soldr to windows-arm64 via cargo-xwin
+/// on a linux runner.
+///
+/// The fix is to tell cc-rs to use `clang-cl` (clang's MSVC-compatible
+/// driver) explicitly. cc-rs reads `CC_<triple-underscored>` ahead of
+/// its default heuristic; setting it routes ring's assembly compilation
+/// to the right driver and the build succeeds.
+///
+/// The caller's existing `CC_*` / `CXX_*` / `AR_*` env vars take
+/// precedence (the apply loop checks `std::env::var_os` first); this
+/// hook only fills in the gaps.
+fn compute_subcommand_env_overrides(args: &[String]) -> Vec<(String, String)> {
+    let Some(sub) = first_cargo_subcommand(args) else {
+        return Vec::new();
+    };
+    if sub != "xwin" {
+        return Vec::new();
+    }
+    // Verify the inner verb is `build` / `test` / etc. (anything cc-rs
+    // would invoke a build script for). cargo-xwin's other verbs
+    // (`download`, `pre-download`) don't compile anything.
+    let mut after_sub = args.iter().skip_while(|a| a.as_str() != sub);
+    after_sub.next(); // consume the matched `xwin`
+    let needs_cc = matches!(
+        after_sub.clone().next().map(String::as_str),
+        Some("build" | "test" | "check" | "run" | "bench" | "doc" | "clippy" | "rustc"),
+    );
+    if !needs_cc {
+        return Vec::new();
+    }
+    let Some(triple) = extract_target_arg(args) else {
+        return Vec::new();
+    };
+    if !triple.ends_with("-pc-windows-msvc") {
+        return Vec::new();
+    }
+    let suffix = triple.replace('-', "_");
+    vec![
+        (format!("CC_{suffix}"), "clang-cl".to_string()),
+        (format!("CXX_{suffix}"), "clang-cl".to_string()),
+        (format!("AR_{suffix}"), "llvm-lib".to_string()),
+    ]
+}
+
+/// Find the value of `--target <triple>` or `--target=<triple>` in a
+/// cargo arg vector. Returns `None` if the arg isn't present. Used by
+/// `compute_subcommand_env_overrides` to decide whether to inject
+/// MSVC-target cc-rs env vars.
+fn extract_target_arg(args: &[String]) -> Option<&str> {
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        if a == "--target" {
+            return it.next().map(String::as_str);
+        }
+        if let Some(rest) = a.strip_prefix("--target=") {
+            return Some(rest);
+        }
+    }
+    None
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/src/cargo_front_door/tests.rs
+++ b/crates/soldr-cli/src/cargo_front_door/tests.rs
@@ -688,3 +688,127 @@ fn find_on_path_returns_none_when_missing() {
     }
     assert_eq!(resolved, None);
 }
+
+// ---------------------------------------------------------------------------
+// compute_subcommand_env_overrides — fixes ring's build.rs picking the
+// GNU clang driver instead of clang-cl when cross-compiling to
+// *-pc-windows-msvc via cargo-xwin.
+// ---------------------------------------------------------------------------
+
+fn argvec(s: &str) -> Vec<String> {
+    s.split_whitespace().map(String::from).collect()
+}
+
+#[test]
+fn extract_target_arg_handles_space_separated_form() {
+    assert_eq!(
+        extract_target_arg(&argvec(
+            "xwin build --release --target aarch64-pc-windows-msvc"
+        )),
+        Some("aarch64-pc-windows-msvc"),
+    );
+}
+
+#[test]
+fn extract_target_arg_handles_equals_form() {
+    assert_eq!(
+        extract_target_arg(&argvec(
+            "xwin build --release --target=x86_64-pc-windows-msvc"
+        )),
+        Some("x86_64-pc-windows-msvc"),
+    );
+}
+
+#[test]
+fn extract_target_arg_returns_none_when_absent() {
+    assert_eq!(extract_target_arg(&argvec("xwin build --release")), None);
+}
+
+#[test]
+fn xwin_arm64_msvc_target_injects_cc_clang_cl_env() {
+    let env = compute_subcommand_env_overrides(&argvec(
+        "xwin build --release --target aarch64-pc-windows-msvc",
+    ));
+    let map: std::collections::HashMap<_, _> = env.into_iter().collect();
+    assert_eq!(
+        map.get("CC_aarch64_pc_windows_msvc").map(String::as_str),
+        Some("clang-cl"),
+    );
+    assert_eq!(
+        map.get("CXX_aarch64_pc_windows_msvc").map(String::as_str),
+        Some("clang-cl"),
+    );
+    assert_eq!(
+        map.get("AR_aarch64_pc_windows_msvc").map(String::as_str),
+        Some("llvm-lib"),
+    );
+}
+
+#[test]
+fn xwin_x64_msvc_target_injects_underscored_triple_keys() {
+    let env = compute_subcommand_env_overrides(&argvec(
+        "xwin build --target x86_64-pc-windows-msvc --release",
+    ));
+    let map: std::collections::HashMap<_, _> = env.into_iter().collect();
+    assert_eq!(
+        map.get("CC_x86_64_pc_windows_msvc").map(String::as_str),
+        Some("clang-cl"),
+    );
+}
+
+#[test]
+fn zigbuild_does_not_inject_cc_overrides_even_for_msvc_target() {
+    // cargo-zigbuild also builds for windows-msvc but uses zig as the
+    // linker — cc-rs's clang / clang-cl distinction is xwin-specific.
+    let env = compute_subcommand_env_overrides(&argvec(
+        "zigbuild --target x86_64-pc-windows-msvc --release",
+    ));
+    assert!(
+        env.is_empty(),
+        "zigbuild lane shouldn't inject xwin env: {env:?}"
+    );
+}
+
+#[test]
+fn xwin_with_non_msvc_target_does_not_inject_anything() {
+    let env =
+        compute_subcommand_env_overrides(&argvec("xwin build --target x86_64-unknown-linux-gnu"));
+    assert!(
+        env.is_empty(),
+        "non-msvc target shouldn't inject xwin env: {env:?}"
+    );
+}
+
+#[test]
+fn xwin_without_target_does_not_inject_anything() {
+    // The injection is keyed on an explicit triple (so we can name the
+    // env vars); skip when no triple is in the args.
+    let env = compute_subcommand_env_overrides(&argvec("xwin build --release"));
+    assert!(
+        env.is_empty(),
+        "no --target shouldn't inject xwin env: {env:?}"
+    );
+}
+
+#[test]
+fn xwin_download_subverb_does_not_inject() {
+    // `cargo xwin download` only fetches the MSVC SDK; cc-rs never
+    // runs, so no env injection is needed.
+    let env =
+        compute_subcommand_env_overrides(&argvec("xwin download --target aarch64-pc-windows-msvc"));
+    assert!(
+        env.is_empty(),
+        "xwin download shouldn't inject env: {env:?}"
+    );
+}
+
+#[test]
+fn non_xwin_subcommand_does_not_inject_anything() {
+    let env = compute_subcommand_env_overrides(&argvec(
+        "build --target x86_64-pc-windows-msvc --release",
+    ));
+    assert!(
+        env.is_empty(),
+        "bare cargo build shouldn't inject xwin env: {env:?}"
+    );
+}


### PR DESCRIPTION
## What this fixes

Cross-compiling rust crates to Windows MSVC via cargo-xwin from a Linux host was failing for any crate whose `build.rs` uses cc-rs (most notably `ring`, also `blake3`, `bzip2-sys`, etc.):

```
cargo:warning=clang: error: no such file or directory: '/imsvc'
```

Observed in cross-compile run [27896771286](https://github.com/zackees/soldr/actions/runs/27896771286), job 82550006865 (windows-arm lane).

## Diagnosis

cc-rs detects `target=*-pc-windows-msvc` and formats its include flags MSVC-style (`/imsvc <path>`). But cc-rs's default driver on that triple, when `cl.exe` isn't on PATH (typical on Linux cross-compile hosts), is the **GNU-flavoured `clang`** — which interprets `/imsvc` as a literal filename. The correct driver is **`clang-cl`** (clang's MSVC-compatible front-end), which knows `/imsvc` is a flag, not a file.

The user confirmed they could compile locally; their environment had the right env vars wired up. CI doesn't.

## Fix

Per CLAUDE.md's "soldr is the bootstrapper" rule, this belongs in soldr itself — the same way #841 auto-bootstraps zig for cargo-zigbuild.

`cargo_front_door::compute_subcommand_env_overrides` now inspects the cargo arg vector. When `soldr cargo xwin <build-like-verb> --target <triple>` is invoked and the triple ends with `-pc-windows-msvc`, it injects:

```
CC_<triple-underscored>  = clang-cl
CXX_<triple-underscored> = clang-cl
AR_<triple-underscored>  = llvm-lib
```

Onto the child cargo's environment. The injection is gated on:
- subcommand is `xwin` (zigbuild is unaffected — it uses zig as the linker)
- inner verb actually compiles (`build` / `test` / `check` / `run` / `bench` / `doc` / `clippy` / `rustc`) — `xwin download` doesn't need cc-rs
- `--target` is explicit (need a triple to name the env vars)
- triple ends with `-pc-windows-msvc`

**Caller env wins.** The apply loop checks `std::env::var_os` before clobbering — if a user has already exported their own CC / CXX / AR, this hook only fills in the gaps.

## Tests

10 new unit tests cover every branch of the gating logic — both arch variants (x86_64 + aarch64), both `--target` shapes (space and equals), and every negative case (zigbuild, non-msvc target, no target, xwin download, non-xwin subcommand). All pass.

## Test plan

- [x] `cargo build -p soldr-cli` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p soldr-cli cargo_front_door` — 10/10 new tests pass
- [ ] Re-dispatch `cross-compile-all-targets.yml` after merge — verify windows-arm and windows-x64 lanes get past the ring build

## Pre-existing test note

`cargo_front_door_does_not_start_cache_for_non_build_subcommands` integration test still panics on bare main — verified earlier in this session by stashing my diff. Not addressed here.

Closes #838.