### PR TITLE
ci: bound workflow curl downloads

### DIFF
--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -173,6 +173,7 @@ jobs:
           echo "manifest: zccache $zccache_version linux-x64-musl"
           echo "         $asset_url"
           curl --fail --location \
+              --connect-timeout 10 --max-time 120 \
               --retry 6 --retry-delay 5 --retry-all-errors \
               --output "/tmp/${asset_filename}" "$asset_url"
           tar -xzf "/tmp/${asset_filename}" -C dist/zccache-stage
@@ -358,6 +359,7 @@ jobs:
           echo "manifest: $tool host-asset $asset_filename"
           echo "         $asset_url"
           curl --fail --location \
+              --connect-timeout 10 --max-time 120 \
               --retry 6 --retry-delay 5 --retry-all-errors \
               --output "/tmp/${asset_filename}" "$asset_url"
           # Tarball layout differs across tools (flat vs per-triple
@@ -493,6 +495,7 @@ jobs:
           echo "manifest: zccache $zccache_version ${{ matrix.target }}"
           echo "         $asset_url"
           curl --fail --location \
+              --connect-timeout 10 --max-time 120 \
               --retry 6 --retry-delay 5 --retry-all-errors \
               --output "/tmp/${asset_filename}" "$asset_url"
           case "$asset_filename" in

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -337,7 +337,8 @@ jobs:
           # that motivated the soldr-side retry refactor (#432) applies
           # here too, and on the release runner we can't fall back to
           # cargo install.
-          curl --fail --location --retry 6 --retry-delay 5 --retry-all-errors \
+          curl --fail --location --connect-timeout 10 --max-time 120 \
+            --retry 6 --retry-delay 5 --retry-all-errors \
             --output "/tmp/${asset}" "${url}"
 
           case "$ext" in


### PR DESCRIPTION
## Summary
- add connect and total time caps to remaining retrying workflow curl downloads
- align cross-compile and release bootstrap downloads with existing bounded curl usage

## Validation
- git diff --check
- soldr cargo fmt --all -- --check