### PR TITLE
feat(toolchain): catalogue origin + `soldr toolchain catalogue` verb (soldr#988 Phase 2)

### DIFF
--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -707,6 +707,18 @@ pub(crate) enum ToolchainSubcommand {
         #[arg(long)]
         json: bool,
     },
+    /// soldr#988 Phase 2 — print the resolved soldr-toolchain
+    /// catalogue origin and a one-line response summary (HTTP
+    /// status, content-length, etag, last-modified). Honors
+    /// `SOLDR_TOOLCHAIN_ORIGIN` (default
+    /// `https://zackees.github.io/soldr-toolchain`).
+    Catalogue {
+        /// Emit the stable machine-facing JSON form
+        /// (`schema_version: 1`) for tooling. Same shape conventions
+        /// as the other `toolchain` JSON outputs.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(clap::Subcommand)]

--- a/crates/soldr-cli/src/fetch/manifest_lookup.rs
+++ b/crates/soldr-cli/src/fetch/manifest_lookup.rs
@@ -61,9 +61,28 @@ use serde::Deserialize;
 use crate::core::SoldrError;
 
 /// Default URL of the soldr-published asset index on the `manifest`
-/// branch. Overridable via [`MANIFEST_URL_ENV_VAR`].
+/// branch. Overridable via [`MANIFEST_URL_ENV_VAR`]. soldr#988
+/// migration: the catalogue origin defined by
+/// [`DEFAULT_TOOLCHAIN_ORIGIN`] / [`TOOLCHAIN_ORIGIN_ENV_VAR`] is
+/// tried FIRST; this constant is the one-release fallback.
 pub const DEFAULT_MANIFEST_URL: &str =
     "https://raw.githubusercontent.com/zackees/soldr/manifest/asset-index.json";
+
+/// soldr#988 Phase 2 — default origin of the v1 catalogue document
+/// published by `zackees/soldr-toolchain`. The full URL we fetch is
+/// `{origin}/catalogue.v1.json`. Overridable via
+/// [`TOOLCHAIN_ORIGIN_ENV_VAR`].
+pub const DEFAULT_TOOLCHAIN_ORIGIN: &str = "https://zackees.github.io/soldr-toolchain";
+
+/// soldr#988 Phase 2 — env var that overrides
+/// [`DEFAULT_TOOLCHAIN_ORIGIN`]. Set to an `https://` URL (no
+/// trailing slash). Test seam + air-gapped-mirror seam.
+pub const TOOLCHAIN_ORIGIN_ENV_VAR: &str = "SOLDR_TOOLCHAIN_ORIGIN";
+
+/// Catalogue document name. Producers on `zackees/soldr-toolchain`
+/// emit this filename under the configured origin; consumers GET
+/// `{origin}/{CATALOGUE_DOC_NAME}`.
+pub const CATALOGUE_DOC_NAME: &str = "catalogue.v1.json";
 
 /// Env var that overrides [`DEFAULT_MANIFEST_URL`]. Set to a `file://`,
 /// `http://`, or `https://` URL pointing at the same flat-array JSON
@@ -179,6 +198,23 @@ fn resolve_url() -> String {
     }
 }
 
+/// soldr#988 Phase 2 — resolve the catalogue origin, honoring
+/// [`TOOLCHAIN_ORIGIN_ENV_VAR`]. Trailing slash is stripped so the
+/// caller can append `/catalogue.v1.json` unconditionally.
+pub fn resolve_toolchain_origin() -> String {
+    let raw = match std::env::var(TOOLCHAIN_ORIGIN_ENV_VAR) {
+        Ok(value) if !value.trim().is_empty() => value.trim().to_string(),
+        _ => DEFAULT_TOOLCHAIN_ORIGIN.to_string(),
+    };
+    raw.trim_end_matches('/').to_string()
+}
+
+/// soldr#988 Phase 2 — full URL of the catalogue document.
+/// `{resolve_toolchain_origin()}/catalogue.v1.json`.
+pub fn resolve_catalogue_url() -> String {
+    format!("{}/{}", resolve_toolchain_origin(), CATALOGUE_DOC_NAME)
+}
+
 /// Fetch the manifest body once, caching the parsed index in
 /// [`MANIFEST_CACHE`]. On any error (disable env var, HTTP failure,
 /// network failure, timeout, parse failure) caches an empty index so
@@ -207,12 +243,38 @@ pub async fn get_or_fetch() -> &'static ManifestIndex {
 }
 
 /// One-shot fetch of the manifest, used by [`get_or_fetch`] on a
