### PR TITLE
manifest: add python + node tool registrations (closes #931, #932, #933, #944)

### DIFF
--- a/asset-index.json
+++ b/asset-index.json
@@ -2744,6 +2744,102 @@
       "asset": "zccache-v1.4.0-x86_64-unknown-linux-musl.tar.gz",
       "url": "https://github.com/zackees/zccache/releases/download/v1.4.0/zccache-v1.4.0-x86_64-unknown-linux-musl.tar.gz",
       "sha256": "e2d6a0dec2e95ec7af02d54ced1546b7d014f1e7c0b61015f88f04aa5dc4e294"
+    },
+    {
+      "owner": "astral-sh",
+      "repo": "python-build-standalone",
+      "tag": "20260610",
+      "asset": "cpython-3.13.14+20260610-x86_64-pc-windows-msvc-install_only.tar.gz",
+      "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-pc-windows-msvc-install_only.tar.gz",
+      "sha256": "9a77f87ec431f16e79fc7e90d9115edf187d18b64100b6f6c27189f419fd79be"
+    },
+    {
+      "owner": "astral-sh",
+      "repo": "python-build-standalone",
+      "tag": "20260610",
+      "asset": "cpython-3.13.14+20260610-aarch64-pc-windows-msvc-install_only.tar.gz",
+      "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-pc-windows-msvc-install_only.tar.gz",
+      "sha256": "7146b88d4b8fcd2f7154f516dee051b0891536bf48a1c2fe625a540c7bc06be6"
+    },
+    {
+      "owner": "astral-sh",
+      "repo": "python-build-standalone",
+      "tag": "20260610",
+      "asset": "cpython-3.13.14+20260610-x86_64-apple-darwin-install_only.tar.gz",
+      "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-apple-darwin-install_only.tar.gz",
+      "sha256": "592d3d807a493e4e21dbc972f81d1b2ece6381a7e687bcf0da68555a1282d49a"
+    },
+    {
+      "owner": "astral-sh",
+      "repo": "python-build-standalone",
+      "tag": "20260610",
+      "asset": "cpython-3.13.14+20260610-aarch64-apple-darwin-install_only.tar.gz",
+      "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-apple-darwin-install_only.tar.gz",
+      "sha256": "0e255968ed96255df59b6bc9504545260c11de3171e48f7640668d88154945ba"
+    },
+    {
+      "owner": "astral-sh",
+      "repo": "python-build-standalone",
+      "tag": "20260610",
+      "asset": "cpython-3.13.14+20260610-x86_64-unknown-linux-gnu-install_only.tar.gz",
+      "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-unknown-linux-gnu-install_only.tar.gz",
+      "sha256": "31ebbb024fecb446d7f25a5b59ca1d4955597ca3f5b4b76f55b30a8987eb61c9"
+    },
+    {
+      "owner": "astral-sh",
+      "repo": "python-build-standalone",
+      "tag": "20260610",
+      "asset": "cpython-3.13.14+20260610-aarch64-unknown-linux-gnu-install_only.tar.gz",
+      "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-unknown-linux-gnu-install_only.tar.gz",
+      "sha256": "fe5b366ecf26fe565113b195a03ea18d7030f2dab691c0bed41cf19318100be2"
+    },
+    {
+      "owner": "astral-sh",
+      "repo": "python-build-standalone",
+      "tag": "20260610",
+      "asset": "cpython-3.13.14+20260610-x86_64-unknown-linux-musl-install_only.tar.gz",
+      "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-unknown-linux-musl-install_only.tar.gz",
+      "sha256": "14ff3ae99951784204ea2528d0b1c8442c7c6f1e78ab27e5ea05cfd9a0b27ced"
+    },
+    {
+      "owner": "astral-sh",
+      "repo": "python-build-standalone",
+      "tag": "20260610",
+      "asset": "cpython-3.13.14+20260610-aarch64-unknown-linux-musl-install_only.tar.gz",
+      "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-unknown-linux-musl-install_only.tar.gz",
+      "sha256": "ad0388569f1f7904eaacb7b29926542925d23d38b65ba652876ae9c3c03ab55d"
+    },
+    {
+      "owner": "nodejs",
+      "repo": "node",
+      "tag": "v22.23.0",
+      "asset": "win-x64/node.lib",
+      "url": "https://nodejs.org/dist/v22.23.0/win-x64/node.lib",
+      "sha256": "ac15f1e9d7c8279353723a77f6319967f1a41c06026521094a8234c2e6fbe052"
+    },
+    {
+      "owner": "nodejs",
+      "repo": "node",
+      "tag": "v22.23.0",
+      "asset": "win-arm64/node.lib",
+      "url": "https://nodejs.org/dist/v22.23.0/win-arm64/node.lib",
+      "sha256": "e56e62f4a7ae6643a40db01f09072e8a93ccbe73be8abff927b793344691d6b7"
+    },
+    {
+      "owner": "nodejs",
+      "repo": "node",
+      "tag": "v22.23.0",
+      "asset": "win-x86/node.lib",
+      "url": "https://nodejs.org/dist/v22.23.0/win-x86/node.lib",
+      "sha256": "66949ba371a159f5e3626f6ce960f85ab6bcdd237eafcdfbc11d1377a2767652"
+    },
+    {
+      "owner": "nodejs",
+      "repo": "node",
+      "tag": "v22.23.0",
+      "asset": "node-v22.23.0-headers.tar.gz",
+      "url": "https://nodejs.org/dist/v22.23.0/node-v22.23.0-headers.tar.gz",
+      "sha256": "ac07673009b92d70f3d842df28204e92785234bae6b4d5785f63fbca8408fc69"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -354,6 +354,26 @@
         "1.3.0",
         "1.2.8"
       ]
