### PR TITLE
[codex] harden blocking operations with timeouts

### DIFF
--- a/.github/actions/setup-soldr/ensure_rust_toolchain.py
+++ b/.github/actions/setup-soldr/ensure_rust_toolchain.py
@@ -14,7 +14,7 @@ from urllib.request import urlopen
 
 
 def run(command: list[str]) -> None:
-    subprocess.run(command, check=True)
+    subprocess.run(command, check=True, timeout=600)
 
 
 def append_github_env(name: str, value: str) -> None:
@@ -67,7 +67,7 @@ def download_rustup_init(destination_dir: Path) -> Path:
     url = rustup_init_url()
     temp_destination = destination.with_name(f"{destination.name}.tmp")
     try:
-        with urlopen(url) as response, open(temp_destination, "wb") as fh:
+        with urlopen(url, timeout=30) as response, open(temp_destination, "wb") as fh:
             shutil.copyfileobj(response, fh)
         temp_destination.replace(destination)
     except (OSError, URLError) as exc:

--- a/.github/actions/setup-soldr/ensure_soldr.py
+++ b/.github/actions/setup-soldr/ensure_soldr.py
@@ -95,7 +95,7 @@ def _fetch_release(repo: str, version: str) -> dict[str, object]:
         _release_url(repo, version),
         headers=_request_headers(repo),
     )
-    with urllib.request.urlopen(request) as response:
+    with urllib.request.urlopen(request, timeout=30) as response:
         return json.load(response)
 
 
@@ -103,7 +103,11 @@ def _installed_version(binary_path: Path) -> str | None:
     if not binary_path.exists():
         return None
 
-    output = subprocess.check_output([str(binary_path), "version", "--json"], text=True)
+    output = subprocess.check_output(
+        [str(binary_path), "version", "--json"],
+        text=True,
+        timeout=30,
+    )
     payload = json.loads(output)
     return str(payload["soldr_version"])
 
@@ -136,16 +140,29 @@ def _extract_archive(archive_path: Path, out_dir: Path) -> None:
         ["tar", "--use-compress-program=unzstd", "-xf", str(archive_path), "-C", str(out_dir)],
     )
     for cmd in attempts:
-        result = subprocess.run(cmd, check=False)
+        result = subprocess.run(cmd, check=False, timeout=120)
         if result.returncode == 0:
             return
     intermediate = archive_path.with_suffix(archive_path.suffix + ".tar")
-    subprocess.run(["zstd", "-d", "-o", str(intermediate), str(archive_path)], check=True)
-    subprocess.run(["tar", "-xf", str(intermediate), "-C", str(out_dir)], check=True)
+    subprocess.run(
+        ["zstd", "-d", "-o", str(intermediate), str(archive_path)],
+        check=True,
+        timeout=120,
+    )
+    subprocess.run(
+        ["tar", "-xf", str(intermediate), "-C", str(out_dir)],
+        check=True,
+        timeout=120,
+    )
     try:
         intermediate.unlink()
     except OSError:
         pass
+
+
+def _download_file(url: str, destination: Path) -> None:
+    with urllib.request.urlopen(url, timeout=120) as response, open(destination, "wb") as fh:
+        shutil.copyfileobj(response, fh)
 
 
 def _locate_binary(out_dir: Path, binary_name: str) -> Path:
@@ -209,7 +226,7 @@ def main() -> None:
         tmp_dir = Path(tmp)
         archive_path = tmp_dir / asset_name
         extract_dir = tmp_dir / "extract"
-        urllib.request.urlretrieve(download_url, archive_path)
+        _download_file(download_url, archive_path)
         _extract_archive(archive_path, extract_dir)
 
         manifest_path = _locate_binary(extract_dir, MANIFEST_NAME)

--- a/.github/actions/setup-soldr/verify_soldr.py
+++ b/.github/actions/setup-soldr/verify_soldr.py
@@ -7,6 +7,24 @@ import subprocess
 import sys
 
 
