### PR TITLE
Timeout rustup-init bootstrap

### DIFF
--- a/crates/soldr-cli/src/fetch/rustup_init.rs
+++ b/crates/soldr-cli/src/fetch/rustup_init.rs
@@ -29,6 +29,8 @@ use super::http_client;
 use super::trust::{sha256_of, verify_download, PinnedChecksumStore, TrustMode, VerifyOutcome};
 use crate::core::{SoldrError, SoldrPaths};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
+use wait_timeout::ChildExt;
 
 /// Opt-out env var. When set to a truthy value (`1`, `true`, `yes`, `on`,
 /// case-insensitive), the auto-bootstrap path becomes a no-op and the caller
@@ -46,6 +48,9 @@ pub const RUSTUP_INIT_URL_ENV_VAR: &str = "SOLDR_RUSTUP_INIT_URL_OVERRIDE";
 
 const RUSTUP_INIT_TOOL_NAME: &str = "rustup-init";
 const RUSTUP_INIT_PSEUDO_VERSION: &str = "latest";
+const RUSTUP_INIT_TIMEOUT_ENV_VAR: &str = "SOLDR_RUSTUP_INIT_TIMEOUT_SECS";
+const DEFAULT_RUSTUP_INIT_TIMEOUT_SECS: u64 = 15 * 60;
+const KILLED_RUSTUP_INIT_REAP_TIMEOUT_SECS: u64 = 5;
 
 /// Result of a bootstrap attempt.
 #[derive(Debug, Clone)]
@@ -163,12 +168,7 @@ pub async fn bootstrap_rustup(paths: &SoldrPaths) -> Result<BootstrapReport, Sol
     ]);
     command.env("CARGO_HOME", &cargo_home);
     command.env("RUSTUP_HOME", &rustup_home);
-    let status = command.status().map_err(|err| {
-        SoldrError::Other(format!(
-            "bootstrap: failed to launch rustup-init ({}): {err}",
-            installer.display()
-        ))
-    })?;
+    let status = run_rustup_init(&mut command, &installer)?;
     if !status.success() {
         return Err(SoldrError::Other(format!(
             "bootstrap: rustup-init exited with status {status}"
@@ -400,6 +400,59 @@ fn no_bootstrap_opt_out() -> bool {
     }
 }
 
+fn rustup_init_timeout() -> Duration {
+    std::env::var(RUSTUP_INIT_TIMEOUT_ENV_VAR)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_RUSTUP_INIT_TIMEOUT_SECS))
+}
+
+fn run_rustup_init(
+    command: &mut std::process::Command,
+    installer: &Path,
+) -> Result<std::process::ExitStatus, SoldrError> {
+    let mut child = command.spawn().map_err(|err| {
+        SoldrError::Other(format!(
+            "bootstrap: failed to launch rustup-init ({}): {err}",
+            installer.display()
+        ))
+    })?;
+    let timeout = rustup_init_timeout();
+    match child.wait_timeout(timeout).map_err(|err| {
+        SoldrError::Other(format!(
+            "bootstrap: failed waiting for rustup-init ({}): {err}",
+            installer.display()
+        ))
+    })? {
+        Some(status) => Ok(status),
+        None => {
+            let kill_result = child.kill();
+            let reap_result =
+                child.wait_timeout(Duration::from_secs(KILLED_RUSTUP_INIT_REAP_TIMEOUT_SECS));
+            let timeout_secs = timeout.as_secs();
+            let mut message = format!(
+                "bootstrap: rustup-init ({}) timed out after {timeout_secs} seconds \
+                 (set {RUSTUP_INIT_TIMEOUT_ENV_VAR} to override)",
+                installer.display()
+            );
+            match kill_result {
+                Ok(()) => message.push_str("; killed child process"),
+                Err(err) => message.push_str(&format!("; kill failed: {err}")),
+            }
+            match reap_result {
+                Ok(Some(_)) => {}
+                Ok(None) => message.push_str(&format!(
+                    "; process did not exit within {KILLED_RUSTUP_INIT_REAP_TIMEOUT_SECS} seconds after kill"
+                )),
+                Err(err) => message.push_str(&format!("; reap after kill failed: {err}")),
+            }
+            Err(SoldrError::Other(message))
+        }
+    }
+}
+
 fn is_truthy(value: &str) -> bool {
     matches!(
         value.trim().to_ascii_lowercase().as_str(),
@@ -502,6 +555,30 @@ mod tests {
         for v in ["0", "false", "no", "off", "", "maybe"] {
             assert!(!is_truthy(v), "expected {v:?} to be falsy");
         }
+    }
+
+    #[test]
+    fn rustup_init_timeout_uses_positive_env_override_only() {
+        let _env_lock = test_env_lock();
+
+        {
+            let _guard = EnvVarGuard::set(RUSTUP_INIT_TIMEOUT_ENV_VAR, "17");
+            assert_eq!(rustup_init_timeout(), Duration::from_secs(17));
+        }
+
+        for value in ["0", "-1", "not-a-number"] {
+            let _guard = EnvVarGuard::set(RUSTUP_INIT_TIMEOUT_ENV_VAR, value);
+            assert_eq!(
+                rustup_init_timeout(),
+                Duration::from_secs(DEFAULT_RUSTUP_INIT_TIMEOUT_SECS)
+            );
+        }
+
+        let _guard = EnvVarGuard::remove(RUSTUP_INIT_TIMEOUT_ENV_VAR);
+        assert_eq!(
+            rustup_init_timeout(),
+            Duration::from_secs(DEFAULT_RUSTUP_INIT_TIMEOUT_SECS)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a bounded wait around downloaded rustup-init execution
- kill and reap stalled rustup-init children before returning a clear timeout error
- add SOLDR_RUSTUP_INIT_TIMEOUT_SECS for slow-host overrides and a focused parser test

## Verification
- soldr cargo fmt --all -- --check
- soldr cargo test -p soldr-cli --bin soldr rustup_init_timeout_uses_positive_env_override_only -- --nocapture
- soldr cargo clippy -p soldr-cli --bin soldr -- -D warnings
- soldr cargo check -p soldr-cli --bin soldr
- ./lint
- git diff --check