### PR TITLE
[codex] fix cargo-zigbuild shim dispatch

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/zig_shim.rs
+++ b/crates/soldr-cli/src/cargo_front_door/zig_shim.rs
@@ -60,17 +60,17 @@ fn rust_target_to_zig_target(triple: &str) -> Result<&'static str, SoldrError> {
 
 fn render_cc_wrapper(subcommand: &str, zig_target: &str) -> String {
     if cfg!(windows) {
-        format!("@echo off\r\ncargo-zigbuild {subcommand} -target {zig_target} %*\r\n",)
+        format!("@echo off\r\ncargo-zigbuild zig {subcommand} -- -target {zig_target} %*\r\n",)
     } else {
-        format!("#!/bin/sh\nexec cargo-zigbuild {subcommand} -target {zig_target} \"$@\"\n",)
+        format!("#!/bin/sh\nexec cargo-zigbuild zig {subcommand} -- -target {zig_target} \"$@\"\n",)
     }
 }
 
 fn render_tool_wrapper(subcommand: &str) -> String {
     if cfg!(windows) {
-        format!("@echo off\r\ncargo-zigbuild {subcommand} %*\r\n")
+        format!("@echo off\r\ncargo-zigbuild zig {subcommand} -- %*\r\n")
     } else {
-        format!("#!/bin/sh\nexec cargo-zigbuild {subcommand} \"$@\"\n")
+        format!("#!/bin/sh\nexec cargo-zigbuild zig {subcommand} -- \"$@\"\n")
     }
 }
 
@@ -124,7 +124,7 @@ mod tests {
         }
         let body = render_cc_wrapper("cc", "aarch64-linux-musl");
         assert!(body.starts_with("#!/bin/sh\n"));
-        assert!(body.contains("cargo-zigbuild cc -target aarch64-linux-musl"));
+        assert!(body.contains("cargo-zigbuild zig cc -- -target aarch64-linux-musl"));
         assert!(body.contains("\"$@\""));
     }
 
@@ -134,7 +134,7 @@ mod tests {
             return;
         }
         let body = render_tool_wrapper("ranlib");
-        assert!(body.contains("cargo-zigbuild ranlib"));
+        assert!(body.contains("cargo-zigbuild zig ranlib --"));
         assert!(body.contains("\"$@\""));
     }
 }


### PR DESCRIPTION
## Summary
- fix generated zigbuild shims to call cargo-zigbuild's actual `zig <tool> -- ...` subcommand surface
- keep CC/CXX target arguments and AR/RANLIB forwarding intact for build scripts

## Root cause
The previous shim called `cargo-zigbuild cc`, but cargo-zigbuild 0.20 exposes compiler wrappers under `cargo-zigbuild zig cc -- ...`. CI hit this in the macOS ARM64 cross build when `ring` invoked the generated `CC_aarch64_apple_darwin` wrapper.

## Validation
- soldr cargo fmt --all -- --check
- soldr cargo test -p soldr-cli --bin soldr zig_shim
- soldr cargo test -p soldr-cli --bin soldr zigbuild
- git diff --check