### PR TITLE
feat(blessed-build): scaffold *-sys catalogue overrides (#1064 phase B)

### DIFF
--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -178,7 +178,139 @@ pub async fn prepare(
         }
     }
 
+    // -------------------------- *-sys library overrides ----------------------
+    // soldr#1064 Phase B. For each registered *-sys library, try to
+    // materialize the catalogue sysroot for the active target. On
+    // success, push the crate-specific override env vars so the *-sys
+    // build.rs skips its vendored compile. On error (not yet ingested,
+    // unsupported triple, network failure), log + fall through — the
+    // crate's vendored compile path still works.
+    if !legacy_vendored_sys_opt_out() {
+        inject_sys_library_overrides(paths, target_triple, &mut prep).await;
+    }
+
     Ok(prep)
+}
+
+/// Env var that opts out of the entire `*-sys` catalogue-substitution
+/// path and falls through to each crate's vendored compile. Set to any
+/// non-empty value (other than `"0"`) to trigger. Mirrors the
+/// `SOLDR_USE_LEGACY_{XWIN,ZIGBUILD}` env-var contract.
+pub const USE_LEGACY_VENDORED_SYS_ENV_VAR: &str = "SOLDR_USE_LEGACY_VENDORED_SYS";
+
+fn legacy_vendored_sys_opt_out() -> bool {
+    std::env::var(USE_LEGACY_VENDORED_SYS_ENV_VAR)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+}
+
+/// Per-*-sys-crate catalogue substitution. Each block follows the same
+/// shape: call the consumer module's `ensure_<lib>_sysroot`, and on
+/// success push the override env vars. Failures are logged but never
+/// fatal — the *-sys crate's vendored compile remains the safety net.
+async fn inject_sys_library_overrides(
+    paths: &SoldrPaths,
+    target_triple: &str,
+    prep: &mut BlessedPrep,
+) {
+    // zstd-sys → ZSTD_SYS_USE_PKG_CONFIG=1 + PKG_CONFIG_PATH
+    match crate::fetch::zstd_sysroot::ensure_zstd_sysroot(paths, target_triple).await {
+        Ok(sysroot) => {
+            prep.env
+                .push(("ZSTD_SYS_USE_PKG_CONFIG".to_string(), "1".to_string()));
+            prepend_pkg_config_path(prep, &sysroot);
+        }
+        Err(e) => log_sys_unavailable("zstd", target_triple, &e),
+    }
+
+    // libsqlite3-sys → LIBSQLITE3_SYS_USE_PKG_CONFIG=1 + PKG_CONFIG_PATH
+    match crate::fetch::sqlite_sysroot::ensure_sqlite_sysroot(paths, target_triple).await {
+        Ok(sysroot) => {
+            prep.env
+                .push(("LIBSQLITE3_SYS_USE_PKG_CONFIG".to_string(), "1".to_string()));
+            prepend_pkg_config_path(prep, &sysroot);
+        }
+        Err(e) => log_sys_unavailable("sqlite", target_triple, &e),
+    }
+
+    // tikv-jemalloc-sys → JEMALLOC_OVERRIDE=<lib>/libjemalloc.a
+    match crate::fetch::jemalloc_sysroot::ensure_jemalloc_sysroot(paths, target_triple).await {
+        Ok(sysroot) => {
+            let lib = sysroot.join("lib").join("libjemalloc.a");
+            prep.env.push((
+                "JEMALLOC_OVERRIDE".to_string(),
+                lib.to_string_lossy().into_owned(),
+            ));
+        }
+        Err(e) => log_sys_unavailable("jemalloc", target_triple, &e),
+    }
+
+    // libmimalloc-sys → MIMALLOC_OVERRIDE=<lib>/libmimalloc.a
+    match crate::fetch::mimalloc_sysroot::ensure_mimalloc_sysroot(paths, target_triple).await {
+        Ok(sysroot) => {
+            let lib = sysroot.join("lib").join("libmimalloc.a");
+            prep.env.push((
+                "MIMALLOC_OVERRIDE".to_string(),
+                lib.to_string_lossy().into_owned(),
+            ));
+        }
+        Err(e) => log_sys_unavailable("mimalloc", target_triple, &e),
+    }
+
+    // libz-ng-sys → PKG_CONFIG_PATH (pkg-config-only contract)
+    match crate::fetch::zlib_ng_sysroot::ensure_zlib_ng_sysroot(paths, target_triple).await {
+        Ok(sysroot) => prepend_pkg_config_path(prep, &sysroot),
+        Err(e) => log_sys_unavailable("zlib-ng", target_triple, &e),
+    }
+
+    // lzma-sys → LZMA_API_STATIC=1 + PKG_CONFIG_PATH
+    match crate::fetch::lzma_sysroot::ensure_lzma_sysroot(paths, target_triple).await {
+        Ok(sysroot) => {
+            prep.env
+                .push(("LZMA_API_STATIC".to_string(), "1".to_string()));
+            prepend_pkg_config_path(prep, &sysroot);
+        }
+        Err(e) => log_sys_unavailable("lzma", target_triple, &e),
+    }
+
+    // bzip2-sys → PKG_CONFIG_PATH (pkg-config-only contract)
+    match crate::fetch::bzip2_sysroot::ensure_bzip2_sysroot(paths, target_triple).await {
+        Ok(sysroot) => prepend_pkg_config_path(prep, &sysroot),
+        Err(e) => log_sys_unavailable("bzip2", target_triple, &e),
+    }
+}
+
+/// Prepend `<sysroot>/lib/pkgconfig` to whatever `PKG_CONFIG_PATH`
+/// value is already queued on `prep.env`. Multiple sysroots stack via
+/// repeated calls (last-wins lookup order = first-pushed sysroot).
+fn prepend_pkg_config_path(prep: &mut BlessedPrep, sysroot: &std::path::Path) {
+    let pkgconfig_dir = sysroot.join("lib").join("pkgconfig");
+    let new_entry = pkgconfig_dir.to_string_lossy().into_owned();
+    // If a prior call already pushed a PKG_CONFIG_PATH entry, prepend
+    // to it rather than clobbering. cargo + the child cargo will see
+    // the final composed value at child-process spawn time.
+    if let Some(existing) = prep
+        .env
+        .iter_mut()
+        .find(|(name, _)| name == "PKG_CONFIG_PATH")
+    {
+        let sep = if cfg!(windows) { ';' } else { ':' };
+        existing.1 = format!("{new_entry}{sep}{}", existing.1);
+    } else {
+        prep.env
+            .push(("PKG_CONFIG_PATH".to_string(), new_entry));
+    }
+}
+
+fn log_sys_unavailable(lib_name: &str, target_triple: &str, err: &SoldrError) {
+    eprintln!(
+        "soldr build: catalogue {lib_name} sysroot unavailable for \
+         {target_triple}: {err}"
+    );
+    eprintln!(
+        "soldr build: continuing — {lib_name}-sys will compile from its \
+         vendored C source as usual"
+    );
 }
 
 fn legacy_xwin_opt_out() -> bool {

--- a/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
@@ -1,0 +1,97 @@
+//! bzip2 (libbz2) sysroot fetcher — soldr#1064 Phase B.
+//!
+//! Consumes the soldr-toolchain `recipes/bzip2-<platform>/` catalogue
+//! rows. Each row ships:
+//!
+//! ```
+//! lib/libbz2.{a,lib}
+//! lib/pkgconfig/bzip2.pc
+//! include/bzlib.h
+//! ```
+//!
+//! When `bzip2-sys` is in the transitive deps and the catalogue row is
+//! ingested, the blessed path exports `PKG_CONFIG_PATH` pointing at the
+//! materialized `lib/pkgconfig/` directory so `bzip2-sys`' build.rs
+//! uses pkg-config to locate the precompiled libbz2 instead of
+//! recompiling the in-tree bzip2 sources (1-3s).
+//!
+//! Lowest-cost crate in the in-scope list — included for completeness
+//! since the recipe pattern is identical.
+
+use std::path::PathBuf;
+
+use crate::core::{SoldrError, SoldrPaths};
+
+pub const MANAGED_BZIP2_VERSION: &str = "1.0.8";
+
+pub const BZIP2_TARGETS: &[(&str, &str)] = &[
+    ("x86_64-pc-windows-msvc", "windows-x64"),
+    ("aarch64-pc-windows-msvc", "windows-arm64"),
+    ("x86_64-apple-darwin", "darwin-x64"),
+    ("aarch64-apple-darwin", "darwin-arm64"),
+    ("x86_64-unknown-linux-gnu", "linux-x64-gnu"),
+    ("aarch64-unknown-linux-gnu", "linux-arm64-gnu"),
+    ("x86_64-unknown-linux-musl", "linux-x64-musl"),
+    ("aarch64-unknown-linux-musl", "linux-arm64-musl"),
+];
+
+pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
+    BZIP2_TARGETS
+        .iter()
+        .find(|(rust, _)| *rust == triple)
+        .map(|(_, slug)| *slug)
+}
+
+pub fn asset_url_for(version: &str, slug: &str) -> String {
+    format!(
+        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
+         deps/bzip2/{version}/{slug}/bundle.tar.zst"
+    )
+}
+
+pub async fn ensure_bzip2_sysroot(
+    paths: &SoldrPaths,
+    target_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let _ = paths;
+    let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
+        SoldrError::UnsupportedPlatform(format!(
+            "no bzip2 sysroot recipe for target {target_triple}; \
+             supported: {:?}",
+            BZIP2_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+        ))
+    })?;
+    let url = asset_url_for(MANAGED_BZIP2_VERSION, slug);
+    Err(SoldrError::Other(format!(
+        "bzip2 sysroot for {target_triple} ({slug}) not yet ingested into the \
+         soldr-toolchain catalogue. Expected URL: {url}\n\
+         Tracking: https://github.com/zackees/soldr/issues/1064"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(slug_for_supported_triples, {
+        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
+        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
+    });
+
+    crate::timed_test!(asset_url_layout_matches_catalogue, {
+        let u = asset_url_for(MANAGED_BZIP2_VERSION, "linux-x64-gnu");
+        assert!(u.contains("/deps/bzip2/1.0.8/linux-x64-gnu/"));
+        assert!(u.ends_with("/bundle.tar.zst"));
+    });
+
+    crate::timed_test!(ensure_bzip2_sysroot_returns_not_yet_ingested, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_bzip2_sysroot(&paths, "x86_64-unknown-linux-gnu"));
+        let err = result.expect_err("must error until catalogue row lands");
+        assert!(err.to_string().contains("not yet ingested"));
+    });
+}

