### PR TITLE
manifest: add crgx + cargo-chef prebuilts (15 of 16 tool×target combos)

### DIFF
--- a/deps/aarch64-apple-darwin/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-apple-darwin.tar.zst
+++ b/deps/aarch64-apple-darwin/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-apple-darwin.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:965e7562b4d33d258d609e3264756ad33dc6e9e831b20da60841637c84a3ee12
+size 1443890

--- a/deps/aarch64-apple-darwin/crgx/0.1.0/crgx-0.1.0-aarch64-apple-darwin.tar.zst
+++ b/deps/aarch64-apple-darwin/crgx/0.1.0/crgx-0.1.0-aarch64-apple-darwin.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00ebed8368e903ba96189f4b57bd8361988650448c755922c1188a3a8c1e1f85
+size 1441800

--- a/deps/aarch64-pc-windows-msvc/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-pc-windows-msvc.tar.zst
+++ b/deps/aarch64-pc-windows-msvc/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-pc-windows-msvc.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86182063eb742637c4db51786dc9ff86b819aba33e6e27f58ce33ed9561c4332
+size 1302907

--- a/deps/aarch64-unknown-linux-gnu/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-unknown-linux-gnu.tar.zst
+++ b/deps/aarch64-unknown-linux-gnu/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-unknown-linux-gnu.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05864a6db36847da758ed59084b4bd3e5d4079de04bee3a33b5e94790bb5dc5d
+size 1341100

--- a/deps/aarch64-unknown-linux-gnu/crgx/0.1.0/crgx-0.1.0-aarch64-unknown-linux-gnu.tar.zst
+++ b/deps/aarch64-unknown-linux-gnu/crgx/0.1.0/crgx-0.1.0-aarch64-unknown-linux-gnu.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90fbf43e32f0c13d827b68cbb0b8bc72ac4071543253b6541f2d78d7e1c067f7
+size 1370947

--- a/deps/aarch64-unknown-linux-musl/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-unknown-linux-musl.tar.zst
+++ b/deps/aarch64-unknown-linux-musl/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-unknown-linux-musl.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d52791101a4fd26e22cde89be7f28fa1b2e8ec256162fae14bb35bc2d1b9b0e4
+size 1329847

--- a/deps/aarch64-unknown-linux-musl/crgx/0.1.0/crgx-0.1.0-aarch64-unknown-linux-musl.tar.zst
+++ b/deps/aarch64-unknown-linux-musl/crgx/0.1.0/crgx-0.1.0-aarch64-unknown-linux-musl.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd776a10f1ac2996a8de0dee3be5195e358d210e68847bfdc1b6ad9f1160e21c
+size 1401912

--- a/deps/x86_64-apple-darwin/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-apple-darwin.tar.zst
+++ b/deps/x86_64-apple-darwin/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-apple-darwin.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a33f996ef5e99d74ef6ef238535e3ee25be8bd0021ed2b1b9e0d7d68daad0db
+size 1519056

--- a/deps/x86_64-apple-darwin/crgx/0.1.0/crgx-0.1.0-x86_64-apple-darwin.tar.zst
+++ b/deps/x86_64-apple-darwin/crgx/0.1.0/crgx-0.1.0-x86_64-apple-darwin.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85c0d854558d7f06f709c7758380ce043f07bd99a1d44ed2d22dbcec81344e57
+size 1541258

--- a/deps/x86_64-pc-windows-msvc/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-pc-windows-msvc.tar.zst
+++ b/deps/x86_64-pc-windows-msvc/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-pc-windows-msvc.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff94e622f2802a7cfb29b6d3af935e917acd5cfbc560ddb80b1ed836c3b26d63
+size 1393734

--- a/deps/x86_64-pc-windows-msvc/crgx/0.1.0/crgx-0.1.0-x86_64-pc-windows-msvc.tar.zst
+++ b/deps/x86_64-pc-windows-msvc/crgx/0.1.0/crgx-0.1.0-x86_64-pc-windows-msvc.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:932cde7ab7b787a39fe89eada9c38178e0481f5428cf0260941d8c9e63927aae
+size 1496209

