### PR TITLE
feat(fetch): auto-bootstrap Apple SDK for cargo-zigbuild darwin lanes (#854)

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -380,8 +380,11 @@ pub(crate) async fn run_cargo_front_door(
 
     // If the user invoked a known ecosystem subcommand (e.g. `cargo nextest`),
     // fetch the corresponding `cargo-<sub>` binary and prepend its directory to
-    // PATH so cargo's subcommand dispatch finds it.
-    let extra_bin_dirs = ensure_known_subcommand_tool(args, &paths).await?;
+    // PATH so cargo's subcommand dispatch finds it. Also collect transitive
+    // bootstrap env (e.g. SDKROOT for `cargo zigbuild --target *-apple-darwin`).
+    let subcommand_tool_bootstrap = ensure_known_subcommand_tool(args, &paths).await?;
+    let extra_bin_dirs = subcommand_tool_bootstrap.bin_dirs;
+    let transitive_env_overrides = subcommand_tool_bootstrap.env;
     // Compute env-var overrides keyed off the subcommand + its
     // --target argument. Today this fixes ring's build.rs on
     // `cargo xwin build --target *-pc-windows-msvc` by routing cc-rs
@@ -454,6 +457,14 @@ pub(crate) async fn run_cargo_front_door(
         if std::env::var_os(key).is_none() {
             command.env(key, value);
         }
+    }
+    // Apply transitive-bootstrap env overrides (e.g. SDKROOT for
+    // `cargo zigbuild --target *-apple-darwin`). These come from
+    // `ensure_known_subcommand_tool` which calls into ensure_apple_sdk
+    // / ensure_zig / etc. The functions themselves already gate on
+    // `var_os` being unset before pushing, so just apply them.
+    for (key, value) in &transitive_env_overrides {
+        command.env(key, value);
     }
 
     let build_like_cargo = cargo_args_are_cacheable(args);
@@ -931,25 +942,38 @@ fn find_on_path(tool: &str) -> Option<std::path::PathBuf> {
     None
 }
 
+/// Result of subcommand tool resolution: PATH-prepended bin dirs +
+/// env-var overrides for the child cargo invocation.
+pub(crate) struct SubcommandToolBootstrap {
+    pub bin_dirs: Vec<std::path::PathBuf>,
+    pub env: Vec<(String, String)>,
+}
+
 async fn ensure_known_subcommand_tool(
     args: &[String],
     paths: &SoldrPaths,
-) -> Result<Vec<std::path::PathBuf>, SoldrError> {
+) -> Result<SubcommandToolBootstrap, SoldrError> {
     let Some(sub) = first_cargo_subcommand(args) else {
-        return Ok(Vec::new());
+        return Ok(SubcommandToolBootstrap {
+            bin_dirs: Vec::new(),
+            env: Vec::new(),
+        });
     };
     let Some(spec) = crate::fetch::lookup_by_cargo_subcommand(sub) else {
         // Issue #412: when the typed subcommand isn't in
         // `known_tools` but LOOKS like a typo of one that IS, drop a
-        // "did you mean?" hint on stderr. We still return Ok(empty)
-        // so the underlying cargo invocation continues as today —
-        // the suggestion is advisory and cargo's own external-command
+        // "did you mean?" hint on stderr. We still return empty so the
+        // underlying cargo invocation continues as today — the
+        // suggestion is advisory and cargo's own external-command
         // dispatch may still find the tool on PATH.
         if let Some(suggestion) = suggest_cargo_subcommand_typo(sub) {
             eprintln!("soldr: '{sub}' is not a cargo subcommand soldr ships a prebuilt for.");
             eprintln!("soldr: did you mean: cargo {suggestion}?");
         }
-        return Ok(Vec::new());
+        return Ok(SubcommandToolBootstrap {
+            bin_dirs: Vec::new(),
+            env: Vec::new(),
+        });
     };
 
     // Issue #816: if `cargo-<sub>` is already on PATH, defer to it instead
@@ -967,6 +991,7 @@ async fn ensure_known_subcommand_tool(
     // managed fetch even when PATH has the tool — useful for CI runs that
     // want byte-identical pinned binaries.
     let mut extra_bin_dirs: Vec<std::path::PathBuf> = Vec::new();
+    let mut extra_env: Vec<(String, String)> = Vec::new();
 
     if !force_managed_cargo_subcommands() {
         let exe_name = format!("cargo-{sub}");
@@ -979,8 +1004,18 @@ async fn ensure_known_subcommand_tool(
             // still shells out to `zig`. Run the transitive bootstrap
             // before returning so the deferred-on-PATH branch doesn't
             // silently regress.
-            append_subcommand_transitive_bin_dirs(sub, args, paths, &mut extra_bin_dirs).await?;
-            return Ok(extra_bin_dirs);
+            append_subcommand_transitive_bin_dirs(
+                sub,
+                args,
+                paths,
+                &mut extra_bin_dirs,
+                &mut extra_env,
+            )
+            .await?;
+            return Ok(SubcommandToolBootstrap {
+                bin_dirs: extra_bin_dirs,
+                env: extra_env,
+            });
         }
     }
 
@@ -1012,27 +1047,52 @@ async fn ensure_known_subcommand_tool(
         })?
         .to_path_buf();
     extra_bin_dirs.push(dir);
-    append_subcommand_transitive_bin_dirs(sub, args, paths, &mut extra_bin_dirs).await?;
-    Ok(extra_bin_dirs)
+    append_subcommand_transitive_bin_dirs(sub, args, paths, &mut extra_bin_dirs, &mut extra_env)
+        .await?;
+    Ok(SubcommandToolBootstrap {
+        bin_dirs: extra_bin_dirs,
+        env: extra_env,
+    })
 }
 
 /// Resolve transitive runtime dependencies for `cargo-<sub>` and append
-/// their bin directories to `extra_bin_dirs`.
+/// their bin directories to `extra_bin_dirs` (PATH-prepended on the
+/// child cargo) and any required env overrides to `extra_env`.
 ///
-/// Today the only registered transitive bootstrap is `zig` for
-/// `cargo-zigbuild`. cargo-zigbuild shells out to a `zig` binary to do
-/// the cross-link step; without this, `soldr cargo zigbuild ...` on a
-/// fresh runner explodes with `Error: Failed to find zig` even though
-/// soldr happily fetched cargo-zigbuild itself.
+/// Registered bootstraps:
+///   - `cargo zigbuild` → ensure `zig` is on PATH (PR #841).
+///   - `cargo zigbuild --target *-apple-darwin` → ensure Apple SDK on
+///     disk + set `SDKROOT` env (issue #854).
+///   - `cargo xwin build --target *-pc-windows-msvc` → ensure `clang`
+///     shim on PATH that forces `--driver-mode=cl` (PR #849).
 async fn append_subcommand_transitive_bin_dirs(
     sub: &str,
     args: &[String],
     paths: &SoldrPaths,
     extra_bin_dirs: &mut Vec<std::path::PathBuf>,
+    extra_env: &mut Vec<(String, String)>,
 ) -> Result<(), SoldrError> {
     if sub == "zigbuild" {
         let zig_dir = crate::fetch::ensure_zig(paths).await?;
         extra_bin_dirs.push(zig_dir);
+        // `soldr cargo zigbuild --target *-apple-darwin` needs the
+        // Apple SDK on disk + `SDKROOT` exported so cargo-zigbuild's
+        // mach-O linker can resolve `-framework IOKit` / etc.
+        // Without this, every Rust dep with an Apple-framework
+        // dependency (ring, sysinfo, dirs, …) fails to link.
+        if let Some(triple) = extract_target_arg(args) {
+            if triple.ends_with("-apple-darwin") {
+                let sdk_dir = crate::fetch::ensure_apple_sdk(paths).await?;
+                // Don't clobber a caller-set SDKROOT — escape hatch
+                // for users with their own Xcode SDK or a custom one.
+                if std::env::var_os("SDKROOT").is_none() {
+                    extra_env.push((
+                        "SDKROOT".to_string(),
+                        sdk_dir.to_string_lossy().into_owned(),
+                    ));
+                }
+            }
+        }
     }
     // `soldr cargo xwin build --target *-pc-windows-msvc` needs a
     // `clang` shim that forces `--driver-mode=cl`. ring's build.rs

--- a/crates/soldr-cli/src/fetch/apple_sdk.rs
+++ b/crates/soldr-cli/src/fetch/apple_sdk.rs
@@ -1,0 +1,225 @@
+//! Auto-bootstrap the Apple macOS SDK for `cargo zigbuild --target
+//! *-apple-darwin` cross-compile.
+//!
+//! Without an Apple SDK on disk + `SDKROOT` exported, cargo-zigbuild's
+//! mach-O linker fails on every Rust dep that links `-framework IOKit`
+//! / `-framework CoreFoundation` etc. (ring, sysinfo, dirs, …):
+//!
+//!     error: unable to find framework 'IOKit'. searched paths:  none
+//!
+//! Mirrors PR #841's `ensure_zig` pattern: soldr is the bootstrapper
+//! (CLAUDE.md "Pre-built first"), so every consumer of `soldr cargo
+//! zigbuild --target *-apple-darwin` Just Works on a stock device.
+//!
+//! Resolution order:
+//!   1. `SDKROOT` env var pointing at an existing dir → use it (escape
+//!      hatch for Xcode users on macOS hosts + advanced users with a
+//!      custom SDK).
+//!   2. `xcrun --show-sdk-path` (macOS host only, with Xcode installed)
+//!      → use what Apple's tooling points at.
+//!   3. Managed fetch from the soldr `manifest` branch
+//!      (`deps/mac/sdk.tar.zstd`, ~52 MiB compressed), cached at
+//!      `~/.soldr/sdk/MacOSX11.3.sdk/`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::core::{SoldrError, SoldrPaths};
+
+use super::github::http_client;
+use super::trust;
+
+/// Pinned macOS SDK version that soldr's managed bootstrap ships.
+/// 11.3 is the version extracted from `messense/cargo-zigbuild:0.20.0`
+/// (the docker image the cross-compile workflow used before this
+/// auto-bootstrap landed). Building for `mmacosx-version-min=10.12.0`
+/// or newer works fine with this SDK.
+pub const MANAGED_APPLE_SDK_VERSION: &str = "11.3";
+
+/// Directory basename of the extracted SDK (matches the upstream
+/// tarball's top-level directory, which is what cargo-zigbuild's auto
+/// discovery expects).
+pub const MANAGED_APPLE_SDK_DIRNAME: &str = "MacOSX11.3.sdk";
+
+/// URL of the SDK blob on soldr's `manifest` branch. Public CDN
+/// (`raw.githubusercontent.com`) — NOT subject to the GitHub API rate
+/// limit. The blob was extracted once from `messense/cargo-zigbuild:0.20.0`
+/// and pushed under `deps/mac/sdk.tar.zstd` (see manifest branch
+/// README for the recipe).
+pub const MANAGED_APPLE_SDK_URL: &str =
+    "https://raw.githubusercontent.com/zackees/soldr/manifest/deps/mac/sdk.tar.zstd";
+
+/// SHA-256 of the SDK blob. Hard-coded for integrity verification on
+/// every fetch. Bump alongside `MANAGED_APPLE_SDK_VERSION` when the
+/// blob is regenerated.
+pub const MANAGED_APPLE_SDK_SHA256: &str =
+    "053ac5617f5e6afd5218bec4e871cc55a6a9ab2c0b1f2f77e336dbdd48eabe56";
+
+const SDKROOT_ENV_VAR: &str = "SDKROOT";
+
+/// Ensure an Apple macOS SDK is available for cargo-zigbuild's
+/// mach-O linker. Returns the **path of the SDK directory** (the
+/// `*.sdk` dir, not its parent) so the caller can set `SDKROOT` to
+/// it on the child cargo invocation.
+pub async fn ensure_apple_sdk(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
+    if let Some(sdk) = sdk_from_env_var() {
+        return Ok(sdk);
+    }
+    if let Some(sdk) = sdk_from_xcrun() {
+        return Ok(sdk);
+    }
+    fetch_managed_sdk(paths).await
+}
+
+fn sdk_from_env_var() -> Option<PathBuf> {
+    let value = std::env::var_os(SDKROOT_ENV_VAR)?;
+    let p = PathBuf::from(value);
+    if p.is_dir() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// On macOS hosts with Xcode installed, `xcrun --show-sdk-path` returns
+/// the SDK path Apple's tooling expects. Use it when present so we
+/// don't redundantly fetch our own copy on developer macs.
+fn sdk_from_xcrun() -> Option<PathBuf> {
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    let out = Command::new("xcrun")
+        .args(["--show-sdk-path"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path_str = String::from_utf8(out.stdout).ok()?;
+    let p = PathBuf::from(path_str.trim());
+    if p.is_dir() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+async fn fetch_managed_sdk(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
+    paths.ensure_dirs()?;
+    let install_dir = paths.bin.join("apple-sdk").join(MANAGED_APPLE_SDK_VERSION);
+    let stamp = install_dir.join(".complete");
+    let sdk_dir = install_dir.join(MANAGED_APPLE_SDK_DIRNAME);
+
+    if stamp.is_file() && sdk_dir.is_dir() {
+        return Ok(sdk_dir);
+    }
+
+    eprintln!(
+        "soldr: fetching Apple SDK v{MANAGED_APPLE_SDK_VERSION} from {MANAGED_APPLE_SDK_URL}..."
+    );
+
+    let client = http_client()?;
+    let resp = client
+        .get(MANAGED_APPLE_SDK_URL)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(SoldrError::Network(format!(
+            "Apple SDK download failed: HTTP {}",
+            resp.status()
+        )));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    // Integrity check is mandatory — the blob is hand-curated and the
+    // sha256 is pinned in this file. A mismatch means either the
+    // manifest branch was tampered with or the constants drifted; refuse
+    // to extract in either case.
+    let digest = trust::sha256_of(&bytes);
+    if digest != MANAGED_APPLE_SDK_SHA256 {
+        return Err(SoldrError::Other(format!(
+            "Apple SDK sha256 mismatch: expected {MANAGED_APPLE_SDK_SHA256}, got {digest} \
+             (manifest branch blob may have been replaced — refusing to extract)"
+        )));
+    }
+    eprintln!("soldr: trust: verified Apple SDK v{MANAGED_APPLE_SDK_VERSION} sha256={digest}");
+
+    if install_dir.exists() {
+        std::fs::remove_dir_all(&install_dir)?;
+    }
+    std::fs::create_dir_all(&install_dir)?;
+    extract_tar_zst_tree(&bytes, &install_dir)?;
+
+    if !sdk_dir.is_dir() {
+        return Err(SoldrError::Archive(format!(
+            "Apple SDK extract did not produce expected directory {}",
+            sdk_dir.display()
+        )));
+    }
+
+    std::fs::write(&stamp, MANAGED_APPLE_SDK_VERSION)?;
+    eprintln!("soldr: extracted Apple SDK to {}", sdk_dir.display());
+    Ok(sdk_dir)
+}
+
+fn extract_tar_zst_tree(data: &[u8], dest: &Path) -> Result<(), SoldrError> {
+    let reader = std::io::Cursor::new(data);
+    let zst = zstd::stream::read::Decoder::new(reader)
+        .map_err(|e| SoldrError::Archive(format!("zstd decoder init: {e}")))?;
+    let mut archive = tar::Archive::new(zst);
+    archive
+        .unpack(dest)
+        .map_err(|e| SoldrError::Archive(format!("tar.zst unpack: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(env_var_overrides_when_pointing_at_real_dir, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let fake_sdk = tmp.path().join("FakeMacOSX.sdk");
+        std::fs::create_dir_all(&fake_sdk).expect("mk");
+        let prev = std::env::var_os(SDKROOT_ENV_VAR);
+        std::env::set_var(SDKROOT_ENV_VAR, &fake_sdk);
+        let resolved = sdk_from_env_var();
+        match prev {
+            Some(v) => std::env::set_var(SDKROOT_ENV_VAR, v),
+            None => std::env::remove_var(SDKROOT_ENV_VAR),
+        }
+        assert_eq!(resolved.as_deref(), Some(fake_sdk.as_path()));
+    });
+
+    crate::timed_test!(env_var_ignored_when_path_is_missing, {
+        let prev = std::env::var_os(SDKROOT_ENV_VAR);
+        std::env::set_var(SDKROOT_ENV_VAR, "/definitely/not/a/real/path/3819237");
+        let resolved = sdk_from_env_var();
+        match prev {
+            Some(v) => std::env::set_var(SDKROOT_ENV_VAR, v),
+            None => std::env::remove_var(SDKROOT_ENV_VAR),
+        }
+        assert!(
+            resolved.is_none(),
+            "missing dir should be ignored: {resolved:?}"
+        );
+    });
+
+    crate::timed_test!(constants_are_well_formed, {
+        // Smoke: catch typos in the URL / sha256 / dir name during refactor.
+        assert!(MANAGED_APPLE_SDK_URL.starts_with("https://"));
+        assert!(
+            MANAGED_APPLE_SDK_URL.ends_with(".tar.zst")
+                || MANAGED_APPLE_SDK_URL.ends_with(".tar.zstd")
+        );
+        assert_eq!(MANAGED_APPLE_SDK_SHA256.len(), 64);
+        assert!(MANAGED_APPLE_SDK_SHA256
+            .chars()
+            .all(|c| c.is_ascii_hexdigit()));
+        assert!(MANAGED_APPLE_SDK_DIRNAME.ends_with(".sdk"));
+    });
+}

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -37,6 +37,7 @@ pub use rustup_init::{
     BootstrapReport, NO_BOOTSTRAP_ENV_VAR, RUSTUP_INIT_TRIPLE_ENV_VAR, RUSTUP_INIT_URL_ENV_VAR,
 };
 
+pub mod apple_sdk;
 pub mod archive;
 pub mod github;
 pub mod zccache;
@@ -44,6 +45,7 @@ pub mod zccache_install;
 pub mod zccache_runtime;
 pub mod zig;
 
+pub use apple_sdk::{ensure_apple_sdk, MANAGED_APPLE_SDK_VERSION};
 pub use zig::{ensure_zig, MANAGED_ZIG_VERSION};
 
 #[cfg(test)]


### PR DESCRIPTION
Refs #853 (meta: soldr as full cross-compile bootstrapper).
Implements sub-issue #854.

## Summary
- Adds `crate::fetch::ensure_apple_sdk`, mirroring PR #841's `ensure_zig` pattern. cargo-zigbuild's mach-O linker needs a macOS SDK on disk + `SDKROOT` exported, otherwise every Rust dep that links `-framework IOKit`/`-framework CoreFoundation` (ring, sysinfo, dirs, …) fails with `unable to find framework 'IOKit'`.
- Wires it into the `cargo zigbuild --target *-apple-darwin` dispatch through a new `SubcommandToolBootstrap { bin_dirs, env }` shape so the bootstrap can surface env vars (SDKROOT) on the child cargo, not just PATH entries.

## Resolution order
1. `SDKROOT` env var pointing at an existing directory → use it (escape hatch for Xcode users on macOS hosts and advanced users with a custom SDK).
2. `xcrun --show-sdk-path` (macOS host only, with Xcode installed) → use what Apple's tooling points at.
3. Managed fetch from the soldr `manifest` branch (`deps/mac/sdk.tar.zstd`, ~52 MiB compressed), cached at `~/.soldr/bin/apple-sdk/<version>/MacOSX11.3.sdk/`. SHA-256 is hard-pinned (`053ac561…48eabe56`); mismatch is a hard error.

## Notes
- The workflow-level fixes that landed earlier (#848, #851, #852) made the cross-compile lanes green by exporting SDKROOT inline in the YAML. This PR moves that responsibility INTO soldr per the meta direction in #853, so the same path works on a stock developer machine without YAML scaffolding.
- 3 unit tests cover the env-var resolution paths (override-with-real-dir, ignore-missing-path, well-formed constants). The managed-fetch path is exercised by the cross-compile workflow itself once SDKROOT is unset.

## Test plan
- [x] `soldr cargo build -p soldr-cli` clean on Windows host
- [x] `soldr cargo clippy --workspace -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo test -p soldr-cli --lib fetch::apple_sdk::` — 3/3 pass
- [ ] Cross-compile workflow green on this branch (will trigger on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)