### PR TITLE
feat(ci): cache crgx + cargo-chef prebuilts on manifest branch

### DIFF
--- a/.github/scripts/fetch_or_build_tool.sh
+++ b/.github/scripts/fetch_or_build_tool.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# fetch_or_build_tool.sh — Try the manifest branch first; fall back to
+# a source build only on a miss.
+#
+# Used by `cross-compile-all-targets.yml` to install `crgx` and
+# `cargo-chef` into the per-target soldr distribution archive. The
+# fast path is a single curl from the LFS-aware CDN; the fallback
+# preserves the old behavior (git clone + soldr cargo (xwin|zigbuild)
+# build).
+#
+# USAGE: fetch_or_build_tool.sh <tool> <target-triple> <build-tool> <exe-suffix> <dest-dir>
+#
+#   tool         crgx | cargo-chef
+#   target       e.g. x86_64-unknown-linux-gnu
+#   build-tool   zigbuild | xwin | "" (native)
+#   exe-suffix   .exe (windows) or "" (unix)
+#   dest-dir     destination directory for the binary
+#
+# The script exports a per-tool `<TOOL>_SOURCE_COMMIT` to $GITHUB_ENV
+# when it source-builds (so the downstream manifest.json writer keeps
+# carrying a real commit sha). On the fast path the value is the
+# string "prebuilt".
+
+set -euo pipefail
+
+tool="${1:?tool required}"
+target="${2:?target required}"
+build_tool="${3:?build-tool required (zigbuild|xwin|empty for native)}"
+exe_suffix="${4:-}"
+dest_dir="${5:?dest-dir required}"
+
+# Resolve the pinned tool version out of the source tree (the same
+# files refresh-tool-prebuilts.yml reads).
+case "$tool" in
+  crgx)
+    version=$(sed -n 's/.*MANAGED_CRGX_VERSION: &str = "\(.*\)";/\1/p' \
+      crates/soldr-cli/src/fetch/mod.rs | head -n1)
+    upstream_repo="https://github.com/yfedoseev/crgx.git"
+    env_var="CRGX_SOURCE_COMMIT"
+    cargo_extra_args=""
+    ;;
+  cargo-chef)
+    version=$(sed -n 's/.*CARGO_CHEF_PINNED_VERSION: &str = "\(.*\)";/\1/p' \
+      crates/soldr-cli/src/fetch/known_tools.rs | head -n1)
+    upstream_repo="https://github.com/LukeMathWalker/cargo-chef.git"
+    env_var="CARGO_CHEF_SOURCE_COMMIT"
+    cargo_extra_args="--bin cargo-chef"
+    ;;
+  *)
+    echo "fetch_or_build_tool.sh: unknown tool '$tool'" >&2
+    exit 2
+    ;;
+esac
+
+if [ -z "$version" ]; then
+  echo "fetch_or_build_tool.sh: failed to resolve version for $tool" >&2
+  exit 2
+fi
+
+mkdir -p "$dest_dir"
+
+# Map rust target triple -> tool_query.py CLI flags. Keep this in
+# lockstep with TARGET_TO_PLATFORM_KEY in install_prebuilts.py.
+case "$target" in
+  x86_64-pc-windows-msvc)    q="--platform windows --arch x86 --extra msvc" ;;
+  aarch64-pc-windows-msvc)   q="--platform windows --arch arm --extra msvc" ;;
+  x86_64-unknown-linux-gnu)  q="--platform linux   --arch x86 --extra gnu"  ;;
+  aarch64-unknown-linux-gnu) q="--platform linux   --arch arm --extra gnu"  ;;
+  x86_64-unknown-linux-musl) q="--platform linux   --arch x86 --extra musl" ;;
+  aarch64-unknown-linux-musl) q="--platform linux  --arch arm --extra musl" ;;
+  x86_64-apple-darwin)       q="--platform mac     --arch x86" ;;
+  aarch64-apple-darwin)      q="--platform mac     --arch arm" ;;
+  *)
+    echo "fetch_or_build_tool.sh: no manifest mapping for target $target" >&2
+    exit 2
+    ;;
+esac
+
+asset_url=""
+# tool_query.py exits non-zero on a miss; capture stdout if it
+# succeeds. The version we ask for is the soldr-source-tree-pinned
+# version so we can never end up with a manifest hit for some other
+# tag.
+if asset_url=$(python3 .github/scripts/tool_query.py \
+    $q --version "$version" "$tool" 2>/dev/null); then
+  echo "manifest hit: $tool $version $target -> $asset_url"
+fi
+
+if [ -n "$asset_url" ]; then
+  # Fast path: download + extract the prebuilt and we're done.
+  asset_filename=$(basename "$asset_url")
+  if ! curl --fail --location \
+      --retry 6 --retry-delay 5 --retry-all-errors \
+      --output "/tmp/${asset_filename}" "$asset_url"; then
+    echo "manifest URL fetch failed; falling back to source build" >&2
+    asset_url=""
+  else
+    extract_tmp=$(mktemp -d)
+    case "$asset_filename" in
+      *.tar.zst|*.tar.zstd)
+        tar --use-compress-program='zstd -d' \
+            -xf "/tmp/${asset_filename}" -C "$extract_tmp"
+        ;;
+      *.tar.gz)
+        tar -xzf "/tmp/${asset_filename}" -C "$extract_tmp"
+        ;;
+      *.zip)
+        unzip -oq "/tmp/${asset_filename}" -d "$extract_tmp"
+        ;;
+      *)
+        tar -xaf "/tmp/${asset_filename}" -C "$extract_tmp" || {
+          echo "unknown archive format: $asset_filename; falling back" >&2
+          asset_url=""
+        }
+        ;;
+    esac
+    if [ -n "$asset_url" ]; then
+      binary_src=$(find "$extract_tmp" -type f -name "${tool}${exe_suffix}" -print -quit)
+      if [ -z "$binary_src" ]; then
+        echo "extracted archive missing ${tool}${exe_suffix}; falling back" >&2
+        find "$extract_tmp" -maxdepth 3 -print >&2 || true
+        asset_url=""
+      else
+        cp "$binary_src" "${dest_dir}/${tool}${exe_suffix}"
+        chmod +x "${dest_dir}/${tool}${exe_suffix}" || true
+        rm -rf "$extract_tmp"
+        if [ -n "${GITHUB_ENV:-}" ]; then
+          echo "${env_var}=prebuilt" >> "$GITHUB_ENV"
+        fi
+        echo "fetched prebuilt $tool $version for $target into $dest_dir"
+        exit 0
+      fi
+    fi
+  fi
+fi
+
+# Fallback: source build (preserves the previous behavior verbatim).
+echo "manifest miss for $tool $version $target; source-building"
+work_dir="${RUNNER_TEMP:-/tmp}/${tool}-build"
+rm -rf "$work_dir"
+git clone --depth 1 --branch "v${version}" "$upstream_repo" "$work_dir"
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "${env_var}=$(git -C "$work_dir" rev-parse HEAD)" >> "$GITHUB_ENV"
+fi
+.github/scripts/print_build_banner.sh \
+    "${tool} v${version}" \
+    release \
+    "$target" \
+    "soldr cargo ${build_tool:-build} build" \
+    "$work_dir/Cargo.toml"
+
+case "$build_tool" in
+  xwin)
+    # shellcheck disable=SC2086
+    soldr cargo xwin build \
+      --release \
+      --manifest-path "$work_dir/Cargo.toml" \
+      --target "$target" \
+      --locked $cargo_extra_args
+    ;;
+  zigbuild)
+    # shellcheck disable=SC2086
+    soldr cargo zigbuild \
+      --release \
+      --manifest-path "$work_dir/Cargo.toml" \
+      --target "$target" \
+      --locked $cargo_extra_args
+    ;;
+  ""|"native")
+    # shellcheck disable=SC2086
+    soldr cargo build \
+      --release \
+      --manifest-path "$work_dir/Cargo.toml" \
+      --target "$target" \
+      --locked $cargo_extra_args
+    ;;
+  *)
+    echo "fetch_or_build_tool.sh: unknown build-tool '$build_tool'" >&2
+    exit 2
+    ;;
+esac
+
+built="$work_dir/target/${target}/release/${tool}${exe_suffix}"
+if [ ! -f "$built" ]; then
+  echo "source build completed but binary missing at $built" >&2
+  ls -la "$work_dir/target/${target}/release/" >&2 || true
+  exit 1
+fi
+cp "$built" "${dest_dir}/${tool}${exe_suffix}"
+chmod +x "${dest_dir}/${tool}${exe_suffix}" || true
+echo "source-built $tool $version for $target into $dest_dir"