+    },
+    "python": {
+      "path": "python/manifest.json",
+      "owner": "astral-sh",
+      "repo": "python-build-standalone",
+      "latest": "20260610",
+      "pinned": null,
+      "tracked_tags": [
+        "20260610"
+      ]
+    },
+    "node": {
+      "path": "node/manifest.json",
+      "owner": "nodejs",
+      "repo": "node",
+      "latest": "v22.23.0",
+      "pinned": null,
+      "tracked_tags": [
+        "v22.23.0"
+      ]
     }
   }
 }

--- a/node/manifest.json
+++ b/node/manifest.json
@@ -1,0 +1,74 @@
+[
+  {
+    "tool": "node",
+    "owner": "nodejs",
+    "repo": "node",
+    "tag": "v22.23.0",
+    "version": "22.23.0",
+    "name": "v22.23.0",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2026-06-18T04:37:21Z",
+    "published_at": "2026-06-18T04:37:21Z",
+    "release_html_url": "https://github.com/nodejs/node/releases/tag/v22.23.0",
+    "platforms": {
+      "windows-x64-msvc": {
+        "filename": "node.lib",
+        "filename_full": "win-x64/node.lib",
+        "url": "https://nodejs.org/dist/v22.23.0/win-x64/node.lib",
+        "size": 2790574,
+        "sha256": "ac15f1e9d7c8279353723a77f6319967f1a41c06026521094a8234c2e6fbe052"
+      },
+      "windows-arm64-msvc": {
+        "filename": "node.lib",
+        "filename_full": "win-arm64/node.lib",
+        "url": "https://nodejs.org/dist/v22.23.0/win-arm64/node.lib",
+        "size": 2790226,
+        "sha256": "e56e62f4a7ae6643a40db01f09072e8a93ccbe73be8abff927b793344691d6b7"
+      },
+      "windows-x86-msvc": {
+        "filename": "node.lib",
+        "filename_full": "win-x86/node.lib",
+        "url": "https://nodejs.org/dist/v22.23.0/win-x86/node.lib",
+        "size": 2795474,
+        "sha256": "66949ba371a159f5e3626f6ce960f85ab6bcdd237eafcdfbc11d1377a2767652"
+      }
+    },
+    "assets": {
+      "win-x64/node.lib": {
+        "url": "https://nodejs.org/dist/v22.23.0/win-x64/node.lib",
+        "size": 2790574,
+        "sha256": "ac15f1e9d7c8279353723a77f6319967f1a41c06026521094a8234c2e6fbe052",
+        "content_type": "application/octet-stream",
+        "created_at": "2026-06-18T04:37:21Z",
+        "updated_at": "2026-06-18T04:37:21Z"
+      },
+      "win-arm64/node.lib": {
+        "url": "https://nodejs.org/dist/v22.23.0/win-arm64/node.lib",
+        "size": 2790226,
+        "sha256": "e56e62f4a7ae6643a40db01f09072e8a93ccbe73be8abff927b793344691d6b7",
+        "content_type": "application/octet-stream",
+        "created_at": "2026-06-18T04:37:21Z",
+        "updated_at": "2026-06-18T04:37:21Z"
+      },
+      "win-x86/node.lib": {
+        "url": "https://nodejs.org/dist/v22.23.0/win-x86/node.lib",
+        "size": 2795474,
+        "sha256": "66949ba371a159f5e3626f6ce960f85ab6bcdd237eafcdfbc11d1377a2767652",
+        "content_type": "application/octet-stream",
+        "created_at": "2026-06-18T04:37:21Z",
+        "updated_at": "2026-06-18T04:37:21Z"
+      },
+      "node-v22.23.0-headers.tar.gz": {
+        "url": "https://nodejs.org/dist/v22.23.0/node-v22.23.0-headers.tar.gz",
+        "size": 9931828,
+        "sha256": "ac07673009b92d70f3d842df28204e92785234bae6b4d5785f63fbca8408fc69",
+        "content_type": "application/gzip",
+        "created_at": "2026-06-18T04:37:21Z",
+        "updated_at": "2026-06-18T04:37:21Z",
+        "notes": "Platform-agnostic headers (node.h, napi.h, etc.) for native addon builds."
+      }
+    },
+    "notes": "Windows node.lib import library (per arch) + platform-agnostic headers tarball. Sourced from official nodejs.org/dist/ (not GitHub Releases -- Node publishes win-<arch>/node.lib outside the GitHub release attachments). For Rust crates building Windows native addons (napi-rs, neon). See zackees/soldr#944."
+  }
+]

