### PR TITLE
fix(ci): preserve vendored manifest entries + drop bogus cargo-xwin download

### DIFF
--- a/.github/scripts/build_manifest.py
+++ b/.github/scripts/build_manifest.py
@@ -411,6 +411,54 @@ def build_merged_tool_releases(
     return ordered, latest_tag
 
 
+def preserve_vendored_top_level_entries(
+    output_dir: Path,
+    per_tool_index: dict[str, dict[str, Any]],
+) -> None:
+    """Re-add vendored / non-GitHub-Releases entries from the EXISTING
+    root manifest.json into the in-progress index so the nightly
+    refresh doesn't wipe them.
+
+    The Apple SDK (manifest branch's `deps/mac/manifest.json`, indexed
+    as `apple-sdk` at the top level) is the canonical example —
+    populated by a manual procedure (extracted from
+    messense/cargo-zigbuild:0.20.0) and committed once, but invisible
+    to `build_merged_tool_releases` because it doesn't come from a
+    GitHub release.
+
+    Strategy: walk the OLD top-level manifest.json (if present), keep
+    every entry whose `path` exists on disk and isn't already in the
+    fresh index. Entries that reference a now-missing file get
+    silently dropped (the per-tool file was hand-deleted, so the
+    index pointer is stale).
+    """
+    top_path = output_dir / TOP_LEVEL_FILENAME
+    if not top_path.is_file():
+        return
+    try:
+        existing = json.loads(top_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    existing_tools = existing.get("tools") or {}
+    for name, entry in existing_tools.items():
+        if name in per_tool_index:
+            continue
+        path_ref = entry.get("path")
+        if not path_ref:
+            continue
+        if not (output_dir / path_ref).is_file():
+            print(
+                f"  dropping stale vendored entry: {name} -> {path_ref} (file missing)",
+                file=sys.stderr,
+            )
+            continue
+        per_tool_index[name] = entry
+        print(
+            f"  preserving vendored entry: {name} -> {path_ref}",
+            file=sys.stderr,
+        )
+
+
 def write_if_changed(path: Path, new_content: str) -> bool:
     """Write `new_content` to `path` only if it differs from current.
 
@@ -496,6 +544,13 @@ def main() -> int:
             changed_count += 1
         else:
             print(f"  unchanged {tool_path}", file=sys.stderr)
+
+    # Preserve vendored / non-GitHub-Releases entries (e.g. the Apple
+    # SDK at deps/mac/manifest.json) that this script doesn't know how
+    # to regenerate but which already exist on the manifest branch.
+    # Without this, the nightly refresh wipes them from the top-level
+    # index every run.
+    preserve_vendored_top_level_entries(output_dir, per_tool_index)
 
     top_manifest = {
         "schema_version": SCHEMA_VERSION,

--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -440,15 +440,10 @@ jobs:
               -xf /tmp/apple-sdk.tar.zst -C /opt
           ls -la /opt/MacOSX11.3.sdk/System/Library/Frameworks/ | head -5
 
-      # Pre-download the MSVC CRT + Windows SDK via cargo-xwin so the
-      # subsequent build doesn't race the network on first compile.
-      # The download itself isn't expensive but doing it explicitly
-      # gives a clean diagnostic if it fails.
-      - name: Pre-download MSVC CRT (xwin lanes)
-        if: matrix.tool == 'xwin'
-        run: |
-          set -euo pipefail
-          soldr cargo xwin download --target "${{ matrix.target }}"
+      # (cargo-xwin v0.23.0 doesn't expose a `download` subcommand —
+      # the previous "Pre-download MSVC CRT" step was bogus and broke
+      # every xwin lane. The SDK is downloaded automatically on first
+      # `cargo xwin build` instead.)
 
       - name: Cross-compile soldr — --release ${{ matrix.target }} (${{ matrix.tool }})
         id: build


### PR DESCRIPTION
## What broke

Cross-compile [run 27901229166](https://github.com/zackees/soldr/actions/runs/27901229166) (first run on main after #848 + #849 merged) had all 4 mac+windows lanes fail for two new reasons:

### 1) Nightly refresh wiped \`apple-sdk\` from root manifest.json
\`build_manifest.py\`'s hardcoded \`tools\` list doesn't know about vendored entries. The 2026-06-21 nightly regenerated the root index without \`apple-sdk\`, so \`tool_query.py --platform mac --arch x86 apple-sdk\` errored with:

\`\`\`
tool 'apple-sdk' not in manifest. Known: cargo-chef, cargo-xwin, cargo-zigbuild, crgx, zccache
\`\`\`

The per-tool file at \`deps/mac/manifest.json\` and the SDK blob at \`deps/mac/sdk.tar.zstd\` were both preserved — only the top-level pointer was missing.

### 2) \`cargo xwin download\` isn't a real subcommand
PR #848 added a \`Pre-download MSVC CRT\` step that ran \`soldr cargo xwin download --target ...\`. cargo-xwin v0.23.0 doesn't have a \`download\` verb, so the step failed instantly with \`unrecognized subcommand 'download'\`, breaking both windows-msvc lanes before they reached the actual build.

## Fix

### \`build_manifest.py\`: new \`preserve_vendored_top_level_entries\`
Reads the existing root manifest.json before overwriting. Any entry whose \`path\` points at a file still on disk gets carried forward into the fresh index. Stale pointers (file gone) get dropped with a one-line note.

Validated locally with a fixture that seeds \`apple-sdk\` in the root index + a real \`deps/mac/manifest.json\` next to it; after \`build_manifest.py\` runs, the regenerated root index still contains \`apple-sdk\`. Log line:

\`\`\`
preserving vendored entry: apple-sdk -> deps/mac/manifest.json
\`\`\`

### Workflow: drop the bogus pre-download step
cargo-xwin auto-downloads the SDK on first \`cargo xwin build\`, so the explicit pre-step was unnecessary anyway.

## Manifest branch already restored

The live manifest branch's \`apple-sdk\` entry has been hand-restored in commit [2c1fb5b](https://github.com/zackees/soldr/commit/2c1fb5b) on the \`manifest\` branch. The script change in this PR prevents the regression on the next nightly run.

## Test plan

- [x] \`ruff check build_manifest.py\` clean
- [x] Local fixture run: apple-sdk seeded, regen preserves it
- [x] Manifest branch hand-restored already
- [ ] Re-dispatch cross-compile-all-targets.yml after merge — verify mac AND windows lanes green