### PR TITLE
manifest: bootstrap asset-index.json (#868)

### DIFF
--- a/asset-index.json
+++ b/asset-index.json
@@ -1,0 +1,2613 @@
+{
+  "schema_version": 5,
+  "entries": [
+    {
+      "owner": "vendored",
+      "repo": "messense/cargo-zigbuild",
+      "tag": "MacOSX11.3",
+      "asset": "sdk.tar.zstd",
+      "url": "https://raw.githubusercontent.com/zackees/soldr/manifest/deps/mac/sdk.tar.zstd",
+      "sha256": "053ac5617f5e6afd5218bec4e871cc55a6a9ab2c0b1f2f77e336dbdd48eabe56"
+    },
+    {
+      "owner": "zackees",
+      "repo": "soldr",
+      "tag": "manifest",
+      "asset": "deps/mac/manifest.json",
+      "url": "https://raw.githubusercontent.com/zackees/soldr/manifest/deps/mac/manifest.json",
+      "sha256": "dd681becd5668eb29a598456eaf4277edd60e923b2ed283b8af78567a37734e8"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.10.0",
+      "asset": "zccache-v1.10.0-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.10.0/zccache-v1.10.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "2de768be6df5dda1f13772058047768737613b47e5161300592c8bf7af044287"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.10.0",
+      "asset": "zccache-v1.10.0-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.10.0/zccache-v1.10.0-aarch64-pc-windows-msvc.zip",
+      "sha256": "131baeb02ee080f2cfa425c4529443324808f6ef57c7e51249e3e8d2f800fc2c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.10.0",
+      "asset": "zccache-v1.10.0-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.10.0/zccache-v1.10.0-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "d4ca0e3f8311d0fa18043eb22ea676f8ca48b45e97e1fb9391048994196ee154"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.10.0",
+      "asset": "zccache-v1.10.0-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.10.0/zccache-v1.10.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "6b61c8379f83d0a620cca65e2ab2d8e37e25dc824df8297ac2222c5aa6f89bbd"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.10.0",
+      "asset": "zccache-v1.10.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.10.0/zccache-v1.10.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "ce7efc1dd5d758dae631ecd47f833f40dff470657e4b7a57c77433e0699d0ee4"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.10.0",
+      "asset": "zccache-v1.10.0-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.10.0/zccache-v1.10.0-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "58a88705dfcb5c049691b78e688424736b532fd0cb8a53a35d143a54a3e488a4"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.0",
+      "asset": "zccache-v1.11.0-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.0/zccache-v1.11.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "c1c30c3aca6f1b0530691bc6ae39d0ce2ea4b371d75afbc854d5b21e94d13827"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.0",
+      "asset": "zccache-v1.11.0-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.0/zccache-v1.11.0-aarch64-pc-windows-msvc.zip",
+      "sha256": "d2b013cbbb83bd4e98d322f61b83f0cb97129d25e45a2823cdea8f92e5188084"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.0",
+      "asset": "zccache-v1.11.0-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.0/zccache-v1.11.0-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "e7c05cf17f77c6d28a58bb97b78dfd4656a8529ad5c00b36117fcad995342b95"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.0",
+      "asset": "zccache-v1.11.0-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.0/zccache-v1.11.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "821058974e009a1e1a20704c606cdcb79d4a3365a702be493c7a1566d56aa0bd"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.0",
+      "asset": "zccache-v1.11.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.0/zccache-v1.11.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "85049ece6b88a938d7ab26172400f74d69367456cb0ea1c58628d8757b05cb86"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.0",
+      "asset": "zccache-v1.11.0-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.0/zccache-v1.11.0-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "cb3392375564f6200904a618f49274c90e10b446a12a08033d202a8a1d483449"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.1",
+      "asset": "zccache-v1.11.1-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.1/zccache-v1.11.1-aarch64-apple-darwin.tar.gz",
+      "sha256": "3cb70e0280f3609f1594a2853770a1e28c6a17f94d9b4b998bba37963f2753f9"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.1",
+      "asset": "zccache-v1.11.1-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.1/zccache-v1.11.1-aarch64-pc-windows-msvc.zip",
+      "sha256": "d946bba4cef805782d6d87e4dee734376acbd14eb1dd08c7f16d71e29f322f99"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.1",
+      "asset": "zccache-v1.11.1-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.1/zccache-v1.11.1-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "ee464ac496a8f7eeb55afcb597e900c60401b59baaedae79be8518059bef8f52"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.1",
+      "asset": "zccache-v1.11.1-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.1/zccache-v1.11.1-x86_64-apple-darwin.tar.gz",
+      "sha256": "e28a40fc0606327729b4e98fdff4d7906520a8d3b6ea59ae2cfe891704ea2ef0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.1",
+      "asset": "zccache-v1.11.1-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.1/zccache-v1.11.1-x86_64-pc-windows-msvc.zip",
+      "sha256": "a4aa37477f83c8664bd4b52abd44a82f282835fd1ef7371cad54615fe15fae27"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.1",
+      "asset": "zccache-v1.11.1-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.1/zccache-v1.11.1-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "5bf20686b6e1c41244590e5efb3287c051af00c7f2b5dfc40b8c373d39332473"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.10",
+      "asset": "zccache-v1.11.10-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.10/zccache-v1.11.10-aarch64-apple-darwin.tar.gz",
+      "sha256": "bf9ecf8c959c66d6801c146d6efc1d70a2d71e5979832a9d4759d61e8171eb4b"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.10",
+      "asset": "zccache-v1.11.10-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.10/zccache-v1.11.10-aarch64-pc-windows-msvc.zip",
+      "sha256": "00b07202e1fbdb271b846024cfea43eef5415c5ce318e42cee51c09e7fe3cf04"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.10",
+      "asset": "zccache-v1.11.10-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.10/zccache-v1.11.10-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "47aecd810ab86c6194eafa0496fe68ed4e0040ec876afa444609007d80595b8d"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.10",
+      "asset": "zccache-v1.11.10-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.10/zccache-v1.11.10-x86_64-apple-darwin.tar.gz",
+      "sha256": "858c3f9fdbe384dec0f759957bef09de7ef3d12af848779b19e444458ccd8a11"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.10",
+      "asset": "zccache-v1.11.10-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.10/zccache-v1.11.10-x86_64-pc-windows-msvc.zip",
+      "sha256": "301cc5e4155e90cb76687a617bd97f459f5623867541b1d4de2ab911b037ad00"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.10",
+      "asset": "zccache-v1.11.10-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.10/zccache-v1.11.10-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "3242ed0a80d1aa1aded10d76c7ac9f17ebe1688c5eaa5cdf8f917cef1edb1f8e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.11",
+      "asset": "zccache-v1.11.11-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.11/zccache-v1.11.11-aarch64-apple-darwin.tar.gz",
+      "sha256": "2c1731a4e01d7bd5e8bf1e1af337c042ee1e1f41bbdaa8ae7835f8d17822f3cd"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.11",
+      "asset": "zccache-v1.11.11-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.11/zccache-v1.11.11-aarch64-pc-windows-msvc.zip",
+      "sha256": "7d408f24594d72c8cf5c522ffc07d5ba4569908178562b713fa4c9d9460ff7fe"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.11",
+      "asset": "zccache-v1.11.11-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.11/zccache-v1.11.11-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "5755d25e180e2551770662fe3f69ea735a3e9ce17f4e61ef098ba32a891cc7c9"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.11",
+      "asset": "zccache-v1.11.11-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.11/zccache-v1.11.11-x86_64-apple-darwin.tar.gz",
+      "sha256": "762a718c068dcb41fbd8f7d21317330ec3993a5036f18f439a2be1dc783e91bb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.11",
+      "asset": "zccache-v1.11.11-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.11/zccache-v1.11.11-x86_64-pc-windows-msvc.zip",
+      "sha256": "b3073016a97a430e6a413a00f8b8e145065001bfbf82951671c9dcdb76916c3c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.11",
+      "asset": "zccache-v1.11.11-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.11/zccache-v1.11.11-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "c1b728c67b3513b5c775704c18dff6854a23a0b7f4efb5c21600853ec0b1173a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.12",
+      "asset": "zccache-v1.11.12-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.12/zccache-v1.11.12-aarch64-apple-darwin.tar.gz",
+      "sha256": "5e9895226cd05e2208e9a26a73d22358e5972755df583db4c0c60fa2337405ef"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.12",
+      "asset": "zccache-v1.11.12-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.12/zccache-v1.11.12-aarch64-pc-windows-msvc.zip",
+      "sha256": "af19d3da954a2f29a1fca9c11bb2ab5ba0aebd9c6fb90e3e73aeb45e58f624c7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.12",
+      "asset": "zccache-v1.11.12-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.12/zccache-v1.11.12-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "f5ae0682e64752b1bac5644a1f13501b0222afc415531bbf2f2c4eea4565e292"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.12",
+      "asset": "zccache-v1.11.12-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.12/zccache-v1.11.12-x86_64-apple-darwin.tar.gz",
+      "sha256": "8ad84cfa4ebf362249efefbf8b30e9129a5299c709cfba96df002f0486d0fd18"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.12",
+      "asset": "zccache-v1.11.12-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.12/zccache-v1.11.12-x86_64-pc-windows-msvc.zip",
+      "sha256": "1bc6c33ac233d6caa040321145a78f858f5660b498a41f01d538b245cb0ff3ae"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.12",
+      "asset": "zccache-v1.11.12-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.12/zccache-v1.11.12-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "d3724e4732f786f978a6ed5d331e18c7045277ff1278b3c94085790b77b36447"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.13",
+      "asset": "zccache-v1.11.13-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.13/zccache-v1.11.13-aarch64-apple-darwin.tar.gz",
+      "sha256": "e01734900156c278cbff23cee8caa2ddde4655214b7db8bedd3e3bd363e994a1"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.13",
+      "asset": "zccache-v1.11.13-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.13/zccache-v1.11.13-aarch64-pc-windows-msvc.zip",
+      "sha256": "5eb1b4fc360cee1bb9d379f8d6eebc714120afaae9b1ad8470413faadaad6d83"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.13",
+      "asset": "zccache-v1.11.13-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.13/zccache-v1.11.13-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "f50c686e286dfb6290bb49d7314c9867bd44c2edb19a2ed24376102a3a10124f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.13",
+      "asset": "zccache-v1.11.13-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.13/zccache-v1.11.13-x86_64-apple-darwin.tar.gz",
+      "sha256": "a9fb2b1ccfc1b386b3df345d885e48ba48420e469a98c0c51b4b58525ac6780e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.13",
+      "asset": "zccache-v1.11.13-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.13/zccache-v1.11.13-x86_64-pc-windows-msvc.zip",
+      "sha256": "6b1d11d391192a5256590e184e206d55489151c6817c667aa393ea4d8a802d33"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.13",
+      "asset": "zccache-v1.11.13-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.13/zccache-v1.11.13-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "be95f00b4c54fa6e1c7f60e832ef11d982c41b00baf427deaff313a4583ff7e9"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.14",
+      "asset": "zccache-v1.11.14-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.14/zccache-v1.11.14-aarch64-apple-darwin.tar.gz",
+      "sha256": "35680229c46f08936c4cceac08ceb97a4c12eab2a54e94b9c156de33e31079db"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.14",
+      "asset": "zccache-v1.11.14-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.14/zccache-v1.11.14-aarch64-pc-windows-msvc.zip",
+      "sha256": "c895152371da9d58987cb0d2b27c9fad9eaafa7a1f8692b5105f5fb78bf0bb57"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.14",
+      "asset": "zccache-v1.11.14-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.14/zccache-v1.11.14-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "64377ccba18e2a7fc7b472d7aa2d0eeea118e74da6403918ac12a79f81f497bb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.14",
+      "asset": "zccache-v1.11.14-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.14/zccache-v1.11.14-x86_64-apple-darwin.tar.gz",
+      "sha256": "d1955aa1cfb133b429ece0f672111dc52af29febeba02928b34e118763860ce9"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.14",
+      "asset": "zccache-v1.11.14-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.14/zccache-v1.11.14-x86_64-pc-windows-msvc.zip",
+      "sha256": "e7736e0b17494d2c6c1631b6e9b4cfd0ca0dffc804d5ed31c2828d669bc3ead5"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.14",
+      "asset": "zccache-v1.11.14-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.14/zccache-v1.11.14-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "dabb51bdc01891543d4193e2422faadf65b40075c25f1833d5feae494e8147d1"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.15",
+      "asset": "zccache-v1.11.15-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.15/zccache-v1.11.15-aarch64-apple-darwin.tar.gz",
+      "sha256": "5bd86a7fce46161677a744be355e201c527a74b7a940539d9462a55fa528e356"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.15",
+      "asset": "zccache-v1.11.15-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.15/zccache-v1.11.15-aarch64-pc-windows-msvc.zip",
+      "sha256": "148400aa6e5c3563c3c2f9c6b46ac0ba028ee60c34eca11eca83ff1950c072ce"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.15",
+      "asset": "zccache-v1.11.15-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.15/zccache-v1.11.15-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "14d13ab968955ee253070b21d4b28f1b3e47c4d250f131d64f2aca94c7040755"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.15",
+      "asset": "zccache-v1.11.15-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.15/zccache-v1.11.15-x86_64-apple-darwin.tar.gz",
+      "sha256": "298ec8152d14e25d05f7ed94bbae23ec31913a25a35048c2aac64f5ab66bf392"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.15",
+      "asset": "zccache-v1.11.15-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.15/zccache-v1.11.15-x86_64-pc-windows-msvc.zip",
+      "sha256": "7772921d5bf17d4c955414aaef5cb50a81b962afe57df415f7a1fde74bcd87a8"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.15",
+      "asset": "zccache-v1.11.15-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.15/zccache-v1.11.15-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "d4b2397d26a3f732b59c1702ecf271eea780f33ef305e44bfbdc676798386e65"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.16",
+      "asset": "zccache-v1.11.16-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.16/zccache-v1.11.16-aarch64-apple-darwin.tar.gz",
+      "sha256": "4c597f371ebb6a79201d6079f1c6ff79dd526b2f2ed4bd689b09bc42e1e6bdb4"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.16",
+      "asset": "zccache-v1.11.16-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.16/zccache-v1.11.16-aarch64-pc-windows-msvc.zip",
+      "sha256": "c065a1fac593460789472a1edb07872e6e67d705dd4fda92fac8afad611d3dbf"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.16",
+      "asset": "zccache-v1.11.16-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.16/zccache-v1.11.16-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "8bba3e50cb47bddf2b1fd33743ba644d759110bcd2274ba628e3200a3d102c95"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.16",
+      "asset": "zccache-v1.11.16-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.16/zccache-v1.11.16-x86_64-apple-darwin.tar.gz",
+      "sha256": "609f843d337f29e82d23d8a745eeccc7a13b2a4295984e5042b88029f60e0993"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.16",
+      "asset": "zccache-v1.11.16-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.16/zccache-v1.11.16-x86_64-pc-windows-msvc.zip",
+      "sha256": "6da9e43774bb56b3d1b99298b511d412424e1a42dea4fc64c3166cb12fa5a306"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.16",
+      "asset": "zccache-v1.11.16-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.16/zccache-v1.11.16-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "51377b951a9617ada43c980c0840b74a1ec1e128c42c701e1ddba805cb5596af"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.17",
+      "asset": "zccache-v1.11.17-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.17/zccache-v1.11.17-aarch64-apple-darwin.tar.gz",
+      "sha256": "efffa1954540ea54fbf6a9896928e905ec67c9581e3e11fee1b53dca9f9981f0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.17",
+      "asset": "zccache-v1.11.17-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.17/zccache-v1.11.17-aarch64-pc-windows-msvc.zip",
+      "sha256": "398294d4549964b8399f6b094041071d67eebb4a104a89ee9e4d3ccf091258e0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.17",
+      "asset": "zccache-v1.11.17-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.17/zccache-v1.11.17-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "667727d3394abe2de6a5a920dd74e5de1640d853b8630221f9fda5778946c413"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.17",
+      "asset": "zccache-v1.11.17-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.17/zccache-v1.11.17-x86_64-apple-darwin.tar.gz",
+      "sha256": "dc0d8cc5ba2837489bb9a98c48e6333d6ed1eca49c32eabd57618685375b22aa"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.17",
+      "asset": "zccache-v1.11.17-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.17/zccache-v1.11.17-x86_64-pc-windows-msvc.zip",
+      "sha256": "6c6e04cf5c8d680adad4799a8665db0c2908247de7da752dc7319e0882dc22cb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.17",
+      "asset": "zccache-v1.11.17-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.17/zccache-v1.11.17-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "e015b36fbda3860f85cde2e1732d9ec6cb8c9ebe0ce39228700ef8d4d9c40431"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.18",
+      "asset": "zccache-v1.11.18-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.18/zccache-v1.11.18-aarch64-apple-darwin.tar.gz",
+      "sha256": "a8d38bb258c4a5541fff2c7a80f2c4789d6005c3807d5ff07f40313bc6636e95"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.18",
+      "asset": "zccache-v1.11.18-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.18/zccache-v1.11.18-aarch64-pc-windows-msvc.zip",
+      "sha256": "120ed1a66ace36a9f445f23a6106a2a99d9cc940cc77ceb2b25b94657b7c17db"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.18",
+      "asset": "zccache-v1.11.18-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.18/zccache-v1.11.18-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "fd9d3802ed42d3858351f1278b6f7de30cf985e82372fdae3f7af697daf22453"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.18",
+      "asset": "zccache-v1.11.18-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.18/zccache-v1.11.18-x86_64-apple-darwin.tar.gz",
+      "sha256": "243368880f8dad822b3bd2904495d01e36d6fb85f161541a054bfb4e35b44b30"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.18",
+      "asset": "zccache-v1.11.18-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.18/zccache-v1.11.18-x86_64-pc-windows-msvc.zip",
+      "sha256": "35abeba5211e5a1b1149a3c32caf8432f5a6c3c9542c5ef4dd51cd9da22695b1"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.18",
+      "asset": "zccache-v1.11.18-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.18/zccache-v1.11.18-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "aef2804cdcfc7cd044c8bc0bc76ef3b18a2276f9ffc79014d34b0b1affe3fc40"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.19",
+      "asset": "zccache-v1.11.19-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.19/zccache-v1.11.19-aarch64-apple-darwin.tar.gz",
+      "sha256": "54692664d8cb1f39172b46fa1d60572a99ec260618981a30db04c6ebbd56387a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.19",
+      "asset": "zccache-v1.11.19-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.19/zccache-v1.11.19-aarch64-pc-windows-msvc.zip",
+      "sha256": "c4f66abf8ff0817057fdc8b8b10e0fe69952a7996d8f68163c3bfe51123f2f2f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.19",
+      "asset": "zccache-v1.11.19-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.19/zccache-v1.11.19-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "07927dbb6c53dc41157b3eb3b11420eb89efe2c2051b1924bb407ca10ced95d7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.19",
+      "asset": "zccache-v1.11.19-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.19/zccache-v1.11.19-x86_64-apple-darwin.tar.gz",
+      "sha256": "f8410817a9d6eb9aa93d1da723b070b4b503f27f0b9b7e2acc77ddef7879bd23"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.19",
+      "asset": "zccache-v1.11.19-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.19/zccache-v1.11.19-x86_64-pc-windows-msvc.zip",
+      "sha256": "09f9a719a472322b70d0166ab7c0ea555ee5f3708224bf3d3e3a5f0f17dd6bdc"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.19",
+      "asset": "zccache-v1.11.19-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.19/zccache-v1.11.19-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "b50096a9edbce4e97d31f4c9f0eef54a68171487fb112a1b951417bb26a9263c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.2",
+      "asset": "zccache-v1.11.2-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.2/zccache-v1.11.2-aarch64-apple-darwin.tar.gz",
+      "sha256": "801437e716df51e78573dd7238cca333efe9307ec406b1cefbbe6d6aa04e2ce5"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.2",
+      "asset": "zccache-v1.11.2-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.2/zccache-v1.11.2-aarch64-pc-windows-msvc.zip",
+      "sha256": "e4332cb462fd9347a2aa9814b48841392f13546a9a4725f428754cc1e0d4c7f8"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.2",
+      "asset": "zccache-v1.11.2-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.2/zccache-v1.11.2-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "08dde96c792db1f6e98668c7c8fd1aecc99c9a0e811413e1ab890ea613487a24"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.2",
+      "asset": "zccache-v1.11.2-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.2/zccache-v1.11.2-x86_64-apple-darwin.tar.gz",
+      "sha256": "3a82b0443ab4766db56d99f324510d39e124012cbd4b2f7a9a4d63210719eec6"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.2",
+      "asset": "zccache-v1.11.2-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.2/zccache-v1.11.2-x86_64-pc-windows-msvc.zip",
+      "sha256": "72c0e936d942d57727f26f5708150813d8e4170cc2c71cfe1282080e417ba1bf"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.2",
+      "asset": "zccache-v1.11.2-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.2/zccache-v1.11.2-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "f2eb6c8eb0d1b7d03521ab3862ef865df3ae952f6caa5b87dab12242460ce885"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.20",
+      "asset": "zccache-v1.11.20-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.20/zccache-v1.11.20-aarch64-apple-darwin.tar.gz",
+      "sha256": "c3b0e0781cfe63da4c7454a5ab3b3a203bb26008cb34ffd578904338ac5f7e2c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.20",
+      "asset": "zccache-v1.11.20-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.20/zccache-v1.11.20-aarch64-pc-windows-msvc.zip",
+      "sha256": "64c3fe9df2a933a599d763aeec33effa88d79a9c0c41cf48c0810fb41f491956"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.20",
+      "asset": "zccache-v1.11.20-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.20/zccache-v1.11.20-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "6ab9e468e44ce88b1cad730e11ed56a429cacd6320acd9c9bf1cbe04b7dbdf04"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.20",
+      "asset": "zccache-v1.11.20-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.20/zccache-v1.11.20-x86_64-apple-darwin.tar.gz",
+      "sha256": "59ab9da491ee138a9308da8a73414f8ed0ff21902370d7e29d9b71303de115c7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.20",
+      "asset": "zccache-v1.11.20-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.20/zccache-v1.11.20-x86_64-pc-windows-msvc.zip",
+      "sha256": "691a563f5edc0c9b5dbeabae21df8935bc0695b182deaff5719ead7c03546c45"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.20",
+      "asset": "zccache-v1.11.20-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.20/zccache-v1.11.20-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "be9a87e96a37a3fc3106ca5e995c99c712022b41d44945cc1cda36642f8b4fd7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.21",
+      "asset": "zccache-v1.11.21-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.21/zccache-v1.11.21-aarch64-apple-darwin.tar.gz",
+      "sha256": "4642d6ac2f53bbeb528ead3599e3918f4c6cba2c65bd5341aa36618ff4cf30df"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.21",
+      "asset": "zccache-v1.11.21-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.21/zccache-v1.11.21-aarch64-pc-windows-msvc.zip",
+      "sha256": "512657c4ae24b22813d34cd7ef93678face8cd074a7a9c5bbf5b03ad137587af"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.21",
+      "asset": "zccache-v1.11.21-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.21/zccache-v1.11.21-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "ad096c354150e6a79fae75d6d85c08301c3d5cd839a578d32e29931e125bdb4f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.21",
+      "asset": "zccache-v1.11.21-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.21/zccache-v1.11.21-x86_64-apple-darwin.tar.gz",
+      "sha256": "778602756a67147ceadb69dc83377d312fdf9fbbcc08b1e8600c660122d209da"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.21",
+      "asset": "zccache-v1.11.21-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.21/zccache-v1.11.21-x86_64-pc-windows-msvc.zip",
+      "sha256": "9d3d0af9cc1f1290b73368f8493f6bd853fbb3aeef299e00e19ef7be29bc03be"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.21",
+      "asset": "zccache-v1.11.21-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.21/zccache-v1.11.21-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "086a1bece553059595464d5d551362d46dc2032ab1d3e21ab95567380ac3defb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.22",
+      "asset": "zccache-v1.11.22-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.22/zccache-v1.11.22-aarch64-apple-darwin.tar.gz",
+      "sha256": "c50c7727f4d673b2438a31716504a3cce420c4293bd147931f4a81ad0e642354"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.22",
+      "asset": "zccache-v1.11.22-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.22/zccache-v1.11.22-aarch64-pc-windows-msvc.zip",
+      "sha256": "4b34e99a6774230c1bc7e2e217e8481816dd6fb3e5806214cf2db7dc7a93fa17"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.22",
+      "asset": "zccache-v1.11.22-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.22/zccache-v1.11.22-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "bcc65948684d60ac3e726eed9b8d8125f425373515ed21436dee6ff527ac8b27"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.22",
+      "asset": "zccache-v1.11.22-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.22/zccache-v1.11.22-x86_64-apple-darwin.tar.gz",
+      "sha256": "d4686ff6ec0c66db631192e8c4e5642ba79f9ab8cc665abf5d1d52ba21507334"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.22",
+      "asset": "zccache-v1.11.22-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.22/zccache-v1.11.22-x86_64-pc-windows-msvc.zip",
+      "sha256": "3c2f0f799c1adc04269c1d572a02ed3fe59b0f3be28e0bd4278be373c5ea9f81"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.22",
+      "asset": "zccache-v1.11.22-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.22/zccache-v1.11.22-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "f751828c5d63ce9f31e551e52e8b47c0401f8e75a79e3341b4ca2458b18466b8"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.4",
+      "asset": "zccache-v1.11.4-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.4/zccache-v1.11.4-aarch64-apple-darwin.tar.gz",
+      "sha256": "cc5662c2cf3f8c850e65e1b12a912246754632ac7ab1919e205525258fc4b650"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.4",
+      "asset": "zccache-v1.11.4-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.4/zccache-v1.11.4-aarch64-pc-windows-msvc.zip",
+      "sha256": "a772a810b8fa4e834b81bb3ce008f558cde08e047bf2c213b9dcddba8d70180f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.4",
+      "asset": "zccache-v1.11.4-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.4/zccache-v1.11.4-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "d78d5c7d551c5a4fc8e404d35d8230f17a0382d1b9636875d1f50c048e8efe9e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.4",
+      "asset": "zccache-v1.11.4-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.4/zccache-v1.11.4-x86_64-apple-darwin.tar.gz",
+      "sha256": "01ae5a1fe3c9674332868c26a913a3d11e2ba420ce7e720927c0cd1f267f4b45"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.4",
+      "asset": "zccache-v1.11.4-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.4/zccache-v1.11.4-x86_64-pc-windows-msvc.zip",
+      "sha256": "fcad21d67fb27a2b6b02c0fe992d0295bba7c3d2fd62b671fb458f5c58bf4f44"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.4",
+      "asset": "zccache-v1.11.4-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.4/zccache-v1.11.4-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "f69b6a09ac6dd1e58080fc578f66696ff6fd18f084ad629b3e4f2bc71cd38755"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.5",
+      "asset": "zccache-v1.11.5-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.5/zccache-v1.11.5-aarch64-apple-darwin.tar.gz",
+      "sha256": "f34ec03c58e9ce8a953b434a3b58d19de76e1756d8ad8911246cd431fee124e3"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.5",
+      "asset": "zccache-v1.11.5-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.5/zccache-v1.11.5-aarch64-pc-windows-msvc.zip",
+      "sha256": "25574550d8533879d82bf97f391feae662f8ec8989570f71f5a8d90f0a9bec7d"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.5",
+      "asset": "zccache-v1.11.5-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.5/zccache-v1.11.5-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "01b97aa416d6a5748dc31b117c20e7710b3cbab3806e2c155b0de1da85138ca9"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.5",
+      "asset": "zccache-v1.11.5-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.5/zccache-v1.11.5-x86_64-apple-darwin.tar.gz",
+      "sha256": "ba5ca097b0b940b83ac594dc16f39bfd1348edca26f9539ea64c7794df3755d7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.5",
+      "asset": "zccache-v1.11.5-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.5/zccache-v1.11.5-x86_64-pc-windows-msvc.zip",
+      "sha256": "d68405f20a9d7c1691b47960c679cd098f4a91b7c4d277ad864f635ac6ae1f84"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.5",
+      "asset": "zccache-v1.11.5-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.5/zccache-v1.11.5-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "eb69051a816fe6a2e0fd00c1b8a6bfd8c697bd8e035abd6861233c54170bc202"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.6",
+      "asset": "zccache-v1.11.6-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.6/zccache-v1.11.6-aarch64-apple-darwin.tar.gz",
+      "sha256": "57cf3b56d89afdda00555bacb9949ae9e8c2cb1bb34a60a3f989d31caad19a01"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.6",
+      "asset": "zccache-v1.11.6-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.6/zccache-v1.11.6-aarch64-pc-windows-msvc.zip",
+      "sha256": "188ef86fbb15f7e2fa655e54ea6f18e304aef3492e3ff8b01fbcdfc3b178fc9d"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.6",
+      "asset": "zccache-v1.11.6-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.6/zccache-v1.11.6-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "838bde4b3e24f9cbebe2d85b3abf21aff13aaf6874f8887935559ec8f9ba2039"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.6",
+      "asset": "zccache-v1.11.6-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.6/zccache-v1.11.6-x86_64-apple-darwin.tar.gz",
+      "sha256": "6d0adf8037b6f1b490fe243d3e59d850fb5d91bf8c171580a99ad1725650276e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.6",
+      "asset": "zccache-v1.11.6-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.6/zccache-v1.11.6-x86_64-pc-windows-msvc.zip",
+      "sha256": "cac892a0f90efb9e86e5a36c498723b3d738bdf9e19f0ae591413320c4fe5ddb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.6",
+      "asset": "zccache-v1.11.6-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.6/zccache-v1.11.6-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "3930777fdd5cd8b216c1e7a0ee9a0eb6cdd6d0e948e54266fce2c991380a253a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.7",
+      "asset": "zccache-v1.11.7-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.7/zccache-v1.11.7-aarch64-apple-darwin.tar.gz",
+      "sha256": "10324235f5225adf1758d2e9038c60875508dc866ded237a04c54f5ccb502eb8"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.7",
+      "asset": "zccache-v1.11.7-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.7/zccache-v1.11.7-aarch64-pc-windows-msvc.zip",
+      "sha256": "4cb77a3776c2938e806cb63016c3be1e5870c2fd5630c8d734d6ab7231788c6c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.7",
+      "asset": "zccache-v1.11.7-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.7/zccache-v1.11.7-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "623b48f3b2926036b612e79cc1a53647854a0e1b87c2356ea71d1ef66f186cba"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.7",
+      "asset": "zccache-v1.11.7-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.7/zccache-v1.11.7-x86_64-apple-darwin.tar.gz",
+      "sha256": "2289975a65f3e060804045d2ff914ef52411b1f72a56f8bd0b1db112060b27c7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.7",
+      "asset": "zccache-v1.11.7-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.7/zccache-v1.11.7-x86_64-pc-windows-msvc.zip",
+      "sha256": "bebc4c267ddfa824271554cd7f471f8059b388eba15a6da5065496da304f47e6"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.7",
+      "asset": "zccache-v1.11.7-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.7/zccache-v1.11.7-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "99261c2d02ec8083989eb1122eb165a59ae0d5573c890d6d8bf284ccab3b76d0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.8",
+      "asset": "zccache-v1.11.8-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.8/zccache-v1.11.8-aarch64-apple-darwin.tar.gz",
+      "sha256": "787be42a17980ea977ac82562f5d4242cc7eb6190a20bca4658773d9958f7ea7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.8",
+      "asset": "zccache-v1.11.8-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.8/zccache-v1.11.8-aarch64-pc-windows-msvc.zip",
+      "sha256": "5604c7e88ac673f5f14a4b366a358f436b89c1452ba4ec83f475920d0355e94d"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.8",
+      "asset": "zccache-v1.11.8-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.8/zccache-v1.11.8-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "e53cd8641b02f9b7c64e9fa6f61059c2cc6a21ac6b3f6a4dcb8fdd8e26fcb2d4"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.8",
+      "asset": "zccache-v1.11.8-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.8/zccache-v1.11.8-x86_64-apple-darwin.tar.gz",
+      "sha256": "48e1daa900afe86ad7ed4125672263fbafaf1fbdcf09b9f4ae0d887e50c70ce5"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.8",
+      "asset": "zccache-v1.11.8-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.8/zccache-v1.11.8-x86_64-pc-windows-msvc.zip",
+      "sha256": "b6fff929217c29a1966549706043ef1b7b7b99bbebde418c269f7fba76741e70"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.8",
+      "asset": "zccache-v1.11.8-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.8/zccache-v1.11.8-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "5950013c5e497a7ab24bfbc58cb05c37c25accff5e47905595f52e947f01fb1a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.9",
+      "asset": "zccache-v1.11.9-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.9/zccache-v1.11.9-aarch64-apple-darwin.tar.gz",
+      "sha256": "1d35f068fcfc5707054704884a29940dffdc1e315b3749ac9d1e374d344d37ab"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.9",
+      "asset": "zccache-v1.11.9-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.9/zccache-v1.11.9-aarch64-pc-windows-msvc.zip",
+      "sha256": "3d2cf905f02803e7fa50476016363002670feb8f67aa026d73c5a101b3fced8e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.9",
+      "asset": "zccache-v1.11.9-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.9/zccache-v1.11.9-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "5d803523ec8daf29b6869e96c42c1801a4826808ce001e8b93357583a7a0c3f6"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.9",
+      "asset": "zccache-v1.11.9-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.9/zccache-v1.11.9-x86_64-apple-darwin.tar.gz",
+      "sha256": "008d44e044a3139bf17696526720e5c759cc3bf7ea16aec51a0af9c68299b3e1"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.9",
+      "asset": "zccache-v1.11.9-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.9/zccache-v1.11.9-x86_64-pc-windows-msvc.zip",
+      "sha256": "5eca69e40d803d80571db08c70935f33b7a5f5225deed1f5cfec77a93de182a3"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.11.9",
+      "asset": "zccache-v1.11.9-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.11.9/zccache-v1.11.9-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "9b661302d06590c91306f5baf3b32d11a45299eb946555d9286c23a9d7160551"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.0",
+      "asset": "zccache-v1.12.0-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.0/zccache-v1.12.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "9f33e5d3cf2e01806542589c51359a20639c640b814c3365f9b217b9b7619b84"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.0",
+      "asset": "zccache-v1.12.0-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.0/zccache-v1.12.0-aarch64-pc-windows-msvc.zip",
+      "sha256": "52932ed8b6319d4266f6af6042fd9b12948163841a3dc13e6794ab34ae31ec4f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.0",
+      "asset": "zccache-v1.12.0-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.0/zccache-v1.12.0-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "b49ba57c7b26d8aab746dde4ef4974bd5b6c44f019db16f06557b7a89abe4fbe"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.0",
+      "asset": "zccache-v1.12.0-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.0/zccache-v1.12.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "d8018bad2b2e368660a7adf5aa12f6531370541e731be77400f60f845e0d5924"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.0",
+      "asset": "zccache-v1.12.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.0/zccache-v1.12.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "0fe54afd0c87e4d64a34b903107d9a4e1f4c5cf5274400482cbb64f45ea31c14"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.0",
+      "asset": "zccache-v1.12.0-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.0/zccache-v1.12.0-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "601f68d19f2bfdc0f277636851dc582989fbcb697c6754952416dd6a2a9b2adb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.1",
+      "asset": "zccache-v1.12.1-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.1/zccache-v1.12.1-aarch64-apple-darwin.tar.gz",
+      "sha256": "ffe9a5239024cd8e570ea02a61c53d31d91a656bc53b207c3e2227cd71d4e173"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.1",
+      "asset": "zccache-v1.12.1-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.1/zccache-v1.12.1-aarch64-pc-windows-msvc.zip",
+      "sha256": "0686cd9f477dc071a356497600e189a6ad338dd446bad3d15a0658369c629a09"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.1",
+      "asset": "zccache-v1.12.1-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.1/zccache-v1.12.1-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "26e604033c3bfbe55a2a73f689c87f32ad27c2e6964e997379866e52608875f0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.1",
+      "asset": "zccache-v1.12.1-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.1/zccache-v1.12.1-x86_64-apple-darwin.tar.gz",
+      "sha256": "30de4189f78d35ec6ec7a149fc7344c39eeb7c559b15367fe5cb2287fa59c924"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.1",
+      "asset": "zccache-v1.12.1-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.1/zccache-v1.12.1-x86_64-pc-windows-msvc.zip",
+      "sha256": "4f2637b09fa052676df98cd73ef7caa1e7f60f7bb191a85715d8e722256e13bc"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.1",
+      "asset": "zccache-v1.12.1-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.1/zccache-v1.12.1-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "bbfedf7465215d22e745c7d3a14058c2fd599f52d71c87961061da09252af560"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.2",
+      "asset": "zccache-v1.12.2-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.2/zccache-v1.12.2-aarch64-apple-darwin.tar.gz",
+      "sha256": "b666725387113f0e36752864005660472a36fee103f2706a0a03ec32df4b920f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.2",
+      "asset": "zccache-v1.12.2-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.2/zccache-v1.12.2-aarch64-pc-windows-msvc.zip",
+      "sha256": "975b7feaa6c3e2ebcd176a53c2d3772c0bdb97bb6998c8b8d4a6de25400ae853"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.2",
+      "asset": "zccache-v1.12.2-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.2/zccache-v1.12.2-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "48b3cddf071e475eee5cff21d5337953da83ba3a6e03c0f2b573f7cc7ee54745"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.2",
+      "asset": "zccache-v1.12.2-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.2/zccache-v1.12.2-x86_64-apple-darwin.tar.gz",
+      "sha256": "3faefdb660511888e276b3d5580e0def82d564f574a1eef35b339e4cdc0fccf0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.2",
+      "asset": "zccache-v1.12.2-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.2/zccache-v1.12.2-x86_64-pc-windows-msvc.zip",
+      "sha256": "013891039bac3743d6c87e8948cddb22355d8d086bade34c5bc75034840d8dd0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.2",
+      "asset": "zccache-v1.12.2-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.2/zccache-v1.12.2-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "a36cf7f0029bfdc4f71fe7c79f555d744946cd4acea5d465bda61096ab3f00ef"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.3",
+      "asset": "zccache-v1.12.3-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.3/zccache-v1.12.3-aarch64-apple-darwin.tar.gz",
+      "sha256": "9f08800ffd71f4749616d10e408ee23daa72a807042df645afe8494931577a5d"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.3",
+      "asset": "zccache-v1.12.3-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.3/zccache-v1.12.3-aarch64-pc-windows-msvc.zip",
+      "sha256": "64853fceade001056fecdff5427f609d676dea0fc8a85cd3fc4ab16aaa4d773c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.3",
+      "asset": "zccache-v1.12.3-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.3/zccache-v1.12.3-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "3940f5371430c58036b2e1fe8fd20418e9d312449e04f3eb736343f112706f4a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.3",
+      "asset": "zccache-v1.12.3-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.3/zccache-v1.12.3-x86_64-apple-darwin.tar.gz",
+      "sha256": "243a488c9a50fc595d5ae3ddd763aac3a57e53ba6e05eaaa2df607dccabd3e54"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.3",
+      "asset": "zccache-v1.12.3-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.3/zccache-v1.12.3-x86_64-pc-windows-msvc.zip",
+      "sha256": "a7a5d2eecf49cd982cbf711154c94b89159a5036d6009b740612bb3a3ced6167"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.3",
+      "asset": "zccache-v1.12.3-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.3/zccache-v1.12.3-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "00dedaad20b0803168714c10766d55cc104cd4174109ca87c3e7c7563ff1e9a2"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.4",
+      "asset": "zccache-v1.12.4-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.4/zccache-v1.12.4-aarch64-apple-darwin.tar.gz",
+      "sha256": "859749823cd66e9d455d60d856dea73ef0949776facee69095d7369bd503d751"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.4",
+      "asset": "zccache-v1.12.4-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.4/zccache-v1.12.4-aarch64-pc-windows-msvc.zip",
+      "sha256": "6dbc83d076387fe0ee016ef9a6c62fd28827cf256720ac903959e9d47b23294f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.4",
+      "asset": "zccache-v1.12.4-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.4/zccache-v1.12.4-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "d12bbb5f87608e57ad2d0c9bfbf9219853104ee290cf4d39d5dc9ce2818e6964"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.4",
+      "asset": "zccache-v1.12.4-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.4/zccache-v1.12.4-x86_64-apple-darwin.tar.gz",
+      "sha256": "55fcc2433407adf711aeaaebe530343ad42805953a3308ecac5ddb2aa981aba9"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.4",
+      "asset": "zccache-v1.12.4-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.4/zccache-v1.12.4-x86_64-pc-windows-msvc.zip",
+      "sha256": "fae9ae3419fab9df217b60ba4c0219ce16b56415b43fe22f026fb574962d85e0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.4",
+      "asset": "zccache-v1.12.4-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.4/zccache-v1.12.4-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "69d3f625d1fcc013f5b20e4c3bd282b002be3ce74c08bbdcd3eec5ed9c05f7d6"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.5",
+      "asset": "zccache-v1.12.5-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.5/zccache-v1.12.5-aarch64-apple-darwin.tar.gz",
+      "sha256": "fc59e8ab3f84e63373a1e02b4beff00009b03f04881b3fa3d22a4d1ef71fb5be"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.5",
+      "asset": "zccache-v1.12.5-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.5/zccache-v1.12.5-aarch64-pc-windows-msvc.zip",
+      "sha256": "4692a37d7d91f7d48ba362403237e0045669417ba8651190cf912484da5fa479"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.5",
+      "asset": "zccache-v1.12.5-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.5/zccache-v1.12.5-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "11c4b6fd2f97b9117ccb707df78b44d768274265176ab3fc480d5ae472d03331"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.5",
+      "asset": "zccache-v1.12.5-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.5/zccache-v1.12.5-x86_64-apple-darwin.tar.gz",
+      "sha256": "c9a9851ef5116bc0dba51ed625e3ff535a8484af2e2c6e392a6974a798f6a561"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.5",
+      "asset": "zccache-v1.12.5-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.5/zccache-v1.12.5-x86_64-pc-windows-msvc.zip",
+      "sha256": "ffd22bef1a6ea190a682ebc84b33f887a79c05b7bad5560d74b8fd1e18ee58cb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.5",
+      "asset": "zccache-v1.12.5-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.5/zccache-v1.12.5-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "dfbfd318331dd57c0e9f1ed9560272c5f692f77e4d7170b431e47c0e4294bcd7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.6",
+      "asset": "zccache-v1.12.6-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.6/zccache-v1.12.6-aarch64-apple-darwin.tar.gz",
+      "sha256": "8f87e8b62c3c751d81864ccba04908b1c89497158ad5ee61351c2c56aaca016f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.6",
+      "asset": "zccache-v1.12.6-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.6/zccache-v1.12.6-aarch64-pc-windows-msvc.zip",
+      "sha256": "780a9b14a046184a1bb369ff9ca63628f321ad489952ee3207d5dcff66b0dc51"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.6",
+      "asset": "zccache-v1.12.6-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.6/zccache-v1.12.6-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "a10a9ca5f6cbf6d8746134f08a947e5aae9cda3476440da1ed7e9334a834f99a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.6",
+      "asset": "zccache-v1.12.6-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.6/zccache-v1.12.6-x86_64-apple-darwin.tar.gz",
+      "sha256": "4bfd4ad54175615e0f1c1bcf5e6a5a168a46280ec36b71b63c4db2157266301c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.6",
+      "asset": "zccache-v1.12.6-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.6/zccache-v1.12.6-x86_64-pc-windows-msvc.zip",
+      "sha256": "1d0083da0189fe482360544b74536ea2473caecb92d8db26980cd79d3b873669"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.6",
+      "asset": "zccache-v1.12.6-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.6/zccache-v1.12.6-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "26cf06dfa6188424a9b1623747ce13320afa55951441618bd3e07c6ceceb327c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.7",
+      "asset": "zccache-v1.12.7-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.7/zccache-v1.12.7-aarch64-apple-darwin.tar.gz",
+      "sha256": "69e16d984fd5e56ff968f746699f6ab7e3fa4b0af202e7efa2d7cb2963474cea"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.7",
+      "asset": "zccache-v1.12.7-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.7/zccache-v1.12.7-aarch64-pc-windows-msvc.zip",
+      "sha256": "d1b712e7c996d33354111d4763c191ea388c6ec58e1bd6242b4edb7d964433e6"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.7",
+      "asset": "zccache-v1.12.7-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.7/zccache-v1.12.7-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "74769eef5b1636cf0e7f44795abb3771b9f1f7c819f61c6f4715ef225fbbe7dc"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.7",
+      "asset": "zccache-v1.12.7-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.7/zccache-v1.12.7-x86_64-apple-darwin.tar.gz",
+      "sha256": "7998fba4dc888b9c25d2ba74485836bc0db673ae9686398c2082c85c2ed7521e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.7",
+      "asset": "zccache-v1.12.7-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.7/zccache-v1.12.7-x86_64-pc-windows-msvc.zip",
+      "sha256": "84e10c70a8997cb3e549b6c389939691e52dc12c0b2330fdf373621b58111b7d"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.7",
+      "asset": "zccache-v1.12.7-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.7/zccache-v1.12.7-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "2f2f8390824b67306ddf0bb60b863e3f6ce3beb66f760a1a73ef6a86de2e692e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.8",
+      "asset": "zccache-v1.12.8-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.8/zccache-v1.12.8-aarch64-apple-darwin.tar.gz",
+      "sha256": "47f956d5ae76db21575ac8bb7e010535655a88f9ac005ddddcfe91192557643c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.8",
+      "asset": "zccache-v1.12.8-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.8/zccache-v1.12.8-aarch64-pc-windows-msvc.zip",
+      "sha256": "47e8ed0bbe0c2f775168b0c50d3f6ea08932c04b3957a77b61f043ce46e82583"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.8",
+      "asset": "zccache-v1.12.8-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.8/zccache-v1.12.8-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "ee5bb98caf23dd73498787fd6f23e557f00ad74e97ba09c4f9e36f7064d7a3ed"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.8",
+      "asset": "zccache-v1.12.8-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.8/zccache-v1.12.8-x86_64-apple-darwin.tar.gz",
+      "sha256": "6e469993213517543baa870c4ffcefd204f24487a54178f340324747b1138295"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.8",
+      "asset": "zccache-v1.12.8-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.8/zccache-v1.12.8-x86_64-pc-windows-msvc.zip",
+      "sha256": "5b1d2c056ad6984aad563de80e01902c4abb6053da8fd31811feb5c00a524025"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.8",
+      "asset": "zccache-v1.12.8-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.8/zccache-v1.12.8-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "76aa0ac6c0b0a16e04624489558759cb070af07d7a0cf8fc326ff9f19b94c4d2"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.9",
+      "asset": "zccache-v1.12.9-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.9/zccache-v1.12.9-aarch64-apple-darwin.tar.gz",
+      "sha256": "422228fd61e6c4687c2e0f9ab40e75fa61bbb11fe058d042ba3bdc51f882a6d0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.9",
+      "asset": "zccache-v1.12.9-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.9/zccache-v1.12.9-aarch64-pc-windows-msvc.zip",
+      "sha256": "d03ac0dbfd2cc08cbd73b1615be49020827662e4579c8853a37b98778113fef4"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.9",
+      "asset": "zccache-v1.12.9-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.9/zccache-v1.12.9-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "8274f2b5c7a74544180ad6d2c75ab64153bf8a287abd2c68a35b684b6b48c1d8"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.9",
+      "asset": "zccache-v1.12.9-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.9/zccache-v1.12.9-x86_64-apple-darwin.tar.gz",
+      "sha256": "49c71f93d584a3a3ad2609c4a1d9242ab0c91b358f0f17b960b70f9d6738a9ca"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.9",
+      "asset": "zccache-v1.12.9-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.9/zccache-v1.12.9-x86_64-pc-windows-msvc.zip",
+      "sha256": "379a849a3f86d7e9278a3a7755d5bc521238b57b72475bbc42aac605ab5fdb4f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.12.9",
+      "asset": "zccache-v1.12.9-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.12.9/zccache-v1.12.9-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "6d7547ab9fd790166b9ce889c8ae796b033016c36bd113653a662b1a604562f5"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.0",
+      "asset": "zccache-v1.3.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.0/zccache-v1.3.tar.gz",
+      "sha256": "ebc1f85a4d086e79e7fcb873f0daaf52119c566c55a5c06fc08c34252850bc2d"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.0",
+      "asset": "zccache-v1.3.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.0/zccache-v1.3.zip",
+      "sha256": "54073a89806d7331e24836cc147e370336aace9527ba1a5744516a62418886bd"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.1",
+      "asset": "zccache-v1.3.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.1/zccache-v1.3.tar.gz",
+      "sha256": "133fca1dd6f4bfc61c93eb215c184466a39a6ce79622f2044acdcbb21b5389da"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.1",
+      "asset": "zccache-v1.3.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.1/zccache-v1.3.zip",
+      "sha256": "2c840760fb77bda3dfd1fb788ed1602bf2f7119baa84a5515d48e844e5ada79f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.4",
+      "asset": "zccache-v1.3.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.4/zccache-v1.3.tar.gz",
+      "sha256": "391ad5b334b5d6cce8916a4548578ff0823d39ebdf536740e38e8e3a8c11de1a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.4",
+      "asset": "zccache-v1.3.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.4/zccache-v1.3.zip",
+      "sha256": "9217e182e372ecc222ccfa4a0e71bb9ec8dfa765a34a5828ce39ca868dacdbac"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.7",
+      "asset": "zccache-v1.3.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.7/zccache-v1.3.tar.gz",
+      "sha256": "55de6d6b757e89a83a89be78b900792c20c0ac027e3ee4c342cd41f11726e738"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.7",
+      "asset": "zccache-v1.3.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.7/zccache-v1.3.zip",
+      "sha256": "2074d5502126bbb29e31214518eec27d3999d62856c1191a89fdb3ec70040589"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.8",
+      "asset": "zccache-v1.3.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.8/zccache-v1.3.tar.gz",
+      "sha256": "0e1b054aaf61f021a6150af02372ce9b2294ddb9050bba9700842a0e1c6a54ed"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.8",
+      "asset": "zccache-v1.3.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.8/zccache-v1.3.zip",
+      "sha256": "2dd21474d31e0be59190fdc9375da314563951f43a4449f9577a54c8d02dcd5b"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.9",
+      "asset": "zccache-v1.3.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.9/zccache-v1.3.tar.gz",
+      "sha256": "e7892d3e3cac198564f238c99790a018945fff0e2d5a4ab743b4eaf26de0a33c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.3.9",
+      "asset": "zccache-v1.3.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.3.9/zccache-v1.3.zip",
+      "sha256": "8fdd3479ee195ff27c450f9889548b10833f1bb09995bd81587bef3382c4328b"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.2",
+      "asset": "zccache-v1.4.2-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.2/zccache-v1.4.2-aarch64-apple-darwin.tar.gz",
+      "sha256": "34ab67f77bf7147ed842a86a528b2e35d2d6e71a3b648fe92c5755ce9430a266"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.2",
+      "asset": "zccache-v1.4.2-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.2/zccache-v1.4.2-aarch64-pc-windows-msvc.zip",
+      "sha256": "f24e72113b6e11b3afed50a2f2a1f320fc11800d14333c3a03e3698ca5ae7a57"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.2",
+      "asset": "zccache-v1.4.2-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.2/zccache-v1.4.2-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "7084b1da914c0ae58775e08275f84cdc5758ab70eea643e08831b361c15f7aed"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.2",
+      "asset": "zccache-v1.4.2-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.2/zccache-v1.4.2-x86_64-apple-darwin.tar.gz",
+      "sha256": "5791a40f92cf5a1eeacba14d4e40a399dee13bb0f29f054a023431f08e35f972"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.2",
+      "asset": "zccache-v1.4.2-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.2/zccache-v1.4.2-x86_64-pc-windows-msvc.zip",
+      "sha256": "d8c02f7d88cc1ec2b249f51bb11a3e1066e5abffe292c8fea691d6f87e6255ef"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.2",
+      "asset": "zccache-v1.4.2-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.2/zccache-v1.4.2-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "6b30914546c7828c7d1d7a4a0fdb80788f8d9614be116e8bfe64a81204964f1b"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.3",
+      "asset": "zccache-v1.4.3-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.3/zccache-v1.4.3-aarch64-apple-darwin.tar.gz",
+      "sha256": "3ae03b3ea80d4da87bf71191dd9b8320072b5fc8eb4394078bbaa46f43f1c921"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.3",
+      "asset": "zccache-v1.4.3-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.3/zccache-v1.4.3-aarch64-pc-windows-msvc.zip",
+      "sha256": "3670cc9223d8857be55ca71ba647d4f150424efa82ef5eea7e4eec7bca06b955"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.3",
+      "asset": "zccache-v1.4.3-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.3/zccache-v1.4.3-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "90d8e68eaf4dc83e189152dff2d156d444c085bde88f83b8b1c1b3e3e1ffe7cc"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.3",
+      "asset": "zccache-v1.4.3-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.3/zccache-v1.4.3-x86_64-apple-darwin.tar.gz",
+      "sha256": "8bf9a1602ecf502a3ac074f703990fc37d113e4632bed86d5fcb9d94fe09c73a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.3",
+      "asset": "zccache-v1.4.3-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.3/zccache-v1.4.3-x86_64-pc-windows-msvc.zip",
+      "sha256": "7f599f985856d6278ef3cdf158c9e91655186954f67c0ee8e9d5bf5d723ba733"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.3",
+      "asset": "zccache-v1.4.3-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.3/zccache-v1.4.3-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "734cae04812bdcaae7251b74dd0de96dcaad5329dd78d447f9d32e94577e207a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.4",
+      "asset": "zccache-v1.4.4-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.4/zccache-v1.4.4-aarch64-apple-darwin.tar.gz",
+      "sha256": "afe6087f150e7ff7e494d5be758d1a3d3f56343ad69ecb94098718d70737d3dc"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.4",
+      "asset": "zccache-v1.4.4-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.4/zccache-v1.4.4-aarch64-pc-windows-msvc.zip",
+      "sha256": "c8deb50cad0b3f600aad45667f26fa0215cb1d7af4e471d0294cfa43988305b4"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.4",
+      "asset": "zccache-v1.4.4-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.4/zccache-v1.4.4-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "f43c27166bdea17a24911e8e642d300981efa478bda9e55015cc53ca7760fb55"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.4",
+      "asset": "zccache-v1.4.4-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.4/zccache-v1.4.4-x86_64-apple-darwin.tar.gz",
+      "sha256": "50ab0b986b655c2af1801a698f96daac47a57fb0ceaec34cd3c1bd3fdebb68d2"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.4",
+      "asset": "zccache-v1.4.4-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.4/zccache-v1.4.4-x86_64-pc-windows-msvc.zip",
+      "sha256": "bfaf34f1e59b4f44e5e94e877c8b3c15e3703bec327630eac8a2eac721b72abe"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.4",
+      "asset": "zccache-v1.4.4-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.4/zccache-v1.4.4-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "cdba781a4f6fc57c1308a717a68de9ec69c6e394b8a47c1cc858df12d5a8b07c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.5",
+      "asset": "zccache-v1.4.5-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.5/zccache-v1.4.5-aarch64-apple-darwin.tar.gz",
+      "sha256": "6c3c80a470505d7bb251378ef70a96d6d56164e836fbcd56c916f15b4e3f10ee"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.5",
+      "asset": "zccache-v1.4.5-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.5/zccache-v1.4.5-aarch64-pc-windows-msvc.zip",
+      "sha256": "2131888d1fea7644e945658fcbcb28ca952402bbf136dc5b895b09beeefc658f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.5",
+      "asset": "zccache-v1.4.5-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.5/zccache-v1.4.5-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "4664a0e653d5a41bd315a5d8c7fe8e87c1d2f7eeb36dae4fff7822dde292ac68"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.5",
+      "asset": "zccache-v1.4.5-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.5/zccache-v1.4.5-x86_64-apple-darwin.tar.gz",
+      "sha256": "186181896147ae9a451988cc922fcbf183a27e417f592029a85ddeb7db231290"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.5",
+      "asset": "zccache-v1.4.5-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.5/zccache-v1.4.5-x86_64-pc-windows-msvc.zip",
+      "sha256": "dd88db1c2f8cf13c423d0a8fc0f3e146d8c81c6cd53ac4fd9c101b62dfbd9f39"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.5",
+      "asset": "zccache-v1.4.5-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.5/zccache-v1.4.5-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "bcca33410d7eef9cc67ce3cc4939c63aacb96b737312fb47410674f4c28a32b8"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.6",
+      "asset": "zccache-v1.4.6-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.6/zccache-v1.4.6-aarch64-apple-darwin.tar.gz",
+      "sha256": "c27f15594e7db31761e93a39ac1b0d14b6233f8c27196b0c9e345ca1caee7019"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.6",
+      "asset": "zccache-v1.4.6-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.6/zccache-v1.4.6-aarch64-pc-windows-msvc.zip",
+      "sha256": "39093a2d7cf0f4c43294f7234b4a947f968ada12ce180bdd6eb6e325ad7834e7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.6",
+      "asset": "zccache-v1.4.6-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.6/zccache-v1.4.6-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "3a94d18e90382c173b68e3ca7cdd81c113ed93f33fc30211622f0dbc9415bbfc"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.6",
+      "asset": "zccache-v1.4.6-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.6/zccache-v1.4.6-x86_64-apple-darwin.tar.gz",
+      "sha256": "dd28869fa7267d042a44f8c1d07f344f225a68e00cd11ea833a99019c4cf6bba"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.6",
+      "asset": "zccache-v1.4.6-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.6/zccache-v1.4.6-x86_64-pc-windows-msvc.zip",
+      "sha256": "917e75d2988311e3973a8850c0ec2f9c49e11d7d9c4ce4de76899499fd0e2ac6"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.6",
+      "asset": "zccache-v1.4.6-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.6/zccache-v1.4.6-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "58fc1af4d23d4a202c829fb5084f076d1c55a86c8869fe1e5d5021a479b1df88"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.7",
+      "asset": "zccache-v1.4.7-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.7/zccache-v1.4.7-aarch64-apple-darwin.tar.gz",
+      "sha256": "d776fe1a449b61c15e461dd190e0d055821b84ee01868bf9207391b85741e2a2"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.7",
+      "asset": "zccache-v1.4.7-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.7/zccache-v1.4.7-aarch64-pc-windows-msvc.zip",
+      "sha256": "133e075247c6e3f1f12547e54f74ad188571c6aea7c8c01b981c51c6b83a56c5"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.7",
+      "asset": "zccache-v1.4.7-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.7/zccache-v1.4.7-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "a6742afee939e3bce82e35d08de74b036a43c99703033e9c3a7a319a4a456cfd"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.7",
+      "asset": "zccache-v1.4.7-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.7/zccache-v1.4.7-x86_64-apple-darwin.tar.gz",
+      "sha256": "49ac550a722d0635d6c12d7a0181fab825a726e88144b6ffe3d3140c161b0a4f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.7",
+      "asset": "zccache-v1.4.7-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.7/zccache-v1.4.7-x86_64-pc-windows-msvc.zip",
+      "sha256": "2c40d31b2afe4ffc9834116f7e1cdb4e41a08867b0ac60f7db383fa481f95583"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.7",
+      "asset": "zccache-v1.4.7-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.7/zccache-v1.4.7-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "006a6eb4a5450786168581432c2594d280df50a8907597379de8d9858b0a949e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.8",
+      "asset": "zccache-v1.4.8-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.8/zccache-v1.4.8-aarch64-apple-darwin.tar.gz",
+      "sha256": "ef2aad29a313ce9099ea7ea70a2f3a42b3b03be4dcf513f55150fd83ca29d46d"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.8",
+      "asset": "zccache-v1.4.8-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.8/zccache-v1.4.8-aarch64-pc-windows-msvc.zip",
+      "sha256": "42f038b38ab60af5543d2f86cbe6f4d2f1a2d4e5104f222b9a21b53a9ae142dc"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.8",
+      "asset": "zccache-v1.4.8-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.8/zccache-v1.4.8-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "6fb9488fd8a2eff6624c8f20c9415615c744cfef34b0bec898d87abe61cf089a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.8",
+      "asset": "zccache-v1.4.8-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.8/zccache-v1.4.8-x86_64-apple-darwin.tar.gz",
+      "sha256": "a5e8c7bf08efbd91f950806477cb2c78fd034d10c9dcbacf66978ec31f764b6f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.8",
+      "asset": "zccache-v1.4.8-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.8/zccache-v1.4.8-x86_64-pc-windows-msvc.zip",
+      "sha256": "8470307bbaa92e5c1c15e7835fcab674e9794520dcde71845043e170aaa33cdd"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.4.8",
+      "asset": "zccache-v1.4.8-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.4.8/zccache-v1.4.8-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "aa37e0a8dd3d8a4c63a337e2faac7de80e7b19b8c51fcb8546fdbcdbc70138d2"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.5.0",
+      "asset": "zccache-v1.5.0-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.5.0/zccache-v1.5.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "07abed49b16f897285ba67c0674922cd7e08b7c9275178f3a345041af7999dae"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.5.0",
+      "asset": "zccache-v1.5.0-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.5.0/zccache-v1.5.0-aarch64-pc-windows-msvc.zip",
+      "sha256": "872aa4fc50af466b58552a4e1daf1034c379cf6e008b3c866ebfce49ad9ecf41"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.5.0",
+      "asset": "zccache-v1.5.0-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.5.0/zccache-v1.5.0-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "1f8d8ebcfdaa5324c6987715268230552aa5487cbc14ae18675bd8f145dcbc6a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.5.0",
+      "asset": "zccache-v1.5.0-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.5.0/zccache-v1.5.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "d6649a95de4d4b488e40e03b90a2572c11e81fea22d630db470c331d56133980"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.5.0",
+      "asset": "zccache-v1.5.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.5.0/zccache-v1.5.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "805a31fe8014a37e6706ba8887505b8f62f47aaca509dc9c0e440f1182ec53fe"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.5.0",
+      "asset": "zccache-v1.5.0-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.5.0/zccache-v1.5.0-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "7fc775eee511fc9adba4e893f7c5b052c29dc66cc22be0109de9bf8c57145611"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.6.0",
+      "asset": "zccache-v1.6.0-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.6.0/zccache-v1.6.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "787c25b21f869a55b230f187f76618b34ae13185e0661d7face0c7ee0f3d01c1"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.6.0",
+      "asset": "zccache-v1.6.0-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.6.0/zccache-v1.6.0-aarch64-pc-windows-msvc.zip",
+      "sha256": "573212d83067b75bc7d97a7772acab635e526ce5535b6a5977c000d93114c04e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.6.0",
+      "asset": "zccache-v1.6.0-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.6.0/zccache-v1.6.0-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "aa2d10f778b0a16a5d0e127115fae352234e10bd17d49f61c6cf5b5612bc681f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.6.0",
+      "asset": "zccache-v1.6.0-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.6.0/zccache-v1.6.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "b223761f74c94ae9c95b08266a1da10ffbf4a420a414ba56f41e65f825f17a3d"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.6.0",
+      "asset": "zccache-v1.6.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.6.0/zccache-v1.6.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "48985a8d4701fd29b23416292bbc930fcf9e4674a0659681d1c6d6cc54d89715"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.6.0",
+      "asset": "zccache-v1.6.0-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.6.0/zccache-v1.6.0-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "f15aa1374ca211cb1e6f70852f04324cd8b8f9e19269b382e482130847ccc3cc"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.0",
+      "asset": "zccache-v1.7.0-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.0/zccache-v1.7.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "877421a5454da32eda017573de369583dce8bf856442a820c2189808feba153c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.0",
+      "asset": "zccache-v1.7.0-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.0/zccache-v1.7.0-aarch64-pc-windows-msvc.zip",
+      "sha256": "ad313f977f1a0e9e2a12c1ca15cc369a054625923ef9da1d905ccb37325ce24b"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.0",
+      "asset": "zccache-v1.7.0-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.0/zccache-v1.7.0-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "9f40c73258028b11ce37ccd912273e041e4ce345f91902d5cf36d23c4274853e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.0",
+      "asset": "zccache-v1.7.0-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.0/zccache-v1.7.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "ece020e29c5b09b7d94366d46c796d699f374f526ac7ba49a3e980257f5b895c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.0",
+      "asset": "zccache-v1.7.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.0/zccache-v1.7.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "ef1b2f709c0b70c20e3b8caf7a270fc8fb636d1d10abfbc78872f26180297eaa"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.0",
+      "asset": "zccache-v1.7.0-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.0/zccache-v1.7.0-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "d90b5886fb8eb9e3b9effae7c6c7c298eb4c11c1a9a0b28a480ae6ee1c184758"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.1",
+      "asset": "zccache-v1.7.1-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.1/zccache-v1.7.1-aarch64-apple-darwin.tar.gz",
+      "sha256": "b0cd2d7a772662d26e9e30950f563ac7de30e0cd721eca223f05a9788c932def"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.1",
+      "asset": "zccache-v1.7.1-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.1/zccache-v1.7.1-aarch64-pc-windows-msvc.zip",
+      "sha256": "70ca240750fa9c9fee8e2985ad72a0f7dba4ce65fb64318b96336cc261092894"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.1",
+      "asset": "zccache-v1.7.1-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.1/zccache-v1.7.1-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "4cc45792f454d233a9cd9946d035e618ded6e17146ee67a8340601975f5c4b3c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.1",
+      "asset": "zccache-v1.7.1-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.1/zccache-v1.7.1-x86_64-apple-darwin.tar.gz",
+      "sha256": "2f145cb4980bbfe3c91f16e860b3903bffed6788e346c4d5ebc82ccbdb747bf4"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.1",
+      "asset": "zccache-v1.7.1-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.1/zccache-v1.7.1-x86_64-pc-windows-msvc.zip",
+      "sha256": "82a1bce457916980cbd349f54ce41c61fede3db568506b1fefa626312f12c87e"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.1",
+      "asset": "zccache-v1.7.1-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.1/zccache-v1.7.1-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "0b325a125c3983006ce9a307447b532e6b448aaa52af79204893d5f2d5a3e8cc"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.2",
+      "asset": "zccache-v1.7.2-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.2/zccache-v1.7.2-aarch64-apple-darwin.tar.gz",
+      "sha256": "c76e47d49300c06c4964a1b04e824eb530e7eab8d93084dad54d69327b9d365f"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.2",
+      "asset": "zccache-v1.7.2-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.2/zccache-v1.7.2-aarch64-pc-windows-msvc.zip",
+      "sha256": "3f636d600aa3faa72a20a24cb1331f776d4dd7decd6b96f998713aec407399d9"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.2",
+      "asset": "zccache-v1.7.2-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.2/zccache-v1.7.2-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "71ceb7d8a127cf99a69361f04488db53c59acb2b0dd0d36c0c685d3604e07dcf"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.2",
+      "asset": "zccache-v1.7.2-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.2/zccache-v1.7.2-x86_64-apple-darwin.tar.gz",
+      "sha256": "684fd2e7df05219974efdee68f545b0900de42951ba06a5cb9df08a4ade7f1e8"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.2",
+      "asset": "zccache-v1.7.2-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.2/zccache-v1.7.2-x86_64-pc-windows-msvc.zip",
+      "sha256": "4ba12e233a83659959fba634f315b9e4251e472df9550a4982f803a3765372ff"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.7.2",
+      "asset": "zccache-v1.7.2-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.7.2/zccache-v1.7.2-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "556a3f3baed44069d57b02f54afccda568636388c3158850583035ff81b29e54"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.0",
+      "asset": "zccache-v1.8.0-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.0/zccache-v1.8.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "2327c163dac0975a71b1b754ad001fc10e767c6af57fc501944914201925b289"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.0",
+      "asset": "zccache-v1.8.0-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.0/zccache-v1.8.0-aarch64-pc-windows-msvc.zip",
+      "sha256": "e42dc1506c37e295657ac83b2a80a78e0c7c1122f12d751ce168da05ba1b0efb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.0",
+      "asset": "zccache-v1.8.0-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.0/zccache-v1.8.0-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "a8946857da5b9165c57cd32bd798bc387c166a927561b8c4179ead814cbef262"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.0",
+      "asset": "zccache-v1.8.0-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.0/zccache-v1.8.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "129a1a5a6fa925c598d2f2ad64d6d27e289b2a0ca5ae4093c41f806d27f921a3"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.0",
+      "asset": "zccache-v1.8.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.0/zccache-v1.8.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "e6cfdba891eef47085dafbfbded8676da5ce98f83b5a2650aabb6e9f7abe896a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.0",
+      "asset": "zccache-v1.8.0-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.0/zccache-v1.8.0-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "f9d71b73a29db188684641c6f89fdcfbfbb28d49096ceb7179e6cc0b89e265cb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.1",
+      "asset": "zccache-v1.8.1-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.1/zccache-v1.8.1-aarch64-apple-darwin.tar.gz",
+      "sha256": "4a578851c37dea87edc0545a72e421a1cbfedeb9ecfa569bda362ed725379630"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.1",
+      "asset": "zccache-v1.8.1-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.1/zccache-v1.8.1-aarch64-pc-windows-msvc.zip",
+      "sha256": "07c483a2eaecf54bbde2e869a1be5062b1323938ad53e95ea06c465ab428d0b4"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.1",
+      "asset": "zccache-v1.8.1-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.1/zccache-v1.8.1-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "e1886b9e8464bbcdf38570354209b891ab0e924d078f0e45bf173ceff3cd10f0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.1",
+      "asset": "zccache-v1.8.1-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.1/zccache-v1.8.1-x86_64-apple-darwin.tar.gz",
+      "sha256": "4ef030f5441cbaec596683df7cc34a10715c1ee4fc22ee12543636181cd6b9d2"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.1",
+      "asset": "zccache-v1.8.1-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.1/zccache-v1.8.1-x86_64-pc-windows-msvc.zip",
+      "sha256": "960931d63b2416eeff631d0c98a7ce1437862bdaa4ffdb2ea38feaea18eb5f7c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.1",
+      "asset": "zccache-v1.8.1-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.1/zccache-v1.8.1-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "65c94badcd07dfc2259d3e51d858d59f0173ffe92e7f84e9713393d6fbc7a1e7"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.2",
+      "asset": "zccache-v1.8.2-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.2/zccache-v1.8.2-aarch64-apple-darwin.tar.gz",
+      "sha256": "b4db4997cbcb811438ab98c921580b9f572ca8594df2a2fc7d8b49cc7a584a2c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.2",
+      "asset": "zccache-v1.8.2-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.2/zccache-v1.8.2-aarch64-pc-windows-msvc.zip",
+      "sha256": "beb74d6e368200469aa3b564855a8b12f97dce851345174c622e25ccade51235"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.2",
+      "asset": "zccache-v1.8.2-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.2/zccache-v1.8.2-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "68769df7607edd1fbf2051ed4c1a7663df05d49806a07bad50b77139404c7b81"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.2",
+      "asset": "zccache-v1.8.2-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.2/zccache-v1.8.2-x86_64-apple-darwin.tar.gz",
+      "sha256": "921ed778f3824d28e18fd9cd1c35a2e16990cad158281a494cd7f25f54fe4bd9"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.2",
+      "asset": "zccache-v1.8.2-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.2/zccache-v1.8.2-x86_64-pc-windows-msvc.zip",
+      "sha256": "aefec575d7da6de5998c3f38758552815f6435fbc1d3dbea65942fcf57a81717"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.8.2",
+      "asset": "zccache-v1.8.2-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.8.2/zccache-v1.8.2-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "661d087b018cba8987380645307e74de762da4a079e692b5b967ee45ae3d49b0"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.0",
+      "asset": "zccache-v1.9.0-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.0/zccache-v1.9.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "7b0ff607c2bb81c6b1c6df573a3bedfa64c7aa547cdddc40b47d3b7b2a79aeed"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.0",
+      "asset": "zccache-v1.9.0-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.0/zccache-v1.9.0-aarch64-pc-windows-msvc.zip",
+      "sha256": "521a33c32a978c733eed1f23cab62207636fd0a24d0ae160e3aee31669045220"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.0",
+      "asset": "zccache-v1.9.0-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.0/zccache-v1.9.0-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "8e3542f117294ad2eb8884be686c1f8170cde7b78f47a47f6aabb215eb6d6aca"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.0",
+      "asset": "zccache-v1.9.0-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.0/zccache-v1.9.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "9f64f59a3704cbd535c67db8c2084860ea6640f83ec5323b5d8fe028388de2af"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.0",
+      "asset": "zccache-v1.9.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.0/zccache-v1.9.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "380d1040b2a9fa53677da5137465ba0b3e097ee017662e101f6d24ef4feba5b8"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.0",
+      "asset": "zccache-v1.9.0-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.0/zccache-v1.9.0-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "7bd29c959f60cda2c0cc58770d42308e6d4b307b48cb0725020ed6697d73517c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.1",
+      "asset": "zccache-v1.9.1-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.1/zccache-v1.9.1-aarch64-apple-darwin.tar.gz",
+      "sha256": "69c558963f70952cc1cc6dd22fea2bdcb7ec54ffb6a384602c4e2c3436377f02"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.1",
+      "asset": "zccache-v1.9.1-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.1/zccache-v1.9.1-aarch64-pc-windows-msvc.zip",
+      "sha256": "6bfbc8d80e919b7c4c32583a50f6c0d3490881ea1fc4e8db738d6776bc08d645"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.1",
+      "asset": "zccache-v1.9.1-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.1/zccache-v1.9.1-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "283da5004b0733322eba9c5a1077f6835399aa6a0efa3ea8f2ce357ca4a7b348"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.1",
+      "asset": "zccache-v1.9.1-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.1/zccache-v1.9.1-x86_64-apple-darwin.tar.gz",
+      "sha256": "0734de34e65bc597692a1a4768274d16c55416082459115cd96de6c4a3b678ef"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.1",
+      "asset": "zccache-v1.9.1-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.1/zccache-v1.9.1-x86_64-pc-windows-msvc.zip",
+      "sha256": "d3d2d4f85e05a2212cb015faaa44d1cd7e617a2200aff201166a6b64412198bf"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "1.9.1",
+      "asset": "zccache-v1.9.1-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/1.9.1/zccache-v1.9.1-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "d145e8ae3ac2fc535c301f6928086ee17a3040858e6379ced49374860587099c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.3.10",
+      "asset": "zccache-v1.3.10-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.3.10/zccache-v1.3.10-aarch64-apple-darwin.tar.gz",
+      "sha256": "9c7a925b9e1b6b0a84b1e5389fd19fc8e1b72b0ea3cf99dd0aa5ff34cc9fead4"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.3.10",
+      "asset": "zccache-v1.3.10-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.3.10/zccache-v1.3.10-aarch64-pc-windows-msvc.zip",
+      "sha256": "e8065a91253f5358a2c79ff07413e324eaabe5587add3414cf791f3b251f7a8c"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.3.10",
+      "asset": "zccache-v1.3.10-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.3.10/zccache-v1.3.10-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "eb3abe2e101d559ebf8d44ae240b1152cc0a70c7013af911f2dac4fb82bef6b2"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.3.10",
+      "asset": "zccache-v1.3.10-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.3.10/zccache-v1.3.10-x86_64-apple-darwin.tar.gz",
+      "sha256": "d0e41719acc362f2e7fa7e2d0359eae77659a8e082f99bc6225da0075c56a724"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.3.10",
+      "asset": "zccache-v1.3.10-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.3.10/zccache-v1.3.10-x86_64-pc-windows-msvc.zip",
+      "sha256": "683a223a197680460ea9f439e98291bb7f7d408cd776231042b009adc8105eea"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.3.10",
+      "asset": "zccache-v1.3.10-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.3.10/zccache-v1.3.10-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "1dad045c094fe4bca7c9d98be16926ac8b4def333618fe220f62368df87e2c75"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.4.0",
+      "asset": "zccache-v1.4.0-aarch64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.4.0/zccache-v1.4.0-aarch64-apple-darwin.tar.gz",
+      "sha256": "f308a51afa7c0ae0404983482775e32c79113e1dad5439d6c2a981f7b5ca9746"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.4.0",
+      "asset": "zccache-v1.4.0-aarch64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.4.0/zccache-v1.4.0-aarch64-pc-windows-msvc.zip",
+      "sha256": "8490f794b945cf33fc9ba47aa691333b0e1113fa5f8dc62e4688f2ca23f8e136"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.4.0",
+      "asset": "zccache-v1.4.0-aarch64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.4.0/zccache-v1.4.0-aarch64-unknown-linux-musl.tar.gz",
+      "sha256": "a4384d5e030ff3702e54ae76b187b2ddf4e80a836a62b26501613d95516c4b2a"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.4.0",
+      "asset": "zccache-v1.4.0-x86_64-apple-darwin.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.4.0/zccache-v1.4.0-x86_64-apple-darwin.tar.gz",
+      "sha256": "1ef8c2ad3fc69f7c8d74b32967c8b5a37cdd1df2005737a85d365c58b501efbb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.4.0",
+      "asset": "zccache-v1.4.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.4.0/zccache-v1.4.0-x86_64-pc-windows-msvc.zip",
+      "sha256": "3e42264e11b7b3e77df6ce91f98b1e8b5053c1a3667a2be33306c791f1a2adcb"
+    },
+    {
+      "owner": "zackees",
+      "repo": "zccache",
+      "tag": "v1.4.0",
+      "asset": "zccache-v1.4.0-x86_64-unknown-linux-musl.tar.gz",
+      "url": "https://github.com/zackees/zccache/releases/download/v1.4.0/zccache-v1.4.0-x86_64-unknown-linux-musl.tar.gz",
+      "sha256": "e2d6a0dec2e95ec7af02d54ced1546b7d014f1e7c0b61015f88f04aa5dc4e294"
+    }
+  ]
+}


### PR DESCRIPTION
First generated `asset-index.json` for the `manifest` branch, produced by `.github/scripts/build_asset_index.py` (landing in #875).

## What's in it

326 entries (sorted ascending by `(owner, repo, tag, asset)` for reviewable diffs):

- **324** zackees/zccache release assets — sha256s parsed straight out of each release's `SHA256SUMS` file
- **1** vendored Apple SDK row attributed to `(vendored, messense/cargo-zigbuild, MacOSX11.3)` — sha matches the pre-recorded `053ac5617f5e6afd5218bec4e871cc55a6a9ab2c0b1f2f77e336dbdd48eabe56` in `deps/mac/manifest.json`
- **1** self-attributed row for `deps/mac/manifest.json` itself

## Why merge directly to manifest

The `manifest` branch is the publishing target for `.github/workflows/refresh-manifest.yml` (nightly cron). This bootstrap commit lets the new runtime resolver in `crates/soldr-cli/src/fetch/manifest_lookup.rs` (landed in #866) actually find rows starting now, rather than waiting for the next 06:30 UTC refresh.

## Test plan

- [x] `asset-index.json` parses as JSON
- [x] Schema matches what `ManifestIndex::from_json` in `manifest_lookup.rs` expects
- [x] Pre-recorded sha for `deps/mac/sdk.tar.zstd` matches the on-disk byte hash

Refs #868. Refs #853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)