### PR TITLE
fix(hooks): add --no-project to uv run --script tool_guard invocations

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "top=$(git rev-parse --show-toplevel 2>/dev/null); while [ -n \"$top\" ] && [ ! -f \"$top/.claude/hooks/tool_guard.py\" ]; do parent=$(dirname \"$top\"); [ \"$parent\" = \"$top\" ] && break; top=$parent; done; if [ -f \"$top/.claude/hooks/tool_guard.py\" ]; then uv run --script \"$top/.claude/hooks/tool_guard.py\"; fi",
+            "command": "top=$(git rev-parse --show-toplevel 2>/dev/null); while [ -n \"$top\" ] && [ ! -f \"$top/.claude/hooks/tool_guard.py\" ]; do parent=$(dirname \"$top\"); [ \"$parent\" = \"$top\" ] && break; top=$parent; done; if [ -f \"$top/.claude/hooks/tool_guard.py\" ]; then uv run --no-project --script \"$top/.claude/hooks/tool_guard.py\"; fi",
             "timeout": 5
           }
         ]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
+            "command": "uv run --no-project --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
+            "command": "uv run --no-project --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
             "timeout": 5
           }
         ]
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
+            "command": "uv run --no-project --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- Bare `uv run --script` in agent hooks walks up to `pyproject.toml` and triggers a full maturin re-sync on every hook fire — minutes per call in this Python+Rust polyglot repo, often timing out silently past the 5s hook deadline.
- Adds `--no-project` to all four `tool_guard.py` invocations so uv ignores the surrounding project and just runs the PEP 723 script with its inline-declared dependencies.

## Changes
- `.claude/settings.json` — `PreToolUse` `Bash|Shell|PowerShell` hook
- `.codex/hooks.json` — `PreToolUse` matchers: `Bash`, `shell_command`, `functions.shell_command`

## Test plan
- [ ] Confirm `clud uv_run_hook_guard` no longer flags these files
- [ ] Confirm `tool_guard.py` still denies bare `cargo` / `python` invocations as expected (script runs identically; only project-discovery side effects were suppressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)