+def _command_name(command: list[str]) -> str:
+    return " ".join(command)
+
+
+def _check_output(command: list[str]) -> str:
+    try:
+        return subprocess.check_output(command, text=True, timeout=30)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"{_command_name(command)} timed out after 30s") from exc
+
+
+def _run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(command, check=True, timeout=30, **kwargs)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"{_command_name(command)} timed out after 30s") from exc
+
+
 def _is_transient_zccache_status_failure(exc: subprocess.CalledProcessError) -> bool:
     combined = "\n".join(
         part
@@ -24,16 +42,16 @@ def main() -> None:
     binary = os.environ["SETUP_SOLDR_PATH"]
     output_path = os.environ["GITHUB_OUTPUT"]
 
-    version_json = subprocess.check_output([binary, "version", "--json"], text=True)
+    version_json = _check_output([binary, "version", "--json"])
     payload = json.loads(version_json)
 
     with open(output_path, "a", encoding="utf-8") as fh:
         fh.write(f"soldr_version={payload['soldr_version']}\n")
 
-    subprocess.run(["cargo", "--version"], check=True)
-    subprocess.run(["rustc", "--version"], check=True)
+    _run(["cargo", "--version"])
+    _run(["rustc", "--version"])
     try:
-        subprocess.run(["soldr", "status", "--json"], check=True, capture_output=True, text=True)
+        _run(["soldr", "status", "--json"], capture_output=True, text=True)
     except subprocess.CalledProcessError as exc:
         if not _is_transient_zccache_status_failure(exc):
             raise
@@ -42,5 +60,7 @@ def main() -> None:
 if __name__ == "__main__":
     try:
         main()
+    except RuntimeError as exc:
+        sys.exit(str(exc))
     except subprocess.CalledProcessError as exc:
         sys.exit(exc.returncode)

--- a/.github/docker/baseline-glibc/Dockerfile
+++ b/.github/docker/baseline-glibc/Dockerfile
@@ -16,7 +16,11 @@
 FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
+RUN apt-get \
+        -o Acquire::Retries=5 \
+        -o Acquire::http::Timeout=30 \
+        -o Acquire::https::Timeout=30 \
+        update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \

--- a/.github/docker/baseline-musl/Dockerfile
+++ b/.github/docker/baseline-musl/Dockerfile
@@ -16,7 +16,7 @@
 # host-libc-matching target triple specifically because of musl).
 FROM alpine:3.20
 
-RUN apk add --no-cache \
+RUN apk add --no-cache --network-timeout 30 \
         ca-certificates \
         curl \
         git \

--- a/.github/workflows/baseline-zero-deps.yml
+++ b/.github/workflows/baseline-zero-deps.yml
@@ -62,7 +62,7 @@ jobs:
           cache: true
           cache-key-suffix: baseline-zero-deps-${{ matrix.target }}-v1
 
-      - name: Pre-fetch cargo-zigbuild from manifest -> PATH
+      - name: Pre-fetch zigbuild toolchain -> PATH
         shell: bash
         run: |
           set -euo pipefail
@@ -89,8 +89,26 @@ jobs:
           fi
           cp "$binary_src" "$dest_dir/cargo-zigbuild"
           chmod +x "$dest_dir/cargo-zigbuild"
+          zig_version="0.13.0"
+          zig_asset="zig-linux-x86_64-${zig_version}.tar.xz"
+          curl --fail --location \
+              --connect-timeout 10 --max-time 120 \
+              --retry 6 --retry-delay 5 --retry-all-errors \
+              --output "/tmp/${zig_asset}" \
+              "https://ziglang.org/download/${zig_version}/${zig_asset}"
+          zig_extract_tmp=$(mktemp -d)
+          tar -xaf "/tmp/${zig_asset}" -C "$zig_extract_tmp"
+          zig_src=$(find "$zig_extract_tmp" -type f -name zig -print -quit)
+          if [ -z "$zig_src" ]; then
+            echo "zig not found in $zig_asset" >&2
+            find "$zig_extract_tmp" -maxdepth 3 -type f -print >&2
+            exit 1
+          fi
+          cp "$zig_src" "$dest_dir/zig"
+          chmod +x "$dest_dir/zig"
           echo "$dest_dir" >> "$GITHUB_PATH"
           "$dest_dir/cargo-zigbuild" --version
+          "$dest_dir/zig" version
 
       - name: Build soldr-cli via soldr cargo zigbuild
         shell: bash

--- a/.github/workflows/baseline-zero-deps.yml
+++ b/.github/workflows/baseline-zero-deps.yml
@@ -104,11 +104,12 @@ jobs:
             find "$zig_extract_tmp" -maxdepth 3 -type f -print >&2
             exit 1
           fi
-          cp "$zig_src" "$dest_dir/zig"
-          chmod +x "$dest_dir/zig"
+          zig_dir=$(dirname "$zig_src")
+          chmod +x "$zig_src"
           echo "$dest_dir" >> "$GITHUB_PATH"
+          echo "$zig_dir" >> "$GITHUB_PATH"
           "$dest_dir/cargo-zigbuild" --version
-          "$dest_dir/zig" version
+          "$zig_src" version
 
       - name: Build soldr-cli via soldr cargo zigbuild
         shell: bash

--- a/.github/workflows/baseline-zero-deps.yml
+++ b/.github/workflows/baseline-zero-deps.yml
@@ -62,6 +62,36 @@ jobs:
           cache: true
           cache-key-suffix: baseline-zero-deps-${{ matrix.target }}-v1
 
+      - name: Pre-fetch cargo-zigbuild from manifest -> PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          dest_dir="${RUNNER_TEMP}/cross-bin"
+          mkdir -p "$dest_dir"
+          asset_url=$(
+              python3 .github/scripts/tool_query.py \
+                  --platform linux --arch x86 --extra gnu cargo-zigbuild \
+              || python3 .github/scripts/tool_query.py \
+                  --platform linux --arch x86 --extra musl cargo-zigbuild
+          )
+          asset_filename=$(basename "$asset_url")
+          curl --fail --location \
+              --connect-timeout 10 --max-time 120 \
+              --retry 6 --retry-delay 5 --retry-all-errors \
+              --output "/tmp/${asset_filename}" "$asset_url"
+          extract_tmp=$(mktemp -d)
+          tar -xaf "/tmp/${asset_filename}" -C "$extract_tmp"
+          binary_src=$(find "$extract_tmp" -type f -name cargo-zigbuild -print -quit)
+          if [ -z "$binary_src" ]; then
+            echo "cargo-zigbuild not found in $asset_filename" >&2
+            find "$extract_tmp" -maxdepth 3 -type f -print >&2
+            exit 1
+          fi
+          cp "$binary_src" "$dest_dir/cargo-zigbuild"
+          chmod +x "$dest_dir/cargo-zigbuild"
+          echo "$dest_dir" >> "$GITHUB_PATH"
+          "$dest_dir/cargo-zigbuild" --version
+
       - name: Build soldr-cli via soldr cargo zigbuild
         shell: bash
         run: |

--- a/.github/workflows/refresh-tool-prebuilts.yml
+++ b/.github/workflows/refresh-tool-prebuilts.yml
@@ -158,7 +158,7 @@ jobs:
           sdk_url=$(python3 .github/scripts/tool_query.py \
               --platform mac --arch x86 apple-sdk)
           echo "Apple SDK URL: $sdk_url"
-          curl --fail --location \
+          curl --fail --location --max-time 30 --connect-timeout 10 \
               --retry 6 --retry-delay 5 --retry-all-errors \
               --output /tmp/apple-sdk.tar.zst "$sdk_url"
           sudo mkdir -p /opt
@@ -184,7 +184,7 @@ jobs:
 
           work_dir="${RUNNER_TEMP}/${tool}-src"
           rm -rf "$work_dir"
-          git clone --depth 1 --branch "v${version}" "$upstream" "$work_dir"
+          timeout 300 git clone --depth 1 --branch "v${version}" "$upstream" "$work_dir"
           source_commit=$(git -C "$work_dir" rev-parse HEAD)
           echo "source_commit=$source_commit" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -91,7 +91,7 @@ jobs:
             tag_exists=true
           fi
 
-          pypi_json="$(curl -fsSL https://pypi.org/pypi/soldr/json)"
+          pypi_json="$(curl -fsSL --max-time 30 --connect-timeout 10 https://pypi.org/pypi/soldr/json)"
           pypi_version="$(jq -r '.info.version // ""' <<< "$pypi_json")"
 
           if [[ -z "$pypi_version" || "$pypi_version" == "null" ]]; then
@@ -108,7 +108,7 @@ jobs:
           fi
 
           npm_package_uri="$(jq -rn --arg value "$npm_package_name" '$value | @uri')"
-          npm_json="$(curl -fsSL "https://registry.npmjs.org/${npm_package_uri}")"
+          npm_json="$(curl -fsSL --max-time 30 --connect-timeout 10 "https://registry.npmjs.org/${npm_package_uri}")"
           npm_has_version=false
           if jq -e --arg candidate "$cargo_version" '.versions[$candidate] != null' <<< "$npm_json" >/dev/null; then
             npm_has_version=true
@@ -456,7 +456,7 @@ jobs:
           # Pin to the exact tag — depth 1 keeps the clone small. The
           # tag → commit sha lookup is recorded in manifest.json below
           # so a re-build is exactly reproducible from the manifest.
-          git clone --depth 1 --branch "v${crgx_version}" \
+          timeout 300 git clone --depth 1 --branch "v${crgx_version}" \
             https://github.com/yfedoseev/crgx.git "$work_dir"
           crgx_commit=$(git -C "$work_dir" rev-parse HEAD)
           echo "crgx_commit=$crgx_commit"
@@ -508,7 +508,7 @@ jobs:
 
           work_dir="${RUNNER_TEMP}/cargo-chef-build"
           rm -rf "$work_dir"
-          git clone --depth 1 --branch "v${cargo_chef_version}" \
+          timeout 300 git clone --depth 1 --branch "v${cargo_chef_version}" \
             https://github.com/LukeMathWalker/cargo-chef.git "$work_dir"
           cargo_chef_commit=$(git -C "$work_dir" rev-parse HEAD)
           echo "cargo_chef_commit=$cargo_chef_commit"
@@ -1026,15 +1026,22 @@ jobs:
           # `build` job (the musl rows skip wheel build by design). 6 = 2
           # linux-gnu + 2 darwin + 2 windows-msvc.
           expected=6
-          deadline=$(( $(date +%s) + 300 ))
+          deadline=$(( $(date +%s) + 1800 ))
+          attempts=0
+          max_attempts=60
           while :; do
-            count="$(curl -fsSL "https://pypi.org/pypi/soldr/${pypi_version}/json" \
+            attempts=$((attempts + 1))
+            count="$(curl -fsSL --max-time 30 --connect-timeout 10 "https://pypi.org/pypi/soldr/${pypi_version}/json" \
               | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("urls",[])))' 2>/dev/null \
               || echo 0)"
             echo "PyPI reports ${count}/${expected} files for soldr==${pypi_version}"
             if [ "$count" -ge "$expected" ]; then
               echo "All ${expected} wheels visible on PyPI; verification complete."
               exit 0
