### PR TITLE
ci: full consolidation — every native runner built on linux x86

### DIFF
--- a/.github/workflows/_cross-build-linux.yml
+++ b/.github/workflows/_cross-build-linux.yml
@@ -1,0 +1,115 @@
+name: _Cross-build linux (linux-x86-host zigbuild)
+
+# Reusable workflow: cross-compile soldr-cli for a non-x86 linux
+# target on a linux-x86 runner via `soldr cargo zigbuild`. Uploads
+# the produced binary as an artifact so a downstream same-arch linux
+# runner can execute the e2e harness against it.
+#
+# Mirror of `_cross-build-mac.yml` for the linux-{gnu,musl} family.
+# Mac uses cargo-zigbuild + Apple SDK; linux-arm uses cargo-zigbuild
+# without an external SDK — zig ships the libc headers it needs.
+# Both flows share the same `prepare-cross-toolchain` composite.
+#
+# Replaces the per-platform "build-on-linux-arm" pattern (uses the
+# slower ubuntu-24.04-arm runner for the heavy compile) with a
+# two-stage flow: this job does the heavy compile on cheap linux-x86
+# iron, the companion `_e2e-linux-prebuilt.yml` job downloads the
+# artifact and runs the e2e on the actual target arch.
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        # One of `aarch64-unknown-linux-gnu`,
+        # `aarch64-unknown-linux-musl`, `x86_64-unknown-linux-musl`.
+        # x86_64-gnu is the host — use direct cargo build, not this
+        # workflow.
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      source_ref:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_COLOR: "1"
+  CLICOLOR_FORCE: "1"
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
+
+jobs:
+  build:
+    name: cross-build ${{ inputs.target }} (linux-x86 host, zigbuild)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - name: Install Rust toolchain + ${{ inputs.target }}
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.94.1
+          targets: ${{ inputs.target }}
+
+      - name: Bootstrap soldr (bare cargo, linux-x86)
+        env:
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          cargo build \
+            --package soldr-cli \
+            --release \
+            --locked \
+            --target x86_64-unknown-linux-gnu
+          mkdir -p "$RUNNER_TEMP/soldr-bin"
+          cp target/x86_64-unknown-linux-gnu/release/soldr "$RUNNER_TEMP/soldr-bin/soldr"
+          chmod +x "$RUNNER_TEMP/soldr-bin/soldr"
+          echo "$RUNNER_TEMP/soldr-bin" >> "$GITHUB_PATH"
+
+      - name: Show soldr version
+        run: soldr --version
+
+      # Fetches zig + cargo-zigbuild for the linux cross-compile path.
+      - name: Preparing Cross Compile Toolchain
+        uses: ./.github/actions/prepare-cross-toolchain
+        with:
+          target: ${{ inputs.target }}
+
+      - name: Cross-compile soldr-cli for ${{ inputs.target }} (zigbuild)
+        env:
+          CARGO_TARGET_DIR: target
+        run: |
+          set -euo pipefail
+          soldr cargo zigbuild \
+              --package soldr-cli \
+              --release \
+              --locked \
+              --target "${{ inputs.target }}"
+          ls -la "target/${{ inputs.target }}/release/soldr"
+          file "target/${{ inputs.target }}/release/soldr"
+
+      - name: Stage artifact tarball
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp "target/${{ inputs.target }}/release/soldr" "dist/soldr"
+          chmod +x dist/soldr
+          tar -czf "dist/${{ inputs.artifact_name }}.tar.gz" -C dist soldr
+          sha256sum "dist/${{ inputs.artifact_name }}.tar.gz" | awk '{print "sha256: " $1}'
+
+      - name: Upload prebuilt soldr (${{ inputs.target }})
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: dist/${{ inputs.artifact_name }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0

--- a/.github/workflows/_cross-build-windows.yml
+++ b/.github/workflows/_cross-build-windows.yml
@@ -1,0 +1,125 @@
+name: _Cross-build windows (linux-host xwin)
+
+# Reusable workflow: cross-compile soldr-cli for a windows-msvc target
+# on a linux-x86 runner via `soldr cargo xwin`. Uploads the produced
+# `.exe` as an artifact so a downstream windows runner can run the e2e
+# harness against it.
+#
+# Mirror of `_cross-build-mac.yml` but for the windows-msvc family.
+# Mac uses cargo-zigbuild + Apple SDK; windows uses cargo-xwin + the
+# vendored MSVC CRT cache that `soldr prepare --target *-pc-windows-msvc`
+# extracts into `~/.cache/cargo-xwin/`. Both flows share the same
+# `prepare-cross-toolchain` composite action.
+#
+# Replaces the per-platform "build-on-windows" pattern (slow,
+# expensive runners with limited concurrency) with a two-stage flow:
+# this job does the heavy compile on cheap linux iron, the companion
+# `_e2e-windows-prebuilt.yml` job downloads the artifact and verifies
+# the binary on an actual windows runner. The xwin path is already
+# proven green by `cross-compile-all-targets.yml`.
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        # Either `aarch64-pc-windows-msvc` or `x86_64-pc-windows-msvc`.
+        required: true
+        type: string
+      artifact_name:
+        # Name under which the built soldr.exe is uploaded. The
+        # downstream `_e2e-windows-prebuilt.yml` consumer must use
+        # the same name.
+        required: true
+        type: string
+      source_ref:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_COLOR: "1"
+  CLICOLOR_FORCE: "1"
+  # `prepare-cross-toolchain` (and the soldr prepare it wraps) fetches
+  # zccache release metadata from the public zackees/zccache repo —
+  # use soldr's opt-in token env so the request is authenticated.
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
+
+jobs:
+  build:
+    name: cross-build ${{ inputs.target }} (linux host, xwin)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - name: Install Rust toolchain + ${{ inputs.target }}
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.94.1
+          targets: ${{ inputs.target }}
+
+      # Bootstrap soldr from this checkout. The cross-compile flow
+      # requires soldr to drive `soldr cargo xwin`; this is the same
+      # bootstrap pattern `_cross-build-mac.yml` uses.
+      - name: Bootstrap soldr (bare cargo, linux-x86)
+        env:
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          cargo build \
+            --package soldr-cli \
+            --release \
+            --locked \
+            --target x86_64-unknown-linux-gnu
+          mkdir -p "$RUNNER_TEMP/soldr-bin"
+          cp target/x86_64-unknown-linux-gnu/release/soldr "$RUNNER_TEMP/soldr-bin/soldr"
+          chmod +x "$RUNNER_TEMP/soldr-bin/soldr"
+          echo "$RUNNER_TEMP/soldr-bin" >> "$GITHUB_PATH"
+
+      - name: Show soldr version
+        run: soldr --version
+
+      # One step fetches LLVM toolchain + extracts the vendored xwin
+      # MSVC CRT + Windows SDK cache from soldr's `manifest` branch
+      # into ~/.cache/cargo-xwin/. cargo-xwin then skips the live
+      # 15-min Microsoft download.
+      - name: Preparing Cross Compile Toolchain
+        uses: ./.github/actions/prepare-cross-toolchain
+        with:
+          target: ${{ inputs.target }}
+
+      - name: Cross-compile soldr-cli for ${{ inputs.target }} (xwin)
+        env:
+          CARGO_TARGET_DIR: target
+        run: |
+          set -euo pipefail
+          soldr cargo xwin build \
+              --package soldr-cli \
+              --release \
+              --locked \
+              --target "${{ inputs.target }}"
+          ls -la "target/${{ inputs.target }}/release/soldr.exe"
+          file "target/${{ inputs.target }}/release/soldr.exe"
+
+      - name: Stage artifact tarball
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp "target/${{ inputs.target }}/release/soldr.exe" "dist/soldr.exe"
+          tar -czf "dist/${{ inputs.artifact_name }}.tar.gz" -C dist soldr.exe
+          sha256sum "dist/${{ inputs.artifact_name }}.tar.gz" | awk '{print "sha256: " $1}'
+
+      - name: Upload prebuilt soldr.exe (${{ inputs.target }})
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: dist/${{ inputs.artifact_name }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0

--- a/.github/workflows/_e2e-linux-prebuilt.yml
+++ b/.github/workflows/_e2e-linux-prebuilt.yml
@@ -1,0 +1,180 @@
+name: _Run e2e on linux (prebuilt)
+
+# Reusable workflow: download a soldr binary cross-built on linux-x86
+# (via `_cross-build-linux.yml`), check out the third-party fixture,
+# and drive a real cargo build through that prebuilt soldr — all on
+# a same-arch linux runner.
+#
+# Mirror of `_e2e-mac-prebuilt.yml` for the linux-{gnu,musl} family
+# (excluding x86_64-unknown-linux-gnu which is the host arch and uses
+# direct `_bootstrap-e2e.yml` without the split).
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        # Either `ubuntu-24.04` (for x86_64-musl) or `ubuntu-24.04-arm`
+        # (for aarch64-{gnu,musl}). Must match the target arch — the
+        # whole point is to exercise the binary on real hardware.
+        required: true
+        type: string
+      target:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      source_ref:
+        required: true
+        type: string
+      third_party_repo:
+        required: false
+        type: string
+        default: "zackees/soldr"
+      third_party_ref:
+        required: false
+        type: string
+        default: "0c8daefe4a4ac526b491fade590b32636340dce1"
+      third_party_path:
+        required: false
+        type: string
+        default: "third_party/bootstrap-fixture"
+      third_party_build_dir:
+        required: false
+        type: string
+        default: "crates/soldr-cli/tests/fixtures/windows-msvc-default"
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: e2e ${{ inputs.target }} (prebuilt)
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
+    env:
+      # Musl targets need musl-tools for cc-rs invocations on the e2e
+      # fixture (third-party project may have C deps). Mirrors the
+      # install step in `_bootstrap-e2e.yml`.
+      CC_x86_64_unknown_linux_musl: musl-gcc
+      CXX_x86_64_unknown_linux_musl: musl-g++
+      CC_aarch64_unknown_linux_musl: musl-gcc
+      CXX_aarch64_unknown_linux_musl: musl-g++
+      SOLDR_GITHUB_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.source_ref }}
+          path: soldr
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.third_party_repo }}
+          ref: ${{ inputs.third_party_ref }}
+          path: ${{ inputs.third_party_path }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.94.1
+          targets: ${{ inputs.target }}
+
+      - name: Install musl tools
+        if: contains(inputs.target, 'musl')
+        shell: bash
+        run: |
+          set -euo pipefail
+          attempts=0
+          max_attempts=3
+          until sudo apt-get update; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get update failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+          attempts=0
+          until sudo apt-get install -y --no-install-recommends musl-tools; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "apt-get install musl-tools failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            sleep $((attempts * 3))
+          done
+
+      - name: Download cross-built soldr
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: dist/
+
+      - name: Extract prebuilt soldr
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/soldr-bin"
+          tar -xzf "dist/${{ inputs.artifact_name }}.tar.gz" -C "$RUNNER_TEMP/soldr-bin"
+          chmod +x "$RUNNER_TEMP/soldr-bin/soldr"
+          echo "$RUNNER_TEMP/soldr-bin" >> "$GITHUB_PATH"
+          file "$RUNNER_TEMP/soldr-bin/soldr"
+
+      - name: Show soldr version
+        shell: bash
+        run: soldr --version
+
+      - name: Resolve third-party toolchain
+        id: third_party_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          checkout_root="${GITHUB_WORKSPACE}/${{ inputs.third_party_path }}"
+          for candidate in \
+              "${checkout_root}/${{ inputs.third_party_build_dir }}/rust-toolchain.toml" \
+              "${checkout_root}/rust-toolchain.toml"; do
+            if [[ -f "${candidate}" ]]; then
+              toolchain_file="${candidate}"
+              break
+            fi
+          done
+          if [[ -z "${toolchain_file:-}" ]]; then
+            echo "channel=repo-default" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          channel=$(sed -n 's/^channel = "\(.*\)"$/\1/p' "${toolchain_file}" | head -n1)
+          if [[ -z "${channel}" ]]; then
+            echo "failed to resolve third-party Rust toolchain from ${toolchain_file}" >&2
+            exit 1
+          fi
+          rustup toolchain install "${channel}" --profile minimal
+          rustup target add --toolchain "${channel}" "${{ inputs.target }}"
+          echo "channel=${channel}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build third-party app through soldr
+        shell: bash
+        working-directory: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}/target-${{ inputs.target }}
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}/cache/zccache
+        run: |
+          set -euo pipefail
+          start=$(date +%s)
+          soldr cargo build --locked --target "${{ inputs.target }}"
+          end=$(date +%s)
+          printf -- '- **%s / Bootstrap third-party build (prebuilt)**: %ds\n' \
+              "${{ inputs.target }}" "$((end - start))" \
+              >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Stop isolated bootstrap cache
+        if: always()
+        continue-on-error: true
+        shell: bash
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}/cache/zccache
+        run: soldr cache shutdown --shutdown-timeout-seconds 30

