### PR TITLE
fix(vcpkg): rename libcurl → curl in pin list

### DIFF
--- a/.github/vcpkg-pin.txt
+++ b/.github/vcpkg-pin.txt
@@ -14,7 +14,7 @@
 
 openssl
 zlib
-libcurl
+curl
 sqlite3
 protobuf
 libssh2


### PR DESCRIPTION
soldr#1006 Lane 5. vcpkg-windows-refresh failed with `libcurl does not exist` — the vcpkg port name is `curl`, not `libcurl`.