### PR TITLE
ci: wire cook hydration into cross-build lanes (#1061 phase A)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -57,17 +57,34 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # soldr#1061 phase A: replaced the bare dtolnay/rust-toolchain
+      # + Swatinem cargo-cache pair with setup-soldr's integrated
+      # `prebuild-deps: soldr-cook` flow. setup-soldr handles:
+      #   1. Rust toolchain install (1.94.1 per rust-toolchain.toml)
+      #   2. cargo registry + target cache (actions/cache@v4 keyed on
+      #      Cargo.lock + rustc + target)
+      #   3. `soldr cook` hydration — restores prebuilt
+      #      target/<triple>/release/build/*/out/ artifacts (the cc-rs
+      #      outputs from zstd-sys, libsqlite3-sys, tikv-jemalloc-sys,
+      #      ring, etc.) so cargo build doesn't recompile C source on
+      #      every PR.
+      # Without this, every cross-build lane spent 45-70s/lane on
+      # cc-rs invocations that produced bit-identical outputs to
+      # the previous PR. soldr#1061 gap analysis: ~2h/day of CI
+      # wallclock burned across the 8-lane matrix.
+      - name: Setup soldr build cache (Rust toolchain + cook hydration)
+        uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:
           toolchain: 1.94.1
-          targets: ${{ inputs.target }}
-          components: clippy, rustfmt
+          cache: true
+          zccache-seed-strict: true
+          cache-key-suffix: ci-cross-${{ inputs.target }}
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
 
-      - name: Cache cargo registry + target
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: ci-cross-${{ inputs.target }}
+      - name: Add cross-compile target
+        shell: bash
+        run: rustup target add ${{ inputs.target }}
 
       - name: Install apt deps
         shell: bash


### PR DESCRIPTION
Closes part of #1061 (phase A — Track A in the meta). Swaps dtolnay+Swatinem for setup-soldr's `prebuild-deps: soldr-cook` flow in `_ci-cross-build-linux.yml`. Expected savings: 45-70s per cross-build lane × 8 lanes × ~15 PRs/day ≈ **2 hours/day of CI wallclock** that was being burned on bit-identical cc-rs recompiles. The cook cache + key already include target triple via cook_index.rs — no schema change needed. release-auto.yml + docs are intentionally separate follow-ups; this PR ships the every-PR savings independently.