### PR TITLE
Bound script network operations

### DIFF
--- a/.github/actions/setup-soldr/install_tool_shims.py
+++ b/.github/actions/setup-soldr/install_tool_shims.py
@@ -14,6 +14,7 @@ TOOL_GROUPS = {
     "all": ["cargo", "rustc", "rustfmt", "clippy-driver", "rustdoc"],
 }
 DISABLED_VALUES = {"", "0", "false", "no", "none", "off"}
+RUSTUP_WHICH_TIMEOUT_SECS = 30
 
 
 def _write_env(name: str, value: str) -> None:
@@ -62,6 +63,7 @@ def resolve_tool(tool: str) -> str:
             check=False,
             capture_output=True,
             text=True,
+            timeout=RUSTUP_WHICH_TIMEOUT_SECS,
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()

--- a/.github/scripts/fetch_or_build_tool.sh
+++ b/.github/scripts/fetch_or_build_tool.sh
@@ -23,6 +23,10 @@
 
 set -euo pipefail
 
+CURL_CONNECT_TIMEOUT_SECS="${FETCH_OR_BUILD_TOOL_CURL_CONNECT_TIMEOUT_SECS:-10}"
+CURL_MAX_TIME_SECS="${FETCH_OR_BUILD_TOOL_CURL_MAX_TIME_SECS:-120}"
+GIT_CLONE_TIMEOUT_SECS="${FETCH_OR_BUILD_TOOL_GIT_CLONE_TIMEOUT_SECS:-300}"
+
 tool="${1:?tool required}"
 target="${2:?target required}"
 build_tool="${3:?build-tool required (zigbuild|xwin|empty for native)}"
@@ -90,6 +94,8 @@ if [ -n "$asset_url" ]; then
   # Fast path: download + extract the prebuilt and we're done.
   asset_filename=$(basename "$asset_url")
   if ! curl --fail --location \
+      --connect-timeout "$CURL_CONNECT_TIMEOUT_SECS" \
+      --max-time "$CURL_MAX_TIME_SECS" \
       --retry 6 --retry-delay 5 --retry-all-errors \
       --output "/tmp/${asset_filename}" "$asset_url"; then
     echo "manifest URL fetch failed; falling back to source build" >&2
@@ -138,7 +144,8 @@ fi
 echo "manifest miss for $tool $version $target; source-building"
 work_dir="${RUNNER_TEMP:-/tmp}/${tool}-build"
 rm -rf "$work_dir"
-git clone --depth 1 --branch "v${version}" "$upstream_repo" "$work_dir"
+timeout "$GIT_CLONE_TIMEOUT_SECS" \
+  git clone --depth 1 --branch "v${version}" "$upstream_repo" "$work_dir"
 if [ -n "${GITHUB_ENV:-}" ]; then
   echo "${env_var}=$(git -C "$work_dir" rev-parse HEAD)" >> "$GITHUB_ENV"
 fi

--- a/.github/scripts/verify_setup_soldr_pin.py
+++ b/.github/scripts/verify_setup_soldr_pin.py
@@ -21,6 +21,8 @@ SETUP_SOLDR_USE_RE = re.compile(r"\buses:\s*zackees/setup-soldr@([^\s#]+)")
 FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 AUTOFIX_BRANCH_PREFIX = "ci/update-setup-soldr-v0"
 AUTOFIX_ISSUE_TITLE = "Update setup-soldr workflow pin to current @v0"
+GIT_LS_REMOTE_TIMEOUT_SECS = 300
+SUBPROCESS_TIMEOUT_SECS = 300
 
 
 def resolve_setup_soldr_v0_sha() -> str:
@@ -34,6 +36,7 @@ def resolve_setup_soldr_v0_sha() -> str:
             f"{SETUP_SOLDR_V0_REF}^{{}}",
         ],
         encoding="utf-8",
+        timeout=GIT_LS_REMOTE_TIMEOUT_SECS,
     )
     refs: dict[str, str] = {}
     for line in output.splitlines():
@@ -325,7 +328,7 @@ def github_api(
 
 
 def run(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
-    return subprocess.run(args, cwd=cwd, check=check)
+    return subprocess.run(args, cwd=cwd, check=check, timeout=SUBPROCESS_TIMEOUT_SECS)
 
 
 def main() -> int:

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 REPO="${SOLDR_REPO:-zackees/soldr}"
 INSTALL_DIR="${SOLDR_INSTALL_DIR:-$HOME/.local/bin}"
+CONNECT_TIMEOUT_SECS="${SOLDR_INSTALL_CONNECT_TIMEOUT_SECS:-10}"
+DOWNLOAD_TIMEOUT_SECS="${SOLDR_INSTALL_DOWNLOAD_TIMEOUT_SECS:-120}"
 VERSION=""
 
 usage() {
@@ -15,6 +17,10 @@ Usage:
 Environment:
   SOLDR_REPO         Override the GitHub repository (default: zackees/soldr)
   SOLDR_INSTALL_DIR  Override the installation directory (default: ~/.local/bin)
+  SOLDR_INSTALL_CONNECT_TIMEOUT_SECS
+                     curl connection timeout in seconds (default: 10)
+  SOLDR_INSTALL_DOWNLOAD_TIMEOUT_SECS
+                     curl total request timeout in seconds (default: 120)
 EOF
 }
 
@@ -99,6 +105,8 @@ fetch_release_json() {
   fi
 
   curl -fsSL \
+    --connect-timeout "$CONNECT_TIMEOUT_SECS" \
+    --max-time "$DOWNLOAD_TIMEOUT_SECS" \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "$url"
@@ -179,7 +187,11 @@ ASSET_PATH="${TMP_DIR}/${ASSET_NAME}"
 EXTRACT_DIR="${TMP_DIR}/extract"
 mkdir -p "$EXTRACT_DIR" "$INSTALL_DIR"
 
-curl -fsSL "$DOWNLOAD_URL" -o "$ASSET_PATH"
+curl -fsSL \
+  --connect-timeout "$CONNECT_TIMEOUT_SECS" \
+  --max-time "$DOWNLOAD_TIMEOUT_SECS" \
+  "$DOWNLOAD_URL" \
+  -o "$ASSET_PATH"
 
 if [[ "$ARCHIVE_EXT" == "zip" ]]; then
   unzip -q "$ASSET_PATH" -d "$EXTRACT_DIR"


### PR DESCRIPTION
Summary:
- Add curl connect and total request timeouts to `install.sh` release queries/downloads.
- Bound `fetch_or_build_tool.sh` prebuilt downloads and fallback `git clone`.
- Add subprocess timeouts to setup-soldr shim resolution and setup pin verification helpers.

Tests:
- `bash -n install.sh`
- `bash -n .github/scripts/fetch_or_build_tool.sh`
- `uv run --no-project python -m py_compile .github/actions/setup-soldr/install_tool_shims.py .github/scripts/verify_setup_soldr_pin.py`
- `./lint`
- `git diff --check`