### PR TITLE
manifest: point crgx + cargo-chef platforms at vendored LFS prebuilts (#887 follow-up)

### DIFF
--- a/cargo-chef/manifest.json
+++ b/cargo-chef/manifest.json
@@ -400,24 +400,60 @@
     "release_html_url": "https://github.com/LukeMathWalker/cargo-chef/releases/tag/v0.1.73",
     "platforms": {
       "darwin-x64": {
-        "filename": "cargo-chef-x86_64-apple-darwin.tar.gz",
-        "url": "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.73/cargo-chef-x86_64-apple-darwin.tar.gz",
-        "size": 2039012
+        "filename": "cargo-chef-0.1.73-x86_64-apple-darwin.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-apple-darwin/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-apple-darwin.tar.zst",
+        "size": 1519056,
+        "sha256": "8a33f996ef5e99d74ef6ef238535e3ee25be8bd0021ed2b1b9e0d7d68daad0db",
+        "archive": "tar.zst"
       },
       "linux-arm64-gnu": {
-        "filename": "cargo-chef-aarch64-unknown-linux-gnu.tar.gz",
-        "url": "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.73/cargo-chef-aarch64-unknown-linux-gnu.tar.gz",
-        "size": 2062588
+        "filename": "cargo-chef-0.1.73-aarch64-unknown-linux-gnu.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-unknown-linux-gnu/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-unknown-linux-gnu.tar.zst",
+        "size": 1341100,
+        "sha256": "05864a6db36847da758ed59084b4bd3e5d4079de04bee3a33b5e94790bb5dc5d",
+        "archive": "tar.zst"
       },
       "linux-x64-musl": {
-        "filename": "cargo-chef-x86_64-unknown-linux-musl.tar.gz",
-        "url": "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.73/cargo-chef-x86_64-unknown-linux-musl.tar.gz",
-        "size": 2244225
+        "filename": "cargo-chef-0.1.73-x86_64-unknown-linux-musl.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-unknown-linux-musl/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-unknown-linux-musl.tar.zst",
+        "size": 1428000,
+        "sha256": "ab93fd8e1ee47058361680f92f6c3259b6eeccc9dea5c319965d56481e2278ab",
+        "archive": "tar.zst"
       },
       "windows-x64-msvc": {
-        "filename": "cargo-chef-x86_64-pc-windows-msvc.zip",
-        "url": "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.73/cargo-chef-x86_64-pc-windows-msvc.zip",
-        "size": 1735430
+        "filename": "cargo-chef-0.1.73-x86_64-pc-windows-msvc.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-pc-windows-msvc/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-pc-windows-msvc.tar.zst",
+        "size": 1393734,
+        "sha256": "ff94e622f2802a7cfb29b6d3af935e917acd5cfbc560ddb80b1ed836c3b26d63",
+        "archive": "tar.zst"
+      },
+      "darwin-arm64": {
+        "filename": "cargo-chef-0.1.73-aarch64-apple-darwin.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-apple-darwin/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-apple-darwin.tar.zst",
+        "size": 1443890,
+        "sha256": "965e7562b4d33d258d609e3264756ad33dc6e9e831b20da60841637c84a3ee12",
+        "archive": "tar.zst"
+      },
+      "windows-arm64-msvc": {
+        "filename": "cargo-chef-0.1.73-aarch64-pc-windows-msvc.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-pc-windows-msvc/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-pc-windows-msvc.tar.zst",
+        "size": 1302907,
+        "sha256": "86182063eb742637c4db51786dc9ff86b819aba33e6e27f58ce33ed9561c4332",
+        "archive": "tar.zst"
+      },
+      "linux-x64-gnu": {
+        "filename": "cargo-chef-0.1.73-x86_64-unknown-linux-gnu.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-unknown-linux-gnu/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-unknown-linux-gnu.tar.zst",
+        "size": 1444396,
+        "sha256": "9b40985f25286bc9933494d30c1628091711812cfe097c4eb7e8cecbccb700e4",
+        "archive": "tar.zst"
+      },
+      "linux-arm64-musl": {
+        "filename": "cargo-chef-0.1.73-aarch64-unknown-linux-musl.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-unknown-linux-musl/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-unknown-linux-musl.tar.zst",
+        "size": 1329847,
+        "sha256": "d52791101a4fd26e22cde89be7f28fa1b2e8ec256162fae14bb35bc2d1b9b0e4",
+        "archive": "tar.zst"
       }
     },
     "assets": {
@@ -448,6 +484,54 @@
         "content_type": "application/x-gtar",
         "created_at": "2025-10-03T08:48:59Z",
         "updated_at": "2025-10-03T08:48:59Z"
+      },
+      "cargo-chef-0.1.73-x86_64-apple-darwin.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-apple-darwin/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-apple-darwin.tar.zst",
+        "size": 1519056,
+        "sha256": "8a33f996ef5e99d74ef6ef238535e3ee25be8bd0021ed2b1b9e0d7d68daad0db",
+        "content_type": "application/zstd"
+      },
+      "cargo-chef-0.1.73-aarch64-apple-darwin.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-apple-darwin/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-apple-darwin.tar.zst",
+        "size": 1443890,
+        "sha256": "965e7562b4d33d258d609e3264756ad33dc6e9e831b20da60841637c84a3ee12",
+        "content_type": "application/zstd"
+      },
+      "cargo-chef-0.1.73-x86_64-pc-windows-msvc.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-pc-windows-msvc/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-pc-windows-msvc.tar.zst",
+        "size": 1393734,
+        "sha256": "ff94e622f2802a7cfb29b6d3af935e917acd5cfbc560ddb80b1ed836c3b26d63",
+        "content_type": "application/zstd"
+      },
+      "cargo-chef-0.1.73-aarch64-pc-windows-msvc.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-pc-windows-msvc/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-pc-windows-msvc.tar.zst",
+        "size": 1302907,
+        "sha256": "86182063eb742637c4db51786dc9ff86b819aba33e6e27f58ce33ed9561c4332",
+        "content_type": "application/zstd"
+      },
+      "cargo-chef-0.1.73-x86_64-unknown-linux-gnu.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-unknown-linux-gnu/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-unknown-linux-gnu.tar.zst",
+        "size": 1444396,
+        "sha256": "9b40985f25286bc9933494d30c1628091711812cfe097c4eb7e8cecbccb700e4",
+        "content_type": "application/zstd"
+      },
+      "cargo-chef-0.1.73-aarch64-unknown-linux-gnu.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-unknown-linux-gnu/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-unknown-linux-gnu.tar.zst",
+        "size": 1341100,
+        "sha256": "05864a6db36847da758ed59084b4bd3e5d4079de04bee3a33b5e94790bb5dc5d",
+        "content_type": "application/zstd"
+      },
+      "cargo-chef-0.1.73-x86_64-unknown-linux-musl.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-unknown-linux-musl/cargo-chef/0.1.73/cargo-chef-0.1.73-x86_64-unknown-linux-musl.tar.zst",
+        "size": 1428000,
+        "sha256": "ab93fd8e1ee47058361680f92f6c3259b6eeccc9dea5c319965d56481e2278ab",
+        "content_type": "application/zstd"
+      },
+      "cargo-chef-0.1.73-aarch64-unknown-linux-musl.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-unknown-linux-musl/cargo-chef/0.1.73/cargo-chef-0.1.73-aarch64-unknown-linux-musl.tar.zst",
+        "size": 1329847,
+        "sha256": "d52791101a4fd26e22cde89be7f28fa1b2e8ec256162fae14bb35bc2d1b9b0e4",
+        "content_type": "application/zstd"
       }
     },
     "is_pinned": true