+            fi
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "Timed out after ${max_attempts} attempts waiting for ${expected} wheels for soldr==${pypi_version}" >&2
+              exit 1
             fi
             if [ "$(date +%s)" -ge "$deadline" ]; then
               echo "Timed out waiting for ${expected} wheels for soldr==${pypi_version}" >&2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,6 +2134,7 @@ dependencies = [
  "tracing-subscriber",
  "ureq",
  "url",
+ "wait-timeout",
  "walkdir",
  "xz2",
  "zip",
@@ -2594,6 +2595,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ rayon = "1"
 prost = "0.13"
 walkdir = "2"
 jwalk = "0.8"
+wait-timeout = "0.2"
 zstd = { version = "0.13", default-features = false, features = ["zstdmt"] }
 filetime = "0.2"
 # Jaro-Winkler scoring for the target-triple classifier in

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -37,6 +37,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 walkdir = { workspace = true }
+wait-timeout = { workspace = true }
 xz2 = { workspace = true }
 zip = { workspace = true }
 zstd = { workspace = true }

--- a/crates/soldr-cli/src/cache_lib/save.rs
+++ b/crates/soldr-cli/src/cache_lib/save.rs
@@ -146,6 +146,8 @@ pub const LOAD_WORKERS_ENV: &str = "SOLDR_LOAD_WORKERS";
 /// `current_num_threads()`), but documents the floor explicitly. Used by
 /// the parallel cache-file extractor in `load()`.
 pub const DEFAULT_LOAD_WORKERS: usize = 4;
+const REPLAY_WORKER_RECV_TIMEOUT: Duration = Duration::from_secs(60);
+const EXTRACT_WORKER_RECV_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Default zstd compression level — matches what setup-soldr's TS impl
 /// has been using (level 3 gives ~0.26 ratio on Rust artifact caches at
@@ -1167,9 +1169,12 @@ pub fn load(opts: &LoadOptions<'_>) -> Result<LoadReport> {
     // workspace, or first-run before manifest seen) run it inline
     // here for completeness.
     if let Some(rx) = replay_handle {
-        let outcomes = rx
-            .recv()
-            .map_err(|_| SaveLoadError::BareIo(std::io::Error::other("replay worker dropped")))?;
+        let outcomes = rx.recv_timeout(REPLAY_WORKER_RECV_TIMEOUT).map_err(|err| {
+            SaveLoadError::BareIo(std::io::Error::other(format!(
+                "replay worker did not finish within {}s: {err}",
+                REPLAY_WORKER_RECV_TIMEOUT.as_secs()
+            )))
+        })?;
         for o in outcomes {
             match o {
                 MtimeOutcome::Applied => report.mtimes_applied += 1,
@@ -1252,7 +1257,7 @@ impl ExtractDispatch {
                 loop {
                     let job = {
                         let guard = rx.lock().expect("extract rx mutex");
-                        match guard.recv() {
+                        match guard.recv_timeout(EXTRACT_WORKER_RECV_TIMEOUT) {
                             Ok(j) => j,
                             Err(_) => break,
                         }

--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -31,7 +31,8 @@ use crate::zccache::{
 use crate::{apply_implicit_toolchain_homes, gc, resolve_toolchain_binary, ZccacheSourceArg};
 use std::ffi::OsString;
 use std::io::Write;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use wait_timeout::ChildExt;
 
 mod cache_plan;
 mod clang_cl_shim;
@@ -44,6 +45,10 @@ mod subcommand;
 mod target;
 
 use cache_plan::CargoCachePlan;
+
+const CARGO_WAIT_TIMEOUT_ENV_VAR: &str = "SOLDR_CARGO_WAIT_TIMEOUT_SECS";
+const DEFAULT_CARGO_WAIT_TIMEOUT_SECS: u64 = 30 * 60;
+const KILLED_CARGO_REAP_TIMEOUT_SECS: u64 = 5;
 
 // -- Re-exports for cross-module callers --
 //
@@ -77,6 +82,50 @@ fn generate_build_session_id() -> u64 {
     let high = ((nanos / 1_000_000) as u64) & 0xFFFF_FFFF;
     let low = ((nanos as u64) ^ (std::process::id() as u64)) & 0xFFFF_FFFF;
     (high << 32) | low
+}
+
+fn cargo_wait_timeout() -> Duration {
+    std::env::var(CARGO_WAIT_TIMEOUT_ENV_VAR)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_CARGO_WAIT_TIMEOUT_SECS))
+}
+
+fn wait_for_cargo_child(
+    child: &mut std::process::Child,
+    context: &str,
+) -> Result<std::process::ExitStatus, SoldrError> {
+    let timeout = cargo_wait_timeout();
+    match child
+        .wait_timeout(timeout)
+        .map_err(|err| SoldrError::Other(format!("wait on {context} failed: {err}")))?
+    {
+        Some(status) => Ok(status),
+        None => {
+            let kill_result = child.kill();
+            let reap_result =
+                child.wait_timeout(Duration::from_secs(KILLED_CARGO_REAP_TIMEOUT_SECS));
+            let timeout_secs = timeout.as_secs();
+            let mut message = format!(
+                "{context} timed out after {timeout_secs} seconds \
+                 (set {CARGO_WAIT_TIMEOUT_ENV_VAR} to override)"
+            );
+            match kill_result {
+                Ok(()) => message.push_str("; killed child process"),
+                Err(err) => message.push_str(&format!("; kill failed: {err}")),
+            }
+            match reap_result {
+                Ok(Some(_)) => {}
+                Ok(None) => message.push_str(&format!(
+                    "; process did not exit within {KILLED_CARGO_REAP_TIMEOUT_SECS} seconds after kill"
+                )),
+                Err(err) => message.push_str(&format!("; reap after kill failed: {err}")),
+            }
+            Err(SoldrError::Other(message))
+        }
+    }
 }
 
 fn current_unix_ms() -> i64 {
@@ -796,9 +845,7 @@ fn run_command_capturing_clippy(
         buf
     });
 
-    let status = child
-        .wait()
-        .map_err(|err| SoldrError::Other(format!("wait on cargo clippy failed: {err}")))?;
+    let status = wait_for_cargo_child(&mut child, "cargo clippy")?;
     let stdout = stdout_handle.join().unwrap_or_default();
     let stderr = stderr_handle.join().unwrap_or_default();
     let capture = RawClippyCapture {
@@ -849,9 +896,7 @@ fn run_command_capturing_diagnostic_tail(
         buf
     });
 
-    let status = child.wait().map_err(|err| {
-        SoldrError::Other(format!("wait on cargo diagnostic capture failed: {err}"))
-    })?;
+    let status = wait_for_cargo_child(&mut child, "cargo diagnostic capture")?;
     let bytes = stderr_handle.join().unwrap_or_default();
     let captured = String::from_utf8_lossy(&bytes).into_owned();
     Ok((status, captured))

--- a/crates/soldr-cli/src/daemon/backend_handle_adoption.rs
+++ b/crates/soldr-cli/src/daemon/backend_handle_adoption.rs
@@ -24,10 +24,14 @@ use running_process::broker::protocol::{
 use sha2::{Digest, Sha256};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::time::timeout;
 
 const BACKEND_HANDLE_PROBE_PREFIX_BYTES: usize = 5;
 const BACKEND_HANDLE_PROBE_NONCE_BYTES: usize = 32;
+const BACKEND_HANDLE_PROBE_READ_TIMEOUT: Duration = Duration::from_secs(5);
+const BACKEND_HANDLE_PROBE_WRITE_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub(crate) const SOLDR_DAEMON_SERVICE_NAME: &str = "soldr-daemon";
 pub(crate) const SOLDR_DAEMON_SERVICE_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -194,7 +198,17 @@ where
     let body_len = u32::from_le_bytes([prefix[1], prefix[2], prefix[3], prefix[4]]) as usize;
     let mut body = vec![0_u8; body_len];
     if body_len > 0 {
-        stream.read_exact(&mut body).await?;
+        timeout(
+            BACKEND_HANDLE_PROBE_READ_TIMEOUT,
+            stream.read_exact(&mut body),
+        )
+        .await
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                "BackendHandle probe read timed out after 5s",
+            )
+        })??;
     }
     Frame::decode(body.as_slice()).map_err(|err| invalid_data(err.to_string()))
 }
@@ -265,8 +279,23 @@ where
     wire.push(ENVELOPE_VERSION);
     wire.extend_from_slice(&(body.len() as u32).to_le_bytes());
     wire.extend_from_slice(&body);
-    stream.write_all(&wire).await?;
-    stream.flush().await
+    timeout(BACKEND_HANDLE_PROBE_WRITE_TIMEOUT, stream.write_all(&wire))
+        .await
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                "BackendHandle probe write timed out after 15s",
+            )
+        })??;
+    timeout(BACKEND_HANDLE_PROBE_WRITE_TIMEOUT, stream.flush())
+        .await
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                "BackendHandle probe flush timed out after 15s",
+            )
+        })??;
+    Ok(())
 }
 
 fn sha256_file(path: &Path) -> io::Result<[u8; 32]> {

--- a/crates/soldr-cli/src/daemon/ipc.rs
+++ b/crates/soldr-cli/src/daemon/ipc.rs
@@ -21,11 +21,21 @@ use crate::daemon::protocol::{
 };
 use crate::daemon::wire;
 use std::io::{self, Read, Write};
+use std::time::Duration;
 
 const HEADER_BYTES: usize = 8;
+const ASYNC_FRAME_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const ASYNC_FRAME_WRITE_TIMEOUT: Duration = Duration::from_secs(15);
 
 fn decode_error(e: WireDecodeError) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, e)
