### PR TITLE
fix(release): v0.7.66 — zig 0.14.1 extraction + clang-shim packaging + catalogue cargo-zigbuild (#1032)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -418,6 +418,26 @@ jobs:
           cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" \
              "dist/package/${{ matrix.binary }}"
           chmod +x "dist/package/${{ matrix.binary }}" 2>/dev/null || true
+
+          # soldr#1032 bug 2: ship soldr-clang-shim next to soldr.
+          # The shim is a tiny clang/clang++ wrapper installed by
+          # Commands::Build (#1015 + #1016) to route ring 0.17.x's
+          # hardcoded `c.compiler("clang")` to clang-cl on
+          # *-pc-windows-msvc targets. `Commands::Build` looks for it
+          # at `~/.soldr/bin/soldr-clang-shim`, sourced FROM the release
+          # archive — so every archive must include it. Including it on
+          # every target keeps the archive layout uniform; it's a no-op
+          # binary on non-MSVC lanes.
+          shim_suffix=""
+          case "${{ matrix.target }}" in *-pc-windows-msvc) shim_suffix=".exe" ;; esac
+          shim_src="target/${{ matrix.target }}/release/soldr-clang-shim${shim_suffix}"
+          if [ ! -f "$shim_src" ]; then
+            echo "expected soldr-clang-shim${shim_suffix} in target dir; observed release dir:" >&2
+            ls -la "target/${{ matrix.target }}/release" >&2 || true
+            exit 1
+          fi
+          cp "$shim_src" "dist/package/soldr-clang-shim${shim_suffix}"
+          chmod +x "dist/package/soldr-clang-shim${shim_suffix}" 2>/dev/null || true
           case "${{ matrix.target }}" in
             *-pc-windows-msvc)
               # Windows MSVC always emits a `.pdb` next to the binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.65"
+version = "0.7.66"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.65"
+version = "0.7.66"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/ci/docker-aarch64-musl-cross/Dockerfile
+++ b/ci/docker-aarch64-musl-cross/Dockerfile
@@ -126,11 +126,54 @@ ENV PATH=/root/.cargo/bin:$PATH \
     RUSTUP_HOME=/root/.rustup \
     CARGO_HOME=/root/.cargo
 
