### PR TITLE
feat(prepare): --target all reads [workspace.metadata.soldr].targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,22 @@ license = "BSD-3-Clause"
 repository = "https://github.com/zackees/soldr"
 homepage = "https://github.com/zackees/soldr"
 
+[workspace.metadata.soldr]
+# Shipping matrix consumed by `soldr prepare --target all` (RFC #914).
+# Cargo ignores `[workspace.metadata.*]` — this is the blessed way to
+# attach tool-specific config to a manifest. Kept in sync with the
+# `cross-compile-all-targets.yml` workflow matrix.
+targets = [
+    "x86_64-pc-windows-msvc",
+    "aarch64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+]
+
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/soldr-cli/src/cargo_metadata_soldr.rs
+++ b/crates/soldr-cli/src/cargo_metadata_soldr.rs
@@ -1,0 +1,278 @@
+//! Reader for `[workspace.metadata.soldr]` / `[package.metadata.soldr]`
+//! sections of `Cargo.toml` (RFC #914).
+//!
+//! Cargo's manifest reference explicitly blesses `[*.metadata.*]` tables
+//! as the place for tool-specific configuration:
+//!
+//! > The `package.metadata` table, however, is completely ignored by
+//! > Cargo and will not be warned about. This section can be used for
+//! > tools which would like to store package configuration in
+//! > `Cargo.toml`.
+//!
+//! soldr uses this to discover the multi-target shipping matrix for
+//! `soldr prepare --target all` without inventing a new file format
+//! and without piggybacking on `rust-toolchain.toml [toolchain].targets`
+//! (rustup would unconditionally install every entry — ~30–80 MB of
+//! `rust-std` per triple — on every fresh checkout).
+//!
+//! Lookup order:
+//! 1. `[workspace.metadata.soldr].targets` — primary.
+//! 2. `[package.metadata.soldr].targets`   — fallback for single-crate
+//!    repos with no workspace table.
+//! 3. Both missing → ERROR with a directive message naming the missing
+//!    table. No fallback to `rust-toolchain.toml` or `.cargo/config.toml`
+//!    because their semantics differ ("install these components" /
+//!    "build for these by default") from "this is the shipping matrix".
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::core::SoldrError;
+
+/// Top-level shape of a `Cargo.toml` for the keys we care about.
+/// `serde(default)` everywhere so the parse succeeds against any
+/// well-formed manifest, even ones that don't mention soldr at all.
+#[derive(Debug, Deserialize, Default)]
+struct CargoToml {
+    #[serde(default)]
+    workspace: Option<WorkspaceTable>,
+    #[serde(default)]
+    package: Option<PackageTable>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct WorkspaceTable {
+    #[serde(default)]
+    metadata: Option<MetadataTable>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PackageTable {
+    #[serde(default)]
+    metadata: Option<MetadataTable>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct MetadataTable {
+    #[serde(default)]
+    soldr: Option<SoldrMetadata>,
+}
+
+/// `[workspace.metadata.soldr]` / `[package.metadata.soldr]` body.
+/// Public so future fields can be added (e.g. `[..].cache_archive`
+/// default) without rewriting consumers.
+#[derive(Debug, Deserialize, Default, Clone, PartialEq, Eq)]
+pub struct SoldrMetadata {
+    /// The shipping matrix: list of rust target triples this repo
+    /// declares it builds for. Consumed by `soldr prepare --target all`.
+    #[serde(default)]
+    pub targets: Vec<String>,
+}
+
+/// Read soldr metadata from the `Cargo.toml` at `path`. Returns the
+/// merged `SoldrMetadata` honoring the workspace → package fallback
+/// order described in the module docstring.
+///
+/// **Does not error on missing tables** — returns `Ok(SoldrMetadata
+/// { targets: vec![] })` when no `[*.metadata.soldr]` section exists.
+/// Callers that need to require the section (e.g. `--target all`)
+/// must check `targets.is_empty()` themselves and surface a
+/// directive error; that keeps this reader reusable for any future
+/// soldr-metadata field that's genuinely optional.
+pub fn read_soldr_metadata(cargo_toml_path: &Path) -> Result<SoldrMetadata, SoldrError> {
+    let body = std::fs::read_to_string(cargo_toml_path).map_err(|e| {
+        SoldrError::Other(format!(
+            "soldr prepare: read {}: {e}",
+            cargo_toml_path.display()
+        ))
+    })?;
+    let parsed: CargoToml = toml::from_str(&body).map_err(|e| {
+        SoldrError::Other(format!(
+            "soldr prepare: parse {}: {e}",
+            cargo_toml_path.display()
+        ))
+    })?;
+    // Workspace takes precedence; package-scoped metadata is fallback
+    // for single-crate repos that don't declare a workspace table.
+    let workspace_meta = parsed
+        .workspace
+        .and_then(|w| w.metadata)
+        .and_then(|m| m.soldr);
+    if let Some(meta) = workspace_meta {
+        return Ok(meta);
+    }
+    let package_meta = parsed
+        .package
+        .and_then(|p| p.metadata)
+        .and_then(|m| m.soldr);
+    Ok(package_meta.unwrap_or_default())
+}
+
+/// Walk up from `start_dir` looking for the first `Cargo.toml`. Used
+/// when `soldr prepare --target all` is invoked from a subdirectory
+/// of the repo. Returns `None` if no manifest is found before the
+/// filesystem root.
+pub fn find_cargo_toml(start_dir: &Path) -> Option<PathBuf> {
+    let mut cur = start_dir;
+    loop {
+        let candidate = cur.join("Cargo.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        match cur.parent() {
+            Some(p) => cur = p,
+            None => return None,
+        }
+    }
+}
+
+/// Resolve `--target all` to the explicit target list by walking up
+/// from the current working directory, reading the nearest
+/// `Cargo.toml`, and returning `[*.metadata.soldr].targets`. Errors
+/// with a directive when the section is missing or empty — the
+/// caller asked for "all" and we must not silently substitute a
+/// host-only default.
+pub fn resolve_all_targets() -> Result<Vec<String>, SoldrError> {
+    let cwd = std::env::current_dir()
+        .map_err(|e| SoldrError::Other(format!("soldr prepare: cwd: {e}")))?;
+    let manifest = find_cargo_toml(&cwd).ok_or_else(|| {
+        SoldrError::Other(format!(
+            "soldr prepare --target all: no Cargo.toml found in `{}` or any parent",
+            cwd.display()
+        ))
+    })?;
+    let meta = read_soldr_metadata(&manifest)?;
+    if meta.targets.is_empty() {
+        return Err(SoldrError::Other(format!(
+            "soldr prepare --target all: no targets declared in `{}`. \
+             Add a `[workspace.metadata.soldr]` (or `[package.metadata.soldr]`) \
+             table with `targets = [\"...\", ...]`",
+            manifest.display()
+        )));
+    }
+    Ok(meta.targets)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: write a Cargo.toml fixture to `tmpdir/Cargo.toml` and
+    /// return the path.
+    fn write_fixture(tmpdir: &Path, body: &str) -> PathBuf {
+        let p = tmpdir.join("Cargo.toml");
+        std::fs::write(&p, body).expect("write fixture");
+        p
+    }
+
+    crate::timed_test!(reads_workspace_metadata, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let p = write_fixture(
+            tmp.path(),
+            r#"
+[workspace]
+
+[workspace.metadata.soldr]
+targets = [
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+]
+"#,
+        );
+        let meta = read_soldr_metadata(&p).expect("parse");
+        assert_eq!(
+            meta.targets,
+            vec![
+                "x86_64-pc-windows-msvc".to_string(),
+                "aarch64-apple-darwin".to_string(),
+            ]
+        );
+    });
+
+    crate::timed_test!(reads_package_metadata_when_no_workspace, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let p = write_fixture(
+            tmp.path(),
+            r#"
+[package]
+name = "thing"
+version = "0.1.0"
+
+[package.metadata.soldr]
+targets = ["x86_64-unknown-linux-gnu"]
+"#,
+        );
+        let meta = read_soldr_metadata(&p).expect("parse");
+        assert_eq!(meta.targets, vec!["x86_64-unknown-linux-gnu".to_string()]);
+    });
+
+    crate::timed_test!(workspace_metadata_wins_over_package, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let p = write_fixture(
+            tmp.path(),
+            r#"
+[package]
+name = "thing"
+version = "0.1.0"
+
+[package.metadata.soldr]
+targets = ["aarch64-unknown-linux-musl"]
+
+[workspace]
+
+[workspace.metadata.soldr]
+targets = ["x86_64-pc-windows-msvc"]
+"#,
+        );
+        let meta = read_soldr_metadata(&p).expect("parse");
+        // workspace block wins
+        assert_eq!(meta.targets, vec!["x86_64-pc-windows-msvc".to_string()]);
+    });
+
+    crate::timed_test!(no_metadata_returns_empty, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let p = write_fixture(
+            tmp.path(),
+            r#"
+[package]
+name = "thing"
+version = "0.1.0"
+"#,
+        );
+        let meta = read_soldr_metadata(&p).expect("parse");
+        assert!(meta.targets.is_empty());
+    });
+
+    crate::timed_test!(malformed_toml_errors_with_path, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let p = write_fixture(tmp.path(), "this is = = not valid toml");
+        let err = read_soldr_metadata(&p).expect_err("malformed");
+        let msg = err.to_string();
+        assert!(msg.contains("parse"), "msg: {msg}");
+        assert!(msg.contains("Cargo.toml"), "msg: {msg}");
+    });
+
+    crate::timed_test!(find_cargo_toml_walks_up, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let p = write_fixture(tmp.path(), "[package]\nname = \"x\"\nversion = \"0\"\n");
+        // create a nested subdir
+        let nested = tmp.path().join("a").join("b").join("c");
+        std::fs::create_dir_all(&nested).expect("mkdir");
+        let found = find_cargo_toml(&nested).expect("walked up");
+        assert_eq!(found, p);
+    });
+
+    crate::timed_test!(find_cargo_toml_returns_none_when_missing, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let nested = tmp.path().join("nothing-here");
+        std::fs::create_dir_all(&nested).expect("mkdir");
+        // tmp is under TEMP which has no Cargo.toml ancestor on a
+        // freshly-created TempDir; but the actual filesystem may
+        // have one above TEMP. Use the canonical root to verify the
+        // None path is reachable in principle.
+        // We can't guarantee no Cargo.toml exists above tmpdir on
+        // every host, so only assert this is a safe call (no panic).
+        let _ = find_cargo_toml(&nested);
+    });
+}

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -397,8 +397,12 @@ pub(crate) enum Commands {
         long_about = "Uniform cross-compile toolchain bootstrap. Same invocation shape for every target — only `--target` varies. Internally dispatches based on the triple:\n\n  *-pc-windows-msvc:  ensure cargo-xwin + LLVM toolchain + extract the vendored xwin MSVC CRT cache from the soldr `manifest` branch into ~/.cache/cargo-xwin/ so `cargo xwin build` skips the live Microsoft download.\n  *-apple-darwin:     ensure cargo-zigbuild + zig + Apple SDK; print `SDKROOT=<path>` (and append to $GITHUB_ENV when --github-env is set).\n  *-unknown-linux-*:  ensure cargo-zigbuild + zig (when triple != host).\n  All targets:        `rustup target add <triple>`.\n\nCollapses the per-step ad-hoc downloads in `cross-compile-all-targets.yml` into a single 'Preparing Cross Compile Toolchain' step. Designed to be wrapped by `.github/actions/prepare-cross-toolchain/action.yml`."
     )]
     Prepare {
-        /// Target triple to prepare the toolchain for.
-        #[arg(long, value_name = "TRIPLE")]
+        /// Target triple to prepare the toolchain for. Pass the
+        /// literal `all` to prepare every triple declared under
+        /// `[workspace.metadata.soldr].targets` (or
+        /// `[package.metadata.soldr].targets`) in the nearest
+        /// `Cargo.toml`. See zackees/soldr#914.
+        #[arg(long, value_name = "TRIPLE|all")]
         target: String,
         /// Optional path to append `KEY=VALUE` env-var lines (e.g.
         /// `SDKROOT=<path>` for darwin lanes). When running under

--- a/crates/soldr-cli/src/lib.rs
+++ b/crates/soldr-cli/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(dead_code)]
 
 pub mod cache_lib;
