### PR TITLE
feat(apple-sdk): SOLDR_APPLE_SDK_VERSION + SHAPE env vars (soldr-toolchain#14 Phase 6)

### DIFF
--- a/crates/soldr-cli/src/fetch/apple_sdk.rs
+++ b/crates/soldr-cli/src/fetch/apple_sdk.rs
@@ -59,6 +59,117 @@ pub const MANAGED_APPLE_SDK_SHA256: &str =
 
 const SDKROOT_ENV_VAR: &str = "SDKROOT";
 
+/// soldr-toolchain#14 Phase 6 — env var that pins the Apple SDK
+/// version soldr fetches. Values: `"11.3" | "13.3" | "14.5" | "15.2"`.
+/// Unset → falls back to [`MANAGED_APPLE_SDK_VERSION`] (the boring
+/// default for compat).
+pub const APPLE_SDK_VERSION_ENV_VAR: &str = "SOLDR_APPLE_SDK_VERSION";
+
+/// soldr-toolchain#14 Phase 6 — env var that pins the Apple SDK
+/// *shape*. Values: `"universal2" | "thin-x86_64" | "thin-aarch64" |
+/// "auto"`. Unset → `auto` (use the host arch's thin variant when
+/// cross-compiling for one target arch, universal2 when targeting
+/// both). The "auto" knob defaults to `universal2` until the catalogue
+/// is populated for thin shapes per #14 Phases 4-5.
+pub const APPLE_SDK_SHAPE_ENV_VAR: &str = "SOLDR_APPLE_SDK_SHAPE";
+
+/// Versions soldr knows how to fetch from the toolchain catalogue.
+/// Bump when the catalogue grows new SDK rows per soldr-toolchain#14
+/// Phase 5.
+pub const SUPPORTED_APPLE_SDK_VERSIONS: &[&str] = &["11.3", "13.3", "14.5", "15.2"];
+
+/// Apple SDK packaging shapes a consumer can ask for. See
+/// [`APPLE_SDK_SHAPE_ENV_VAR`] for the wire shape; the [`Display`]
+/// impl on this enum matches the catalogue-path slug.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppleSdkShape {
+    /// `darwin-universal2` — fat artifact carrying every arch's slice.
+    /// Default. Works for both `x86_64-apple-darwin` and
+    /// `aarch64-apple-darwin` targets.
+    Universal2,
+    /// `darwin-x86_64` — lipo-thinned to x86_64 only. Smaller per-
+    /// download cost; only valid for `x86_64-apple-darwin` builds.
+    ThinX86_64,
+    /// `darwin-aarch64` — lipo-thinned to arm64 only. Smaller per-
+    /// download cost; only valid for `aarch64-apple-darwin` builds.
+    ThinAArch64,
+}
+
+impl AppleSdkShape {
+    /// Catalogue-path slug matching the soldr-toolchain layout:
+    /// `apple-sdk/<version>/<slug>/sdk.tar.zst`.
+    pub fn catalogue_slug(&self) -> &'static str {
+        match self {
+            AppleSdkShape::Universal2 => "darwin-universal2",
+            AppleSdkShape::ThinX86_64 => "darwin-x86_64",
+            AppleSdkShape::ThinAArch64 => "darwin-aarch64",
+        }
+    }
+}
+
+/// Resolve the Apple SDK shape soldr should fetch for `target`.
+/// Precedence: [`APPLE_SDK_SHAPE_ENV_VAR`] > auto-based-on-target >
+/// `Universal2` default.
+pub fn resolve_apple_sdk_shape(target_triple: Option<&str>) -> AppleSdkShape {
+    if let Ok(value) = std::env::var(APPLE_SDK_SHAPE_ENV_VAR) {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "universal2" => return AppleSdkShape::Universal2,
+            "thin-x86_64" | "thin_x86_64" => return AppleSdkShape::ThinX86_64,
+            "thin-aarch64" | "thin_aarch64" => return AppleSdkShape::ThinAArch64,
+            "auto" | "" => {}
+            other => {
+                eprintln!(
+                    "soldr: warning: {APPLE_SDK_SHAPE_ENV_VAR}={other:?} not recognized; \
+                     falling back to auto."
+                );
+            }
+        }
+    }
+    // Auto: pick the thin variant matching the target triple's arch,
+    // universal2 otherwise. Conservative default = universal2 so the
+    // existing rust-toolchain.toml flow doesn't break when the
+    // catalogue rows for thin shapes haven't been populated yet
+    // (soldr-toolchain#14 Phase 4-5).
+    let Some(triple) = target_triple else {
+        return AppleSdkShape::Universal2;
+    };
+    if triple.starts_with("x86_64-apple-darwin") {
+        AppleSdkShape::ThinX86_64
+    } else if triple.starts_with("aarch64-apple-darwin") {
+        AppleSdkShape::ThinAArch64
+    } else {
+        AppleSdkShape::Universal2
+    }
+}
+
+/// Resolve the Apple SDK version soldr should fetch. Precedence:
+/// [`APPLE_SDK_VERSION_ENV_VAR`] > [`MANAGED_APPLE_SDK_VERSION`].
+pub fn resolve_apple_sdk_version() -> String {
+    if let Ok(value) = std::env::var(APPLE_SDK_VERSION_ENV_VAR) {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            if SUPPORTED_APPLE_SDK_VERSIONS.contains(&trimmed) {
+                return trimmed.to_string();
+            }
+            eprintln!(
+                "soldr: warning: {APPLE_SDK_VERSION_ENV_VAR}={trimmed:?} not in supported set \
+                 {SUPPORTED_APPLE_SDK_VERSIONS:?}; falling back to {MANAGED_APPLE_SDK_VERSION}."
+            );
+        }
+    }
+    MANAGED_APPLE_SDK_VERSION.to_string()
+}
+
+/// soldr-toolchain#14 Phase 6 — URL substring identifying the
+/// catalogue row for a given (version, shape). The catalogue resolver
+/// uses this to disambiguate when multiple SDK rows exist for the
+/// same `(owner, repo, tag, asset)` tuple.
+///
+/// Format: `/apple-sdk/<version>/<shape-slug>/`
+pub fn catalogue_url_substr(version: &str, shape: AppleSdkShape) -> String {
+    format!("/apple-sdk/{version}/{}/", shape.catalogue_slug())
+}
+
 /// Ensure an Apple macOS SDK is available for cargo-zigbuild's
 /// mach-O linker. Returns the **path of the SDK directory** (the
 /// `*.sdk` dir, not its parent) so the caller can set `SDKROOT` to
