### PR TITLE
manifest: re-vendor xwin cache with symlinks preserved (#901 fix)

### DIFF
--- a/deps/xwin-cache/2026-06-22b/xwin-cache.tar.zst
+++ b/deps/xwin-cache/2026-06-22b/xwin-cache.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:957a51e5738d1352c18bd14caa664a88099e2f4e78afaf94f911f0cb925745fa
+size 88430176


### PR DESCRIPTION
Original cache tarball (#890) was packaged from Windows-host-mounted docker volume → lost cargo-xwin's case-sensitive symlinks (`windows.h` → `Windows.h`). Linux CI clang-cl couldn't find `windows.h` despite `Windows.h` being on disk. Regenerated inside container, symlinks intact. New sha 957a51e5...