+pub mod cargo_metadata_soldr;
 pub mod core;
 pub mod daemon;
 pub mod defender;

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -15,6 +15,7 @@ mod cache;
 mod cache_lib;
 mod cargo_diagnostics;
 mod cargo_front_door;
+mod cargo_metadata_soldr;
 mod cli_args;
 mod cook;
 mod core;
@@ -354,7 +355,45 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             save,
             restore,
         } => {
-            prepare_cmd::run(target, github_env, save, restore).await?;
+            // `--target all` expands to every triple declared in
+            // `[workspace.metadata.soldr].targets`; any other value is
+            // passed through to a single-triple `prepare_cmd::run`. See
+            // zackees/soldr#914 for the resolution semantics.
+            let targets: Vec<String> = if target == "all" {
+                cargo_metadata_soldr::resolve_all_targets()?
+            } else {
+                vec![target]
+            };
+            // Per-triple errors are collected so a single bad target in
+            // a multi-target run doesn't hide later failures. The whole
+            // command still exits non-zero if any iteration failed.
+            let mut failures: Vec<(String, String)> = Vec::new();
+            for triple in &targets {
+                eprintln!("soldr prepare: ===== target {triple} =====");
+                if let Err(e) = prepare_cmd::run(
+                    triple.clone(),
+                    github_env.clone(),
+                    save.clone(),
+                    restore.clone(),
+                )
+                .await
+                {
+                    eprintln!("soldr prepare: target {triple} failed: {e}");
+                    failures.push((triple.clone(), e.to_string()));
+                }
+            }
+            if !failures.is_empty() {
+                let summary = failures
+                    .iter()
+                    .map(|(t, e)| format!("  {t}: {e}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return Err(SoldrError::Other(format!(
+                    "soldr prepare: {} of {} target(s) failed:\n{summary}",
+                    failures.len(),
+                    targets.len()
+                )));
+            }
         }
         Commands::BuildFromSource {
             tool,

--- a/crates/soldr-cli/src/prepare_cmd.rs
+++ b/crates/soldr-cli/src/prepare_cmd.rs
@@ -890,6 +890,31 @@ mod tests {
         assert_eq!(attrs.abi, Some(TargetAbi::Msvc));
     });
 
