### PR TITLE
fix(ci): apple SDK + MSVC CRT prefetch + cc-rs env for cross-compile lanes

### DIFF
--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -417,10 +417,62 @@ jobs:
       - name: Stage layout
         run: mkdir -p dist/package dist/zccache-stage stats
 
+      # Apple SDK lives on the manifest branch (deps/mac/sdk.tar.zstd,
+      # extracted once from messense/cargo-zigbuild:0.20.0). Without
+      # this, every darwin lane fails at link time with
+      # `error: unable to find framework 'IOKit'. searched paths: none`
+      # because cargo-zigbuild has no Apple SDK on a vanilla
+      # ubuntu-24.04 runner. Drop the SDK at /opt/MacOSX11.3.sdk so
+      # cargo-zigbuild's auto-SDK discovery picks it up — no SDKROOT
+      # env var needed.
+      - name: Download Apple SDK for darwin cross-compile
+        if: contains(matrix.target, 'apple-darwin')
+        run: |
+          set -euo pipefail
+          sdk_url=$(python3 .github/scripts/tool_query.py \
+              --platform mac --arch x86 apple-sdk)
+          echo "Apple SDK URL: $sdk_url"
+          curl --fail --location \
+              --retry 6 --retry-delay 5 --retry-all-errors \
+              --output /tmp/apple-sdk.tar.zst "$sdk_url"
+          sudo mkdir -p /opt
+          sudo tar --use-compress-program='zstd -d' \
+              -xf /tmp/apple-sdk.tar.zst -C /opt
+          ls -la /opt/MacOSX11.3.sdk/System/Library/Frameworks/ | head -5
+
+      # Pre-download the MSVC CRT + Windows SDK via cargo-xwin so the
+      # subsequent build doesn't race the network on first compile.
+      # The download itself isn't expensive but doing it explicitly
+      # gives a clean diagnostic if it fails.
+      - name: Pre-download MSVC CRT (xwin lanes)
+        if: matrix.tool == 'xwin'
+        run: |
+          set -euo pipefail
+          soldr cargo xwin download --target "${{ matrix.target }}"
+
       - name: Cross-compile soldr — --release ${{ matrix.target }} (${{ matrix.tool }})
         id: build
         env:
           CARGO_TARGET_DIR: target
+          # cc-rs env overrides for the xwin lanes. soldr's cargo front
+          # door also injects these (see compute_subcommand_env_overrides
+          # in cargo_front_door/mod.rs), but the debug trace from
+          # run 27898887800 confirmed the soldr-side injection isn't
+          # surviving to ring's build.rs — cargo or cargo-xwin
+          # apparently scrubs/overrides them on the inner cargo
+          # subprocess. Setting at workflow level scopes the env to the
+          # runner process so EVERY nested child inherits them.
+          # Without this, ring's build.rs picks the GNU `clang` driver
+          # (which doesn't understand cargo-xwin's `/imsvc` flags) and
+          # the cross-compile fails. Both triples are listed because
+          # the matrix runs both windows-x64-msvc and windows-arm64-msvc;
+          # the unused triple's env vars are harmless to non-matching lanes.
+          CC_aarch64_pc_windows_msvc:  clang-cl
+          CXX_aarch64_pc_windows_msvc: clang-cl
+          AR_aarch64_pc_windows_msvc:  llvm-lib
+          CC_x86_64_pc_windows_msvc:   clang-cl
+          CXX_x86_64_pc_windows_msvc:  clang-cl
+          AR_x86_64_pc_windows_msvc:   llvm-lib
         run: |
           set -euo pipefail
           log=stats/${{ matrix.friendly }}.log


### PR DESCRIPTION
## What this fixes

Two cross-compile lanes have been chronically broken for different reasons:

### macos-x86 / macos-arm
\`error: unable to find framework 'IOKit'. searched paths: none\` at link time. cargo-zigbuild can cross-compile from Linux to apple-darwin but needs the Apple SDK on disk to link against; the ubuntu-24.04 runner has none.

### windows-arm / windows-x86
\`clang: error: no such file or directory: '/imsvc'\` during ring's build.rs. cc-rs sees \`*-pc-windows-msvc\` and formats include flags MSVC-style (\`/imsvc\`), but the compiler binary ends up as GNU \`clang\` (can't parse \`/imsvc\`) instead of \`clang-cl\`.

## Fixes

### Apple SDK download (darwin lanes only)
New step pulls \`deps/mac/sdk.tar.zstd\` from the manifest branch (already populated, 52.6 MiB compressed) and extracts to \`/opt/MacOSX11.3.sdk\`. cargo-zigbuild's auto-SDK discovery finds it at that path — no \`SDKROOT\` env needed. URL resolved via \`tool_query.py\` so the manifest branch is the single source of truth.

### MSVC CRT pre-download (xwin lanes only)
Explicit \`soldr cargo xwin download --target ...\` warms cargo-xwin's SDK cache before the build. Avoids build-time races + cleaner failure diagnostic.

### cc-rs env overrides at workflow level (xwin lanes only)
\`CC_<triple>=clang-cl\` / \`CXX_<triple>=clang-cl\` / \`AR_<triple>=llvm-lib\` on the build step env so cc-rs (called transitively by ring's build.rs) picks the MSVC-compatible clang-cl driver.

soldr's cargo front door **already** injects these on its child cargo subprocess (PR #847's \`compute_subcommand_env_overrides\`), but a debug trace from [run 27898887800](https://github.com/zackees/soldr/actions/runs/27898887800) confirmed they aren't surviving through cargo → cargo-xwin → inner cargo → build.rs. Setting at workflow level scopes the env vars to the runner process so every nested child inherits them regardless of intermediate \`env_clear()\` calls.

## Locally validated

Recipe verified on a Windows host before this PR by reproducing the macos-x86 build locally:
1. Downloaded \`deps/mac/sdk.tar.zstd\` from the manifest branch (50 MiB)
2. Extracted to \`~/.soldr/sdk/MacOSX11.3.sdk\`
3. Ran \`soldr cargo zigbuild --release --target x86_64-apple-darwin --package soldr-cli --bin soldr\`
4. Got a 13.9 MiB \`Mach-O 64-bit x86_64 executable\` cleanly

The CI workflow does the same thing on Linux (Linux runners don't need the symlink resolution step Windows required because Linux honors symlinks natively).

## Test plan

- [x] YAML parses
- [x] Apple SDK recipe validated locally on Windows (proves cargo-zigbuild + SDK works)
- [ ] Re-dispatch \`cross-compile-all-targets.yml\` after merge — verify all 7 lanes (5 previously-failing) succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)