--- a/crates/soldr-cli/src/fetch/jemalloc_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/jemalloc_sysroot.rs
@@ -1,0 +1,111 @@
+//! jemalloc sysroot fetcher — soldr#1064 Phase B.
+//!
+//! Consumes the soldr-toolchain `recipes/jemalloc-<platform>/`
+//! catalogue rows. Each row ships:
+//!
+//! ```
+//! lib/libjemalloc.a    (the load-bearing file)
+//! lib/libjemalloc_pic.a
+//! include/jemalloc/*.h
+//! ```
+//!
+//! When `tikv-jemalloc-sys` is in the transitive deps and the
+//! catalogue row is ingested, the blessed path exports:
+//!
+//!   * `JEMALLOC_OVERRIDE=<sysroot>/lib/libjemalloc.a`
+//!
+//! tikv-jemalloc-sys' build.rs short-circuits the 20-40s autotools
+//! build entirely when this env var points at a static archive.
+
+use std::path::PathBuf;
+
+use crate::core::{SoldrError, SoldrPaths};
+
+/// Pinned jemalloc version the soldr-toolchain `jemalloc-*` recipes
+/// ship.
+pub const MANAGED_JEMALLOC_VERSION: &str = "5.3.0";
+
+/// Catalogue layout: Rust target triple → recipe slug.
+/// Note: jemalloc does NOT support Windows MSVC — upstream
+/// build system is autotools-only. Windows targets are
+/// intentionally absent from this table.
+pub const JEMALLOC_TARGETS: &[(&str, &str)] = &[
+    ("x86_64-apple-darwin", "darwin-x64"),
+    ("aarch64-apple-darwin", "darwin-arm64"),
+    ("x86_64-unknown-linux-gnu", "linux-x64-gnu"),
+    ("aarch64-unknown-linux-gnu", "linux-arm64-gnu"),
+    ("x86_64-unknown-linux-musl", "linux-x64-musl"),
+    ("aarch64-unknown-linux-musl", "linux-arm64-musl"),
+];
+
+pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
+    JEMALLOC_TARGETS
+        .iter()
+        .find(|(rust, _)| *rust == triple)
+        .map(|(_, slug)| *slug)
+}
+
+pub fn asset_url_for(version: &str, slug: &str) -> String {
+    format!(
+        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
+         deps/jemalloc/{version}/{slug}/bundle.tar.zst"
+    )
+}
+
+pub async fn ensure_jemalloc_sysroot(
+    paths: &SoldrPaths,
+    target_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let _ = paths;
+    let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
+        SoldrError::UnsupportedPlatform(format!(
+            "no jemalloc sysroot recipe for target {target_triple} \
+             (note: jemalloc has no Windows support); supported: {:?}",
+            JEMALLOC_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+        ))
+    })?;
+    let url = asset_url_for(MANAGED_JEMALLOC_VERSION, slug);
+    Err(SoldrError::Other(format!(
+        "jemalloc sysroot for {target_triple} ({slug}) not yet ingested into the \
+         soldr-toolchain catalogue. Expected URL: {url}\n\
+         Tracking: https://github.com/zackees/soldr/issues/1064"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(slug_for_supported_triples, {
+        assert_eq!(catalogue_slug_for("x86_64-unknown-linux-musl"), Some("linux-x64-musl"));
+        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        // Windows is intentionally unsupported for jemalloc.
+        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), None);
+    });
+
+    crate::timed_test!(asset_url_layout_matches_catalogue, {
+        let u = asset_url_for(MANAGED_JEMALLOC_VERSION, "linux-x64-musl");
+        assert!(u.contains("/deps/jemalloc/5.3.0/linux-x64-musl/"));
+        assert!(u.ends_with("/bundle.tar.zst"));
+    });
+
+    crate::timed_test!(ensure_jemalloc_sysroot_returns_not_yet_ingested, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_jemalloc_sysroot(&paths, "x86_64-unknown-linux-musl"));
+        let err = result.expect_err("must error until catalogue row lands");
+        assert!(err.to_string().contains("not yet ingested"));
+    });
+
+    crate::timed_test!(ensure_jemalloc_rejects_windows, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_jemalloc_sysroot(&paths, "x86_64-pc-windows-msvc"));
+        let err = result.expect_err("jemalloc must reject windows");
+        assert!(matches!(err, SoldrError::UnsupportedPlatform(_)));
+    });
+}

