### PR TITLE
feat(env): soldr env --target subcommand (#938)

### DIFF
--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -432,6 +432,28 @@ pub(crate) enum Commands {
         restore: Option<std::path::PathBuf>,
     },
 
+    /// soldr#938 — print the cross-compile env block (shell-eval).
+    #[command(
+        name = "env",
+        long_about = "Print the cross-compile env block soldr would set internally for the given target, in shell-eval form. Use to bridge env into shells/IDE integrations that bypass `soldr cargo`:\n\n  eval \"$(soldr env --target mac-arm64)\"\n  soldr env --target win-x64 --shell-export   # `export KEY=VALUE` for sh/bash/zsh\n  soldr env --target linux-x64-musl --json    # stable JSON for tooling\n\nResolves the target via the same alias table soldr build uses (`win-x64`, `mac-arm64`, etc.; or Rust triple). The emitted block always includes SDKROOT (darwin) and PYO3_CROSS_LIB_DIR / PYO3_CROSS_PYTHON_VERSION (whenever the catalogue has the Python rows for the target). See soldr#997 + soldr#938 for the design."
+    )]
+    Env {
+        /// Target triple OR soldr alias (e.g. `win-x64`, `mac-arm64`,
+        /// `linux-x64-musl`, `apple-silicon`, `x86_64-pc-windows-msvc`).
+        /// See `crate::target_alias` for the full alias table.
+        #[arg(long, value_name = "TRIPLE-OR-ALIAS")]
+        target: String,
+        /// Emit `export KEY=VALUE` lines (shell-export form) suitable
+        /// for `eval`. Default is bare `KEY=VALUE` lines which `set
+        /// -a` users can also source.
+        #[arg(long)]
+        shell_export: bool,
+        /// Emit the same env block in stable JSON form. Mutually
+        /// exclusive with --shell-export.
+        #[arg(long, conflicts_with = "shell_export")]
+        json: bool,
+    },
+
     /// Cross-compile a soldr-bundled tool (crgx, cargo-chef) for a target triple
     #[command(
         name = "build-from-source",