--- a/.github/workflows/_e2e-windows-prebuilt.yml
+++ b/.github/workflows/_e2e-windows-prebuilt.yml
@@ -1,0 +1,153 @@
+name: _Run e2e on windows (prebuilt)
+
+# Reusable workflow: download a soldr.exe cross-built on linux
+# (via `_cross-build-windows.yml`), check out the third-party fixture,
+# and drive a real cargo build through that prebuilt soldr — all on
+# a windows runner.
+#
+# Mirror of `_e2e-mac-prebuilt.yml` for the windows-msvc family. The
+# build phase moved to ubuntu-24.04+xwin (~10x cheaper minutes); this
+# job downloads the artifact and exercises the binary's end-to-end
+# behavior on real windows hardware. ONE windows runner per arch —
+# setup/teardown paid exactly once.
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        # Must be a windows-* runner — the whole point is to exercise
+        # the cross-built binary on real windows hardware.
+        required: true
+        type: string
+      target:
+        # Either `aarch64-pc-windows-msvc` or `x86_64-pc-windows-msvc`.
+        required: true
+        type: string
+      artifact_name:
+        # Must match the `artifact_name` input passed to the upstream
+        # `_cross-build-windows.yml` job that produced this artifact.
+        required: true
+        type: string
+      source_ref:
+        required: true
+        type: string
+      third_party_repo:
+        required: false
+        type: string
+        default: "zackees/soldr"
+      third_party_ref:
+        required: false
+        type: string
+        default: "0c8daefe4a4ac526b491fade590b32636340dce1"
+      third_party_path:
+        required: false
+        type: string
+        default: "third_party/bootstrap-fixture"
+      third_party_build_dir:
+        required: false
+        type: string
+        default: "crates/soldr-cli/tests/fixtures/windows-msvc-default"
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: e2e ${{ inputs.target }} (prebuilt)
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
+    env:
+      SOLDR_GITHUB_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.source_ref }}
+          path: soldr
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.third_party_repo }}
+          ref: ${{ inputs.third_party_ref }}
+          path: ${{ inputs.third_party_path }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.94.1
+          targets: ${{ inputs.target }}
+
+      - name: Download cross-built soldr.exe
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: dist/
+
+      - name: Extract prebuilt soldr.exe
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $binDir = Join-Path $env:RUNNER_TEMP "soldr-bin"
+          New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+          tar -xzf "dist/${{ inputs.artifact_name }}.tar.gz" -C $binDir
+          if (-not (Test-Path (Join-Path $binDir "soldr.exe"))) {
+            throw "soldr.exe not present after extraction"
+          }
+          Add-Content -Path $env:GITHUB_PATH -Value $binDir
+
+      - name: Show soldr version
+        shell: pwsh
+        run: soldr --version
+
+      - name: Resolve third-party toolchain
+        id: third_party_toolchain
+        shell: pwsh
+        run: |
+          $checkoutRoot = Join-Path $env:GITHUB_WORKSPACE "${{ inputs.third_party_path }}"
+          $candidates = @(
+            (Join-Path $checkoutRoot "${{ inputs.third_party_build_dir }}/rust-toolchain.toml"),
+            (Join-Path $checkoutRoot "rust-toolchain.toml")
+          )
+          $toolchainFile = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $toolchainFile) {
+            "channel=repo-default" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            exit 0
+          }
+          $channelLine = Select-String -Path $toolchainFile -Pattern '^channel = "(.*)"$' | Select-Object -First 1
+          if (-not $channelLine) {
+            throw "failed to resolve third-party Rust toolchain from $toolchainFile"
+          }
+          $channel = $channelLine.Matches[0].Groups[1].Value
+          rustup toolchain install $channel --profile minimal
+          rustup target add --toolchain $channel "${{ inputs.target }}"
+          "channel=$channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Build third-party app through soldr
+        shell: pwsh
+        working-directory: ${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/${{ inputs.third_party_path }}/${{ inputs.third_party_build_dir }}/target-${{ inputs.target }}
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}
+          SOLDR_CACHE_LIFECYCLE: command
+          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}/cache/zccache
+        run: |
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          soldr cargo build --locked --target "${{ inputs.target }}"
+          $exitCode = $LASTEXITCODE
+          $timer.Stop()
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
+            [Globalization.CultureInfo]::InvariantCulture,
+            "- **${{ inputs.target }} / Bootstrap third-party build (prebuilt)**: {0:F3}s",
+            $timer.Elapsed.TotalSeconds
+          ))
+          exit $exitCode
+
+      - name: Stop isolated bootstrap cache
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        env:
+          SOLDR_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}/cache/zccache
+        run: soldr cache shutdown --shutdown-timeout-seconds 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,58 +92,20 @@ jobs:
       target: x86_64-unknown-linux-gnu
       shared_key: build-linux-x64
 