--- a/crates/soldr-cli/src/fetch/lzma_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/lzma_sysroot.rs
@@ -1,0 +1,99 @@
+//! lzma (xz / liblzma) sysroot fetcher — soldr#1064 Phase B.
+//!
+//! Consumes the soldr-toolchain `recipes/lzma-<platform>/` catalogue
+//! rows. Each row ships:
+//!
+//! ```
+//! lib/liblzma.{a,lib}
+//! lib/pkgconfig/liblzma.pc
+//! include/lzma.h
+//! include/lzma/*.h
+//! ```
+//!
+//! When `lzma-sys` is in the transitive deps and the catalogue row is
+//! ingested, the blessed path exports:
+//!
+//!   * `LZMA_API_STATIC=1`
+//!   * `PKG_CONFIG_PATH=<sysroot>/lib/pkgconfig:$PKG_CONFIG_PATH`
+//!
+//! so `lzma-sys`' build.rs uses pkg-config to locate the precompiled
+//! liblzma static archive instead of recompiling its in-tree xz copy
+//! (5-10s).
+
+use std::path::PathBuf;
+
+use crate::core::{SoldrError, SoldrPaths};
+
+pub const MANAGED_LZMA_VERSION: &str = "5.6.3";
+
+pub const LZMA_TARGETS: &[(&str, &str)] = &[
+    ("x86_64-pc-windows-msvc", "windows-x64"),
+    ("aarch64-pc-windows-msvc", "windows-arm64"),
+    ("x86_64-apple-darwin", "darwin-x64"),
+    ("aarch64-apple-darwin", "darwin-arm64"),
+    ("x86_64-unknown-linux-gnu", "linux-x64-gnu"),
+    ("aarch64-unknown-linux-gnu", "linux-arm64-gnu"),
+    ("x86_64-unknown-linux-musl", "linux-x64-musl"),
+    ("aarch64-unknown-linux-musl", "linux-arm64-musl"),
+];
+
+pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
+    LZMA_TARGETS
+        .iter()
+        .find(|(rust, _)| *rust == triple)
+        .map(|(_, slug)| *slug)
+}
+
+pub fn asset_url_for(version: &str, slug: &str) -> String {
+    format!(
+        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
+         deps/lzma/{version}/{slug}/bundle.tar.zst"
+    )
+}
+
+pub async fn ensure_lzma_sysroot(
+    paths: &SoldrPaths,
+    target_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let _ = paths;
+    let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
+        SoldrError::UnsupportedPlatform(format!(
+            "no lzma sysroot recipe for target {target_triple}; \
+             supported: {:?}",
+            LZMA_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+        ))
+    })?;
+    let url = asset_url_for(MANAGED_LZMA_VERSION, slug);
+    Err(SoldrError::Other(format!(
+        "lzma sysroot for {target_triple} ({slug}) not yet ingested into the \
+         soldr-toolchain catalogue. Expected URL: {url}\n\
+         Tracking: https://github.com/zackees/soldr/issues/1064"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(slug_for_supported_triples, {
+        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
+        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
+    });
+
+    crate::timed_test!(asset_url_layout_matches_catalogue, {
+        let u = asset_url_for(MANAGED_LZMA_VERSION, "darwin-arm64");
+        assert!(u.contains("/deps/lzma/5.6.3/darwin-arm64/"));
+        assert!(u.ends_with("/bundle.tar.zst"));
+    });
+
+    crate::timed_test!(ensure_lzma_sysroot_returns_not_yet_ingested, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_lzma_sysroot(&paths, "aarch64-apple-darwin"));
+        let err = result.expect_err("must error until catalogue row lands");
+        assert!(err.to_string().contains("not yet ingested"));
+    });
+}

