### PR TITLE
feat(ci): cross-compile from Windows host via zigbuild (soldr#988 Phase 3)

### DIFF
--- a/.github/workflows/_cross-build-windows-host.yml
+++ b/.github/workflows/_cross-build-windows-host.yml
@@ -1,0 +1,133 @@
+name: _Cross-build linux/mac (windows-host zigbuild)
+
+# soldr#988 Phase 3: cross-compile soldr-cli for a Linux or Mac
+# target FROM A WINDOWS RUNNER via `soldr cargo zigbuild`. Mirrors
+# _cross-build-linux.yml (which runs on Linux hosts) so Windows
+# contributors can produce Linux + Mac binaries locally and CI can
+# prove the path stays green.
+#
+# What this changes vs the existing flow:
+#
+#   * Host is `windows-2022` instead of `ubuntu-24.04`.
+#   * Bootstrap soldr step uses bash via Git-for-Windows / msys
+#     (preinstalled on windows runners) and targets
+#     `x86_64-pc-windows-msvc` so the bootstrap binary runs on the
+#     host. The cross-compile step then uses that host soldr to
+#     fetch zig / cargo-zigbuild for the target triple.
+#
+# Notes:
+#   * Apple targets need the Apple SDK (vendored via the toolchain
+#     catalogue). `soldr prepare --target <triple>` handles the
+#     fetch and exposes `SDKROOT=<path>` if not exported yet. We
+#     defer to `prepare-cross-toolchain` for that. The composite
+#     action is platform-agnostic — `target` is the only input that
+#     varies.
+#   * `actions/checkout` with `submodules: recursive` so the zccache
+#     submodule under `_vender/zccache` is materialized (path-dep).
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        # Linux: aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl,
+        # x86_64-unknown-linux-musl, x86_64-unknown-linux-gnu.
+        # Mac:   x86_64-apple-darwin, aarch64-apple-darwin.
+        # Windows targets cross-build via cargo-xwin (see
+        # _cross-build-windows.yml), not zigbuild.
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      source_ref:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_COLOR: "1"
+  CLICOLOR_FORCE: "1"
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
+
+jobs:
+  build:
+    name: cross-build ${{ inputs.target }} (windows host, zigbuild)
+    runs-on: windows-2022
+    timeout-minutes: 45
+    defaults:
+      run:
+        # Use bash so the shell idioms in this workflow match
+        # _cross-build-linux.yml byte-for-byte. Git-for-Windows
+        # ships bash preinstalled on windows-2022 runners.
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+          ref: ${{ inputs.source_ref }}
+
+      - name: Install Rust toolchain + host x86_64-pc-windows-msvc + ${{ inputs.target }}
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.94.1
+          targets: x86_64-pc-windows-msvc,${{ inputs.target }}
+
+      - name: Bootstrap soldr (bare cargo, windows host)
+        env:
+          RUSTC_WRAPPER: ""
+        run: |
+          set -euo pipefail
+          cargo build \
+            --package soldr-cli \
+            --release \
+            --locked \
+            --target x86_64-pc-windows-msvc
+          mkdir -p "$RUNNER_TEMP/soldr-bin"
+          cp target/x86_64-pc-windows-msvc/release/soldr.exe "$RUNNER_TEMP/soldr-bin/soldr.exe"
+          echo "$RUNNER_TEMP/soldr-bin" >> "$GITHUB_PATH"
+
+      - name: Show soldr version
+        run: soldr --version
+
+      # Fetches zig + cargo-zigbuild for the target triple. The
+      # composite is host-agnostic — same recipe Linux uses.
+      - name: Preparing Cross Compile Toolchain
+        uses: ./.github/actions/prepare-cross-toolchain
+        with:
+          target: ${{ inputs.target }}
+
+      - name: Cross-compile soldr-cli for ${{ inputs.target }} (zigbuild)
+        env:
+          CARGO_TARGET_DIR: target
+        run: |
+          set -euo pipefail
+          soldr cargo zigbuild \
+              --package soldr-cli \
+              --release \
+              --locked \
+              --target "${{ inputs.target }}"
+          # The cross-built binary is just "soldr" on Linux/Mac (no
+          # .exe), even though we ran the bootstrap as soldr.exe.
+          ls -la "target/${{ inputs.target }}/release/soldr"
+
+      - name: Stage artifact tarball
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp "target/${{ inputs.target }}/release/soldr" "dist/soldr"
+          chmod +x dist/soldr
+          tar -czf "dist/${{ inputs.artifact_name }}.tar.gz" -C dist soldr
+          sha256sum "dist/${{ inputs.artifact_name }}.tar.gz" | awk '{print "sha256: " $1}'
+
+      - name: Upload prebuilt soldr (${{ inputs.target }})
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: dist/${{ inputs.artifact_name }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,22 @@ jobs:
       artifact_name: soldr-ci-e2e-linux-arm64-musl
       source_ref: ${{ github.sha }}
 
+  # soldr#988 Phase 3 regression — cross-compile soldr-cli for a
+  # Linux target FROM A WINDOWS RUNNER via `soldr cargo zigbuild`.
+  # Keeps the Windows-host cross-compile path green so contributors
+  # on Windows can build Linux/Mac soldr binaries locally without
+  # pushing a branch and waiting on CI. Cheapest target — same arch,
+  # different OS — proves the zigbuild path works on Windows; the
+  # produced binary is uploaded but not e2e-exercised (the
+  # cross-build IS the regression test).
+  cross-build-from-windows-x64-linux:
+    name: cross-build x86_64-unknown-linux-gnu (windows host)
+    uses: ./.github/workflows/_cross-build-windows-host.yml
+    with:
+      target: x86_64-unknown-linux-gnu
+      artifact_name: soldr-ci-cross-windows-x64-linux
+      source_ref: ${{ github.sha }}
+
   e2e-linux-arm64-musl:
     name: build
     needs: e2e-linux-arm64-musl-build

--- a/docs/CROSS_COMPILE.md
+++ b/docs/CROSS_COMPILE.md
@@ -25,6 +25,8 @@ instead.
 |---|---|
 | Linux → Windows GNU | `cargo-zigbuild` + `ziglang` ([Section 1](#1-linux--windows-gnu-via-cargo-zigbuild-recommended)) |
 | Linux → Windows MSVC | `cargo-xwin` ([Section 2](#2-linux--windows-msvc-via-cargo-xwin)) |
+| **Windows → Linux** | `cargo-zigbuild` ([Section 1a](#1a-windows--linux-via-cargo-zigbuild-soldr988-phase-3)) |
+| **Windows → Mac** | `cargo-zigbuild` + Apple SDK ([Section 1a](#1a-windows--linux-via-cargo-zigbuild-soldr988-phase-3)) |
 | Declare cross targets up-front | `[toolchain].targets` + `[soldr.plugins]` ([Section 3](#3-pinned-host-triples-per-project-current-state)) |
 
 ---
@@ -73,6 +75,49 @@ soldr cargo zigbuild --release --target x86_64-pc-windows-gnu
   upstream ships `.tar.xz` archives and soldr's extractor does not yet
   handle that format. Until then, `[soldr.plugins]` performs a `cargo
   install` on first `soldr toolchain prepare`.
+
+---
+
+## 1a. Windows → Linux via `cargo-zigbuild` (soldr#988 Phase 3)
+
+Same `cargo-zigbuild` tool, host-flipped. Windows contributors can produce
+Linux and Mac binaries locally instead of pushing a branch and waiting on
+CI. `zig` ships the libc headers / `libSystem` shims `zigbuild` needs;
+no mingw or wsl required.
+
+### Recipe
+
+```powershell
+# Pin the cross targets in rust-toolchain.toml (same shape as Section 1):
+#   [toolchain]
+#   targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
+#
+# Then materialize the toolchain + fetch zig/cargo-zigbuild:
+soldr prepare --target x86_64-unknown-linux-gnu
+soldr prepare --target aarch64-apple-darwin   # also fetches the Apple SDK
+
+# Build:
+soldr cargo zigbuild --target x86_64-unknown-linux-gnu --release -p soldr-cli
+soldr cargo zigbuild --target aarch64-apple-darwin   --release -p soldr-cli
+```
+
+### What soldr handles automatically
+
+- `cargo-zigbuild` install (fetched from the soldr-toolchain catalogue
+  per `SOLDR_TOOLCHAIN_ORIGIN`).
+- `zig` install (same).
+- Apple SDK fetch for `*-apple-darwin` targets — `prepare` writes
+  `SDKROOT=<path>` for the build step.
+
+### CI
+
+The reusable workflow `.github/workflows/_cross-build-windows-host.yml`
+runs this exact recipe on a `windows-2022` runner. The
+`cross-build-from-windows-x64-linux` job in `ci.yml` exercises it on every
+PR with `target = x86_64-unknown-linux-gnu` as the regression test.
+
+[Section 1](#1-linux--windows-gnu-via-cargo-zigbuild-recommended) covers
+the Linux → Windows-GNU mirror of this recipe.
 
 ---
 


### PR DESCRIPTION
Phase 3 of [#988](https://github.com/zackees/soldr/issues/988). Mirrors `_cross-build-linux.yml` for Windows runners + adds a regression job in ci.yml + docs. Verified locally that the workflow YAML parses; the actual Windows zigbuild path is exercised by the new `cross-build-from-windows-x64-linux` job in this PR's own CI run.