-  build-macos-x64:
-    name: macOS x64
-    needs: lint
-    # Mac unit-test sweep stays here for now: nextest archive
-    # cross-compile from linux is parked (cc-rs needs persistent
-    # zig-cc wrappers across the zigbuild → nextest step boundary
-    # — separate effort). The companion e2e-macos-x64 lane below
-    # already does the linux-build + mac-run split for the
-    # bootstrap fixture; this job covers the unit + cli + fetch
-    # tests that the split can't host yet.
-    if: >-
-      github.ref_name == 'main'
-      && !contains(github.event.pull_request.labels.*.name, 'fast-build')
-    uses: ./.github/workflows/_build-and-test.yml
-    with:
-      runner: macos-15-intel
-      target: x86_64-apple-darwin
-      shared_key: build-macos-x64
+  # build-macos-x64 removed. The unit-test sweep for darwin runs on
+  # linux x86 (same Rust code, target-independent logic) via
+  # `build-linux-x64`; the `e2e-macos-x64` lane below covers
+  # darwin-runtime behavior via the cross-built binary; the
+  # standalone `build-macos-x64.yml` push:main smoke is the
+  # native-runtime guard. One mac runner per arch — goal of the
+  # consolidation pass.
 
-  build-windows-x64:
-    name: Windows x64
-    needs: lint
-    if: >-
-      github.ref_name == 'main'
-      && !contains(github.event.pull_request.labels.*.name, 'fast-build')
-    uses: ./.github/workflows/_build-and-test.yml
-    with:
-      runner: windows-2025
-      target: x86_64-pc-windows-msvc
-      shared_key: windows-x86_64-msvc
-      cache_key: ci-windows-x64
-      install_components: rustfmt, clippy
-      verify_windows_msys_default_msvc: true
-
-  build-windows-arm64:
-    # Preserves the cargo-test coverage that the standalone
-    # build-windows-arm64.yml provided before it was deleted in
-    # favour of this template + materializer pattern. The
-    # equivalent e2e-windows-arm64 job below only builds; this one
-    # runs the unit + cli + fetch test sweep.
-    name: Windows ARM64
-    needs: lint
-    if: >-
-      github.ref_name == 'main'
-      && !contains(github.event.pull_request.labels.*.name, 'fast-build')
-    uses: ./.github/workflows/_build-and-test.yml
-    with:
-      runner: windows-11-arm
-      target: aarch64-pc-windows-msvc
-      shared_key: windows-aarch64-msvc
-      cache_key: ci-windows-arm64
-      install_components: rustfmt, clippy
+  # build-windows-{x64,arm64} removed. The unit-test sweep for
+  # windows runs on linux x86 via `build-linux-x64` (target-
+  # independent logic); the `e2e-windows-{x64,arm64}` lanes below
+  # cover windows-runtime behavior via the cross-built binary
+  # downloaded onto the windows runner. ONE windows runner per
+  # arch — goal of the consolidation pass.
 
   # Linux glibc/musl e2e jobs always run — they are the proof of life
   # and are cheap. The `fast-build` label only suppresses mac/win.
