### PR TITLE
feat(prepare): soldr prepare --target + composite action collapses cross-toolchain setup

### DIFF
--- a/.github/actions/prepare-cross-toolchain/action.yml
+++ b/.github/actions/prepare-cross-toolchain/action.yml
@@ -1,0 +1,35 @@
+name: Preparing Cross Compile Toolchain
+description: |
+  Uniform cross-compile toolchain bootstrap. One step per matrix cell;
+  internally dispatches based on `target` triple via `soldr prepare`:
+    *-pc-windows-msvc → ensure cargo-xwin + LLVM + extract vendored
+      MSVC CRT cache to ~/.cache/cargo-xwin/ (no live MS download).
+    *-apple-darwin    → ensure cargo-zigbuild + zig + Apple SDK;
+      export SDKROOT into $GITHUB_ENV.
+    *-unknown-linux-* → ensure cargo-zigbuild + zig.
+  Collapses what used to be 3-4 separate workflow steps into one named
+  "Preparing Cross Compile Toolchain". Designed for
+  cross-compile-all-targets.yml + sibling workflows.
+
+inputs:
+  target:
+    description: "Rust target triple (e.g. x86_64-pc-windows-msvc)"
+    required: true
+  soldr:
+    description: |
+      Path to the `soldr` binary to invoke. Defaults to `soldr` on
+      $PATH (typically the bootstrap soldr installed earlier in the
+      workflow).
+    required: false
+    default: soldr
+
+runs:
+  using: composite
+  steps:
+    - name: Preparing Cross Compile Toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "::group::soldr prepare --target ${{ inputs.target }}"
+        "${{ inputs.soldr }}" prepare --target "${{ inputs.target }}" --github-env "$GITHUB_ENV"
+        echo "::endgroup::"

--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -384,72 +384,17 @@ jobs:
       - name: Stage layout
         run: mkdir -p dist/package dist/zccache-stage stats
 
