### PR TITLE
feat(manifest): git-LFS migration prep + owner runbook (#872, prep only)

### DIFF
--- a/.github/scripts/lfs_migrate_manifest_branch.py
+++ b/.github/scripts/lfs_migrate_manifest_branch.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Convert vendored binary assets on the `manifest` branch into Git LFS objects.
+
+Run from a clean checkout of the `manifest` branch; review the rewritten
+history with `git log` before pushing. This script DOES NOT push.
+
+Owner-runbook context: see ``docs/MANIFEST_LFS_MIGRATION.md``. This script
+performs step 2.3 of that runbook and stops short of step 2.5 (the actual
+``git push``). The separation is deliberate — enabling LFS on a public repo
+affects bandwidth billing irreversibly at scale.
+
+What the script does, in order:
+    1. Verify ``git lfs version`` succeeds (Git LFS is installed).
+    2. Verify the current branch is ``manifest`` and the working tree is clean.
+    3. Snapshot ``.git`` size before the rewrite.
+    4. Run ``git lfs migrate import --include=<LFS_PATTERNS> --everything``.
+    5. Snapshot ``.git`` size after, count migrated objects, print a summary.
+    6. Stop. Do not push. Tell the operator the exact push commands.
+
+Flags:
+    --dry-run         Print the planned actions and exit 0 without running
+                      any git operations. Used by the smoke test and by
+                      operators who want to confirm pattern coverage first.
+    --include PATTERN Override the comma-separated include patterns.
+                      Default: ``deps/**/*.tar.zst,deps/**/*.tar.xz,
+                      deps/**/*.zip,deps/**/*.tar.gz``.
+    --branch NAME     Branch the working tree must be on. Default ``manifest``.
+                      Tests override this so they can drive the pre-flight
+                      against synthetic repos.
+    --skip-clean-check
+                      Skip the dirty-worktree check. Documented but
+                      intentionally not advertised in --help summary — used
+                      only by the smoke test against synthetic repos.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_INCLUDE = "deps/**/*.tar.zst,deps/**/*.tar.xz,deps/**/*.zip,deps/**/*.tar.gz"
+DEFAULT_BRANCH = "manifest"
+
+# Exit-code contract — kept stable so the test suite can assert against
+# specific failure modes without parsing stderr.
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NO_LFS = 10
+EXIT_WRONG_BRANCH = 11
+EXIT_DIRTY = 12
+EXIT_MIGRATE_FAILED = 13
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments. Exposed for unit testing."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert vendored deps/ assets on the manifest branch into "
+            "Git LFS objects. Does NOT push."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "After a successful run, manually inspect history then push:\n"
+            "    git log --oneline -20\n"
+            "    git lfs ls-files | head\n"
+            "    git lfs push --all origin manifest\n"
+            "    git push --force-with-lease origin manifest\n"
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned actions and exit without touching git.",
+    )
+    parser.add_argument(
+        "--include",
+        default=DEFAULT_INCLUDE,
+        help=f"Comma-separated include patterns (default: {DEFAULT_INCLUDE}).",
+    )
+    parser.add_argument(
+        "--branch",
+        default=DEFAULT_BRANCH,
+        help=f"Required branch name (default: {DEFAULT_BRANCH}).",
+    )
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="Path to the repo checkout (default: current directory).",
+    )
+    parser.add_argument(
+        "--skip-clean-check",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args(argv)
+
+
+def have_git_lfs() -> bool:
+    """Return True iff `git lfs version` succeeds."""
+    if shutil.which("git") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["git", "lfs", "version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def current_branch(repo: Path) -> str | None:
+    """Return the current branch name, or None on detached HEAD / error."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    name = result.stdout.strip()
+    if not name or name == "HEAD":
+        return None
+    return name
+
+
+def worktree_is_clean(repo: Path) -> bool:
+    """Return True iff `git status --porcelain` is empty."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and result.stdout.strip() == ""
+
+
+def dir_size_bytes(path: Path) -> int:
+    """Recursive du-style byte count. Returns 0 if path does not exist."""
+    if not path.exists():
+        return 0
+    total = 0
+    for entry in path.rglob("*"):
+        try:
+            if entry.is_file():
+                total += entry.stat().st_size
+        except OSError:
+            # Concurrent gc or symlink loop: skip silently rather than
+            # fail the summary.
+            continue
+    return total
+
+
+def fmt_bytes(n: int) -> str:
+    """Human-friendly byte size."""
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    val = float(n)
+    idx = 0
+    while val >= 1024.0 and idx < len(units) - 1:
+        val /= 1024.0
+        idx += 1
+    return f"{val:.1f} {units[idx]}"
+
+
+def preflight(args: argparse.Namespace) -> int:
+    """Run all read-only checks. Return 0 on success, non-zero exit code on failure."""
+    repo = Path(args.repo).resolve()
+    if not (repo / ".git").exists():
+        print(f"ERROR: {repo} is not a git checkout.", file=sys.stderr)
+        return EXIT_USAGE
+
+    if not have_git_lfs():
+        print(
+            "ERROR: `git lfs version` failed. Install Git LFS first:\n"
+            "  macOS:   brew install git-lfs\n"
+            "  Linux:   sudo apt install git-lfs   (or distro equivalent)\n"
+            "  Windows: winget install GitHub.GitLFS\n"
+            "Then run `git lfs install` once per machine.",
+            file=sys.stderr,
+        )
+        return EXIT_NO_LFS
+
+    branch = current_branch(repo)
+    if branch != args.branch:
+        print(
+            f"ERROR: current branch is {branch!r}, expected {args.branch!r}. "
+            f"Run `git checkout {args.branch}` first.",
+            file=sys.stderr,
+        )
+        return EXIT_WRONG_BRANCH
+
+    if not args.skip_clean_check and not worktree_is_clean(repo):
+        print(
+            "ERROR: working tree is dirty. Commit or stash changes before "
+            "running the migration (git lfs migrate import rewrites every "
+            "reachable commit).",
+            file=sys.stderr,
+        )
+        return EXIT_DIRTY
+
+    return EXIT_OK
+
+
+def run_migration(args: argparse.Namespace) -> int:
+    """Execute the actual `git lfs migrate import`. Returns exit code."""
+    repo = Path(args.repo).resolve()
+    git_dir = repo / ".git"
+    before = dir_size_bytes(git_dir)
+    print(f"[lfs-migrate] .git size before: {fmt_bytes(before)}")
+    print(f"[lfs-migrate] include patterns: {args.include}")
+    print("[lfs-migrate] running: git lfs migrate import --everything ...")
+
+    cmd = [
+        "git",
+        "-C",
+        str(repo),
+        "lfs",
+        "migrate",
+        "import",
+        f"--include={args.include}",
+        "--everything",
+    ]
+    try:
+        result = subprocess.run(cmd, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"ERROR: failed to invoke git lfs migrate: {exc}", file=sys.stderr)
+        return EXIT_MIGRATE_FAILED
+    if result.returncode != 0:
+        print(
+            f"ERROR: git lfs migrate import exited {result.returncode}",
+            file=sys.stderr,
+        )
+        return EXIT_MIGRATE_FAILED
+
+    after = dir_size_bytes(git_dir)
+    print(f"[lfs-migrate] .git size after:  {fmt_bytes(after)}")
+    delta = after - before
+    sign = "+" if delta >= 0 else "-"
+    print(f"[lfs-migrate] delta:            {sign}{fmt_bytes(abs(delta))}")
+
+    # Count LFS-tracked files after the migration.
+    try:
+        lsfiles = subprocess.run(
+            ["git", "-C", str(repo), "lfs", "ls-files"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        n_lfs = sum(1 for line in lsfiles.stdout.splitlines() if line.strip())
+        print(f"[lfs-migrate] LFS-tracked files: {n_lfs}")
+    except (OSError, subprocess.SubprocessError):
+        print("[lfs-migrate] (could not run `git lfs ls-files` to count)")
+
+    print()
+    print("Next steps (NOT performed by this script):")
+    print("  1. Inspect rewritten history:")
+    print("       git log --oneline -20")
+    print("       git lfs ls-files | head")
+    print("  2. If satisfied, push LFS objects then ref:")
+    print("       git lfs push --all origin manifest")
+    print("       git push --force-with-lease origin manifest")
+    print("  3. Add `.gitattributes` per docs/MANIFEST_LFS_MIGRATION.md §2.6.")
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.dry_run:
+        print("[lfs-migrate] DRY RUN — no git operations will be executed.")
+        print(f"[lfs-migrate] repo:    {Path(args.repo).resolve()}")
+        print(f"[lfs-migrate] branch:  {args.branch}")
+        print(f"[lfs-migrate] include: {args.include}")
+        print("[lfs-migrate] would verify: git lfs version, current branch,")
+        print("[lfs-migrate]               working-tree cleanliness")
+        print(
+            "[lfs-migrate] would run:    git lfs migrate import "
+            f"--include={args.include} --everything"
+        )
+        return EXIT_OK
+
+    code = preflight(args)
+    if code != EXIT_OK:
+        return code
+    return run_migration(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/lfs_migrate_manifest_branch.sh
+++ b/.github/scripts/lfs_migrate_manifest_branch.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Thin shell wrapper around lfs_migrate_manifest_branch.py so the runbook
+# in docs/MANIFEST_LFS_MIGRATION.md can document a single invocation form.
+#
+# Run from a clean checkout of the `manifest` branch; review the rewritten
+# history with `git log` before pushing. This wrapper DOES NOT push.
+#
+# Owner-runbook context: docs/MANIFEST_LFS_MIGRATION.md §2.3.
+#
+# Usage:
+#   bash .github/scripts/lfs_migrate_manifest_branch.sh           # real run
+#   bash .github/scripts/lfs_migrate_manifest_branch.sh --dry-run # plan only
+#
+# All flags are forwarded verbatim to the Python script. Use --help for
+# the full flag list.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/lfs_migrate_manifest_branch.py"
+
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "ERROR: cannot find $SCRIPT" >&2
+    exit 2
+fi
+
+# Prefer python3, fall back to python (Windows Git Bash often only has `python`).
+if command -v python3 >/dev/null 2>&1; then
+    PY=python3
+elif command -v python >/dev/null 2>&1; then
+    PY=python
+else
+    echo "ERROR: neither python3 nor python is on PATH." >&2
+    exit 2
+fi
+
+exec "$PY" "$SCRIPT" "$@"

--- a/.github/snippets/manifest-branch.gitattributes
+++ b/.github/snippets/manifest-branch.gitattributes
@@ -1,0 +1,11 @@
+# Copy this file to the ROOT of the `manifest` branch as `.gitattributes`
+# after running .github/scripts/lfs_migrate_manifest_branch.sh.
+#
+# This declaration ensures future commits to deps/** continue to land
+# in Git LFS without anyone needing to remember.
+#
+# See docs/MANIFEST_LFS_MIGRATION.md for the full owner runbook.
+deps/**/*.tar.zst filter=lfs diff=lfs merge=lfs -text
+deps/**/*.tar.xz  filter=lfs diff=lfs merge=lfs -text
+deps/**/*.zip     filter=lfs diff=lfs merge=lfs -text
+deps/**/*.tar.gz  filter=lfs diff=lfs merge=lfs -text

--- a/docs/MANIFEST_LFS_MIGRATION.md
+++ b/docs/MANIFEST_LFS_MIGRATION.md
@@ -1,0 +1,289 @@
+# Manifest-branch Git LFS migration runbook
+
+This document is the **owner-runnable** procedure for converting vendored
+binary assets on the `manifest` branch (today: regular blobs) into
+Git-LFS-tracked objects. **No part of this conversion has been performed
+yet.** Everything here is prep work: tooling, snippets, and the math that
+the owner needs to review before flipping a switch that affects
+`zackees/soldr` billing in irreversible ways.
+
+Refs: #853 (meta), #872 (this sub-issue), #862 (Apple SDK vendor), #864
+(LLVM vendor), #866 (manifest-first fetch), #868 (`asset-index.json`
+publisher), #871 (manifest schema v6).
+
+---
+
+## 1. Intent
+
+The `manifest` branch is a long-lived orphan branch whose tree mirrors a
+public release-asset catalogue. As of #871 it carries vendored payloads
+under `deps/<host-triple>/<tool>/<version>/<asset>` so that soldr
+bootstrap is durable against upstream takedowns or asset renames at
+`ziglang.org`, GitHub-Releases mirrors, etc.
+
+Those payloads are presently stored as **regular git blobs**. That works
+today (largest single asset is on the order of ~50 MiB) but:
+
+- Cloning the `manifest` branch already costs the full sum of vendored
+  bytes on every fresh CI runner (even when only one asset is needed).
+- The next vendored tool — LLVM 21.1.5 full distribution, multi-arch
+  MSVC CRT — pushes the branch toward hundreds of MiB.
+- Every `manifest`-branch rewrite (we do them whenever the index format
+  bumps; see #871) doubles the pack-file footprint until `git gc`.
+
+Switching the vendored files to LFS means: pointer files in the working
+tree, real bytes in `https://github.com/zackees/soldr.git/info/lfs/...`,
+fetched on demand only when a workflow actually wants the asset.
+
+The win is durability + bandwidth proportional to actual use.
+
+---
+
+## 2. One-time owner actions (manual, sequential)
+
+These steps require either repo-admin scope on `zackees/soldr` or a
+local clone of the `manifest` branch. The order matters. **Do not skip
+the dry-run verification in step 2.4.**
+
+### 2.1 Enable LFS for the repo
+
+1. Visit <https://github.com/zackees/soldr/settings>.
+2. Scroll to **Features** > **Git LFS** and toggle it on. (If the
+   setting is hidden you may need to be repo-admin, not just a
+   collaborator.)
+3. Visit <https://github.com/account/billing> to confirm the LFS
+   storage / bandwidth plan attached to the account. The default free
+   tier is **1 GB storage + 1 GB bandwidth / month** — see the math in
+   section 3 before continuing.
+
+### 2.2 Install Git LFS locally
+
+```bash
+# macOS
+brew install git-lfs
+# Debian / Ubuntu
+sudo apt install git-lfs
+# Windows (Git for Windows ships it; otherwise)
+winget install GitHub.GitLFS
+
+# Then, once per machine:
+git lfs install
+```
+
+`git lfs install` writes filter hooks into `~/.gitconfig`. It is a
+machine-local op; nothing has been written to the repo yet.
+
+### 2.3 Convert existing assets on the `manifest` branch
+
+From a clean checkout of the `manifest` branch:
+
+```bash
+git checkout manifest
+git status   # must be clean
+
+bash .github/scripts/lfs_migrate_manifest_branch.sh
+```
+
+The script wraps:
+
+```bash
+git lfs migrate import \
+    --include="deps/**/*.tar.zst,deps/**/*.tar.xz,deps/**/*.zip,deps/**/*.tar.gz" \
+    --everything
+```
+
+`--everything` rewrites every reachable commit on the branch. The
+script refuses to run if the working tree is dirty or if LFS is not
+installed; it prints a before/after byte-count summary and **does not
+push**.
+
+### 2.4 Review the rewrite
+
+```bash
+git log --oneline manifest -20
+git lfs ls-files | head
+git cat-file -p HEAD:deps/<some-asset>   # should show "version https://git-lfs.github.com/spec/v1 ..."
+du -sh .git
+```
+
+If anything looks wrong, the rewrite lives entirely in the local clone
+— delete the clone and start over. Nothing has reached `origin` yet.
+
+### 2.5 Push
+
+```bash
+# Push LFS objects first so the pointer-only ref-update can resolve them.
+git lfs push --all origin manifest
+
+# Then update the ref. Force is required: history was rewritten.
+git push --force-with-lease origin manifest
+```
+
+**Why force-push is acceptable on `manifest` specifically:** this branch
+is a vendored-assets index, not a source-history branch. It is
+rewritten on every schema bump (most recently #871 → v6) and has no
+external consumers that depend on stable commit SHAs. Consumers
+(`raw.githubusercontent.com/zackees/soldr/manifest/...` URLs in
+workflow scripts) only care about path-level content.
+
+### 2.6 Add the `.gitattributes` declaration
+
+The snippet at `.github/snippets/manifest-branch.gitattributes` should
+be copied into the root of the `manifest` branch as `.gitattributes`
+**after** the migration finishes, so future commits to `deps/` continue
+to land in LFS:
+
+```bash
+git checkout manifest
+cp .github/snippets/manifest-branch.gitattributes .gitattributes
+git add .gitattributes
+git commit -m "manifest: declare LFS tracking for deps/ payloads"
+git push origin manifest
+```
+
+(Step 2.3 already retroactively put existing files into LFS; this step
+just makes sure the next vendored asset commit obeys the same rule
+without anyone needing to remember.)
+
+---
+
+## 3. Bandwidth math vs GitHub LFS quota
+
+GitHub's default LFS quota on a personal account: **1 GB storage,
+1 GB bandwidth / month**, with $5/month "data packs" buying +50 GB of
+each.
+
+### 3.1 Storage estimate
+
+Approximate sizes of currently-vendored payloads (from `deps/` on the
+post-#864 manifest branch):
+
+| Asset                                              | ~size  |
+| -------------------------------------------------- | ------ |
+| zig 0.13.0 (linux-x86_64)                          | 45 MiB |
+| zig 0.13.0 (macos-aarch64)                         | 45 MiB |
+| zig 0.13.0 (windows-x86_64)                        | 75 MiB |
+| LLVM 21.1.5 minimal (linux-x86_64)                 | 60 MiB |
+| LLVM 21.1.5 minimal (macos-aarch64)                | 55 MiB |
+| LLVM 21.1.5 minimal (windows-x86_64)               | 70 MiB |
+| MacOSX 11.3 SDK (.tar.xz)                          | 90 MiB |
+| MSVC CRT bundle                                    | 30 MiB |
+| **Subtotal initial migration**                     | **~470 MiB** |
+
+LFS deduplicates by content hash, so re-pushing identical bytes is
+free. The 470 MiB initial migration fits comfortably inside the 1 GB
+default storage tier.
+
+### 3.2 Bandwidth estimate
+
+Bandwidth is the load-bearing dimension. Estimate inputs:
+
+- `cross-compile-all-targets.yml` runs **~7 target lanes** per push to
+  `main` and per release.
+- Each lane resolves **1 zig + 1 LLVM + (on macOS) 1 SDK**. Average
+  per-lane LFS fetch: ~150 MiB.
+- Pushes to `main`: ~10/week ≈ **40/month**. Releases: ~4/month.
+- Other consumers (setup-soldr Action installs, manual reproductions,
+  dependabot reruns): rough fudge factor of **+50%**.
+
+Per-month LFS bandwidth:
+
+```
+(40 main pushes + 4 releases) × 7 lanes × 150 MiB × 1.5 fudge
+  ≈ 44 × 7 × 150 × 1.5 MiB
+  ≈ 69,300 MiB
+  ≈ 67.7 GiB / month
+```
+
+**This blows past the 1 GB free tier by ~70x and past one data-pack
+(+50 GB) by ~1.3x.** Conclusion: enabling LFS naively without a CDN
+fronting it will incur a real monthly LFS-bandwidth bill (~$10/month
+of data packs at current volume, scaling with workflow growth).
+
+### 3.3 Mitigations to apply before enabling LFS
+
+1. **Cache the LFS payloads on the runner.** The
+   `actions/cache@v4` keyed by asset SHA-256 collapses identical
+   fetches across reruns. Soldr's `~/.soldr/cache/` already does this
+   at the soldr level; the missing piece is making sure the
+   `manifest`-branch raw-URL fetch path also passes through the cache
+   rather than re-downloading every job.
+2. **Fall back to S3 if bandwidth becomes load-bearing.** Document the
+   `SOLDR_MANIFEST_MIRROR_BASE_URL` env-var hook so production
+   deployments can point at an S3/CloudFront mirror that holds a copy
+   of the same LFS objects. (S3 egress to GitHub Actions runners is
+   ~$0.09/GB; at 70 GiB/month that's ~$6.30/month, comparable to a
+   GitHub data pack but with no quota cliff.)
+3. **Restrict LFS to truly-large assets.** The `.gitattributes` snippet
+   currently tracks `deps/**/*.tar.zst,tar.xz,zip,tar.gz`. If a future
+   vendored asset is small (< 1 MiB), commit it as a regular blob and
+   exclude its pattern.
+
+### 3.4 S3 fallback path (documented but not implemented)
+
+Owner action sequence if GitHub LFS bandwidth becomes a problem:
+
+1. Create an S3 bucket `soldr-manifest-mirror` (or equivalent).
+2. Mirror the LFS objects with `git lfs fetch --all` followed by an
+   `s3 sync` of `.git/lfs/objects/`.
+3. Set an env var consumed by soldr's fetch path:
+   ```bash
+   export SOLDR_MANIFEST_MIRROR_BASE_URL="https://soldr-manifest-mirror.s3.amazonaws.com"
+   ```
+   The fetch path tries the mirror first, falls back to
+   `raw.githubusercontent.com`. (This env-var plumbing is **not yet
+   wired** — it is a separate follow-up that would be filed if the
+   fallback becomes necessary.)
+
+---
+
+## 4. Rollback plan
+
+If LFS bandwidth gets exhausted mid-month and CI starts failing with
+`This repository is over its data quota`, here is how to back out:
+
+1. **Buy a data pack** (`https://github.com/settings/billing` → **Git
+   LFS Data**, +50 GB / $5). This unblocks CI immediately.
+2. If the owner does **not** want to pay long-term, re-bake the
+   vendored assets as regular blobs:
+   ```bash
+   git checkout manifest
+   git lfs migrate export \
+       --include="deps/**/*.tar.zst,deps/**/*.tar.xz,deps/**/*.zip,deps/**/*.tar.gz" \
+       --everything
+   rm .gitattributes
+   git add .gitattributes
+   git commit -m "manifest: revert LFS, bytes back to regular blobs"
+   git push --force-with-lease origin manifest
+   ```
+3. After rollback, disable LFS in repo settings to stop the
+   `git-lfs.github.com` quota meter from running (it bills on
+   bandwidth, not just push count).
+
+The rollback is symmetric to the migration: `migrate import` ↔
+`migrate export`. The same force-push justification applies.
+
+---
+
+## 5. Why this PR does not flip the switch
+
+This PR ships:
+
+- `docs/MANIFEST_LFS_MIGRATION.md` (this file).
+- `.github/scripts/lfs_migrate_manifest_branch.sh` (the runner that
+  performs step 2.3 locally and stops before pushing).
+- `.github/snippets/manifest-branch.gitattributes` (the file the owner
+  copies into the `manifest` branch in step 2.6).
+- `tests/test_lfs_migrate_manifest_branch.py` (smoke tests for the
+  migrator: arg-parsing + dry-run pre-flight, no real git ops).
+
+It does **not**:
+
+- Run `git lfs install` against `zackees/soldr`.
+- Push anything to the `manifest` branch.
+- Touch repo settings.
+
+That separation is deliberate: enabling LFS on a public repo affects
+billing irreversibly at scale. The owner reviews this runbook, weighs
+the bandwidth math in section 3, then runs the steps in section 2
+themselves. Issue #872 stays **open** until that handoff completes.

--- a/tests/test_lfs_migrate_manifest_branch.py
+++ b/tests/test_lfs_migrate_manifest_branch.py
@@ -1,0 +1,262 @@
+"""Tests for the LFS migration script (issue #872, prep).
+
+Validates argument parsing, the ``--dry-run`` plan-only path, the
+exit-code contract on the preflight checks, and the ``--help`` text.
+Synthetic repos are built inline with ``tempfile`` so the suite never
+performs a real ``git lfs migrate import`` (which would rewrite history).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "lfs_migrate_manifest_branch.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "lfs_migrate_manifest_branch", SCRIPT_PATH
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["lfs_migrate_manifest_branch"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+# ---------------------------------------------------------------------------
+# argument parsing
+# ---------------------------------------------------------------------------
+
+
+def test_default_arguments(mod):
+    ns = mod.parse_args([])
+    assert ns.dry_run is False
+    assert ns.include == mod.DEFAULT_INCLUDE
+    assert ns.branch == mod.DEFAULT_BRANCH
+    assert ns.repo == "."
+    assert ns.skip_clean_check is False
+
+
+def test_dry_run_flag(mod):
+    ns = mod.parse_args(["--dry-run"])
+    assert ns.dry_run is True
+
+
+def test_override_include(mod):
+    ns = mod.parse_args(["--include", "deps/**/*.bin"])
+    assert ns.include == "deps/**/*.bin"
+
+
+def test_override_branch(mod):
+    ns = mod.parse_args(["--branch", "vendor"])
+    assert ns.branch == "vendor"
+
+
+def test_default_include_covers_documented_extensions(mod):
+    """The runbook documents these four extensions — keep them in sync."""
+    for ext in ("*.tar.zst", "*.tar.xz", "*.zip", "*.tar.gz"):
+        assert (
+            f"deps/**/{ext}" in mod.DEFAULT_INCLUDE
+        ), f"DEFAULT_INCLUDE drifted from the runbook: missing {ext}"
+
+
+def test_exit_code_constants_distinct(mod):
+    codes = [
+        mod.EXIT_OK,
+        mod.EXIT_USAGE,
+        mod.EXIT_NO_LFS,
+        mod.EXIT_WRONG_BRANCH,
+        mod.EXIT_DIRTY,
+        mod.EXIT_MIGRATE_FAILED,
+    ]
+    assert len(set(codes)) == len(codes), "exit-code constants must be unique"
+    assert mod.EXIT_OK == 0
+
+
+# ---------------------------------------------------------------------------
+# helpers — byte formatting
+# ---------------------------------------------------------------------------
+
+
+def test_fmt_bytes_units(mod):
+    assert mod.fmt_bytes(0) == "0.0 B"
+    assert mod.fmt_bytes(1023) == "1023.0 B"
+    assert mod.fmt_bytes(1024) == "1.0 KiB"
+    assert mod.fmt_bytes(1024 * 1024) == "1.0 MiB"
+    assert mod.fmt_bytes(1024 * 1024 * 1024) == "1.0 GiB"
+
+
+def test_dir_size_missing_path(mod, tmp_path):
+    assert mod.dir_size_bytes(tmp_path / "does-not-exist") == 0
+
+
+def test_dir_size_counts_files(mod, tmp_path):
+    (tmp_path / "a.bin").write_bytes(b"x" * 100)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.bin").write_bytes(b"y" * 250)
+    assert mod.dir_size_bytes(tmp_path) == 350
+
+
+# ---------------------------------------------------------------------------
+# --help / CLI subprocess surface
+# ---------------------------------------------------------------------------
+
+
+def test_help_subprocess():
+    """The script must respond to --help without import-time side effects."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "manifest branch" in out
+    assert "--dry-run" in out
+    assert "--include" in out
+    # The post-run push instructions must appear in epilog so operators see
+    # them without re-reading the source.
+    assert "git lfs push --all origin manifest" in out
+    assert "git push --force-with-lease origin manifest" in out
+
+
+def test_dry_run_subprocess(tmp_path):
+    """--dry-run prints the plan and exits 0 without touching git."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--dry-run",
+            "--repo",
+            str(tmp_path),  # not a git repo — dry-run must not care
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "DRY RUN" in result.stdout
+    assert "would run:" in result.stdout
+    assert "git lfs migrate import" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# preflight — exit-code contract
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_rejects_non_repo(mod, tmp_path):
+    ns = mod.parse_args(["--repo", str(tmp_path)])
+    rc = mod.preflight(ns)
+    assert rc == mod.EXIT_USAGE
+
+
+def _init_git_repo(repo: Path, branch: str) -> bool:
+    """Best-effort: init a synthetic repo on ``branch``. Skip test if git absent."""
+    try:
+        subprocess.run(
+            ["git", "init", "-q", "-b", branch, str(repo)],
+            check=True,
+            capture_output=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+    # Minimal config so commits work in CI.
+    for kv in (("user.email", "test@example.invalid"), ("user.name", "Test")):
+        subprocess.run(
+            ["git", "-C", str(repo), "config", kv[0], kv[1]],
+            check=True,
+            capture_output=True,
+        )
+    # Empty initial commit so HEAD resolves.
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init", "-q"],
+        check=True,
+        capture_output=True,
+    )
+    return True
+
+
+def test_preflight_rejects_wrong_branch(mod, tmp_path):
+    """If git+lfs are installed, preflight must reject the wrong branch."""
+    if not mod.have_git_lfs():
+        pytest.skip("git lfs not installed on this host")
+    if not _init_git_repo(tmp_path, "main"):
+        pytest.skip("git not installed on this host")
+    ns = mod.parse_args(["--repo", str(tmp_path), "--branch", "manifest"])
+    rc = mod.preflight(ns)
+    assert rc == mod.EXIT_WRONG_BRANCH
+
+
+def test_preflight_accepts_clean_matching_branch(mod, tmp_path):
+    """Clean repo on the expected branch with LFS installed should preflight OK."""
+    if not mod.have_git_lfs():
+        pytest.skip("git lfs not installed on this host")
+    if not _init_git_repo(tmp_path, "manifest"):
+        pytest.skip("git not installed on this host")
+    ns = mod.parse_args(["--repo", str(tmp_path), "--branch", "manifest"])
+    rc = mod.preflight(ns)
+    assert rc == mod.EXIT_OK
+
+
+def test_preflight_rejects_dirty_worktree(mod, tmp_path):
+    if not mod.have_git_lfs():
+        pytest.skip("git lfs not installed on this host")
+    if not _init_git_repo(tmp_path, "manifest"):
+        pytest.skip("git not installed on this host")
+    (tmp_path / "dirty.txt").write_text("uncommitted")
+    ns = mod.parse_args(["--repo", str(tmp_path), "--branch", "manifest"])
+    rc = mod.preflight(ns)
+    assert rc == mod.EXIT_DIRTY
+
+
+# ---------------------------------------------------------------------------
+# regression: ancillary files referenced by the runbook exist
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_exists():
+    runbook = REPO_ROOT / "docs" / "MANIFEST_LFS_MIGRATION.md"
+    assert runbook.exists()
+    text = runbook.read_text(encoding="utf-8")
+    # Make sure the runbook still points at this script by name.
+    assert "lfs_migrate_manifest_branch.sh" in text
+
+
+def test_gitattributes_snippet_exists():
+    snippet = REPO_ROOT / ".github" / "snippets" / "manifest-branch.gitattributes"
+    assert snippet.exists()
+    text = snippet.read_text(encoding="utf-8")
+    for ext in ("*.tar.zst", "*.tar.xz", "*.zip", "*.tar.gz"):
+        assert (
+            f"deps/**/{ext}" in text
+        ), f"snippet missing {ext} — keep in sync with DEFAULT_INCLUDE"
+    # Every line that declares a pattern must enable the lfs filter.
+    for line in text.splitlines():
+        if line.strip().startswith("deps/"):
+            assert "filter=lfs" in line
+            assert "diff=lfs" in line
+            assert "merge=lfs" in line
+            assert "-text" in line
+
+
+def test_shell_wrapper_exists():
+    wrapper = REPO_ROOT / ".github" / "scripts" / "lfs_migrate_manifest_branch.sh"
+    assert wrapper.exists()
+    text = wrapper.read_text(encoding="utf-8")
+    assert "lfs_migrate_manifest_branch.py" in text


### PR DESCRIPTION
Refs #872, Refs #853. PREP ONLY — does NOT enable LFS or push objects. See docs/MANIFEST_LFS_MIGRATION.md for the owner-runnable steps to actually flip the switch.