### PR TITLE
fix(release): refresh Cargo.lock for v0.7.65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.64"
+version = "0.7.65"
 dependencies = [
  "blake3",
  "clap",


### PR DESCRIPTION
Run 28338586417 failed every matrix lane with `cannot update the lock file because --locked was passed`. PR #1024 bumped `Cargo.toml` 0.7.64→0.7.65 but did not refresh `Cargo.lock`.

This is a recurring trap — the version bump must touch THREE files in lockstep (Cargo.toml, package.json, Cargo.lock). Will file a release-prep checklist follow-up.