--- a/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
@@ -1,0 +1,95 @@
+//! mimalloc sysroot fetcher — soldr#1064 Phase B.
+//!
+//! Consumes the soldr-toolchain `recipes/mimalloc-<platform>/`
+//! catalogue rows. Each row ships:
+//!
+//! ```
+//! lib/libmimalloc.{a,lib}
+//! include/mimalloc.h
+//! ```
+//!
+//! When `libmimalloc-sys` is in the transitive deps and the catalogue
+//! row is ingested, the blessed path exports:
+//!
+//!   * `MIMALLOC_OVERRIDE=<sysroot>/lib/libmimalloc.a`
+//!
+//! `libmimalloc-sys`' build.rs (v0.1.49+) honors `MIMALLOC_OVERRIDE`
+//! and skips its cmake compile entirely.
+
+use std::path::PathBuf;
+
+use crate::core::{SoldrError, SoldrPaths};
+
+pub const MANAGED_MIMALLOC_VERSION: &str = "3.0.4";
+
+pub const MIMALLOC_TARGETS: &[(&str, &str)] = &[
+    ("x86_64-pc-windows-msvc", "windows-x64"),
+    ("aarch64-pc-windows-msvc", "windows-arm64"),
+    ("x86_64-apple-darwin", "darwin-x64"),
+    ("aarch64-apple-darwin", "darwin-arm64"),
+    ("x86_64-unknown-linux-gnu", "linux-x64-gnu"),
+    ("aarch64-unknown-linux-gnu", "linux-arm64-gnu"),
+    ("x86_64-unknown-linux-musl", "linux-x64-musl"),
+    ("aarch64-unknown-linux-musl", "linux-arm64-musl"),
+];
+
+pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
+    MIMALLOC_TARGETS
+        .iter()
+        .find(|(rust, _)| *rust == triple)
+        .map(|(_, slug)| *slug)
+}
+
+pub fn asset_url_for(version: &str, slug: &str) -> String {
+    format!(
+        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
+         deps/mimalloc/{version}/{slug}/bundle.tar.zst"
+    )
+}
+
+pub async fn ensure_mimalloc_sysroot(
+    paths: &SoldrPaths,
+    target_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let _ = paths;
+    let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
+        SoldrError::UnsupportedPlatform(format!(
+            "no mimalloc sysroot recipe for target {target_triple}; \
+             supported: {:?}",
+            MIMALLOC_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+        ))
+    })?;
+    let url = asset_url_for(MANAGED_MIMALLOC_VERSION, slug);
+    Err(SoldrError::Other(format!(
+        "mimalloc sysroot for {target_triple} ({slug}) not yet ingested into the \
+         soldr-toolchain catalogue. Expected URL: {url}\n\
+         Tracking: https://github.com/zackees/soldr/issues/1064"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(slug_for_supported_triples, {
+        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
+        assert_eq!(catalogue_slug_for("aarch64-unknown-linux-gnu"), Some("linux-arm64-gnu"));
+        assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
+    });
+
+    crate::timed_test!(asset_url_layout_matches_catalogue, {
+        let u = asset_url_for(MANAGED_MIMALLOC_VERSION, "windows-x64");
+        assert!(u.contains("/deps/mimalloc/3.0.4/windows-x64/"));
+        assert!(u.ends_with("/bundle.tar.zst"));
+    });
+
+    crate::timed_test!(ensure_mimalloc_sysroot_returns_not_yet_ingested, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_mimalloc_sysroot(&paths, "aarch64-apple-darwin"));
+        let err = result.expect_err("must error until catalogue row lands");
+        assert!(err.to_string().contains("not yet ingested"));
+    });
+}

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -63,6 +63,19 @@ pub mod openssl_sysroot;
 /// soldr#997 Phase A — Python sysroot bundle for PyO3 cross-compile
 /// (closes parts of #931, #932, #933).
 pub mod python_sysroot;
