### PR TITLE
perf(daemon): per-phase JSONL trace + harness plumbing (soldr#981)

### DIFF
--- a/bench/parse_compile_trace.py
+++ b/bench/parse_compile_trace.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Bucket and analyze a SOLDR_DAEMON_TRACE JSONL file.
+
+Reads the JSONL trace file produced by the soldr daemon (when the
+`SOLDR_DAEMON_TRACE` env var was set during the run) and prints
+per-phase aggregate statistics: count, total micros, p50/p95/p99, and
+share of the total dispatch budget.
+
+This is the analysis half of the soldr#981 cold-build diagnostic plan.
+We expect the output to identify the per-compile dispatch phase that
+the failed zccache#939 buffer-elimination plan missed.
+
+Usage:
+  python bench/parse_compile_trace.py PATH_TO_TRACE.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+
+def percentile(values: List[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    s = sorted(values)
+    k = (len(s) - 1) * pct
+    f = int(k)
+    c = min(f + 1, len(s) - 1)
+    if f == c:
+        return s[f]
+    return s[f] + (s[c] - s[f]) * (k - f)
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__.strip(), file=sys.stderr)
+        return 64
+    path = Path(argv[1])
+    if not path.exists():
+        print(f"error: {path} does not exist", file=sys.stderr)
+        return 65
+
+    phase_values: Dict[str, List[int]] = defaultdict(list)
+    bad_lines = 0
+    total_lines = 0
+    with path.open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            raw = raw.strip()
+            if not raw:
+                continue
+            total_lines += 1
+            try:
+                obj = json.loads(raw)
+                phase = obj["phase"]
+                micros = int(obj["micros"])
+            except (json.JSONDecodeError, KeyError, ValueError):
+                bad_lines += 1
+                continue
+            phase_values[phase].append(micros)
+
+    if not phase_values:
+        print("no records parsed", file=sys.stderr)
+        return 1
+
+    timing_keys = {"inner_compile", "wire_stdout", "wire_stderr", "wire_done", "total_dispatch", "inner_compile_err"}
+    counter_keys = {"stdout_bytes", "stderr_bytes"}
+
+    total_dispatch = phase_values.get("total_dispatch", [])
+    total_grand_us = sum(total_dispatch)
+
+    print(f"trace file       : {path}")
+    print(f"lines parsed     : {total_lines - bad_lines} (bad: {bad_lines})")
+    print(f"compiles         : {len(total_dispatch)}")
+    print(f"total dispatch s : {total_grand_us / 1e6:.3f}")
+    print()
+    print(f"{'phase':<22} {'count':>7} {'sum_ms':>10} {'p50_us':>9} {'p95_us':>9} {'p99_us':>9} {'%total':>7}")
+    print("-" * 80)
+
+    for phase in sorted(timing_keys):
+        vals = phase_values.get(phase, [])
+        if not vals:
+            continue
+        s = sum(vals)
+        pct = (s / total_grand_us * 100.0) if total_grand_us else 0.0
+        print(
+            f"{phase:<22} {len(vals):>7} "
+            f"{s/1000:>10.1f} "
+            f"{percentile(vals, 0.50):>9.0f} "
+            f"{percentile(vals, 0.95):>9.0f} "
+            f"{percentile(vals, 0.99):>9.0f} "
+            f"{pct:>6.1f}%"
+        )
+
+    print()
+    print("byte counters:")
+    for phase in sorted(counter_keys):
+        vals = phase_values.get(phase, [])
+        if not vals:
+            continue
+        s = sum(vals)
+        print(
+            f"  {phase:<20} count={len(vals):>6}  total={s/1e6:>8.2f} MB  "
+            f"p50={percentile(vals, 0.50):>9.0f} B  "
+            f"p99={percentile(vals, 0.99):>9.0f} B"
+        )
+
+    print()
+    print("any phase not in the timing/counter sets above:")
+    for phase, vals in sorted(phase_values.items()):
+        if phase in timing_keys or phase in counter_keys:
+            continue
+        print(f"  {phase:<20} count={len(vals):>6}  sum={sum(vals)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/ci/docker/profile/run_profile.sh
+++ b/ci/docker/profile/run_profile.sh
@@ -103,8 +103,10 @@ run_scenario() {
     log "==[scenario: ${name}]=="
 
     # Per-scenario workspace + per-scenario soldr cache.
+    # soldr#981: route the cache dir under /out so daemon-spawn.log
+    # and other diagnostic artifacts survive the container exit.
     local workspace="/tmp/workspace-${name}"
-    local soldr_cache="/tmp/soldr-cache-${name}"
+    local soldr_cache="${scen_out}/soldr-cache"
     mkdir -p "${soldr_cache}"
 
     local fixture_path

--- a/ci/docker/profile/run_profile.sh
+++ b/ci/docker/profile/run_profile.sh
@@ -118,10 +118,17 @@ run_scenario() {
         cold|warm)
             cmd=("${SOLDR_BIN}" cargo build --manifest-path "${fixture_path}/Cargo.toml")
             export SOLDR_CACHE_DIR="${soldr_cache}"
+            # soldr#981 diagnostic: tell the embedded daemon to emit
+            # per-phase JSONL into the scenario output dir. Off when
+            # the var is unset (zero hot-path cost). Soaked at the
+            # whole scenario including warm so the comparison is
+            # apples-to-apples.
+            export SOLDR_DAEMON_TRACE="${scen_out}/daemon-trace.jsonl"
             ;;
         bare)
             cmd=(cargo build --manifest-path "${fixture_path}/Cargo.toml")
             unset SOLDR_CACHE_DIR
+            unset SOLDR_DAEMON_TRACE
             ;;
         *)
             log "unknown scenario ${name} — skipping"

--- a/crates/soldr-cli/src/daemon/compile_trace.rs
+++ b/crates/soldr-cli/src/daemon/compile_trace.rs
@@ -1,0 +1,92 @@
+//! Per-phase compile tracing for soldr-981 diagnosis.
+//!
+//! When the `SOLDR_DAEMON_TRACE` env var points to a writable file
+//! path, every call to [`record`] appends a single JSONL line with
+//! the phase name, elapsed microseconds, and the compile identifier
+//! that produced it. Off by default — zero cost when the env var is
+//! unset (one atomic-bool read per call).
+//!
+//! Output format (one JSON object per line):
+//! ```jsonl
+//! {"ts_ns":<u128>, "phase":"<name>", "micros":<u64>, "compile_id":"<str>"}
+//! ```
+//!
+//! Loaded by `bench/parse_compile_trace.py` (or any JSONL reader) for
+//! per-phase p50/p99/total analysis.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static TRACE_FILE: OnceLock<Option<Mutex<std::fs::File>>> = OnceLock::new();
+
+fn init() -> Option<Mutex<std::fs::File>> {
+    let path = std::env::var_os("SOLDR_DAEMON_TRACE")?;
+    let path = PathBuf::from(path);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .ok()?;
+    Some(Mutex::new(file))
+}
+
+fn writer() -> Option<&'static Mutex<std::fs::File>> {
+    TRACE_FILE.get_or_init(init).as_ref()
+}
+
+/// Append a single phase-record line to the trace file. No-op when
+/// `SOLDR_DAEMON_TRACE` is unset. Errors are silently dropped — the
+/// trace file is diagnostic-only and must never block compile work.
+pub fn record(phase: &str, micros: u64, compile_id: &str) {
+    let Some(file_mu) = writer() else { return };
+    let ts_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let line = format!(
+        r#"{{"ts_ns":{ts_ns},"phase":"{}","micros":{micros},"compile_id":"{}"}}{nl}"#,
+        escape(phase),
+        escape(compile_id),
+        nl = "\n",
+    );
+    if let Ok(mut guard) = file_mu.lock() {
+        let _ = guard.write_all(line.as_bytes());
+    }
+}
+
+fn escape(s: &str) -> String {
+    // Tight enough escape for our phase names and content-addressed
+    // compile ids. Both come from internal call sites; we don't need
+    // a full JSON encoder for this.
+    s.replace('\\', r"\\").replace('"', r#"\""#)
+}
+
+/// Convenience RAII guard. Construct with the phase name; records the
+/// elapsed micros on drop. Use when the phase is a single scope.
+pub struct Phase<'a> {
+    name: &'a str,
+    compile_id: &'a str,
+    start: std::time::Instant,
+}
+
+impl<'a> Phase<'a> {
+    pub fn start(name: &'a str, compile_id: &'a str) -> Self {
+        Self {
+            name,
+            compile_id,
+            start: std::time::Instant::now(),
+        }
+    }
+}
+
+impl Drop for Phase<'_> {
+    fn drop(&mut self) {
+        let micros = self.start.elapsed().as_micros() as u64;
+        record(self.name, micros, self.compile_id);
+    }
+}

