### PR TITLE
fix(release): add cmake + perl to musl install; ship docker validator (#1022)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -245,16 +245,23 @@ jobs:
             fi
             sleep $((attempts * 3))
           done
+          # cmake + perl added soldr#1022: zstd-sys (cmake) and
+          # openssl-sys (perl) transitively-depended build scripts
+          # need them. ubuntu-latest ships both, so this was implicit;
+          # locally-validated in `ci/docker-aarch64-musl-cross/` via a
+          # vanilla ubuntu:24.04 container to surface the dependency.
           attempts=0
-          until sudo apt-get install -y --no-install-recommends musl-tools; do
+          until sudo apt-get install -y --no-install-recommends musl-tools cmake perl; do
             attempts=$((attempts + 1))
             if [ "$attempts" -ge "$max_attempts" ]; then
-              echo "apt-get install musl-tools failed after $max_attempts attempts" >&2
+              echo "apt-get install musl-tools+cmake+perl failed after $max_attempts attempts" >&2
               exit 1
             fi
             sleep $((attempts * 3))
           done
           dpkg-query -W -f='musl-tools installed version: ${Version}\n' musl-tools
+          dpkg-query -W -f='cmake installed version: ${Version}\n' cmake
+          dpkg-query -W -f='perl installed version: ${Version}\n' perl
 
       # soldr#1012 release-pipeline followup: tikv-jemalloc-sys (via
       # vendored zccache's `cfg(unix)` allocator dep) needs a proper

--- a/ci/docker-aarch64-musl-cross/Dockerfile
+++ b/ci/docker-aarch64-musl-cross/Dockerfile
@@ -1,0 +1,75 @@
+# Simulate soldr's release-auto.yml Linux ARM64 (musl) build lane in a
+# vanilla Ubuntu 24.04 container. Cross-compiles soldr to
+# `aarch64-unknown-linux-musl` from x86_64 host using musl.cc's
+# prebuilt aarch64-linux-musl-cross + a stock rustup toolchain.
+#
+# Purpose (per user directive 2026-06-28): all soldr cross-compile
+# changes that touch the release pipeline MUST be validated locally
+# in this docker before being pushed to GitHub. The container needs
+# to match what GHA's `ubuntu-latest` provides so a green run here
+# means a green run there.
+#
+# Build:
+#   docker build -f ci/docker-aarch64-musl-cross/Dockerfile \
+#       -t soldr-aarch64-musl-cross .
+#
+# Run (from repo root):
+#   docker run --rm -v "$PWD:/src" -w /src soldr-aarch64-musl-cross \
+#       bash ci/docker-aarch64-musl-cross/build.sh
+#
+# `build.sh` produces the soldr binary at
+# `target/aarch64-unknown-linux-musl/release/soldr` and asserts via
+# `file(1)` that it's a `ELF 64-bit LSB ... aarch64` executable.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Minimum apt set — mirrors what release-auto.yml's Linux ARM64 (musl)
+# lane has access to today, plus the new aarch64-linux-musl-cross
+# install that lives one step before the rustup toolchain setup.
+#   curl + ca-certificates  → toolchain + rustup downloads
+#   git                     → cargo fetch from git deps
+#   xz-utils + bzip2        → tar extraction for various release archives
+#   build-essential         → host cc/ld for build scripts
+#   pkg-config              → many *-sys crates poke pkg-config at build time
+#   file                    → final verification of the cross-compile output
+#   musl-tools              → musl-gcc for the HOST arch (x86_64-musl native)
+#   cmake + perl            → a transitive *-sys crate in soldr's tree calls
+#                            cmake (likely zstd-sys or similar); perl is
+#                            needed by openssl-sys when it's pulled. These
+#                            are pre-installed on GHA's ubuntu-latest image
+#                            but not in a vanilla ubuntu:24.04 base.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates curl git xz-utils bzip2 \
+        build-essential pkg-config file musl-tools \
+        cmake perl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Download the aarch64-linux-musl-cross toolchain from musl.cc. This
+# is the load-bearing piece that makes jemalloc-sys's build script
+# succeed for the aarch64-unknown-linux-musl target — without it
+# jemalloc's configure script fails atomics detection.
+RUN curl -fsSL --retry 5 \
+        https://musl.cc/aarch64-linux-musl-cross.tgz \
+        -o /tmp/cross.tgz \
+ && mkdir -p /opt \
+ && tar -xzf /tmp/cross.tgz -C /opt \
+ && rm /tmp/cross.tgz
+
+ENV PATH=/opt/aarch64-linux-musl-cross/bin:$PATH \
+    CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
+    CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++ \
+    AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+
+# Stock rustup — installs the pinned toolchain from rust-toolchain.toml
+# automatically when cargo first runs in /src.
+RUN curl -fsSL https://sh.rustup.rs | sh -s -- \
+        --default-toolchain none -y \
+ && /root/.cargo/bin/rustup --version
+
+ENV PATH=/root/.cargo/bin:$PATH \
+    RUSTUP_HOME=/root/.rustup \
+    CARGO_HOME=/root/.cargo

--- a/ci/docker-aarch64-musl-cross/README.md
+++ b/ci/docker-aarch64-musl-cross/README.md
@@ -1,0 +1,47 @@
+# `ci/docker-aarch64-musl-cross/`
+
+Local validation harness for soldr's `aarch64-unknown-linux-musl`
+cross-compile lane. Mirrors what `release-auto.yml`'s Linux ARM64
+(musl) job runs on `ubuntu-latest`.
+
+**Per the 2026-06-28 user directive**: every soldr cross-compile
+change that touches the release pipeline MUST be validated locally
+in this docker before being pushed to GitHub. Catches issues like
+the jemalloc atomics-detection failure that previously blocked
+v0.7.60+ from shipping.
+
+## Build + run
+
+```bash
+# Build the image (once)
+docker build -f ci/docker-aarch64-musl-cross/Dockerfile \
+    -t soldr-aarch64-musl-cross .
+
+# Cross-compile soldr
+docker run --rm -v "$PWD:/src" -w /src soldr-aarch64-musl-cross \
+    bash ci/docker-aarch64-musl-cross/build.sh
+```
+
+`build.sh` produces `staging/soldr` and asserts via `file(1)` that
+it's a valid `ELF 64-bit LSB ... aarch64` executable. The NO CHEATING
+gate that proves the cross-compile actually worked.
+
+## What this validates
+
+* `aarch64-linux-musl-cross` from musl.cc is installed correctly
+* `CC_aarch64_unknown_linux_musl` env var is honored by cc-rs
+* `tikv-jemalloc-sys`'s build script can compile its bundled C source
+  for the musl target (the v0.7.60+ release blocker)
+* The pinned rustup toolchain (1.94.1) builds the soldr binary clean
+* The output is a real arm64 ELF, not silently a host-arch binary
+
+## When to invoke this
+
+Before pushing ANY change to:
+
+* `.github/workflows/release-auto.yml`'s Linux ARM64 (musl) lane
+* `.github/workflows/_bootstrap-e2e.yml` musl env vars
+* Crates dependencies that pull `tikv-jemalloc-sys` (`_vender/zccache`)
+* `Cargo.toml` workspace lints / profile settings
+
+A green run here means the GHA equivalent should also pass.

--- a/ci/docker-aarch64-musl-cross/build.sh
+++ b/ci/docker-aarch64-musl-cross/build.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run inside the soldr-aarch64-musl-cross docker image.
+# Cross-compiles the soldr binary to aarch64-unknown-linux-musl using
+# the aarch64-linux-musl-cross toolchain pre-installed in the image.
+#
+# Output verification: asserts the produced binary is a valid
+# ELF 64-bit LSB aarch64 executable. The NO CHEATING gate that
+# proves the cross-compile actually worked.
+
+set -euo pipefail
+
+TARGET="${1:-aarch64-unknown-linux-musl}"
+STAGING="${STAGING:-$PWD/staging}"
+mkdir -p "$STAGING"
+
+echo "::group::rustup + target install"
+rustup toolchain install 1.94.1 --profile minimal --no-self-update
+rustup default 1.94.1
+rustup target add "$TARGET"
+echo "::endgroup::"
+
+echo "::group::env probe"
+echo "PATH=$PATH"
+echo "CC_aarch64_unknown_linux_musl=${CC_aarch64_unknown_linux_musl:-<unset>}"
+echo "which aarch64-linux-musl-gcc: $(which aarch64-linux-musl-gcc || echo NOT-FOUND)"
+echo "aarch64-linux-musl-gcc --version:"
+aarch64-linux-musl-gcc --version | head -1
+echo "::endgroup::"
+
+echo "::group::Build soldr-cli for $TARGET"
+# Skip the soldr wrapper — this is a fresh container without soldr
+# bootstrapped — call cargo directly through rustup.
+cargo build --release \
+    --target "$TARGET" \
+    -p soldr-cli \
+    --bin soldr
+echo "::endgroup::"
+
+echo "::group::Stage + verify"
+BIN="target/$TARGET/release/soldr"
+if [ ! -f "$BIN" ]; then
+    echo "ERROR: $BIN missing after build" >&2
+    exit 1
+fi
+cp "$BIN" "$STAGING/soldr"
+desc="$(file "$STAGING/soldr")"
+echo "  $desc"
+if ! echo "$desc" | grep -qE "ELF 64-bit LSB.*aarch64"; then
+    echo "ERROR: expected ELF 64-bit aarch64 binary; got: $desc" >&2
+    exit 1
+fi
+size=$(stat -c%s "$STAGING/soldr")
+echo "  size: $size bytes ($((size / 1024 / 1024)) MiB)"
+echo "::endgroup::"
+
+echo
+echo "OK: soldr cross-compiled to $TARGET successfully."
+echo "Output: $STAGING/soldr"


### PR DESCRIPTION
Closes soldr#1022. Two pieces:

1. `release-auto.yml`: explicit `cmake` + `perl` in the apt install. zstd-sys (cmake) and openssl-sys (perl) need them; ubuntu-latest ships both implicitly — vanilla ubuntu:24.04 doesn't.
2. `ci/docker-aarch64-musl-cross/`: new local validator per the 'test in docker before pushing' directive. Validated 2026-06-28: produces valid `ELF 64-bit LSB ... ARM aarch64 ... statically linked` binary (12.6 MB) from vanilla ubuntu:24.04.