+    crate::timed_test!(soldr_workspace_metadata_dogfood, {
+        // Regression guard: soldr's own workspace `Cargo.toml`
+        // declares `[workspace.metadata.soldr].targets` (RFC #914).
+        // Every entry must classify cleanly via the fuzzy classifier
+        // — typos in soldr's own manifest fail at test time, not
+        // mid-CI when `soldr prepare --target all` blows up.
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace parent of crate dir")
+            .parent()
+            .expect("workspace root")
+            .join("Cargo.toml");
+        assert!(manifest.is_file(), "workspace manifest at {manifest:?}");
+        let meta = crate::cargo_metadata_soldr::read_soldr_metadata(&manifest)
+            .expect("parse soldr Cargo.toml");
+        assert!(
+            !meta.targets.is_empty(),
+            "soldr's own [workspace.metadata.soldr].targets is empty — regression"
+        );
+        for triple in &meta.targets {
+            classify_target(triple)
+                .unwrap_or_else(|e| panic!("triple `{triple}` in soldr Cargo.toml: {e}"));
+        }
+    });
+
     // ---- Corpus test ----
     //
     // `triple_corpus.txt` is the canonical `rustc --print target-list`


### PR DESCRIPTION
## Summary

RFC #914 **Phase 1+2** — the metadata reader plus the multi-target loop. No `--cache-archive` rewiring yet (that's Phase 3 in a follow-up PR); splitting keeps the diff reviewable and unblocks setup-soldr from using the new `--target all` shape immediately.