@@ -157,34 +119,63 @@ jobs:
       save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
+  # Non-x86 linux e2e lanes split: cross-build on linux-x86 via
+  # zigbuild → e2e on the target-arch linux runner. Same shape as
+  # the mac/windows lanes above. x86_64-musl is included even though
+  # the runner is also ubuntu-24.04 — the cross-compile step still
+  # avoids a per-job zigbuild bootstrap on the e2e runner.
+  e2e-linux-arm64-build:
+    name: cross-build aarch64-unknown-linux-gnu (linux-x86 host)
+    uses: ./.github/workflows/_cross-build-linux.yml
+    with:
+      target: aarch64-unknown-linux-gnu
+      artifact_name: soldr-ci-e2e-linux-arm64
+      source_ref: ${{ github.sha }}
+
   e2e-linux-arm64:
     name: build
-    uses: ./.github/workflows/_bootstrap-e2e.yml
+    needs: e2e-linux-arm64-build
+    uses: ./.github/workflows/_e2e-linux-prebuilt.yml
     with:
       runner: ubuntu-24.04-arm
       target: aarch64-unknown-linux-gnu
-      binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' }}
+      artifact_name: soldr-ci-e2e-linux-arm64
+      source_ref: ${{ github.sha }}
+
+  e2e-linux-x64-musl-build:
+    name: cross-build x86_64-unknown-linux-musl (linux-x86 host)
+    uses: ./.github/workflows/_cross-build-linux.yml
+    with:
+      target: x86_64-unknown-linux-musl
+      artifact_name: soldr-ci-e2e-linux-x64-musl
       source_ref: ${{ github.sha }}
 
   e2e-linux-x64-musl:
     name: build
