### PR TITLE
feat(targets): canonical 8-target const + workspace-less prepare fallback (#941 + #937)

### DIFF
--- a/crates/soldr-cli/src/cargo_metadata_soldr.rs
+++ b/crates/soldr-cli/src/cargo_metadata_soldr.rs
@@ -127,31 +127,49 @@ pub fn find_cargo_toml(start_dir: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Resolve `--target all` to the explicit target list by walking up
-/// from the current working directory, reading the nearest
-/// `Cargo.toml`, and returning `[*.metadata.soldr].targets`. Errors
-/// with a directive when the section is missing or empty — the
-/// caller asked for "all" and we must not silently substitute a
-/// host-only default.
+/// Resolve `--target all` to the explicit target list.
+///
+/// Resolution order (soldr#937 — containerized image-build needs a
+/// no-workspace fallback):
+///
+/// 1. Walk up from the current working directory; on the first
+///    `Cargo.toml` found, return `[*.metadata.soldr].targets` if the
+///    section is present **and non-empty**.
+/// 2. Otherwise fall back to [`crate::core::canonical_targets`] —
+///    soldr's compiled-in 8-target list. Prints a one-line stderr
+///    notice so the fallback is visible in container build logs.
+///
+/// The fallback path is what makes `soldr prepare --target all`
+/// work inside `examples/docker-cross-all/Dockerfile` where the
+/// soldr source isn't mounted — no need for the explicit
+/// comma-separated 8-triple form the Dockerfile used to ship.
 pub fn resolve_all_targets() -> Result<Vec<String>, SoldrError> {
     let cwd = std::env::current_dir()
         .map_err(|e| SoldrError::Other(format!("soldr prepare: cwd: {e}")))?;
-    let manifest = find_cargo_toml(&cwd).ok_or_else(|| {
-        SoldrError::Other(format!(
-            "soldr prepare --target all: no Cargo.toml found in `{}` or any parent",
-            cwd.display()
-        ))
-    })?;
-    let meta = read_soldr_metadata(&manifest)?;
-    if meta.targets.is_empty() {
-        return Err(SoldrError::Other(format!(
-            "soldr prepare --target all: no targets declared in `{}`. \
-             Add a `[workspace.metadata.soldr]` (or `[package.metadata.soldr]`) \
-             table with `targets = [\"...\", ...]`",
+
+    if let Some(manifest) = find_cargo_toml(&cwd) {
+        let meta = read_soldr_metadata(&manifest)?;
+        if !meta.targets.is_empty() {
+            return Ok(meta.targets);
+        }
+        eprintln!(
+            "soldr prepare --target all: `{}` declares no \
+             `[workspace.metadata.soldr].targets` — falling back to soldr's \
+             compiled-in canonical 8-target list (soldr#937).",
             manifest.display()
-        )));
+        );
+    } else {
+        eprintln!(
+            "soldr prepare --target all: no Cargo.toml under `{}` — \
+             falling back to soldr's compiled-in canonical 8-target list (soldr#937).",
+            cwd.display()
+        );
     }
-    Ok(meta.targets)
+
+    Ok(crate::core::canonical_targets()
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect())
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/src/core/canonical_targets.rs
+++ b/crates/soldr-cli/src/core/canonical_targets.rs
@@ -1,0 +1,93 @@
+//! Single source of truth for soldr's canonical 8-target list (#941).
+//!
+//! These are the Rust target triples soldr ships full cross-compile
+//! support for:
+//!
+//! - Linux x86_64-musl / aarch64-musl / x86_64-gnu / aarch64-gnu
+//! - macOS x86_64 / aarch64
+//! - Windows MSVC x86_64 / aarch64
+//!
+//! 32-bit triples (i686-*, armv7-*) and tier-2/tier-3 targets
+//! (freebsd, wasm32, android, …) are deliberately omitted from this
+//! list. They can still be passed explicitly via `--target <triple>`;
+//! they just aren't covered by the catalogue-backed asset bundles
+//! soldr#997 expands.
+//!
+//! ## Why this lives in `crate::core`
+//!
+//! Three call sites need the same constant — `--target all` fallback
+//! (soldr#937), the `examples/docker-cross-all/` recipe scripts, and
+//! the future `soldr targets` discovery subcommand. Previously the
+//! list lived in `[workspace.metadata.soldr].targets` in the root
+//! `Cargo.toml`; reading that requires `cargo metadata` which is
+//! unavailable in containerized image-build contexts. Promoting the
+//! list to a compile-time constant in `core` lets every soldr call
+//! site reach it without runtime metadata.
+//!
+//! The workspace metadata block is **kept** (`Cargo.toml`
+//! `[workspace.metadata.soldr]`) as the project-pinned form. A unit
+//! test in `tests/canonical_targets_parity.rs` asserts the two
+//! lists agree byte-for-byte at build time so they cannot drift.
+
+/// Soldr's canonical 8-target list. Order is stable — callers may
+/// iterate it deterministically.
+pub const CANONICAL_TARGETS: &[&str] = &[
+    "x86_64-pc-windows-msvc",
+    "aarch64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+];
+
+/// Borrowed accessor — the canonical 8-target list as `&'static [&'static str]`.
+/// Use this from any soldr call site that today queries
+/// `[workspace.metadata.soldr].targets` so the same byte-identical
+/// list is returned in every context (with or without a workspace
+/// `Cargo.toml` on disk).
+pub fn canonical_targets() -> &'static [&'static str] {
+    CANONICAL_TARGETS
+}
+
+/// Returns `true` iff `triple` is in [`CANONICAL_TARGETS`].
+/// Cheap linear scan over 8 entries.
+pub fn is_canonical(triple: &str) -> bool {
+    CANONICAL_TARGETS.iter().any(|t| *t == triple)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(canonical_targets_length_is_8, {
+        assert_eq!(CANONICAL_TARGETS.len(), 8);
+    });
+
+    crate::timed_test!(canonical_targets_are_all_recognized_triples, {
+        // Every entry must parse as a Rust target triple — guards
+        // against typos like accidentally dropping a hyphen.
+        // Apple triples have 2 hyphens (arch-apple-darwin); the
+        // others have 3 (arch-vendor-os-env). Both are valid.
+        for triple in CANONICAL_TARGETS {
+            assert!(
+                triple.matches('-').count() >= 2,
+                "{triple} is missing components — should be `<arch>-<vendor>-<os>[-<env>]`",
+            );
+            assert!(
+                !triple.contains(' '),
+                "{triple} contains whitespace",
+            );
+        }
+    });
+
+    crate::timed_test!(is_canonical_matches_listing, {
+        for t in CANONICAL_TARGETS {
+            assert!(is_canonical(t), "{t} not recognized by is_canonical");
+        }
+        assert!(!is_canonical("i686-pc-windows-msvc"), "32-bit shouldn't be canonical");
+        assert!(!is_canonical("wasm32-unknown-unknown"), "wasm not canonical");
+        assert!(!is_canonical(""), "empty string");
+    });
+}

--- a/crates/soldr-cli/src/core/mod.rs
+++ b/crates/soldr-cli/src/core/mod.rs
@@ -17,12 +17,17 @@ use std::time::Duration;
 use thiserror::Error;
 use wait_timeout::ChildExt;
 
+/// soldr#941 — single-source-of-truth for the canonical 8-target list.
+/// Mirror of `[workspace.metadata.soldr].targets` in the root
+/// `Cargo.toml`; a parity test enforces byte-equality.
+pub mod canonical_targets;
 pub mod git;
 mod paths;
 mod target_triple;
 mod toolchain_manifest;
 mod toolchain_resolve;
 
+pub use canonical_targets::{canonical_targets, is_canonical, CANONICAL_TARGETS};
 pub use paths::{
     resolve_cargo_home, resolve_rustup_home, AutoGcConfig, CookConfig, GcConfig, PinsConfig,
     SoldrConfig, SoldrPaths, SOLDR_CACHE_DIR_ENV_VAR,

--- a/crates/soldr-cli/tests/canonical_targets_parity.rs
+++ b/crates/soldr-cli/tests/canonical_targets_parity.rs
@@ -1,0 +1,67 @@
+//! soldr#941 — parity test that asserts
+//! `crate::core::canonical_targets::CANONICAL_TARGETS` matches the
+//! `[workspace.metadata.soldr].targets` block in the root
+//! `Cargo.toml` byte-for-byte. Drift between the two would
+//! silently produce different `--target all` behaviour depending on
+//! whether the workspace metadata is reachable.
+//!
+//! Standalone test binary so a workspace `Cargo.toml` parse failure
+//! (corrupt TOML, missing file in a container build) only fails
+//! THIS file, not the rest of the integration tests.
+
+use soldr_cli::core::CANONICAL_TARGETS;
+use soldr_cli::timed_test;
+
+timed_test!(canonical_const_matches_workspace_metadata, {
+    // Walk up from the test binary's directory to find the workspace
+    // root. Cargo gives us `CARGO_MANIFEST_DIR` for the bin crate
+    // (`crates/soldr-cli`); the workspace root is its parent's
+    // parent.
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_toml = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root resolvable from bin manifest dir")
+        .join("Cargo.toml");
+    assert!(
+        workspace_toml.is_file(),
+        "expected workspace Cargo.toml at {workspace_toml:?}"
+    );
+
+    let text = std::fs::read_to_string(&workspace_toml).expect("read root Cargo.toml");
+    let parsed: toml::Value = toml::from_str(&text).expect("parse root Cargo.toml");
+    let metadata_targets = parsed
+        .get("workspace")
+        .and_then(|v| v.get("metadata"))
+        .and_then(|v| v.get("soldr"))
+        .and_then(|v| v.get("targets"))
+        .and_then(|v| v.as_array())
+        .expect("[workspace.metadata.soldr].targets must be present in root Cargo.toml");
+
+    let workspace_list: Vec<&str> = metadata_targets
+        .iter()
+        .map(|v| v.as_str().expect("each target is a string"))
+        .collect();
+
+    assert_eq!(
+        workspace_list.len(),
+        CANONICAL_TARGETS.len(),
+        "length mismatch — workspace has {} entries, const has {}",
+        workspace_list.len(),
+        CANONICAL_TARGETS.len(),
+    );
+
+    // Order must match too. The const is documented as
+    // deterministic-order; consumers (docker-cross-all build.sh
+    // generators, soldr targets shorthand) rely on the order.
+    for (i, (workspace_triple, const_triple)) in workspace_list
+        .iter()
+        .zip(CANONICAL_TARGETS.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            workspace_triple, const_triple,
+            "drift at index {i}: workspace={workspace_triple}, const={const_triple}",
+        );
+    }
+});


### PR DESCRIPTION
Closes #941 (single source of truth for the 8-target list) and #937 (workspace-less prepare --target all fallback). Both blockers under soldr#997 + soldr#930. New `crate::core::canonical_targets::CANONICAL_TARGETS` const, byte-parity test against `[workspace.metadata.soldr].targets`, and `resolve_all_targets` falls back to it when no workspace is reachable. 4/4 unit + integration tests pass.