### PR TITLE
chore(release): bump to v0.7.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.64"
+version = "0.7.65"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.64",
+  "version": "0.7.65",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Picks up two release-pipeline fixes:

* #1020 — aarch64-linux-musl cross-toolchain (musl.cc) + macOS `gtimeout` fallback
* #1023 — explicit `cmake` + `perl` in apt install + local docker validator at `ci/docker-aarch64-musl-cross/`

Validated 2026-06-28 locally: produces `ELF 64-bit LSB ... ARM aarch64 ... statically linked` (12.6 MB) from vanilla ubuntu:24.04 container.

Closes the soldr#1012 followup work.