--- a/python/manifest.json
+++ b/python/manifest.json
@@ -1,0 +1,132 @@
+[
+  {
+    "tool": "python",
+    "owner": "astral-sh",
+    "repo": "python-build-standalone",
+    "tag": "20260610",
+    "version": "3.13.14",
+    "name": "cpython-3.13.14+20260610",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2026-06-11T05:42:30Z",
+    "published_at": "2026-06-11T05:42:30Z",
+    "release_html_url": "https://github.com/astral-sh/python-build-standalone/releases/tag/20260610",
+    "platforms": {
+      "windows-x64-msvc": {
+        "filename": "cpython-3.13.14+20260610-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "size": 47123990,
+        "sha256": "9a77f87ec431f16e79fc7e90d9115edf187d18b64100b6f6c27189f419fd79be"
+      },
+      "windows-arm64-msvc": {
+        "filename": "cpython-3.13.14+20260610-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "size": 43805508,
+        "sha256": "7146b88d4b8fcd2f7154f516dee051b0891536bf48a1c2fe625a540c7bc06be6"
+      },
+      "darwin-x64": {
+        "filename": "cpython-3.13.14+20260610-x86_64-apple-darwin-install_only.tar.gz",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-apple-darwin-install_only.tar.gz",
+        "size": 25032612,
+        "sha256": "592d3d807a493e4e21dbc972f81d1b2ece6381a7e687bcf0da68555a1282d49a"
+      },
+      "darwin-arm64": {
+        "filename": "cpython-3.13.14+20260610-aarch64-apple-darwin-install_only.tar.gz",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-apple-darwin-install_only.tar.gz",
+        "size": 25281944,
+        "sha256": "0e255968ed96255df59b6bc9504545260c11de3171e48f7640668d88154945ba"
+      },
+      "linux-x64-gnu": {
+        "filename": "cpython-3.13.14+20260610-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "size": 119009873,
+        "sha256": "31ebbb024fecb446d7f25a5b59ca1d4955597ca3f5b4b76f55b30a8987eb61c9"
+      },
+      "linux-arm64-gnu": {
+        "filename": "cpython-3.13.14+20260610-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "size": 90226359,
+        "sha256": "fe5b366ecf26fe565113b195a03ea18d7030f2dab691c0bed41cf19318100be2"
+      },
+      "linux-x64-musl": {
+        "filename": "cpython-3.13.14+20260610-x86_64-unknown-linux-musl-install_only.tar.gz",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-unknown-linux-musl-install_only.tar.gz",
+        "size": 105460599,
+        "sha256": "14ff3ae99951784204ea2528d0b1c8442c7c6f1e78ab27e5ea05cfd9a0b27ced"
+      },
+      "linux-arm64-musl": {
+        "filename": "cpython-3.13.14+20260610-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "size": 105246873,
+        "sha256": "ad0388569f1f7904eaacb7b29926542925d23d38b65ba652876ae9c3c03ab55d"
+      }
+    },
+    "assets": {
+      "cpython-3.13.14+20260610-x86_64-pc-windows-msvc-install_only.tar.gz": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-pc-windows-msvc-install_only.tar.gz",
+        "size": 47123990,
+        "sha256": "9a77f87ec431f16e79fc7e90d9115edf187d18b64100b6f6c27189f419fd79be",
+        "content_type": "application/gzip",
+        "created_at": "2026-06-11T05:42:30Z",
+        "updated_at": "2026-06-11T05:42:30Z"
+      },
+      "cpython-3.13.14+20260610-aarch64-pc-windows-msvc-install_only.tar.gz": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-pc-windows-msvc-install_only.tar.gz",
+        "size": 43805508,
+        "sha256": "7146b88d4b8fcd2f7154f516dee051b0891536bf48a1c2fe625a540c7bc06be6",
+        "content_type": "application/gzip",
+        "created_at": "2026-06-11T05:42:30Z",
+        "updated_at": "2026-06-11T05:42:30Z"
+      },
+      "cpython-3.13.14+20260610-x86_64-apple-darwin-install_only.tar.gz": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-apple-darwin-install_only.tar.gz",
+        "size": 25032612,
+        "sha256": "592d3d807a493e4e21dbc972f81d1b2ece6381a7e687bcf0da68555a1282d49a",
+        "content_type": "application/gzip",
+        "created_at": "2026-06-11T05:42:30Z",
+        "updated_at": "2026-06-11T05:42:30Z"
+      },
+      "cpython-3.13.14+20260610-aarch64-apple-darwin-install_only.tar.gz": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-apple-darwin-install_only.tar.gz",
+        "size": 25281944,
+        "sha256": "0e255968ed96255df59b6bc9504545260c11de3171e48f7640668d88154945ba",
+        "content_type": "application/gzip",
+        "created_at": "2026-06-11T05:42:30Z",
+        "updated_at": "2026-06-11T05:42:30Z"
+      },
+      "cpython-3.13.14+20260610-x86_64-unknown-linux-gnu-install_only.tar.gz": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        "size": 119009873,
+        "sha256": "31ebbb024fecb446d7f25a5b59ca1d4955597ca3f5b4b76f55b30a8987eb61c9",
+        "content_type": "application/gzip",
+        "created_at": "2026-06-11T05:42:30Z",
+        "updated_at": "2026-06-11T05:42:30Z"
+      },
+      "cpython-3.13.14+20260610-aarch64-unknown-linux-gnu-install_only.tar.gz": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        "size": 90226359,
+        "sha256": "fe5b366ecf26fe565113b195a03ea18d7030f2dab691c0bed41cf19318100be2",
+        "content_type": "application/gzip",
+        "created_at": "2026-06-11T05:42:30Z",
+        "updated_at": "2026-06-11T05:42:30Z"
+      },
+      "cpython-3.13.14+20260610-x86_64-unknown-linux-musl-install_only.tar.gz": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-x86_64-unknown-linux-musl-install_only.tar.gz",
+        "size": 105460599,
+        "sha256": "14ff3ae99951784204ea2528d0b1c8442c7c6f1e78ab27e5ea05cfd9a0b27ced",
+        "content_type": "application/gzip",
+        "created_at": "2026-06-11T05:42:30Z",
+        "updated_at": "2026-06-11T05:42:30Z"
+      },
+      "cpython-3.13.14+20260610-aarch64-unknown-linux-musl-install_only.tar.gz": {
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.13.14+20260610-aarch64-unknown-linux-musl-install_only.tar.gz",
+        "size": 105246873,
+        "sha256": "ad0388569f1f7904eaacb7b29926542925d23d38b65ba652876ae9c3c03ab55d",
+        "content_type": "application/gzip",
+        "created_at": "2026-06-11T05:42:30Z",
+        "updated_at": "2026-06-11T05:42:30Z"
+      }
+    },
+    "notes": "install_only tarball -- extract for Python.h headers, libpython3.x.so/dylib, and python3.lib on Windows. Sourced from astral-sh/python-build-standalone. Use for PyO3 cross-compile (PYO3_CROSS_LIB_DIR -> install/lib for non-Windows; install/libs for Windows MSVC) and direct C extension builds. See zackees/soldr#931, #932, #933."
+  }
+]