+// soldr#1064 Phase B — *-sys C library catalogue distribution.
+// Each module is a stub-until-ingested consumer modeled on
+// openssl_sysroot.rs. Once the soldr-toolchain forge dispatches
+// land the assets, blessed_build::prepare wires the corresponding
+// _SYSTEM / _OVERRIDE env vars onto the child cargo invocation so
+// the *-sys crate's build.rs skips its vendored compile.
+pub mod bzip2_sysroot;
+pub mod jemalloc_sysroot;
+pub mod lzma_sysroot;
+pub mod mimalloc_sysroot;
+pub mod sqlite_sysroot;
+pub mod zlib_ng_sysroot;
+pub mod zstd_sysroot;
 pub mod zccache;
 pub mod zccache_install;
 pub mod zccache_runtime;

--- a/crates/soldr-cli/src/fetch/sqlite_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/sqlite_sysroot.rs
@@ -1,0 +1,102 @@
+//! SQLite (libsqlite3) sysroot fetcher — soldr#1064 Phase B.
+//!
+//! Consumes the soldr-toolchain `recipes/sqlite-<platform>/` catalogue
+//! rows. Each row ships:
+//!
+//! ```
+//! lib/libsqlite3.{a,lib}
+//! lib/pkgconfig/sqlite3.pc
+//! include/{sqlite3.h, sqlite3ext.h}
+//! ```
+//!
+//! When `libsqlite3-sys` is in the transitive deps and the catalogue
+//! row is ingested, the blessed path exports:
+//!
+//!   * `LIBSQLITE3_SYS_USE_PKG_CONFIG=1`
+//!   * `PKG_CONFIG_PATH=<sysroot>/lib/pkgconfig:$PKG_CONFIG_PATH`
+//!
+//! This is the highest-cost crate in the in-scope list (35-47s per
+//! lane for the SQLite amalgamation compile). Mirrors
+//! [`super::openssl_sysroot`]'s stub-until-ingested shape.
+
+use std::path::PathBuf;
+
+use crate::core::{SoldrError, SoldrPaths};
+
+/// Pinned SQLite version the soldr-toolchain `sqlite-*` recipes ship.
+/// Bump alongside the recipe dispatch + the Cargo.lock entry for
+/// `libsqlite3-sys`.
+pub const MANAGED_SQLITE_VERSION: &str = "3.46.0";
+
+/// Catalogue layout: Rust target triple → recipe slug.
+pub const SQLITE_TARGETS: &[(&str, &str)] = &[
+    ("x86_64-pc-windows-msvc", "windows-x64"),
+    ("aarch64-pc-windows-msvc", "windows-arm64"),
+    ("x86_64-apple-darwin", "darwin-x64"),
+    ("aarch64-apple-darwin", "darwin-arm64"),
+    ("x86_64-unknown-linux-gnu", "linux-x64-gnu"),
+    ("aarch64-unknown-linux-gnu", "linux-arm64-gnu"),
+    ("x86_64-unknown-linux-musl", "linux-x64-musl"),
+    ("aarch64-unknown-linux-musl", "linux-arm64-musl"),
+];
+
+pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
+    SQLITE_TARGETS
+        .iter()
+        .find(|(rust, _)| *rust == triple)
+        .map(|(_, slug)| *slug)
+}
+
+pub fn asset_url_for(version: &str, slug: &str) -> String {
+    format!(
+        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
+         deps/sqlite/{version}/{slug}/bundle.tar.zst"
+    )
+}
+
+pub async fn ensure_sqlite_sysroot(
+    paths: &SoldrPaths,
+    target_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let _ = paths;
+    let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
+        SoldrError::UnsupportedPlatform(format!(
+            "no sqlite sysroot recipe for target {target_triple}; \
+             supported: {:?}",
+            SQLITE_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+        ))
+    })?;
+    let url = asset_url_for(MANAGED_SQLITE_VERSION, slug);
+    Err(SoldrError::Other(format!(
+        "sqlite sysroot for {target_triple} ({slug}) not yet ingested into the \
+         soldr-toolchain catalogue. Expected URL: {url}\n\
+         Tracking: https://github.com/zackees/soldr/issues/1064"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(slug_for_supported_triples, {
+        assert_eq!(catalogue_slug_for("x86_64-unknown-linux-musl"), Some("linux-x64-musl"));
+        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
+    });
+
+    crate::timed_test!(asset_url_layout_matches_catalogue, {
+        let u = asset_url_for(MANAGED_SQLITE_VERSION, "linux-arm64-musl");
+        assert!(u.contains("/deps/sqlite/3.46.0/linux-arm64-musl/"));
+        assert!(u.ends_with("/bundle.tar.zst"));
+    });
+
+    crate::timed_test!(ensure_sqlite_sysroot_returns_not_yet_ingested, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_sqlite_sysroot(&paths, "x86_64-unknown-linux-musl"));
+        let err = result.expect_err("must error until catalogue row lands");
+        assert!(err.to_string().contains("not yet ingested"));
+    });
+}