-/// cache miss. Returns `Err` on every failure; the caller maps that to
-/// an empty index for graceful degradation.
+/// cache miss. Tries the soldr#988 toolchain catalogue origin first;
+/// on any failure (network, parse, HTTP error) falls back to the
+/// legacy `manifest` branch URL. Returns `Err` only when BOTH paths
+/// fail; the caller maps that to an empty index for graceful
+/// degradation.
 async fn fetch_once() -> Result<ManifestIndex, SoldrError> {
-    let url = resolve_url();
+    // 1. Try the v1 catalogue origin first.
+    let catalogue_url = resolve_catalogue_url();
+    match fetch_index_from(&catalogue_url).await {
+        Ok(idx) => return Ok(idx),
+        Err(err) => {
+            tracing::debug!(
+                target: "soldr::manifest_lookup",
+                url = %catalogue_url,
+                "toolchain catalogue fetch failed, falling back to legacy manifest branch: {err}",
+            );
+        }
+    }
+
+    // 2. Fall back to the legacy `manifest` branch URL.
+    let legacy_url = resolve_url();
+    fetch_index_from(&legacy_url).await
+}
+
+/// HTTP-GET + JSON-parse a single index URL. Shared by both the v1
+/// catalogue origin and the legacy `manifest` branch URL. The
+/// `ManifestIndex` deserializer ignores unknown top-level fields
+/// (e.g. v1's `schema_version`, `generated_at`, `origin`), so the
+/// same struct cleanly absorbs both shapes.
+async fn fetch_index_from(url: &str) -> Result<ManifestIndex, SoldrError> {
     let client = super::github::http_client()?;
-    let resp = tokio::time::timeout(MANIFEST_FETCH_TIMEOUT, client.get(&url).send())
+    let resp = tokio::time::timeout(MANIFEST_FETCH_TIMEOUT, client.get(url).send())
         .await
         .map_err(|_| SoldrError::Network(format!("manifest fetch timed out: {url}")))?
         .map_err(|e| SoldrError::Network(e.to_string()))?;
@@ -228,6 +290,108 @@ async fn fetch_once() -> Result<ManifestIndex, SoldrError> {
         .map_err(|e| SoldrError::Network(e.to_string()))?;
     ManifestIndex::from_json(&body)
         .ok_or_else(|| SoldrError::Other(format!("manifest {url} did not parse as JSON")))
+}
+
+/// soldr#988 Phase 2 — `soldr toolchain catalogue` verb. Fetches
+/// the catalogue's HEAD-equivalent metadata (one cheap GET, body
+/// streamed only as needed for the entry count) and prints either a
+/// human-readable summary or the stable JSON form.
+pub async fn run_toolchain_catalogue(json: bool) -> Result<i32, SoldrError> {
+    let url = resolve_catalogue_url();
+    let client = super::github::http_client()?;
+    let resp_result = tokio::time::timeout(MANIFEST_FETCH_TIMEOUT, client.get(&url).send()).await;
+
+    match resp_result {
+        Err(_) => {
+            print_catalogue_error(&url, "request timed out", json);
+            Ok(1)
+        }
+        Ok(Err(e)) => {
+            print_catalogue_error(&url, &format!("network error: {e}"), json);
+            Ok(1)
+        }
+        Ok(Ok(resp)) => {
+            let status = resp.status();
+            let etag = resp
+                .headers()
+                .get("etag")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+            let last_modified = resp
+                .headers()
+                .get("last-modified")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+            let content_length = resp
+                .headers()
+                .get("content-length")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok());
+            if !status.is_success() {
+                print_catalogue_error(
+                    &url,
+                    &format!("HTTP {} (the catalogue file may not be published yet)", status),
+                    json,
+                );
+                return Ok(1);
+            }
+            let body = match tokio::time::timeout(MANIFEST_FETCH_TIMEOUT, resp.text()).await {
+                Ok(Ok(b)) => b,
+                Ok(Err(e)) => {
+                    print_catalogue_error(&url, &format!("body read error: {e}"), json);
+                    return Ok(1);
+                }
+                Err(_) => {
+                    print_catalogue_error(&url, "body read timed out", json);
+                    return Ok(1);
+                }
+            };
+            let parsed = ManifestIndex::from_json(&body);
+            let n_entries = parsed.as_ref().map(|i| i.entries.len()).unwrap_or(0);
+            if json {
+                let payload = serde_json::json!({
+                    "schema_version": 1,
+                    "origin": resolve_toolchain_origin(),
+                    "url": url,
+                    "http_status": status.as_u16(),
+                    "content_length": content_length,
+                    "etag": etag,
+                    "last_modified": last_modified,
+                    "entries": n_entries,
+                });
+                println!("{}", serde_json::to_string(&payload).unwrap_or_default());
+            } else {
+                println!("soldr-toolchain catalogue:");
+                println!("  url:            {url}");
+                println!("  http status:    {}", status.as_u16());
+                if let Some(len) = content_length {
+                    println!("  content-length: {len}");
+                }
+                if let Some(etag) = etag {
+                    println!("  etag:           {etag}");
+                }
+                if let Some(lm) = last_modified {
+                    println!("  last-modified:  {lm}");
+                }
+                println!("  entries:        {n_entries}");
+            }
+            Ok(0)
+        }
+    }
+}
+
+fn print_catalogue_error(url: &str, reason: &str, json: bool) {
+    if json {
+        let payload = serde_json::json!({
+            "schema_version": 1,
+            "origin": resolve_toolchain_origin(),
+            "url": url,
+            "error": reason,
+        });
+        eprintln!("{}", serde_json::to_string(&payload).unwrap_or_default());
+    } else {
+        eprintln!("soldr toolchain catalogue: {url} — {reason}");
+    }
 }
 
 // NOTE: there is intentionally no `reset_cache_for_tests` helper.
