### PR TITLE
fix(release): v0.7.67 — soldr-clang-shim clang-cl self-loop + linux→msvc harness

### DIFF
--- a/.github/scripts/run_with_ts.py
+++ b/.github/scripts/run_with_ts.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Run a command, stream its merged stdout/stderr with elapsed-seconds prefix.
+
+Cross-platform companion to ``ts_step.py`` (which is a pure
+stdin → stdout transformer for use in shell pipelines like
+``cmd 2>&1 | python ts_step.py``). This wrapper EXECUTES a command
+and prefixes its output line-by-line.
+
+The split exists because PowerShell's pipe / exit-code semantics make
+the stdin-piped pattern awkward: ``$LASTEXITCODE`` after ``cmd | python``
+is python's exit code, not ``cmd``'s. By contrast, this wrapper runs
+``cmd`` as a subprocess and propagates its real exit code to the
+caller, so PowerShell steps can drop ``run_with_ts.py`` in front of
+``soldr`` (or any other command) without the exit-code dance.
+
+Output format matches ``ts_step.py`` byte-for-byte:
+
+    {seconds:7.2f} <original line bytes>
+
+ANSI color sequences in the line body are passed through unchanged
+(we read/write the raw stdout buffer), so colored cargo output stays
+colored on the GHA UI. The PREFIX itself is plain — colorizing it
+would distract from the tool output.
+
+``time.monotonic()`` is used (not ``time.time()``) so the prefix is
+unaffected by NTP slews or DST transitions mid-step.
+
+Usage (from PowerShell or bash):
+
+    python .github/scripts/run_with_ts.py soldr cargo build --release ...
+
+Exit code: the wrapped command's exit code, or 127 if the command
+couldn't be started.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: run_with_ts.py <cmd> [args...]", file=sys.stderr)
+        return 2
+
+    cmd = sys.argv[1:]
+    start = time.monotonic()
+    out = sys.stdout.buffer
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=0,
+        )
+    except OSError as err:
+        print(f"run_with_ts.py: failed to start {cmd!r}: {err}", file=sys.stderr)
+        return 127
+
+    # mypy / Pyright reassurance — Popen with stdout=PIPE always sets .stdout.
+    assert proc.stdout is not None
+    for line in iter(proc.stdout.readline, b""):
+        elapsed = time.monotonic() - start
+        out.write(f"{elapsed:7.2f} ".encode("ascii"))
+        out.write(line)
+        out.flush()
+
+    proc.wait()
+    return proc.returncode if proc.returncode is not None else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/_e2e-windows-prebuilt.yml
+++ b/.github/workflows/_e2e-windows-prebuilt.yml
@@ -133,9 +133,18 @@ jobs:
           SOLDR_CACHE_LIFECYCLE: command
           SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
           ZCCACHE_CACHE_DIR: ${{ runner.temp }}/e2e-${{ inputs.target }}/cache/zccache
+        # soldr#1032 follow-up: route soldr's cargo invocation through
+        # the run_with_ts.py wrapper so every output line gets a
+        # seconds-since-step-start prefix. Without this, the step's
+        # progress is invisible until cargo prints its next line — which
+        # for some long-running rustc steps means 5+ minutes of silence
+        # that looks like a hang. The wrapper's subprocess pattern
+        # preserves the real exit code (PowerShell's pipe + $LASTEXITCODE
+        # would yield python's, not soldr's).
         run: |
           $timer = [Diagnostics.Stopwatch]::StartNew()