--- a/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
@@ -1,0 +1,94 @@
+//! zlib-ng sysroot fetcher — soldr#1064 Phase B.
+//!
+//! Consumes the soldr-toolchain `recipes/zlib-ng-<platform>/`
+//! catalogue rows. Each row ships:
+//!
+//! ```
+//! lib/libz-ng.{a,lib}
+//! lib/pkgconfig/zlib-ng.pc
+//! include/zlib-ng.h
+//! ```
+//!
+//! When `libz-ng-sys` is in the transitive deps and the catalogue row
+//! is ingested, the blessed path exports `PKG_CONFIG_PATH` pointing at
+//! the materialized `lib/pkgconfig/` directory so `libz-ng-sys`'
+//! build.rs uses pkg-config to locate the precompiled libz-ng instead
+//! of triggering its cmake build (10-20s).
+
+use std::path::PathBuf;
+
+use crate::core::{SoldrError, SoldrPaths};
+
+pub const MANAGED_ZLIB_NG_VERSION: &str = "2.2.5";
+
+pub const ZLIB_NG_TARGETS: &[(&str, &str)] = &[
+    ("x86_64-pc-windows-msvc", "windows-x64"),
+    ("aarch64-pc-windows-msvc", "windows-arm64"),
+    ("x86_64-apple-darwin", "darwin-x64"),
+    ("aarch64-apple-darwin", "darwin-arm64"),
+    ("x86_64-unknown-linux-gnu", "linux-x64-gnu"),
+    ("aarch64-unknown-linux-gnu", "linux-arm64-gnu"),
+    ("x86_64-unknown-linux-musl", "linux-x64-musl"),
+    ("aarch64-unknown-linux-musl", "linux-arm64-musl"),
+];
+
+pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
+    ZLIB_NG_TARGETS
+        .iter()
+        .find(|(rust, _)| *rust == triple)
+        .map(|(_, slug)| *slug)
+}
+
+pub fn asset_url_for(version: &str, slug: &str) -> String {
+    format!(
+        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
+         deps/zlib-ng/{version}/{slug}/bundle.tar.zst"
+    )
+}
+
+pub async fn ensure_zlib_ng_sysroot(
+    paths: &SoldrPaths,
+    target_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let _ = paths;
+    let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
+        SoldrError::UnsupportedPlatform(format!(
+            "no zlib-ng sysroot recipe for target {target_triple}; \
+             supported: {:?}",
+            ZLIB_NG_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+        ))
+    })?;
+    let url = asset_url_for(MANAGED_ZLIB_NG_VERSION, slug);
+    Err(SoldrError::Other(format!(
+        "zlib-ng sysroot for {target_triple} ({slug}) not yet ingested into the \
+         soldr-toolchain catalogue. Expected URL: {url}\n\
+         Tracking: https://github.com/zackees/soldr/issues/1064"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(slug_for_supported_triples, {
+        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
+        assert_eq!(catalogue_slug_for("aarch64-unknown-linux-musl"), Some("linux-arm64-musl"));
+        assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
+    });
+
+    crate::timed_test!(asset_url_layout_matches_catalogue, {
+        let u = asset_url_for(MANAGED_ZLIB_NG_VERSION, "linux-x64-gnu");
+        assert!(u.contains("/deps/zlib-ng/2.2.5/linux-x64-gnu/"));
+        assert!(u.ends_with("/bundle.tar.zst"));
+    });
+
+    crate::timed_test!(ensure_zlib_ng_sysroot_returns_not_yet_ingested, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_zlib_ng_sysroot(&paths, "x86_64-unknown-linux-gnu"));
+        let err = result.expect_err("must error until catalogue row lands");
+        assert!(err.to_string().contains("not yet ingested"));
+    });
+}