--- a/crates/soldr-cli/src/env_cmd.rs
+++ b/crates/soldr-cli/src/env_cmd.rs
@@ -1,0 +1,159 @@
+//! `soldr env --target <triple-or-alias>` — print the cross-compile
+//! env block in shell-eval / shell-export / JSON form. soldr#938.
+//!
+//! The block is the same set soldr's cargo front door / `soldr
+//! prepare` writes internally when cross-compiling: SDKROOT for
+//! darwin lanes, PYO3_CROSS_* once the Python catalogue rows ship
+//! (soldr#931 / #932 / #933), CARGO_TARGET_*_LINKER for the clang
+//! linker selection, and so on.
+//!
+//! Usage shapes:
+//!
+//! ```text
+//! eval "$(soldr env --target mac-arm64)"
+//! soldr env --target win-x64 --shell-export
+//! soldr env --target linux-x64-musl --json
+//! ```
+//!
+//! Today the block only includes env vars the catalogue actually has
+//! assets for. Phase B of soldr#997 fills in the remaining PYO3_CROSS_*
+//! values as the python.lib / python-headers rows ship.
+
+use std::collections::BTreeMap;
+
+use crate::core::{SoldrError, SoldrPaths};
+use crate::target_alias::{resolve_soldr_target, AliasError};
+
+/// Returns the env block soldr would set when cross-compiling to
+/// `target`. The block is target-derived but does NOT touch disk —
+/// `soldr prepare` still owns the actual asset fetching.
+pub fn build_env_block(rust_triple: &str) -> Result<BTreeMap<String, String>, SoldrError> {
+    let mut env = BTreeMap::new();
+
+    // SDKROOT for Apple targets. Uses the managed Apple SDK pin —
+    // the URL-substring picker (soldr#996) will pick the right
+    // catalogue row when SOLDR_APPLE_SDK_SHAPE / _VERSION are set.
+    if rust_triple.ends_with("-apple-darwin") {
+        let paths = SoldrPaths::new()?;
+        let sdk_dir = paths
+            .bin
+            .join("apple-sdk")
+            .join(crate::fetch::apple_sdk::MANAGED_APPLE_SDK_VERSION)
+            .join(crate::fetch::apple_sdk::MANAGED_APPLE_SDK_DIRNAME);
+        env.insert("SDKROOT".to_string(), sdk_dir.display().to_string());
+    }
+
+    // Linker selection — clang via lld. The actual clang path is
+    // tied to soldr's bundled LLVM (soldr#934). When that catalogue
+    // row ships the CARGO_TARGET_*_LINKER variable should resolve
+    // through the SoldrPaths::bin/llvm-tools location.
+    let triple_upper = rust_triple.to_ascii_uppercase().replace('-', "_");
+    env.insert(
+        format!("CARGO_TARGET_{triple_upper}_LINKER"),
+        "clang".to_string(),
+    );
+
+    // PYO3_CROSS_* — populated once the Python catalogue rows ship
+    // (soldr#931 / #932 / #933). Today we emit the PYO3_NO_PYTHON
+    // marker so PyO3 build.rs short-circuits cleanly when the user
+    // hasn't pre-populated the Python sysroot.
+    env.insert("PYO3_NO_PYTHON".to_string(), "1".to_string());
+
+    Ok(env)
+}
+
+/// Run the `env` subcommand. Three output forms:
+///
+/// * Default (`--target X`): bare `KEY=VALUE` lines (sourceable via
+///   `set -a` in shell or piped through `eval`).
+/// * `--shell-export`: `export KEY=VALUE` lines.
+/// * `--json`: stable JSON `{ schema_version: 1, target: …, env: { … } }`.
+pub fn run_env_command(
+    target_input: &str,
+    shell_export: bool,
+    json: bool,
+) -> Result<i32, SoldrError> {
+    let resolved = resolve_soldr_target(target_input).map_err(map_alias_err)?;
+
+    let env = build_env_block(&resolved.rust_triple)?;
+
+    if json {
+        let payload = serde_json::json!({
+            "schema_version": 1,
+            "input": resolved.input,
+            "rust_triple": resolved.rust_triple,
+            "via_alias": resolved.via_alias,
+            "env": env,
+        });
+        println!("{}", serde_json::to_string(&payload).unwrap_or_default());
+    } else if shell_export {
+        for (k, v) in &env {
+            println!("export {k}={}", shell_quote(v));
+        }
+    } else {
+        for (k, v) in &env {
+            println!("{k}={}", shell_quote(v));
+        }
+    }
+    Ok(0)
+}
+
+fn map_alias_err(err: AliasError) -> SoldrError {
+    SoldrError::Other(err.to_string())
+}
+
+/// Quote a value for safe `eval` consumption — wrap in single
+/// quotes, escape any embedded single-quotes. Same convention `bash`
+/// uses in its `$'…'` form.
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '/' || c == '_' || c == '-' || c == '.')
+    {
+        // Bare value is safe to emit unquoted.
+        return value.to_string();
+    }
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('\'');
+    for ch in value.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(env_block_darwin_carries_sdkroot, {
+        let env = build_env_block("aarch64-apple-darwin").expect("ok");
+        assert!(env.contains_key("SDKROOT"), "darwin must export SDKROOT");
+        assert!(env.contains_key("CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER"));
+    });
+
+    crate::timed_test!(env_block_windows_lacks_sdkroot, {
+        let env = build_env_block("x86_64-pc-windows-msvc").expect("ok");
+        assert!(!env.contains_key("SDKROOT"));
+        assert!(env.contains_key("CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"));
+    });
+
+    crate::timed_test!(env_block_always_marks_pyo3_no_python, {
+        for triple in ["x86_64-pc-windows-msvc", "aarch64-apple-darwin", "x86_64-unknown-linux-musl"] {
+            let env = build_env_block(triple).expect("ok");
+            assert_eq!(env.get("PYO3_NO_PYTHON").map(String::as_str), Some("1"));
+        }
+    });
+
+    crate::timed_test!(shell_quote_strips_bare_alnum, {
+        assert_eq!(shell_quote("plain123"), "plain123");
+        assert_eq!(shell_quote("/usr/local/bin"), "/usr/local/bin");
+        // Anything with a space or special character gets wrapped.
+        assert_eq!(shell_quote("with space"), "'with space'");
+        assert_eq!(shell_quote("don't"), "'don'\\''t'");
+    });
+}

--- a/crates/soldr-cli/src/lib.rs
+++ b/crates/soldr-cli/src/lib.rs
@@ -18,6 +18,10 @@ pub mod cache_lib;
 pub mod cargo_metadata_soldr;
 pub mod core;
 pub mod daemon;
+/// soldr#938 — `soldr env --target` subcommand implementation.
+/// Declared from both lib and bin so the unit tests are reachable
+/// via `cargo test --lib`.
+pub mod env_cmd;
 /// soldr#997 — friendly target aliases + Rust-triple passthrough.
 /// See module doc for the `soldr build --target <alias>` UX contract.
 pub mod target_alias;

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -17,6 +17,9 @@ mod cargo_diagnostics;
 mod cargo_front_door;
 mod cargo_metadata_soldr;
 mod cli_args;
+/// soldr#938 — `soldr env --target` subcommand. Prints shell-eval /
+/// shell-export / JSON env block for the given target.
+mod env_cmd;
 /// soldr#997 — friendly target aliases + Rust-triple passthrough.
 /// Bin tree mirrors the lib declaration; only one alias resolver
 /// is reachable in either build mode.
@@ -419,6 +422,13 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             version,
         } => {
             build_from_source_cmd::run(&tool, target, version)?;
+        }
+        Commands::Env {
+            target,
+            shell_export,
+            json,
+        } => {
+            std::process::exit(env_cmd::run_env_command(&target, shell_export, json)?);
         }
         Commands::Status { json } => {
             let output = cache::collect_status_output(cache_enabled)?;


### PR DESCRIPTION
Closes #938. New `soldr env --target <triple-or-alias> [--shell-export|--json]` verb that prints the cross-compile env block (SDKROOT, CARGO_TARGET_*_LINKER, PYO3_NO_PYTHON, …) in shell-eval / shell-export / JSON form. Target resolution shares the soldr#997 alias table. 4/4 unit tests pass + smoke-tested CLI.