-# Pre-install cargo-zigbuild so the per-build step doesn't need to
-# fetch from crates.io. Pinned to a known-working version.
-RUN /root/.cargo/bin/rustup toolchain install stable --profile minimal --no-self-update \
- && /root/.cargo/bin/cargo +stable install cargo-zigbuild --version 0.19.7 --locked \
- && cargo-zigbuild --version
+# cargo-zigbuild — catalogue-first / upstream-fallback chain, same
+# pattern as the zig install above. soldr-toolchain ships a prebuilt
+# binary for linux-x86_64-gnu in the catalogue (the result of
+# rust-cross/cargo-zigbuild's own release pipeline + soldr-toolchain's
+# nightly manifest refresh). Falling back to upstream GitHub release
+# URL keeps the harness functional if soldr-toolchain CDN is briefly
+# unreachable. The previous `cargo install` path required a full
+# stable Rust toolchain + ~10 min of source compile — both gone now.
+ENV CARGO_ZIGBUILD_VERSION=v0.23.0 \
+    CARGO_ZIGBUILD_CATALOGUE_URL=https://raw.githubusercontent.com/zackees/soldr-toolchain/assets/cargo-zigbuild/manifest.json \
+    CARGO_ZIGBUILD_FALLBACK_URL=https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.23.0/cargo-zigbuild-x86_64-unknown-linux-gnu.tar.xz \
+    CARGO_ZIGBUILD_FALLBACK_SHA256=c636e4f72b6f40a40ddf0414c8c6056f78b87eea3be0edf01f08d65fa028a373
+
+RUN set -eu; \
+    echo "resolving cargo-zigbuild ${CARGO_ZIGBUILD_VERSION} via catalogue: ${CARGO_ZIGBUILD_CATALOGUE_URL}"; \
+    czb_url=""; \
+    czb_sha=""; \
+    if curl -fsSL --connect-timeout 15 --max-time 30 \
+            "$CARGO_ZIGBUILD_CATALOGUE_URL" -o /tmp/czb-manifest.json; then \
+        czb_url=$(jq -r --arg v "$CARGO_ZIGBUILD_VERSION" '.releases[] | select(.version==$v) | .platforms[] | select(.platform.os=="linux" and .platform.arch=="x86_64" and .platform.libc=="glibc") | .asset.urls[0]' /tmp/czb-manifest.json); \
+        czb_sha=$(jq -r --arg v "$CARGO_ZIGBUILD_VERSION" '.releases[] | select(.version==$v) | .platforms[] | select(.platform.os=="linux" and .platform.arch=="x86_64" and .platform.libc=="glibc") | .asset.sha256' /tmp/czb-manifest.json); \
+        if [ -z "$czb_url" ] || [ "$czb_url" = "null" ]; then \
+            echo "catalogue resolved but ${CARGO_ZIGBUILD_VERSION} not in manifest; falling back" >&2; \
+            czb_url=""; \
+        fi; \
+        rm -f /tmp/czb-manifest.json; \
+    else \
+        echo "catalogue unreachable; falling back to hardcoded GitHub URL" >&2; \
+    fi; \
+    if [ -z "$czb_url" ]; then \
+        czb_url="$CARGO_ZIGBUILD_FALLBACK_URL"; \
+        czb_sha="$CARGO_ZIGBUILD_FALLBACK_SHA256"; \
+    fi; \
+    echo "fetching cargo-zigbuild from: $czb_url"; \
+    curl -fsSL --connect-timeout 30 --max-time 600 --retry 5 \
+        "$czb_url" -o /tmp/czb.tar.xz; \
+    echo "${czb_sha}  /tmp/czb.tar.xz" | sha256sum -c -; \
+    mkdir -p /tmp/czb-extract; \
+    tar -xJf /tmp/czb.tar.xz -C /tmp/czb-extract; \
+    czb_bin=$(find /tmp/czb-extract -type f -name cargo-zigbuild | head -n1); \
+    if [ -z "$czb_bin" ] || [ ! -f "$czb_bin" ]; then \
+        echo "FATAL: cargo-zigbuild binary not found in extracted tarball" >&2; \
+        find /tmp/czb-extract -maxdepth 3 -print >&2; \
+        exit 1; \
+    fi; \
+    install -m 0755 "$czb_bin" /usr/local/bin/cargo-zigbuild; \
+    rm -rf /tmp/czb.tar.xz /tmp/czb-extract; \
+    cargo-zigbuild --version
 
 # Kernel-independent 32-bit ELF guard (soldr#1029 agent option C).
 # Detects toolchain binaries that ship as 32-bit i386 — these run on

--- a/crates/soldr-cli/src/fetch/zig.rs
+++ b/crates/soldr-cli/src/fetch/zig.rs
@@ -263,18 +263,60 @@ fn zig_binary_filename() -> &'static str {
 }
 
 fn managed_zig_binary_path(install_dir: &Path) -> PathBuf {
-    install_dir
+    // Try the constructed name first (no I/O). Fall back to a single-
+    // depth scan if the constructed name doesn't exist. The scan is
+    // the robustness layer for future upstream naming changes
+    // (see soldr#1032 — the zig-0.14.0 asset-naming swap also flipped
+    // the tarball's internal top-level dir name, and the previous
+    // hardcoded `zig-{os}-{arch}-{ver}` formula in `managed_zig_archive_root`
+    // pointed at a directory that doesn't exist for 0.14+).
+    let constructed = install_dir
         .join(managed_zig_archive_root())
-        .join(zig_binary_filename())
+        .join(zig_binary_filename());
+    if constructed.is_file() {
+        return constructed;
+    }
+    if let Some(scanned) = scan_for_zig_binary(install_dir) {
+        return scanned;
+    }
+    constructed
 }
 