## What lands

- New module `crate::cargo_metadata_soldr` (visible from both bin + lib trees) that walks up from CWD to find the nearest `Cargo.toml`, reads `[workspace.metadata.soldr].targets` with `[package.metadata.soldr].targets` as fallback, and errors with a directive when both are missing.
- `Commands::Prepare`'s dispatch now expands `--target all` to the declared list, iterates per-triple, collects per-target failures, and surfaces them in a single summary error at the end. Single-triple invocations are unchanged.
- soldr's own workspace `Cargo.toml` declares its 8-triple shipping matrix under `[workspace.metadata.soldr]`.
- Dogfood test `prepare_cmd::tests::soldr_workspace_metadata_dogfood` pipes every declared triple through the fuzzy classifier from #913 — typos in soldr's own manifest fail at test time, not mid-CI.

## Why not `rust-toolchain.toml [toolchain].targets`?

Rustup unconditionally installs every entry there (~30–80 MB `rust-std` per triple) on every fresh checkout via its proxy auto-install mechanism. That's the wrong default for soldr's on-demand prepare model. The `[*.metadata.*]` reader is **intent-only** — no side effects from declaring targets.

Cargo blesses the pattern explicitly ([manifest reference](https://doc.rust-lang.org/cargo/reference/manifest.html#the-metadata-table)):

> The `package.metadata` table is completely ignored by Cargo and will not be warned about. This section can be used for tools which would like to store package configuration in `Cargo.toml`.

## Verification

```
$ soldr prepare --target all   # in a repo with [workspace.metadata.soldr].targets
soldr prepare: ===== target x86_64-pc-windows-msvc =====
soldr prepare: dispatch=xwin
soldr prepare: LLVM toolchain at .../llvm-21.1.5/...
soldr prepare: xwin cache already present at ...
soldr prepare: done
soldr prepare: ===== target aarch64-pc-windows-msvc =====
...
```

Confirms the investigation finding from issue #914: LLVM + xwin are host-shared across same-OS-family targets, so a 2-target Windows run fetches each asset *once*, not twice.

Missing-metadata error path:

```
$ soldr prepare --target all   # in a repo without the table
soldr: soldr prepare --target all: no targets declared in `.../Cargo.toml`.
Add a `[workspace.metadata.soldr]` (or `[package.metadata.soldr]`) table
with `targets = ["...", ...]`
```

## Test plan

- [x] `cargo build -p soldr-cli`
- [x] `cargo test -p soldr-cli --bin soldr cargo_metadata_soldr` — 7 reader unit tests pass
- [x] `cargo test -p soldr-cli --bin soldr soldr_workspace_metadata_dogfood` — dogfood guard passes (all 8 soldr triples classify cleanly via PR #913's fuzzy classifier)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p soldr-cli -- -D warnings`
- [x] End-to-end smoke test: `--target all` against a tmpdir fixture resolves + iterates; missing-metadata path errors with directive

## Out of scope (Phase 3+)

- `--cache-archive <dir>` flag wiring — separate PR.
- `index.json` writer + sha verification — separate PR.
- setup-soldr composite action update — tracked in setup-soldr repo.
- Deprecating `--save` / `--restore` — deferred until `--cache-archive` lands.

Refs #914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
