### PR TITLE
feat(prepare): parallel asset fetching (intra + inter target) (#940)

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -385,22 +385,58 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 prepare_cmd::ParsedTargetArg::All => cargo_metadata_soldr::resolve_all_targets()?,
                 prepare_cmd::ParsedTargetArg::Explicit(list) => list,
             };
-            // Per-triple errors are collected so a single bad target in
-            // a multi-target run doesn't hide later failures. The whole
-            // command still exits non-zero if any iteration failed.
-            let mut failures: Vec<(String, String)> = Vec::new();
+            // soldr#940 — run per-target preparations concurrently with
+            // a bounded worker pool. `--target all` previously serialized
+            // 8 cold downloads on top of each other; now they overlap.
+            // Per-target dispatch (zig + Apple SDK, LLVM + xwin, …) is
+            // also internally parallelized — see `prepare_cmd::run`.
+            //
+            // Concurrency cap: min(num_cpus, num_targets, 4). 4 is the
+            // GitHub-runner-friendly ceiling — beyond that the
+            // contention on the NIC dominates the parallelism win.
+            let cpu_cap = std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(2);
+            let concurrency = cpu_cap.min(targets.len()).min(4).max(1);
+            if targets.len() > 1 {
+                eprintln!(
+                    "soldr prepare: parallelizing {} targets with {} workers (soldr#940)",
+                    targets.len(),
+                    concurrency,
+                );
+            }
+            let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
+            let mut handles = Vec::with_capacity(targets.len());
             for triple in &targets {
-                eprintln!("soldr prepare: ===== target {triple} =====");
-                if let Err(e) = prepare_cmd::run(
-                    triple.clone(),
-                    github_env.clone(),
-                    save.clone(),
-                    restore.clone(),
-                )
-                .await
-                {
+                let triple_owned = triple.clone();
+                let github_env_clone = github_env.clone();
+                let save_clone = save.clone();
+                let restore_clone = restore.clone();
+                let sem_clone = std::sync::Arc::clone(&sem);
+                handles.push(tokio::spawn(async move {
+                    let _permit = sem_clone
+                        .acquire_owned()
+                        .await
+                        .expect("semaphore not closed");
+                    eprintln!("soldr prepare: ===== target {triple_owned} =====");
+                    let result = prepare_cmd::run(
+                        triple_owned.clone(),
+                        github_env_clone,
+                        save_clone,
+                        restore_clone,
+                    )
+                    .await;
+                    (triple_owned, result)
+                }));
+            }
+            let mut failures: Vec<(String, String)> = Vec::new();
+            for handle in handles {
+                let (triple, result) = handle
+                    .await
+                    .map_err(|e| SoldrError::Other(format!("prepare worker join: {e}")))?;
+                if let Err(e) = result {
                     eprintln!("soldr prepare: target {triple} failed: {e}");
-                    failures.push((triple.clone(), e.to_string()));
+                    failures.push((triple, e.to_string()));
                 }
             }
             if !failures.is_empty() {

--- a/crates/soldr-cli/src/prepare_cmd.rs
+++ b/crates/soldr-cli/src/prepare_cmd.rs
@@ -257,30 +257,42 @@ pub async fn run(
         eprintln!("soldr prepare: warning: rustup target add failed: {e}");
     }
 
+    // soldr#940 — assets within a target's dispatch are fetched
+    // concurrently via `tokio::try_join!`. Each ensure_* call already
+    // implements its own integrity verification + caching, so racing
+    // them only affects net-bandwidth ordering — not the on-disk
+    // result.
     match attrs.os {
         TargetOs::Windows => {
             // Windows MSVC cross-compile path: needs cargo-xwin, LLVM
             // toolchain (for clang/lld-link), and the MSVC CRT cache.
-            eprintln!("soldr prepare: dispatch=xwin");
-            let llvm_dir = match ensure_llvm_toolchain(&paths).await {
-                Ok(p) => p,
-                Err(SoldrError::UnsupportedPlatform(m)) => {
-                    eprintln!("soldr prepare: LLVM auto-bootstrap not supported on host: {m}");
-                    PathBuf::new()
+            // Run LLVM and the xwin cache extract concurrently.
+            eprintln!("soldr prepare: dispatch=xwin (parallel)");
+            let llvm_fut = async {
+                match ensure_llvm_toolchain(&paths).await {
+                    Ok(p) => Ok::<PathBuf, SoldrError>(p),
+                    Err(SoldrError::UnsupportedPlatform(m)) => {
+                        eprintln!(
+                            "soldr prepare: LLVM auto-bootstrap not supported on host: {m}"
+                        );
+                        Ok(PathBuf::new())
+                    }
+                    Err(e) => Err(e),
                 }
-                Err(e) => return Err(e),
             };
+            let xwin_fut = ensure_xwin_cache();
+            let (llvm_dir, _) = tokio::try_join!(llvm_fut, xwin_fut)?;
             if !llvm_dir.as_os_str().is_empty() {
                 eprintln!("soldr prepare: LLVM toolchain at {}", llvm_dir.display());
             }
-            ensure_xwin_cache().await?;
         }
         TargetOs::Darwin => {
             // Darwin cross-compile path: needs zig + Apple SDK; export SDKROOT.
-            eprintln!("soldr prepare: dispatch=zigbuild+apple-sdk");
-            let zig_dir = ensure_zig(&paths).await?;
+            // Both fetches independent — race them.
+            eprintln!("soldr prepare: dispatch=zigbuild+apple-sdk (parallel)");
+            let (zig_dir, sdk) =
+                tokio::try_join!(ensure_zig(&paths), ensure_apple_sdk(&paths))?;
             eprintln!("soldr prepare: zig at {}", zig_dir.display());
-            let sdk = ensure_apple_sdk(&paths).await?;
             eprintln!("soldr prepare: Apple SDK at {}", sdk.display());
             let sdk_str = sdk.to_string_lossy();
             println!("SDKROOT={sdk_str}");
@@ -288,7 +300,8 @@ pub async fn run(
         }
         TargetOs::Linux => {
             // Linux cross-compile via zigbuild (musl always, gnu when
-            // host != target arch).
+            // host != target arch). Only one asset to fetch; no parallel
+            // bench yet — leave as-is.
             eprintln!("soldr prepare: dispatch=zigbuild");
             let zig_dir = ensure_zig(&paths).await?;
             eprintln!("soldr prepare: zig at {}", zig_dir.display());


### PR DESCRIPTION
Closes #940. Two-level concurrency in soldr prepare: inter-target via bounded tokio::Semaphore (cap = min(num_cpus, num_targets, 4)) and intra-target via tokio::try_join! within each dispatch (LLVM+xwin race for Windows MSVC; zig+Apple SDK race for darwin). Build clean. No test changes needed — ensure_* functions already have own caching + integrity verification.