### PR TITLE
fix(ci): replace ls | head with test -d framework checks (mac SDK)

### DIFF
--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -438,7 +438,14 @@ jobs:
           sudo mkdir -p /opt
           sudo tar --use-compress-program='zstd -d' \
               -xf /tmp/apple-sdk.tar.zst -C /opt
-          ls -la /opt/MacOSX11.3.sdk/System/Library/Frameworks/ | head -5
+          # Sanity check: assert the two frameworks ring/sysinfo need
+          # actually exist. Avoid `ls | head` — `head` closes the pipe
+          # early, `ls` gets SIGPIPE, `set -o pipefail` propagates a
+          # non-zero exit that silently breaks the entire build right
+          # after a successful extract.
+          test -d /opt/MacOSX11.3.sdk/System/Library/Frameworks/IOKit.framework
+          test -d /opt/MacOSX11.3.sdk/System/Library/Frameworks/CoreFoundation.framework
+          echo "Apple SDK extracted: IOKit + CoreFoundation frameworks present"
 
       # (cargo-xwin v0.23.0 doesn't expose a `download` subcommand —
       # the previous "Pre-download MSVC CRT" step was bogus and broke


### PR DESCRIPTION
## Symptom

Mac lanes (macos-x86, macos-arm) failed in run 27901722295 even though everything else worked. Log showed:

```
3.20 drwxr-xr-x+ 201 packer packer 12288 May  3  2021 .
3.20 drwxr-xr-x+   3 packer packer  4096 May  3  2021 AGL.framework
3.20 drwxr-xr-x+   3 packer packer  4096 May  3  2021 AVFAudio.framework
3.20 ls: write error: Broken pipe
##[error]Process completed with exit code 2.
```

## Cause

`ls -la /opt/MacOSX11.3.sdk/System/Library/Frameworks/ | head -5` — `head` closes the pipe after 5 lines, `ls` gets SIGPIPE, `set -o pipefail` propagates exit 2 right after a fully-successful SDK extract. Classic shell gotcha.

## Fix

Replace the diagnostic `ls | head` with explicit `test -d` checks on the two frameworks that ring/sysinfo actually need at link time. Cleaner diagnostic + no pipe race.

## Test plan

- [x] YAML parses
- [ ] Re-dispatch after merge — all 4 mac+win lanes should be green
EOF
)