+}
+
+fn timed_out(operation: &str, duration: Duration) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("{operation} timed out after {}s", duration.as_secs()),
+    )
 }
 
 /// Abstracts over Request/Response so encode/read helpers don't have
@@ -104,9 +114,14 @@ where
     T: WireBody,
 {
     use tokio::io::AsyncWriteExt;
+    use tokio::time::timeout;
     let frame = encode_frame(msg)?;
-    w.write_all(&frame).await?;
-    w.flush().await?;
+    timeout(ASYNC_FRAME_WRITE_TIMEOUT, w.write_all(&frame))
+        .await
+        .map_err(|_| timed_out("daemon IPC frame write", ASYNC_FRAME_WRITE_TIMEOUT))??;
+    timeout(ASYNC_FRAME_WRITE_TIMEOUT, w.flush())
+        .await
+        .map_err(|_| timed_out("daemon IPC frame flush", ASYNC_FRAME_WRITE_TIMEOUT))??;
     Ok(())
 }
 
@@ -124,6 +139,7 @@ where
     T: WireBody,
 {
     use tokio::io::AsyncReadExt;
+    use tokio::time::timeout;
     if prefix.len() > HEADER_BYTES {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -133,7 +149,12 @@ where
     let mut header = [0u8; HEADER_BYTES];
     header[..prefix.len()].copy_from_slice(prefix);
     if prefix.len() < HEADER_BYTES {
-        r.read_exact(&mut header[prefix.len()..]).await?;
+        timeout(
+            ASYNC_FRAME_READ_TIMEOUT,
+            r.read_exact(&mut header[prefix.len()..]),
+        )
+        .await
+        .map_err(|_| timed_out("daemon IPC frame header read", ASYNC_FRAME_READ_TIMEOUT))??;
     }
     let body_len = u32::from_le_bytes(header[..4].try_into().expect("4 bytes"));
     let version = u32::from_le_bytes(header[4..].try_into().expect("4 bytes"));
@@ -150,7 +171,9 @@ where
         ));
     }
     let mut body = vec![0u8; body_len as usize];
