### PR TITLE
fix: bound toolchain probe output commands

### DIFF
--- a/crates/soldr-cli/src/binaries.rs
+++ b/crates/soldr-cli/src/binaries.rs
@@ -1,7 +1,9 @@
 //! Toolchain / rustup / zccache binary resolution helpers. Extracted from
 //! `main.rs` as part of issue #339.
 
-use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
+use crate::core::{
+    command_output_with_timeout, suppress_windows_console_window, SoldrError, SoldrPaths,
+};
 use crate::fetch::VersionSpec;
 use crate::{
     REAL_TOOLCHAIN_BINARY_ENV_PREFIX, TEST_CARGO_BIN_ENV_VAR, TEST_RUSTC_BIN_ENV_VAR,
@@ -22,7 +24,7 @@ pub(crate) fn resolve_toolchain_binary(tool: &str) -> Result<std::path::PathBuf,
     command.args(["which", tool]);
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
-    let output = command.output();
+    let output = command_output_with_timeout(&mut command, &format!("rustup which {tool}"));
 
     match output {
         Ok(output) if output.status.success() => {

--- a/crates/soldr-cli/src/core/mod.rs
+++ b/crates/soldr-cli/src/core/mod.rs
@@ -8,9 +8,14 @@
 //! identifier consumers reach for must show up in this `mod.rs`.
 
 use std::ffi::OsStr;
+use std::io::Read;
 use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use thiserror::Error;
+use wait_timeout::ChildExt;
 
 pub mod git;
 mod paths;
@@ -34,6 +39,9 @@ pub use toolchain_resolve::{
 pub const CARGO_HOME_ENV_VAR: &str = "CARGO_HOME";
 pub const RUSTUP_HOME_ENV_VAR: &str = "RUSTUP_HOME";
 pub(crate) const RUSTUP_TOOLCHAIN_ENV_VAR: &str = "RUSTUP_TOOLCHAIN";
+const COMMAND_OUTPUT_TIMEOUT_ENV_VAR: &str = "SOLDR_COMMAND_OUTPUT_TIMEOUT_SECS";
+const DEFAULT_COMMAND_OUTPUT_TIMEOUT_SECS: u64 = 60;
+const KILLED_COMMAND_OUTPUT_REAP_TIMEOUT_SECS: u64 = 5;
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -121,6 +129,98 @@ pub(crate) fn home_dir() -> Result<PathBuf, SoldrError> {
     Err(SoldrError::NoHomeDir)
 }
 
+pub(crate) fn command_output_with_timeout(
+    command: &mut Command,
+    context: &str,
+) -> Result<Output, SoldrError> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|err| SoldrError::Other(format!("failed to invoke {context}: {err}")))?;
+    let stdout_reader = child.stdout.take().map(read_pipe_async);
+    let stderr_reader = child.stderr.take().map(read_pipe_async);
+    let timeout = command_output_timeout();
+    let status = match child
+        .wait_timeout(timeout)
+        .map_err(|err| SoldrError::Other(format!("wait on {context} failed: {err}")))?
+    {
+        Some(status) => status,
+        None => {
+            let kill_result = child.kill();
+            let reap_result =
+                child.wait_timeout(Duration::from_secs(KILLED_COMMAND_OUTPUT_REAP_TIMEOUT_SECS));
+            let timeout_secs = timeout.as_secs();
+            let mut message = format!(
+                "{context} timed out after {timeout_secs} seconds \
+                 (set {COMMAND_OUTPUT_TIMEOUT_ENV_VAR} to override)"
+            );
+            match kill_result {
+                Ok(()) => message.push_str("; killed child process"),
+                Err(err) => message.push_str(&format!("; kill failed: {err}")),
+            }
+            match reap_result {
+                Ok(Some(_)) => {}
+                Ok(None) => message.push_str(&format!(
+                    "; process did not exit within {KILLED_COMMAND_OUTPUT_REAP_TIMEOUT_SECS} seconds after kill"
+                )),
+                Err(err) => message.push_str(&format!("; reap after kill failed: {err}")),
+            }
+            return Err(SoldrError::Other(message));
+        }
+    };
+
+    let stdout = join_pipe_reader(stdout_reader, context, "stdout")?;
+    let stderr = join_pipe_reader(stderr_reader, context, "stderr")?;
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+fn read_pipe_async<R>(mut pipe: R) -> JoinHandle<std::io::Result<Vec<u8>>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        pipe.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    })
+}
+
+fn join_pipe_reader(
+    reader: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
+    context: &str,
+    pipe_name: &str,
+) -> Result<Vec<u8>, SoldrError> {
+    match reader {
+        Some(handle) => handle
+            .join()
+            .map_err(|_| SoldrError::Other(format!("{pipe_name} reader panicked for {context}")))?
+            .map_err(|err| {
+                SoldrError::Other(format!("failed to read {pipe_name} from {context}: {err}"))
+            }),
+        None => Ok(Vec::new()),
+    }
+}
+
+fn command_output_timeout() -> Duration {
+    std::env::var(COMMAND_OUTPUT_TIMEOUT_ENV_VAR)
+        .ok()
+        .and_then(|value| command_output_timeout_from_str(&value))
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_COMMAND_OUTPUT_TIMEOUT_SECS))
+}
+
+fn command_output_timeout_from_str(value: &str) -> Option<Duration> {
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|seconds| *seconds > 0)
+        .map(Duration::from_secs)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,5 +228,15 @@ mod tests {
     #[test]
     fn test_version() {
         assert_eq!(version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn command_output_timeout_parses_positive_values_only() {
+        assert_eq!(
+            command_output_timeout_from_str("7"),
+            Some(Duration::from_secs(7))
+        );
+        assert_eq!(command_output_timeout_from_str("0"), None);
+        assert_eq!(command_output_timeout_from_str("not-a-number"), None);
     }
 }

--- a/crates/soldr-cli/src/core/toolchain_resolve.rs
+++ b/crates/soldr-cli/src/core/toolchain_resolve.rs
@@ -280,7 +280,11 @@ pub(super) fn detect_runtime_rustc_triple(start_dir: Option<&Path>) -> Option<St
     if let Some(start_dir) = start_dir {
         command.current_dir(start_dir);
     }
-    let output = command.args(["--print", "target-triple"]).output().ok()?;
+    let output = crate::core::command_output_with_timeout(
+        command.args(["--print", "target-triple"]),
+        "rustc --print target-triple",
+    )
+    .ok()?;
     if !output.status.success() {
         return None;
     }
@@ -304,7 +308,11 @@ fn resolve_runtime_rustc(start_dir: Option<&Path>) -> Option<PathBuf> {
     if let Some(start_dir) = start_dir {
         rustup.current_dir(start_dir);
     }
-    let rustup_output = rustup.args(["which", "rustc"]).output().ok()?;
+    let rustup_output = crate::core::command_output_with_timeout(
+        rustup.args(["which", "rustc"]),
+        "rustup which rustc",
+    )
+    .ok()?;
     if rustup_output.status.success() {
         let path = String::from_utf8_lossy(&rustup_output.stdout)
             .trim()

--- a/crates/soldr-cli/src/doctor.rs
+++ b/crates/soldr-cli/src/doctor.rs
@@ -2,7 +2,9 @@
 //! from `main.rs` as part of issue #339.
 
 use crate::cache::print_json;
-use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
+use crate::core::{
+    command_output_with_timeout, suppress_windows_console_window, SoldrError, SoldrPaths,
+};
 use crate::defender_probe::{self, DefenderProbeState, DefenderVerdict, SCANNED_THRESHOLD_MS};
 use crate::fetch::{ZccacheBinarySummary, ZccacheSource};
 use crate::{apply_implicit_toolchain_homes, rustup_binary, JSON_SCHEMA_VERSION};
@@ -922,7 +924,7 @@ fn rustup_toolchain_is_installed(channel: &str) -> Result<bool, SoldrError> {
     command.args(["toolchain", "list"]);
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
-    let output = command.output()?;
+    let output = command_output_with_timeout(&mut command, "rustup toolchain list")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         return Err(SoldrError::Other(format!(
@@ -944,7 +946,7 @@ fn rustup_installed_components(channel: &str) -> Result<Vec<String>, SoldrError>
     command.args(["component", "list", "--installed", "--toolchain", channel]);
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
-    let output = command.output()?;
+    let output = command_output_with_timeout(&mut command, "rustup component list --installed")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         return Err(SoldrError::Other(format!(
@@ -960,7 +962,7 @@ fn rustup_installed_targets(channel: &str) -> Result<Vec<String>, SoldrError> {
     command.args(["target", "list", "--installed", "--toolchain", channel]);
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
-    let output = command.output()?;
+    let output = command_output_with_timeout(&mut command, "rustup target list --installed")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         return Err(SoldrError::Other(format!(

--- a/crates/soldr-cli/src/rust_plan.rs
+++ b/crates/soldr-cli/src/rust_plan.rs
@@ -7,7 +7,7 @@ use crate::cargo_front_door::{
     file_hash_or_missing, first_cargo_subcommand, path_string, rustflags_inputs, stable_hash_json,
     workspace_manifest_hashes, CargoProfileDebugDefault,
 };
-use crate::core::{suppress_windows_console_window, SoldrError};
+use crate::core::{command_output_with_timeout, suppress_windows_console_window, SoldrError};
 use crate::zccache::{
     command_stderr, normalize_path_for_compare,
     run_zccache_command_strings_in_cache_dir_with_daemon_name, ZccacheBuildSession,
@@ -510,7 +510,7 @@ fn cargo_metadata(cargo: &std::path::Path, args: &[String]) -> Result<CargoMetad
     command.env_remove("MAKEFLAGS");
     command.env_remove("CARGO_MAKEFLAGS");
 
-    let output = command.output()?;
+    let output = command_output_with_timeout(&mut command, "cargo metadata")?;
     if !output.status.success() {
         return Err(SoldrError::Other(format!(
             "cargo metadata failed while preparing Rust artifact cache plan: {}",
@@ -594,7 +594,10 @@ fn tool_output(tool: &std::path::Path, args: &[&str]) -> Result<String, SoldrErr
     command.args(args);
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
-    let output = command.output()?;
+    let output = command_output_with_timeout(
+        &mut command,
+        &format!("{} {}", tool.display(), args.join(" ")),
+    )?;
     if !output.status.success() {
         return Err(SoldrError::Other(format!(
             "{} {} failed: {}",

--- a/crates/soldr-cli/src/toolchain_ensure.rs
+++ b/crates/soldr-cli/src/toolchain_ensure.rs
@@ -10,7 +10,9 @@
 use serde::Serialize;
 use std::time::Instant;
 
-use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
+use crate::core::{
+    command_output_with_timeout, suppress_windows_console_window, SoldrError, SoldrPaths,
+};
 use crate::{
     apply_implicit_toolchain_homes, resolve_toolchain_binary,
     toolchain::{run_prepare_inner, PrepareSummary},
@@ -165,7 +167,7 @@ fn probe_version(tool: &str) -> Option<String> {
     command.arg("--version");
     apply_implicit_toolchain_homes(&mut command);
     suppress_windows_console_window(&mut command);
-    let output = command.output().ok()?;
+    let output = command_output_with_timeout(&mut command, &format!("{tool} --version")).ok()?;
     if !output.status.success() {
         return None;
     }


### PR DESCRIPTION
## Summary
- add a shared bounded-output helper for short probe commands
- cap rustup/rustc/cargo metadata/version probes with SOLDR_COMMAND_OUTPUT_TIMEOUT_SECS
- drain child stdout/stderr concurrently so large probe output cannot block waiting

## Validation
- soldr cargo fmt --all -- --check
- soldr cargo test -p soldr-cli --bin soldr command_output_timeout_parses_positive_values_only -- --nocapture
- soldr cargo clippy -p soldr-cli --bin soldr -- -D warnings
- soldr cargo check -p soldr-cli --bin soldr
- ./lint
- git diff --check