--- a/crates/soldr-cli/src/fetch/zstd_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/zstd_sysroot.rs
@@ -1,0 +1,121 @@
+//! zstd (libzstd) sysroot fetcher — soldr#1064 Phase B.
+//!
+//! Consumes the soldr-toolchain `recipes/zstd-<platform>/` catalogue
+//! rows. Each row ships:
+//!
+//! ```
+//! lib/libzstd.{a,lib}
+//! lib/pkgconfig/libzstd.pc
+//! include/{zstd.h, zdict.h, zstd_errors.h}
+//! ```
+//!
+//! When the workspace's transitive deps include `zstd-sys` and the
+//! catalogue row for the active target is ingested, the blessed build
+//! path exports:
+//!
+//!   * `ZSTD_SYS_USE_PKG_CONFIG=1`
+//!   * `PKG_CONFIG_PATH=<sysroot>/lib/pkgconfig:$PKG_CONFIG_PATH`
+//!
+//! so `zstd-sys`' build script links against the precompiled libzstd
+//! instead of recompiling 11-15s of C source on every fresh checkout.
+//!
+//! Mirrors [`super::openssl_sysroot`]'s stub-until-ingested shape.
+//! Asset population happens via the soldr-toolchain forge pipeline;
+//! until those rows land, `ensure_zstd_sysroot` returns the
+//! "not yet ingested" error and the caller falls through to the
+//! crate's vendored compile.
+
+use std::path::PathBuf;
+
+use crate::core::{SoldrError, SoldrPaths};
+
+/// Pinned libzstd version the soldr-toolchain `zstd-*` recipes ship.
+/// Bump alongside the recipe dispatch + the Cargo.lock entry for
+/// `zstd-sys`.
+pub const MANAGED_ZSTD_VERSION: &str = "1.5.7";
+
+/// Catalogue layout: Rust target triple → recipe slug.
+pub const ZSTD_TARGETS: &[(&str, &str)] = &[
+    ("x86_64-pc-windows-msvc", "windows-x64"),
+    ("aarch64-pc-windows-msvc", "windows-arm64"),
+    ("x86_64-apple-darwin", "darwin-x64"),
+    ("aarch64-apple-darwin", "darwin-arm64"),
+    ("x86_64-unknown-linux-gnu", "linux-x64-gnu"),
+    ("aarch64-unknown-linux-gnu", "linux-arm64-gnu"),
+    ("x86_64-unknown-linux-musl", "linux-x64-musl"),
+    ("aarch64-unknown-linux-musl", "linux-arm64-musl"),
+];
+
+pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
+    ZSTD_TARGETS
+        .iter()
+        .find(|(rust, _)| *rust == triple)
+        .map(|(_, slug)| *slug)
+}
+
+/// Construct the expected `assets`-branch URL.
+///
+///     deps/zstd/<version>/<slug>/bundle.tar.zst
+pub fn asset_url_for(version: &str, slug: &str) -> String {
+    format!(
+        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
+         deps/zstd/{version}/{slug}/bundle.tar.zst"
+    )
+}
+
+pub async fn ensure_zstd_sysroot(
+    paths: &SoldrPaths,
+    target_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let _ = paths;
+    let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
+        SoldrError::UnsupportedPlatform(format!(
+            "no zstd sysroot recipe for target {target_triple}; \
+             supported: {:?}",
+            ZSTD_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+        ))
+    })?;
+    let url = asset_url_for(MANAGED_ZSTD_VERSION, slug);
+    Err(SoldrError::Other(format!(
+        "zstd sysroot for {target_triple} ({slug}) not yet ingested into the \
+         soldr-toolchain catalogue. Expected URL: {url}\n\
+         Tracking: https://github.com/zackees/soldr/issues/1064"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(slug_for_supported_triples, {
+        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
+        assert_eq!(catalogue_slug_for("aarch64-pc-windows-msvc"), Some("windows-arm64"));
+        assert_eq!(catalogue_slug_for("x86_64-apple-darwin"), Some("darwin-x64"));
+        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(catalogue_slug_for("x86_64-unknown-linux-gnu"), Some("linux-x64-gnu"));
+        assert_eq!(catalogue_slug_for("aarch64-unknown-linux-gnu"), Some("linux-arm64-gnu"));
+        assert_eq!(catalogue_slug_for("x86_64-unknown-linux-musl"), Some("linux-x64-musl"));
+        assert_eq!(catalogue_slug_for("aarch64-unknown-linux-musl"), Some("linux-arm64-musl"));
+        assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
+    });
+
+    crate::timed_test!(asset_url_layout_matches_catalogue, {
+        let u = asset_url_for(MANAGED_ZSTD_VERSION, "linux-x64-musl");
+        assert!(u.contains("/deps/zstd/1.5.7/linux-x64-musl/"));
+        assert!(u.ends_with("/bundle.tar.zst"));
+    });
+
+    crate::timed_test!(ensure_zstd_sysroot_returns_not_yet_ingested, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_zstd_sysroot(&paths, "x86_64-unknown-linux-musl"));
+        let err = result.expect_err("must error until catalogue row lands");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not yet ingested"),
+            "expected 'not yet ingested' marker in error, got: {msg}"
+        );
+    });
+}