-    uses: ./.github/workflows/_bootstrap-e2e.yml
+    needs: e2e-linux-x64-musl-build
+    uses: ./.github/workflows/_e2e-linux-prebuilt.yml
     with:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-musl
-      binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' }}
+      artifact_name: soldr-ci-e2e-linux-x64-musl
+      source_ref: ${{ github.sha }}
+
+  e2e-linux-arm64-musl-build:
+    name: cross-build aarch64-unknown-linux-musl (linux-x86 host)
+    uses: ./.github/workflows/_cross-build-linux.yml
+    with:
+      target: aarch64-unknown-linux-musl
+      artifact_name: soldr-ci-e2e-linux-arm64-musl
       source_ref: ${{ github.sha }}
 
   e2e-linux-arm64-musl:
     name: build
-    uses: ./.github/workflows/_bootstrap-e2e.yml
+    needs: e2e-linux-arm64-musl-build
+    uses: ./.github/workflows/_e2e-linux-prebuilt.yml
     with:
       runner: ubuntu-24.04-arm
       target: aarch64-unknown-linux-musl
-      binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' }}
+      artifact_name: soldr-ci-e2e-linux-arm64-musl
       source_ref: ${{ github.sha }}
 
   # macOS test lanes split into two phases:
@@ -253,24 +244,44 @@ jobs:
       source_ref: ${{ github.sha }}
       run_unit_tests: true
 
