### PR TITLE
chore(release): 0.7.58 — strip mac + windows runners from release pipeline

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -196,22 +196,14 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             binary: soldr
-          - name: macOS x64
-            runner: macos-15-intel
-            target: x86_64-apple-darwin
-            binary: soldr
-          - name: macOS ARM64
-            runner: macos-15
-            target: aarch64-apple-darwin
-            binary: soldr
-          - name: Windows x64
-            runner: windows-2025
-            target: x86_64-pc-windows-msvc
-            binary: soldr.exe
-          - name: Windows ARM64
-            runner: windows-11-arm
-            target: aarch64-pc-windows-msvc
-            binary: soldr.exe
+          # mac + windows native runners temporarily removed — mac runners
+          # have been blocking the release pipeline for ~2 hours. linux-only
+          # cross-compile lanes (cargo-zigbuild for darwin, cargo-xwin for
+          # windows-msvc) are tracked as a follow-up. Until they ship, mac
+          # + windows PyPI/npm consumers stay on whatever version
+          # last successfully published (currently 0.7.57). The standalone
+          # tarballs for those targets in the GitHub Release for 0.7.57
+          # also remain valid.
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -1023,9 +1015,10 @@ jobs:
           # Tag-style version is `vX.Y.Z`; PyPI keys releases by `X.Y.Z`.
           pypi_version="${PYPI_VERSION#v}"
           # Expected wheel count == number of non-musl matrix rows in the
-          # `build` job (the musl rows skip wheel build by design). Update
-          # this if the wheel-producing matrix changes.
-          expected=6
+          # `build` job (the musl rows skip wheel build by design). With
+          # mac + windows temporarily stripped this is the 2 linux-gnu
+          # rows. Bump back up when those lanes return.
+          expected=2
           deadline=$(( $(date +%s) + 300 ))
           while :; do
             count="$(curl -fsSL "https://pypi.org/pypi/soldr/${pypi_version}/json" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.57"
+version = "0.7.58"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.57"
+version = "0.7.58"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Why
Mac runners on the release pipeline have been blocking for ~2 hours per release. Stripping them so 0.7.58 ships now, on linux-only.

## Changes
- `.github/workflows/release-auto.yml`: removed macOS + Windows matrix entries. Wheel-count check dropped from 6 → 2 (linux gnu x64 + arm64).
- `Cargo.toml` + `package.json` + `Cargo.lock`: 0.7.57 → 0.7.58.

## Trade-off
- mac + windows PyPI/npm consumers stay on 0.7.57 until linux-only cross-compile lanes ship (follow-up).
- Standalone `.tar.zst` archives for mac/windows in the 0.7.57 GitHub Release stay valid.
- Linux gnu (x64, arm64) + linux musl (x64, arm64) ship 0.7.58 as normal.

## Follow-up
Bring darwin + windows-msvc back via linux-only cross-compile lanes (cargo-zigbuild + cargo-xwin), gated on the manifest-branch prebuilt cache for crgx + cargo-chef.

🤖 Generated with [Claude Code](https://claude.com/claude-code)