### PR TITLE
feat(prepare): accept comma-separated --target list (image-bake friendly)

### DIFF
--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -397,12 +397,21 @@ pub(crate) enum Commands {
         long_about = "Uniform cross-compile toolchain bootstrap. Same invocation shape for every target — only `--target` varies. Internally dispatches based on the triple:\n\n  *-pc-windows-msvc:  ensure cargo-xwin + LLVM toolchain + extract the vendored xwin MSVC CRT cache from the soldr `manifest` branch into ~/.cache/cargo-xwin/ so `cargo xwin build` skips the live Microsoft download.\n  *-apple-darwin:     ensure cargo-zigbuild + zig + Apple SDK; print `SDKROOT=<path>` (and append to $GITHUB_ENV when --github-env is set).\n  *-unknown-linux-*:  ensure cargo-zigbuild + zig (when triple != host).\n  All targets:        `rustup target add <triple>`.\n\nCollapses the per-step ad-hoc downloads in `cross-compile-all-targets.yml` into a single 'Preparing Cross Compile Toolchain' step. Designed to be wrapped by `.github/actions/prepare-cross-toolchain/action.yml`."
     )]
     Prepare {
-        /// Target triple to prepare the toolchain for. Pass the
-        /// literal `all` to prepare every triple declared under
-        /// `[workspace.metadata.soldr].targets` (or
-        /// `[package.metadata.soldr].targets`) in the nearest
-        /// `Cargo.toml`. See zackees/soldr#914.
-        #[arg(long, value_name = "TRIPLE|all")]
+        /// Target triple to prepare the toolchain for. Three shapes
+        /// are accepted:
+        ///
+        ///   * a single triple, e.g. `x86_64-pc-windows-msvc`;
+        ///   * a comma-separated list, e.g.
+        ///     `x86_64-pc-windows-msvc,aarch64-apple-darwin` —
+        ///     useful for docker-image bake steps where no workspace
+        ///     `Cargo.toml` is mounted yet;
+        ///   * the literal `all` — expands to every triple declared
+        ///     under `[workspace.metadata.soldr].targets` (or
+        ///     `[package.metadata.soldr].targets`) in the nearest
+        ///     `Cargo.toml`.
+        ///
+        /// See zackees/soldr#914.
+        #[arg(long, value_name = "TRIPLE[,TRIPLE...]|all")]
         target: String,
         /// Optional path to append `KEY=VALUE` env-var lines (e.g.
         /// `SDKROOT=<path>` for darwin lanes). When running under

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -355,14 +355,20 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             save,
             restore,
         } => {
-            // `--target all` expands to every triple declared in
-            // `[workspace.metadata.soldr].targets`; any other value is
-            // passed through to a single-triple `prepare_cmd::run`. See
-            // zackees/soldr#914 for the resolution semantics.
-            let targets: Vec<String> = if target == "all" {
-                cargo_metadata_soldr::resolve_all_targets()?
-            } else {
-                vec![target]
+            // `--target` accepts three shapes — see
+            // `prepare_cmd::parse_target_arg` for the parser:
+            //   - `all`         → every triple under
+            //                     `[workspace.metadata.soldr].targets`
+            //                     (needs a workspace context — #914).
+            //   - `<a>,<b>,<c>` → an explicit comma-separated list.
+            //                     Useful for docker-image bake steps
+            //                     where no Cargo.toml is mounted yet.
+            //   - `<triple>`    → a single triple (legacy default).
+            let targets: Vec<String> = match prepare_cmd::parse_target_arg(&target)? {
+                prepare_cmd::ParsedTargetArg::All => {
+                    cargo_metadata_soldr::resolve_all_targets()?
+                }
+                prepare_cmd::ParsedTargetArg::Explicit(list) => list,
             };
             // Per-triple errors are collected so a single bad target in
             // a multi-target run doesn't hide later failures. The whole

--- a/crates/soldr-cli/src/prepare_cmd.rs
+++ b/crates/soldr-cli/src/prepare_cmd.rs
@@ -162,6 +162,45 @@ async fn ensure_xwin_cache() -> Result<PathBuf, SoldrError> {
     Ok(xwin_dir)
 }
 
+/// Parse the `--target` argument into a list of triples.
+///
+/// Accepts three shapes — see `cli_args::Commands::Prepare::target` for
+/// the user-facing documentation. The literal `all` is a sentinel that
+/// callers must expand via `cargo_metadata_soldr::resolve_all_targets`;
+/// the dispatch returns `Err(SentinelAll)` so callers branch explicitly.
+///
+/// Comma-separated entries are trimmed and empty tokens dropped; an
+/// empty effective list errors instead of silently producing a zero-
+/// target run.
+pub fn parse_target_arg(target: &str) -> Result<ParsedTargetArg, SoldrError> {
+    if target == "all" {
+        return Ok(ParsedTargetArg::All);
+    }
+    if target.contains(',') {
+        let parsed: Vec<String> = target
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if parsed.is_empty() {
+            return Err(SoldrError::Other(
+                "soldr prepare --target: comma-separated list was empty".to_string(),
+            ));
+        }
+        return Ok(ParsedTargetArg::Explicit(parsed));
+    }
+    Ok(ParsedTargetArg::Explicit(vec![target.to_string()]))
+}
+
+/// Result of parsing the `--target` CLI argument.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedTargetArg {
+    /// `--target all` — caller must resolve from `Cargo.toml`.
+    All,
+    /// One or more explicit triples (single or comma-separated form).
+    Explicit(Vec<String>),
+}
+
 /// Top-level entry point for `soldr prepare --target <triple>`.
 pub async fn run(
     target: String,
@@ -757,6 +796,66 @@ mod tests {
 
     crate::timed_test!(append_env_no_op_when_none, {
         append_env(None, "FOO", "bar").expect("no-op");
+    });
+
+    crate::timed_test!(parse_target_arg_all_is_sentinel, {
+        assert_eq!(parse_target_arg("all").unwrap(), ParsedTargetArg::All);
+    });
+
+    crate::timed_test!(parse_target_arg_single_triple, {
+        let got = parse_target_arg("x86_64-unknown-linux-gnu").unwrap();
+        assert_eq!(
+            got,
+            ParsedTargetArg::Explicit(vec!["x86_64-unknown-linux-gnu".into()])
+        );
+    });
+
+    crate::timed_test!(parse_target_arg_comma_separated, {
+        let got = parse_target_arg(
+            "x86_64-pc-windows-msvc,aarch64-apple-darwin,x86_64-unknown-linux-musl",
+        )
+        .unwrap();
+        assert_eq!(
+            got,
+            ParsedTargetArg::Explicit(vec![
+                "x86_64-pc-windows-msvc".into(),
+                "aarch64-apple-darwin".into(),
+                "x86_64-unknown-linux-musl".into(),
+            ])
+        );
+    });
+
+    crate::timed_test!(parse_target_arg_trims_whitespace, {
+        let got = parse_target_arg(" x86_64-pc-windows-msvc , aarch64-apple-darwin ").unwrap();
+        assert_eq!(
+            got,
+            ParsedTargetArg::Explicit(vec![
+                "x86_64-pc-windows-msvc".into(),
+                "aarch64-apple-darwin".into(),
+            ])
+        );
+    });
+
+    crate::timed_test!(parse_target_arg_drops_empty_entries, {
+        // Leading / trailing / consecutive commas are silently dropped
+        // because they're a common copy-paste mistake. The error path
+        // covers the "every entry was empty" case below.
+        let got = parse_target_arg(",x86_64-pc-windows-msvc,,aarch64-apple-darwin,").unwrap();
+        assert_eq!(
+            got,
+            ParsedTargetArg::Explicit(vec![
+                "x86_64-pc-windows-msvc".into(),
+                "aarch64-apple-darwin".into(),
+            ])
+        );
+    });
+
+    crate::timed_test!(parse_target_arg_all_empty_errors, {
+        let err = parse_target_arg(", , ,").unwrap_err();
+        assert!(
+            err.to_string().contains("comma-separated list was empty"),
+            "unexpected error: {err}"
+        );
     });
 
     crate::timed_test!(classify_target_windows_msvc, {


### PR DESCRIPTION
## Summary
`soldr prepare --target all` requires a workspace `Cargo.toml` with `[workspace.metadata.soldr].targets` populated. Docker-image bake steps don't have one mounted yet — the source volume is mounted at `docker run` time, not at `docker build` time.

Extend `--target` to accept three shapes:
- `<triple>` — single triple (unchanged)
- `<a>,<b>,<c>` — explicit comma-separated list (**new**)
- `all` — workspace-metadata resolution (unchanged)

## Why this matters

The new comma-separated form lets a Dockerfile bake the full cross-toolchain into the image without inventing a placeholder Cargo.toml:

```dockerfile
RUN soldr prepare --target \
      x86_64-pc-windows-msvc,aarch64-apple-darwin,x86_64-unknown-linux-musl,...
```

That's exactly what the upcoming `examples/docker-cross-all/` recipe (#924) needs — it has no source volume mounted at image bake time.

## Implementation

- Parsing in `prepare_cmd::parse_target_arg` returns `ParsedTargetArg::All` or `ParsedTargetArg::Explicit(Vec<String>)`.
- `main.rs` dispatches on the enum: `All` → `resolve_all_targets()`, `Explicit` → use as-is.
- Whitespace around comma-separated entries is trimmed; leading / trailing / consecutive commas are silently dropped (copy-paste tolerance); an all-empty list errors instead of producing a zero-target run.

## Tests

Six new unit tests cover the parser. Existing CLI surface unchanged; the legacy single-triple and `all` shapes pass through identical to before.

```
running 6 tests
test prepare_cmd::tests::parse_target_arg_all_is_sentinel ... ok
test prepare_cmd::tests::parse_target_arg_single_triple ... ok
test prepare_cmd::tests::parse_target_arg_drops_empty_entries ... ok
test prepare_cmd::tests::parse_target_arg_comma_separated ... ok
test prepare_cmd::tests::parse_target_arg_trims_whitespace ... ok
test prepare_cmd::tests::parse_target_arg_all_empty_errors ... ok
```

Refs zackees/soldr#914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)