### PR TITLE
chore: align codex hook repo discovery

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --no-project --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
+            "command": "top=$(git rev-parse --show-toplevel 2>/dev/null); while [ -n \"$top\" ] && [ ! -f \"$top/.claude/hooks/tool_guard.py\" ]; do parent=$(dirname \"$top\"); [ \"$parent\" = \"$top\" ] && break; top=$parent; done; if [ -f \"$top/.claude/hooks/tool_guard.py\" ]; then uv run --no-project --script \"$top/.claude/hooks/tool_guard.py\"; fi",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --no-project --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
+            "command": "top=$(git rev-parse --show-toplevel 2>/dev/null); while [ -n \"$top\" ] && [ ! -f \"$top/.claude/hooks/tool_guard.py\" ]; do parent=$(dirname \"$top\"); [ \"$parent\" = \"$top\" ] && break; top=$parent; done; if [ -f \"$top/.claude/hooks/tool_guard.py\" ]; then uv run --no-project --script \"$top/.claude/hooks/tool_guard.py\"; fi",
             "timeout": 5
           }
         ]
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --no-project --script \"$(git rev-parse --show-toplevel)/.claude/hooks/tool_guard.py\"",
+            "command": "top=$(git rev-parse --show-toplevel 2>/dev/null); while [ -n \"$top\" ] && [ ! -f \"$top/.claude/hooks/tool_guard.py\" ]; do parent=$(dirname \"$top\"); [ \"$parent\" = \"$top\" ] && break; top=$parent; done; if [ -f \"$top/.claude/hooks/tool_guard.py\" ]; then uv run --no-project --script \"$top/.claude/hooks/tool_guard.py\"; fi",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- use the same upward repo search in Codex PreToolUse hooks as Claude hooks
- preserve the existing uv --no-project script invocation

## Investigation
- current hook configs no longer contain the pasted bare uv run command
- clud --dry-run --fix-hooks reports warnings: none

## Validation
- uv run --no-project --directory .claude/hooks python -m unittest test_tool_guard