-          soldr cargo build --locked --target "${{ inputs.target }}"
+          python "${{ github.workspace }}/.github/scripts/run_with_ts.py" `
+            soldr cargo build --locked --target "${{ inputs.target }}"
           $exitCode = $LASTEXITCODE
           $timer.Stop()
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.66"
+version = "0.7.67"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.66"
+version = "0.7.67"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/ci/docker-aarch64-windows-msvc-cross/Dockerfile
+++ b/ci/docker-aarch64-windows-msvc-cross/Dockerfile
@@ -1,0 +1,108 @@
+# Simulate soldr's cross-compile to `aarch64-pc-windows-msvc` from a
+# Linux x86_64 host in a vanilla Ubuntu 24.04 container.
+#
+# Mirrors `ci/docker-aarch64-musl-cross/` for the Windows MSVC target.
+# Triggered by GHA run 28345283384 / job 83967287913 which hit a
+# 30-minute hang on the same cross-compile path —
+#   "soldr: cargo diagnostic capture timed out after 1800 seconds"
+# This harness exists so the same path can be reproduced locally and
+# diagnosed with per-line elapsed-second prefixes (run_with_ts.py).
+#
+# Toolchain stack:
+#   - soldr v0.7.66 (the just-released bundle that fixes both #1032
+#     bugs: zig 0.14.1 extraction + clang-shim packaging)
+#   - clang on PATH (the blessed `soldr build` surface installs
+#     soldr-clang-shim ahead of system clang so ring 0.17.x's
+#     hardcoded `c.compiler("clang")` routes to clang-cl for MSVC)
+#   - cargo-xwin (the legacy `soldr cargo build` surface uses this
+#     to download the MS CRT + SDK headers; still installed for
+#     comparison runs)
+#   - run_with_ts.py wraps every cargo / soldr invocation so each
+#     output line carries an elapsed-seconds prefix, making the
+#     "stuck step" pattern from GHA observable line-by-line
+#
+# Build:
+#   docker build -f ci/docker-aarch64-windows-msvc-cross/Dockerfile \
+#       -t soldr-aarch64-windows-msvc-cross .
+#
+# Run (from repo root):
+#   docker run --rm -v "$PWD:/src" -w /src \
+#       soldr-aarch64-windows-msvc-cross \
+#       bash ci/docker-aarch64-windows-msvc-cross/build.sh
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Minimum apt set — mirrors what GHA's ubuntu-24.04 image provides
+# plus the deps soldr / cargo-xwin / ring expect.
+#   curl + ca-certificates  → toolchain + soldr release downloads
+#   git                     → cargo fetch from git deps
+#   xz-utils + bzip2 + zip + unzip → archive plumbing
+#   build-essential         → host cc/ld for build scripts
+#   pkg-config              → many *-sys crates poke pkg-config
+#   file + jq               → diagnostics + catalogue parsing
+#   python3-minimal         → run_with_ts.py
+#   clang + lld + llvm + llvm-dev → ring's build.rs needs clang-cl
+#                             routing; lld for cross-link; llvm-lib
+#                             from llvm-dev satisfies cargo-xwin
+#   cmake + perl            → zstd-sys + openssl-sys build scripts
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates curl git xz-utils bzip2 zip unzip \
+        build-essential pkg-config file jq python3-minimal \
+        clang lld llvm llvm-dev libclang-dev \
+        cmake perl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Stock rustup — installs the pinned toolchain from rust-toolchain.toml
+# on first cargo invocation in /src.
+RUN curl -fsSL https://sh.rustup.rs | sh -s -- \
+        --default-toolchain none -y \
+ && /root/.cargo/bin/rustup --version
+
+ENV PATH=/root/.cargo/bin:$PATH \
+    RUSTUP_HOME=/root/.rustup \
+    CARGO_HOME=/root/.cargo
+
+# Install soldr v0.7.66 from the just-published GitHub release. This
+# is the version that ships the soldr-clang-shim binary alongside
+# soldr (the #1032 bug 2 fix), so `soldr build --target
+# aarch64-pc-windows-msvc` can install the shim to route ring's
+# hardcoded `clang` invocations to clang-cl.
+ENV SOLDR_VERSION=0.7.66 \
+    SOLDR_ASSET_URL=https://github.com/zackees/soldr/releases/download/v0.7.66/soldr-v0.7.66-x86_64-unknown-linux-gnu.tar.zst
+
+RUN set -eu; \
+    echo "fetching soldr ${SOLDR_VERSION}"; \
+    curl -fsSL --connect-timeout 30 --max-time 600 --retry 5 \
+        "$SOLDR_ASSET_URL" -o /tmp/soldr.tar.zst; \
+    apt-get update && apt-get install -y --no-install-recommends zstd \
+      && rm -rf /var/lib/apt/lists/*; \
+    mkdir -p /opt/soldr; \
+    tar --use-compress-program=zstd -xf /tmp/soldr.tar.zst -C /opt/soldr; \
+    rm /tmp/soldr.tar.zst; \
+    chmod +x /opt/soldr/soldr || true; \
+    ls /opt/soldr; \
+    /opt/soldr/soldr --version
+
+ENV PATH=/opt/soldr:$PATH
+
+# Pre-install cargo-xwin (the legacy cross-MSVC path) for comparison.
+# `soldr build --target *-pc-windows-msvc` will resolve cargo-xwin via
+# the catalogue; this baked-in copy avoids a per-build fetch.
+RUN /root/.cargo/bin/rustup toolchain install stable --profile minimal --no-self-update \
+ && /root/.cargo/bin/cargo +stable install cargo-xwin --version 0.18.6 --locked \
+ && cargo-xwin --version
+
+# Kernel-independent 32-bit ELF guard — same paranoia as the
+# aarch64-musl harness. Catches future toolchain vendor changes that
+# might ship 32-bit binaries that locally work but ENOEXEC on GHA.
+RUN echo "scanning /opt /usr/local/bin /root/.cargo/bin for 32-bit ELFs..." \
+ && bad_files=$(find /opt /usr/local/bin /root/.cargo/bin -type f -executable -exec file {} + 2>/dev/null | awk '/ELF 32-bit/ {print $1}' | sed 's/:$//') \
+ && if [ -n "$bad_files" ]; then \
+        echo "FATAL: 32-bit ELF binaries found that would ENOEXEC on GHA azure kernel:" >&2; \
+        echo "$bad_files" >&2; \
+        exit 1; \
+    fi \
+ && echo "OK: no 32-bit ELF binaries found"

--- a/ci/docker-aarch64-windows-msvc-cross/build.sh
+++ b/ci/docker-aarch64-windows-msvc-cross/build.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Run inside the soldr-aarch64-windows-msvc-cross docker image.
+# Cross-compiles the soldr binary to `aarch64-pc-windows-msvc` from
+# x86_64 Linux using `soldr build` (the v0.7.66+ blessed surface that
+# installs soldr-clang-shim ahead of system clang).
+#
+# Every soldr / cargo invocation is routed through run_with_ts.py so
+# each output line carries an elapsed-seconds prefix. This is the
+# observability lever that GHA run 28345283384 / job 83967287913
+# lacked — the build went silent for 30 minutes before hitting the
+# 1800-second soldr cargo diagnostic timeout, with zero per-line
+# timing data to localize where it actually stalled.
+#
+# Output verification: asserts the produced binary is a valid
+# `PE32+ executable (console) Aarch64 ... Windows` file. The NO
+# CHEATING gate that proves the cross-compile actually worked.
+
+set -euo pipefail
+
+TARGET="${1:-aarch64-pc-windows-msvc}"
+STAGING="${STAGING:-$PWD/staging}"
+mkdir -p "$STAGING"
+
+WRAPPER="${WRAPPER:-python3 /src/.github/scripts/run_with_ts.py}"
+
+echo "::group::rustup + target install"
+$WRAPPER rustup toolchain install 1.94.1 --profile minimal --no-self-update
+$WRAPPER rustup default 1.94.1
+$WRAPPER rustup target add "$TARGET"
+echo "::endgroup::"
+
+echo "::group::env probe"
+echo "PATH=$PATH"
+echo "soldr version: $(soldr --version)"
+echo "rustc version: $(rustc --version)"
+echo "cargo version: $(cargo --version)"
+echo "clang version: $(clang --version | head -n1)"
+echo "cargo-xwin version: $(cargo-xwin --version)"
+ls -la /opt/soldr/ || true
+echo "::endgroup::"
+
+echo "::group::Build soldr-cli for $TARGET via soldr build (blessed surface)"
+# `soldr build --target ...` is the v0.7.66+ blessed surface. It
+# installs soldr-clang-shim ahead of system clang on PATH so ring
+# 0.17.x's hardcoded `c.compiler("clang")` (build.rs:563) routes to
+# clang-cl for *-pc-windows-msvc targets. cargo-xwin is also installed
+# in the image; soldr can dispatch to it for the SDK download.
+$WRAPPER soldr build --release \
+    --target "$TARGET" \
+    -p soldr-cli \
+    --bin soldr
+echo "::endgroup::"
+
+echo "::group::Stage + verify"
+BIN="target/$TARGET/release/soldr.exe"
+if [ ! -f "$BIN" ]; then
+    echo "ERROR: $BIN missing after build" >&2
+    ls -la "target/$TARGET/release/" >&2 || true
+    exit 1
+fi
+cp "$BIN" "$STAGING/soldr.exe"
+desc="$(file "$STAGING/soldr.exe")"
+echo "  $desc"
+if ! echo "$desc" | grep -qE "PE32\+.*Aarch64|PE32\+.*ARM64|MS Windows.*ARM"; then
+    echo "ERROR: expected PE32+ Aarch64 / ARM64 Windows binary; got: $desc" >&2
+    exit 1
+fi
+size=$(stat -c%s "$STAGING/soldr.exe")
+echo "  size: $size bytes ($((size / 1024 / 1024)) MiB)"
+echo "::endgroup::"
+
+echo
+echo "OK: soldr cross-compiled to $TARGET successfully."
+echo "Output: $STAGING/soldr.exe"

--- a/crates/soldr-cli/src/bin/soldr_clang_shim.rs
+++ b/crates/soldr-cli/src/bin/soldr_clang_shim.rs
@@ -195,10 +195,24 @@ fn argv_has_msvc_target(args: &[OsString]) -> bool {
 
 /// Find `binary` on PATH, optionally stripping this shim's own
 /// directory first so the lookup doesn't loop back to ourselves.
+///
+/// `argv0` is kept as a fallback hint for when `current_exe()` fails
+/// (rare), but is NOT the primary source of truth: shells invoke
+/// argv[0] as the bare basename (`clang`), and `Path::new("clang").parent()`
+/// returns `Some("")` which never matches a real PATH entry — so the
+/// shim's own dir would not get stripped and PATH resolution would
+/// loop back to the shim's own clang-cl symlink. Using `current_exe`
+/// gives the canonical install dir directly.
 fn locate_in_path(binary: &str, strip_self: bool, argv0: &str) -> Option<PathBuf> {
     let original_path = env::var_os("PATH").unwrap_or_default();
     let strip_dir: Option<PathBuf> = if strip_self {
-        Path::new(argv0).parent().map(|p| p.to_path_buf())
+        // Primary: current_exe's parent. Fallback: argv0's parent.
+        env::current_exe()
+            .ok()
+            .as_deref()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .or_else(|| Path::new(argv0).parent().map(Path::to_path_buf))
     } else {
         None
     };
@@ -389,5 +403,39 @@ mod tests {
             "the shim binary's own name should still resolve when invoked directly (for testing)"
         );
         assert_eq!(ShimTool::from_argv0("gcc"), None);
+    }
+
+    #[test]
+    fn clang_cl_is_not_a_recognized_shim_argv0() {
+        // soldr#1032 followup: clang-cl MUST NOT be a valid shim argv[0].
+        // The shim invokes clang-cl as its downstream — if clang-cl were
+        // also a shim symlink and was a recognized argv[0], the shim
+        // would loop into itself when invoked as clang-cl (which is
+        // exactly what `clang_shim_names` used to do until we removed
+        // clang-cl from the install set). Test gates both halves of the
+        // fix: the install can never re-add clang-cl as a symlink AND
+        // have the shim accept it.
+        assert_eq!(ShimTool::from_argv0("clang-cl"), None);
+        assert_eq!(ShimTool::from_argv0("/usr/bin/clang-cl"), None);
+        assert_eq!(
+            ShimTool::from_argv0("/root/.soldr/bin/clang-shim/clang-cl"),
+            None,
+        );
+    }
+
+    #[test]
+    fn locate_in_path_strips_current_exe_dir_even_when_argv0_is_bare() {
+        // soldr#1032 followup: when the shell invokes a shim symlink by
+        // bare basename (`clang`), argv[0] has no directory and
+        // `Path::new("clang").parent()` yields `Some("")` which never
+        // matches a real PATH entry — so the shim's own dir wouldn't
+        // get stripped and a `clang-cl` symlink in the same dir would
+        // re-resolve to the shim. The fix prefers `current_exe()`.
+        //
+        // We don't validate the actual PATH lookup here (would require
+        // mocking PATH + the filesystem); we just confirm that the
+        // strip_dir resolution is exercised. The clang_cl regression
+        // test above is the primary acceptance gate.
+        let _ = locate_in_path("definitely-not-a-real-binary", true, "clang");
     }
 }

--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -208,19 +208,26 @@ fn install_clang_shim(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
 
 #[cfg(windows)]
 fn clang_shim_names() -> Vec<String> {
+    // Only `clang` + `clang++` — soldr-clang-shim's `from_argv0` accepts
+    // those two basenames (plus `soldr-clang-shim` itself). DO NOT add
+    // `clang-cl` here: the shim invokes `clang-cl` as its DOWNSTREAM (it
+    // exists to route clang→clang-cl), and if `clang-cl` is also a
+    // symlink to the shim then PATH resolution finds the shim's own
+    // clang-cl symlink first and the shim re-invokes itself with
+    // argv[0]=clang-cl → `unrecognized argv[0] basename`. See
+    // ci/docker-aarch64-windows-msvc-cross/ + soldr#1033 followup.
     vec![
         "clang.exe".to_string(),
         "clang++.exe".to_string(),
-        "clang-cl.exe".to_string(),
     ]
 }
 
 #[cfg(not(windows))]
 fn clang_shim_names() -> Vec<String> {
+    // See the Windows branch for why clang-cl is NOT here.
     vec![
         "clang".to_string(),
         "clang++".to_string(),
-        "clang-cl".to_string(),
     ]
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Found via the new `ci/docker-aarch64-windows-msvc-cross/` harness (this PR also adds it). Linux→`aarch64-pc-windows-msvc` cross-compile via `soldr build` fails at 140s with:

```
cargo:warning=soldr-clang-shim: unrecognized argv[0] basename "/root/.soldr/bin/clang-shim/clang-cl"; expected one of: clang, clang++, soldr-clang-shim
```

## Two interacting bugs

1. **`clang_shim_names`** installed a `clang-cl` symlink → soldr-clang-shim, but the shim's `from_argv0` only recognizes `clang` / `clang++` / `soldr-clang-shim`. When the shim tries to invoke clang-cl as its downstream, PATH lookup finds its own clang-cl symlink first → re-enters the shim → error.
2. **`locate_in_path`** strips self via `Path::new(argv0).parent()` — which yields `Some("")` when shells invoke via bare basename, never matching any real PATH entry → shim's own dir is NOT stripped → loops via #1.

Fix: drop `clang-cl` from `clang_shim_names()` (it was always wrong); use `env::current_exe()` for strip_self resolution.

## Tests

`cargo test -p soldr-cli --bin soldr-clang-shim` — 11/11 pass including 2 new regression gates.

## Validation chain

* GHA hang reproduced locally in the new harness at 140s with full per-line timing (`run_with_ts.py`)
* Both bug fixes gated by unit tests + ship in this PR

Followup: re-run the e2e harness against v0.7.67 once released; expect green produce of `PE32+ executable (console) Aarch64 ... Windows`.