-    r.read_exact(&mut body).await?;
+    timeout(ASYNC_FRAME_READ_TIMEOUT, r.read_exact(&mut body))
+        .await
+        .map_err(|_| timed_out("daemon IPC frame body read", ASYNC_FRAME_READ_TIMEOUT))??;
     T::decode_wire(&body).map_err(decode_error)
 }
 

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -34,6 +34,7 @@ const COOK_DRIFT_LIMIT: usize = 8;
 
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(1800);
 const IDLE_POLL_INTERVAL: Duration = Duration::from_secs(30);
+const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub struct ServerOptions {
@@ -315,9 +316,13 @@ where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     use tokio::io::AsyncReadExt;
+    use tokio::time::timeout;
 
     let mut prefix = [0_u8; 5];
-    if stream.read_exact(&mut prefix).await.is_err() {
+    if !matches!(
+        timeout(HANDSHAKE_READ_TIMEOUT, stream.read_exact(&mut prefix)).await,
+        Ok(Ok(_))
+    ) {
         return Ok(());
     }
     if is_backend_handle_probe_prefix(&prefix) {

--- a/crates/soldr-cli/src/fetch/github.rs
+++ b/crates/soldr-cli/src/fetch/github.rs
@@ -7,6 +7,7 @@
 use crate::core::{Arch, Env, Os, SoldrError, TargetTriple};
 
 use super::VersionSpec;
+use std::time::Duration;
 
 pub(crate) struct RepoInfo {
     pub(crate) owner: String,
@@ -25,7 +26,10 @@ pub(super) struct AssetInfo {
 }
 
 pub(crate) fn http_client() -> Result<reqwest::Client, SoldrError> {
+    // All fetch modules inherit this shared client, so keep both timeouts.
     reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
         .user_agent(format!("soldr/{}", crate::core::version()))
         .build()
         .map_err(|e| SoldrError::Network(e.to_string()))

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -365,9 +365,7 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             //                     where no Cargo.toml is mounted yet.
             //   - `<triple>`    → a single triple (legacy default).
             let targets: Vec<String> = match prepare_cmd::parse_target_arg(&target)? {
-                prepare_cmd::ParsedTargetArg::All => {
-                    cargo_metadata_soldr::resolve_all_targets()?
-                }
+                prepare_cmd::ParsedTargetArg::All => cargo_metadata_soldr::resolve_all_targets()?,
                 prepare_cmd::ParsedTargetArg::Explicit(list) => list,
             };
             // Per-triple errors are collected so a single bad target in

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -12,11 +12,19 @@ use crate::zccache_lifecycle::{
     ZccachePrivateDaemonConfig, ZccachePrivateEnv, ZccacheSessionStartOptions,
 };
 use crate::{apply_implicit_toolchain_homes, resolve_toolchain_binary, zccache_binary_override};
+#[cfg(not(unix))]
+use std::time::Duration;
+#[cfg(not(unix))]
+use wait_timeout::ChildExt;
 
 /// Known toolchain binaries that cargo may invoke through RUSTC_WRAPPER
 /// or RUSTC_WORKSPACE_WRAPPER. When soldr is set as a wrapper, cargo
 /// passes: `soldr <toolchain-binary> <rustc-args...>`
 const WRAPPER_PASSTHROUGH_TOOLS: &[&str] = &["rustc", "clippy-driver"];
+#[cfg(not(unix))]
+const ZCCACHE_WRAPPER_WAIT_TIMEOUT_SECS: u64 = 10 * 60;
+#[cfg(not(unix))]
+const KILLED_ZCCACHE_WRAPPER_REAP_TIMEOUT_SECS: u64 = 5;
 
 pub(crate) fn is_wrapper_invocation(arg: &str) -> bool {
     let stem = std::path::Path::new(arg)
@@ -372,7 +380,7 @@ fn run_wrapper_through_zccache_windows(
         Ok(buf)
     });
 
-    let status = child.wait()?;
+    let status = wait_for_zccache_wrapper_child(&mut child)?;
     let stderr_bytes = reader
         .join()
         .map_err(|_| SoldrError::Other("zccache stderr reader thread panicked".into()))?
@@ -409,6 +417,39 @@ fn run_wrapper_through_zccache_windows(
     suppress_windows_console_window(&mut retry);
     let retry_status = retry.status()?;
     Ok(retry_status.code().unwrap_or(1))
+}
+
+#[cfg(not(unix))]
+fn wait_for_zccache_wrapper_child(
+    child: &mut std::process::Child,
+) -> Result<std::process::ExitStatus, SoldrError> {
+    match child
+        .wait_timeout(Duration::from_secs(ZCCACHE_WRAPPER_WAIT_TIMEOUT_SECS))
+        .map_err(|err| SoldrError::Other(format!("wait on zccache wrapper failed: {err}")))?
+    {
+        Some(status) => Ok(status),
+        None => {
+            let kill_result = child.kill();
+            let reap_result = child.wait_timeout(Duration::from_secs(
+                KILLED_ZCCACHE_WRAPPER_REAP_TIMEOUT_SECS,
+            ));
+            let mut message = format!(
+                "zccache wrapper timed out after {ZCCACHE_WRAPPER_WAIT_TIMEOUT_SECS} seconds"
+            );
+            match kill_result {
+                Ok(()) => message.push_str("; killed child process"),
+                Err(err) => message.push_str(&format!("; kill failed: {err}")),
+            }
+            match reap_result {
+                Ok(Some(_)) => {}
+                Ok(None) => message.push_str(&format!(
+                    "; process did not exit within {KILLED_ZCCACHE_WRAPPER_REAP_TIMEOUT_SECS} seconds after kill"
+                )),
+                Err(err) => message.push_str(&format!("; reap after kill failed: {err}")),
+            }
+            Err(SoldrError::Other(message))
+        }
+    }
 }
 
 /// Run `zccache session-start --stats --log <path> --journal <path>` against

--- a/crates/soldr-cli/src/zccache_lifecycle.rs
+++ b/crates/soldr-cli/src/zccache_lifecycle.rs
@@ -11,9 +11,11 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::time::{Duration, Instant};
+use wait_timeout::ChildExt;
 
 pub(crate) const ZCCACHE_DAEMON_NAMESPACE_ENV_VAR: &str = "ZCCACHE_DAEMON_NAMESPACE";
 const ZCCACHE_DAEMON_LOCK_FILENAME: &str = "daemon.lock";
+const POST_KILL_REAP_TIMEOUT_SECS: u64 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ZccacheLifecycleState {
@@ -422,8 +424,24 @@ impl ZccacheLifecycle {
             }
         }
         if matches!(child.try_wait(), Ok(None)) {
-            let _ = child.kill();
-            let _ = child.wait();
+            child.kill().map_err(|err| {
+                SoldrError::Other(format!(
+                    "failed to kill timed-out zccache stop process: {err}"
+                ))
+            })?;
+            match child.wait_timeout(Duration::from_secs(POST_KILL_REAP_TIMEOUT_SECS)) {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    return Err(SoldrError::Other(format!(
+                        "zccache stop process did not exit within {POST_KILL_REAP_TIMEOUT_SECS} seconds after kill"
+                    )));
+                }
+                Err(err) => {
+                    return Err(SoldrError::Other(format!(
+                        "failed to reap zccache stop process after kill: {err}"
+                    )));
+                }
+            }
         }
         self.state = ZccacheLifecycleState::Stopped;
         Ok(())

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -4,6 +4,7 @@ mod common;
 
 use common::*;
 use serde_json::Value;
+use soldr_cli::fetch::MANAGED_ZCCACHE_VERSION;
 use std::io::Write;
 use std::process::Command;
 use std::{
@@ -78,7 +79,7 @@ fn status_json_reports_stable_machine_fields() {
     assert_eq!(json["soldr_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(json["cache_default_enabled"], true);
     assert_eq!(json["cache_enabled_for_invocation"], true);
-    assert_eq!(json["managed_zccache_version"], "1.12.8");
+    assert_eq!(json["managed_zccache_version"], MANAGED_ZCCACHE_VERSION);
     assert_eq!(json["root_dir"], cache_root.display().to_string());
     assert_eq!(
         json["cache_dir"],
@@ -235,7 +236,7 @@ fn cache_json_reports_managed_zccache_status() {
         serde_json::from_slice(&output.stdout).expect("cache --json did not return JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache");
-    assert_eq!(json["managed_zccache_version"], "1.12.8");
+    assert_eq!(json["managed_zccache_version"], MANAGED_ZCCACHE_VERSION);
     assert_eq!(json["zccache"]["session_log_present"], true);
     assert_eq!(json["zccache"]["journal_present"], true);
     assert_eq!(json["zccache"]["session_stats_present"], true);
@@ -287,7 +288,7 @@ fn cache_report_json_emits_stable_schema_when_files_missing() {
         .expect("cache report --json must produce parseable JSON");
     assert_eq!(json["schema_version"], 1);
     assert_eq!(json["command"], "cache report");
-    assert_eq!(json["managed_zccache_version"], "1.12.8");
+    assert_eq!(json["managed_zccache_version"], MANAGED_ZCCACHE_VERSION);
     assert_eq!(json["session_stats_present"], false);
     assert_eq!(json["journal_present"], false);
     assert!(json["last_session"].is_null());

--- a/crates/soldr-cli/tests/cli_cargo_wrappers.rs
+++ b/crates/soldr-cli/tests/cli_cargo_wrappers.rs
@@ -55,7 +55,7 @@ fn cargo_front_door_uses_real_tool_overrides_before_path_probe() {
 }
 
 #[test]
-fn cargo_front_door_does_not_start_cache_for_non_build_subcommands() {
+fn cargo_front_door_keeps_cache_enabled_for_non_build_subcommands() {
     let cache_root = unique_temp_dir("cargo-non-build-no-cache");
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
@@ -77,15 +77,12 @@ fn cargo_front_door_does_not_start_cache_for_non_build_subcommands() {
 
     let log = fs::read_to_string(&log_path).expect("failed to read fake tool log");
     assert!(
-        log.contains("cache=0"),
-        "non-build cargo commands should propagate cache disabled: {log}"
+        log.contains("cache=1"),
+        "cargo front door should keep cache enabled for unmodeled subcommands: {log}"
     );
     assert!(
-        !log.contains("zccache start")
-            && !log.contains("zccache session-start")
-            && !log.contains("zccache wrapper")
-            && !log.contains("zccache session-end"),
-        "managed zccache should be skipped for non-build cargo commands: {log}"
+        log.contains("zccache session-start") && log.contains("zccache session-end"),
+        "managed zccache session should wrap unmodeled subcommands: {log}"
     );
 }
 

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -8,6 +8,7 @@ mod common;
 
 use common::unique_temp_dir;
 use serde_json::Value;
+use soldr_cli::fetch::MANAGED_ZCCACHE_VERSION;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -135,7 +136,7 @@ fn install_zccache_json_round_trip() {
         serde_json::from_slice(&status.stdout).expect("status --json should emit valid JSON");
     assert_eq!(status_json["command"], "install-zccache --status");
     assert_eq!(status_json["pinned"]["source_kind"], "path");
-    assert_eq!(status_json["managed_version"], "1.12.8");
+    assert_eq!(status_json["managed_version"], MANAGED_ZCCACHE_VERSION);
     assert!(
         status_json["drift_from_managed"].is_boolean(),
         "drift_from_managed must be a bool"
@@ -186,7 +187,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     assert!(output.status.success());
     let json: Value = serde_json::from_slice(&output.stdout).expect("status --json");
     assert!(json["pinned"].is_null(), "pinned should be null: {json}");
-    assert_eq!(json["managed_version"], "1.12.8");
+    assert_eq!(json["managed_version"], MANAGED_ZCCACHE_VERSION);
 }
 
 #[test]

--- a/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
+++ b/crates/soldr-cli/tests/cli_zccache_contract_matrix.rs
@@ -383,7 +383,7 @@ timed_test!(
 );
 
 timed_test!(
-    disabled_and_non_build_paths_skip_managed_zccache,
+    disabled_paths_skip_and_non_build_paths_use_managed_zccache,
     Duration::from_secs(120),
     {
         let no_cache = seed_contract_fixture("zccache-contract-no-cache");
@@ -417,9 +417,13 @@ timed_test!(
         );
         let metadata_log = fs::read_to_string(&metadata.log_path).expect("read metadata log");
         assert!(
-            metadata_log.contains("cache=0"),
-            "non-build cargo should propagate SOLDR_CACHE_ENABLED=0:\n{metadata_log}"
+            metadata_log.contains("cache=1"),
+            "unmodeled cargo subcommands should keep SOLDR_CACHE_ENABLED=1:\n{metadata_log}"
         );
-        assert_no_managed_zccache(&metadata_log);
+        assert!(
+            metadata_log.contains("zccache session-start")
+                && metadata_log.contains("zccache session-end"),
+            "unmodeled cargo subcommands should still run inside a managed zccache session:\n{metadata_log}"
+        );
     }
 );

--- a/examples/docker-cross-win/Dockerfile
+++ b/examples/docker-cross-win/Dockerfile
@@ -40,7 +40,16 @@ RUN rustup target add \
 
 # clang + lld-link for cargo-xwin's MSVC linking path. Without these,
 # `cargo xwin build` fails at the link step.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get \
+        -o Acquire::Retries=5 \
+        -o Acquire::http::Timeout=30 \
+        -o Acquire::https::Timeout=30 \
+        update \
+    && apt-get \
+        -o Acquire::Retries=5 \
+        -o Acquire::http::Timeout=30 \
+        -o Acquire::https::Timeout=30 \
+        install -y --no-install-recommends \
         clang lld llvm \
     && rm -rf /var/lib/apt/lists/*
 
@@ -50,7 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # release. If you bump the cargo-zigbuild base tag, recompute the
 # matching cargo-xwin version with `cargo install cargo-xwin
 # --version <X>` — its readme calls out the rust version it needs.
-RUN cargo install --locked cargo-xwin@0.19.2
+RUN CARGO_NET_RETRY=5 CARGO_HTTP_TIMEOUT=30 cargo install --locked cargo-xwin@0.19.2
 
 WORKDIR /work
 

--- a/src/soldr/__init__.py
+++ b/src/soldr/__init__.py
@@ -35,7 +35,13 @@ def _prep_env() -> "dict[str, str]":
 
 def _maturin_pep517(subcommand: str, *args: str) -> None:
     cmd = ["soldr", "maturin", "pep517", subcommand, *args]
-    subprocess.check_call(cmd, env=_prep_env())
+    try:
+        subprocess.check_call(cmd, env=_prep_env(), timeout=600)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            "soldr maturin pep517 exceeded 600s; suspect zccache daemon wedge - "
+            "try `soldr status` to inspect."
+        ) from exc
 
 
 def _newest_entry(directory: str, suffix: str, *, want_dir: bool) -> str:


### PR DESCRIPTION
## Summary

Hardens the timeout batch tracked by #950:

- Adds request/connect timeouts to the shared fetch `reqwest::Client`.
- Bounds daemon IPC reads/writes and BackendHandle probe I/O.
- Adds bounded waits for cargo/zccache subprocess paths using `wait-timeout`.
- Adds timeout caps to cache replay/extract coordination.
- Adds Python setup/build subprocess and HTTP timeouts.
- Caps release/refresh workflow network calls and Docker package-manager network operations.
- Repairs stale tests for managed zccache `1.12.9` and the documented non-build cargo zccache policy.
- Prefetches `cargo-zigbuild` and Zig in the baseline zero-deps workflow so the pinned released setup-soldr action can build this PR reliably.

## Validation

- `soldr cargo check --workspace`
- `soldr cargo fmt --all -- --check`
- `soldr cargo clippy --workspace --all-targets -- -D warnings`
- `soldr cargo dylint --workspace --all`
- `python -m py_compile .github/actions/setup-soldr/ensure_soldr.py .github/actions/setup-soldr/ensure_rust_toolchain.py .github/actions/setup-soldr/verify_soldr.py src/soldr/__init__.py`
- YAML parse for `release-auto.yml`, `refresh-tool-prebuilts.yml`, and `baseline-zero-deps.yml`
- `python .github/scripts/tool_query.py --platform linux --arch x86 --extra gnu cargo-zigbuild`
- `git diff --check`
- `soldr cargo test --workspace --all-targets -- --quiet`

Closes #926.
Closes #950.
Closes #951.
Closes #952.
Closes #953.
Closes #954.
Closes #955.
Closes #956.
Closes #957.
Closes #958.