### PR TITLE
feat(build): Commands::Build materializes xwin-cache + clang shim (#1012 PR 5)

### DIFF
--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -1,0 +1,282 @@
+//! soldr#1012 PR 5 — blessed cross-compile sysroot preparation for
+//! `soldr build --target <T>`.
+//!
+//! When `Commands::Build` (soldr#1013) detects a canonical cross-
+//! compile target, this module materializes the per-target sysroot
+//! from the soldr-toolchain catalogue, sets the env vars cargo + cc-rs
+//! + linker tools need, and installs the clang shim ahead of the
+//! system clang on PATH.
+//!
+//! ## Target coverage
+//!
+//! * `*-pc-windows-msvc` — xwin-cache + clang shim (sidesteps the
+//!   ring 0.17.14:563 oversight described in [`crate::fetch::xwin_cache`]
+//!   and the `soldr-clang-shim` binary doc)
+//! * `*-apple-darwin` — soldr's existing apple-sdk fetcher already
+//!   handles this via `soldr prepare`; the blessed `soldr build` path
+//!   just calls into [`crate::fetch::apple_sdk::ensure_apple_sdk`]
+//!
+//! Other targets (linux musl, linux gnu) get no sysroot prep — they
+//! work out-of-the-box with the host cargo + zigbuild flow.
+//!
+//! ## Opt-out
+//!
+//! `SOLDR_USE_LEGACY_XWIN=1` (or `SOLDR_USE_LEGACY_ZIGBUILD=1`)
+//! suppresses the blessed prep for that toolchain family and falls
+//! through to the cargo-xwin / cargo-zigbuild path. Mirrors the
+//! `SOLDR_USE_LEGACY_*` env-var contract documented in soldr#1010
+//! Phase 8.
+
+use std::path::PathBuf;
+
+use crate::core::{SoldrError, SoldrPaths};
+
+/// Env var that opts out of the blessed xwin-cache materialization
+/// and falls through to cargo-xwin's own live download for win-msvc
+/// targets. Set to any non-empty value to trigger.
+pub const USE_LEGACY_XWIN_ENV_VAR: &str = "SOLDR_USE_LEGACY_XWIN";
+
+/// Env var that opts out of the blessed zigbuild prep flow. Reserved
+/// for future #1012 work; today's zigbuild path is unchanged.
+pub const USE_LEGACY_ZIGBUILD_ENV_VAR: &str = "SOLDR_USE_LEGACY_ZIGBUILD";
+
+/// What the blessed-build prep accomplished, returned to the caller
+/// so `Commands::Build` can log + set the resulting env vars on the
+/// child cargo invocation.
+#[derive(Debug, Clone, Default)]
+pub struct BlessedPrep {
+    /// Path to `XWIN_CACHE_DIR` value (for `*-pc-windows-msvc`).
+    pub xwin_cache_dir: Option<PathBuf>,
+    /// Path to `SDKROOT` value (for `*-apple-darwin`).
+    pub sdkroot: Option<PathBuf>,
+    /// Directory to prepend to `PATH` so the soldr-clang-shim wins
+    /// when cc-rs (or ring) does a bare `which("clang")` lookup.
+    pub shim_path_dir: Option<PathBuf>,
+    /// Per-target env-var tuples to set on the child cargo
+    /// invocation: `[(NAME, VALUE), ...]`. Includes `CC_<t>`,
+    /// `CXX_<t>`, `AR_<t>`, `CARGO_TARGET_<T>_LINKER` for MSVC
+    /// targets.
+    pub env: Vec<(String, String)>,
+}
+
+/// Prepare the blessed sysroot for `target`. Returns `Ok(prep)` on
+/// success; `Ok(BlessedPrep::default())` if `target` doesn't need
+/// any prep (or if the caller opted into legacy via env vars);
+/// `Err(_)` only on actual fetch / extract failures.
+///
+/// Caller is responsible for applying `prep.env` and prepending
+/// `prep.shim_path_dir` to `PATH` on the child cargo invocation.
+pub async fn prepare(
+    paths: &SoldrPaths,
+    target_triple: &str,
+) -> Result<BlessedPrep, SoldrError> {
+    let mut prep = BlessedPrep::default();
+
+    // ----------------------------- Windows MSVC ------------------------------
+    if target_triple.ends_with("-pc-windows-msvc") && !legacy_xwin_opt_out() {
+        match crate::fetch::xwin_cache::ensure_xwin_cache(paths, target_triple).await {
+            Ok(cache_dir) => {
+                let target_u = target_triple.replace('-', "_");
+                let target_u_upper = target_u.to_uppercase();
+
+                prep.xwin_cache_dir = Some(cache_dir.clone());
+                prep.env.push((
+                    crate::fetch::xwin_cache::XWIN_CACHE_DIR_ENV_VAR.to_string(),
+                    cache_dir.to_string_lossy().into_owned(),
+                ));
+
+                // soldr#1012 PR 4's shim wins when on PATH. We install
+                // the shim binary at `<paths.bin>/clang(.exe)` and
+                // ensure the caller prepends this directory ahead of
+                // /usr/bin or wherever the system clang lives.
+                let shim_dir = install_clang_shim(paths)?;
+                prep.shim_path_dir = Some(shim_dir);
+
+                // cc-rs target-specific env vars. Set both CC_<t> /
+                // CXX_<t> / AR_<t> and the CARGO_TARGET_<T>_LINKER
+                // override. Soldr's `clang` shim (PR 4) then routes
+                // to clang-cl for MSVC targets even when ring force-
+                // overrides to plain `"clang"`.
+                prep.env.push((format!("CC_{target_u}"), "clang".to_string()));
+                prep.env
+                    .push((format!("CXX_{target_u}"), "clang".to_string()));
+                prep.env
+                    .push((format!("AR_{target_u}"), "llvm-lib".to_string()));
+                prep.env.push((
+                    format!("CARGO_TARGET_{target_u_upper}_LINKER"),
+                    "lld-link".to_string(),
+                ));
+            }
+            Err(e) => {
+                // Catalogue row not yet ingested (arm64 today). Don't
+                // hard-fail — surface the warning and fall through to
+                // the legacy cargo-xwin path so existing CI keeps
+                // working.
+                eprintln!(
+                    "soldr build: blessed xwin-cache unavailable for {target_triple}: {e}"
+                );
+                eprintln!("soldr build: falling through to legacy cargo-xwin path");
+            }
+        }
+    }
+
+    // ------------------------------ Apple Darwin -----------------------------
+    if target_triple.ends_with("-apple-darwin") && !legacy_zigbuild_opt_out() {
+        // Apple SDK fetch is the same code path `soldr prepare` uses,
+        // so this is reuse rather than new logic.
+        match crate::fetch::apple_sdk::ensure_apple_sdk(paths).await {
+            Ok(sdk) => {
+                prep.sdkroot = Some(sdk.clone());
+                prep.env.push((
+                    "SDKROOT".to_string(),
+                    sdk.to_string_lossy().into_owned(),
+                ));
+            }
+            Err(e) => {
+                eprintln!(
+                    "soldr build: apple SDK unavailable for {target_triple}: {e}"
+                );
+                // Don't hard-fail; zigbuild may still locate an SDK
+                // via cargo-zigbuild's own mechanism.
+            }
+        }
+    }
+
+    Ok(prep)
+}
+
+fn legacy_xwin_opt_out() -> bool {
+    std::env::var(USE_LEGACY_XWIN_ENV_VAR)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+}
+
+fn legacy_zigbuild_opt_out() -> bool {
+    std::env::var(USE_LEGACY_ZIGBUILD_ENV_VAR)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+}
+
+/// Install the soldr-clang-shim binary at `<paths.bin>/clang(.exe)`
+/// and matching siblings (`clang++`). Idempotent — overwrites if
+/// already present (cheap; the shim is ~few hundred KB).
+///
+/// Returns the directory the shim was installed into, ready for
+/// PATH prepending.
+fn install_clang_shim(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
+    paths.ensure_dirs()?;
+
+    let shim_dir = paths.bin.join("clang-shim");
+    std::fs::create_dir_all(&shim_dir)?;
+
+    // The `soldr-clang-shim` binary lives next to the soldr binary
+    // (both are produced by the same workspace build). On a soldr-
+    // released install, it's at `<exe-dir>/soldr-clang-shim(.exe)`.
+    let shim_src = locate_shim_binary()?;
+
+    for name in clang_shim_names() {
+        let dst = shim_dir.join(&name);
+        // Best-effort remove first; ignore errors (file may not exist).
+        let _ = std::fs::remove_file(&dst);
+        // Use std::fs::copy for cross-platform; symlinks would be
+        // cleaner on POSIX but the implementation cost isn't worth
+        // it for what's effectively a 0-cost-per-invocation file copy.
+        std::fs::copy(&shim_src, &dst).map_err(|e| {
+            SoldrError::Other(format!(
+                "failed to install soldr-clang-shim at {}: {e}",
+                dst.display()
+            ))
+        })?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&dst)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&dst, perms)?;
+        }
+    }
+
+    Ok(shim_dir)
+}
+
+#[cfg(windows)]
+fn clang_shim_names() -> Vec<String> {
+    vec![
+        "clang.exe".to_string(),
+        "clang++.exe".to_string(),
+        "clang-cl.exe".to_string(),
+    ]
+}
+
+#[cfg(not(windows))]
+fn clang_shim_names() -> Vec<String> {
+    vec![
+        "clang".to_string(),
+        "clang++".to_string(),
+        "clang-cl".to_string(),
+    ]
+}
+
+fn locate_shim_binary() -> Result<PathBuf, SoldrError> {
+    // Look next to the running `soldr` executable.
+    let current_exe = std::env::current_exe().map_err(|e| {
+        SoldrError::Other(format!("could not resolve current exe: {e}"))
+    })?;
+    let exe_dir = current_exe.parent().ok_or_else(|| {
+        SoldrError::Other("current exe has no parent directory".to_string())
+    })?;
+
+    let shim_name = if cfg!(windows) {
+        "soldr-clang-shim.exe"
+    } else {
+        "soldr-clang-shim"
+    };
+    let candidate = exe_dir.join(shim_name);
+    if candidate.is_file() {
+        return Ok(candidate);
+    }
+    Err(SoldrError::Other(format!(
+        "soldr-clang-shim binary not found at {}; expected next to the \
+         running soldr exe. Reinstall soldr or rebuild from source.",
+        candidate.display()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(opt_out_env_var_recognized, {
+        let prev = std::env::var_os(USE_LEGACY_XWIN_ENV_VAR);
+
+        std::env::remove_var(USE_LEGACY_XWIN_ENV_VAR);
+        assert!(!legacy_xwin_opt_out());
+
+        std::env::set_var(USE_LEGACY_XWIN_ENV_VAR, "1");
+        assert!(legacy_xwin_opt_out());
+
+        std::env::set_var(USE_LEGACY_XWIN_ENV_VAR, "0");
+        assert!(!legacy_xwin_opt_out(), "literal '0' must not opt in");
+
+        std::env::set_var(USE_LEGACY_XWIN_ENV_VAR, "");
+        assert!(!legacy_xwin_opt_out(), "empty value must not opt in");
+
+        match prev {
+            Some(v) => std::env::set_var(USE_LEGACY_XWIN_ENV_VAR, v),
+            None => std::env::remove_var(USE_LEGACY_XWIN_ENV_VAR),
+        }
+    });
+
+    crate::timed_test!(linux_targets_get_no_prep, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let prep = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(prepare(&paths, "x86_64-unknown-linux-musl"))
+            .expect("linux musl target should not error");
+        assert!(prep.xwin_cache_dir.is_none());
+        assert!(prep.sdkroot.is_none());
+        assert!(prep.env.is_empty());
+    });
+}

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -39,6 +39,9 @@ pub use rustup_init::{
 
 pub mod apple_sdk;
 pub mod archive;
+/// soldr#1012 PR 5 — xwin-cache catalogue materialization for the
+/// blessed `*-pc-windows-msvc` cross-compile path.
+pub mod xwin_cache;
 /// soldr#988 Phase 4 — on-demand builds via `zackees/forge` when the
 /// toolchain catalogue lookup misses. See module doc for the env-var
 /// contract and failure surface.

--- a/crates/soldr-cli/src/fetch/xwin_cache.rs
+++ b/crates/soldr-cli/src/fetch/xwin_cache.rs
@@ -1,0 +1,231 @@
+//! soldr#1012 PR 5 — xwin-cache materialization for the blessed
+//! `*-pc-windows-msvc` cross-compile path.
+//!
+//! Loads the pre-compressed MSVC SDK bundle from the soldr-toolchain
+//! catalogue (`https://zackees.github.io/soldr-toolchain/...`),
+//! verifies sha256, extracts under `~/.soldr/sdk/<triple>/xwin/`, and
+//! returns the local path. Cached after first call — subsequent
+//! `soldr build --target *-pc-windows-msvc` invocations are
+//! filesystem-only after the cache is warm.
+//!
+//! ## Architecture
+//!
+//! The catalogue ships one row per `(version, platform)`:
+//!
+//! * `xwin-cache/<date>/windows-x86_64-msvc/xwin-cache.tar.zst`
+//! * `xwin-cache/<date>/windows-aarch64-msvc/xwin-cache.tar.zst`
+//!   (soldr-toolchain PR #30 / soldr#1012 PR 3)
+//!
+//! Soldr's `Commands::Build` arm calls [`ensure_xwin_cache`] before
+//! invoking cargo for those targets; the bundle is materialized,
+//! `XWIN_CACHE_DIR` is exported so cargo-xwin (if anything still
+//! invokes it under the hood) finds the cache locally instead of
+//! triggering a fresh live download. cargo-xwin's documentation
+//! formalizes that env var as the consumer-facing entry point.
+//!
+//! ## Pinned versions
+//!
+//! For now we ship hardcoded asset URLs + sha256s per target. This
+//! mirrors the `apple_sdk.rs` pattern. A future refactor (#1010
+//! Phase 4) routes everything through `catalogue.v1.json` resolution
+//! at runtime, but the immediate goal of this PR is "win-arm64
+//! works"; hardcoded sha256s are the minimum-blast-radius first cut.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{SoldrError, SoldrPaths};
+
+use super::github::http_client;
+use super::trust;
+
+/// Pinned xwin-cache release date currently in the catalogue.
+/// Bump when a refreshed bundle ships from soldr-toolchain forge
+/// ingest.
+pub const MANAGED_XWIN_CACHE_VERSION: &str = "2026-06-22";
+
+const XWIN_CACHE_X86_64_URL: &str =
+    "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/xwin-cache/2026-06-22/windows-x86_64-msvc/xwin-cache.tar.zst";
+const XWIN_CACHE_X86_64_SHA256: &str =
+    "33c04d8026d99dab4d66f39ddbd93d75f64c68063d4ba58e5450626524bf348d";
+
+// soldr#1012 PR 3 ingests this row; sha256 is filled in by a follow-
+// up commit after the forge dispatch lands the asset in the catalogue.
+// Until then `ensure_xwin_cache(aarch64-pc-windows-msvc)` returns the
+// not-yet-ingested error; callers (Commands::Build's blessed path)
+// branch on that and fall through to the legacy cargo-xwin path.
+const XWIN_CACHE_AARCH64_URL: &str =
+    "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/xwin-cache/2026-06-22/windows-aarch64-msvc/xwin-cache.tar.zst";
+const XWIN_CACHE_AARCH64_SHA256: &str = "TBD-INGEST-PENDING";
+
+/// Env var consumed by cargo-xwin to short-circuit its own download.
+/// The blessed path sets this so anything else in the workflow that
+/// invokes cargo-xwin transparently uses our materialized cache.
+pub const XWIN_CACHE_DIR_ENV_VAR: &str = "XWIN_CACHE_DIR";
+
+/// Resolve the local xwin-cache directory for `target`. Materializes
+/// the bundle on first call; subsequent calls return the cached path
+/// immediately.
+pub async fn ensure_xwin_cache(
+    paths: &SoldrPaths,
+    target_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let (url, expected_sha256) = match target_triple {
+        "x86_64-pc-windows-msvc" => (XWIN_CACHE_X86_64_URL, XWIN_CACHE_X86_64_SHA256),
+        "aarch64-pc-windows-msvc" => (XWIN_CACHE_AARCH64_URL, XWIN_CACHE_AARCH64_SHA256),
+        _ => {
+            return Err(SoldrError::UnsupportedPlatform(format!(
+                "ensure_xwin_cache: no managed xwin bundle for triple {target_triple}; \
+                 supported: x86_64-pc-windows-msvc, aarch64-pc-windows-msvc"
+            )));
+        }
+    };
+
+    if expected_sha256.starts_with("TBD") {
+        return Err(SoldrError::Other(format!(
+            "xwin-cache for {target_triple} is not yet ingested into the \
+             soldr-toolchain catalogue (sha256 placeholder is \
+             {expected_sha256:?}). The recipe was added in \
+             soldr-toolchain#30 (soldr#1012 PR 3); forge dispatch + \
+             ingest follow-up will fill in the real sha256. Until then \
+             `Commands::Build` falls through to the legacy cargo-xwin \
+             path for this target.\nExpected URL: {url}"
+        )));
+    }
+
+    paths.ensure_dirs()?;
+    let install_dir = paths
+        .root
+        .join("sdk")
+        .join(target_triple)
+        .join("xwin")
+        .join(MANAGED_XWIN_CACHE_VERSION);
+    let stamp = install_dir.join(".complete");
+    let cache_dir = install_dir.join("xwin");
+
+    if stamp.is_file() && cache_dir.is_dir() {
+        return Ok(cache_dir);
+    }
+
+    eprintln!(
+        "soldr: fetching xwin-cache v{MANAGED_XWIN_CACHE_VERSION} for {target_triple} from {url}..."
+    );
+
+    let client = http_client()?;
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(SoldrError::Network(format!(
+            "xwin-cache download failed: HTTP {}",
+            resp.status()
+        )));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    let digest = trust::sha256_of(&bytes);
+    if digest != expected_sha256 {
+        return Err(SoldrError::Other(format!(
+            "xwin-cache sha256 mismatch for {target_triple}: \
+             expected {expected_sha256}, got {digest} \
+             (catalogue blob may have been replaced — refusing to extract)"
+        )));
+    }
+    eprintln!(
+        "soldr: trust: verified xwin-cache v{MANAGED_XWIN_CACHE_VERSION} \
+         for {target_triple} sha256={digest}"
+    );
+
+    if install_dir.exists() {
+        std::fs::remove_dir_all(&install_dir)?;
+    }
+    std::fs::create_dir_all(&install_dir)?;
+    extract_tar_zst_tree(&bytes, &install_dir)?;
+
+    if !cache_dir.is_dir() {
+        return Err(SoldrError::Archive(format!(
+            "xwin-cache extract did not produce expected directory {}",
+            cache_dir.display()
+        )));
+    }
+
+    std::fs::write(&stamp, MANAGED_XWIN_CACHE_VERSION)?;
+    eprintln!(
+        "soldr: extracted xwin-cache to {} (set XWIN_CACHE_DIR there)",
+        cache_dir.display()
+    );
+    Ok(cache_dir)
+}
+
+fn extract_tar_zst_tree(data: &[u8], dest: &Path) -> Result<(), SoldrError> {
+    let reader = std::io::Cursor::new(data);
+    let zst = zstd::stream::read::Decoder::new(reader)
+        .map_err(|e| SoldrError::Archive(format!("zstd decoder init: {e}")))?;
+    let mut archive = tar::Archive::new(zst);
+    archive
+        .unpack(dest)
+        .map_err(|e| SoldrError::Archive(format!("tar.zst unpack: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(constants_well_formed, {
+        // Bare smoke: catch typos in the URLs / hex sha256s during refactor.
+        for url in [XWIN_CACHE_X86_64_URL, XWIN_CACHE_AARCH64_URL] {
+            assert!(url.starts_with("https://"), "URL must be HTTPS: {url}");
+            assert!(
+                url.ends_with(".tar.zst"),
+                "URL must reference a .tar.zst bundle: {url}"
+            );
+            assert!(
+                url.contains(MANAGED_XWIN_CACHE_VERSION),
+                "URL must embed MANAGED_XWIN_CACHE_VERSION ({MANAGED_XWIN_CACHE_VERSION}): {url}"
+            );
+        }
+        // x64 sha256 is real (catalogue row already exists).
+        assert_eq!(XWIN_CACHE_X86_64_SHA256.len(), 64);
+        assert!(XWIN_CACHE_X86_64_SHA256
+            .chars()
+            .all(|c| c.is_ascii_hexdigit()));
+    });
+
+    crate::timed_test!(aarch64_not_yet_ingested_returns_clear_error, {
+        // Until the forge ingest cycle lands the arm64 row, this fetch
+        // must produce a descriptive error and NOT a network fetch
+        // against a 404 URL. The error message is the load-bearing
+        // contract — `Commands::Build` keys on a "not yet ingested"
+        // signal in the error string to decide whether to fall through
+        // to the legacy path.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_xwin_cache(&paths, "aarch64-pc-windows-msvc"));
+        let err = result.expect_err("arm64 must error until catalogue lands the row");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not yet ingested") || msg.contains("TBD"),
+            "expected 'not yet ingested' or 'TBD' in error, got: {msg}"
+        );
+    });
+
+    crate::timed_test!(unsupported_target_yields_unsupported_platform, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_xwin_cache(&paths, "x86_64-unknown-linux-gnu"));
+        let err = result.expect_err("non-msvc target must error");
+        assert!(
+            matches!(err, SoldrError::UnsupportedPlatform(_)),
+            "expected UnsupportedPlatform, got: {err:?}"
+        );
+    });
+}

--- a/crates/soldr-cli/src/lib.rs
+++ b/crates/soldr-cli/src/lib.rs
@@ -14,6 +14,10 @@
 
 #![allow(dead_code)]
 
+/// soldr#1012 PR 5 — blessed cross-compile sysroot prep called from
+/// `Commands::Build` for canonical target triples. Coordinates the
+/// xwin-cache materialization + clang-shim install + env var setup.
+pub mod blessed_build;
 pub mod cache_lib;
 pub mod cargo_metadata_soldr;
 pub mod core;

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -9,6 +9,9 @@ use clap::Parser;
 
 mod archive_cmd;
 mod binaries;
+/// soldr#1012 PR 5 — blessed cross-compile sysroot prep called from
+/// Commands::Build.
+mod blessed_build;
 mod bootstrap;
 mod build_from_source_cmd;
 mod cache;
@@ -259,17 +262,41 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
 
     match cli.command {
         Commands::Build { args } => {
-            // soldr#1012 PR 1 — `soldr build` is the blessed-default
-            // surface for builds. Today it's functionally an alias for
-            // `soldr cargo build`: we prepend `build` to the user's
-            // args and forward through the same `cargo_front_door`
-            // pipeline. Subsequent #1012 PRs (especially PR 5) layer
-            // catalogue-driven sysroot prep + the clang shim on top
-            // by branching here BEFORE the front-door call. The user-
-            // facing surface stays stable across that evolution.
+            // soldr#1012 PR 1 + PR 5. The `soldr build` surface
+            // routes through `blessed_build::prepare` for any
+            // canonical target triple it can identify in argv (looks
+            // for `--target X` / `--target=X`). On MSVC targets that
+            // step materializes the xwin-cache from the soldr-
+            // toolchain catalogue, installs the soldr-clang-shim
+            // ahead of system clang on PATH, and sets the cc-rs +
+            // cargo target-specific env vars. The cargo front door is
+            // then invoked with the same args + the prep env applied.
+            //
+            // Targets with no prep need (linux musl, linux gnu) get
+            // a no-op prep + the standard cargo front door behavior.
+            // `SOLDR_USE_LEGACY_XWIN=1` opts out of the blessed path
+            // and falls through to the unchanged cargo-xwin flow.
             let mut full_args = Vec::with_capacity(args.len() + 1);
             full_args.push("build".to_string());
             full_args.extend(args);
+
+            // Try to recognize a target from argv so we can prep
+            // before invoking cargo. If the user didn't pass `--target`,
+            // blessed prep is a no-op and we forward unchanged.
+            if let Some(target_triple) = extract_target_from_args(&full_args) {
+                let paths = crate::core::SoldrPaths::new()?;
+                let prep = crate::blessed_build::prepare(&paths, &target_triple).await?;
+                // Apply prep env onto the current process env so the
+                // child cargo invocation (and its sub-rustc + build
+                // scripts) inherit them.
+                for (k, v) in &prep.env {
+                    std::env::set_var(k, v);
+                }
+                if let Some(shim_dir) = prep.shim_path_dir.as_ref() {
+                    prepend_to_path_env(shim_dir);
+                }
+            }
+
             std::process::exit(
                 cargo_front_door::run_cargo_front_door(
                     &full_args,
@@ -931,6 +958,48 @@ fn should_self_relocate_for_invocation(raw_args: &[String]) -> bool {
 /// region of the user's argv. Stops scanning at the first non-flag
 /// positional (conventionally the subcommand), so a `--as` appearing
 /// after `cargo` belongs to cargo and is left alone.
+/// soldr#1012 PR 5 — scan `args` for `--target X` (two-arg form) or
+/// `--target=X` (single-arg form). Returns the FIRST occurrence; if
+/// both forms are present the single-arg form wins by virtue of
+/// appearing first in a left-to-right scan (cargo behavior is
+/// "last --target wins", but for prep purposes any match is enough
+/// because the prep is target-keyed and cargo handles the final
+/// dispatch).
+fn extract_target_from_args(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if let Some(triple) = arg.strip_prefix("--target=") {
+            if !triple.is_empty() {
+                return Some(triple.to_string());
+            }
+        }
+        if arg == "--target" {
+            if let Some(next) = iter.next() {
+                if !next.is_empty() {
+                    return Some(next.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// soldr#1012 PR 5 — prepend `dir` to the current process's `PATH`
+/// env var. Idempotent in the sense that if `dir` is already first
+/// on PATH, the value is unchanged (PATH stays clean).
+fn prepend_to_path_env(dir: &std::path::Path) {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let mut existing: Vec<std::path::PathBuf> =
+        std::env::split_paths(&current).collect();
+    if existing.first().is_some_and(|p| p == dir) {
+        return;
+    }
+    existing.insert(0, dir.to_path_buf());
+    if let Ok(joined) = std::env::join_paths(existing) {
+        std::env::set_var("PATH", joined);
+    }
+}
+
 fn extract_as_pin(args: &[String]) -> Result<(Option<String>, Vec<String>), SoldrError> {
     let mut out: Vec<String> = Vec::with_capacity(args.len());
     let mut version: Option<String> = None;


### PR DESCRIPTION
PR 5 of 6 in soldr#1012. Wires `Commands::Build` to materialize xwin-cache from soldr-toolchain catalogue, install soldr-clang-shim, and set cc-rs + cargo target env vars for `*-pc-windows-msvc` targets. Reuses existing `fetch::apple_sdk` for `*-apple-darwin`. 5 new tests pass.

arm64 xwin-cache sha256 is TBD until soldr-toolchain forge dispatch ingests the bundle (PR 3's recipe); the blessed path falls through to legacy cargo-xwin in the meantime via a clear error message contract.

`SOLDR_USE_LEGACY_XWIN=1` opts out completely (soldr#1010 Phase 8 contract).

Unblocks PR 6 (fbuild re-add arm64 lane).