-/// The official zig tarballs / zips unpack to a single top-level
-/// directory `zig-<os>-<arch>-<version>` (the 0.13.x naming
-/// convention). Mirror that so we know exactly where to find the
-/// extracted binary without scanning.
+/// The official zig tarballs unpack to a single top-level directory
+/// `zig-<arch>-<os>-<version>` (the 0.14+ naming) or
+/// `zig-<os>-<arch>-<version>` (the 0.13.x naming). Match the same
+/// branching used by `zig_download_url` so the extracted directory
+/// name is found on the first try without scanning.
 fn managed_zig_archive_root() -> String {
     let (os, arch) = host_zig_os_arch().unwrap_or(("linux", "x86_64"));
-    format!("zig-{os}-{arch}-{MANAGED_ZIG_VERSION}")
+    let pre_0_14 = matches!(
+        MANAGED_ZIG_VERSION,
+        "0.13.0" | "0.12.0" | "0.11.0" | "0.10.1" | "0.10.0"
+    );
+    if pre_0_14 {
+        format!("zig-{os}-{arch}-{MANAGED_ZIG_VERSION}")
+    } else {
+        format!("zig-{arch}-{os}-{MANAGED_ZIG_VERSION}")
+    }
+}
+
+/// Fallback: look one level down from `install_dir` for a directory
+/// that contains the zig binary. Robustness layer if upstream changes
+/// the top-level directory naming again in a future release without
+/// soldr getting a coordinated bump.
+fn scan_for_zig_binary(install_dir: &Path) -> Option<PathBuf> {
+    let exe = zig_binary_filename();
+    let read_dir = std::fs::read_dir(install_dir).ok()?;
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let candidate = path.join(exe);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
 }
 
 fn host_zig_os_arch() -> Option<(&'static str, &'static str)> {
@@ -376,6 +418,41 @@ mod tests {
         let post_14 = format!("zig-{arch}-{os}-0.14.1");
         assert!(asset_13.starts_with(&pre_13), "0.13.0: {asset_13}");
         assert!(asset_14.starts_with(&post_14), "0.14.1: {asset_14}");
+    });
+
+    crate::timed_test!(managed_zig_archive_root_swaps_with_version, {
+        // The directory name inside the tarball mirrors the asset name.
+        // 0.13.x uses `zig-{os}-{arch}-{ver}/`, 0.14+ uses
+        // `zig-{arch}-{os}-{ver}/`. This test confirms managed_zig_archive_root
+        // follows the same pre/post-0.14 branching as zig_download_url —
+        // they MUST agree or extracts land in a directory the lookup misses
+        // (soldr#1032).
+        let Some((os, arch)) = host_zig_os_arch() else { return };
+        let root = managed_zig_archive_root();
+        // MANAGED_ZIG_VERSION is currently 0.14.1 (post-swap).
+        let expected = format!("zig-{arch}-{os}-{MANAGED_ZIG_VERSION}");
+        assert_eq!(
+            root, expected,
+            "managed_zig_archive_root should match the 0.14+ post-swap layout"
+        );
+    });
+
+    crate::timed_test!(managed_zig_binary_path_falls_back_to_scan, {
+        // Even if upstream changes the directory naming AGAIN in a future
+        // release without soldr getting a coordinated bump, the scan
+        // fallback should locate the binary. soldr#1032 hardening.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        // Create a directory whose name does NOT match the constructed
+        // one, containing the zig binary.
+        let surprise = tmp.path().join("zig-some-weird-future-naming-0.99.0");
+        std::fs::create_dir_all(&surprise).unwrap();
+        let zig = surprise.join(zig_binary_filename());
+        std::fs::write(&zig, b"#!/bin/sh\necho fake\n").unwrap();
+        let resolved = managed_zig_binary_path(tmp.path());
+        assert_eq!(
+            resolved, zig,
+            "scan fallback should find the zig binary in any subdirectory"
+        );
     });
 
     crate::timed_test!(env_var_overrides_path_and_managed_install, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.65",
+  "version": "0.7.66",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Closes #1032.

Bundle of 3 fixes (each independently load-bearing):

## 1. zig 0.14.1 tarball extraction (#1032 bug 1)
`managed_zig_archive_root` hardcoded the pre-0.14 `zig-{os}-{arch}-{ver}` layout; the asset-naming swap in 0.14+ landed only in `zig_download_url`. Fix branches both the same way + adds a `scan_for_zig_binary` fallback. Two new unit tests gate both pathways.

## 2. soldr-clang-shim packaging (#1032 bug 2)
`release-auto.yml`'s Stage step only copied `soldr`, not the `soldr-clang-shim` bin (#1015). Adds shim alongside soldr on every target.

## 3. Dockerfile cargo-zigbuild via catalogue (#1029 follow-up)
Replaces `cargo install cargo-zigbuild --locked` (~10 min, requires full Rust toolchain) with a catalogue-first fetch from `soldr-toolchain`. Build time: 45s vs 10+ min. Pattern parity with the zig catalogue fetch in #1030.

## Validation

- `cargo test -p soldr-cli --lib fetch::zig` — 5/5 pass
- `docker build --add-host musl.cc:127.0.0.1` against updated Dockerfile — image built in 45s, both catalogue paths exercised, 32-bit ELF guard passed
- E2E cross-compile in progress at PR time

Companion: zackees/soldr-toolchain#33 (zig producer).