### PR TITLE
[codex] fix main CI regressions after timeout hardening

### DIFF
--- a/.github/docker/baseline-musl/Dockerfile
+++ b/.github/docker/baseline-musl/Dockerfile
@@ -16,7 +16,7 @@
 # host-libc-matching target triple specifically because of musl).
 FROM alpine:3.20
 
-RUN apk add --no-cache --network-timeout 30 \
+RUN apk add --no-cache --timeout 30 \
         ca-certificates \
         curl \
         git \

--- a/.github/workflows/baseline-zero-deps.yml
+++ b/.github/workflows/baseline-zero-deps.yml
@@ -208,7 +208,7 @@ jobs:
             --env SOLDR_GITHUB_TOKEN="${{ github.token }}" \
             "${{ matrix.image_tag }}" \
             bash -eux -c '
-              soldr cargo init --name hello /tmp/hello
+              soldr cargo new --bin --name hello /tmp/hello
               cd /tmp/hello
               echo "fn main() { println!(\"hi\"); }" > src/main.rs
               soldr cargo build --target ${{ matrix.native_target }}
@@ -237,7 +237,7 @@ jobs:
             --env SOLDR_GITHUB_TOKEN="${{ github.token }}" \
             "${{ matrix.image_tag }}" \
             bash -eux -c '
-              soldr cargo init --name hellomac /tmp/hellomac
+              soldr cargo new --bin --name hellomac /tmp/hellomac
               cd /tmp/hellomac
               echo "fn main() { println!(\"hi\"); }" > src/main.rs
               soldr cargo zigbuild --target aarch64-apple-darwin
@@ -265,7 +265,7 @@ jobs:
             --env SOLDR_GITHUB_TOKEN="${{ github.token }}" \
             "${{ matrix.image_tag }}" \
             bash -eux -c '
-              soldr cargo init --name hellowin /tmp/hellowin
+              soldr cargo new --bin --name hellowin /tmp/hellowin
               cd /tmp/hellowin
               echo "fn main() { println!(\"hi\"); }" > src/main.rs
               soldr cargo xwin build --target x86_64-pc-windows-msvc

--- a/.github/workflows/cook-size-gate.yml
+++ b/.github/workflows/cook-size-gate.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Run soldr cook against zccache (release profile)
         working-directory: zccache-fixture
+        env:
+          SOLDR_GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # cargo-chef happens in-process via soldr's bundled chef; using


### PR DESCRIPTION
## Summary

Fixes the fresh main failures after #959:

- Use Alpine apk's supported \--timeout\ option instead of \--network-timeout\.
- Use \cargo new\ in baseline zero-deps exercises so the target project directory is created.
- Pass \SOLDR_GITHUB_TOKEN\ to the cook-size gate's \soldr cook\ invocation to avoid unauthenticated GitHub release lookup rate limits.

## Validation

- YAML parse for \aseline-zero-deps.yml\ and \cook-size-gate.yml\
- \git diff --check\

Fixes post-merge CI from #959.