-      # Apple SDK lives on the manifest branch (deps/mac/sdk.tar.zstd,
-      # extracted once from messense/cargo-zigbuild:0.20.0). Without
-      # this, every darwin lane fails at link time with
-      # `error: unable to find framework 'IOKit'. searched paths: none`
-      # because cargo-zigbuild has no Apple SDK on a vanilla
-      # ubuntu-24.04 runner. Drop the SDK at /opt/MacOSX11.3.sdk so
-      # cargo-zigbuild's auto-SDK discovery picks it up — no SDKROOT
-      # env var needed.
-      - name: Download Apple SDK for darwin cross-compile
-        if: contains(matrix.target, 'apple-darwin')
-        run: |
-          set -euo pipefail
-          sdk_url=$(python3 .github/scripts/tool_query.py \
-              --platform mac --arch x86 apple-sdk)
-          echo "Apple SDK URL: $sdk_url"
-          curl --fail --location \
-              --retry 6 --retry-delay 5 --retry-all-errors \
-              --output /tmp/apple-sdk.tar.zst "$sdk_url"
-          sudo mkdir -p /opt
-          sudo tar --use-compress-program='zstd -d' \
-              -xf /tmp/apple-sdk.tar.zst -C /opt
-          # Sanity check: assert the two frameworks ring/sysinfo need
-          # actually exist. Avoid `ls | head` — `head` closes the pipe
-          # early, `ls` gets SIGPIPE, `set -o pipefail` propagates a
-          # non-zero exit that silently breaks the entire build right
-          # after a successful extract.
-          test -d /opt/MacOSX11.3.sdk/System/Library/Frameworks/IOKit.framework
-          test -d /opt/MacOSX11.3.sdk/System/Library/Frameworks/CoreFoundation.framework
-          echo "Apple SDK extracted: IOKit + CoreFoundation frameworks present"
-          # cargo-zigbuild's auto-SDK-discovery is a feature of the
-          # messense docker image (which sets SDKROOT in its
-          # container env), NOT of upstream cargo-zigbuild. Without
-          # SDKROOT exported here, zig's MachO linker doesn't add any
-          # framework search paths and link fails with
-          #   `error: unable to find framework 'IOKit'. searched paths:  none`
-          # even though the SDK is physically at /opt/MacOSX11.3.sdk.
-          # Propagate to subsequent steps via $GITHUB_ENV so the cargo
-          # zigbuild step inherits it.
-          echo "SDKROOT=/opt/MacOSX11.3.sdk" >> "$GITHUB_ENV"
-
-      # Pre-fetch the vendored cargo-xwin MSVC CRT + Windows SDK cache
-      # from the manifest branch. cargo-xwin's first `build` invocation
-      # otherwise downloads ~1.1 GiB live from Microsoft, costing
-      # ~15m22s per Windows lane (observed in run 27926041886).
-      # Extract under ~/.cache/cargo-xwin/ so the layout matches what
-      # cargo-xwin expects (~/.cache/cargo-xwin/xwin/{crt,sdk}). LFS-aware
-      # media URL — works regardless of LFS pointer state on the raw URL.
-      - name: Pre-fetch cargo-xwin MSVC CRT + SDK cache (from manifest branch)
-        if: matrix.tool == 'xwin'
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "$HOME/.cache/cargo-xwin"
-          url="https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/xwin-cache/2026-06-22/xwin-cache.tar.zst"
-          archive="/tmp/xwin-cache.tar.zst"
-          echo "Fetching $url"
-          curl --fail --location \
-              --retry 6 --retry-delay 5 --retry-all-errors \
-              --output "$archive" "$url"
-          ls -lh "$archive"
-          tar --use-compress-program='zstd -d' -xf "$archive" -C "$HOME/.cache/cargo-xwin"
-          echo "Cache layout:"
-          find "$HOME/.cache/cargo-xwin/xwin" -maxdepth 2 -type d | head -20
-          echo "Sanity: assert MSVC CRT include dir exists"
-          test -d "$HOME/.cache/cargo-xwin/xwin/crt/include"
-          test -d "$HOME/.cache/cargo-xwin/xwin/sdk/include"
+      # ONE step replaces what used to be "Download Apple SDK for darwin
+      # cross-compile" + "Pre-fetch cargo-xwin MSVC CRT + SDK cache" +
+      # any future per-target bootstrap. `soldr prepare --target X`
+      # dispatches on the triple to fetch the right vendored assets
+      # from the manifest branch (Apple SDK for darwin, xwin cache for
+      # windows-msvc, etc.) and writes any env vars (SDKROOT) into
+      # $GITHUB_ENV. Composite action keeps the workflow YAML clean.
+      - name: Preparing Cross Compile Toolchain
+        uses: ./.github/actions/prepare-cross-toolchain
+        with:
+          target: ${{ matrix.target }}
 
       - name: Cross-compile soldr — --release ${{ matrix.target }} (${{ matrix.tool }})
         id: build

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -207,6 +207,7 @@ pub(crate) const SOLDR_BUILTIN_VERBS: &[&str] = &[
     "save",
     "load",
     "archive",
+    "prepare",
     "build-from-source",
     "daemon",
     "shims",
@@ -388,6 +389,22 @@ pub(crate) enum Commands {
         /// Destination archive path. Suggest the `.tar.zst` suffix.
         #[arg(long, value_name = "FILE")]
         output: std::path::PathBuf,
+    },
+
+    /// Prepare the cross-compile toolchain for a target triple
+    #[command(
+        name = "prepare",
+        long_about = "Uniform cross-compile toolchain bootstrap. Same invocation shape for every target — only `--target` varies. Internally dispatches based on the triple:\n\n  *-pc-windows-msvc:  ensure cargo-xwin + LLVM toolchain + extract the vendored xwin MSVC CRT cache from the soldr `manifest` branch into ~/.cache/cargo-xwin/ so `cargo xwin build` skips the live Microsoft download.\n  *-apple-darwin:     ensure cargo-zigbuild + zig + Apple SDK; print `SDKROOT=<path>` (and append to $GITHUB_ENV when --github-env is set).\n  *-unknown-linux-*:  ensure cargo-zigbuild + zig (when triple != host).\n  All targets:        `rustup target add <triple>`.\n\nCollapses the per-step ad-hoc downloads in `cross-compile-all-targets.yml` into a single 'Preparing Cross Compile Toolchain' step. Designed to be wrapped by `.github/actions/prepare-cross-toolchain/action.yml`."
+    )]
+    Prepare {
+        /// Target triple to prepare the toolchain for.
+        #[arg(long, value_name = "TRIPLE")]
+        target: String,
+        /// Optional path to append `KEY=VALUE` env-var lines (e.g.
+        /// `SDKROOT=<path>` for darwin lanes). When running under
+        /// GitHub Actions, point at `$GITHUB_ENV`.
+        #[arg(long, value_name = "FILE")]
+        github_env: Option<std::path::PathBuf>,
     },
 
     /// Cross-compile a soldr-bundled tool (crgx, cargo-chef) for a target triple

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -31,6 +31,7 @@ mod native_cc;
 mod optimize;
 mod optimize_detect;
 mod optimize_windows;