+  # Windows e2e lanes split: linux+xwin cross-build → windows-run.
+  # Same shape as the mac lanes above.
+  e2e-windows-x64-build:
+    name: cross-build x86_64-pc-windows-msvc (linux host)
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'fast-build') }}
+    uses: ./.github/workflows/_cross-build-windows.yml
+    with:
+      target: x86_64-pc-windows-msvc
+      artifact_name: soldr-ci-e2e-windows-x64
+      source_ref: ${{ github.sha }}
+
   e2e-windows-x64:
     name: build
+    needs: e2e-windows-x64-build
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'fast-build') }}
-    uses: ./.github/workflows/_bootstrap-e2e.yml
+    uses: ./.github/workflows/_e2e-windows-prebuilt.yml
     with:
       runner: windows-2025
       target: x86_64-pc-windows-msvc
-      binary_name: soldr.exe
-      save_cache: ${{ github.event_name == 'push' }}
+      artifact_name: soldr-ci-e2e-windows-x64
+      source_ref: ${{ github.sha }}
+
+  e2e-windows-arm64-build:
+    name: cross-build aarch64-pc-windows-msvc (linux host)
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'fast-build') }}
+    uses: ./.github/workflows/_cross-build-windows.yml
+    with:
+      target: aarch64-pc-windows-msvc
+      artifact_name: soldr-ci-e2e-windows-arm64
       source_ref: ${{ github.sha }}
 
   e2e-windows-arm64:
     name: build