--- a/crates/soldr-cli/src/daemon/compile_trace.rs
+++ b/crates/soldr-cli/src/daemon/compile_trace.rs
@@ -27,12 +27,28 @@ fn init() -> Option<Mutex<std::fs::File>> {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let file = std::fs::OpenOptions::new()
+    match std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&path)
-        .ok()?;
-    Some(Mutex::new(file))
+    {
+        Ok(file) => {
+            // One-line startup confirmation so the harness can verify
+            // the daemon process actually picked up the env var.
+            eprintln!(
+                "soldr-daemon: SOLDR_DAEMON_TRACE active, writing to {}",
+                path.display()
+            );
+            Some(Mutex::new(file))
+        }
+        Err(e) => {
+            eprintln!(
+                "soldr-daemon: SOLDR_DAEMON_TRACE set to {} but open failed: {e}",
+                path.display()
+            );
+            None
+        }
+    }
 }
 
 fn writer() -> Option<&'static Mutex<std::fs::File>> {

--- a/crates/soldr-cli/src/daemon/mod.rs
+++ b/crates/soldr-cli/src/daemon/mod.rs
@@ -22,6 +22,11 @@
 pub mod backend_handle_adoption;
 pub mod broker_discovery;
 pub mod client;
+/// Per-compile JSONL phase trace, gated by `SOLDR_DAEMON_TRACE`.
+/// Diagnostic-only — see `compile_trace.rs` for format. Wired in by
+/// soldr#981 to identify the per-compile dispatch bottleneck that
+/// the zccache#939 buffer-elimination plan failed to find.
+pub mod compile_trace;
 pub mod db;
 /// L4 (issue soldr#980) — background batcher that coalesces
 /// per-compile redb event writes into one fsync per 64 rows / 100 ms.

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -233,7 +233,15 @@ pub fn run(opts: ServerOptions) -> Result<(), ServerError> {
     runtime.block_on(run_async(opts))
 }
 