--- a/deps/x86_64-unknown-linux-gnu/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-unknown-linux-gnu.tar.zst
+++ b/deps/x86_64-unknown-linux-gnu/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-unknown-linux-gnu.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b40985f25286bc9933494d30c1628091711812cfe097c4eb7e8cecbccb700e4
+size 1444396

--- a/deps/x86_64-unknown-linux-gnu/crgx/0.1.0/crgx-0.1.0-x86_64-unknown-linux-gnu.tar.zst
+++ b/deps/x86_64-unknown-linux-gnu/crgx/0.1.0/crgx-0.1.0-x86_64-unknown-linux-gnu.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:370cc24418de0195f04fd97f7240b71d78dcc2908e95fc1ff9a2531c171ae5e3
+size 1470140

--- a/deps/x86_64-unknown-linux-musl/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-unknown-linux-musl.tar.zst
+++ b/deps/x86_64-unknown-linux-musl/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-unknown-linux-musl.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab93fd8e1ee47058361680f92f6c3259b6eeccc9dea5c319965d56481e2278ab
+size 1428000

--- a/deps/x86_64-unknown-linux-musl/crgx/0.1.0/crgx-0.1.0-x86_64-unknown-linux-musl.tar.zst
+++ b/deps/x86_64-unknown-linux-musl/crgx/0.1.0/crgx-0.1.0-x86_64-unknown-linux-musl.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b158b57003035c6b536f9e06756f74da67c62ee030ca29620aeb8166a9953fa
+size 1522295


### PR DESCRIPTION
## Summary

Vendors 15 prebuilt tool binaries on the \`manifest\` branch as Git-LFS \`.tar.zst\` archives under \`deps/<triple>/<tool>/<version>/<tool>-<version>-<triple>.tar.zst\`.

Cuts the per-CI-run source-build of crgx + cargo-chef on every cross-compile lane (~60s crgx + 42s cargo-chef warm per Windows lane today; multiply across the matrix).

## Coverage

| tool | version | targets vendored |
|---|---|---|
| crgx | 0.1.0 | 7 of 8 — all but aarch64-pc-windows-msvc |
| cargo-chef | 0.1.73 | 8 of 8 |

**Missing**: crgx × aarch64-pc-windows-msvc — blocked by [#886](https://github.com/zackees/soldr/issues/886) (ring sha256-armv8-win64.S clang-shim only active under soldr-managed cargo-xwin, not under raw docker container). cargo-chef has no ring dep, so it built fine for the same target.

## Build recipe used

- \`messense/cargo-zigbuild:0.23.0\` for the 6 non-windows triples (\`.2.34\` glibc pin for gnu lanes — system liblzma in the container needs it)
- \`messense/cargo-xwin:0.23.0\` for windows-msvc lanes

All artifacts compressed at \`zstd -19 -T0\`, 1.3–1.5 MiB each, ~24 MiB total uncompressed.

## What this PR does NOT do

- Does NOT update \`crgx/manifest.json\` or \`cargo-chef/manifest.json\` with platforms entries pointing at the new URLs — follow-up commit after this lands (so the cross-compile workflow's tool_query.py lookup finds them).
- Does NOT regenerate \`asset-index.json\` — the nightly refresh-manifest workflow will pick that up, or it can be re-run manually.
- Does NOT modify the cross-compile workflow itself — the fetch_or_build_tool.sh helper falls back to source-build gracefully on a manifest miss, so this PR alone won't speed up CI until the manifest.json updates also land.

Refs: cross-compile asset caching work; follow-up to closed meta #853. Filed alongside: #886 (ring/xwin/arm64 blocker), #884 (rustup-broken-state detection), #885 (Git-Bash dep documentation), #882 (\`soldr build --target\` auto-dispatch).