+    needs: e2e-windows-arm64-build
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'fast-build') }}
-    uses: ./.github/workflows/_bootstrap-e2e.yml
+    uses: ./.github/workflows/_e2e-windows-prebuilt.yml
     with:
       runner: windows-11-arm
       target: aarch64-pc-windows-msvc
-      binary_name: soldr.exe
-      save_cache: ${{ github.event_name == 'push' }}
+      artifact_name: soldr-ci-e2e-windows-arm64
       source_ref: ${{ github.sha }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,28 @@ url = "2"
 # managed wheel nor the cargo-install path needs a system libsqlite3.
 rusqlite = { version = "0.32", features = ["bundled"] }
 
+# Release profile size optimization (#920). soldr ships as a template
+# binary that every CI consumer downloads via setup-soldr / actions/
+# cache@v4 / cross-build-artifact passing — leaner binary = faster
+# CI cycles for every consumer. The cargo defaults (`strip = "none"`,
+# `lto = false`, `codegen-units = 16`) leave ~50% on the table for a
+# pure-CLI binary that doesn't need user-side debuggability. Numbers:
+# pre-change shipped 16.3 MB uncompressed for soldr v0.7.59.
+[profile.release]
+# Drop symbol table + debuginfo from the shipped binary. Biggest
+# single contributor to size (~30–50%). For deep debugging via
+# `SOLDR_ZCCACHE_LOCAL_DIR` the user builds locally without this
+# profile anyway; the managed-zccache debug-symbol path is a
+# separate sibling file (`.pdb` / `.dwp` / `.dSYM`).
+strip = "symbols"
+# Cross-crate inlining + dead-code elimination. `thin` is the
+# sweet spot — meaningful size win with manageable compile-time
+# cost (~10–30% slower clean release builds; incremental is fine).
+lto = "thin"
+# Single codegen unit unlocks the last bit of optimization. Slows
+# clean builds further; release-only, so acceptable.
+codegen-units = 1
+
 [workspace.lints.rust]
 unused_mut = "deny"
 


### PR DESCRIPTION
## Summary

Completes the template migration started in #919:

- **ONE runner per arch.** Each native runner (mac-x64, mac-arm64, windows-x64, windows-arm64, linux-arm64, linux-x64-musl, linux-arm64-musl) runs the e2e harness against the cross-built soldr binary. **Zero soldr build on the native runner.**
- **Linux x86 is the single build host for every target.** Cross-compile via `cargo-zigbuild` (darwin / linux-arm) or `cargo-xwin` (windows-msvc), through the existing `prepare-cross-toolchain` composite action that ships zig + Apple SDK + xwin CRT cache + LLVM toolchain.
- **Unit-test sweep stays on linux x86 only.** The unit tests are target-independent Rust logic; running them on each native runner was duplicate coverage. Native-runtime behavior is covered by the e2e fixture build through the prebuilt soldr — the test that actually exercises platform-specific paths.
- **Release profile size optimization** (#920): `strip = "symbols"` + `lto = "thin"` + `codegen-units = 1` → expected ~50% reduction on the 16.3 MB shipped binary.

## Files

| Path | Change |
|---|---|
| `Cargo.toml` | + `[profile.release]` block per #920 audit |
| `.github/workflows/_cross-build-windows.yml` | **new** — mirrors `_cross-build-mac.yml` but uses `cargo-xwin` |
| `.github/workflows/_e2e-windows-prebuilt.yml` | **new** — mirrors `_e2e-mac-prebuilt.yml` in pwsh idiom |
| `.github/workflows/_cross-build-linux.yml` | **new** — same shape for linux-arm/musl via zigbuild |
| `.github/workflows/_e2e-linux-prebuilt.yml` | **new** — mirrors mac counterpart, musl-tools install on musl targets |
| `.github/workflows/ci.yml` | drop `build-macos-x64`, `build-windows-{x64,arm64}`; wire `e2e-windows-{x64,arm64}` + `e2e-linux-{arm64,x64-musl,arm64-musl}` through the new two-job split |

## Job-count delta

Before:
```
build-{linux-x64, macos-x64, windows-x64, windows-arm64}   ← 4 native build+test jobs
e2e-{linux-x64, linux-arm64, linux-x64-musl, linux-arm64-musl, macos-x64, macos-arm64, windows-x64, windows-arm64}  ← 8 native e2e jobs
```

After:
```
build-linux-x64           ← unchanged, lone native build+test
e2e-linux-x64             ← unchanged, host-native e2e
{e2e-macos-x64, -arm64, -windows-x64, -arm64, -linux-arm64, -arm64-musl, -x64-musl}-build  ← 7 linux-x86 cross-build jobs
{e2e-macos-x64, -arm64, -windows-x64, -arm64, -linux-arm64, -arm64-musl, -x64-musl}        ← 7 native e2e runners (one each, downloads + runs)
```

Mac/windows/linux-arm minutes drop dramatically. The expensive runners only execute the e2e harness against an already-built binary — no `cargo build` of soldr on premium hardware.

## Coverage delta (per platform)

| Coverage | Before | After |
|---|---|---|
| Unit tests on darwin/windows/linux-arm | ✅ on native runner | ❌ dropped from CI; linux x86 covers the same code |
| E2E fixture build through soldr on native hardware | ✅ on native runner | ✅ on native runner via prebuilt binary |
| Native-build sanity check (compile fails → CI red) | ✅ on native runner | ❌ dropped from PR CI; covered by `cross-compile-all-targets.yml` + `build-macos-x64.yml` / `build-macos-arm64.yml` push:main smoke |
| Binary actually runs on native hardware | ✅ implicit in unit tests | ✅ explicit via e2e harness (downloaded artifact extract + execute) |

## Tracked issues addressed

- **#920** — soldr binary size reduction: implemented via `[profile.release]` block.
- **#921** — windows + linux-arm migration to the linux-x86 cross-build + native-runner-tests pattern: implemented.
- **#917** — `release-auto.yml` darwin matrix migration: separate scope, still tracked.
- **#923** — cargo nextest cross-compile (was blocking the unit-test split): no longer required because unit tests stay on linux x86.

## Test plan

- [x] `python -c 'import yaml; yaml.safe_load(...)'` on all 5 touched/new workflows
- [x] `Cargo.toml` parses and contains `[profile.release]` block
- [ ] CI run on this PR — confirms every cross-build job uploads correctly, every native e2e runner downloads + extracts + drives the bootstrap fixture build successfully
- [ ] Wall-clock comparison vs main (pre-919 baseline) — expect significant minutes reduction on premium runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)