### PR DESCRIPTION
Part of [#930 bootstrap meta](https://github.com/zackees/soldr/issues/930). First wave of asset registrations on the `manifest` branch — addresses the four cleanest sub-issues (no producer infrastructure needed, just pointer manifests against well-hosted upstreams).

## Summary

Adds two new tool entries to the manifest branch, following the existing `cargo-zigbuild/manifest.json` pointer-manifest pattern:

| Tool | Upstream | Asset shape | Sub-issues |
|---|---|---|---|
| `python` | astral-sh/python-build-standalone | install_only tarball for all 8 canonical triples | #931, #932, #933 |
| `node` | nodejs/node (nodejs.org/dist) | `win-<arch>/node.lib` + headers tarball | #944 |

## Files changed

- `python/manifest.json` — cpython 3.13.14 (release tag `20260610`), 8 platforms, each with sha256-verified URL pointing at github.com/astral-sh/python-build-standalone/releases.
- `node/manifest.json` — Node v22.23.0, 3 Windows arches (x64/arm64/x86), each with sha256-verified URL pointing at nodejs.org/dist + the platform-agnostic headers tarball.
- `manifest.json` — registers `python` and `node` in the top-level `tools` map.
- `asset-index.json` — appends 12 new flat entries (8 Python + 3 Node libs + 1 Node headers).

## Why pointer manifests (not mirrored binaries)

- python-build-standalone publishes ~853 assets per release on github.com — well-CDN'd, stable URLs, sha256 sums published. Mirroring would add ~660 MB to this branch.
- nodejs.org/dist has been the canonical Node distribution for 15+ years; stable URLs, SHASUMS256.txt sidecar.
- Pattern matches `cargo-zigbuild/manifest.json` which already does the same (URLs point at github.com/rust-cross/cargo-zigbuild/releases).
- If upstream reliability becomes an issue, mirroring is a future, additive PR — no migration needed.

## SHA256 provenance

Python hashes pulled from `https://github.com/astral-sh/python-build-standalone/releases/download/20260610/SHA256SUMS`. Node hashes pulled from `https://nodejs.org/dist/v22.23.0/SHASUMS256.txt`. Sizes are the raw content-length from a `HEAD` against each URL.

## What this PR does NOT do

- **Does not modify `.github/scripts/build_manifest.py`** on main. That script currently knows only about GitHub-Releases-shaped tools; teaching it about python-build-standalone and nodejs.org/dist is a follow-up PR against main. Until that lands, these entries are hand-maintained on this branch — but the file shapes are wire-compatible with what the script produces for the other tools, so a future merge is straightforward.
- **Does not wire soldr-CLI consumption.** Soldr's `prepare`, cargo-front-door PYO3 auto-set, and `soldr env` subcommand are tracked in #938/#939/etc. and need code changes against main. This PR just stages the assets so those consumers have something to fetch.
- **Does not cover OpenSSL (#943), vcpkg (#945/#946), or libLLVM (#934)** — those need different producer paths (slproweb extraction, Windows CI runner, rustup component install). Filed separately.

## Verification

    python3 -c "
    import json
    d = json.load(open('python/manifest.json'))
    print('platforms:', sorted(d[0]['platforms'].keys()))
    "
    # → ['darwin-arm64', 'darwin-x64', 'linux-arm64-gnu', 'linux-arm64-musl',
    #    'linux-x64-gnu', 'linux-x64-musl', 'windows-arm64-msvc', 'windows-x64-msvc']

Schema-equivalent to `cargo-zigbuild/manifest.json` — same top-level keys (`tool`, `owner`, `repo`, `tag`, `version`, `name`, `draft`, `prerelease`, `created_at`, `published_at`, `release_html_url`, `platforms`, `assets`).

## Test plan

- [ ] CI on the manifest branch (if any — most checks are on main).
- [ ] Spot-check: `curl -fsSLI <one of the URLs from python/manifest.json>` returns the expected Content-Length matching the manifest's `size` field.
- [ ] Verify top-level `manifest.json` schema_version is still 5 (no breaking change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)