### PR TITLE
feat(ci): pre-fetch cargo-xwin MSVC CRT cache from manifest (kills 15m22s/Windows lane)

### DIFF
--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -424,10 +424,32 @@ jobs:
           # zigbuild step inherits it.
           echo "SDKROOT=/opt/MacOSX11.3.sdk" >> "$GITHUB_ENV"
 
-      # (cargo-xwin v0.23.0 doesn't expose a `download` subcommand —
-      # the previous "Pre-download MSVC CRT" step was bogus and broke
-      # every xwin lane. The SDK is downloaded automatically on first
-      # `cargo xwin build` instead.)
+      # Pre-fetch the vendored cargo-xwin MSVC CRT + Windows SDK cache
+      # from the manifest branch. cargo-xwin's first `build` invocation
+      # otherwise downloads ~1.1 GiB live from Microsoft, costing
+      # ~15m22s per Windows lane (observed in run 27926041886).
+      # Extract under ~/.cache/cargo-xwin/ so the layout matches what
+      # cargo-xwin expects (~/.cache/cargo-xwin/xwin/{crt,sdk}). LFS-aware
+      # media URL — works regardless of LFS pointer state on the raw URL.
+      - name: Pre-fetch cargo-xwin MSVC CRT + SDK cache (from manifest branch)
+        if: matrix.tool == 'xwin'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.cache/cargo-xwin"
+          url="https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/xwin-cache/2026-06-22/xwin-cache.tar.zst"
+          archive="/tmp/xwin-cache.tar.zst"
+          echo "Fetching $url"
+          curl --fail --location \
+              --retry 6 --retry-delay 5 --retry-all-errors \
+              --output "$archive" "$url"
+          ls -lh "$archive"
+          tar --use-compress-program='zstd -d' -xf "$archive" -C "$HOME/.cache/cargo-xwin"
+          echo "Cache layout:"
+          find "$HOME/.cache/cargo-xwin/xwin" -maxdepth 2 -type d | head -20
+          echo "Sanity: assert MSVC CRT include dir exists"
+          test -d "$HOME/.cache/cargo-xwin/xwin/crt/include"
+          test -d "$HOME/.cache/cargo-xwin/xwin/sdk/include"
 
       - name: Cross-compile soldr — --release ${{ matrix.target }} (${{ matrix.tool }})
         id: build


### PR DESCRIPTION
Adds a pre-step that downloads the vendored xwin cache (PR #890, 81 MiB tar.zst on the manifest branch) and extracts to ~/.cache/cargo-xwin/. Subsequent 'cargo xwin build' finds the populated cache and skips the live Microsoft download entirely. Expected Windows lane duration: ~19min -> ~4-5min.