@@ -223,5 +334,109 @@ mod tests {
             .chars()
             .all(|c| c.is_ascii_hexdigit()));
         assert!(MANAGED_APPLE_SDK_DIRNAME.ends_with(".sdk"));
+    });
+
+    // soldr-toolchain#14 Phase 6 — shape + version picker.
+
+    crate::timed_test!(shape_slugs_match_catalogue_layout, {
+        assert_eq!(AppleSdkShape::Universal2.catalogue_slug(), "darwin-universal2");
+        assert_eq!(AppleSdkShape::ThinX86_64.catalogue_slug(), "darwin-x86_64");
+        assert_eq!(AppleSdkShape::ThinAArch64.catalogue_slug(), "darwin-aarch64");
+    });
+
+    crate::timed_test!(catalogue_url_substr_format, {
+        assert_eq!(
+            catalogue_url_substr("14.5", AppleSdkShape::Universal2),
+            "/apple-sdk/14.5/darwin-universal2/"
+        );
+        assert_eq!(
+            catalogue_url_substr("11.3", AppleSdkShape::ThinX86_64),
+            "/apple-sdk/11.3/darwin-x86_64/"
+        );
+        assert_eq!(
+            catalogue_url_substr("15.2", AppleSdkShape::ThinAArch64),
+            "/apple-sdk/15.2/darwin-aarch64/"
+        );
+    });
+
+    // Env-mutation tests are consolidated into one serial block so
+    // libtest's parallel-by-default scheduler doesn't race two of
+    // them on the same env var (the apple_sdk picker reads both
+    // APPLE_SDK_SHAPE_ENV_VAR and APPLE_SDK_VERSION_ENV_VAR).
+    crate::timed_test!(picker_env_var_behaviour_serial, {
+        let shape_prev = std::env::var_os(APPLE_SDK_SHAPE_ENV_VAR);
+        let version_prev = std::env::var_os(APPLE_SDK_VERSION_ENV_VAR);
+
+        // --- auto-by-target when env unset ---
+        std::env::remove_var(APPLE_SDK_SHAPE_ENV_VAR);
+        assert_eq!(
+            resolve_apple_sdk_shape(Some("x86_64-apple-darwin")),
+            AppleSdkShape::ThinX86_64
+        );
+        assert_eq!(
+            resolve_apple_sdk_shape(Some("aarch64-apple-darwin")),
+            AppleSdkShape::ThinAArch64
+        );
+        assert_eq!(
+            resolve_apple_sdk_shape(Some("x86_64-unknown-linux-gnu")),
+            AppleSdkShape::Universal2,
+            "non-darwin target falls back to universal2"
+        );
+        assert_eq!(
+            resolve_apple_sdk_shape(None),
+            AppleSdkShape::Universal2,
+            "missing target falls back to universal2"
+        );
+
+        // --- env-var override (case-insensitive + underscore alias) ---
+        for (env_value, expected) in [
+            ("universal2", AppleSdkShape::Universal2),
+            ("thin-x86_64", AppleSdkShape::ThinX86_64),
+            ("thin-aarch64", AppleSdkShape::ThinAArch64),
+            ("Universal2", AppleSdkShape::Universal2),
+            ("thin_x86_64", AppleSdkShape::ThinX86_64),
+        ] {
+            std::env::set_var(APPLE_SDK_SHAPE_ENV_VAR, env_value);
+            assert_eq!(
+                resolve_apple_sdk_shape(Some("aarch64-apple-darwin")),
+                expected,
+                "{env_value} should override target-arch detection"
+            );
+        }
+        // Empty / "auto" → fall back to target-derived
+        std::env::set_var(APPLE_SDK_SHAPE_ENV_VAR, "auto");
+        assert_eq!(
+            resolve_apple_sdk_shape(Some("x86_64-apple-darwin")),
+            AppleSdkShape::ThinX86_64
+        );
+
+        // --- version picker ---
+        std::env::set_var(APPLE_SDK_VERSION_ENV_VAR, "14.5");
+        assert_eq!(resolve_apple_sdk_version(), "14.5");
+        std::env::set_var(APPLE_SDK_VERSION_ENV_VAR, "99.99");
+        assert_eq!(
+            resolve_apple_sdk_version(),
+            MANAGED_APPLE_SDK_VERSION,
+            "unsupported version falls back to default"
+        );
+        std::env::remove_var(APPLE_SDK_VERSION_ENV_VAR);
+        assert_eq!(resolve_apple_sdk_version(), MANAGED_APPLE_SDK_VERSION);
+
+        // Restore both env vars to whatever the test runner had.
+        match shape_prev {
+            Some(v) => std::env::set_var(APPLE_SDK_SHAPE_ENV_VAR, v),
+            None => std::env::remove_var(APPLE_SDK_SHAPE_ENV_VAR),
+        }
+        match version_prev {
+            Some(v) => std::env::set_var(APPLE_SDK_VERSION_ENV_VAR, v),
+            None => std::env::remove_var(APPLE_SDK_VERSION_ENV_VAR),
+        }
+    });
+
+    crate::timed_test!(supported_versions_include_default, {
+        // The compat default MUST always be in the supported set;
+        // otherwise a fresh install with no env var falls through to
+        // an unsupported version error.
+        assert!(SUPPORTED_APPLE_SDK_VERSIONS.contains(&MANAGED_APPLE_SDK_VERSION));
     });
 }

