### PR TITLE
[codex] fix zigbuild linker env parity

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -43,6 +43,7 @@ mod inputs;
 mod profile_debug;
 mod subcommand;
 mod target;
+mod zig_shim;
 
 use cache_plan::CargoCachePlan;
 
@@ -1119,13 +1120,14 @@ async fn append_subcommand_transitive_bin_dirs(
 ) -> Result<(), SoldrError> {
     if sub == "zigbuild" {
         let zig_dir = crate::fetch::ensure_zig(paths).await?;
-        extra_bin_dirs.push(zig_dir);
+        extra_bin_dirs.push(zig_dir.clone());
         // `soldr cargo zigbuild --target *-apple-darwin` needs the
         // Apple SDK on disk + `SDKROOT` exported so cargo-zigbuild's
         // mach-O linker can resolve `-framework IOKit` / etc.
         // Without this, every Rust dep with an Apple-framework
         // dependency (ring, sysinfo, dirs, …) fails to link.
         if let Some(triple) = extract_target_arg(args) {
+            append_zigbuild_env_overrides(paths, triple, extra_env)?;
             if triple.ends_with("-apple-darwin") {
                 let sdk_dir = crate::fetch::ensure_apple_sdk(paths).await?;
                 // Don't clobber a caller-set SDKROOT — escape hatch
@@ -1133,6 +1135,12 @@ async fn append_subcommand_transitive_bin_dirs(
                 if std::env::var_os("SDKROOT").is_none() {
                     extra_env.push((
                         "SDKROOT".to_string(),
+                        sdk_dir.to_string_lossy().into_owned(),
+                    ));
+                }
+                if std::env::var_os("PKG_CONFIG_SYSROOT_DIR").is_none() {
+                    extra_env.push((
+                        "PKG_CONFIG_SYSROOT_DIR".to_string(),
                         sdk_dir.to_string_lossy().into_owned(),
                     ));
                 }
@@ -1210,6 +1218,35 @@ async fn append_subcommand_transitive_bin_dirs(
                     Err(err) => return Err(err),
                 }
             }
+        }
+    }
+    Ok(())
+}
+
+fn append_zigbuild_env_overrides(
+    paths: &SoldrPaths,
+    triple: &str,
+    extra_env: &mut Vec<(String, String)>,
+) -> Result<(), SoldrError> {
+    let wrappers = match zig_shim::ensure_zig_wrappers(paths, triple) {
+        Ok(wrappers) => wrappers,
+        Err(SoldrError::UnsupportedPlatform(_)) => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    let suffix = triple.replace('-', "_");
+    let upper = suffix.to_uppercase();
+    for (key, val) in [
+        (format!("CC_{suffix}"), wrappers.cc.as_path()),
+        (format!("CXX_{suffix}"), wrappers.cxx.as_path()),
+        (format!("AR_{suffix}"), wrappers.ar.as_path()),
+        (format!("RANLIB_{suffix}"), wrappers.ranlib.as_path()),
+        (
+            format!("CARGO_TARGET_{upper}_LINKER"),
+            wrappers.cc.as_path(),
+        ),
+    ] {
+        if std::env::var_os(&key).is_none() {
+            extra_env.push((key, val.to_string_lossy().into_owned()));
         }
     }
     Ok(())

--- a/crates/soldr-cli/src/cargo_front_door/tests.rs
+++ b/crates/soldr-cli/src/cargo_front_door/tests.rs
@@ -770,6 +770,31 @@ fn zigbuild_does_not_inject_cc_overrides_even_for_msvc_target() {
 }
 
 #[test]
+fn zigbuild_env_overrides_include_cc_and_linker_for_supported_target() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let paths = SoldrPaths::with_root(dir.path().join("soldr"));
+    let mut env = Vec::new();
+
+    append_zigbuild_env_overrides(&paths, "aarch64-unknown-linux-musl", &mut env).unwrap();
+
+    let map: std::collections::HashMap<_, _> = env.into_iter().collect();
+    for key in [
+        "CC_aarch64_unknown_linux_musl",
+        "CXX_aarch64_unknown_linux_musl",
+        "AR_aarch64_unknown_linux_musl",
+        "RANLIB_aarch64_unknown_linux_musl",
+        "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER",
+    ] {
+        let value = map.get(key).unwrap_or_else(|| panic!("missing {key}"));
+        assert!(
+            value.contains("zigbuild-shims"),
+            "{key} should point at generated zigbuild shim, got {value}"
+        );
+    }
+}
+
+#[test]
 fn xwin_with_non_msvc_target_does_not_inject_anything() {
     let env =
         compute_subcommand_env_overrides(&argvec("xwin build --target x86_64-unknown-linux-gnu"));

--- a/crates/soldr-cli/src/cargo_front_door/zig_shim.rs
+++ b/crates/soldr-cli/src/cargo_front_door/zig_shim.rs
@@ -1,0 +1,140 @@
+//! Per-target Zig compiler wrappers for `soldr cargo zigbuild`.
+//!
+//! `cargo-zigbuild` prepares a similar shape for its own inner cargo
+//! invocation. soldr also needs process-side env exports so build scripts
+//! and nested cargo calls see the same target linker policy.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{SoldrError, SoldrPaths};
+
+const SHIM_DIR_BASENAME: &str = "zigbuild-shims";
+
+pub(super) struct ZigWrappers {
+    pub cc: PathBuf,
+    pub cxx: PathBuf,
+    pub ar: PathBuf,
+    pub ranlib: PathBuf,
+}
+
+pub(super) fn ensure_zig_wrappers(
+    paths: &SoldrPaths,
+    triple: &str,
+) -> Result<ZigWrappers, SoldrError> {
+    let zig_target = rust_target_to_zig_target(triple)?;
+    let dir = paths.bin.join(SHIM_DIR_BASENAME).join(triple);
+    std::fs::create_dir_all(&dir)?;
+
+    let ext = if cfg!(windows) { ".cmd" } else { "" };
+    let cc = dir.join(format!("cc{ext}"));
+    let cxx = dir.join(format!("cxx{ext}"));
+    let ar = dir.join(format!("ar{ext}"));
+    let ranlib = dir.join(format!("ranlib{ext}"));
+
+    write_wrapper(&cc, &render_cc_wrapper("cc", zig_target))?;
+    write_wrapper(&cxx, &render_cc_wrapper("c++", zig_target))?;
+    write_wrapper(&ar, &render_tool_wrapper("ar"))?;
+    write_wrapper(&ranlib, &render_tool_wrapper("ranlib"))?;
+
+    Ok(ZigWrappers {
+        cc,
+        cxx,
+        ar,
+        ranlib,
+    })
+}
+
+fn rust_target_to_zig_target(triple: &str) -> Result<&'static str, SoldrError> {
+    match triple {
+        "x86_64-unknown-linux-gnu" => Ok("x86_64-linux-gnu"),
+        "aarch64-unknown-linux-gnu" => Ok("aarch64-linux-gnu"),
+        "x86_64-unknown-linux-musl" => Ok("x86_64-linux-musl"),
+        "aarch64-unknown-linux-musl" => Ok("aarch64-linux-musl"),
+        "x86_64-apple-darwin" => Ok("x86_64-macos-none"),
+        "aarch64-apple-darwin" => Ok("aarch64-macos-none"),
+        _ => Err(SoldrError::UnsupportedPlatform(format!(
+            "soldr cargo zigbuild env bootstrap does not support target `{triple}`"
+        ))),
+    }
+}
+
+fn render_cc_wrapper(subcommand: &str, zig_target: &str) -> String {
+    if cfg!(windows) {
+        format!("@echo off\r\ncargo-zigbuild {subcommand} -target {zig_target} %*\r\n",)
+    } else {
+        format!("#!/bin/sh\nexec cargo-zigbuild {subcommand} -target {zig_target} \"$@\"\n",)
+    }
+}
+
+fn render_tool_wrapper(subcommand: &str) -> String {
+    if cfg!(windows) {
+        format!("@echo off\r\ncargo-zigbuild {subcommand} %*\r\n")
+    } else {
+        format!("#!/bin/sh\nexec cargo-zigbuild {subcommand} \"$@\"\n")
+    }
+}
+
+fn write_wrapper(path: &Path, body: &str) -> Result<(), SoldrError> {
+    let existing = std::fs::read_to_string(path).ok();
+    if existing.as_deref() != Some(body) {
+        std::fs::write(path, body)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_supported_rust_targets_to_zig_targets() {
+        assert_eq!(
+            rust_target_to_zig_target("x86_64-unknown-linux-gnu").unwrap(),
+            "x86_64-linux-gnu"
+        );
+        assert_eq!(
+            rust_target_to_zig_target("aarch64-unknown-linux-musl").unwrap(),
+            "aarch64-linux-musl"
+        );
+        assert_eq!(
+            rust_target_to_zig_target("x86_64-apple-darwin").unwrap(),
+            "x86_64-macos-none"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_targets() {
+        assert!(matches!(
+            rust_target_to_zig_target("wasm32-unknown-unknown"),
+            Err(SoldrError::UnsupportedPlatform(_))
+        ));
+    }
+
+    #[test]
+    fn cc_wrapper_routes_through_zig_with_target() {
+        if cfg!(windows) {
+            return;
+        }
+        let body = render_cc_wrapper("cc", "aarch64-linux-musl");
+        assert!(body.starts_with("#!/bin/sh\n"));
+        assert!(body.contains("cargo-zigbuild cc -target aarch64-linux-musl"));
+        assert!(body.contains("\"$@\""));
+    }
+
+    #[test]
+    fn tool_wrapper_routes_through_cargo_zigbuild() {
+        if cfg!(windows) {
+            return;
+        }
+        let body = render_tool_wrapper("ranlib");
+        assert!(body.contains("cargo-zigbuild ranlib"));
+        assert!(body.contains("\"$@\""));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the zigbuild cargo-front-door parity issue tracked by #948/#928:

- Generates per-target zigbuild wrapper scripts for supported Linux and Darwin targets.
- Exports absolute-path \CC_*\, \CXX_*\, \AR_*\, \RANLIB_*\, and \CARGO_TARGET_*_LINKER\ values for \soldr cargo zigbuild --target ...\.
- Routes wrappers through \cargo-zigbuild cc/c++/ar/ranlib\ so cargo-zigbuild keeps its linker-argument filtering and platform behavior.
- Preserves existing Darwin \SDKROOT\ injection and adds \PKG_CONFIG_SYSROOT_DIR\.
- Leaves unsupported zigbuild targets alone, so the existing MSVC/non-primary paths do not regress.

## Validation

- \soldr cargo fmt --all -- --check\
- \soldr cargo check -p soldr-cli --bin soldr\
- \soldr cargo test -p soldr-cli --bin soldr zigbuild\
- \soldr cargo test -p soldr-cli --bin soldr zig_shim\
- \soldr cargo test -p soldr-cli --bin soldr cargo_front_door\

Closes #948.
Refs #928.