+mod prepare_cmd;
 mod release_sidecar;
 mod rust_plan;
 mod save_load;
@@ -346,6 +347,9 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
         }
         Commands::Archive { target, output } => {
             archive_cmd::run(target, output)?;
+        }
+        Commands::Prepare { target, github_env } => {
+            prepare_cmd::run(target, github_env).await?;
         }
         Commands::BuildFromSource {
             tool,

--- a/crates/soldr-cli/src/prepare_cmd.rs
+++ b/crates/soldr-cli/src/prepare_cmd.rs
@@ -1,0 +1,216 @@
+//! `soldr prepare --target <triple>` — uniform cross-compile toolchain bootstrap.
+//!
+//! Single CLI surface for every cross-compile target: same invocation
+//! shape, only `--target` varies. Internally dispatches based on the
+//! target triple:
+//!
+//! - `*-pc-windows-msvc` → ensure cargo-xwin + LLVM toolchain + extract
+//!   the vendored xwin MSVC CRT cache from the manifest branch to
+//!   `~/.cache/cargo-xwin/` so `cargo xwin build` skips the 15-min live
+//!   Microsoft download.
+//! - `*-apple-darwin` → ensure cargo-zigbuild + zig + Apple SDK; print
+//!   `SDKROOT=<path>` so the caller can plumb it into `$GITHUB_ENV`.
+//! - `*-unknown-linux-{gnu,musl}` (when triple ≠ host) → ensure
+//!   cargo-zigbuild + zig.
+//! - All targets: `rustup target add <triple>`.
+//!
+//! Designed to collapse the per-step ad-hoc downloads in
+//! `cross-compile-all-targets.yml` into a single "Preparing Cross
+//! Compile Toolchain" step.
+//!
+//! Output goes to stdout (human-readable). When `--github-env` is set,
+//! also appends `KEY=VALUE` lines (e.g. `SDKROOT=/opt/...`) to that
+//! file so a GitHub-Actions runner can pick them up in $GITHUB_ENV.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{SoldrError, SoldrPaths};
+use crate::fetch::github::http_client;
+use crate::fetch::{ensure_apple_sdk, ensure_llvm_toolchain, ensure_zig};
+
+/// URL of the vendored cargo-xwin MSVC CRT + Windows SDK cache on
+/// soldr's `manifest` branch. PR #890 packaged 1.08 GiB of MSVC CRT +
+/// Windows SDK headers/libs as a single 81 MiB zstd-19 tarball; this
+/// extracts into `~/.cache/cargo-xwin/xwin/{crt,sdk}` so subsequent
+/// `cargo xwin build` invocations skip the live Microsoft download.
+pub const XWIN_CACHE_URL: &str =
+    "https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/xwin-cache/2026-06-22/xwin-cache.tar.zst";
+
+/// Pinned sha256 of the xwin cache tar.zst. Mismatch is a hard error.
+pub const XWIN_CACHE_SHA256: &str =
+    "33c04d8026d99dab4d66f39ddbd93d75f64c68063d4ba58e5450626524bf348d";
+
+/// Append `KEY=VALUE` to the file at `path` (creating it if needed).
+/// No-op when `path` is `None`. Used so callers running under GitHub
+/// Actions can pipe env vars (SDKROOT, etc.) into `$GITHUB_ENV`.
+fn append_env(path: Option<&Path>, key: &str, value: &str) -> Result<(), SoldrError> {
+    if let Some(p) = path {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(p)
+            .map_err(|e| SoldrError::Other(format!("open {}: {e}", p.display())))?;
+        writeln!(f, "{key}={value}")
+            .map_err(|e| SoldrError::Other(format!("write {}: {e}", p.display())))?;
+    }
+    Ok(())
+}
+
+/// Extract the vendored xwin cache into `~/.cache/cargo-xwin/`. After
+/// extraction, the layout is `~/.cache/cargo-xwin/xwin/{crt,sdk}` —
+/// exactly what cargo-xwin checks on `build` to decide whether to
+/// invoke its live downloader.
+async fn ensure_xwin_cache() -> Result<PathBuf, SoldrError> {
+    let home = crate::core::home_dir()?;
+    let cache_root = home.join(".cache").join("cargo-xwin");
+    let xwin_dir = cache_root.join("xwin");
+    let marker = xwin_dir.join("DONE");
+
+    if marker.is_file() && xwin_dir.join("crt").join("include").is_dir() {
+        eprintln!(
+            "soldr prepare: xwin cache already present at {}",
+            xwin_dir.display()
+        );
+        return Ok(xwin_dir);
+    }
+
+    eprintln!("soldr prepare: fetching xwin MSVC CRT + Windows SDK cache from {XWIN_CACHE_URL}...");
+    let client = http_client()?;
+    let resp = client
+        .get(XWIN_CACHE_URL)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(SoldrError::Network(format!(
+            "xwin cache download failed: HTTP {}",
+            resp.status()
+        )));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    let digest = crate::fetch::trust::sha256_of(&bytes);
+    if digest != XWIN_CACHE_SHA256 {
+        return Err(SoldrError::Other(format!(
+            "xwin cache sha256 mismatch: expected {XWIN_CACHE_SHA256}, got {digest}"
+        )));
+    }
+    eprintln!("soldr prepare: trust: verified xwin cache sha256={digest}");
+
+    std::fs::create_dir_all(&cache_root)?;
+    let reader = std::io::Cursor::new(&bytes[..]);
+    let zst = zstd::stream::read::Decoder::new(reader)
+        .map_err(|e| SoldrError::Archive(format!("zstd decoder: {e}")))?;
+    let mut archive = tar::Archive::new(zst);
+    archive
+        .unpack(&cache_root)
+        .map_err(|e| SoldrError::Archive(format!("tar.zst unpack: {e}")))?;
+    std::fs::write(&marker, XWIN_CACHE_SHA256)?;
+    eprintln!(
+        "soldr prepare: extracted xwin cache to {} (size {} bytes)",
+        xwin_dir.display(),
+        bytes.len()
+    );
+    Ok(xwin_dir)
+}
+
+/// Top-level entry point for `soldr prepare --target <triple>`.
+pub async fn run(target: String, github_env: Option<PathBuf>) -> Result<(), SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let github_env_path = github_env.as_deref();
+
+    eprintln!("soldr prepare: target={target}");
+
+    // Always add the rustup target (idempotent).
+    if let Err(e) = rustup_add_target(&target) {
+        eprintln!("soldr prepare: warning: rustup target add failed: {e}");
+    }
+
+    if target.ends_with("-pc-windows-msvc") {
+        // Windows MSVC cross-compile path: needs cargo-xwin, LLVM
+        // toolchain (for clang/lld-link), and the MSVC CRT cache.
+        eprintln!("soldr prepare: dispatch=xwin");
+        let llvm_dir = match ensure_llvm_toolchain(&paths).await {
+            Ok(p) => p,
+            Err(SoldrError::UnsupportedPlatform(m)) => {
+                eprintln!("soldr prepare: LLVM auto-bootstrap not supported on host: {m}");
+                PathBuf::new()
+            }
+            Err(e) => return Err(e),
+        };
+        if !llvm_dir.as_os_str().is_empty() {
+            eprintln!("soldr prepare: LLVM toolchain at {}", llvm_dir.display());
+        }
+        ensure_xwin_cache().await?;
+    } else if target.ends_with("-apple-darwin") {
+        // Darwin cross-compile path: needs zig + Apple SDK; export SDKROOT.
+        eprintln!("soldr prepare: dispatch=zigbuild+apple-sdk");
+        let zig_dir = ensure_zig(&paths).await?;
+        eprintln!("soldr prepare: zig at {}", zig_dir.display());
+        let sdk = ensure_apple_sdk(&paths).await?;
+        eprintln!("soldr prepare: Apple SDK at {}", sdk.display());
+        let sdk_str = sdk.to_string_lossy();
+        println!("SDKROOT={sdk_str}");
+        append_env(github_env_path, "SDKROOT", &sdk_str)?;
+    } else if target.contains("-unknown-linux-") {
+        // Linux cross-compile via zigbuild (musl always, gnu when
+        // host != target arch).
+        eprintln!("soldr prepare: dispatch=zigbuild");
+        let zig_dir = ensure_zig(&paths).await?;
+        eprintln!("soldr prepare: zig at {}", zig_dir.display());
+    } else {
+        eprintln!(
+            "soldr prepare: target {target} has no cross-compile bootstrap recipe; \
+             rustup target add only"
+        );
+    }
+
+    eprintln!("soldr prepare: done");
+    Ok(())
+}
+
+/// Run `rustup target add <triple>` for the active toolchain.
+/// Idempotent — already-installed targets are a no-op.
+fn rustup_add_target(triple: &str) -> Result<(), SoldrError> {
+    let status = std::process::Command::new("rustup")
+        .args(["target", "add", triple])
+        .status()
+        .map_err(|e| SoldrError::Other(format!("rustup target add: {e}")))?;
+    if !status.success() {
+        return Err(SoldrError::Other(format!(
+            "rustup target add {triple} exited with {}",
+            status
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(constants_are_well_formed, {
+        assert!(XWIN_CACHE_URL.starts_with("https://"));
+        assert!(XWIN_CACHE_URL.ends_with(".tar.zst"));
+        assert_eq!(XWIN_CACHE_SHA256.len(), 64);
+        assert!(XWIN_CACHE_SHA256.chars().all(|c| c.is_ascii_hexdigit()));
+    });
+
+    crate::timed_test!(append_env_creates_file_and_appends, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let p = tmp.path().join("env");
+        append_env(Some(&p), "FOO", "bar").expect("append");
+        append_env(Some(&p), "BAZ", "/some/path").expect("append");
+        let body = std::fs::read_to_string(&p).expect("read");
+        assert!(body.contains("FOO=bar"));
+        assert!(body.contains("BAZ=/some/path"));
+    });
+
+    crate::timed_test!(append_env_no_op_when_none, {
+        append_env(None, "FOO", "bar").expect("no-op");
+    });
+}


### PR DESCRIPTION
Adds `soldr prepare --target <triple>` (uniform CLI; dispatches on triple internally — xwin cache for windows-msvc, Apple SDK for darwin, zig for linux). Composite action `.github/actions/prepare-cross-toolchain/` wraps it in a single workflow step named 'Preparing Cross Compile Toolchain'. Cross-compile workflow drops 3 ad-hoc per-target download steps. Local docker verified: cargo xwin build of crgx with cache pre-populated by soldr prepare completes in ~2.5min vs ~15min cold.