### PR TITLE
feat(cli): soldr build native verb (soldr#1012 PR 1)

### DIFF
--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -136,7 +136,12 @@ pub(crate) enum ZccacheSourceArg {
 /// output of first-party commands; new cargo verbs (rare) need an
 /// explicit add here.
 pub(crate) const CARGO_BUILTIN_VERBS: &[&str] = &[
-    "build",
+    // `build` is intentionally NOT here. As of soldr#1012 PR 1, `build`
+    // is a soldr-native verb (`Commands::Build`) — clap captures it
+    // before the External arm runs. It joins `clean`, `config`, and
+    // `version` as a collision verb whose meaning is owned by soldr.
+    // `soldr cargo build` is the explicit legacy-passthrough escape
+    // hatch; `soldr build` is the blessed default.
     "test",
     "check",
     "run",
@@ -176,6 +181,11 @@ pub(crate) fn is_cargo_builtin_verb(verb: &str) -> bool {
 }
 
 pub(crate) const SOLDR_BUILTIN_VERBS: &[&str] = &[
+    // soldr#1012 PR 1: `build` is a soldr-native verb (the blessed-
+    // default surface). Today functionally aliases `soldr cargo build`;
+    // future #1012 PRs layer catalogue-driven sysroot prep on this arm.
+    // Stays paired with `Commands::Build` in the enum.
+    "build",
     "cargo",
     "cook",
     "rustc",
@@ -200,6 +210,10 @@ pub(crate) const SOLDR_BUILTIN_VERBS: &[&str] = &[
     "shims",
     "optimize",
     "defender-exclusions",
+    // pre-existing drift caught by the SOLDR_BUILTIN_VERBS gate while
+    // landing soldr#1012 PR 1 — `Commands::Env` was added but never
+    // registered in this const. Belongs here next to other verbs.
+    "env",
     "session-start",
     "session-end",
     "install-zccache",
@@ -215,6 +229,32 @@ pub(crate) const SOLDR_BUILTIN_VERBS: &[&str] = &[
 
 #[derive(clap::Subcommand)]
 pub(crate) enum Commands {
+    /// Build the workspace via soldr's blessed cross-compile path
+    ///
+    /// `soldr build --target X` is the **blessed-default surface** for
+    /// builds. Today this is functionally an alias for `soldr cargo
+    /// build` — all arguments are forwarded to `cargo build` verbatim
+    /// through the same `cargo_front_door` pipeline, with the same
+    /// caching, target resolution, and managed-toolchain behavior. The
+    /// surface contract is the load-bearing part: callers asking for
+    /// `soldr build` get the soldr-blessed toolchain story, while
+    /// callers asking for `soldr cargo build` get the explicit legacy
+    /// passthrough.
+    ///
+    /// Per soldr#1010 / soldr#1012, future work layers catalogue-driven
+    /// sysroot prep + a clang/clang-cl shim on top of this verb so
+    /// cross-compile to `*-pc-windows-msvc` lands without `cargo xwin`
+    /// — but those land behind this same `Commands::Build` arm; today's
+    /// users get a stable surface that won't change.
+    ///
+    /// Internal sharing of dispatch with `Commands::Cargo` is
+    /// intentional and expected; what matters is the user-facing
+    /// contract that `soldr build` evolves into the blessed-default
+    /// without breaking the alias surface.
+    Build {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Run cargo through soldr (cached, pinned toolchain)
     Cargo {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -258,6 +258,28 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
     let trust_inherited_soldr_env = cli.trust_inherited_soldr_env;
 
     match cli.command {
+        Commands::Build { args } => {
+            // soldr#1012 PR 1 — `soldr build` is the blessed-default
+            // surface for builds. Today it's functionally an alias for
+            // `soldr cargo build`: we prepend `build` to the user's
+            // args and forward through the same `cargo_front_door`
+            // pipeline. Subsequent #1012 PRs (especially PR 5) layer
+            // catalogue-driven sysroot prep + the clang shim on top
+            // by branching here BEFORE the front-door call. The user-
+            // facing surface stays stable across that evolution.
+            let mut full_args = Vec::with_capacity(args.len() + 1);
+            full_args.push("build".to_string());
+            full_args.extend(args);
+            std::process::exit(
+                cargo_front_door::run_cargo_front_door(
+                    &full_args,
+                    cache_enabled,
+                    zccache_source,
+                    trust_inherited_soldr_env,
+                )
+                .await?,
+            );
+        }
         Commands::Cargo { args } => {
             std::process::exit(
                 cargo_front_door::run_cargo_front_door(

--- a/crates/soldr-cli/src/main_tests.rs
+++ b/crates/soldr-cli/src/main_tests.rs
@@ -499,7 +499,9 @@ fn cargo_builtin_shorthand_covers_every_verb_in_the_const() {
     // hard-coded — adding a new cargo verb to the const without
     // also adding it here is the kind of drift this test catches.
     let expected = [
-        "build",
+        // `build` deliberately not in this list: soldr#1012 PR 1
+        // promoted `build` to a soldr-native verb (clap-captured before
+        // External). It joins clean/config/version as a collision verb.
         "test",
         "check",
         "run",
@@ -554,12 +556,13 @@ fn cargo_builtin_shorthand_covers_every_verb_in_the_const() {
 
 #[test]
 fn cargo_builtin_shorthand_excludes_soldr_native_collision_verbs() {
-    // The three collision verbs (`clean`, `config`, `version`) own
-    // a soldr-native meaning today and MUST NOT be remapped to
-    // cargo by the phase-2 hop. Clap captures them before the
-    // External arm runs, but we also assert the const itself
-    // excludes them — defense in depth + intent documentation.
-    for collision_verb in ["clean", "config", "version"] {
+    // Collision verbs (`build`, `clean`, `config`, `version`) own a
+    // soldr-native meaning and MUST NOT be remapped to cargo by the
+    // phase-2 hop. Clap captures them before the External arm runs,
+    // but we also assert the const itself excludes them — defense in
+    // depth + intent documentation. `build` joined this list in
+    // soldr#1012 PR 1 as the blessed-default surface for cross-compile.
+    for collision_verb in ["build", "clean", "config", "version"] {
         assert!(
             !is_cargo_builtin_verb(collision_verb),
             "soldr-native verb {collision_verb:?} must NOT be in CARGO_BUILTIN_VERBS"
@@ -569,13 +572,19 @@ fn cargo_builtin_shorthand_excludes_soldr_native_collision_verbs() {
 
 #[test]
 fn cargo_builtin_shorthand_skips_when_user_pinned_a_version() {
-    // `soldr build@1.0` keeps the existing External fetch path —
+    // `soldr test@1.0` keeps the existing External fetch path —
     // cargo built-ins have no per-invocation version dimension and
     // the parse-time `@version` form is reserved for the
     // crate-fetch path. Same shape as the phase-1
     // `bare_shorthand_skips_when_user_pinned_a_version` test.
-    let (crate_name, version) = parse_tool_spec("build@1.0");
-    assert_eq!(crate_name, "build");
+    //
+    // (Pre-soldr#1012 this test used `build@1.0`, but `build` is
+    // now a soldr-native verb captured by clap before the External
+    // arm runs, so the version-pin code path no longer applies to
+    // it. `test` is the next-shortest cargo-builtin still in the
+    // const and exercises the exact same logic.)
+    let (crate_name, version) = parse_tool_spec("test@1.0");
+    assert_eq!(crate_name, "test");
     assert!(
         matches!(version, VersionSpec::Exact(_)),
         "pinned bare verb must parse to VersionSpec::Exact"

--- a/crates/soldr-cli/tests/cli_build_alias_parity.rs
+++ b/crates/soldr-cli/tests/cli_build_alias_parity.rs
@@ -1,0 +1,150 @@
+//! soldr#1012 PR 1 — parity test for the `soldr build` blessed verb.
+//!
+//! The user-facing contract: today `soldr build` is functionally an
+//! alias for `soldr cargo build`. Both surfaces invoke the same
+//! `cargo_front_door::run_cargo_front_door` pipeline; the only
+//! difference is that the `Commands::Build` handler prepends `"build"`
+//! to the arg list before forwarding.
+//!
+//! These tests pin that contract so future #1012 PRs can layer
+//! catalogue-driven sysroot prep on top without accidentally diverging
+//! the legacy behavior. When PR 5 adds blessed cross-compile, the
+//! contract becomes "byte-identical artifacts when `SOLDR_USE_LEGACY_*`
+//! env vars opt out of the catalogue path"; until then it's
+//! byte-identical unconditionally.
+
+#![allow(unused_imports)]
+
+mod common;
+
+use common::*;
+use std::process::Command;
+
+#[test]
+fn soldr_build_alias_resolves_via_clap_not_external() {
+    // `soldr build --help` must produce build-verb-specific help, not
+    // fall through to the External-arm crate-fetch path (which would
+    // try to install a crate literally named "build"). This is the
+    // simplest possible smoke test that `Commands::Build` exists and
+    // is wired through clap.
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["build", "--help"])
+        .output()
+        .expect("failed to run soldr build --help");
+
+    assert!(
+        output.status.success(),
+        "soldr build --help failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    // No External-arm signal — soldr should NOT have tried to resolve
+    // "build" as a crate or trigger any fetch.
+    assert!(
+        !combined.contains("fetching")
+            && !combined.contains("crates.io")
+            && !combined.contains("not found on crates.io"),
+        "soldr build --help unexpectedly went through External arm:\n{combined}"
+    );
+    // Must reference the build verb's own docstring or `--target`.
+    assert!(
+        combined.contains("build")
+            || combined.contains("--target")
+            || combined.contains("blessed"),
+        "soldr build --help should produce build-verb help text:\n{combined}"
+    );
+}
+
+#[test]
+fn soldr_build_invokes_real_cargo_build() {
+    // Confirm the verb actually reaches `cargo build` and not some
+    // External-arm crate fetch. `cargo build --help` is the safest
+    // probe: it returns cargo's help banner without touching the
+    // filesystem or network. Both `soldr build --help` and `soldr
+    // cargo build --help` must produce the SAME cargo-side help
+    // content (this is the surface-contract parity assertion).
+    //
+    // Important: `--help` here is consumed by cargo, not by clap.
+    // soldr's clap-captured `--help` would print soldr's own build-
+    // verb docstring; cargo's `--help` (which we want) requires the
+    // `--` separator OR a flag cargo recognizes before `--help`. We
+    // use `--manifest-path` pointing at a clearly-bogus path so
+    // cargo errors out FAST with a recognizable error; the soldr →
+    // cargo dispatch is what we're testing, not a successful build.
+    let cache_root = unique_temp_dir("build-alias-routes-to-cargo");
+
+    let build_out = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "--no-cache",
+            "build",
+            "--manifest-path",
+            "/nonexistent/path/to/Cargo.toml",
+        ])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr build");
+
+    let cargo_out = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args([
+            "--no-cache",
+            "cargo",
+            "build",
+            "--manifest-path",
+            "/nonexistent/path/to/Cargo.toml",
+        ])
+        .env("SOLDR_CACHE_DIR", &cache_root)
+        .output()
+        .expect("failed to run soldr cargo build");
+
+    // Both must fail (manifest path doesn't exist) — but they must
+    // BOTH reach cargo's error path, not soldr's own crate-fetch
+    // error path. The parity contract is "same dispatch destination".
+    let build_stderr = String::from_utf8_lossy(&build_out.stderr);
+    let cargo_stderr = String::from_utf8_lossy(&cargo_out.stderr);
+
+    // Cargo's manifest-not-found error contains a recognizable phrase.
+    // If either route fell through to External-arm crate-fetch,
+    // we'd see "fetching"/"crates.io" instead.
+    for (name, stderr) in [
+        ("soldr build", &build_stderr),
+        ("soldr cargo build", &cargo_stderr),
+    ] {
+        assert!(
+            stderr.contains("manifest") || stderr.contains("Cargo.toml") || stderr.contains("nonexistent"),
+            "{name} did not reach cargo's manifest-handling path; stderr was:\n{stderr}"
+        );
+        assert!(
+            !stderr.contains("not found on crates.io")
+                && !stderr.contains("fetching latest release"),
+            "{name} fell through to crate-fetch External path; stderr was:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn soldr_build_help_documents_blessed_surface() {
+    // The clap docstring on `Commands::Build` references the blessed-
+    // default surface contract. The `--help` output must surface that
+    // language so users discovering `soldr build --help` understand
+    // why they'd pick it over `soldr cargo build`.
+    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        .args(["build", "--help"])
+        .output()
+        .expect("failed to run soldr build --help");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        combined.contains("blessed") || combined.contains("cross-compile") || combined.contains("Build the workspace"),
+        "soldr build --help is missing the blessed-surface contract language:\n{combined}"
+    );
+}


### PR DESCRIPTION
soldr#1012 PR 1 of 6. Adds `Commands::Build` clap arm forwarding to `cargo_front_door` (today functionally an alias for `soldr cargo build`; subsequent PRs in #1012 layer catalogue-driven sysroot prep on this same arm). Promotes `build` to a soldr-native frozen verb. 3 new integration tests assert alias semantics.

Unblocks PR 2 (fbuild template swap).