### PR TITLE
scripts: run_with_ts.py wrapper + apply to e2e-windows soldr cargo build

### DIFF
--- a/.github/scripts/run_with_ts.py
+++ b/.github/scripts/run_with_ts.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Run a command, stream its merged stdout/stderr with elapsed-seconds prefix.
+
+Cross-platform companion to ``ts_step.py`` (which is a pure
+stdin → stdout transformer for use in shell pipelines like
+``cmd 2>&1 | python ts_step.py``). This wrapper EXECUTES a command
+and prefixes its output line-by-line.
+
+The split exists because PowerShell's pipe / exit-code semantics make
+the stdin-piped pattern awkward: ``$LASTEXITCODE`` after ``cmd | python``
+is python's exit code, not ``cmd``'s. By contrast, this wrapper runs
+``cmd`` as a subprocess and propagates its real exit code to the
+caller, so PowerShell steps can drop ``run_with_ts.py`` in front of
+``soldr`` (or any other command) without the exit-code dance.
+
+Output format matches ``ts_step.py`` byte-for-byte:
+
+    {seconds:7.2f} <original line bytes>
+
+ANSI color sequences in the line body are passed through unchanged
+(we read/write the raw stdout buffer), so colored cargo output stays
+colored on the GHA UI. The PREFIX itself is plain — colorizing it
+would distract from the tool output.
+
+``time.monotonic()`` is used (not ``time.time()``) so the prefix is
+unaffected by NTP slews or DST transitions mid-step.
+
+Usage (from PowerShell or bash):
+
+    python .github/scripts/run_with_ts.py soldr cargo build --release ...
+
+Exit code: the wrapped command's exit code, or 127 if the command
+couldn't be started.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: run_with_ts.py <cmd> [args...]", file=sys.stderr)
+        return 2
+
+    cmd = sys.argv[1:]
+    start = time.monotonic()
+    out = sys.stdout.buffer
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=0,
+        )
+    except OSError as err:
+        print(f"run_with_ts.py: failed to start {cmd!r}: {err}", file=sys.stderr)
+        return 127
+
+    # mypy / Pyright reassurance — Popen with stdout=PIPE always sets .stdout.
+    assert proc.stdout is not None
+    for line in iter(proc.stdout.readline, b""):
+        elapsed = time.monotonic() - start
+        out.write(f"{elapsed:7.2f} ".encode("ascii"))
+        out.write(line)
+        out.flush()
+
+    proc.wait()
+    return proc.returncode if proc.returncode is not None else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/_e2e-windows-prebuilt.yml
+++ b/.github/workflows/_e2e-windows-prebuilt.yml
@@ -133,9 +133,18 @@ jobs:
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
           ZCCACHE_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}/cache/zccache
+        # soldr#1032 follow-up: route soldr's cargo invocation through
+        # the run_with_ts.py wrapper so every output line gets a
+        # seconds-since-step-start prefix. Without this, the step's
+        # progress is invisible until cargo prints its next line — which
+        # for some long-running rustc steps means 5+ minutes of silence
+        # that looks like a hang. The wrapper's subprocess pattern
+        # preserves the real exit code (PowerShell's pipe + $LASTEXITCODE
+        # would yield python's, not soldr's).
         run: |
           $timer = [Diagnostics.Stopwatch]::StartNew()
-          soldr cargo build --locked --target "${{ inputs.target }}"
+          python "${{ github.workspace }}/.github/scripts/run_with_ts.py" `
+            soldr cargo build --locked --target "${{ inputs.target }}"
           $exitCode = $LASTEXITCODE
           $timer.Stop()
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(


### PR DESCRIPTION
Cross-platform companion to the existing `ts_step.py` shell-pipe transformer.

## Why

The PowerShell + `ts_step.py` composition is awkward: `cmd | python ts_step.py` sets `$LASTEXITCODE` to python's exit code, not the wrapped command's. `run_with_ts.py` is a subprocess wrapper that propagates the real exit code — drop it in front of `soldr` / `cargo` / etc. without the exit-code dance.

Concretely, `_e2e-windows-prebuilt.yml`'s `Build third-party app through soldr` step was silent during long rustc invocations (5+ min between log lines looks like a hang on the GHA UI — [run 28345283384 / job 83967287913](https://github.com/zackees/soldr/actions/runs/28345283384/job/83967287913)).

## Output format

Identical to `ts_step.py` — each line prefixed with `{seconds:7.2f} `, ANSI color preserved:

```
   0.06 hello world
   1.42 Compiling soldr-cli v0.7.66
```

## Tested locally

```
$ python .github/scripts/run_with_ts.py echo 'hello world'
   0.06 hello world

$ python .github/scripts/run_with_ts.py false; echo "exit=$?"
exit=1
```