### PR TITLE
manifest: vendor cargo-xwin MSVC CRT cache (~15min/Windows lane reclaimed)

### DIFF
--- a/deps/xwin-cache/2026-06-22/xwin-cache.tar.zst
+++ b/deps/xwin-cache/2026-06-22/xwin-cache.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33c04d8026d99dab4d66f39ddbd93d75f64c68063d4ba58e5450626524bf348d
+size 84664072


### PR DESCRIPTION
Vendors the cargo-xwin MSVC CRT + Windows SDK cache as an LFS asset. Today every Windows cross-compile lane spends ~15m22s on the live MSVC CRT download from Microsoft (observed in run 27926041886). With this cached + a workflow pre-fetch step (follow-up), that collapses to seconds.\n\nSize: 1.08 GiB uncompressed → 81 MiB zstd-19. Covers x86_64 + aarch64 MSVC 17 + latest SDK. sha256 33c04d80...\n\nFollow-up PR will add the workflow step that fetches + extracts to ~/.cache/cargo-xwin/ before cargo-xwin runs.