### PR TITLE
chore(release): bump 0.7.59 -> 0.7.60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.59"
+version = "0.7.60"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.59"
+version = "0.7.60"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Release bump. Triggers `release-auto.yml`'s `detect-bump` job → wheel/release artifact build → PyPI publish + crates.io publish + GitHub release on merge.

## What ships in 0.7.60

- [soldr#985](https://github.com/zackees/soldr/pull/985) — per-phase JSONL trace in `dispatch_compile_streaming`, gated by `SOLDR_DAEMON_TRACE`. Off by default (one atomic-load per call when unset).
- [soldr#985](https://github.com/zackees/soldr/pull/985) — fix(daemon): avoid nested-runtime panic in `daemon start --foreground` (was hard-blocking perf-matrix cross-builds across the #982/#984 regression window).
- [soldr#986](https://github.com/zackees/soldr/pull/986) — vendor: `_vender/zccache` as a git submodule tracking zccache main; soldr's zccache dep flips from `git + rev` to path-dep via the submodule. The merged [zccache#941](https://github.com/zackees/zccache/pull/941) (per-sub-phase tracing scaffold gated by `ZCCACHE_INNER_TRACE`) lives in this submodule.
- [soldr#986](https://github.com/zackees/soldr/pull/986) — opt out of zccache audit emission via `AuditMode::Off` to satisfy the new strict-validation contract ("audit sink requires output_root when mode > Off"). soldr's own diagnostic trace lives outside the AuditSink.

## Preflight (per CLAUDE.md "Release Publishing Rules")

- [x] `Cargo.toml` `[workspace.package].version` → 0.7.60
- [x] `package.json` `"version"` → 0.7.60
- [x] `Cargo.lock` regenerated → soldr-cli at 0.7.60
- [x] Tag `v0.7.60` does not exist on origin (`git ls-remote --tags origin v0.7.60` 404)
- [x] PyPI `soldr` currently at 0.7.59 — 0.7.60 will be a fresh publish

## Test plan

- [ ] Multi-platform build on the PR's CI matrix passes (or fails only on pre-existing infra flakes — Apple zigbuild `objc`, libz-ng-sys ARM CRC, etc.)
- [ ] On merge: `release-auto.yml` `detect-bump` proceeds → builds 8 target wheels → PyPI publish → crates.io publish → GitHub release `v0.7.60`

🤖 Generated with [Claude Code](https://claude.com/claude-code)