### PR TITLE
Enforce timeout for live cargo runs

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -688,7 +688,7 @@ pub(crate) async fn run_cargo_front_door(
     // For clippy fall-through we need to TEE cargo's stdout/stderr so the
     // user sees diagnostics live AND we have a copy to store in the
     // sidecar for the next run. For build/check we don't need the output;
-    // just inherit fds via .status().
+    // just inherit fds while still enforcing the cargo wait timeout.
     //
     // We ALSO opt into capture when stderr is not a terminal (CI / Docker
     // / `soldr cargo build 2>file`) so the cargo_diagnostics scanner can
@@ -711,7 +711,7 @@ pub(crate) async fn run_cargo_front_door(
         let (status, captured) = run_command_capturing_diagnostic_tail(&mut command)?;
         (status, None, Some(captured))
     } else {
-        (command.status()?, None, None)
+        (run_command_inheriting_stdio(&mut command)?, None, None)
     };
     // Extract whatever stderr text we captured BEFORE the success
     // branch moves `clippy_capture` into `refresh_workspace_sidecar_after_cargo`.
@@ -855,6 +855,15 @@ fn run_command_capturing_clippy(
         exit_code: status.code().unwrap_or(1),
     };
     Ok((status, capture))
+}
+
+fn run_command_inheriting_stdio(
+    command: &mut std::process::Command,
+) -> Result<std::process::ExitStatus, SoldrError> {
+    let mut child = command
+        .spawn()
+        .map_err(|err| SoldrError::Other(format!("spawn cargo failed: {err}")))?;
+    wait_for_cargo_child(&mut child, "cargo")
 }
 
 /// Run cargo with both streams tee'd to the user's stdout/stderr AND

--- a/crates/soldr-cli/src/cargo_front_door/tests.rs
+++ b/crates/soldr-cli/src/cargo_front_door/tests.rs
@@ -52,6 +52,30 @@ fn command_env_override(
 }
 
 #[test]
+fn cargo_wait_timeout_uses_positive_env_override_only() {
+    let _lock = ENV_LOCK.lock().unwrap();
+
+    {
+        let _guard = EnvVarGuard::set(CARGO_WAIT_TIMEOUT_ENV_VAR, "7");
+        assert_eq!(cargo_wait_timeout(), Duration::from_secs(7));
+    }
+
+    for value in ["0", "-1", "not-a-number"] {
+        let _guard = EnvVarGuard::set(CARGO_WAIT_TIMEOUT_ENV_VAR, value);
+        assert_eq!(
+            cargo_wait_timeout(),
+            Duration::from_secs(DEFAULT_CARGO_WAIT_TIMEOUT_SECS)
+        );
+    }
+
+    let _guard = EnvVarGuard::remove(CARGO_WAIT_TIMEOUT_ENV_VAR);
+    assert_eq!(
+        cargo_wait_timeout(),
+        Duration::from_secs(DEFAULT_CARGO_WAIT_TIMEOUT_SECS)
+    );
+}
+
+#[test]
 fn child_cargo_scrubs_soldr_cache_lifecycle_controls() {
     let mut command = std::process::Command::new("cargo");
     command.env(SOLDR_CACHE_LIFECYCLE_ENV_VAR, "command");


### PR DESCRIPTION
## Summary
- route the TTY/live-inherited cargo branch through the existing cargo wait-timeout helper
- preserve inherited stdout/stderr behavior while making SOLDR_CARGO_WAIT_TIMEOUT_SECS apply to every cargo front-door execution path
- add a focused timeout env parsing test

## Verification
- soldr cargo fmt --all -- --check
- soldr cargo test -p soldr-cli --bin soldr cargo_wait_timeout_uses_positive_env_override_only -- --nocapture
- soldr cargo clippy -p soldr-cli --bin soldr -- -D warnings
- soldr cargo check -p soldr-cli --bin soldr
- ./lint
- git diff --check