@@ -325,6 +489,41 @@ mod tests {
         let hits = idx.lookup_release("zackees", "zccache", "1.12.9");
         assert_eq!(hits.len(), 1);
         assert!(hits[0].asset.contains("zccache"));
+    });
+
+    // soldr#988 Phase 2: catalogue origin resolution.
+
+    crate::timed_test!(catalogue_url_defaults_to_pages_origin, {
+        // Caller may have SOLDR_TOOLCHAIN_ORIGIN set in their env;
+        // exercise the public string-shape via the pure helper that
+        // does not read env: build the URL from the default origin.
+        let url = format!("{}/{}", DEFAULT_TOOLCHAIN_ORIGIN, CATALOGUE_DOC_NAME);
+        assert_eq!(url, "https://zackees.github.io/soldr-toolchain/catalogue.v1.json");
+    });
+
+    crate::timed_test!(catalogue_v1_json_parses_through_manifest_index, {
+        // Phase 2 must accept the v1 wire shape transparently — the
+        // top-level extras (schema_version, generated_at, origin)
+        // are unknown fields ManifestIndex must ignore.
+        let v1 = r#"{
+            "schema_version": 1,
+            "generated_at": "2026-06-27T00:00:00Z",
+            "origin": "https://zackees.github.io/soldr-toolchain/catalogue.v1.json",
+            "entries": [
+                {
+                    "owner": "zackees",
+                    "repo": "zccache",
+                    "tag": "1.12.11",
+                    "asset": "zccache-v1.12.11-x86_64-pc-windows-msvc.zip",
+                    "url": "https://github.com/zackees/zccache/releases/download/1.12.11/zccache-v1.12.11-x86_64-pc-windows-msvc.zip",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+                }
+            ]
+        }"#;
+        let idx = ManifestIndex::from_json(v1).expect("v1 catalogue must parse");
+        assert_eq!(idx.entries.len(), 1);
+        assert_eq!(idx.entries[0].owner, "zackees");
+        assert_eq!(idx.entries[0].tag, "1.12.11");
     });
 
     crate::timed_test!(disabled_via_env_handles_truthy_and_falsy_values, {

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -317,6 +317,11 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             ToolchainSubcommand::Doctor { json } => {
                 std::process::exit(toolchain_doctor::run_toolchain_doctor(json)?);
             }
+            ToolchainSubcommand::Catalogue { json } => {
+                std::process::exit(
+                    crate::fetch::manifest_lookup::run_toolchain_catalogue(json).await?,
+                );
+            }
         },
         Commands::Bootstrap { json } => {
             std::process::exit(bootstrap::run_bootstrap(json).await?);


### PR DESCRIPTION
Phase 2 of [#988](https://github.com/zackees/soldr/issues/988). Adds the `SOLDR_TOOLCHAIN_ORIGIN` env var (default `https://zackees.github.io/soldr-toolchain`), a catalogue-first `fetch_once` with legacy fallback, and the `soldr toolchain catalogue [--json]` CLI verb. End-to-end verified against the live origin seeded by [soldr-toolchain#10](https://github.com/zackees/soldr-toolchain/pull/10). 11/11 unit tests pass.