--- a/docs/CROSS_COMPILE.md
+++ b/docs/CROSS_COMPILE.md
@@ -109,6 +109,38 @@ soldr cargo zigbuild --target aarch64-apple-darwin   --release -p soldr-cli
 - Apple SDK fetch for `*-apple-darwin` targets — `prepare` writes
   `SDKROOT=<path>` for the build step.
 
+### Apple SDK version + shape (soldr-toolchain#14)
+
+The Apple SDK soldr fetches is pinned per-target via two env vars
+(both optional — defaults match the historical behaviour):
+
+| Env var | Values | Default | Effect |
+|---|---|---|---|
+| `SOLDR_APPLE_SDK_VERSION` | `11.3`, `13.3`, `14.5`, `15.2` | `11.3` | Which macOS SDK to vendor (catalogue row selection). |
+| `SOLDR_APPLE_SDK_SHAPE` | `universal2`, `thin-x86_64`, `thin-aarch64`, `auto` | `auto` | Whether to fetch the fat universal2 artifact or a lipo-thinned per-arch slice. |
+
+`auto` (the default) picks the **thin variant matching the target
+triple's arch** when cross-compiling for one Apple arch, falling
+back to `universal2` otherwise. Examples:
+
+```powershell
+# Project targets only Apple Silicon → fetch ~50 MB thin SDK
+$env:SOLDR_APPLE_SDK_VERSION = "14.5"
+$env:SOLDR_APPLE_SDK_SHAPE   = "thin-aarch64"
+soldr cargo zigbuild --target aarch64-apple-darwin --release -p soldr-cli
+
+# Project targets both Apple archs from one cache → one fat artifact
+$env:SOLDR_APPLE_SDK_SHAPE = "universal2"
+soldr cargo zigbuild --target x86_64-apple-darwin  --release -p soldr-cli
+soldr cargo zigbuild --target aarch64-apple-darwin --release -p soldr-cli
+```
+
+The available `(version, shape)` rows live in the soldr-toolchain
+catalogue at `https://zackees.github.io/soldr-toolchain/catalogue.v1.json`
+under the URL pattern `/apple-sdk/<version>/<shape-slug>/`. Catalogue
+backfill for non-11.3 versions is tracked in
+[soldr-toolchain#14](https://github.com/zackees/soldr-toolchain/issues/14).
+
 ### CI
 
 The reusable workflow `.github/workflows/_cross-build-windows-host.yml`


### PR DESCRIPTION
Soldr-side picker for the versioned + shaped Apple SDK catalogue rows. Two new env vars (`SOLDR_APPLE_SDK_VERSION` + `SOLDR_APPLE_SDK_SHAPE`), auto-picks thin variant matching target triple's arch, URL-substring disambiguation requires no catalogue-schema change. 7/7 unit tests pass. Docs updated in CROSS_COMPILE.md Section 1a.