### PR TITLE
refactor(tests): SOLDR_TEST_SKIP_SOURCE_TREE marker + fixtures_dir helper (#1040)

### DIFF
--- a/crates/soldr-cli/src/prepare_cmd.rs
+++ b/crates/soldr-cli/src/prepare_cmd.rs
@@ -1287,6 +1287,16 @@ mod tests {
         // Every entry must classify cleanly via the fuzzy classifier
         // — typos in soldr's own manifest fail at test time, not
         // mid-CI when `soldr prepare --target all` blows up.
+        //
+        // soldr#1040 phase 2: source-tree-coupled — skip on cross-build
+        // target runners that don't have the workspace checked out.
+        if std::env::var_os("SOLDR_TEST_SKIP_SOURCE_TREE").is_some() {
+            eprintln!(
+                "skipping soldr_workspace_metadata_dogfood: \
+                 SOLDR_TEST_SKIP_SOURCE_TREE is set (soldr#1040)"
+            );
+            return;
+        }
         let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .expect("workspace parent of crate dir")

--- a/crates/soldr-cli/tests/canonical_targets_parity.rs
+++ b/crates/soldr-cli/tests/canonical_targets_parity.rs
@@ -9,10 +9,18 @@
 //! (corrupt TOML, missing file in a container build) only fails
 //! THIS file, not the rest of the integration tests.
 
+mod common;
+
 use soldr_cli::core::CANONICAL_TARGETS;
 use soldr_cli::timed_test;
 
 timed_test!(canonical_const_matches_workspace_metadata, {
+    // soldr#1040 phase 2: source-tree-coupled — skip on runners that
+    // don't have the workspace checked out (target-run jobs in the
+    // cross-build CI shape).
+    if common::should_skip_source_tree_test("canonical_const_matches_workspace_metadata") {
+        return;
+    }
     // Walk up from the test binary's directory to find the workspace
     // root. Cargo gives us `CARGO_MANIFEST_DIR` for the bin crate
     // (`crates/soldr-cli`); the workspace root is its parent's

--- a/crates/soldr-cli/tests/cli_wrapper.rs
+++ b/crates/soldr-cli/tests/cli_wrapper.rs
@@ -69,10 +69,20 @@ fn cargo_front_door_forces_msvc_target_even_with_polluted_path() {
     .expect("failed to write fake rustc.cmd");
 
     let target_dir = unique_temp_dir("target-dir");
-    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("windows-msvc-default");
+    // soldr#1040 phase 2: resolve fixtures via SOLDR_TEST_FIXTURES_DIR
+    // with CARGO_MANIFEST_DIR fallback so a runner that downloaded
+    // fixtures alongside the test binary works without code changes.
+    let fixture = common::fixtures_dir().join("windows-msvc-default");
+    if !fixture.is_dir() {
+        if common::should_skip_source_tree_test("wrapper_routes_msvc_default_through_msys_bash") {
+            return;
+        }
+        panic!(
+            "windows-msvc-default fixture not found at {} — \
+             SOLDR_TEST_FIXTURES_DIR may need to be set",
+            fixture.display()
+        );
+    }
     let output = Command::new(common::soldr_bin())
         .args(["--no-cache", "cargo", "build"])
         .current_dir(&fixture)

--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -45,6 +45,43 @@ pub(crate) fn soldr_daemon_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_soldr-daemon"))
 }
 
+/// soldr#1040 / #1038 phase 2: runtime skip marker for tests that
+/// genuinely require the source tree on disk (workspace Cargo.toml
+/// walks, `src/`-tree scans, fixture-directory reads, etc.). When
+/// `SOLDR_TEST_SKIP_SOURCE_TREE` is set, these tests early-return.
+/// Default OFF — local `cargo test` exercises them as before.
+///
+/// On the cross-build CI flow (target runner downloaded a pre-built
+/// test artifact + has no source tree checked out), the workflow
+/// step that invokes `nextest run` sets `SOLDR_TEST_SKIP_SOURCE_TREE=1`
+/// so these tests skip cleanly instead of erroring on `read_to_string`
+/// against a non-existent path.
+#[allow(dead_code)]
+pub(crate) fn should_skip_source_tree_test(test_name: &str) -> bool {
+    if std::env::var_os("SOLDR_TEST_SKIP_SOURCE_TREE").is_some() {
+        eprintln!(
+            "skipping {test_name}: SOLDR_TEST_SKIP_SOURCE_TREE is set \
+             (source tree not present on this runner — soldr#1040)"
+        );
+        return true;
+    }
+    false
+}
+
+/// Resolve the test-fixtures directory. Prefers `SOLDR_TEST_FIXTURES_DIR`
+/// (set by the cross-build CI when fixtures are packaged separately
+/// from the test binary); falls back to `<CARGO_MANIFEST_DIR>/tests/fixtures`
+/// for local-dev. soldr#1040 / #1038 phase 2.
+#[allow(dead_code)]
+pub(crate) fn fixtures_dir() -> PathBuf {
+    if let Some(p) = std::env::var_os("SOLDR_TEST_FIXTURES_DIR") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}
+
 pub(crate) fn isolated_soldr_command() -> Command {
     let mut command = Command::new(soldr_bin());
     scrub_outer_soldr_env(&mut command);

--- a/crates/soldr-cli/tests/monocrate_guard.rs
+++ b/crates/soldr-cli/tests/monocrate_guard.rs
@@ -28,6 +28,8 @@
 //!   `CLAUDE.md`. All three should move together so the next
 //!   contributor finds the new shape documented.
 
+mod common;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -37,6 +39,10 @@ const ALLOWED_WORKSPACE_MEMBERS: &[&str] = &["crates/soldr-cli"];
 
 #[test]
 fn workspace_members_contains_exactly_the_allowed_set() {
+    // soldr#1040 phase 2: source-tree-coupled.
+    if common::should_skip_source_tree_test("workspace_members_contains_exactly_the_allowed_set") {
+        return;
+    }
     let root = workspace_root();
     let manifest_path = root.join("Cargo.toml");
     let raw = fs::read_to_string(&manifest_path)
@@ -73,6 +79,9 @@ fn workspace_members_contains_exactly_the_allowed_set() {
 
 #[test]
 fn exactly_one_cargo_toml_under_crates() {
+    if common::should_skip_source_tree_test("exactly_one_cargo_toml_under_crates") {
+        return;
+    }
     let root = workspace_root();
     let crates_dir = root.join("crates");
     let entries = fs::read_dir(&crates_dir)

--- a/crates/soldr-cli/tests/timed_test_lint.rs
+++ b/crates/soldr-cli/tests/timed_test_lint.rs
@@ -38,6 +38,8 @@ use std::path::{Path, PathBuf};
 
 use soldr_cli::timed_test;
 
+mod common;
+
 /// Files that still contain bare `#[test]` declarations. New entries
 /// should NOT be added without explicit reviewer sign-off — migrate
 /// the file to `timed_test!` instead. The list is sorted to make diffs
@@ -237,6 +239,11 @@ fn relative_unix_path(abs: &Path, root: &Path) -> Option<String> {
 }
 
 timed_test!(every_test_uses_timed_test_macro_or_is_allowlisted, {
+    // soldr#1040 phase 2: source-tree-coupled — scans src/ + tests/
+    // directories from disk. Skip on cross-build target runners.
+    if common::should_skip_source_tree_test("every_test_uses_timed_test_macro_or_is_allowlisted") {
+        return;
+    }
     let root = crate_root();
     let mut files = Vec::new();
     collect_rs_files(&root.join("src"), &mut files);


### PR DESCRIPTION
Closes #1040. Phase 2 of #1038.

## What
- `common::should_skip_source_tree_test()` — runtime guard, returns true when `SOLDR_TEST_SKIP_SOURCE_TREE` is set
- `common::fixtures_dir()` — prefers `SOLDR_TEST_FIXTURES_DIR`, falls back to `<CARGO_MANIFEST_DIR>/tests/fixtures`
- 6 source-tree-coupled tests now use the guard, 1 fixture loader uses the helper

## Tested
- Default: tests run normally
- `SOLDR_TEST_SKIP_SOURCE_TREE=1`: tests early-return in 0.00s