### PR TITLE
feat(fetch): switch manifest-branch URLs to media.githubusercontent.com (LFS-aware)

### DIFF
--- a/.github/scripts/build_asset_index.py
+++ b/.github/scripts/build_asset_index.py
@@ -195,12 +195,17 @@ def _entry_sort_key(entry: dict[str, Any]) -> tuple[str, str, str, str]:
 
 
 def _raw_url_for_deps(repo_owner: str, repo_name: str, rel_posix: str) -> str:
-    """Build the ``raw.githubusercontent.com`` URL the vendored asset
-    is served from. Mirrors how the existing ``deps/mac/manifest.json``
-    spells the URLs (``raw.githubusercontent.com/<owner>/<repo>/manifest/...``)
-    so the resolver gets one stable URL form for every vendored row.
+    """Build the LFS-aware CDN URL the vendored asset is served from.
+
+    Uses ``media.githubusercontent.com/media/`` rather than
+    ``raw.githubusercontent.com``: the ``/media/`` endpoint follows
+    Git-LFS pointer files to the actual binary blob (and falls back
+    transparently to the raw content for non-LFS files). This matches
+    the URL pattern used by ``zackees/clang-tool-chain-bins`` and lets
+    the soldr ``manifest`` branch migrate to LFS without breaking the
+    resolver — same URL form works for both pre- and post-LFS state.
     """
-    return f"https://raw.githubusercontent.com/{repo_owner}/{repo_name}/manifest/{rel_posix}"
+    return f"https://media.githubusercontent.com/media/{repo_owner}/{repo_name}/manifest/{rel_posix}"
 
 
 def collect_deps_entries(

--- a/.github/scripts/test_build_asset_index.py
+++ b/.github/scripts/test_build_asset_index.py
@@ -187,7 +187,7 @@ class BuildAssetIndexTest(unittest.TestCase):
             self.assertEqual(entry["sha256"], expected_sha)
             self.assertEqual(
                 entry["url"],
-                "https://raw.githubusercontent.com/zackees/soldr/manifest/"
+                "https://media.githubusercontent.com/media/zackees/soldr/manifest/"
                 "deps/foo/bar.tar.zst",
             )
             self.assertEqual(len(entry["sha256"]), 64)

--- a/crates/soldr-cli/src/fetch/apple_sdk.rs
+++ b/crates/soldr-cli/src/fetch/apple_sdk.rs
@@ -41,13 +41,15 @@ pub const MANAGED_APPLE_SDK_VERSION: &str = "11.3";
 /// discovery expects).
 pub const MANAGED_APPLE_SDK_DIRNAME: &str = "MacOSX11.3.sdk";
 
-/// URL of the SDK blob on soldr's `manifest` branch. Public CDN
-/// (`raw.githubusercontent.com`) — NOT subject to the GitHub API rate
-/// limit. The blob was extracted once from `messense/cargo-zigbuild:0.20.0`
-/// and pushed under `deps/mac/sdk.tar.zstd` (see manifest branch
-/// README for the recipe).
+/// URL of the SDK blob on soldr's `manifest` branch. Uses
+/// `media.githubusercontent.com/media/` — the LFS-aware CDN endpoint
+/// that follows LFS pointer files to the actual binary content (works
+/// for both LFS-tracked and regular blobs, matching the pattern from
+/// `zackees/clang-tool-chain-bins`). NOT subject to the GitHub API
+/// rate limit. The blob was extracted once from
+/// `messense/cargo-zigbuild:0.20.0` and pushed under `deps/mac/sdk.tar.zstd`.
 pub const MANAGED_APPLE_SDK_URL: &str =
-    "https://raw.githubusercontent.com/zackees/soldr/manifest/deps/mac/sdk.tar.zstd";
+    "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/mac/sdk.tar.zstd";
 
 /// SHA-256 of the SDK blob. Hard-coded for integrity verification on
 /// every fetch. Bump alongside `MANAGED_APPLE_SDK_VERSION` when the


### PR DESCRIPTION
Prerequisite for #872 (Git-LFS migration of the manifest branch). Refs #853 (meta).

## Why
Once the manifest branch goes LFS, `raw.githubusercontent.com/zackees/soldr/manifest/<path>` returns the LFS **pointer file** (a small text manifest with `version`/`oid sha256:.../size`), not the actual binary blob. The LFS-aware CDN endpoint at `media.githubusercontent.com/media/zackees/soldr/manifest/<path>` follows the pointer to the real content (and degrades to the raw blob for non-LFS files), so the URL form stays stable across the LFS transition.

This is the pattern `zackees/clang-tool-chain-bins` already uses — their per-platform `manifest.json` files spell out `media.githubusercontent.com/media/...` URLs for every LFS-tracked asset.

## Changes
- `crates/soldr-cli/src/fetch/apple_sdk.rs::MANAGED_APPLE_SDK_URL` flips raw → media.
- `.github/scripts/build_asset_index.py::_raw_url_for_deps` now emits media URLs for every entry under `deps/`. The `asset-index.json` itself (a small JSON, not LFS-tracked) still lives at the raw URL — only entries it generates change.
- Test updated to assert the new URL shape.

## Test plan
- [x] `soldr cargo build -p soldr-cli` clean
- [x] `soldr cargo clippy --workspace -- -D warnings` clean (100% cache hit)
- [x] `soldr cargo fmt --all -- --check` clean
- [x] `python3 -m unittest test_build_asset_index -v` — 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)