-async fn run_async(opts: ServerOptions) -> Result<(), ServerError> {
+/// Async daemon entry point. Use this when calling from inside an
+/// existing tokio runtime (e.g. `soldr daemon start --foreground`
+/// dispatched from `main`'s `#[tokio::main]` runtime). The synchronous
+/// `run` builds its own multi-thread runtime and is the right entry
+/// point for the `soldr-daemon` bin target whose `main` has no
+/// ambient runtime. Calling `run` from within an ambient runtime
+/// panics with "Cannot start a runtime from within a runtime" — that
+/// was the failure on soldr#985's perf-matrix CI run.
+pub async fn run_async(opts: ServerOptions) -> Result<(), ServerError> {
     let paths = SoldrPaths::new()?;
     std::fs::create_dir_all(soldr_daemon_dir(&paths))?;
 

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -772,24 +772,39 @@ async fn dispatch_compile_streaming<S>(
 where
     S: tokio::io::AsyncWrite + Unpin,
 {
+    // Per-compile id for the JSONL phase trace (soldr#981). Cheap —
+    // monotonic counter, only meaningful within a single daemon
+    // lifetime, which is exactly the scope we need for offline
+    // post-cold-build analysis.
+    let compile_id = next_compile_id();
+
+    let total = std::time::Instant::now();
+
+    let inner_started = std::time::Instant::now();
     let body = match state.compile_service.compile(req).await {
         Ok(body) => body,
         Err(err) => {
+            crate::daemon::compile_trace::record(
+                "inner_compile_err",
+                inner_started.elapsed().as_micros() as u64,
+                &compile_id,
+            );
             let reply = Response::Error(format!("embedded zccache compile failed: {err}"));
             return write_frame_async(stream, &reply).await;
         }
     };
+    crate::daemon::compile_trace::record(
+        "inner_compile",
+        inner_started.elapsed().as_micros() as u64,
+        &compile_id,
+    );
 
     let stdout_len = body.stdout.len();
     let stderr_len = body.stderr.len();
     let mut stdout_chunks = 0usize;
     let mut stderr_chunks = 0usize;
 
-    // Stream stdout first, then stderr. zccache already buffers them
-    // separately (different pipes on rustc), so the original
-    // interleaving is gone by this point; the wrapper writes them to
-    // its own stdout/stderr in the same order rustc produced them
-    // within each pipe.
+    let wire_stdout_started = std::time::Instant::now();
     for chunk in body.stdout.chunks(CHUNK_BYTES) {
         write_frame_async(
             stream,
@@ -804,7 +819,13 @@ where
             "stdout chunk emitted",
         );
     }
+    crate::daemon::compile_trace::record(
+        "wire_stdout",
+        wire_stdout_started.elapsed().as_micros() as u64,
+        &compile_id,
+    );
 
+    let wire_stderr_started = std::time::Instant::now();
     for chunk in body.stderr.chunks(CHUNK_BYTES) {
         write_frame_async(
             stream,
@@ -819,15 +840,16 @@ where
             "stderr chunk emitted",
         );
     }
+    crate::daemon::compile_trace::record(
+        "wire_stderr",
+        wire_stderr_started.elapsed().as_micros() as u64,
+        &compile_id,
+    );
 
     let done = Response::CompileDone {
         exit_code: body.exit_code,
         cached: body.cached,
         cache_outcome: body.cache_outcome,
-        // Phase 5b1: zccache's embedded service does not surface an
-        // audit id back through `CompileResponseBody`. Plumbing it
-        // through is part of Phase 5b2; for now the wire field is
-        // an empty string and the wrapper ignores it.
         compile_id: String::new(),
     };
     tracing::debug!(
@@ -841,7 +863,40 @@ where
         stderr_chunks,
         "compile done — streaming reply complete",
     );
-    write_frame_async(stream, &done).await
+    let wire_done_started = std::time::Instant::now();
+    let res = write_frame_async(stream, &done).await;
+    crate::daemon::compile_trace::record(
+        "wire_done",
+        wire_done_started.elapsed().as_micros() as u64,
+        &compile_id,
+    );
+    crate::daemon::compile_trace::record(
+        "total_dispatch",
+        total.elapsed().as_micros() as u64,
+        &compile_id,
+    );
+    // Co-record per-compile output bytes for cross-axis analysis.
+    crate::daemon::compile_trace::record(
+        "stdout_bytes",
+        stdout_len as u64,
+        &compile_id,
+    );
+    crate::daemon::compile_trace::record(
+        "stderr_bytes",
+        stderr_len as u64,
+        &compile_id,
+    );
+    res
+}
+
+/// Monotonic per-daemon compile counter. The id is stable within one
+/// daemon process and meaningless across restarts — exactly the scope
+/// the `SOLDR_DAEMON_TRACE` JSONL is designed for.
+fn next_compile_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering as AOrdering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, AOrdering::Relaxed);
+    format!("c{n:08x}")
 }
 
 /// Best-effort resolver for the `~/.soldr/cache/cook/<sha256>.tar.zst`

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -660,7 +660,7 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             cache::run_session_end_command(id, clear, json)?;
         }
         Commands::Daemon { command } => {
-            run_daemon_command(command)?;
+            run_daemon_command(command).await?;
         }
         Commands::External(args) => {
             if args.is_empty() {
@@ -1025,10 +1025,10 @@ fn render_builds(
     }
 }
 
-fn run_daemon_command(command: DaemonSubcommand) -> Result<(), SoldrError> {
+async fn run_daemon_command(command: DaemonSubcommand) -> Result<(), SoldrError> {
     use crate::daemon::client;
     use crate::daemon::lifecycle::{is_live, try_spawn_detached};
-    use crate::daemon::server::{run as run_server, server_sock_path, ServerOptions};
+    use crate::daemon::server::{run_async, server_sock_path, ServerOptions};
     use core::SoldrPaths;
     use std::time::Duration;
 
@@ -1048,7 +1048,16 @@ fn run_daemon_command(command: DaemonSubcommand) -> Result<(), SoldrError> {
                         Duration::from_secs(idle_timeout)
                     },
                 };
-                run_server(opts)
+                // We're already inside main()'s #[tokio::main] runtime
+                // (run_with_args is async, called from main's runtime).
+                // Calling the sync `server::run` here would have it build
+                // ANOTHER multi-thread runtime + block_on, which panics
+                // with "Cannot start a runtime from within a runtime"
+                // (the symptom on the CI perf-matrix run in soldr#985
+                // diagnosis). Reach run_async directly instead — it
+                // does the same work without building a runtime.
+                run_async(opts)
+                    .await
                     .map_err(|e| SoldrError::Other(format!("soldr-daemon failed: {e:?}")))?;
                 Ok(())
             } else {


### PR DESCRIPTION
## Summary

- Adds a thin, zero-cost-when-off per-phase JSONL trace site to `dispatch_compile_streaming` in the soldr-daemon, gated by `SOLDR_DAEMON_TRACE=<path>`. Records elapsed micros per `inner_compile` / `wire_stdout` / `wire_stderr` / `wire_done` / `total_dispatch` plus per-compile byte counters.
- Plumbs `SOLDR_DAEMON_TRACE` through the docker perf harness on cold + warm scenarios. Moves the scenario-local soldr cache dir under `${scen_out}/soldr-cache` so `daemon-spawn.log` survives the container exit.
- Ships `bench/parse_compile_trace.py` — buckets the JSONL into per-phase count / sum_ms / p50 / p95 / p99 / %total.

## Why

The two prior cold-build closing attempts ([zccache#939 Steps 1+2](https://github.com/zackees/zccache/issues/939#issuecomment-4814053206)) attacked the `Vec<u8>` buffer hop in the daemon's IPC streaming path and **moved cold by zero seconds**. The diagnostic site this PR adds proves the model was wrong by ~250×:

```
phase                    count     sum_ms    p50_us    p99_us  %total
inner_compile              146   218770.1    766552  10964707   99.7%
total_dispatch             146   219488.6    769788  10969618  100.0%
wire_stderr                146       13.4        42       899    0.0%
wire_done                  146       24.3        22      1498    0.0%
wire_stdout                146        0.1         0         3    0.0%
```

99.7% of dispatch time is the embedded `ZccacheService::compile` call (the `state.compile_service.compile(req).await`). All wire phases combined are 38 ms across 146 compiles. The next optimization layer is **inside zccache, not on the daemon-soldr boundary** — filed upstream as [zccache#940](https://github.com/zackees/zccache/issues/940) for per-sub-phase tracing inside `compile`.

Full diagnostic writeup with cold + on-CPU sample breakdown: [soldr#981 comment](https://github.com/zackees/soldr/issues/981#issuecomment-4814332836) and [zccache#939 comment](https://github.com/zackees/zccache/issues/939#issuecomment-4814325652).

## Cost when disabled

One `OnceLock::get_or_init` returning `None` per `record()` call. No allocation. Below noise — the daemon hot path is unaffected when `SOLDR_DAEMON_TRACE` is unset.

## Test plan

- [x] `soldr cargo build -p soldr-cli --bin soldr --bin soldr-daemon` compiles clean
- [x] Trace file produced on docker cold harness — 146 compiles, 92 KB, 0 bad lines (`.codex-artifacts/soldr-trace-cold-2026-06-27-0008/cold/daemon-trace.jsonl`)
- [x] `bench/parse_compile_trace.py` parses cleanly and reports the per-phase table shown above
- [x] `SOLDR_DAEMON_TRACE=path` causes the daemon to log `soldr-daemon: SOLDR_DAEMON_TRACE active, writing to <path>` to stderr on first compile — visible in the harness `daemon-spawn.log` that this PR makes persistent
- [ ] No regression in the regular cold/warm/bare numbers on a follow-up rerun without the env var set (gated check; expected zero impact since the trace site is unreachable when unset)

## Related

- soldr#981 — Phase 5 cold-build regression (this PR is the diagnostic layer that points at the next step)
- zccache#940 — upstream zccache issue asking for per-sub-phase tracing inside `compile` (the actual next debugging layer)
- zccache#939 — the now-falsified three-step buffer-elimination plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)