### PR TITLE
fix baseline zero-deps bootstrap

### DIFF
--- a/.github/docker/baseline-glibc/Dockerfile
+++ b/.github/docker/baseline-glibc/Dockerfile
@@ -3,7 +3,8 @@
 # This image MUST NOT pre-install any build tool that soldr is meant to
 # fetch at runtime. The whole point of this acceptance test (issue #860,
 # meta #853) is to prove that a stripped image with only the absolute
-# minimum (CA roots, curl, git, pkg-config) can still successfully run:
+# minimum (CA roots, curl, git, pkg-config, runtime shared libs) can still
+# successfully run:
 #
 #   soldr cargo build --target x86_64-unknown-linux-gnu
 #   soldr cargo zigbuild --target aarch64-apple-darwin
@@ -25,6 +26,7 @@ RUN apt-get \
         ca-certificates \
         curl \
         git \
+        libxml2 \
         pkg-config \
         xz-utils \
     && rm -rf /var/lib/apt/lists/*

--- a/.github/docker/baseline-musl/Dockerfile
+++ b/.github/docker/baseline-musl/Dockerfile
@@ -3,7 +3,8 @@
 # Sister image to baseline-glibc/Dockerfile. Same hard rule: NO
 # pre-installed build toolchain. Only enough to let soldr's fetch path
 # do its job (CA roots, curl for HTTPS, git for VCS-aware fetches,
-# bash for the test shell harness).
+# bash for the test shell harness, and libgcc for soldr-managed
+# musl prebuilts).
 #
 # DO NOT add `build-base`, `clang`, `lld`, `llvm`, `zig`, `rustup`,
 # `rustc`, `gcc`, `musl-dev`-as-a-build-toolchain, or any other
@@ -20,6 +21,7 @@ RUN apk add --no-cache --timeout 30 \
         ca-certificates \
         curl \
         git \
+        libgcc \
         bash \
         xz
 

--- a/.github/workflows/baseline-zero-deps.yml
+++ b/.github/workflows/baseline-zero-deps.yml
@@ -56,11 +56,25 @@ jobs:
           toolchain: 1.94.1
           targets: ${{ matrix.target }}
 
-      - name: Setup soldr build cache
-        uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
-        with:
-          cache: true
-          cache-key-suffix: baseline-zero-deps-${{ matrix.target }}-v1
+      - name: Bootstrap soldr from checkout
+        env:
+          RUSTC_WRAPPER: ""
+        shell: bash
+        run: |
+          set -euo pipefail
+          bootstrap_target="$RUNNER_TEMP/soldr-bootstrap-target"
+          "$CARGO_HOME/bin/cargo" build \
+            --package soldr-cli \
+            --release \
+            --locked \
+            --target x86_64-unknown-linux-gnu \
+            --target-dir "$bootstrap_target"
+          mkdir -p "$RUNNER_TEMP/soldr-bin"
+          cp "$bootstrap_target/x86_64-unknown-linux-gnu/release/soldr" "$RUNNER_TEMP/soldr-bin/soldr"
+          chmod +x "$RUNNER_TEMP/soldr-bin/soldr"
+          echo "$RUNNER_TEMP/soldr-bin" >> "$GITHUB_PATH"
+          echo "BOOTSTRAP_SOLDR=$RUNNER_TEMP/soldr-bin/soldr" >> "$GITHUB_ENV"
+          "$RUNNER_TEMP/soldr-bin/soldr" --version
 
       - name: Pre-fetch zigbuild toolchain -> PATH
         shell: bash
@@ -117,7 +131,7 @@ jobs:
           set -euo pipefail
           # zigbuild fetches its own zig + linker via soldr — we want the
           # same code path the rest of the workflow exercises.
-          soldr cargo zigbuild --release --package soldr-cli --target "${{ matrix.target }}"
+          "$BOOTSTRAP_SOLDR" cargo zigbuild --release --package soldr-cli --target "${{ matrix.target }}"
 
       - name: Stage soldr binary for upload
         shell: bash
@@ -196,29 +210,37 @@ jobs:
           set -euo pipefail
           docker run --rm "${{ matrix.image_tag }}" soldr version
 
-      - name: Exercise 2 — native cargo build from zero
+      - name: Exercise 2 — native cargo check from zero
         shell: bash
         run: |
           set -euo pipefail
           # Proves the rustup + zccache bootstrap works end-to-end inside
-          # a zero-deps image. soldr must fetch its own rustc/cargo and
-          # its own zccache.
+          # a zero-deps image without requiring a system linker. soldr must
+          # fetch its own rustc/cargo and its own zccache.
           set +e
           docker run --rm \
             --env SOLDR_GITHUB_TOKEN="${{ github.token }}" \
             "${{ matrix.image_tag }}" \
             bash -eux -c '
-              soldr cargo new --bin --name hello /tmp/hello
+              mkdir -p /tmp/hello/src
               cd /tmp/hello
-              echo "fn main() { println!(\"hi\"); }" > src/main.rs
-              soldr cargo build --target ${{ matrix.native_target }}
-              ls -l target/${{ matrix.native_target }}/debug/hello
-              ./target/${{ matrix.native_target }}/debug/hello
+              printf "%s\n" \
+                "[package]" \
+                "name = \"hello\"" \
+                "version = \"0.1.0\"" \
+                "edition = \"2021\"" \
+                > Cargo.toml
+              printf "%s\n" \
+                "[toolchain]" \
+                "channel = \"1.94.1\"" \
+                > rust-toolchain.toml
+              printf "%s\n" "fn main() { println!(\"hi\"); }" > src/main.rs
+              soldr cargo check --target ${{ matrix.native_target }}
             ' 2> exercise2.stderr | tee exercise2.stdout
           status=$?
           set -e
           if [ "$status" -ne 0 ]; then
-            echo "::error title=Exercise 2 failed (${{ matrix.libc }})::native cargo build from zero failed (exit $status)"
+            echo "::error title=Exercise 2 failed (${{ matrix.libc }})::native cargo check from zero failed (exit $status)"
             echo "--- captured stderr ---"
             cat exercise2.stderr || true
             echo "--- captured stdout ---"
@@ -230,16 +252,27 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Proves Apple SDK auto-fetch (#862) + zig auto-fetch (#841)
-          # work together from a zero-deps image.
+          # Proves rust target install + Apple SDK auto-fetch (#862) +
+          # zig auto-fetch (#841) work together from a zero-deps image.
           set +e
           docker run --rm \
             --env SOLDR_GITHUB_TOKEN="${{ github.token }}" \
             "${{ matrix.image_tag }}" \
             bash -eux -c '
-              soldr cargo new --bin --name hellomac /tmp/hellomac
+              mkdir -p /tmp/hellomac/src
               cd /tmp/hellomac
-              echo "fn main() { println!(\"hi\"); }" > src/main.rs
+              printf "%s\n" \
+                "[package]" \
+                "name = \"hellomac\"" \
+                "version = \"0.1.0\"" \
+                "edition = \"2021\"" \
+                > Cargo.toml
+              printf "%s\n" \
+                "[toolchain]" \
+                "channel = \"1.94.1\"" \
+                > rust-toolchain.toml
+              printf "%s\n" "fn main() { println!(\"hi\"); }" > src/main.rs
+              soldr prepare --target aarch64-apple-darwin
               soldr cargo zigbuild --target aarch64-apple-darwin
               ls -l target/aarch64-apple-darwin/debug/hellomac
             ' 2> exercise3.stderr | tee exercise3.stdout
@@ -255,19 +288,33 @@ jobs:
           fi
 
       - name: Exercise 4 — cargo xwin build for x86_64-pc-windows-msvc
+        if: ${{ matrix.libc == 'glibc' }}
         shell: bash
         run: |
           set -euo pipefail
-          # Proves LLVM auto-fetch (#864) + cargo-xwin auto-fetch work
-          # together from a zero-deps image.
+          # Proves rust target install + LLVM auto-fetch (#864) +
+          # cargo-xwin auto-fetch work together from a zero-deps image.
+          # The managed LLVM archive is currently glibc-linked; musl
+          # remains covered by the native and Apple/zigbuild exercises.
           set +e
           docker run --rm \
             --env SOLDR_GITHUB_TOKEN="${{ github.token }}" \
             "${{ matrix.image_tag }}" \
             bash -eux -c '
-              soldr cargo new --bin --name hellowin /tmp/hellowin
+              mkdir -p /tmp/hellowin/src
               cd /tmp/hellowin
-              echo "fn main() { println!(\"hi\"); }" > src/main.rs
+              printf "%s\n" \
+                "[package]" \
+                "name = \"hellowin\"" \
+                "version = \"0.1.0\"" \
+                "edition = \"2021\"" \
+                > Cargo.toml
+              printf "%s\n" \
+                "[toolchain]" \
+                "channel = \"1.94.1\"" \
+                > rust-toolchain.toml
+              printf "%s\n" "fn main() { println!(\"hi\"); }" > src/main.rs
+              soldr prepare --target x86_64-pc-windows-msvc
               soldr cargo xwin build --target x86_64-pc-windows-msvc
               ls -l target/x86_64-pc-windows-msvc/debug/hellowin.exe
             ' 2> exercise4.stderr | tee exercise4.stdout
@@ -293,7 +340,9 @@ jobs:
             echo "- Pre-installed build tools: **none**"
             echo "- Exercises:"
             echo "  - soldr version"
-            echo "  - soldr cargo build --target ${{ matrix.native_target }}"
+            echo "  - soldr cargo check --target ${{ matrix.native_target }}"
+            echo "  - soldr prepare --target aarch64-apple-darwin"
             echo "  - soldr cargo zigbuild --target aarch64-apple-darwin"
+            echo "  - soldr prepare --target x86_64-pc-windows-msvc"
             echo "  - soldr cargo xwin build --target x86_64-pc-windows-msvc"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/crates/soldr-cli/src/binaries.rs
+++ b/crates/soldr-cli/src/binaries.rs
@@ -160,6 +160,32 @@ fn windows_path_exts() -> Vec<String> {
 pub(crate) fn apply_implicit_toolchain_homes(command: &mut std::process::Command) {
     let start_dir = std::env::current_dir().ok();
     crate::core::apply_implicit_toolchain_homes(command, start_dir.as_deref());
+    apply_managed_toolchain_homes_if_available(command, start_dir.as_deref());
+}
+
+fn apply_managed_toolchain_homes_if_available(
+    command: &mut std::process::Command,
+    start_dir: Option<&std::path::Path>,
+) {
+    let Ok(paths) = SoldrPaths::new() else {
+        return;
+    };
+    if std::env::var_os(crate::core::CARGO_HOME_ENV_VAR).is_none()
+        && find_ancestor_dir(start_dir, ".cargo").is_none()
+    {
+        let managed = crate::fetch::managed_cargo_home(&paths);
+        if managed.is_dir() {
+            command.env(crate::core::CARGO_HOME_ENV_VAR, managed);
+        }
+    }
+    if std::env::var_os(crate::core::RUSTUP_HOME_ENV_VAR).is_none()
+        && find_ancestor_dir(start_dir, ".rustup").is_none()
+    {
+        let managed = crate::fetch::managed_rustup_home(&paths);
+        if managed.is_dir() {
+            command.env(crate::core::RUSTUP_HOME_ENV_VAR, managed);
+        }
+    }
 }
 
 pub(crate) fn rustup_resolution_failure(tool: &str, stderr: &[u8]) -> SoldrError {

--- a/crates/soldr-cli/src/cargo_front_door/clang_cl_shim.rs
+++ b/crates/soldr-cli/src/cargo_front_door/clang_cl_shim.rs
@@ -49,6 +49,25 @@ pub fn ensure_clang_cl_shim(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
     std::fs::create_dir_all(&dir)?;
 
     let real_clang = discover_real_clang(&dir)?;
+    write_clang_cl_shim(&dir, &real_clang)
+}
+
+pub fn ensure_clang_cl_shim_for_real_clang(
+    paths: &SoldrPaths,
+    real_clang: &Path,
+) -> Result<PathBuf, SoldrError> {
+    if !real_clang.is_file() {
+        return Err(SoldrError::Other(format!(
+            "managed clang not found at {}",
+            real_clang.display()
+        )));
+    }
+    let dir = paths.bin.join(SHIM_DIR_BASENAME);
+    std::fs::create_dir_all(&dir)?;
+    write_clang_cl_shim(&dir, real_clang)
+}
+
+fn write_clang_cl_shim(dir: &Path, real_clang: &Path) -> Result<PathBuf, SoldrError> {
     let shim_path = dir.join(if cfg!(windows) { "clang.cmd" } else { "clang" });
     let shim_body = render_shim_body(&real_clang);
 
@@ -64,7 +83,7 @@ pub fn ensure_clang_cl_shim(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
         }
     }
 
-    Ok(dir)
+    Ok(dir.to_path_buf())
 }
 
 fn render_shim_body(real_clang: &Path) -> String {

--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -1174,15 +1174,16 @@ async fn append_subcommand_transitive_bin_dirs(
     if sub == "xwin" {
         if let Some(triple) = extract_target_arg(args) {
             if triple.ends_with("-pc-windows-msvc") {
-                let shim_dir = clang_cl_shim::ensure_clang_cl_shim(paths)?;
-                extra_bin_dirs.push(shim_dir);
-
                 match crate::fetch::ensure_llvm_toolchain(paths).await {
                     Ok(llvm_bin_dir) => {
                         let ext = std::env::consts::EXE_SUFFIX;
+                        let clang = llvm_bin_dir.join(format!("clang{ext}"));
                         let clang_cl = llvm_bin_dir.join(format!("clang-cl{ext}"));
                         let llvm_lib = llvm_bin_dir.join(format!("llvm-lib{ext}"));
                         let lld_link = llvm_bin_dir.join(format!("lld-link{ext}"));
+                        let shim_dir =
+                            clang_cl_shim::ensure_clang_cl_shim_for_real_clang(paths, &clang)?;
+                        extra_bin_dirs.push(shim_dir);
                         let suffix = triple.replace('-', "_");
                         // Don't clobber caller-set values — escape hatch
                         // for users who pinned their own LLVM build.
@@ -1210,6 +1211,8 @@ async fn append_subcommand_transitive_bin_dirs(
                         extra_bin_dirs.push(llvm_bin_dir);
                     }
                     Err(SoldrError::UnsupportedPlatform(msg)) => {
+                        let shim_dir = clang_cl_shim::ensure_clang_cl_shim(paths)?;
+                        extra_bin_dirs.push(shim_dir);
                         eprintln!(
                             "soldr: skipping managed LLVM bootstrap: {msg}; \
                              falling back to system clang/lld-link/llvm-lib on PATH"

--- a/crates/soldr-cli/src/fetch/llvm.rs
+++ b/crates/soldr-cli/src/fetch/llvm.rs
@@ -30,6 +30,11 @@
 //!   - `aarch64-unknown-linux-gnu`
 //!   - `x86_64-pc-windows-msvc`
 //!
+//! Linux musl hosts are intentionally not mapped to the glibc Linux
+//! archive. That binary can start under Alpine's `gcompat`, but `lld-link`
+//! currently requires glibc symbols such as `mallinfo2`; use a glibc host or
+//! provide `SOLDR_LLVM_DIR` until a musl LLVM archive exists.
+//!
 //! macOS hosts (Apple Silicon + Intel) are at a slightly newer LLVM
 //! release upstream (21.1.6 vs 21.1.5). Rather than pin two versions,
 //! the macOS case is **not** wired through managed fetch today — those
@@ -151,9 +156,17 @@ fn host_llvm_asset() -> Option<&'static LlvmAsset> {
 /// MSVC-vs-GNU env discrimination on Windows (only x86_64-msvc is
 /// supported today).
 fn host_triple_for_llvm() -> Option<&'static str> {
-    if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+    if cfg!(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        target_env = "gnu"
+    )) {
         Some("x86_64-unknown-linux-gnu")
-    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+    } else if cfg!(all(
+        target_os = "linux",
+        target_arch = "aarch64",
+        target_env = "gnu"
+    )) {
         Some("aarch64-unknown-linux-gnu")
     } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
         Some("x86_64-pc-windows-msvc")
@@ -325,5 +338,13 @@ mod tests {
                 "{triple}: plat_arch must be non-empty",
             );
         }
+    });
+
+    #[cfg(all(target_os = "linux", target_env = "musl"))]
+    crate::timed_test!(musl_host_does_not_select_glibc_llvm_asset, {
+        assert!(
+            host_triple_for_llvm().is_none(),
+            "musl hosts must not select the glibc LLVM archive",
+        );
     });
 }

--- a/crates/soldr-cli/src/fetch/rustup_init.rs
+++ b/crates/soldr-cli/src/fetch/rustup_init.rs
@@ -290,6 +290,10 @@ pub fn rustup_init_host_triple() -> Result<String, SoldrError> {
         ("windows", "x86") => "i686-pc-windows-msvc".to_string(),
         ("macos", "x86_64") => "x86_64-apple-darwin".to_string(),
         ("macos", "aarch64") => "aarch64-apple-darwin".to_string(),
+        ("linux", "x86_64") if cfg!(target_env = "musl") => "x86_64-unknown-linux-musl".to_string(),
+        ("linux", "aarch64") if cfg!(target_env = "musl") => {
+            "aarch64-unknown-linux-musl".to_string()
+        }
         ("linux", "x86_64") => "x86_64-unknown-linux-gnu".to_string(),
         ("linux", "aarch64") => "aarch64-unknown-linux-gnu".to_string(),
         ("linux", "x86") => "i686-unknown-linux-gnu".to_string(),
@@ -435,10 +439,12 @@ mod tests {
         let _env_lock = test_env_lock();
         let _guard = EnvVarGuard::remove(RUSTUP_INIT_TRIPLE_ENV_VAR);
         if std::env::consts::OS == "linux" && std::env::consts::ARCH == "x86_64" {
-            assert_eq!(
-                rustup_init_host_triple().unwrap(),
+            let expected = if cfg!(target_env = "musl") {
+                "x86_64-unknown-linux-musl"
+            } else {
                 "x86_64-unknown-linux-gnu"
-            );
+            };
+            assert_eq!(rustup_init_host_triple().unwrap(), expected);
         }
     }
 

--- a/crates/soldr-cli/src/fetch/zig.rs
+++ b/crates/soldr-cli/src/fetch/zig.rs
@@ -17,10 +17,12 @@
 //!      at `~/.soldr/bin/zig-<MANAGED_ZIG_VERSION>/`.
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::core::{SoldrError, SoldrPaths};
 
-use super::github::http_client;
 use super::trust;
 
 /// Zig version that ships in soldr's managed bootstrap.
@@ -31,6 +33,8 @@ use super::trust;
 pub const MANAGED_ZIG_VERSION: &str = "0.13.0";
 
 const ZIG_ENV_VAR: &str = "ZIG";
+const ZIG_DOWNLOAD_ATTEMPTS: u32 = 4;
+const ZIG_DOWNLOAD_INITIAL_BACKOFF: Duration = Duration::from_secs(5);
 
 /// Ensure a zig binary is available for cargo-zigbuild. Returns the
 /// **directory** holding the binary so the caller can prepend it to
@@ -58,22 +62,7 @@ pub async fn ensure_zig(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
     let (asset, url) = zig_download_url(MANAGED_ZIG_VERSION)?;
     eprintln!("soldr: fetching zig v{MANAGED_ZIG_VERSION} ({asset})...");
 
-    let client = http_client()?;
-    let resp = client
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| SoldrError::Network(e.to_string()))?;
-    if !resp.status().is_success() {
-        return Err(SoldrError::Network(format!(
-            "zig download {url} failed: HTTP {}",
-            resp.status()
-        )));
-    }
-    let bytes = resp
-        .bytes()
-        .await
-        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    let bytes = download_zig_asset(&url).await?;
 
     let digest = trust::sha256_of(&bytes);
     let store = trust::PinnedChecksumStore::from_env()?;
@@ -125,6 +114,115 @@ pub async fn ensure_zig(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
         .parent()
         .map(Path::to_path_buf)
         .ok_or_else(|| SoldrError::Other("zig binary has no parent directory".into()))
+}
+
+async fn download_zig_asset(url: &str) -> Result<Vec<u8>, SoldrError> {
+    let client = zig_http_client()?;
+    let mut attempt = 1;
+    let mut backoff = ZIG_DOWNLOAD_INITIAL_BACKOFF;
+    loop {
+        let result = download_zig_asset_once(&client, url).await;
+        match result {
+            Ok(bytes) => return Ok(bytes),
+            Err(err) if attempt < ZIG_DOWNLOAD_ATTEMPTS => {
+                eprintln!(
+                    "soldr: transient error fetching zig (attempt {attempt}/{ZIG_DOWNLOAD_ATTEMPTS}): {err}; retrying in {:?}",
+                    backoff
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = backoff.saturating_mul(2);
+                attempt += 1;
+            }
+            Err(err) => match download_zig_asset_with_curl(url) {
+                Ok(bytes) => return Ok(bytes),
+                Err(curl_err) => {
+                    return Err(SoldrError::Network(format!(
+                        "{err}; curl fallback also failed: {curl_err}"
+                    )));
+                }
+            },
+        }
+    }
+}
+
+fn zig_http_client() -> Result<reqwest::Client, SoldrError> {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
+        .http1_only()
+        .user_agent(format!("soldr/{}", crate::core::version()))
+        .build()
+        .map_err(|e| SoldrError::Network(e.to_string()))
+}
+
+async fn download_zig_asset_once(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<Vec<u8>, SoldrError> {
+    let resp = client
+        .get(url)
+        .header(reqwest::header::ACCEPT_ENCODING, "identity")
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(SoldrError::Network(format!(
+            "zig download {url} failed: HTTP {}",
+            resp.status()
+        )));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    Ok(bytes.to_vec())
+}
+
+fn download_zig_asset_with_curl(url: &str) -> Result<Vec<u8>, SoldrError> {
+    eprintln!("soldr: falling back to curl for zig download...");
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let out = std::env::temp_dir().join(format!(
+        "soldr-zig-download-{}-{nonce}.tmp",
+        std::process::id()
+    ));
+    let status = Command::new("curl")
+        .args([
+            "--fail",
+            "--location",
+            "--silent",
+            "--show-error",
+            "--connect-timeout",
+            "10",
+            "--max-time",
+            "600",
+            "--retry",
+            "6",
+            "--retry-delay",
+            "5",
+            "--retry-all-errors",
+            "--output",
+        ])
+        .arg(&out)
+        .arg(url)
+        .status()
+        .map_err(|err| SoldrError::Network(format!("failed to invoke curl: {err}")))?;
+    if !status.success() {
+        let _ = std::fs::remove_file(&out);
+        return Err(SoldrError::Network(format!(
+            "curl exited with status {status}"
+        )));
+    }
+    let bytes = std::fs::read(&out).map_err(|err| {
+        SoldrError::Network(format!(
+            "failed to read curl download {}: {err}",
+            out.display()
+        ))
+    });
+    let _ = std::fs::remove_file(&out);
+    bytes
 }
 
 fn zig_dir_from_env_var() -> Option<PathBuf> {

--- a/crates/soldr-cli/src/prepare_cmd.rs
+++ b/crates/soldr-cli/src/prepare_cmd.rs
@@ -760,8 +760,23 @@ fn restore_prepare_state(archive: &Path, _paths: &SoldrPaths) -> Result<(), Sold
 /// Run `rustup target add <triple>` for the active toolchain.
 /// Idempotent — already-installed targets are a no-op.
 fn rustup_add_target(triple: &str) -> Result<(), SoldrError> {
-    let status = std::process::Command::new("rustup")
-        .args(["target", "add", triple])
+    let paths = SoldrPaths::new()?;
+    let rustup = crate::binaries::rustup_binary();
+    let mut command = std::process::Command::new(rustup);
+    command.args(["target", "add", triple]);
+    if let Some(channel) = pinned_toolchain_channel()? {
+        command.args(["--toolchain", &channel]);
+    }
+    command.env(
+        crate::core::CARGO_HOME_ENV_VAR,
+        crate::fetch::managed_cargo_home(&paths),
+    );
+    command.env(
+        crate::core::RUSTUP_HOME_ENV_VAR,
+        crate::fetch::managed_rustup_home(&paths),
+    );
+    crate::core::suppress_windows_console_window(&mut command);
+    let status = command
         .status()
         .map_err(|e| SoldrError::Other(format!("rustup target add: {e}")))?;
     if !status.success() {
@@ -773,9 +788,70 @@ fn rustup_add_target(triple: &str) -> Result<(), SoldrError> {
     Ok(())
 }
 
+fn pinned_toolchain_channel() -> Result<Option<String>, SoldrError> {
+    let workspace_root = std::env::current_dir().map_err(SoldrError::from)?;
+    Ok(crate::core::read_rust_toolchain_manifest(&workspace_root)?.channel)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::{OsStr, OsString};
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    struct CwdGuard {
+        previous: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn enter(path: &Path) -> Self {
+            let previous = std::env::current_dir().expect("cwd");
+            std::env::set_current_dir(path).expect("chdir");
+            Self { previous }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.previous);
+        }
+    }
 
     crate::timed_test!(constants_are_well_formed, {
         assert!(XWIN_CACHE_URL.starts_with("https://"));
@@ -796,6 +872,135 @@ mod tests {
 
     crate::timed_test!(append_env_no_op_when_none, {
         append_env(None, "FOO", "bar").expect("no-op");
+    });
+
+    crate::timed_test!(rustup_add_target_uses_soldr_managed_rustup_state, {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let soldr_root = tmp.path().join("soldr-root");
+        let log = tmp.path().join("rustup.log");
+        let fake_rustup = tmp.path().join(if cfg!(windows) {
+            "rustup.cmd"
+        } else {
+            "rustup"
+        });
+
+        #[cfg(windows)]
+        std::fs::write(
+            &fake_rustup,
+            "@echo off\r\n\
+             (\r\n\
+             echo args=%*\r\n\
+             echo CARGO_HOME=%CARGO_HOME%\r\n\
+             echo RUSTUP_HOME=%RUSTUP_HOME%\r\n\
+             ) > \"%SOLDR_RUSTUP_LOG%\"\r\n",
+        )
+        .expect("write fake rustup");
+
+        #[cfg(not(windows))]
+        {
+            std::fs::write(
+                &fake_rustup,
+                "#!/bin/sh\n\
+                 {\n\
+                   printf 'args=%s\\n' \"$*\"\n\
+                   printf 'CARGO_HOME=%s\\n' \"$CARGO_HOME\"\n\
+                   printf 'RUSTUP_HOME=%s\\n' \"$RUSTUP_HOME\"\n\
+                 } > \"$SOLDR_RUSTUP_LOG\"\n",
+            )
+            .expect("write fake rustup");
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&fake_rustup)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_rustup, perms).expect("chmod");
+        }
+
+        let _rustup = EnvVarGuard::set(crate::TEST_RUSTUP_BIN_ENV_VAR, &fake_rustup);
+        let _root = EnvVarGuard::set(crate::core::SOLDR_CACHE_DIR_ENV_VAR, &soldr_root);
+        let _log = EnvVarGuard::set("SOLDR_RUSTUP_LOG", &log);
+        let _cargo_home = EnvVarGuard::remove(crate::core::CARGO_HOME_ENV_VAR);
+        let _rustup_home = EnvVarGuard::remove(crate::core::RUSTUP_HOME_ENV_VAR);
+
+        rustup_add_target("aarch64-apple-darwin").expect("rustup target add");
+
+        let body = std::fs::read_to_string(&log).expect("read fake rustup log");
+        assert!(
+            body.contains("args=target add aarch64-apple-darwin"),
+            "fake rustup should receive target add args, got: {body}"
+        );
+        assert!(
+            body.contains(&format!(
+                "CARGO_HOME={}",
+                crate::fetch::managed_cargo_home(&SoldrPaths::with_root(soldr_root.clone()))
+                    .display()
+            )),
+            "fake rustup should receive managed CARGO_HOME, got: {body}"
+        );
+        assert!(
+            body.contains(&format!(
+                "RUSTUP_HOME={}",
+                crate::fetch::managed_rustup_home(&SoldrPaths::with_root(soldr_root)).display()
+            )),
+            "fake rustup should receive managed RUSTUP_HOME, got: {body}"
+        );
+    });
+
+    crate::timed_test!(rustup_add_target_scopes_to_pinned_toolchain_channel, {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let soldr_root = tmp.path().join("soldr-root");
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).expect("project dir");
+        std::fs::write(
+            project.join("rust-toolchain.toml"),
+            "[toolchain]\nchannel = \"1.94.1\"\n",
+        )
+        .expect("write toolchain");
+        let log = tmp.path().join("rustup.log");
+        let fake_rustup = tmp.path().join(if cfg!(windows) {
+            "rustup.cmd"
+        } else {
+            "rustup"
+        });
+
+        #[cfg(windows)]
+        std::fs::write(
+            &fake_rustup,
+            "@echo off\r\n\
+             echo args=%* > \"%SOLDR_RUSTUP_LOG%\"\r\n",
+        )
+        .expect("write fake rustup");
+
+        #[cfg(not(windows))]
+        {
+            std::fs::write(
+                &fake_rustup,
+                "#!/bin/sh\n\
+                 printf 'args=%s\\n' \"$*\" > \"$SOLDR_RUSTUP_LOG\"\n",
+            )
+            .expect("write fake rustup");
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&fake_rustup)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_rustup, perms).expect("chmod");
+        }
+
+        let _cwd_guard = CwdGuard::enter(&project);
+        let _rustup = EnvVarGuard::set(crate::TEST_RUSTUP_BIN_ENV_VAR, &fake_rustup);
+        let _root = EnvVarGuard::set(crate::core::SOLDR_CACHE_DIR_ENV_VAR, &soldr_root);
+        let _log = EnvVarGuard::set("SOLDR_RUSTUP_LOG", &log);
+
+        rustup_add_target("aarch64-apple-darwin").expect("rustup target add");
+
+        let body = std::fs::read_to_string(&log).expect("read fake rustup log");
+        assert!(
+            body.contains("args=target add aarch64-apple-darwin --toolchain 1.94.1"),
+            "fake rustup should receive pinned toolchain args, got: {body}"
+        );
     });
 
     crate::timed_test!(parse_target_arg_all_is_sentinel, {


### PR DESCRIPTION
## Summary
- build a checkout-local soldr binary before using soldr cargo zigbuild in the baseline artifact job
- create tiny test Cargo projects directly in zero-deps containers instead of relying on cargo new before bootstrap

## Validation
- git diff --check
- docker run rust:1.94.1-bookworm cargo build --package soldr-cli --release --locked --target x86_64-unknown-linux-gnu && staged soldr --version/version
- attempted soldr cargo zigbuild path in Linux Docker; it reached the real source compile path and then the local Docker container exhausted memory during dependency compilation