### PR TITLE
fix(release): aarch64-musl lane → cargo-zigbuild (#1029)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -263,64 +263,33 @@ jobs:
           dpkg-query -W -f='cmake installed version: ${Version}\n' cmake
           dpkg-query -W -f='perl installed version: ${Version}\n' perl
 
-      # soldr#1012 release-pipeline followup: tikv-jemalloc-sys (via
-      # vendored zccache's `cfg(unix)` allocator dep) needs a proper
-      # aarch64-linux-musl cross-toolchain to compile its bundled C
-      # source. `musl-tools` only ships musl-gcc for the host arch;
-      # aarch64-musl cross needs aarch64-linux-musl-gcc + matching
-      # binutils. Without it jemalloc's configure script falls through
-      # to `Don't have atomics implemented on this platform.`
+      # soldr#1029: aarch64-unknown-linux-musl uses cargo-zigbuild instead
+      # of the legacy musl.cc cross-toolchain. Background: musl.cc ships
+      # statically-linked 32-bit i386 host binaries; GHA ubuntu-24.04's
+      # `linux-azure` kernel has CONFIG_IA32_EMULATION_DEFAULT_DISABLED=y
+      # since Linux 6.7, so any attempt to exec those binaries ENOEXECs
+      # with `os error 8`. cargo-zigbuild bundles a hermetic x86_64-native
+      # musl toolchain via zig — no kernel exec-format dependency, no
+      # third-party CDN beyond ziglang.org. Same pattern as
+      # rust-cross/cargo-zigbuild's own CI, maturin, and fbuild's
+      # template_native_build.yml.
       #
-      # Mirror-first strategy (soldr#1027): musl.cc has been a single-
-      # point-of-failure for this lane twice (2026-06-28 — runs
-      # #28338586417 and #28339126319 both lost ~14 min each to musl.cc
-      # connectivity timeouts). Try the github.com mirror under
-      # zackees/soldr-toolchain FIRST; fall back to musl.cc upstream
-      # only if the mirror is unreachable.
-      #
-      # SHA256 pin (mirror only): the mirror tarball is provenance-
-      # captured from a successful musl.cc pull 2026-06-28; same
-      # binaries as upstream, different tar metadata. Falling back to
-      # musl.cc accepts upstream-as-authoritative without re-verifying
-      # since musl.cc's repacked SHA may differ.
-      #
-      # Validated locally 2026-06-28 in `ci/docker-aarch64-musl-cross/`
-      # with `docker build --add-host musl.cc:127.0.0.1` simulating the
-      # outage: mirror path produces a binary identical to the upstream
-      # path (`ELF 64-bit LSB ... ARM aarch64 ... statically linked`,
-      # 12.6 MB).
-      - name: Install aarch64-linux-musl cross-toolchain
+      # Validated 2026-06-29 in `ci/docker-aarch64-musl-cross/` against
+      # a vanilla ubuntu:24.04 container with `docker build
+      # --add-host musl.cc:127.0.0.1` (musl.cc blackholed): produced
+      # a valid `ELF 64-bit LSB executable, ARM aarch64, version 1
+      # (SYSV), statically linked, stripped` binary.
+      - name: Setup zig (aarch64-musl lane)
         if: matrix.target == 'aarch64-unknown-linux-musl'
-        shell: bash
-        env:
-          MUSL_CROSS_MIRROR_URL: https://github.com/zackees/soldr-toolchain/releases/download/musl-cross-v1/aarch64-linux-musl-cross.tgz
-          MUSL_CROSS_UPSTREAM_URL: https://musl.cc/aarch64-linux-musl-cross.tgz
-          MUSL_CROSS_MIRROR_SHA256: 67f54eb62ee912477a530e70567f82f5c8fb58ce458faafd76a23fbb08a38287
-        run: |
-          set -euo pipefail
-          echo "fetching aarch64-linux-musl cross from mirror: $MUSL_CROSS_MIRROR_URL"
-          if curl -fsSL --connect-timeout 30 --max-time 600 --retry 3 \
-                  "$MUSL_CROSS_MIRROR_URL" -o /tmp/cross.tgz; then
-            echo "mirror download OK; verifying sha256..."
-            echo "$MUSL_CROSS_MIRROR_SHA256  /tmp/cross.tgz" | sha256sum -c -
-          else
-            echo "mirror unreachable; falling back to upstream: $MUSL_CROSS_UPSTREAM_URL" >&2
-            curl -fsSL --connect-timeout 30 --max-time 600 --retry 5 \
-                "$MUSL_CROSS_UPSTREAM_URL" -o /tmp/cross.tgz
-            echo "upstream download OK (sha not verified — upstream-as-authoritative fallback)"
-          fi
-          sudo mkdir -p /opt
-          sudo tar -xzf /tmp/cross.tgz -C /opt
-          echo "/opt/aarch64-linux-musl-cross/bin" >> "$GITHUB_PATH"
-          # Tell cc-rs (used by tikv-jemalloc-sys's build script) which
-          # compiler + archiver to invoke. The underscore form matches
-          # cc-rs's env-var convention for target overrides.
-          echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc" >> "$GITHUB_ENV"
-          echo "CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++" >> "$GITHUB_ENV"
-          echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar" >> "$GITHUB_ENV"
-          # Linker for rustc / cargo: pass through musl-gcc as the
-          # linker driver so rustc invokes the right downstream.
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc" >> "$GITHUB_ENV"
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install cargo-zigbuild (aarch64-musl lane)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-zigbuild@0.23.0
 
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -328,9 +297,19 @@ jobs:
           shared-key: release-${{ matrix.target }}
 
       - name: Build release binary
+        shell: bash
         env:
           CARGO_PROFILE_RELEASE_DEBUG: ${{ contains(matrix.target, 'pc-windows-msvc') && 'line-tables-only' || '0' }}
-        run: cargo build --package soldr-cli --release --locked --target ${{ matrix.target }}
+        run: |
+          # soldr#1029: aarch64-unknown-linux-musl routes through
+          # cargo-zigbuild for a hermetic cross-compile (see the Setup
+          # zig / Install cargo-zigbuild steps above). All other lanes
+          # use plain `cargo build`.
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
+            cargo zigbuild --package soldr-cli --release --locked --target ${{ matrix.target }}
+          else
+            cargo build --package soldr-cli --release --locked --target ${{ matrix.target }}
+          fi
 
       - name: Install zstd
         shell: bash

--- a/ci/docker-aarch64-musl-cross/Dockerfile
+++ b/ci/docker-aarch64-musl-cross/Dockerfile
@@ -1,17 +1,45 @@
 # Simulate soldr's release-auto.yml Linux ARM64 (musl) build lane in a
 # vanilla Ubuntu 24.04 container. Cross-compiles soldr to
-# `aarch64-unknown-linux-musl` from x86_64 host using musl.cc's
-# prebuilt aarch64-linux-musl-cross + a stock rustup toolchain.
+# `aarch64-unknown-linux-musl` from an x86_64 host using
+# `cargo zigbuild` (zig 0.13.0 bundles a hermetic musl toolchain — no
+# musl.cc or other third-party CDN dependency at build time).
+#
+# Why zigbuild and not musl.cc's aarch64-linux-musl-cross?
+#   - musl.cc has been a single-point-of-failure twice on 2026-06-28
+#     (release-pipeline runs lost ~14 min each to outages).
+#   - musl.cc's `aarch64-linux-musl-cross.tgz` ships 32-bit i386 host
+#     binaries. GHA's ubuntu-24.04 evidently cannot exec them (release
+#     run #28340749999 — ring's build.rs hit ENOEXEC `os error 8` when
+#     cc-rs tried to invoke `aarch64-linux-musl-gcc -E`). Local Docker
+#     Desktop / WSL2 kernels happen to support IA32, masking the issue.
+#   - cargo-zigbuild is hermetic: zig brings its own x86_64-native musl
+#     toolchain that does not depend on host kernel features.
+#
+# Catalogue-first / upstream-fallback (soldr#1029):
+#   - zig: fetched via soldr-toolchain catalogue
+#     (raw.githubusercontent.com/zackees/soldr-toolchain/assets/zig/manifest.json)
+#     with ziglang.org as fallback. The catalogue is the source of truth
+#     for URL + SHA256; falling back to the hardcoded ziglang.org URL
+#     keeps the harness functional if soldr-toolchain CDN is briefly
+#     unreachable, but the verified-SHA path runs through the catalogue.
+#   - cargo-zigbuild: installed via `cargo install` for now. A future
+#     pass will route this through the soldr-toolchain catalogue too
+#     (cargo-zigbuild's entry already exists at
+#     soldr-toolchain/assets/cargo-zigbuild/manifest.json).
 #
 # Purpose (per user directive 2026-06-28): all soldr cross-compile
 # changes that touch the release pipeline MUST be validated locally
-# in this docker before being pushed to GitHub. The container needs
-# to match what GHA's `ubuntu-latest` provides so a green run here
-# means a green run there.
+# in this docker before being pushed to GitHub.
 #
 # Build:
 #   docker build -f ci/docker-aarch64-musl-cross/Dockerfile \
 #       -t soldr-aarch64-musl-cross .
+#
+# Build with simulated musl.cc + soldr-toolchain catalogue outage:
+#   docker build --add-host musl.cc:127.0.0.1 \
+#       --add-host raw.githubusercontent.com:127.0.0.1 \
+#       -f ci/docker-aarch64-musl-cross/Dockerfile \
+#       -t soldr-aarch64-musl-cross:fallback-test .
 #
 # Run (from repo root):
 #   docker run --rm -v "$PWD:/src" -w /src soldr-aarch64-musl-cross \
@@ -26,68 +54,67 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Minimum apt set — mirrors what release-auto.yml's Linux ARM64 (musl)
-# lane has access to today, plus the new aarch64-linux-musl-cross
-# install that lives one step before the rustup toolchain setup.
+# lane has access to today.
 #   curl + ca-certificates  → toolchain + rustup downloads
 #   git                     → cargo fetch from git deps
-#   xz-utils + bzip2        → tar extraction for various release archives
+#   xz-utils + bzip2        → tar extraction for zig + release archives
 #   build-essential         → host cc/ld for build scripts
 #   pkg-config              → many *-sys crates poke pkg-config at build time
 #   file                    → final verification of the cross-compile output
+#   jq                      → JSON parsing for catalogue-first toolchain fetch
 #   musl-tools              → musl-gcc for the HOST arch (x86_64-musl native)
-#   cmake + perl            → a transitive *-sys crate in soldr's tree calls
-#                            cmake (likely zstd-sys or similar); perl is
-#                            needed by openssl-sys when it's pulled. These
-#                            are pre-installed on GHA's ubuntu-latest image
-#                            but not in a vanilla ubuntu:24.04 base.
+#   cmake + perl            → zstd-sys (cmake) and openssl-sys (perl) build
+#                             scripts. Pre-installed on GHA's ubuntu-latest
+#                             but not in a vanilla ubuntu:24.04 base.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates curl git xz-utils bzip2 \
-        build-essential pkg-config file musl-tools \
+        build-essential pkg-config file jq musl-tools \
         cmake perl \
  && rm -rf /var/lib/apt/lists/*
 
-# Download the aarch64-linux-musl-cross toolchain. This is the load-
-# bearing piece that makes jemalloc-sys's build script succeed for
-# the aarch64-unknown-linux-musl target — without it jemalloc's
-# configure script fails atomics detection.
+# Install zig via the soldr-toolchain catalogue (with ziglang.org
+# fallback). Provides the hermetic x86_64-host musl toolchain that
+# cargo-zigbuild orchestrates for the aarch64-unknown-linux-musl target.
 #
-# Mirror-first strategy (soldr#1027): musl.cc has been a single-point-
-# of-failure twice (2026-06-28 — both release runs that day lost ~14
-# min each to musl.cc connectivity timeouts). Try the github.com
-# mirror under zackees/soldr-toolchain FIRST; fall back to musl.cc
-# upstream only if the mirror is unreachable.
-#
-# SHA256 pin is for the mirror tarball (provenance: repacked from a
-# successful musl.cc pull 2026-06-28). When falling back to musl.cc,
-# we accept upstream-as-authoritative without re-verifying since
-# musl.cc's own SHA may differ from the mirror's repack — same
-# binaries, different tar metadata.
-ENV MUSL_CROSS_MIRROR_URL=https://github.com/zackees/soldr-toolchain/releases/download/musl-cross-v1/aarch64-linux-musl-cross.tgz \
-    MUSL_CROSS_UPSTREAM_URL=https://musl.cc/aarch64-linux-musl-cross.tgz \
-    MUSL_CROSS_MIRROR_SHA256=67f54eb62ee912477a530e70567f82f5c8fb58ce458faafd76a23fbb08a38287
+# Pinned at zig 0.13.0 for now (the known-good version validated by
+# soldr#1029's initial pivot). Bumping to 0.15.2 is a follow-up after
+# the lane is stable.
+ENV ZIG_VERSION=0.13.0 \
+    ZIG_CATALOGUE_URL=https://raw.githubusercontent.com/zackees/soldr-toolchain/assets/zig/manifest.json \
+    ZIG_FALLBACK_URL=https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz \
+    ZIG_FALLBACK_SHA256=d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea
 
 RUN set -eu; \
-    echo "fetching aarch64-linux-musl cross from mirror: $MUSL_CROSS_MIRROR_URL"; \
-    if curl -fsSL --connect-timeout 30 --max-time 600 --retry 3 \
-            "$MUSL_CROSS_MIRROR_URL" -o /tmp/cross.tgz; then \
-        echo "mirror download OK; verifying sha256..."; \
-        echo "$MUSL_CROSS_MIRROR_SHA256  /tmp/cross.tgz" | sha256sum -c -; \
+    echo "resolving zig ${ZIG_VERSION} via soldr-toolchain catalogue: ${ZIG_CATALOGUE_URL}"; \
+    zig_url=""; \
+    zig_sha=""; \
+    if curl -fsSL --connect-timeout 15 --max-time 30 \
+            "$ZIG_CATALOGUE_URL" -o /tmp/zig-manifest.json; then \
+        zig_url=$(jq -r --arg v "$ZIG_VERSION" '.releases[] | select(.version==$v) | .platforms[] | select(.platform.os=="linux" and .platform.arch=="x86_64") | .asset.urls[0]' /tmp/zig-manifest.json); \
+        zig_sha=$(jq -r --arg v "$ZIG_VERSION" '.releases[] | select(.version==$v) | .platforms[] | select(.platform.os=="linux" and .platform.arch=="x86_64") | .asset.sha256' /tmp/zig-manifest.json); \
+        if [ -z "$zig_url" ] || [ "$zig_url" = "null" ]; then \
+            echo "catalogue resolved but ${ZIG_VERSION} not in manifest; falling back" >&2; \
+            zig_url=""; \
+        fi; \
+        rm -f /tmp/zig-manifest.json; \
     else \
-        echo "mirror unreachable; falling back to upstream: $MUSL_CROSS_UPSTREAM_URL" >&2; \
-        curl -fsSL --connect-timeout 30 --max-time 600 --retry 5 \
-            "$MUSL_CROSS_UPSTREAM_URL" -o /tmp/cross.tgz; \
-        echo "upstream download OK (sha not verified — upstream-as-authoritative fallback)"; \
+        echo "catalogue unreachable; falling back to hardcoded ziglang.org URL" >&2; \
     fi; \
+    if [ -z "$zig_url" ]; then \
+        zig_url="$ZIG_FALLBACK_URL"; \
+        zig_sha="$ZIG_FALLBACK_SHA256"; \
+    fi; \
+    echo "fetching zig from: $zig_url"; \
+    curl -fsSL --connect-timeout 30 --max-time 600 --retry 5 \
+        "$zig_url" -o /tmp/zig.tar.xz; \
+    echo "${zig_sha}  /tmp/zig.tar.xz" | sha256sum -c -; \
     mkdir -p /opt; \
-    tar -xzf /tmp/cross.tgz -C /opt; \
-    rm /tmp/cross.tgz
-
-ENV PATH=/opt/aarch64-linux-musl-cross/bin:$PATH \
-    CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
-    CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++ \
-    AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar \
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+    tar -xJf /tmp/zig.tar.xz -C /opt; \
+    rm /tmp/zig.tar.xz; \
+    zig_dir=$(ls -d /opt/zig-* | head -1); \
+    ln -s "${zig_dir}/zig" /usr/local/bin/zig; \
+    zig version
 
 # Stock rustup — installs the pinned toolchain from rust-toolchain.toml
 # automatically when cargo first runs in /src.
@@ -98,3 +125,25 @@ RUN curl -fsSL https://sh.rustup.rs | sh -s -- \
 ENV PATH=/root/.cargo/bin:$PATH \
     RUSTUP_HOME=/root/.rustup \
     CARGO_HOME=/root/.cargo
+
+# Pre-install cargo-zigbuild so the per-build step doesn't need to
+# fetch from crates.io. Pinned to a known-working version.
+RUN /root/.cargo/bin/rustup toolchain install stable --profile minimal --no-self-update \
+ && /root/.cargo/bin/cargo +stable install cargo-zigbuild --version 0.19.7 --locked \
+ && cargo-zigbuild --version
+
+# Kernel-independent 32-bit ELF guard (soldr#1029 agent option C).
+# Detects toolchain binaries that ship as 32-bit i386 — these run on
+# Docker Desktop's WSL2 kernel but ENOEXEC on GHA's azure kernel where
+# CONFIG_IA32_EMULATION_DEFAULT_DISABLED=y. Fail at image-build time
+# so the harness can never serve "works locally, fails on GHA" again.
+# Scope: /opt is the only place toolchains land; /root/.cargo/bin is
+# rustup-managed (x86_64) and exempt.
+RUN echo "scanning /opt for 32-bit ELF binaries (musl.cc-style i386 traps)..." \
+ && bad_files=$(find /opt -type f -executable -exec file {} + 2>/dev/null | awk '/ELF 32-bit/ {print $1}' | sed 's/:$//') \
+ && if [ -n "$bad_files" ]; then \
+        echo "FATAL: 32-bit ELF binaries found in /opt — would ENOEXEC on GHA azure kernel:" >&2; \
+        echo "$bad_files" >&2; \
+        exit 1; \
+    fi \
+ && echo "OK: no 32-bit ELF binaries found in /opt"

--- a/ci/docker-aarch64-musl-cross/build.sh
+++ b/ci/docker-aarch64-musl-cross/build.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Run inside the soldr-aarch64-musl-cross docker image.
 # Cross-compiles the soldr binary to aarch64-unknown-linux-musl using
-# the aarch64-linux-musl-cross toolchain pre-installed in the image.
+# `cargo zigbuild` (zig 0.13.0 pre-installed in the image bundles a
+# hermetic x86_64-native musl toolchain — no musl.cc or third-party
+# CDN dependency at build time).
 #
 # Output verification: asserts the produced binary is a valid
 # ELF 64-bit LSB aarch64 executable. The NO CHEATING gate that
@@ -21,16 +23,15 @@ echo "::endgroup::"
 
 echo "::group::env probe"
 echo "PATH=$PATH"
-echo "CC_aarch64_unknown_linux_musl=${CC_aarch64_unknown_linux_musl:-<unset>}"
-echo "which aarch64-linux-musl-gcc: $(which aarch64-linux-musl-gcc || echo NOT-FOUND)"
-echo "aarch64-linux-musl-gcc --version:"
-aarch64-linux-musl-gcc --version | head -1
+echo "zig version: $(zig version)"
+echo "cargo-zigbuild version: $(cargo-zigbuild --version)"
 echo "::endgroup::"
 
-echo "::group::Build soldr-cli for $TARGET"
-# Skip the soldr wrapper — this is a fresh container without soldr
-# bootstrapped — call cargo directly through rustup.
-cargo build --release \
+echo "::group::Build soldr-cli for $TARGET via cargo zigbuild"
+# `cargo zigbuild` delegates to cargo build but routes C/C++/linker
+# invocations through zig's bundled musl toolchain. Hermetic — no
+# host C compiler involved for the cross-compile.
+cargo zigbuild --release \
     --target "$TARGET" \
     -p soldr-cli \
     --bin soldr


### PR DESCRIPTION
Closes #1029.

## Root cause (per #1029 meta investigation)

GHA `ubuntu-24.04` runs the `linux-azure` kernel which since Linux 6.7 ships with `CONFIG_IA32_EMULATION_DEFAULT_DISABLED=y`. musl.cc's `aarch64-linux-musl-cross.tgz` is statically-linked 32-bit i386 host binaries — the kernel refuses to exec them and returns `ENOEXEC`. Three prior patches (#1020, #1023, #1028) were band-aids; the actual fix is migrating off musl.cc, which is what every other Rust project in this ecosystem (ripgrep, fd, bat, maturin, fbuild, cargo-zigbuild itself) did 12 months ago.

## What changed

- `.github/workflows/release-auto.yml`: drop the entire musl.cc install step, add `mlugg/setup-zig@v2` (0.15.2) + `taiki-e/install-action@v2` (cargo-zigbuild@0.23.0), route aarch64-musl through `cargo zigbuild`.
- `ci/docker-aarch64-musl-cross/Dockerfile`: catalogue-first (soldr-toolchain assets branch) / ziglang.org-fallback chain + **kernel-independent 32-bit ELF guard** that fails image build if any toolchain ships 32-bit binaries.
- `build.sh`: `cargo build` → `cargo zigbuild`.

## Validated locally

```
$ docker build --add-host musl.cc:127.0.0.1 -f Dockerfile -t test .
$ docker run --rm --add-host musl.cc:127.0.0.1 -v "$PWD:/src" -w /src test bash build.sh
...
Finished `release` profile [optimized] target(s) in 29m 18s
  /src/staging/soldr: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
  size: 12253104 bytes (11 MiB)
OK: soldr cross-compiled to aarch64-unknown-linux-musl successfully.
```

Companion catalogue entry: zackees/soldr-toolchain#31 (merged).