### PR DESCRIPTION
## Summary

Soldr-side scaffolding for `#1064` Phase B (catalogue-distribute `*-sys` C libraries with clean `_SYSTEM` overrides). Lands 7 stub consumer modules + wires them into `blessed_build::prepare`.

The modules follow the `openssl_sysroot.rs` stub-until-ingested pattern — they return the "not yet ingested" error until the soldr-toolchain forge dispatches land the matching asset rows. `blessed_build::prepare` logs each unavailable library and falls through to the crate's vendored compile, so **this PR is a no-op at runtime today**. The value lands automatically once the soldr-toolchain side ships assets.

### Covered libraries (all 7 from the meta)

| Crate | Override contract |
|---|---|
| `zstd-sys` | `ZSTD_SYS_USE_PKG_CONFIG=1` + `PKG_CONFIG_PATH` |
| `libsqlite3-sys` | `LIBSQLITE3_SYS_USE_PKG_CONFIG=1` + `PKG_CONFIG_PATH` |
| `tikv-jemalloc-sys` | `JEMALLOC_OVERRIDE=<lib>/libjemalloc.a` |
| `libmimalloc-sys` | `MIMALLOC_OVERRIDE=<lib>/libmimalloc.a` |
| `libz-ng-sys` | `PKG_CONFIG_PATH` |
| `lzma-sys` | `LZMA_API_STATIC=1` + `PKG_CONFIG_PATH` |
| `bzip2-sys` | `PKG_CONFIG_PATH` |

### New opt-out

`SOLDR_USE_LEGACY_VENDORED_SYS=1` short-circuits the entire `*-sys` override pass — mirrors the existing `SOLDR_USE_LEGACY_{XWIN,ZIGBUILD}` contract.

### Why "scaffolding before assets"

Per the meta: "The two PRs can land independently in either order — soldr's consumer modules return the 'not yet ingested' error gracefully (mirrors how `xwin_cache.rs` handles aarch64-pending today). Once both land + assets are populated, the override path activates automatically."

This PR is the soldr-side half. The soldr-toolchain PR (recipes + forge dispatches + asset population) is the parallel half.

## Test plan

- [x] `soldr cargo build -p soldr-cli --lib` — clean
- [x] `soldr cargo test -p soldr-cli --lib _sysroot::` — 29 tests pass (3-4 per module: slug dispatch, asset URL layout, not-yet-ingested error contract, plus jemalloc's reject-windows guard)
- [x] `soldr cargo clippy -p soldr-cli --lib` — no new clippy issues in the touched files. (Two pre-existing clippy errors on `main` in `core/canonical_targets.rs` and `manifest_lookup.rs` are unrelated.)
- [ ] CI will exercise the wider cross-build matrix

Relates to #1064.