### PR TITLE
chore(ci): strip macOS-runner build/e2e jobs (cross-compile covers them)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,20 +92,11 @@ jobs:
       target: x86_64-unknown-linux-gnu
       shared_key: build-linux-x64
 
-  build-macos-x64:
-    name: macOS x64
-    needs: lint
-    # main-only AND not gated by the `fast-build` PR label. The label
-    # check is a no-op on push events (pull_request payload is null),
-    # so the main-branch sweep is unaffected.
-    if: >-
-      github.ref_name == 'main'
-      && !contains(github.event.pull_request.labels.*.name, 'fast-build')
-    uses: ./.github/workflows/_build-and-test.yml
-    with:
-      runner: macos-15-intel
-      target: x86_64-apple-darwin
-      shared_key: build-macos-x64
+  # build-macos-x64 removed: cross-compile-all-targets.yml builds the
+  # darwin artifacts on linux+zigbuild; smoke-on-mac in
+  # build-macos-x64.yml verifies the cross-built binary runs on real
+  # hardware. Native macOS unit-test sweep was redundant given that
+  # coverage chain — see commit message for the analysis.
 
   build-windows-x64:
     name: Windows x64
@@ -183,31 +174,13 @@ jobs:
       save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
-  e2e-macos-x64:
-    name: build
-    # Original gate: only run on PRs or pushes to main / release.
-    # Added: skip when the `fast-build` PR label is present.
-    if: >-
-      (github.event_name != 'push' || github.ref_name == 'main' || github.ref_name == 'release')
-      && !contains(github.event.pull_request.labels.*.name, 'fast-build')
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: macos-15-intel
-      target: x86_64-apple-darwin
-      binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' }}
-      source_ref: ${{ github.sha }}
-
-  e2e-macos-arm64:
-    name: build
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'fast-build') }}
-    uses: ./.github/workflows/_bootstrap-e2e.yml
-    with:
-      runner: macos-15
-      target: aarch64-apple-darwin
-      binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' }}
-      source_ref: ${{ github.sha }}
+  # e2e-macos-{x64,arm64} removed: the bootstrap-build phase moved to
+  # linux+zigbuild via cross-compile-all-targets.yml, and runtime
+  # verification of the cross-built darwin binary lives in
+  # build-macos-x64.yml + build-macos-arm64.yml (smoke-on-mac jobs
+  # that download the prebuilt artifact and run it). Maintaining a
+  # separate bootstrap+e2e lane on a paid macOS runner duplicated
+  # both halves without adding coverage.
 
   e2e-windows-x64:
     name: build

--- a/.github/workflows/setup-soldr-action.yml
+++ b/.github/workflows/setup-soldr-action.yml
@@ -47,8 +47,14 @@ jobs:
         include:
           - name: Linux
             runner: ubuntu-24.04
-          - name: macOS
-            runner: macos-15
+          # macOS smoke removed: the setup-soldr action is host-OS
+          # agnostic at the YAML level (no `runs:` `shell` differences
+          # between linux and darwin), and runtime verification of the
+          # darwin soldr binary lives in build-macos-x64.yml /
+          # build-macos-arm64.yml, which download the cross-built
+          # artifact from cross-compile-all-targets.yml and exercise
+          # `soldr --version` / `soldr doctor` on real hardware. Two
+          # macOS-runner-minute charges for the same coverage was waste.
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Removes 4 macOS-runner jobs from internal CI workflows. Coverage is replaced by the cross-compile lane (`cross-compile-all-targets.yml` builds darwin binaries on linux+zigbuild) plus the existing smoke jobs in `build-macos-x64.yml` / `build-macos-arm64.yml` that download those cross-built artifacts and exercise them on real macOS hardware.

## Stripped

- `ci.yml::build-macos-x64` — native build+test, redundant with cross-compile + smoke
- `ci.yml::e2e-macos-x64` — bootstrap e2e, same logic
- `ci.yml::e2e-macos-arm64` — bootstrap e2e, same logic
- `setup-soldr-action.yml::smoke` macOS matrix entry — action is YAML-only with no host-OS-specific shell differences; linux verification suffices

## Kept (verify cross-built binaries on real hardware)

- `build-macos-x64.yml::smoke-on-mac` — downloads cross-build artifact, runs `soldr --version` / `soldr doctor`
- `build-macos-arm64.yml::smoke-on-mac` — same on arm64

These two cannot be replaced by cross-compile because they verify the *runtime* behavior of the cross-built binary on actual darwin hardware. That's the coverage cross-compile fundamentally can't provide.

## Out of scope

`release-auto.yml` still ships darwin binaries from `macos-15` runners. That migration is bigger (release pipeline ships to users; needs careful verification of cross-built tarballs landing in `pip install soldr` / `npm install`) so it's tracked separately in #917.

## Test plan

- [x] `python -c 'import yaml; yaml.safe_load(open(...))'` on both modified workflow files — YAML parses clean.
- [ ] CI run on this PR — confirms the stripped jobs don't run and the rest of the workflow remains green (except the same pre-existing-on-main failures hit by #912/#913/#915).

🤖 Generated with [Claude Code](https://claude.com/claude-code)