--- a/.github/scripts/install_prebuilts.py
+++ b/.github/scripts/install_prebuilts.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Drop tool prebuilts into the ``manifest`` branch.
+
+Reads ``<prebuilts-dir>/*.meta.json`` produced by
+``refresh-tool-prebuilts.yml``, copies the sibling tar.zst archive
+into ``<manifest-checkout>/deps/<triple>/<tool>/<version>/`` (the path
+LFS-tracks via ``.gitattributes``), and patches each per-tool
+``<tool>/manifest.json`` so the release entry's ``platforms`` map
+points at the LFS-aware CDN URL.
+
+Each ``meta.json`` looks like::
+
+    {
+      "tool":      "crgx",
+      "version":   "0.1.0",
+      "target":    "aarch64-pc-windows-msvc",
+      "archive":   "crgx-0.1.0-aarch64-pc-windows-msvc.tar.zst",
+      "size":      123456,
+      "sha256":    "<64-char lowercase hex>",
+      "deps_path": "deps/aarch64-pc-windows-msvc/crgx/0.1.0/crgx-..."
+    }
+
+For the manifest.json patching, the (target -> platform-key) mapping
+matches what ``tool_query.py`` expects::
+
+    x86_64-pc-windows-msvc   -> windows-x64-msvc
+    aarch64-pc-windows-msvc  -> windows-arm64-msvc
+    x86_64-unknown-linux-gnu -> linux-x64-gnu
+    aarch64-unknown-linux-gnu-> linux-arm64-gnu
+    x86_64-unknown-linux-musl-> linux-x64-musl
+    aarch64-unknown-linux-musl-> linux-arm64-musl
+    x86_64-apple-darwin      -> darwin-x64
+    aarch64-apple-darwin     -> darwin-arm64
+
+The URL inserted into each ``platforms`` entry uses the LFS-aware
+``media.githubusercontent.com/media/...`` CDN endpoint so consumers
+hit the actual binary blob rather than an LFS pointer file.
+
+Idempotent: re-running over the same prebuilts is a no-op. Existing
+entries pointing at upstream-released assets (e.g. ``windows-x64-msvc``
+for crgx) are preserved unless this script also produces a prebuild
+for them — in which case the vendored URL replaces the upstream one
+(the vendored prebuilt is the byte we can guarantee shape/version
+parity for, since this workflow built it).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# Map rust target triple -> the ``platforms`` key tool_query.py
+# resolves to. Mirrors the per-tool manifest format on the manifest
+# branch.
+TARGET_TO_PLATFORM_KEY: dict[str, str] = {
+    "x86_64-pc-windows-msvc":   "windows-x64-msvc",
+    "aarch64-pc-windows-msvc":  "windows-arm64-msvc",
+    "x86_64-unknown-linux-gnu":  "linux-x64-gnu",
+    "aarch64-unknown-linux-gnu": "linux-arm64-gnu",
+    "x86_64-unknown-linux-musl": "linux-x64-musl",
+    "aarch64-unknown-linux-musl": "linux-arm64-musl",
+    "x86_64-apple-darwin":  "darwin-x64",
+    "aarch64-apple-darwin": "darwin-arm64",
+}
+
+# Soldr's manifest branch lives at zackees/soldr. The /media/ endpoint
+# follows Git-LFS pointers; falls back to raw bytes for non-LFS files.
+LFS_URL_TEMPLATE = (
+    "https://media.githubusercontent.com/media/zackees/soldr/manifest/{rel_path}"
+)
+
+
+def lfs_url_for(deps_path: str) -> str:
+    """Construct the public CDN URL for a manifest-branch deps file."""
+    return LFS_URL_TEMPLATE.format(rel_path=deps_path)
+
+
+def patch_per_tool_manifest(
+    tool_manifest_path: Path,
+    *,
+    tool: str,
+    version: str,
+    platform_key: str,
+    archive_name: str,
+    url: str,
+    size: int,
+    sha256: str,
+) -> bool:
+    """Insert/refresh a single ``platforms`` entry on the matching
+    release dict inside ``<tool>/manifest.json``.
+
+    Returns True if the file was modified, False if the entry was
+    already byte-identical (no-op).
+    """
+    if not tool_manifest_path.is_file():
+        print(
+            f"  warning: per-tool manifest missing: {tool_manifest_path}",
+            file=sys.stderr,
+        )
+        return False
+    payload = json.loads(tool_manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        print(
+            f"  warning: {tool_manifest_path} is not a flat array; skipping",
+            file=sys.stderr,
+        )
+        return False
+
+    # Find the release entry for the requested version. We accept
+    # either tag form (``v0.1.0``) or bare version (``0.1.0``).
+    matches: list[dict] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        entry_ver = entry.get("version")
+        entry_tag = entry.get("tag")
+        if entry_ver == version or entry_tag == f"v{version}" or entry_tag == version:
+            matches.append(entry)
+    if not matches:
+        print(
+            f"  warning: no release entry for {tool} version {version} "
+            f"in {tool_manifest_path}; skipping platforms patch",
+            file=sys.stderr,
+        )
+        return False
+
+    new_entry = {
+        "filename": archive_name,
+        "url": url,
+        "size": size,
+        "sha256": sha256,
+        "source": "soldr-prebuilt",
+    }
+    changed = False
+    for entry in matches:
+        platforms = entry.setdefault("platforms", {})
+        existing = platforms.get(platform_key)
+        if existing == new_entry:
+            continue
+        platforms[platform_key] = new_entry
+        changed = True
+
+    if not changed:
+        return False
+    tool_manifest_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return True
+
+
+def install_one(
+    meta_path: Path,
+    manifest_root: Path,
+) -> None:
+    """Drop one prebuilt's archive into deps/ and patch its
+    per-tool manifest."""
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    tool = meta["tool"]
+    version = meta["version"]
+    target = meta["target"]
+    archive_name = meta["archive"]
+    deps_path = meta["deps_path"]
+    sha256 = meta["sha256"]
+    size = int(meta["size"])
+
+    archive_src = meta_path.parent / archive_name
+    if not archive_src.is_file():
+        print(
+            f"  error: archive missing alongside meta: {archive_src}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    dest = manifest_root / deps_path
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Copy bytes (not move) so a partial failure leaves the artifact
+    # intact for inspection.
+    shutil.copyfile(archive_src, dest)
+    print(f"  vendored {dest} ({size} bytes, sha256 {sha256[:16]}...)")
+
+    platform_key = TARGET_TO_PLATFORM_KEY.get(target)
+    if platform_key is None:
+        print(
+            f"  warning: no platform-key mapping for target {target}; "
+            f"deps/ file vendored but manifest.json not patched",
+            file=sys.stderr,
+        )
+        return
+
+    tool_manifest = manifest_root / tool / "manifest.json"
+    url = lfs_url_for(deps_path)
+    patched = patch_per_tool_manifest(
+        tool_manifest,
+        tool=tool,
+        version=version,
+        platform_key=platform_key,
+        archive_name=archive_name,
+        url=url,
+        size=size,
+        sha256=sha256,
+    )
+    if patched:
+        print(f"  patched {tool_manifest} platforms[{platform_key}]")
+    else:
+        print(
+            f"  no-op: {tool_manifest} platforms[{platform_key}] already up-to-date"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--prebuilts-dir",
+        type=Path,
+        required=True,
+        help="Directory containing the downloaded prebuilt artifacts "
+             "(each as <archive>.tar.zst + <archive>.tar.zst.meta.json).",
+    )
+    parser.add_argument(
+        "--manifest-checkout",
+        type=Path,
+        required=True,
+        help="Path to a local checkout of the soldr `manifest` branch.",
+    )
+    args = parser.parse_args(argv)
+
+    prebuilts_dir: Path = args.prebuilts_dir.resolve()
+    manifest_root: Path = args.manifest_checkout.resolve()
+    if not prebuilts_dir.is_dir():
+        print(f"error: --prebuilts-dir {prebuilts_dir} is not a directory", file=sys.stderr)
+        return 2
+    if not manifest_root.is_dir():
+        print(f"error: --manifest-checkout {manifest_root} is not a directory", file=sys.stderr)
+        return 2
+
+    metas = sorted(prebuilts_dir.glob("*.meta.json"))
+    if not metas:
+        print(f"no *.meta.json files under {prebuilts_dir}; nothing to install")
+        return 0
+
+    print(f"installing {len(metas)} prebuilt(s) into {manifest_root}")
+    for meta_path in metas:
+        install_one(meta_path, manifest_root)
+    print("done")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tool_query.py
+++ b/.github/scripts/tool_query.py
@@ -112,14 +112,23 @@ def find_release(per_tool: list[dict[str, Any]], requested: str) -> dict[str, An
 
     `requested == 'latest'` returns the first entry (the array is
     sorted by published_at desc). Otherwise we scan for an entry whose
-    tag matches.
+    ``tag`` or ``version`` matches — some manifests carry a
+    ``v``-prefixed tag (``v0.1.0``) and a bare ``version`` field
+    (``0.1.0``); accept either form so callers don't have to know
+    which convention each tool follows.
     """
     if not per_tool:
         raise SystemExit("per-tool manifest is empty")
     if requested in ("latest", ""):
         return per_tool[0]
+    bare = requested.lstrip("v")
+    v_prefixed = f"v{bare}"
     for entry in per_tool:
-        if entry.get("tag") == requested:
+        tag = entry.get("tag")
+        version = entry.get("version")
+        if tag in (requested, v_prefixed, bare):
+            return entry
+        if version in (requested, bare):
             return entry
     known = ", ".join(e.get("tag") or "?" for e in per_tool[:6])
     raise SystemExit(

--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -187,54 +187,23 @@ jobs:
             chmod +x "dist/package/${b}"
           done
 
-      - name: Build crgx — --release x86_64-unknown-linux-gnu (soldr cargo)
+      # crgx + cargo-chef were previously source-built here every run
+      # (~60s + ~42s of warm wall time). The
+      # `fetch_or_build_tool.sh` helper checks the public manifest
+      # branch for a prebuilt asset first and falls back to the
+      # source-build path only on a manifest miss. Prebuilts are
+      # produced by `refresh-tool-prebuilts.yml`.
+      - name: Fetch or build crgx — x86_64-unknown-linux-gnu
         run: |
           set -euo pipefail
-          crgx_version=$(sed -n 's/.*MANAGED_CRGX_VERSION: &str = "\(.*\)";/\1/p' \
-            crates/soldr-cli/src/fetch/mod.rs | head -n1)
-          work_dir="${RUNNER_TEMP}/crgx-build"
-          rm -rf "$work_dir"
-          git clone --depth 1 --branch "v${crgx_version}" \
-            https://github.com/yfedoseev/crgx.git "$work_dir"
-          echo "CRGX_SOURCE_COMMIT=$(git -C "$work_dir" rev-parse HEAD)" >> "$GITHUB_ENV"
-          .github/scripts/print_build_banner.sh \
-              "crgx v${crgx_version}" \
-              release \
-              x86_64-unknown-linux-gnu \
-              "soldr cargo build" \
-              "$work_dir/Cargo.toml"
-          soldr cargo build \
-            --release \
-            --manifest-path "$work_dir/Cargo.toml" \
-            --target x86_64-unknown-linux-gnu \
-            --locked
-          cp "$work_dir/target/x86_64-unknown-linux-gnu/release/crgx" "dist/package/crgx"
-          chmod +x "dist/package/crgx"
+          .github/scripts/fetch_or_build_tool.sh \
+              crgx x86_64-unknown-linux-gnu zigbuild "" dist/package
 
-      - name: Build cargo-chef — --release x86_64-unknown-linux-gnu (soldr cargo)
+      - name: Fetch or build cargo-chef — x86_64-unknown-linux-gnu
         run: |
           set -euo pipefail
-          cargo_chef_version=$(sed -n 's/.*CARGO_CHEF_PINNED_VERSION: &str = "\(.*\)";/\1/p' \
-            crates/soldr-cli/src/fetch/known_tools.rs | head -n1)
-          work_dir="${RUNNER_TEMP}/cargo-chef-build"
-          rm -rf "$work_dir"
-          git clone --depth 1 --branch "v${cargo_chef_version}" \
-            https://github.com/LukeMathWalker/cargo-chef.git "$work_dir"
-          echo "CARGO_CHEF_SOURCE_COMMIT=$(git -C "$work_dir" rev-parse HEAD)" >> "$GITHUB_ENV"
-          .github/scripts/print_build_banner.sh \
-              "cargo-chef v${cargo_chef_version}" \
-              release \
-              x86_64-unknown-linux-gnu \
-              "soldr cargo build" \
-              "$work_dir/Cargo.toml"
-          soldr cargo build \
-            --release \
-            --manifest-path "$work_dir/Cargo.toml" \
-            --target x86_64-unknown-linux-gnu \
-            --locked \
-            --bin cargo-chef
-          cp "$work_dir/target/x86_64-unknown-linux-gnu/release/cargo-chef" "dist/package/cargo-chef"
-          chmod +x "dist/package/cargo-chef"
+          .github/scripts/fetch_or_build_tool.sh \
+              cargo-chef x86_64-unknown-linux-gnu zigbuild "" dist/package
 
       - name: Write linux-x86 manifest.json + package
         run: |
@@ -600,75 +569,24 @@ jobs:
             done
           fi
 
-      - name: Build crgx — --release ${{ matrix.target }} (${{ matrix.tool }})
+      # Same fetch-or-build pattern as the bootstrap job. The helper
+      # script first probes the manifest branch for a prebuilt asset
+      # for this (tool, target) and only falls back to a source build
+      # on a manifest miss. Prebuilts come from
+      # `refresh-tool-prebuilts.yml`.
+      - name: Fetch or build crgx — ${{ matrix.target }} (${{ matrix.tool }})
         run: |
           set -euo pipefail
-          crgx_version=$(sed -n 's/.*MANAGED_CRGX_VERSION: &str = "\(.*\)";/\1/p' \
-            crates/soldr-cli/src/fetch/mod.rs | head -n1)
-          work_dir="${RUNNER_TEMP}/crgx-build"
-          rm -rf "$work_dir"
-          git clone --depth 1 --branch "v${crgx_version}" \
-            https://github.com/yfedoseev/crgx.git "$work_dir"
-          echo "CRGX_SOURCE_COMMIT=$(git -C "$work_dir" rev-parse HEAD)" >> "$GITHUB_ENV"
-          .github/scripts/print_build_banner.sh \
-              "crgx v${crgx_version}" \
-              release \
-              "${{ matrix.target }}" \
-              "soldr cargo ${{ matrix.tool }} build" \
-              "$work_dir/Cargo.toml"
-          if [ "${{ matrix.tool }}" = "xwin" ]; then
-            soldr cargo xwin build \
-              --release \
-              --manifest-path "$work_dir/Cargo.toml" \
-              --target "${{ matrix.target }}" \
-              --locked
-          else
-            soldr cargo zigbuild \
-              --release \
-              --manifest-path "$work_dir/Cargo.toml" \
-              --target "${{ matrix.target }}" \
-              --locked
-          fi
-          suffix="${{ matrix.exe_suffix }}"
-          built="$work_dir/target/${{ matrix.target }}/release/crgx${suffix}"
-          cp "$built" "dist/package/crgx${suffix}"
-          chmod +x "dist/package/crgx${suffix}" || true
+          .github/scripts/fetch_or_build_tool.sh \
+              crgx "${{ matrix.target }}" "${{ matrix.tool }}" \
+              "${{ matrix.exe_suffix }}" dist/package
 
-      - name: Build cargo-chef — --release ${{ matrix.target }} (${{ matrix.tool }})
+      - name: Fetch or build cargo-chef — ${{ matrix.target }} (${{ matrix.tool }})
         run: |
           set -euo pipefail
-          cargo_chef_version=$(sed -n 's/.*CARGO_CHEF_PINNED_VERSION: &str = "\(.*\)";/\1/p' \
-            crates/soldr-cli/src/fetch/known_tools.rs | head -n1)
-          work_dir="${RUNNER_TEMP}/cargo-chef-build"
-          rm -rf "$work_dir"
-          git clone --depth 1 --branch "v${cargo_chef_version}" \
-            https://github.com/LukeMathWalker/cargo-chef.git "$work_dir"
-          echo "CARGO_CHEF_SOURCE_COMMIT=$(git -C "$work_dir" rev-parse HEAD)" >> "$GITHUB_ENV"
-          .github/scripts/print_build_banner.sh \
-              "cargo-chef v${cargo_chef_version}" \
-              release \
-              "${{ matrix.target }}" \
-              "soldr cargo ${{ matrix.tool }} build" \
-              "$work_dir/Cargo.toml"
-          if [ "${{ matrix.tool }}" = "xwin" ]; then
-            soldr cargo xwin build \
-              --release \
-              --manifest-path "$work_dir/Cargo.toml" \
-              --target "${{ matrix.target }}" \
-              --locked \
-              --bin cargo-chef
-          else
-            soldr cargo zigbuild \
-              --release \
-              --manifest-path "$work_dir/Cargo.toml" \
-              --target "${{ matrix.target }}" \
-              --locked \
-              --bin cargo-chef
-          fi
-          suffix="${{ matrix.exe_suffix }}"
-          built="$work_dir/target/${{ matrix.target }}/release/cargo-chef${suffix}"
-          cp "$built" "dist/package/cargo-chef${suffix}"
-          chmod +x "dist/package/cargo-chef${suffix}" || true
+          .github/scripts/fetch_or_build_tool.sh \
+              cargo-chef "${{ matrix.target }}" "${{ matrix.tool }}" \
+              "${{ matrix.exe_suffix }}" dist/package
 
       - name: Write manifest.json + package
         run: |

--- a/.github/workflows/refresh-tool-prebuilts.yml
+++ b/.github/workflows/refresh-tool-prebuilts.yml
@@ -1,0 +1,323 @@
+name: Refresh tool prebuilts (crgx, cargo-chef)
+
+# Nightly + on-demand workflow that backfills the `manifest` branch
+# with cross-compiled prebuilts of soldr-bundled tools whose upstream
+# release coverage misses some of the target triples soldr's cross-
+# compile pipeline cares about.
+#
+# Why this exists: `cross-compile-all-targets.yml` used to source-build
+# `crgx` and `cargo-chef` on every matrix cell (60s + 42s of warm wall
+# time per Windows-MSVC lane, more on cold caches). Most of those
+# rebuilds re-emit byte-identical binaries for pinned tool versions.
+# This workflow lifts the source-build into a periodic job that drops
+# the result on the `manifest` branch as a vendored prebuilt, so the
+# downstream cross-compile workflow can fetch instead of compile.
+#
+# Matrix scope: every (tool, target) the cross-compile workflow needs.
+# Per cell:
+#   1. Resolve the pinned tool version from the soldr source tree.
+#   2. Probe the manifest branch for an existing prebuilt at
+#      `deps/<triple>/<tool>/<version>/<tool>-<version>-<triple>.tar.zst`
+#      (LFS-tracked). Skip if already vendored.
+#   3. Otherwise `pip install soldr`, then
+#      `soldr build-from-source <tool> --target <triple>`, package as
+#      tar.zst, and upload as a per-cell artifact.
+#
+# A second job downloads all the artifacts, checks out the manifest
+# branch into a worktree, drops each artifact into
+# `deps/<triple>/<tool>/<version>/`, regenerates `asset-index.json`
+# via `build_asset_index.py`, updates each per-tool `<tool>/manifest.json`
+# with `platforms` entries pointing at the vendored URL, then commits
+# and pushes (with `git lfs push` for the new binary blobs).
+#
+# Triggered nightly + manually.
+
+on:
+  schedule:
+    # 04:00 UTC — runs before `refresh-manifest.yml` (06:30 UTC) so a
+    # newly-vendored prebuilt is picked up by that workflow's
+    # asset-index regeneration in the same calendar day.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-tool-prebuilts
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_COLOR: "1"
+  CLICOLOR_FORCE: "1"
+
+jobs:
+  build-prebuilts:
+    name: ${{ matrix.tool }} / ${{ matrix.target }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: [crgx, cargo-chef]
+        target:
+          - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    outputs:
+      # Stash per-cell metadata so the commit job can produce a
+      # combined manifest.json delta. Outputs land under
+      # `needs.build-prebuilts.outputs.<key>` but matrix outputs are
+      # awkward — we use artifacts instead, see "Stage prebuilt
+      # artifact" below.
+      dummy: "unused"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Resolve pinned tool version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.tool }}" = "crgx" ]; then
+            ver=$(sed -n 's/.*MANAGED_CRGX_VERSION: &str = "\(.*\)";/\1/p' \
+              crates/soldr-cli/src/fetch/mod.rs | head -n1)
+          else
+            ver=$(sed -n 's/.*CARGO_CHEF_PINNED_VERSION: &str = "\(.*\)";/\1/p' \
+              crates/soldr-cli/src/fetch/known_tools.rs | head -n1)
+          fi
+          if [ -z "$ver" ]; then
+            echo "could not resolve version for ${{ matrix.tool }}" >&2
+            exit 1
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          archive_name="${{ matrix.tool }}-${ver}-${{ matrix.target }}.tar.zst"
+          deps_path="deps/${{ matrix.target }}/${{ matrix.tool }}/${ver}/${archive_name}"
+          echo "archive_name=$archive_name" >> "$GITHUB_OUTPUT"
+          echo "deps_path=$deps_path" >> "$GITHUB_OUTPUT"
+          echo "${{ matrix.tool }} version: $ver"
+          echo "expected deps path:   $deps_path"
+
+      - name: Probe manifest branch for existing prebuilt
+        id: probe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          deps_path="${{ steps.version.outputs.deps_path }}"
+          # `gh api ... --silent` exits 0 on 200, non-zero on 404. We
+          # want to set `skip=true` ONLY on a successful 200 (entry
+          # already vendored). Any other failure (network, 5xx) falls
+          # through to a fresh build — the downstream commit job
+          # rewrites manifest.json idempotently so duplicate work is
+          # harmless.
+          if gh api "repos/${{ github.repository }}/contents/${deps_path}?ref=manifest" \
+              --silent 2>/dev/null; then
+            echo "manifest branch already vendors $deps_path; skipping build"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no existing prebuilt at $deps_path; will build"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Rust toolchain + target
+        if: steps.probe.outputs.skip != 'true'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.94.1
+          targets: ${{ matrix.target }}
+
+      - name: Set up Python (for pip install soldr)
+        if: steps.probe.outputs.skip != 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install soldr from PyPI
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # pip install the latest soldr from PyPI — it carries the
+          # `build-from-source` verb introduced in 0.7.57 (#869).
+          pip install --upgrade soldr
+          soldr --version
+
+      - name: Build prebuilt via soldr build-from-source
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        env:
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          target="${{ matrix.target }}"
+          tool="${{ matrix.tool }}"
+          soldr build-from-source "$tool" --target "$target" --version "$version"
+          # Verify the binary landed where we expect.
+          install_dir="$HOME/.soldr/bin/${tool}-from-source/${version}/${target}"
+          case "$target" in
+            *-pc-windows-*) suffix=".exe" ;;
+            *)              suffix=""    ;;
+          esac
+          binary="${install_dir}/${tool}${suffix}"
+          if [ ! -f "$binary" ]; then
+            echo "expected binary not found at $binary" >&2
+            find "$HOME/.soldr/bin/${tool}-from-source" -type f >&2 || true
+            exit 1
+          fi
+          ls -la "$binary"
+
+      - name: Stage prebuilt as tar.zst
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          target="${{ matrix.target }}"
+          tool="${{ matrix.tool }}"
+          archive_name="${{ steps.version.outputs.archive_name }}"
+          case "$target" in
+            *-pc-windows-*) suffix=".exe" ;;
+            *)              suffix=""    ;;
+          esac
+          install_dir="$HOME/.soldr/bin/${tool}-from-source/${version}/${target}"
+          binary="${install_dir}/${tool}${suffix}"
+          stage=$(mktemp -d)
+          # Wrap the bare binary (no parent dirs) — matches the
+          # extraction-side `tar -xaf .. | find -name <tool>` pattern
+          # used by the consumer workflow.
+          cp "$binary" "$stage/${tool}${suffix}"
+          tar -cf - -C "$stage" "${tool}${suffix}" | zstd -19 -T0 -o "$stage/$archive_name"
+          ls -la "$stage/$archive_name"
+          sha256sum "$stage/$archive_name" | awk '{print "sha256: " $1}'
+          # Stash the archive plus a tiny metadata json so the commit
+          # job can populate manifest.json platforms entries.
+          mkdir -p dist
+          cp "$stage/$archive_name" "dist/$archive_name"
+          size=$(stat -c '%s' "dist/$archive_name")
+          sha=$(sha256sum "dist/$archive_name" | awk '{print $1}')
+          cat > "dist/${archive_name}.meta.json" <<EOF
+          {
+            "tool": "${tool}",
+            "version": "${version}",
+            "target": "${target}",
+            "archive": "${archive_name}",
+            "size": ${size},
+            "sha256": "${sha}",
+            "deps_path": "${{ steps.version.outputs.deps_path }}"
+          }
+          EOF
+
+      - name: Upload prebuilt artifact
+        if: steps.probe.outputs.skip != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: prebuilt-${{ matrix.tool }}-${{ matrix.target }}
+          path: |
+            dist/${{ steps.version.outputs.archive_name }}
+            dist/${{ steps.version.outputs.archive_name }}.meta.json
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+  commit-to-manifest:
+    name: Commit new prebuilts to manifest branch
+    needs: build-prebuilts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    # Always run even if some matrix cells failed — partial coverage is
+    # still better than nothing, and the asset-index regen is
+    # idempotent. Each cell's success/failure is independent.
+    if: always()
+    steps:
+      - name: Checkout main (for scripts)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          path: main
+
+      - name: Checkout manifest branch (LFS-aware)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: manifest
+          path: manifest
+          lfs: true
+
+      - name: Download all prebuilt artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: prebuilt-*
+          path: prebuilts
+          merge-multiple: true
+
+      - name: Drop prebuilts into deps/ + patch per-tool manifest.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          metas=(prebuilts/*.meta.json)
+          if [ ${#metas[@]} -eq 0 ]; then
+            echo "no new prebuilt artifacts downloaded; nothing to do"
+            exit 0
+          fi
+          python3 main/.github/scripts/install_prebuilts.py \
+              --prebuilts-dir prebuilts \
+              --manifest-checkout manifest
+
+      - name: Rebuild asset-index.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Always regenerate — install_prebuilts.py may have added
+          # entries under deps/, and asset-index sha-attributes the
+          # on-disk bytes.
+          python3 main/.github/scripts/build_asset_index.py \
+              --manifest-checkout manifest \
+              --output manifest/asset-index.json
+
+      - name: Commit + push to manifest branch
+        shell: bash
+        working-directory: manifest
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # `git lfs install` is implicit when the repo has LFS tracking
+          # configured, but make it explicit for clarity.
+          git lfs install --local
+          git add -A
+          if git diff --cached --quiet; then
+            echo "no new prebuilts to commit; manifest branch unchanged"
+            exit 0
+          fi
+          git status --short
+          tools_summary=$(python3 -c "
+          import json, glob
+          metas = sorted(glob.glob('../prebuilts/*.meta.json'))
+          lines = []
+          for path in metas:
+              with open(path) as fh:
+                  d = json.load(fh)
+              lines.append(f\"  - {d['tool']} {d['version']} {d['target']}\")
+          print('\n'.join(lines))
+          " 2>/dev/null || true)
+          msg="manifest: refresh tool prebuilts ($(date -u +%Y-%m-%d))"
+          if [ -n "$tools_summary" ]; then
+            msg="${msg}
+
+          Added/refreshed:
+          ${tools_summary}"
+          fi
+          git commit -m "$msg"
+          # LFS push first so the binary blobs are uploaded to the LFS
+          # store before the pointer commit lands on the remote.
+          git lfs push --all origin manifest
+          git push origin manifest


### PR DESCRIPTION
## Summary

- Adds `refresh-tool-prebuilts.yml` (nightly + manual) that
  source-builds `crgx` + `cargo-chef` for every (target) cell the
  cross-compile pipeline cares about and commits the results to the
  `manifest` branch as LFS-tracked tar.zst archives.
- Replaces the inline `git clone + soldr cargo build` blocks in
  `cross-compile-all-targets.yml` (bootstrap + matrix) with
  `fetch_or_build_tool.sh` — fetches from the manifest branch when
  available, falls back to the previous source build on a miss.
  Expected per-lane wall-time savings: roughly ~100s of source-build
  work skipped per matrix cell (×7 cells).
- New helper script `install_prebuilts.py` drops downloaded prebuilts
  into `deps/<triple>/<tool>/<version>/` on a manifest checkout,
  patches per-tool `manifest.json` `platforms` maps with LFS-aware
  CDN URLs, and is exercised by the new workflow's commit job.
- `tool_query.py` lookup now accepts either `v0.1.0`-style tag or
  bare `0.1.0`-style version so `MANAGED_CRGX_VERSION` /
  `CARGO_CHEF_PINNED_VERSION` round-trip without per-tool tag-format
  knowledge in callers.

Refs #853 (meta — already closed; this is post-meta speed
optimization).

## Test plan

- [ ] Manually trigger `refresh-tool-prebuilts.yml` after merge; it
      should source-build prebuilts for the 16 (tool, target) cells
      that are not already vendored and commit them to the `manifest`
      branch with `git lfs push`.
- [ ] Re-run `cross-compile-all-targets.yml`; each `Fetch or build
      crgx / cargo-chef` step should print `manifest hit: ...` and
      skip the source build on cells that have a prebuilt now
      vendored.
- [ ] Confirm the source-build fallback still works on a miss
      (delete any one prebuilt from the manifest branch, run again,
      observe `manifest miss for ... source-building`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)