### PR TITLE
ci(release): wire cook hydration into release-auto.yml build job (#1061 phase A followup)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -225,11 +225,26 @@ jobs:
           submodules: recursive
           ref: ${{ needs.prepare.outputs.commit_sha }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # soldr#1061 phase A: replaced dtolnay/rust-toolchain +
+      # Swatinem/rust-cache with setup-soldr's integrated
+      # `prebuild-deps: soldr-cook` flow so the release build benefits
+      # from the same `target/<triple>/release/build/*/out/` cc-rs-
+      # artifact restore that every-commit CI now uses. Saves the
+      # 45-70s/lane that release builds were spending on bit-identical
+      # libsqlite3-sys / tikv-jemalloc-sys / zstd-sys / ring rebuilds.
+      - name: Setup soldr build cache (Rust toolchain + cook hydration)
+        uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:
           toolchain: 1.94.1
-          targets: ${{ matrix.target }}
+          cache: true
+          zccache-seed-strict: true
+          cache-key-suffix: release-${{ matrix.target }}
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
+
+      - name: Add cross-compile target
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
 
       # Mirrors `_bootstrap-e2e.yml`'s musl-tools install: retried apt
       # update + install, --no-install-recommends to narrow the input
@@ -329,10 +344,8 @@ jobs:
         shell: bash
         run: bash .github/scripts/make_zig_cc_wrappers.sh "${{ matrix.target }}"
 
-      - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: release-${{ matrix.target }}
+      # (Cargo registry + target cache is handled by setup-soldr's
+      # `cache: true` input above per soldr#1061.)
 
       - name: Build release binary
         shell: bash


### PR DESCRIPTION
Closes part of #1061 (phase A — release-auto leg). Same swap as PR #1062 but for the release build matrix. setup-soldr installs Rust + cargo cache + cook hydration; Swatinem dropped since setup-soldr's `cache: true` covers it.