### PR TITLE
refactor(tests): tests/common::soldr_bin() helper for SOLDR_BIN override (#1039)

### DIFF
--- a/crates/soldr-cli/tests/agent_worktree_share.rs
+++ b/crates/soldr-cli/tests/agent_worktree_share.rs
@@ -213,7 +213,7 @@ fn git(args: &[&str], cwd: &Path) {
 
 fn soldr_cargo_build(worktree: &Path, cache_dir: &Path) {
     let zccache_dir = cache_dir.join("cache").join("zccache");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .current_dir(worktree)
         .env("SOLDR_CACHE_DIR", cache_dir)

--- a/crates/soldr-cli/tests/cli_build_alias_parity.rs
+++ b/crates/soldr-cli/tests/cli_build_alias_parity.rs
@@ -27,7 +27,7 @@ fn soldr_build_alias_resolves_via_clap_not_external() {
     // try to install a crate literally named "build"). This is the
     // simplest possible smoke test that `Commands::Build` exists and
     // is wired through clap.
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["build", "--help"])
         .output()
         .expect("failed to run soldr build --help");
@@ -78,7 +78,7 @@ fn soldr_build_invokes_real_cargo_build() {
     // cargo dispatch is what we're testing, not a successful build.
     let cache_root = unique_temp_dir("build-alias-routes-to-cargo");
 
-    let build_out = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let build_out = Command::new(common::soldr_bin())
         .args([
             "--no-cache",
             "build",
@@ -89,7 +89,7 @@ fn soldr_build_invokes_real_cargo_build() {
         .output()
         .expect("failed to run soldr build");
 
-    let cargo_out = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let cargo_out = Command::new(common::soldr_bin())
         .args([
             "--no-cache",
             "cargo",
@@ -132,7 +132,7 @@ fn soldr_build_help_documents_blessed_surface() {
     // default surface contract. The `--help` output must surface that
     // language so users discovering `soldr build --help` understand
     // why they'd pick it over `soldr cargo build`.
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["build", "--help"])
         .output()
         .expect("failed to run soldr build --help");

--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -22,7 +22,7 @@ fn status_reports_cache_control_defaults() {
     // a stale host pin would otherwise leak into the test as a fetched
     // binary and break the "not fetched yet" assertion below.
     let home_root = unique_temp_dir("status-home");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("status")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -62,7 +62,7 @@ fn status_json_reports_stable_machine_fields() {
     // discovery so the developer's host-side pin (issue #426) can't leak
     // into the test as a "binary already fetched" signal.
     let home_root = unique_temp_dir("status-json-home");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -153,7 +153,7 @@ fn cache_command_reports_managed_zccache_status() {
     )
     .expect("failed to seed session stats");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("cache")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -223,7 +223,7 @@ fn cache_json_reports_managed_zccache_status() {
     )
     .expect("failed to seed session stats");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -271,7 +271,7 @@ fn cache_json_reports_managed_zccache_status() {
 fn cache_report_json_emits_stable_schema_when_files_missing() {
     let cache_root = unique_temp_dir("cache-report-empty");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "report", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -322,7 +322,7 @@ fn cache_report_json_surfaces_persisted_session_stats() {
     )
     .expect("failed to seed session stats");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "report", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -367,7 +367,7 @@ fn cache_report_json_passes_through_unknown_session_stat_fields() {
     )
     .expect("failed to seed session stats");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "report", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -405,7 +405,7 @@ fn clean_clears_managed_zccache_and_state_dir() {
         .expect("failed to create journal dir");
     fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("clean")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &user_home)
@@ -457,7 +457,7 @@ fn purge_removes_soldr_artifact_dirs_and_keeps_config() {
         .expect("failed to seed zccache state");
     fs::write(&config_file, "cache = true\n").expect("failed to seed config");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("purge")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -497,7 +497,7 @@ fn purge_reports_empty_cache_without_creating_dirs() {
     let bin_dir = cache_root.join("bin");
     let cache_dir = cache_root.join("cache");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("purge")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -530,7 +530,7 @@ fn purge_removes_corrupt_artifact_paths() {
     fs::write(&bin_path, "not a dir").expect("failed to seed corrupt bin path");
     fs::write(&cache_path, "not a dir").expect("failed to seed corrupt cache path");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("purge")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -561,7 +561,7 @@ fn purge_removes_corrupt_artifact_paths() {
 
 #[test]
 fn purge_rejects_json_flag() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["purge", "--json"])
         .output()
         .expect("failed to run soldr purge --json");
@@ -580,7 +580,7 @@ fn purge_rejects_json_flag() {
 
 #[test]
 fn clean_rejects_json_flag() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["clean", "--json"])
         .output()
         .expect("failed to run soldr clean --json");
@@ -606,7 +606,7 @@ fn cache_flush_emits_zccache_stats_on_success() {
     let log_path = cache_root.join("tool.log");
     let (_, _, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "flush", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -644,7 +644,7 @@ fn cache_flush_handles_unsupported_zccache_gracefully() {
     let log_path = cache_root.join("tool.log");
     let (_, _, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "flush", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -681,7 +681,7 @@ fn cache_flush_falls_back_when_json_flag_is_unsupported() {
     let log_path = cache_root.join("tool.log");
     let (_, _, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "flush", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -726,7 +726,7 @@ fn cache_shutdown_waits_for_daemon_to_exit() {
     // Sanity: the marker must not exist before stop runs.
     assert!(!down_marker.exists());
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "shutdown", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -775,7 +775,7 @@ fn cache_shutdown_times_out_when_daemon_does_not_exit() {
     // Deliberately omit SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER, so the
     // fake `status` always reports the daemon as up. The shutdown
     // poll then has to give up after the deadline.
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args([
             "cache",
             "shutdown",
@@ -812,7 +812,7 @@ fn cache_shutdown_no_wait_skips_polling() {
 
     // Daemon never goes down — without the poll this would hang.
     let start = std::time::Instant::now();
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args([
             "cache",
             "shutdown",

--- a/crates/soldr-cli/tests/cli_cache_prune.rs
+++ b/crates/soldr-cli/tests/cli_cache_prune.rs
@@ -44,7 +44,7 @@ fn cache_prune_target_dry_run_emits_json() {
         f.set_modified(newer_when).expect("set newer mtime");
     }
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "prune-target"])
         .arg(&target)
         .args(["--dry-run", "--json"])

--- a/crates/soldr-cli/tests/cli_cache_trim.rs
+++ b/crates/soldr-cli/tests/cli_cache_trim.rs
@@ -50,7 +50,7 @@ fn cache_trim_target_ci_profile_strips_recreatable_noise() {
     let real_artifact = target.join("debug/deps/libreal-eeeeeeeeeeeee.rlib");
     write_bytes(&real_artifact, b"keep me");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "trim-target"])
         .arg(&target)
         .args(["--profile", "ci", "--force", "--json"])
@@ -135,7 +135,7 @@ fn cache_trim_target_local_profile_only_prunes_hash_siblings() {
     write_bytes(&large_stderr, &vec![0u8; 200 * 1024]);
     touch_dir(&incremental_dir);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "trim-target"])
         .arg(&target)
         .args(["--profile", "local", "--force", "--json"])
@@ -182,7 +182,7 @@ fn cache_trim_target_dry_run_does_not_modify_disk() {
     write_bytes(&large_stderr, &vec![0u8; 200 * 1024]);
     touch_dir(&incremental_dir);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "trim-target"])
         .arg(&target)
         .args(["--profile", "ci", "--dry-run", "--json"])
@@ -219,7 +219,7 @@ fn cache_trim_target_refuses_when_cargo_lock_present() {
     fs::write(&rlib, b"x").unwrap();
     fs::write(target.join(".cargo-lock"), b"").unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cache", "trim-target"])
         .arg(&target)
         .args(["--profile", "ci", "--force"])

--- a/crates/soldr-cli/tests/cli_cargo_basic.rs
+++ b/crates/soldr-cli/tests/cli_cargo_basic.rs
@@ -15,7 +15,7 @@ use std::{
 #[test]
 fn cargo_front_door_runs_real_cargo() {
     let cache_root = unique_temp_dir("cargo-version");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["--no-cache", "cargo", "--version"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -38,7 +38,7 @@ fn cargo_front_door_runs_real_cargo() {
 #[test]
 fn cargo_front_door_consumes_no_cache_flag() {
     let cache_root = unique_temp_dir("cargo-no-cache");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["--no-cache", "cargo", "--version"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -69,7 +69,7 @@ fn cargo_build_warns_when_disk_space_is_low() {
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["--no-cache", "cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -105,7 +105,7 @@ fn cargo_build_ignores_disk_space_detection_failures() {
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["--no-cache", "cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -134,7 +134,7 @@ fn cargo_build_ignores_disk_space_detection_failures() {
 #[test]
 fn cargo_subcommand_rejects_no_cache_flag() {
     let cache_root = unique_temp_dir("cargo-subcommand-no-cache");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "--no-cache", "--version"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -163,7 +163,7 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
     // shells out to the fake cargo for `cargo metadata`, gets back `{}`,
     // and fails with "missing field `packages`". Every fake-toolchain
     // test below clears these the same way for the same reason.
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -267,7 +267,7 @@ fn cargo_front_door_recovers_when_session_start_loses_daemon() {
     let log_path = cache_root.join("tool.log");
     let lost_marker = cache_root.join("session-start-lost");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -317,7 +317,7 @@ fn command_lifetime_cache_stops_zccache_after_successful_cargo() {
     let log_path = cache_root.join("tool.log");
     let down_marker = cache_root.join("zccache-down");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_CACHE_LIFECYCLE", "command")
@@ -364,7 +364,7 @@ fn command_lifetime_cache_stops_zccache_after_failing_cargo() {
     write_fake_script(&rustc, &fake_rustc_script(&log_path));
     write_fake_script(&zccache, &fake_zccache_script(&log_path));
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_CACHE_LIFECYCLE", "command")
@@ -400,7 +400,7 @@ fn windows_worktree_copy_relocates_wrapper_and_original_dir_can_be_removed() {
     let source_dir = worktree.join("target").join("debug");
     fs::create_dir_all(&source_dir).expect("failed to create copied exe dir");
     let copied_soldr = source_dir.join("soldr.exe");
-    fs::copy(env!("CARGO_BIN_EXE_soldr"), &copied_soldr)
+    fs::copy(common::soldr_bin(), &copied_soldr)
         .expect("failed to copy soldr exe into temporary worktree");
 
     let log_path = cache_root.join("tool.log");
@@ -468,7 +468,7 @@ fn cargo_front_door_defaults_dev_debug_off_and_warns_once_per_repo() {
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
     let cargo_home = cache_root.join("cargo-home");
 
-    let first = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let first = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .current_dir(&repo)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -489,7 +489,7 @@ fn cargo_front_door_defaults_dev_debug_off_and_warns_once_per_repo() {
         String::from_utf8_lossy(&first.stderr)
     );
 
-    let second = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let second = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .current_dir(&repo)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -547,7 +547,7 @@ fn cargo_front_door_respects_dev_debug_in_cargo_config_toml() {
 
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .current_dir(&repo)
         .env("SOLDR_CACHE_DIR", &cache_root)

--- a/crates/soldr-cli/tests/cli_cargo_native_cc.rs
+++ b/crates/soldr-cli/tests/cli_cargo_native_cc.rs
@@ -26,6 +26,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use soldr_cli::timed_test;
 
+mod common;
+
 static SOLDR_CARGO_BUILD_LOCK: Mutex<()> = Mutex::new(());
 
 fn soldr_cargo_build_lock() -> MutexGuard<'static, ()> {
@@ -68,8 +70,9 @@ fn toml_string(path: &Path) -> String {
         .replace('"', "\\\"")
 }
 
-fn soldr_bin() -> &'static str {
-    env!("CARGO_BIN_EXE_soldr")
+fn soldr_bin() -> std::path::PathBuf {
+    // soldr#1039 phase 1.
+    common::soldr_bin()
 }
 
 /// Issue #692: the four `run_soldr_cargo_build`-based tests in this

--- a/crates/soldr-cli/tests/cli_cargo_run_trampoline.rs
+++ b/crates/soldr-cli/tests/cli_cargo_run_trampoline.rs
@@ -25,8 +25,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime};
 
-fn soldr_bin() -> &'static str {
-    env!("CARGO_BIN_EXE_soldr")
+fn soldr_bin() -> std::path::PathBuf {
+    // soldr#1039 phase 1.
+    common::soldr_bin()
 }
 
 /// Build a tiny project containing a single binary that prints

--- a/crates/soldr-cli/tests/cli_cargo_trampoline_workspace.rs
+++ b/crates/soldr-cli/tests/cli_cargo_trampoline_workspace.rs
@@ -17,8 +17,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
-fn soldr_bin() -> &'static str {
-    env!("CARGO_BIN_EXE_soldr")
+fn soldr_bin() -> std::path::PathBuf {
+    // soldr#1039 phase 1.
+    common::soldr_bin()
 }
 
 /// Tiny crate with a binary and a small library so `cargo build` emits

--- a/crates/soldr-cli/tests/cli_cargo_wrappers.rs
+++ b/crates/soldr-cli/tests/cli_cargo_wrappers.rs
@@ -354,7 +354,7 @@ fn cargo_front_door_uses_custom_rustc_wrapper_from_env_var() {
         expected_sccache_dir.display()
     );
     assert!(
-        !log.contains(env!("CARGO_BIN_EXE_soldr")),
+        !log.contains(common::soldr_bin().to_string_lossy().as_ref()),
         "soldr should not stay in the wrapper slot when overridden: {log}"
     );
     assert!(
@@ -486,7 +486,7 @@ fn no_cache_bypasses_wrapper_and_zccache() {
         "no-cache front door should not start zccache: {log}"
     );
     assert!(
-        !log.contains(env!("CARGO_BIN_EXE_soldr")),
+        !log.contains(common::soldr_bin().to_string_lossy().as_ref()),
         "no-cache front door should not set soldr as wrapper: {log}"
     );
     assert!(

--- a/crates/soldr-cli/tests/cli_cook.rs
+++ b/crates/soldr-cli/tests/cli_cook.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 #[test]
 fn help_advertises_cook_subcommand() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("--help")
         .output()
         .expect("failed to run soldr --help");
@@ -26,7 +26,7 @@ fn help_advertises_cook_subcommand() {
 
 #[test]
 fn cook_help_describes_supported_flags() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cook", "--help"])
         .output()
         .expect("failed to run soldr cook --help");
@@ -48,7 +48,7 @@ fn cook_fails_when_no_cargo_toml_above_cwd() {
     // tempfile::tempdir which is usually under the system temp root — no
     // ancestor will contain Cargo.toml.
     let tmp = tempfile::tempdir().expect("tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("cook")
         .arg("--prepare-only")
         .current_dir(tmp.path())
@@ -74,7 +74,7 @@ fn cook_rejects_cook_only_without_recipe_path() {
         "[package]\nname = \"smoke\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
     )
     .unwrap();
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cook", "--cook-only"])
         .current_dir(tmp.path())
         .output()
@@ -96,7 +96,7 @@ fn cook_rejects_unknown_flag_before_passthrough_separator() {
         "[package]\nname = \"smoke\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
     )
     .unwrap();
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cook", "--definitely-not-a-flag"])
         .current_dir(tmp.path())
         .output()
@@ -138,7 +138,7 @@ fn cook_prepare_only_against_example_project_runs_end_to_end() {
     assert!(lock_status.success());
 
     let recipe = tmp.path().join("recipe.json");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cook", "--prepare-only", "--recipe-path"])
         .arg(&recipe)
         .current_dir(tmp.path())
@@ -309,7 +309,7 @@ fn wipe_target(project: &std::path::Path) {
 /// caller reads naturally; clap doesn't care about quoting at this
 /// level since none of our tokens contain spaces.
 fn time_soldr(project: &std::path::Path, leading: &[&str], tail: &str) -> (Duration, bool) {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_soldr"));
+    let mut cmd = Command::new(common::soldr_bin());
     cmd.args(leading);
     cmd.args(tail.split_whitespace());
     cmd.current_dir(project);

--- a/crates/soldr-cli/tests/cli_daemon_builds.rs
+++ b/crates/soldr-cli/tests/cli_daemon_builds.rs
@@ -14,6 +14,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use serde_json::Value;
 use soldr_cli::daemon::db;
 use soldr_cli::daemon::protocol::BuildRecord;
+mod common;
+
 
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -26,7 +28,7 @@ fn unique_temp_dir(label: &str) -> PathBuf {
 }
 
 fn soldr_daemon_bin() -> PathBuf {
-    let soldr = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let soldr = common::soldr_bin();
     let parent = soldr.parent().expect("parent");
     let stem = if cfg!(windows) {
         "soldr-daemon.exe"
@@ -37,7 +39,7 @@ fn soldr_daemon_bin() -> PathBuf {
 }
 
 fn run_soldr(args: &[&str], cache_root: &Path, home_root: &Path) -> std::process::Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_soldr"));
+    let mut cmd = Command::new(common::soldr_bin());
     cmd.args(args)
         .env("SOLDR_CACHE_DIR", cache_root)
         .env("HOME", home_root)

--- a/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
+++ b/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
@@ -14,6 +14,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 use soldr_cli::core::SoldrPaths;
+mod common;
+
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -50,7 +52,7 @@ fn unique_temp_dir(label: &str) -> PathBuf {
 }
 
 fn soldr_daemon_bin() -> PathBuf {
-    let soldr = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let soldr = common::soldr_bin();
     let parent = soldr.parent().expect("CARGO_BIN_EXE_soldr has a parent");
     let stem = if cfg!(windows) {
         "soldr-daemon.exe"
@@ -87,7 +89,7 @@ fn wait_for_ready(cache_root: &Path, deadline: Instant) -> bool {
 }
 
 fn run_soldr(args: &[&str], cache_root: &Path, home_root: &Path) -> std::process::Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_soldr"));
+    let mut cmd = Command::new(common::soldr_bin());
     cmd.args(args);
     for (k, v) in isolated_env(cache_root, home_root) {
         cmd.env(k, v);
@@ -244,7 +246,7 @@ fn install_servicedef_writes_running_process_definition() {
     });
     fs::write(&daemon_binary, b"stub daemon").expect("write fake daemon binary");
 
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_soldr"));
+    let mut cmd = Command::new(common::soldr_bin());
     cmd.args([
         "daemon",
         "install-servicedef",

--- a/crates/soldr-cli/tests/cli_daemon_target_touch.rs
+++ b/crates/soldr-cli/tests/cli_daemon_target_touch.rs
@@ -13,6 +13,8 @@ use soldr_cli::cache_lib::target_registry::TargetRegistry;
 use soldr_cli::daemon::client;
 use soldr_cli::daemon::lifecycle;
 use soldr_cli::daemon::protocol::Request;
+mod common;
+
 
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -25,7 +27,7 @@ fn unique_temp_dir(label: &str) -> PathBuf {
 }
 
 fn soldr_daemon_bin() -> PathBuf {
-    let soldr = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let soldr = common::soldr_bin();
     let parent = soldr.parent().expect("CARGO_BIN_EXE_soldr has a parent");
     let stem = if cfg!(windows) {
         "soldr-daemon.exe"

--- a/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
+++ b/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
@@ -17,6 +17,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use soldr_cli::daemon::{client, db};
 use soldr_cli::timed_test;
+mod common;
+
 
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -29,7 +31,7 @@ fn unique_temp_dir(label: &str) -> PathBuf {
 }
 
 fn soldr_daemon_bin() -> PathBuf {
-    let soldr = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let soldr = common::soldr_bin();
     let parent = soldr.parent().expect("parent");
     let stem = if cfg!(windows) {
         "soldr-daemon.exe"

--- a/crates/soldr-cli/tests/cli_dispatch.rs
+++ b/crates/soldr-cli/tests/cli_dispatch.rs
@@ -14,7 +14,7 @@ use std::{
 
 #[test]
 fn version_command_prints_workspace_version() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("version")
         .output()
         .expect("failed to run soldr version");
@@ -30,7 +30,7 @@ fn version_command_prints_workspace_version() {
 
 #[test]
 fn version_command_emits_versioned_json() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["version", "--json"])
         .output()
         .expect("failed to run soldr version --json");
@@ -46,7 +46,7 @@ fn version_command_emits_versioned_json() {
 
 #[test]
 fn help_lists_phase_one_command_surface() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .arg("--help")
         .output()
         .expect("failed to run soldr --help");

--- a/crates/soldr-cli/tests/cli_doctor.rs
+++ b/crates/soldr-cli/tests/cli_doctor.rs
@@ -167,7 +167,7 @@ fn doctor_reports_drift_when_component_missing() {
     // on the dev machine causes `soldr doctor` to exit 1 with empty
     // stdout — a real bug worth fixing in `resolve_pinned_zccache`
     // separately, but the test should be hermetic regardless.
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["doctor", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -232,7 +232,7 @@ fn doctor_reports_no_drift_when_everything_installed() {
     // on the dev machine causes `soldr doctor` to exit 1 with empty
     // stdout — a real bug worth fixing in `resolve_pinned_zccache`
     // separately, but the test should be hermetic regardless.
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["doctor", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -269,7 +269,7 @@ fn doctor_handles_missing_manifest() {
     // rustup will write to the log and exit non-zero.
     let rustup = install_failing_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["doctor"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -331,7 +331,7 @@ fn doctor_surfaces_local_zccache_override_when_env_var_set() {
     let log_path = tmp.join("rustup.log");
     let rustup = install_failing_fake_rustup(&log_path);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["doctor", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)
@@ -441,7 +441,7 @@ fn doctor_reports_missing_target() {
     // on the dev machine causes `soldr doctor` to exit 1 with empty
     // stdout — a real bug worth fixing in `resolve_pinned_zccache`
     // separately, but the test should be hermetic regardless.
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["doctor", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_TEST_RUSTUP_BIN", &rustup)

--- a/crates/soldr-cli/tests/cli_gc.rs
+++ b/crates/soldr-cli/tests/cli_gc.rs
@@ -17,7 +17,7 @@ fn gc_summary_is_non_destructive_and_lists_largest_candidates() {
     let cache_root = unique_temp_dir("gc-summary");
     let target = seed_gc_candidate(&cache_root, "summary-project");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "--older-than", "1s", "--larger-than", "1B"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -55,7 +55,7 @@ fn gc_summary_json_reports_candidates_without_deleting() {
     let cache_root = unique_temp_dir("gc-summary-json");
     let target = seed_gc_candidate(&cache_root, "summary-json-project");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "--json", "--older-than", "1s", "--larger-than", "1B"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -92,7 +92,7 @@ fn gc_purge_all_deletes_candidates_without_prompt() {
     let cache_root = unique_temp_dir("gc-purge-all");
     let target = seed_gc_candidate(&cache_root, "purge-project");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args([
             "gc",
             "purge",
@@ -124,7 +124,7 @@ fn gc_purge_enter_accepts_candidate() {
     let cache_root = unique_temp_dir("gc-purge-enter");
     let target = seed_gc_candidate(&cache_root, "purge-enter-project");
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let mut child = Command::new(common::soldr_bin())
         .args(["gc", "purge", "--older-than", "1s", "--larger-than", "1B"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .stdin(std::process::Stdio::piped())
@@ -169,7 +169,7 @@ fn gc_purge_all_json_reports_error_log_path_and_keeps_failed_row() {
     let cache_root = unique_temp_dir("gc-purge-json-failure");
     let target = seed_gc_file_candidate(&cache_root, "purge-json-failure-project");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args([
             "gc",
             "purge",
@@ -234,13 +234,13 @@ fn gc_list_json_reports_built_project_target_dir() {
     fs::create_dir_all(project_dir.join("src")).expect("failed to create src dir");
     fs::write(project_dir.join("src/main.rs"), "fn main() {}\n").expect("failed to write main.rs");
 
-    let soldr_bin = env!("CARGO_BIN_EXE_soldr");
+    let soldr_bin = common::soldr_bin();
     let cargo = rustup_which("cargo");
 
     let build = Command::new(&cargo)
         .args(["build", "--quiet"])
         .current_dir(&project_dir)
-        .env("RUSTC_WRAPPER", soldr_bin)
+        .env("RUSTC_WRAPPER", &soldr_bin)
         .env("SOLDR_CACHE_DIR", &cache_root)
         // This fixture intentionally exercises soldr as a plain
         // RUSTC_WRAPPER, not as a child of the outer `soldr cargo test`
@@ -266,7 +266,7 @@ fn gc_list_json_reports_built_project_target_dir() {
 
     let canonical_target = fs::canonicalize(&target_dir).unwrap_or_else(|_| target_dir.clone());
 
-    let output = Command::new(soldr_bin)
+    let output = Command::new(&soldr_bin)
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &sandbox_cargo_home)
@@ -360,7 +360,7 @@ fn gc_list_json_entries_include_kind_and_purge_safety_defaults() {
     let cache_root = unique_temp_dir("gc-list-kind-defaults");
     let target = seed_gc_candidate(&cache_root, "kind-defaults-project");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -415,7 +415,7 @@ fn gc_list_json_prunes_missing_registry_rows_in_one_pass() {
         );
     }
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &sandbox_cargo_home)
@@ -457,7 +457,7 @@ fn gc_list_json_prunes_missing_registry_rows_in_one_pass() {
 
 #[test]
 fn gc_flat_all_is_rejected_with_purge_hint() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "--all"])
         .env("SOLDR_CACHE_DIR", unique_temp_dir("gc-flat-all"))
         .output()

--- a/crates/soldr-cli/tests/cli_gc_extras.rs
+++ b/crates/soldr-cli/tests/cli_gc_extras.rs
@@ -18,7 +18,7 @@ use std::{
 
 #[test]
 fn gc_cargo_help_lists_max_flags_and_dry_run() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "cargo", "--help"])
         .output()
         .expect("failed to run soldr gc cargo --help");
@@ -48,7 +48,7 @@ fn gc_cargo_help_lists_max_flags_and_dry_run() {
 
 #[test]
 fn gc_cargo_rejects_unknown_flag() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "cargo", "--bogus-flag"])
         .output()
         .expect("failed to run soldr gc cargo --bogus-flag");
@@ -63,7 +63,7 @@ fn gc_cargo_rejects_unknown_flag() {
 #[test]
 fn gc_locations_json_emits_valid_schema_even_without_caches() {
     let cache_root = unique_temp_dir("gc-locations-json");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "locations", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         // Disable auto-GC so the test isn't affected by background work.
@@ -134,7 +134,7 @@ fn gc_sweep_no_cargo_dry_run_runs_end_to_end_without_changes() {
     let cache_root = unique_temp_dir("gc-sweep-dryrun");
     let target = seed_gc_candidate(&cache_root, "sweep-dryrun");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "sweep", "--no-cargo-gc", "--dry-run", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_AUTO_GC_DISABLED", "1")

--- a/crates/soldr-cli/tests/cli_gc_git_checkouts.rs
+++ b/crates/soldr-cli/tests/cli_gc_git_checkouts.rs
@@ -44,7 +44,7 @@ fn gc_list_json_walks_cargo_git_checkouts_under_cargo_home() {
     let _a = seed_git_checkout(&cargo_home, "tokio-abc123", "deadbeef1234");
     let _b = seed_git_checkout(&cargo_home, "serde-def456", "cafefacedeed");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &cargo_home)
@@ -96,7 +96,7 @@ fn gc_list_json_kind_filter_narrows_to_cargo_git_checkouts() {
     let cargo_home = fresh_cargo_home("gc-git-checkouts-filter-cargo");
     let _x = seed_git_checkout(&cargo_home, "tokio-abc", "abc123");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "list", "--json", "--kind", "cargo_git_checkouts"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &cargo_home)
@@ -123,7 +123,7 @@ fn gc_purge_git_checkouts_removes_checkout_directories() {
     let dir = seed_git_checkout(&cargo_home, "tokio-abc", "deadbeef");
     assert!(dir.is_dir());
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "purge", "--git-checkouts", "--all", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &cargo_home)
@@ -153,7 +153,7 @@ fn gc_purge_git_checkouts_removes_checkout_directories() {
 #[test]
 fn gc_purge_rejects_both_registry_src_and_git_checkouts() {
     let cache_root = unique_temp_dir("gc-purge-mutex-cache");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args([
             "gc",
             "purge",

--- a/crates/soldr-cli/tests/cli_gc_registry_src.rs
+++ b/crates/soldr-cli/tests/cli_gc_registry_src.rs
@@ -48,7 +48,7 @@ fn gc_list_json_walks_cargo_registry_src_under_cargo_home() {
     let serde_dir = seed_registry_src_crate(&cargo_home, "serde-1.0.213");
     let chrono_tz_dir = seed_registry_src_crate(&cargo_home, "chrono-tz-0.8.1");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &cargo_home)
@@ -135,7 +135,7 @@ fn gc_list_json_kind_filter_narrows_to_cargo_target() {
     let cargo_home = fresh_cargo_home("gc-list-kind-target-cargo");
     let serde_dir = seed_registry_src_crate(&cargo_home, "serde-1.0.213");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "list", "--json", "--kind", "cargo_target"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &cargo_home)
@@ -170,7 +170,7 @@ fn gc_list_json_kind_filter_narrows_to_cargo_registry_src() {
     let cargo_home = fresh_cargo_home("gc-list-kind-regsrc-cargo");
     let _serde_dir = seed_registry_src_crate(&cargo_home, "serde-1.0.213");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "list", "--json", "--kind", "cargo_registry_src"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &cargo_home)
@@ -202,7 +202,7 @@ fn gc_list_json_kind_filter_narrows_to_cargo_registry_src() {
 #[test]
 fn gc_list_unknown_kind_value_is_rejected() {
     let cache_root = unique_temp_dir("gc-list-bogus-kind");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "list", "--json", "--kind", "bogus"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -226,7 +226,7 @@ fn gc_purge_registry_src_all_deletes_walked_dirs() {
     let serde_dir = seed_registry_src_crate(&cargo_home, "serde-1.0.213");
     assert!(serde_dir.exists(), "precondition: seeded dir must exist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "purge", "--registry-src", "--all", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &cargo_home)
@@ -256,7 +256,7 @@ fn gc_purge_without_kind_does_not_touch_registry_src() {
     assert!(serde_dir.exists());
     assert!(target.exists());
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args([
             "gc",
             "purge",

--- a/crates/soldr-cli/tests/cli_gc_report_only.rs
+++ b/crates/soldr-cli/tests/cli_gc_report_only.rs
@@ -45,7 +45,7 @@ timed_test!(
         let (cache_root, cargo_home, rustup_home, _registry_cache) =
             seed_report_only_roots("gc-report-only-list");
 
-        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        let output = Command::new(common::soldr_bin())
             .args(["gc", "list", "--json"])
             .env("SOLDR_CACHE_DIR", &cache_root)
             .env("CARGO_HOME", &cargo_home)
@@ -102,7 +102,7 @@ timed_test!(gc_purge_report_only_kind_is_rejected_and_preserves_files, {
         seed_report_only_roots("gc-report-only-purge");
     assert!(registry_cache.exists());
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args([
             "gc",
             "purge",

--- a/crates/soldr-cli/tests/cli_gc_target.rs
+++ b/crates/soldr-cli/tests/cli_gc_target.rs
@@ -5,14 +5,17 @@
 
 #![allow(unused_imports)]
 
+mod common;
+
 use serde_json::Value;
 use soldr_cli::timed_test;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-fn soldr_bin() -> &'static str {
-    env!("CARGO_BIN_EXE_soldr")
+fn soldr_bin() -> std::path::PathBuf {
+    // soldr#1039 phase 1.
+    common::soldr_bin()
 }
 
 fn seed_workspace(root: &Path, name: &str, target_bytes: usize) -> PathBuf {

--- a/crates/soldr-cli/tests/cli_gc_target_subtrees.rs
+++ b/crates/soldr-cli/tests/cli_gc_target_subtrees.rs
@@ -74,7 +74,7 @@ timed_test!(gc_list_json_walks_target_subtree_kinds, {
     let target = seed_all_target_subtrees(&cache_root);
     let (cargo_home, rustup_home) = sandbox_env("gc-list-target-subtrees");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["gc", "list", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("CARGO_HOME", &cargo_home)
@@ -130,7 +130,7 @@ timed_test!(gc_purge_target_subtree_flags_delete_only_selected_kind, {
         );
         let (cargo_home, rustup_home) = sandbox_env(&label);
 
-        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        let output = Command::new(common::soldr_bin())
             .args(["gc", "purge", flag, "--all", "--json"])
             .env("SOLDR_CACHE_DIR", &cache_root)
             .env("CARGO_HOME", &cargo_home)

--- a/crates/soldr-cli/tests/cli_install_zccache.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache.rs
@@ -63,7 +63,7 @@ fn install_zccache_from_directory_writes_sidecar() {
     let home_root = unique_home_dir("install-zccache-dir");
     let src = seed_source_dir(&tmp);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["install-zccache"])
         .arg(&src)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -103,7 +103,7 @@ fn install_zccache_json_round_trip() {
     let src = seed_source_dir(&tmp);
 
     // install --json
-    let install = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let install = Command::new(common::soldr_bin())
         .args(["install-zccache", "--json"])
         .arg(&src)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -123,7 +123,7 @@ fn install_zccache_json_round_trip() {
     );
 
     // --status --json
-    let status = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let status = Command::new(common::soldr_bin())
         .args(["install-zccache", "--status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -143,7 +143,7 @@ fn install_zccache_json_round_trip() {
     );
 
     // --remove --json
-    let remove = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let remove = Command::new(common::soldr_bin())
         .args(["install-zccache", "--remove", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -156,7 +156,7 @@ fn install_zccache_json_round_trip() {
     assert_eq!(remove_json["removed"], true);
 
     // Second remove is idempotent: removed=false.
-    let remove2 = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let remove2 = Command::new(common::soldr_bin())
         .args(["install-zccache", "--remove", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -176,7 +176,7 @@ fn install_zccache_status_with_no_install_reports_managed_default() {
     fs::create_dir_all(&cache_root).unwrap();
     let home_root = unique_home_dir("install-zccache-status-empty");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["install-zccache", "--status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -196,7 +196,7 @@ fn install_zccache_no_source_no_flags_errors() {
     let cache_root = tmp.join("soldr-root");
     let home_root = unique_home_dir("install-zccache-empty-args");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["install-zccache"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -219,7 +219,7 @@ fn install_zccache_mutually_exclusive_flags_rejected() {
     let home_root = unique_home_dir("install-zccache-mutex");
 
     // clap should reject `--remove` + `--status` outright.
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["install-zccache", "--remove", "--status"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -233,7 +233,7 @@ fn install_zccache_mutually_exclusive_flags_rejected() {
     );
 
     // SOURCE + --remove is also rejected.
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["install-zccache", "system", "--remove"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -255,7 +255,7 @@ fn install_zccache_unknown_extension_errors() {
     let bogus = tmp.join("zccache.7z");
     fs::write(&bogus, b"junk").unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["install-zccache"])
         .arg(&bogus)
         .env("SOLDR_CACHE_DIR", &cache_root)

--- a/crates/soldr-cli/tests/cli_install_zccache_resolution.rs
+++ b/crates/soldr-cli/tests/cli_install_zccache_resolution.rs
@@ -437,7 +437,7 @@ fn install_then_doctor_subprocess_reports_pinned_active_source() {
     let pin_src = seed_pin_source(&tmp);
 
     // 1. Pin the staged binaries via the CLI.
-    let install = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let install = Command::new(common::soldr_bin())
         .args(["install-zccache", "--json"])
         .arg(&pin_src)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -455,7 +455,7 @@ fn install_then_doctor_subprocess_reports_pinned_active_source() {
     );
 
     // 2. soldr doctor --json must report active_zccache_source = pinned.
-    let doctor = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let doctor = Command::new(common::soldr_bin())
         .args(["doctor", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -485,7 +485,7 @@ fn install_then_doctor_subprocess_reports_pinned_active_source() {
 
     // 3. The new "active zccache source:" diagnostic line appears in the
     //    human output too.
-    let doctor_human = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let doctor_human = Command::new(common::soldr_bin())
         .args(["doctor"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -512,7 +512,7 @@ fn install_then_cache_subprocess_reports_pinned_source() {
     fs::create_dir_all(home_root.join(".soldr").join("bin")).expect("seed home/.soldr/bin");
     let pin_src = seed_pin_source(&tmp);
 
-    let install = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let install = Command::new(common::soldr_bin())
         .args(["install-zccache"])
         .arg(&pin_src)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -528,7 +528,7 @@ fn install_then_cache_subprocess_reports_pinned_source() {
     // executables — `zccache status` will fail to run them. That's
     // fine: `collect_zccache_status` handles the failure and the JSON
     // still contains `binary_source` per the new schema.
-    let cache = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let cache = Command::new(common::soldr_bin())
         .args(["cache", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)

--- a/crates/soldr-cli/tests/cli_optimize.rs
+++ b/crates/soldr-cli/tests/cli_optimize.rs
@@ -22,7 +22,7 @@ fn isolated_soldr_home() -> PathBuf {
 #[test]
 fn optimize_dry_run_json_runs_end_to_end_on_current_platform() {
     let soldr_home = isolated_soldr_home();
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["optimize", "--dry-run", "--json"])
         .current_dir(&soldr_home)
         .env("SOLDR_CACHE_DIR", &soldr_home)
@@ -68,7 +68,7 @@ fn optimize_dry_run_json_runs_end_to_end_on_current_platform() {
 #[test]
 fn optimize_ci_auto_skip_emits_skip_message() {
     let soldr_home = isolated_soldr_home();
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["optimize", "--json"])
         .current_dir(&soldr_home)
         .env("SOLDR_CACHE_DIR", &soldr_home)
@@ -102,7 +102,7 @@ fn optimize_ci_auto_skip_emits_skip_message() {
 #[test]
 fn optimize_project_scope_errors_when_no_cargo_toml() {
     let workspace = unique_temp_dir("soldr-optimize-no-cargo");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["optimize", "--scope", "project", "--dry-run", "--json"])
         .current_dir(&workspace)
         .env_remove("GITHUB_ACTIONS")
@@ -143,7 +143,7 @@ fn optimize_invokes_add_mppreference_with_admin_seam() {
     )
     .expect("Cargo.toml");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["optimize", "--scope", "all", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_CACHE_DIR", &soldr_home)
@@ -238,7 +238,7 @@ fn optimize_undo_only_removes_managed_paths() {
 
     let defender_log = soldr_home.join("defender.log");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["optimize", "--undo", "--scope", "global", "--json"])
         .current_dir(&workspace)
         .env("SOLDR_CACHE_DIR", &soldr_home)
@@ -283,7 +283,7 @@ fn optimize_undo_only_removes_managed_paths() {
 #[test]
 fn defender_exclusions_check_returns_dry_run_json() {
     let soldr_home = isolated_soldr_home();
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["defender-exclusions", "check", "--json"])
         .current_dir(&soldr_home)
         .env("SOLDR_CACHE_DIR", &soldr_home)
@@ -322,7 +322,7 @@ fn defender_exclusions_remove_maps_to_undo() {
     // CI auto-skip lets us prove the dispatch wires `remove` to undo
     // semantics without touching the real subsystem.
     let soldr_home = isolated_soldr_home();
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["defender-exclusions", "remove", "--json"])
         .current_dir(&soldr_home)
         .env("SOLDR_CACHE_DIR", &soldr_home)
@@ -346,7 +346,7 @@ fn defender_exclusions_remove_maps_to_undo() {
 #[test]
 fn defender_exclusions_add_dry_run_does_not_invoke_powershell() {
     let soldr_home = isolated_soldr_home();
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["defender-exclusions", "add", "--dry-run", "--json"])
         .current_dir(&soldr_home)
         .env("SOLDR_CACHE_DIR", &soldr_home)
@@ -377,7 +377,7 @@ fn defender_exclusions_add_dry_run_does_not_invoke_powershell() {
 
 #[test]
 fn defender_exclusions_help_lists_verbs() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["defender-exclusions", "--help"])
         .output()
         .expect("failed to run soldr defender-exclusions --help");
@@ -393,7 +393,7 @@ fn defender_exclusions_help_lists_verbs() {
 
 #[test]
 fn optimize_help_lists_scope_values() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["optimize", "--help"])
         .output()
         .expect("failed to run soldr optimize --help");

--- a/crates/soldr-cli/tests/cli_rust_plan.rs
+++ b/crates/soldr-cli/tests/cli_rust_plan.rs
@@ -70,7 +70,7 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
         .expect("write metadata fixture");
 
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build", "--locked"])
         .current_dir(&workspace)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -174,7 +174,7 @@ fn cargo_front_door_warns_when_rust_plan_restore_is_partial() {
         .expect("write metadata fixture");
 
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build", "--locked"])
         .current_dir(&workspace)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -217,7 +217,7 @@ fn cargo_front_door_recovers_from_stale_zccache_daemon_start() {
     let log_path = cache_root.join("tool.log");
     let stale_marker = cache_root.join("stale-zccache-start");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -265,7 +265,7 @@ fn cargo_front_door_removes_stale_zccache_daemon_lock_before_retry() {
     let log_path = cache_root.join("tool.log");
     let stale_marker = cache_root.join("stale-zccache-lock");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("ZCCACHE_CACHE_DIR", &zccache_session_dir)

--- a/crates/soldr-cli/tests/cli_toolchain.rs
+++ b/crates/soldr-cli/tests/cli_toolchain.rs
@@ -822,10 +822,11 @@ fn toolchain_link_writes_every_routed_tool_into_shim_dir() {
         );
         // The shim must reference the running soldr binary so subprocess
         // exec lands back on this build.
-        let soldr_bin = env!("CARGO_BIN_EXE_soldr");
+        let soldr_bin = common::soldr_bin();
         assert!(
-            body.contains(soldr_bin),
-            "shim body for {tool} should reference soldr binary {soldr_bin}: {body}"
+            body.contains(soldr_bin.to_string_lossy().as_ref()),
+            "shim body for {tool} should reference soldr binary {}: {body}",
+            soldr_bin.display(),
         );
     }
 }

--- a/crates/soldr-cli/tests/cli_toolchain_doctor.rs
+++ b/crates/soldr-cli/tests/cli_toolchain_doctor.rs
@@ -21,7 +21,7 @@ timed_test!(
     {
         let workspace = unique_temp_dir("toolchain-doctor-json");
 
-        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        let output = Command::new(common::soldr_bin())
             .args(["toolchain", "doctor", "--json"])
             .current_dir(&workspace)
             .output()
@@ -71,7 +71,7 @@ timed_test!(
     {
         let workspace = unique_temp_dir("toolchain-doctor-human");
 
-        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        let output = Command::new(common::soldr_bin())
             .args(["toolchain", "doctor"])
             .current_dir(&workspace)
             .output()
@@ -116,7 +116,7 @@ timed_test!(
         fs::create_dir_all(&fingerprint).expect("mkdir fingerprint");
         fs::write(fingerprint.join("invoked.timestamp"), "").expect("seed fingerprint");
 
-        let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+        let output = Command::new(common::soldr_bin())
             .args(["toolchain", "doctor", "--json"])
             .current_dir(&workspace)
             .output()

--- a/crates/soldr-cli/tests/cli_wrapper.rs
+++ b/crates/soldr-cli/tests/cli_wrapper.rs
@@ -14,7 +14,7 @@ use std::{
 
 #[test]
 fn rustup_resolution_failure_reports_raw_error_and_ci_guidance() {
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["--no-cache", "rustc", "--version"])
         .env("RUSTUP_TOOLCHAIN", "soldr-ci-missing-toolchain")
         .output()
@@ -73,7 +73,7 @@ fn cargo_front_door_forces_msvc_target_even_with_polluted_path() {
         .join("tests")
         .join("fixtures")
         .join("windows-msvc-default");
-    let output = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let output = Command::new(common::soldr_bin())
         .args(["--no-cache", "cargo", "build"])
         .current_dir(&fixture)
         .env("PATH", prepend_to_path(&fake_tools))
@@ -132,7 +132,7 @@ fn wrapper_mode_stdin_source_propagates_nonzero_exit_code() {
 
     // Invoke soldr as RUSTC_WRAPPER: soldr <rustc-path> - <flags...>
     // Disable the cache to avoid a zccache binary being required.
-    let mut child = Command::new(env!("CARGO_BIN_EXE_soldr"))
+    let mut child = Command::new(common::soldr_bin())
         .args([
             rustc.as_str(),
             "-",

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -16,8 +16,37 @@ use std::{
 
 static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Resolve the soldr binary path for tests. Prefers the `SOLDR_BIN`
+/// env var so a runner that downloaded a pre-built artifact can point
+/// the tests at it; falls back to `env!("CARGO_BIN_EXE_soldr")` so
+/// local `cargo test` keeps working without setup.
+///
+/// soldr#1039 / #1038 phase 1: `env!` expands at compile time, baking
+/// the build-machine's absolute path into the test binary. On a target
+/// runner that downloaded the test artifact from a Linux builder,
+/// that path doesn't exist. This helper centralizes the lookup so
+/// production CI can set `SOLDR_BIN` explicitly without touching any
+/// test code.
+pub(crate) fn soldr_bin() -> PathBuf {
+    if let Some(p) = std::env::var_os("SOLDR_BIN") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(env!("CARGO_BIN_EXE_soldr"))
+}
+
+/// Companion to `soldr_bin` for tests that need the daemon binary.
+/// Prefers `SOLDR_DAEMON_BIN`; falls back to the in-crate compile-time
+/// path. soldr#1039.
+#[allow(dead_code)]
+pub(crate) fn soldr_daemon_bin() -> PathBuf {
+    if let Some(p) = std::env::var_os("SOLDR_DAEMON_BIN") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(env!("CARGO_BIN_EXE_soldr-daemon"))
+}
+
 pub(crate) fn isolated_soldr_command() -> Command {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_soldr"));
+    let mut command = Command::new(soldr_bin());
     scrub_outer_soldr_env(&mut command);
     command
 }

--- a/crates/soldr-cli/tests/cook_hydrate_preflight.rs
+++ b/crates/soldr-cli/tests/cook_hydrate_preflight.rs
@@ -31,6 +31,8 @@ use soldr_cli::daemon::client::{
 };
 use soldr_cli::timed_test;
 
+mod common;
+
 const HARNESS_ENV: &str = "SOLDR_COOK_DOCKER_HARNESS";
 
 fn harness_enabled() -> bool {
@@ -67,7 +69,7 @@ fn write_file(p: &Path, bytes: &[u8]) {
 }
 
 fn soldr_daemon_bin() -> PathBuf {
-    let soldr = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let soldr = common::soldr_bin();
     let parent = soldr.parent().expect("CARGO_BIN_EXE_soldr has a parent");
     let stem = if cfg!(windows) {
         "soldr-daemon.exe"
@@ -78,7 +80,7 @@ fn soldr_daemon_bin() -> PathBuf {
 }
 
 fn soldr_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_soldr"))
+    common::soldr_bin()
 }
 
 fn run_git_in(dir: &Path, args: &[&str]) {
@@ -264,6 +266,7 @@ timed_test!(
         else {
             panic!("expected CookHit");
         };
+
         assert_eq!(sha256, packed.sha256);
         assert_eq!(size_bytes, packed.size_bytes);
 

--- a/crates/soldr-cli/tests/cook_writes_index.rs
+++ b/crates/soldr-cli/tests/cook_writes_index.rs
@@ -30,6 +30,8 @@ use soldr_cli::core::git::{
 use soldr_cli::daemon::client::{self, cook_lookup, cook_record, CookLookupOutcome};
 use soldr_cli::timed_test;
 
+mod common;
+
 const HARNESS_ENV: &str = "SOLDR_COOK_DOCKER_HARNESS";
 
 fn harness_enabled() -> bool {
@@ -66,13 +68,14 @@ fn write_file(p: &Path, bytes: &[u8]) {
 }
 
 fn soldr_daemon_bin() -> PathBuf {
-    let soldr = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let soldr = common::soldr_bin();
     let parent = soldr.parent().expect("CARGO_BIN_EXE_soldr has a parent");
     let stem = if cfg!(windows) {
         "soldr-daemon.exe"
     } else {
         "soldr-daemon"
     };
+
     parent.join(stem)
 }
 

--- a/crates/soldr-cli/tests/daemon_cook_index.rs
+++ b/crates/soldr-cli/tests/daemon_cook_index.rs
@@ -29,6 +29,8 @@ use soldr_cli::daemon::client::{self, cook_lookup, cook_record, cook_touch, Cook
 use soldr_cli::daemon::protocol::Response;
 use soldr_cli::timed_test;
 
+mod common;
+
 const HARNESS_ENV: &str = "SOLDR_COOK_DOCKER_HARNESS";
 
 fn harness_enabled() -> bool {
@@ -60,7 +62,7 @@ fn unique_temp_dir(label: &str) -> PathBuf {
 }
 
 fn soldr_daemon_bin() -> PathBuf {
-    let soldr = PathBuf::from(env!("CARGO_BIN_EXE_soldr"));
+    let soldr = common::soldr_bin();
     let parent = soldr.parent().expect("CARGO_BIN_EXE_soldr has a parent");
     let stem = if cfg!(windows) {
         "soldr-daemon.exe"
@@ -414,6 +416,7 @@ timed_test!(
         else {
             panic!("expected mac hit")
         };
+
 
         assert_eq!(linux_sha, [0xAAu8; 32]);
         assert_eq!(linux_size, 100);


### PR DESCRIPTION
Closes #1039. Phase 1 of #1038 — CI refactor cross-build prep.

## What

Add `tests/common::soldr_bin()` + `soldr_daemon_bin()` helpers that prefer `SOLDR_BIN` / `SOLDR_DAEMON_BIN` env vars, falling back to `env!(CARGO_BIN_EXE_*)` for local-dev. Mechanically refactored **131 direct call sites** across **34 integration test files** to go through the helper.

## Why

`env!` expands at compile time, baking the build-machine's absolute path into the test binary. On a target runner that downloads the test artifact from a Linux cross-builder (the #1038 design), that path doesn't exist. The helper centralizes the lookup.

## Behavioral equivalence

Zero behavioral change when `SOLDR_BIN` is unset — `soldr_bin()` returns exactly the same `PathBuf::from(env!(CARGO_BIN_EXE_soldr))` as the original sites did.

## Scope

* `tests/common::soldr_bin()` / `soldr_daemon_bin()` — single source of truth
* 131 mechanical replacements via python script
* 8 files got `mod common;` declarations added (they previously had local `fn soldr_bin()` helpers — those now delegate to `common::soldr_bin()`)
* 2 special cases hand-fixed for PathBuf-vs-\&str ownership/format (`cli_gc.rs:237`, `cli_toolchain.rs:825`)

`cargo test -p soldr-cli --tests --no-run` compiles cleanly across the whole crate.