--- a/crgx/manifest.json
+++ b/crgx/manifest.json
@@ -13,14 +13,18 @@
     "release_html_url": "https://github.com/yfedoseev/crgx/releases/tag/v0.1.0",
     "platforms": {
       "darwin-arm64": {
-        "filename": "crgx-macos-aarch64-0.1.0.tar.gz",
-        "url": "https://github.com/yfedoseev/crgx/releases/download/v0.1.0/crgx-macos-aarch64-0.1.0.tar.gz",
-        "size": 1723816
+        "filename": "crgx-0.1.0-aarch64-apple-darwin.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-apple-darwin/crgx/0.1.0/crgx-0.1.0-aarch64-apple-darwin.tar.zst",
+        "size": 1441800,
+        "sha256": "00ebed8368e903ba96189f4b57bd8361988650448c755922c1188a3a8c1e1f85",
+        "archive": "tar.zst"
       },
       "darwin-x64": {
-        "filename": "crgx-macos-x86_64-0.1.0.tar.gz",
-        "url": "https://github.com/yfedoseev/crgx/releases/download/v0.1.0/crgx-macos-x86_64-0.1.0.tar.gz",
-        "size": 1872427
+        "filename": "crgx-0.1.0-x86_64-apple-darwin.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-apple-darwin/crgx/0.1.0/crgx-0.1.0-x86_64-apple-darwin.tar.zst",
+        "size": 1541258,
+        "sha256": "85c0d854558d7f06f709c7758380ce043f07bd99a1d44ed2d22dbcec81344e57",
+        "archive": "tar.zst"
       },
       "linux-arm64": {
         "filename": "crgx-linux-aarch64-0.1.0.tar.gz",
@@ -33,14 +37,39 @@
         "size": 1971123
       },
       "linux-x64-musl": {
-        "filename": "crgx-linux-x86_64-musl-0.1.0.tar.gz",
-        "url": "https://github.com/yfedoseev/crgx/releases/download/v0.1.0/crgx-linux-x86_64-musl-0.1.0.tar.gz",
-        "size": 2067482
+        "filename": "crgx-0.1.0-x86_64-unknown-linux-musl.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-unknown-linux-musl/crgx/0.1.0/crgx-0.1.0-x86_64-unknown-linux-musl.tar.zst",
+        "size": 1522295,
+        "sha256": "7b158b57003035c6b536f9e06756f74da67c62ee030ca29620aeb8166a9953fa",
+        "archive": "tar.zst"
       },
       "windows-x64-msvc": {
-        "filename": "crgx-windows-x86_64-0.1.0.zip",
-        "url": "https://github.com/yfedoseev/crgx/releases/download/v0.1.0/crgx-windows-x86_64-0.1.0.zip",
-        "size": 1685362
+        "filename": "crgx-0.1.0-x86_64-pc-windows-msvc.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-pc-windows-msvc/crgx/0.1.0/crgx-0.1.0-x86_64-pc-windows-msvc.tar.zst",
+        "size": 1496209,
+        "sha256": "932cde7ab7b787a39fe89eada9c38178e0481f5428cf0260941d8c9e63927aae",
+        "archive": "tar.zst"
+      },
+      "linux-x64-gnu": {
+        "filename": "crgx-0.1.0-x86_64-unknown-linux-gnu.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-unknown-linux-gnu/crgx/0.1.0/crgx-0.1.0-x86_64-unknown-linux-gnu.tar.zst",
+        "size": 1470140,
+        "sha256": "370cc24418de0195f04fd97f7240b71d78dcc2908e95fc1ff9a2531c171ae5e3",
+        "archive": "tar.zst"
+      },
+      "linux-arm64-gnu": {
+        "filename": "crgx-0.1.0-aarch64-unknown-linux-gnu.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-unknown-linux-gnu/crgx/0.1.0/crgx-0.1.0-aarch64-unknown-linux-gnu.tar.zst",
+        "size": 1370947,
+        "sha256": "90fbf43e32f0c13d827b68cbb0b8bc72ac4071543253b6541f2d78d7e1c067f7",
+        "archive": "tar.zst"
+      },
+      "linux-arm64-musl": {
+        "filename": "crgx-0.1.0-aarch64-unknown-linux-musl.tar.zst",
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-unknown-linux-musl/crgx/0.1.0/crgx-0.1.0-aarch64-unknown-linux-musl.tar.zst",
+        "size": 1401912,
+        "sha256": "dd776a10f1ac2996a8de0dee3be5195e358d210e68847bfdc1b6ad9f1160e21c",
+        "archive": "tar.zst"
       }
     },
     "assets": {
@@ -85,6 +114,48 @@
         "content_type": "application/zip",
         "created_at": "2026-03-01T07:47:51Z",
         "updated_at": "2026-03-01T07:47:52Z"
+      },
+      "crgx-0.1.0-x86_64-apple-darwin.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-apple-darwin/crgx/0.1.0/crgx-0.1.0-x86_64-apple-darwin.tar.zst",
+        "size": 1541258,
+        "sha256": "85c0d854558d7f06f709c7758380ce043f07bd99a1d44ed2d22dbcec81344e57",
+        "content_type": "application/zstd"
+      },
+      "crgx-0.1.0-aarch64-apple-darwin.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-apple-darwin/crgx/0.1.0/crgx-0.1.0-aarch64-apple-darwin.tar.zst",
+        "size": 1441800,
+        "sha256": "00ebed8368e903ba96189f4b57bd8361988650448c755922c1188a3a8c1e1f85",
+        "content_type": "application/zstd"
+      },
+      "crgx-0.1.0-x86_64-pc-windows-msvc.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-pc-windows-msvc/crgx/0.1.0/crgx-0.1.0-x86_64-pc-windows-msvc.tar.zst",
+        "size": 1496209,
+        "sha256": "932cde7ab7b787a39fe89eada9c38178e0481f5428cf0260941d8c9e63927aae",
+        "content_type": "application/zstd"
+      },
+      "crgx-0.1.0-x86_64-unknown-linux-gnu.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-unknown-linux-gnu/crgx/0.1.0/crgx-0.1.0-x86_64-unknown-linux-gnu.tar.zst",
+        "size": 1470140,
+        "sha256": "370cc24418de0195f04fd97f7240b71d78dcc2908e95fc1ff9a2531c171ae5e3",
+        "content_type": "application/zstd"
+      },
+      "crgx-0.1.0-aarch64-unknown-linux-gnu.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-unknown-linux-gnu/crgx/0.1.0/crgx-0.1.0-aarch64-unknown-linux-gnu.tar.zst",
+        "size": 1370947,
+        "sha256": "90fbf43e32f0c13d827b68cbb0b8bc72ac4071543253b6541f2d78d7e1c067f7",
+        "content_type": "application/zstd"
+      },
+      "crgx-0.1.0-x86_64-unknown-linux-musl.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/x86_64-unknown-linux-musl/crgx/0.1.0/crgx-0.1.0-x86_64-unknown-linux-musl.tar.zst",
+        "size": 1522295,
+        "sha256": "7b158b57003035c6b536f9e06756f74da67c62ee030ca29620aeb8166a9953fa",
+        "content_type": "application/zstd"
+      },
+      "crgx-0.1.0-aarch64-unknown-linux-musl.tar.zst": {
+        "url": "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/aarch64-unknown-linux-musl/crgx/0.1.0/crgx-0.1.0-aarch64-unknown-linux-musl.tar.zst",
+        "size": 1401912,
+        "sha256": "dd776a10f1ac2996a8de0dee3be5195e358d210e68847bfdc1b6ad9f1160e21c",
+        "content_type": "application/zstd"
       }
     },
     "is_pinned": true


### PR DESCRIPTION
Follow-up to #887. Adds platforms entries on each tool pinned-version release entry that point at the LFS-hosted tar.zst archives. Now tool_query.py lookups find the cached prebuilts and the cross-compile workflow fetch_or_build_tool.sh helper hits a cache instead of falling through to source-build. Coverage: crgx 7 platforms (missing aarch64-pc-windows-msvc per #886), cargo-chef 8 platforms (full). Every entry carries sha256 + size + LFS-aware URL.