### PR TITLE
fix(ci): cargo fmt soldr-cli + scope workflow checks to -p soldr-cli (#1066)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -162,7 +162,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          soldr prepare --target ${{ inputs.target }} --github-env
+          soldr prepare --target ${{ inputs.target }} --github-env "$GITHUB_ENV"
 
       # Persistent zig-cc wrapper scripts for darwin (soldr#1043).
       # Required so cargo nextest archive's cc-rs invocation routes

--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -82,6 +82,17 @@ jobs:
           prebuild-deps: soldr-cook
           prebuild-deps-flags: ""
 
+      # `prebuild-deps: soldr-cook` runs cargo-chef under the hood,
+      # which replaces every workspace crate's main.rs / lib.rs / build.rs
+      # with `fn main() {}` stubs while it cooks dependency layers. The
+      # cook step doesn't restore the originals — soldr#1066. Without
+      # this `git restore` the subsequent `cargo fmt --check` sees the
+      # stubs (missing trailing newlines, lone `fn main() {}` content)
+      # and fails. The ci.yml `lint` job uses the identical pattern.
+      - name: Restore checkout after soldr-cook
+        shell: bash
+        run: git restore --worktree -- .
+
       - name: Add cross-compile target
         shell: bash
         run: rustup target add ${{ inputs.target }}

--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -164,8 +164,13 @@ jobs:
           bash .github/scripts/make_zig_cc_wrappers.sh "${{ inputs.target }}"
 
       # Stage A — lint
+      # `-p soldr-cli` instead of `--all`: soldr-cli has a `path`
+      # dependency on `_vender/zccache/crates/zccache`, and although
+      # `_vender/zccache` is in `workspace.exclude`, `cargo fmt --all`
+      # still walks the path-dep target and flags rustfmt drift in
+      # submodule sources we do not own. See soldr#1066.
       - name: cargo fmt --check
-        run: cargo fmt --all -- --check
+        run: cargo fmt -p soldr-cli -- --check
 
       - name: cargo clippy
         run: cargo clippy --workspace --target ${{ inputs.target }} --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,10 @@ jobs:
       - name: Install Rust components
         run: rustup component add rustfmt clippy
 
+      # `-p soldr-cli` not `--all` — `cargo fmt --all` walks the
+      # `_vender/zccache` path-dep submodule. See soldr#1066.
       - name: Check formatting
-        run: soldr cargo fmt --all -- --check
+        run: soldr cargo fmt -p soldr-cli -- --check
 
       - name: Check npm package metadata
         run: node scripts/test-npm-package.js

--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -66,10 +66,7 @@ pub struct BlessedPrep {
 ///
 /// Caller is responsible for applying `prep.env` and prepending
 /// `prep.shim_path_dir` to `PATH` on the child cargo invocation.
-pub async fn prepare(
-    paths: &SoldrPaths,
-    target_triple: &str,
-) -> Result<BlessedPrep, SoldrError> {
+pub async fn prepare(paths: &SoldrPaths, target_triple: &str) -> Result<BlessedPrep, SoldrError> {
     let mut prep = BlessedPrep::default();
 
     // ----------------------------- Windows MSVC ------------------------------
@@ -89,7 +86,8 @@ pub async fn prepare(
         let shim_dir = install_clang_shim(paths)?;
         prep.shim_path_dir = Some(shim_dir);
 
-        prep.env.push((format!("CC_{target_u}"), "clang".to_string()));
+        prep.env
+            .push((format!("CC_{target_u}"), "clang".to_string()));
         prep.env
             .push((format!("CXX_{target_u}"), "clang".to_string()));
         prep.env
@@ -127,7 +125,8 @@ pub async fn prepare(
                 // `/imsvc <path>` MSVC-style include flags.
                 let cflags = xwin_msvc_cflags(&cache_dir);
                 if !cflags.is_empty() {
-                    prep.env.push((format!("CFLAGS_{target_u}"), cflags.clone()));
+                    prep.env
+                        .push((format!("CFLAGS_{target_u}"), cflags.clone()));
                     prep.env.push((format!("CXXFLAGS_{target_u}"), cflags));
                 }
 
@@ -144,9 +143,7 @@ pub async fn prepare(
                 }
             }
             Err(e) => {
-                eprintln!(
-                    "soldr build: catalogue xwin-cache unavailable for {target_triple}: {e}"
-                );
+                eprintln!("soldr build: catalogue xwin-cache unavailable for {target_triple}: {e}");
                 eprintln!(
                     "soldr build: continuing without XWIN_CACHE_DIR — \
                      cargo-xwin's live download will produce the SDK \
@@ -163,15 +160,11 @@ pub async fn prepare(
         match crate::fetch::apple_sdk::ensure_apple_sdk(paths).await {
             Ok(sdk) => {
                 prep.sdkroot = Some(sdk.clone());
-                prep.env.push((
-                    "SDKROOT".to_string(),
-                    sdk.to_string_lossy().into_owned(),
-                ));
+                prep.env
+                    .push(("SDKROOT".to_string(), sdk.to_string_lossy().into_owned()));
             }
             Err(e) => {
-                eprintln!(
-                    "soldr build: apple SDK unavailable for {target_triple}: {e}"
-                );
+                eprintln!("soldr build: apple SDK unavailable for {target_triple}: {e}");
                 // Don't hard-fail; zigbuild may still locate an SDK
                 // via cargo-zigbuild's own mechanism.
             }
@@ -297,8 +290,7 @@ fn prepend_pkg_config_path(prep: &mut BlessedPrep, sysroot: &std::path::Path) {
         let sep = if cfg!(windows) { ';' } else { ':' };
         existing.1 = format!("{new_entry}{sep}{}", existing.1);
     } else {
-        prep.env
-            .push(("PKG_CONFIG_PATH".to_string(), new_entry));
+        prep.env.push(("PKG_CONFIG_PATH".to_string(), new_entry));
     }
 }
 
@@ -378,29 +370,22 @@ fn clang_shim_names() -> Vec<String> {
     // clang-cl symlink first and the shim re-invokes itself with
     // argv[0]=clang-cl → `unrecognized argv[0] basename`. See
     // ci/docker-aarch64-windows-msvc-cross/ + soldr#1033 followup.
-    vec![
-        "clang.exe".to_string(),
-        "clang++.exe".to_string(),
-    ]
+    vec!["clang.exe".to_string(), "clang++.exe".to_string()]
 }
 
 #[cfg(not(windows))]
 fn clang_shim_names() -> Vec<String> {
     // See the Windows branch for why clang-cl is NOT here.
-    vec![
-        "clang".to_string(),
-        "clang++".to_string(),
-    ]
+    vec!["clang".to_string(), "clang++".to_string()]
 }
 
 fn locate_shim_binary() -> Result<PathBuf, SoldrError> {
     // Look next to the running `soldr` executable.
-    let current_exe = std::env::current_exe().map_err(|e| {
-        SoldrError::Other(format!("could not resolve current exe: {e}"))
-    })?;
-    let exe_dir = current_exe.parent().ok_or_else(|| {
-        SoldrError::Other("current exe has no parent directory".to_string())
-    })?;
+    let current_exe = std::env::current_exe()
+        .map_err(|e| SoldrError::Other(format!("could not resolve current exe: {e}")))?;
+    let exe_dir = current_exe
+        .parent()
+        .ok_or_else(|| SoldrError::Other("current exe has no parent directory".to_string()))?;
 
     let shim_name = if cfg!(windows) {
         "soldr-clang-shim.exe"
@@ -563,18 +548,9 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let root = tmp.path();
         for arch in ["arm64", "x64"] {
-            std::fs::create_dir_all(
-                root.join("crt").join("lib").join(arch),
-            )
-            .unwrap();
-            std::fs::create_dir_all(
-                root.join("sdk").join("lib").join("um").join(arch),
-            )
-            .unwrap();
-            std::fs::create_dir_all(
-                root.join("sdk").join("lib").join("ucrt").join(arch),
-            )
-            .unwrap();
+            std::fs::create_dir_all(root.join("crt").join("lib").join(arch)).unwrap();
+            std::fs::create_dir_all(root.join("sdk").join("lib").join("um").join(arch)).unwrap();
+            std::fs::create_dir_all(root.join("sdk").join("lib").join("ucrt").join(arch)).unwrap();
         }
 
         let aarch64 = xwin_msvc_link_args(root, "aarch64-pc-windows-msvc");
@@ -614,8 +590,7 @@ mod tests {
         // would be passed as a plain rustc arg and silently dropped.
         let tmp = tempfile::tempdir().expect("tmpdir");
         let root = tmp.path();
-        std::fs::create_dir_all(root.join("crt").join("lib").join("arm64"))
-            .unwrap();
+        std::fs::create_dir_all(root.join("crt").join("lib").join("arm64")).unwrap();
 
         let out = xwin_msvc_link_args(root, "aarch64-pc-windows-msvc");
         // Count `-C` tokens vs `link-arg=/LIBPATH:` tokens; should be equal.

--- a/crates/soldr-cli/src/core/canonical_targets.rs
+++ b/crates/soldr-cli/src/core/canonical_targets.rs
@@ -75,10 +75,7 @@ mod tests {
                 triple.matches('-').count() >= 2,
                 "{triple} is missing components — should be `<arch>-<vendor>-<os>[-<env>]`",
             );
-            assert!(
-                !triple.contains(' '),
-                "{triple} contains whitespace",
-            );
+            assert!(!triple.contains(' '), "{triple} contains whitespace",);
         }
     });
 
@@ -86,8 +83,14 @@ mod tests {
         for t in CANONICAL_TARGETS {
             assert!(is_canonical(t), "{t} not recognized by is_canonical");
         }
-        assert!(!is_canonical("i686-pc-windows-msvc"), "32-bit shouldn't be canonical");
-        assert!(!is_canonical("wasm32-unknown-unknown"), "wasm not canonical");
+        assert!(
+            !is_canonical("i686-pc-windows-msvc"),
+            "32-bit shouldn't be canonical"
+        );
+        assert!(
+            !is_canonical("wasm32-unknown-unknown"),
+            "wasm not canonical"
+        );
         assert!(!is_canonical(""), "empty string");
     });
 }

--- a/crates/soldr-cli/src/daemon/client.rs
+++ b/crates/soldr-cli/src/daemon/client.rs
@@ -11,9 +11,7 @@ use crate::daemon::db;
 use crate::daemon::ipc::{read_frame_async, write_frame_async};
 #[cfg(unix)]
 use crate::daemon::ipc::{read_frame_sync, write_frame_sync};
-use crate::daemon::protocol::{
-    BuildRecord, CompileRequest, Request, Response, StatusInfo,
-};
+use crate::daemon::protocol::{BuildRecord, CompileRequest, Request, Response, StatusInfo};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -701,7 +699,9 @@ where
                     write_frame_async(&mut stream, &request),
                 )
                 .await
-                .map_err(|_| windows_timeout_error("daemon IPC compile write", COMPILE_REPLY_TIMEOUT))
+                .map_err(|_| {
+                    windows_timeout_error("daemon IPC compile write", COMPILE_REPLY_TIMEOUT)
+                })
                 .and_then(|res| res)
                 {
                     let _ = tx.send(StreamMsg::Err(ClientError::Io(e)));
@@ -720,12 +720,11 @@ where
                             return;
                         }
                         Err(_) => {
-                            let _ = tx.send(StreamMsg::Err(ClientError::Io(
-                                windows_timeout_error(
+                            let _ =
+                                tx.send(StreamMsg::Err(ClientError::Io(windows_timeout_error(
                                     "daemon IPC compile read",
                                     COMPILE_REPLY_TIMEOUT,
-                                ),
-                            )));
+                                ))));
                             return;
                         }
                     };

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -814,11 +814,7 @@ where
 
     let wire_stdout_started = std::time::Instant::now();
     for chunk in body.stdout.chunks(CHUNK_BYTES) {
-        write_frame_async(
-            stream,
-            &Response::CompileStdoutChunk(chunk.to_vec()),
-        )
-        .await?;
+        write_frame_async(stream, &Response::CompileStdoutChunk(chunk.to_vec())).await?;
         stdout_chunks += 1;
         tracing::debug!(
             target: "soldr::daemon::compile_stream",
@@ -835,11 +831,7 @@ where
 
     let wire_stderr_started = std::time::Instant::now();
     for chunk in body.stderr.chunks(CHUNK_BYTES) {
-        write_frame_async(
-            stream,
-            &Response::CompileStderrChunk(chunk.to_vec()),
-        )
-        .await?;
+        write_frame_async(stream, &Response::CompileStderrChunk(chunk.to_vec())).await?;
         stderr_chunks += 1;
         tracing::debug!(
             target: "soldr::daemon::compile_stream",
@@ -884,16 +876,8 @@ where
         &compile_id,
     );
     // Co-record per-compile output bytes for cross-axis analysis.
-    crate::daemon::compile_trace::record(
-        "stdout_bytes",
-        stdout_len as u64,
-        &compile_id,
-    );
-    crate::daemon::compile_trace::record(
-        "stderr_bytes",
-        stderr_len as u64,
-        &compile_id,
-    );
+    crate::daemon::compile_trace::record("stdout_bytes", stdout_len as u64, &compile_id);
+    crate::daemon::compile_trace::record("stderr_bytes", stderr_len as u64, &compile_id);
     res
 }
 

--- a/crates/soldr-cli/src/env_cmd.rs
+++ b/crates/soldr-cli/src/env_cmd.rs
@@ -143,7 +143,11 @@ mod tests {
     });
 
     crate::timed_test!(env_block_always_marks_pyo3_no_python, {
-        for triple in ["x86_64-pc-windows-msvc", "aarch64-apple-darwin", "x86_64-unknown-linux-musl"] {
+        for triple in [
+            "x86_64-pc-windows-msvc",
+            "aarch64-apple-darwin",
+            "x86_64-unknown-linux-musl",
+        ] {
             let env = build_env_block(triple).expect("ok");
             assert_eq!(env.get("PYO3_NO_PYTHON").map(String::as_str), Some("1"));
         }

--- a/crates/soldr-cli/src/fetch/apple_sdk.rs
+++ b/crates/soldr-cli/src/fetch/apple_sdk.rs
@@ -339,9 +339,15 @@ mod tests {
     // soldr-toolchain#14 Phase 6 — shape + version picker.
 
     crate::timed_test!(shape_slugs_match_catalogue_layout, {
-        assert_eq!(AppleSdkShape::Universal2.catalogue_slug(), "darwin-universal2");
+        assert_eq!(
+            AppleSdkShape::Universal2.catalogue_slug(),
+            "darwin-universal2"
+        );
         assert_eq!(AppleSdkShape::ThinX86_64.catalogue_slug(), "darwin-x86_64");
-        assert_eq!(AppleSdkShape::ThinAArch64.catalogue_slug(), "darwin-aarch64");
+        assert_eq!(
+            AppleSdkShape::ThinAArch64.catalogue_slug(),
+            "darwin-aarch64"
+        );
     });
 
     crate::timed_test!(catalogue_url_substr_format, {

--- a/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
@@ -74,8 +74,14 @@ mod tests {
     use super::*;
 
     crate::timed_test!(slug_for_supported_triples, {
-        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
-        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(
+            catalogue_slug_for("x86_64-pc-windows-msvc"),
+            Some("windows-x64")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-apple-darwin"),
+            Some("darwin-arm64")
+        );
         assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
     });
 

--- a/crates/soldr-cli/src/fetch/forge_dispatch.rs
+++ b/crates/soldr-cli/src/fetch/forge_dispatch.rs
@@ -232,9 +232,8 @@ pub async fn request_forge_build(req: &ForgeRequest) -> Result<String, ForgeErro
     let workflow = read_dispatch_workflow();
     let git_ref = read_dispatch_ref();
 
-    let dispatch_url = format!(
-        "https://api.github.com/repos/{repo}/actions/workflows/{workflow}/dispatches"
-    );
+    let dispatch_url =
+        format!("https://api.github.com/repos/{repo}/actions/workflows/{workflow}/dispatches");
 
     let client = super::github::http_client().map_err(|e| ForgeError::Network(e.to_string()))?;
     let body = serde_json::json!({
@@ -409,7 +408,10 @@ mod tests {
         std::env::remove_var(FORGE_TOKEN_ENV_VAR);
         match read_token() {
             Err(ForgeError::MissingToken { repo }) => {
-                assert!(!repo.is_empty(), "missing-token error must carry the dispatch repo");
+                assert!(
+                    !repo.is_empty(),
+                    "missing-token error must carry the dispatch repo"
+                );
             }
             other => panic!("expected MissingToken, got {other:?}"),
         }

--- a/crates/soldr-cli/src/fetch/jemalloc_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/jemalloc_sysroot.rs
@@ -77,8 +77,14 @@ mod tests {
     use super::*;
 
     crate::timed_test!(slug_for_supported_triples, {
-        assert_eq!(catalogue_slug_for("x86_64-unknown-linux-musl"), Some("linux-x64-musl"));
-        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(
+            catalogue_slug_for("x86_64-unknown-linux-musl"),
+            Some("linux-x64-musl")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-apple-darwin"),
+            Some("darwin-arm64")
+        );
         // Windows is intentionally unsupported for jemalloc.
         assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), None);
     });

--- a/crates/soldr-cli/src/fetch/llvm_tools_bundle.rs
+++ b/crates/soldr-cli/src/fetch/llvm_tools_bundle.rs
@@ -42,9 +42,7 @@ pub const MANAGED_LLVM_TOOLS_VERSION: &str = "18.1.8";
 /// only linux x86_64 is wired. Linux arm64 + macOS arm64 hosts can
 /// be added when soldr's bootstrap matrix supports them as drivers
 /// (today the docker image is linux x86_64 only — see soldr#997).
-pub const LLVM_TOOLS_HOSTS: &[(&str, &str)] = &[
-    ("x86_64-unknown-linux-gnu", "linux-x64"),
-];
+pub const LLVM_TOOLS_HOSTS: &[(&str, &str)] = &[("x86_64-unknown-linux-gnu", "linux-x64")];
 
 /// Catalogue slug for a host triple.
 pub fn host_slug_for(host_triple: &str) -> Option<&'static str> {
@@ -96,10 +94,7 @@ mod tests {
     use super::*;
 
     crate::timed_test!(host_slug_for_known_triple, {
-        assert_eq!(
-            host_slug_for("x86_64-unknown-linux-gnu"),
-            Some("linux-x64")
-        );
+        assert_eq!(host_slug_for("x86_64-unknown-linux-gnu"), Some("linux-x64"));
         assert_eq!(host_slug_for("wasm32-unknown-unknown"), None);
     });
 

--- a/crates/soldr-cli/src/fetch/lzma_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/lzma_sysroot.rs
@@ -76,8 +76,14 @@ mod tests {
     use super::*;
 
     crate::timed_test!(slug_for_supported_triples, {
-        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
-        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(
+            catalogue_slug_for("x86_64-pc-windows-msvc"),
+            Some("windows-x64")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-apple-darwin"),
+            Some("darwin-arm64")
+        );
         assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
     });
 

--- a/crates/soldr-cli/src/fetch/manifest_lookup.rs
+++ b/crates/soldr-cli/src/fetch/manifest_lookup.rs
@@ -321,7 +321,10 @@ pub async fn run_toolchain_catalogue(json: bool) -> Result<i32, SoldrError> {
             if !status.is_success() {
                 print_catalogue_error(
                     &url,
-                    &format!("HTTP {} (the catalogue file may not be published yet)", status),
+                    &format!(
+                        "HTTP {} (the catalogue file may not be published yet)",
+                        status
+                    ),
                     json,
                 );
                 return Ok(1);
@@ -489,7 +492,10 @@ mod tests {
         // exercise the public string-shape via the pure helper that
         // does not read env: build the URL from the default origin.
         let url = format!("{}/{}", DEFAULT_TOOLCHAIN_ORIGIN, CATALOGUE_DOC_NAME);
-        assert_eq!(url, "https://zackees.github.io/soldr-toolchain/catalogue.v1.json");
+        assert_eq!(
+            url,
+            "https://zackees.github.io/soldr-toolchain/catalogue.v1.json"
+        );
     });
 
     crate::timed_test!(catalogue_v1_json_parses_through_manifest_index, {
@@ -583,6 +589,9 @@ mod tests {
         // they can't fit that under the `origin + /catalogue.v1.json`
         // composition because the listener path is fixed.
         // Verify the override is recognized via the public const name.
-        assert_eq!(TOOLCHAIN_CATALOGUE_URL_ENV_VAR, "SOLDR_TOOLCHAIN_CATALOGUE_URL");
+        assert_eq!(
+            TOOLCHAIN_CATALOGUE_URL_ENV_VAR,
+            "SOLDR_TOOLCHAIN_CATALOGUE_URL"
+        );
     });
 }

--- a/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
@@ -72,8 +72,14 @@ mod tests {
     use super::*;
 
     crate::timed_test!(slug_for_supported_triples, {
-        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
-        assert_eq!(catalogue_slug_for("aarch64-unknown-linux-gnu"), Some("linux-arm64-gnu"));
+        assert_eq!(
+            catalogue_slug_for("x86_64-pc-windows-msvc"),
+            Some("windows-x64")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-unknown-linux-gnu"),
+            Some("linux-arm64-gnu")
+        );
         assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
     });
 

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -39,9 +39,6 @@ pub use rustup_init::{
 
 pub mod apple_sdk;
 pub mod archive;
-/// soldr#1012 PR 5 — xwin-cache catalogue materialization for the
-/// blessed `*-pc-windows-msvc` cross-compile path.
-pub mod xwin_cache;
 /// soldr#988 Phase 4 — on-demand builds via `zackees/forge` when the
 /// toolchain catalogue lookup misses. See module doc for the env-var
 /// contract and failure surface.
@@ -63,6 +60,9 @@ pub mod openssl_sysroot;
 /// soldr#997 Phase A — Python sysroot bundle for PyO3 cross-compile
 /// (closes parts of #931, #932, #933).
 pub mod python_sysroot;
+/// soldr#1012 PR 5 — xwin-cache catalogue materialization for the
+/// blessed `*-pc-windows-msvc` cross-compile path.
+pub mod xwin_cache;
 // soldr#1064 Phase B — *-sys C library catalogue distribution.
 // Each module is a stub-until-ingested consumer modeled on
 // openssl_sysroot.rs. Once the soldr-toolchain forge dispatches
@@ -74,12 +74,12 @@ pub mod jemalloc_sysroot;
 pub mod lzma_sysroot;
 pub mod mimalloc_sysroot;
 pub mod sqlite_sysroot;
-pub mod zlib_ng_sysroot;
-pub mod zstd_sysroot;
 pub mod zccache;
 pub mod zccache_install;
 pub mod zccache_runtime;
 pub mod zig;
+pub mod zlib_ng_sysroot;
+pub mod zstd_sysroot;
 
 pub use apple_sdk::{ensure_apple_sdk, MANAGED_APPLE_SDK_VERSION};
 pub use llvm::{ensure_llvm_toolchain, MANAGED_LLVM_VERSION};
@@ -509,10 +509,7 @@ async fn fetch_repo_binary_once(
 /// with `--version` (with a short timeout). On failure, evict the
 /// extracted file so the next fetch attempt does a clean re-download
 /// rather than reading the corrupt artifact from cache.
-fn smoke_test_or_evict(
-    binary_path: &std::path::Path,
-    cache_name: &str,
-) -> Result<(), SoldrError> {
+fn smoke_test_or_evict(binary_path: &std::path::Path, cache_name: &str) -> Result<(), SoldrError> {
     use std::process::Command;
 
     if !binary_path.is_file() {
@@ -522,9 +519,7 @@ fn smoke_test_or_evict(
         )));
     }
 
-    let output = Command::new(binary_path)
-        .arg("--version")
-        .output();
+    let output = Command::new(binary_path).arg("--version").output();
 
     let evict = |reason: &str| {
         eprintln!(
@@ -1113,8 +1108,8 @@ mod tests {
     crate::timed_test!(smoke_test_missing_file_errors, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let bogus = tmp.path().join("not-a-binary");
-        let err = smoke_test_or_evict(&bogus, "fake-tool")
-            .expect_err("missing file must fail smoke");
+        let err =
+            smoke_test_or_evict(&bogus, "fake-tool").expect_err("missing file must fail smoke");
         assert!(
             err.to_string().contains("not a file after extract"),
             "expected 'not a file after extract' in error, got: {err}"

--- a/crates/soldr-cli/src/fetch/openssl_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/openssl_sysroot.rs
@@ -79,7 +79,10 @@ mod tests {
     use super::*;
 
     crate::timed_test!(slug_for_supported_triples, {
-        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
+        assert_eq!(
+            catalogue_slug_for("x86_64-pc-windows-msvc"),
+            Some("windows-x64")
+        );
         assert_eq!(
             catalogue_slug_for("aarch64-pc-windows-msvc"),
             Some("windows-arm64")

--- a/crates/soldr-cli/src/fetch/python_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/python_sysroot.rs
@@ -176,10 +176,22 @@ mod tests {
     });
 
     crate::timed_test!(catalogue_slug_for_known_triples, {
-        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
-        assert_eq!(catalogue_slug_for("aarch64-pc-windows-msvc"), Some("windows-arm64"));
-        assert_eq!(catalogue_slug_for("x86_64-apple-darwin"), Some("darwin-x64"));
-        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(
+            catalogue_slug_for("x86_64-pc-windows-msvc"),
+            Some("windows-x64")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-pc-windows-msvc"),
+            Some("windows-arm64")
+        );
+        assert_eq!(
+            catalogue_slug_for("x86_64-apple-darwin"),
+            Some("darwin-x64")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-apple-darwin"),
+            Some("darwin-arm64")
+        );
         assert_eq!(
             catalogue_slug_for("x86_64-unknown-linux-musl"),
             Some("linux-x64-musl")

--- a/crates/soldr-cli/src/fetch/sqlite_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/sqlite_sysroot.rs
@@ -79,8 +79,14 @@ mod tests {
     use super::*;
 
     crate::timed_test!(slug_for_supported_triples, {
-        assert_eq!(catalogue_slug_for("x86_64-unknown-linux-musl"), Some("linux-x64-musl"));
-        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(
+            catalogue_slug_for("x86_64-unknown-linux-musl"),
+            Some("linux-x64-musl")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-apple-darwin"),
+            Some("darwin-arm64")
+        );
         assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
     });
 

--- a/crates/soldr-cli/src/fetch/zig.rs
+++ b/crates/soldr-cli/src/fetch/zig.rs
@@ -353,7 +353,10 @@ fn zig_download_url(version: &str) -> Result<(String, String), SoldrError> {
     // `zig-{arch}-{os}-{ver}.tar.xz`. Branch on the major/minor here
     // rather than threading a per-version table — the swap is the
     // only naming change in the version range soldr cares about.
-    let pre_0_14 = matches!(version, "0.13.0" | "0.12.0" | "0.11.0" | "0.10.1" | "0.10.0");
+    let pre_0_14 = matches!(
+        version,
+        "0.13.0" | "0.12.0" | "0.11.0" | "0.10.1" | "0.10.0"
+    );
     let asset = if pre_0_14 {
         format!("zig-{os}-{arch}-{version}.{ext}")
     } else {
@@ -413,7 +416,9 @@ mod tests {
         let (asset_14, _) = zig_download_url("0.14.1").unwrap();
         // Whatever host the unit tests run on, the arch + os tokens
         // must appear in swapped order between the two versions.
-        let Some((os, arch)) = host_zig_os_arch() else { return };
+        let Some((os, arch)) = host_zig_os_arch() else {
+            return;
+        };
         let pre_13 = format!("zig-{os}-{arch}-0.13.0");
         let post_14 = format!("zig-{arch}-{os}-0.14.1");
         assert!(asset_13.starts_with(&pre_13), "0.13.0: {asset_13}");
@@ -427,7 +432,9 @@ mod tests {
         // follows the same pre/post-0.14 branching as zig_download_url —
         // they MUST agree or extracts land in a directory the lookup misses
         // (soldr#1032).
-        let Some((os, arch)) = host_zig_os_arch() else { return };
+        let Some((os, arch)) = host_zig_os_arch() else {
+            return;
+        };
         let root = managed_zig_archive_root();
         // MANAGED_ZIG_VERSION is currently 0.14.1 (post-swap).
         let expected = format!("zig-{arch}-{os}-{MANAGED_ZIG_VERSION}");

--- a/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
@@ -71,8 +71,14 @@ mod tests {
     use super::*;
 
     crate::timed_test!(slug_for_supported_triples, {
-        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
-        assert_eq!(catalogue_slug_for("aarch64-unknown-linux-musl"), Some("linux-arm64-musl"));
+        assert_eq!(
+            catalogue_slug_for("x86_64-pc-windows-msvc"),
+            Some("windows-x64")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-unknown-linux-musl"),
+            Some("linux-arm64-musl")
+        );
         assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
     });
 

--- a/crates/soldr-cli/src/fetch/zstd_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/zstd_sysroot.rs
@@ -88,14 +88,38 @@ mod tests {
     use super::*;
 
     crate::timed_test!(slug_for_supported_triples, {
-        assert_eq!(catalogue_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
-        assert_eq!(catalogue_slug_for("aarch64-pc-windows-msvc"), Some("windows-arm64"));
-        assert_eq!(catalogue_slug_for("x86_64-apple-darwin"), Some("darwin-x64"));
-        assert_eq!(catalogue_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
-        assert_eq!(catalogue_slug_for("x86_64-unknown-linux-gnu"), Some("linux-x64-gnu"));
-        assert_eq!(catalogue_slug_for("aarch64-unknown-linux-gnu"), Some("linux-arm64-gnu"));
-        assert_eq!(catalogue_slug_for("x86_64-unknown-linux-musl"), Some("linux-x64-musl"));
-        assert_eq!(catalogue_slug_for("aarch64-unknown-linux-musl"), Some("linux-arm64-musl"));
+        assert_eq!(
+            catalogue_slug_for("x86_64-pc-windows-msvc"),
+            Some("windows-x64")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-pc-windows-msvc"),
+            Some("windows-arm64")
+        );
+        assert_eq!(
+            catalogue_slug_for("x86_64-apple-darwin"),
+            Some("darwin-x64")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-apple-darwin"),
+            Some("darwin-arm64")
+        );
+        assert_eq!(
+            catalogue_slug_for("x86_64-unknown-linux-gnu"),
+            Some("linux-x64-gnu")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-unknown-linux-gnu"),
+            Some("linux-arm64-gnu")
+        );
+        assert_eq!(
+            catalogue_slug_for("x86_64-unknown-linux-musl"),
+            Some("linux-x64-musl")
+        );
+        assert_eq!(
+            catalogue_slug_for("aarch64-unknown-linux-musl"),
+            Some("linux-arm64-musl")
+        );
         assert_eq!(catalogue_slug_for("wasm32-unknown-unknown"), None);
     });
 

--- a/crates/soldr-cli/src/lib.rs
+++ b/crates/soldr-cli/src/lib.rs
@@ -22,19 +22,19 @@ pub mod cache_lib;
 pub mod cargo_metadata_soldr;
 pub mod core;
 pub mod daemon;
+pub mod defender;
 /// soldr#938 — `soldr env --target` subcommand implementation.
 /// Declared from both lib and bin so the unit tests are reachable
 /// via `cargo test --lib`.
 pub mod env_cmd;
+pub mod fetch;
 /// soldr#939 — PyO3 auto-detection via cargo metadata.
 pub mod pyo3_detect;
+pub mod release_sidecar;
+pub mod self_relocate;
 /// soldr#997 — friendly target aliases + Rust-triple passthrough.
 /// See module doc for the `soldr build --target <alias>` UX contract.
 pub mod target_alias;
-pub mod defender;
-pub mod fetch;
-pub mod release_sidecar;
-pub mod self_relocate;
 /// `wrapper_target` holds the wrapper hot-path target-registry routing
 /// extracted out of `wrapper.rs` so integration tests under
 /// `tests/cli_wrapper_perf.rs` can drive it in-process (issue #474).

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -20,23 +20,15 @@ mod cargo_diagnostics;
 mod cargo_front_door;
 mod cargo_metadata_soldr;
 mod cli_args;
-/// soldr#938 — `soldr env --target` subcommand. Prints shell-eval /
-/// shell-export / JSON env block for the given target.
-mod env_cmd;
-/// soldr#939 — PyO3 auto-detection via cargo metadata. Used by the
-/// cargo front door to inject PYO3_CROSS_* env vars when the
-/// workspace pulls in PyO3 and target ≠ host.
-mod pyo3_detect;
-/// soldr#997 — friendly target aliases + Rust-triple passthrough.
-/// Bin tree mirrors the lib declaration; only one alias resolver
-/// is reachable in either build mode.
-mod target_alias;
 mod cook;
 mod core;
 mod daemon;
 mod defender;
 mod defender_probe;
 mod doctor;
+/// soldr#938 — `soldr env --target` subcommand. Prints shell-eval /
+/// shell-export / JSON env block for the given target.
+mod env_cmd;
 mod fetch;
 mod fuzzy_match;
 mod gc;
@@ -47,12 +39,20 @@ mod optimize;
 mod optimize_detect;
 mod optimize_windows;
 mod prepare_cmd;
+/// soldr#939 — PyO3 auto-detection via cargo metadata. Used by the
+/// cargo front door to inject PYO3_CROSS_* env vars when the
+/// workspace pulls in PyO3 and target ≠ host.
+mod pyo3_detect;
 mod release_sidecar;
 mod rust_plan;
 mod save_load;
 mod self_relocate;
 mod shim_dir;
 mod startup_profile;
+/// soldr#997 — friendly target aliases + Rust-triple passthrough.
+/// Bin tree mirrors the lib declaration; only one alias resolver
+/// is reachable in either build mode.
+mod target_alias;
 mod toolchain;
 mod toolchain_doctor;
 mod toolchain_ensure;
@@ -306,9 +306,7 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 // hosts — native msvc/darwin host builds keep using
                 // plain cargo build.
                 if let Some(subcmd) = pick_cross_subcommand(&target_triple) {
-                    full_args = rewrite_build_args_for_subcommand(
-                        full_args, subcmd,
-                    );
+                    full_args = rewrite_build_args_for_subcommand(full_args, subcmd);
                 }
             }
 
@@ -1016,31 +1014,31 @@ fn pick_cross_subcommand(target_triple: &str) -> Option<&'static str> {
         return None;
     }
 
-    let legacy_xwin = std::env::var_os(
-        crate::blessed_build::USE_LEGACY_XWIN_ENV_VAR,
-    )
-    .map(|v| !v.is_empty() && v != "0")
-    .unwrap_or(false);
-    let legacy_zigbuild = std::env::var_os(
-        crate::blessed_build::USE_LEGACY_ZIGBUILD_ENV_VAR,
-    )
-    .map(|v| !v.is_empty() && v != "0")
-    .unwrap_or(false);
+    let legacy_xwin = std::env::var_os(crate::blessed_build::USE_LEGACY_XWIN_ENV_VAR)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false);
+    let legacy_zigbuild = std::env::var_os(crate::blessed_build::USE_LEGACY_ZIGBUILD_ENV_VAR)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false);
 
     if target_triple.ends_with("-pc-windows-msvc") {
         return if legacy_xwin { None } else { Some("xwin") };
     }
-    if target_triple.ends_with("-apple-darwin")
-        || target_triple.ends_with("-unknown-linux-musl")
-    {
-        return if legacy_zigbuild { None } else { Some("zigbuild") };
+    if target_triple.ends_with("-apple-darwin") || target_triple.ends_with("-unknown-linux-musl") {
+        return if legacy_zigbuild {
+            None
+        } else {
+            Some("zigbuild")
+        };
     }
     // Cross from x86_64 host to aarch64 linux — needs zigbuild for
     // the bundled libc.
-    if target_triple == "aarch64-unknown-linux-gnu"
-        && cfg!(target_arch = "x86_64")
-    {
-        return if legacy_zigbuild { None } else { Some("zigbuild") };
+    if target_triple == "aarch64-unknown-linux-gnu" && cfg!(target_arch = "x86_64") {
+        return if legacy_zigbuild {
+            None
+        } else {
+            Some("zigbuild")
+        };
     }
     None
 }
@@ -1055,10 +1053,7 @@ fn pick_cross_subcommand(target_triple: &str) -> Option<&'static str> {
 /// pair — prepend `xwin` keeping the `build` verb. So
 /// `["build", "--target", X, ...]` becomes
 /// `["xwin", "build", "--target", X, ...]`.
-fn rewrite_build_args_for_subcommand(
-    mut args: Vec<String>,
-    subcmd: &str,
-) -> Vec<String> {
+fn rewrite_build_args_for_subcommand(mut args: Vec<String>, subcmd: &str) -> Vec<String> {
     match subcmd {
         "zigbuild" => {
             if let Some(first) = args.first_mut() {
@@ -1081,8 +1076,7 @@ fn rewrite_build_args_for_subcommand(
 /// on PATH, the value is unchanged (PATH stays clean).
 fn prepend_to_path_env(dir: &std::path::Path) {
     let current = std::env::var_os("PATH").unwrap_or_default();
-    let mut existing: Vec<std::path::PathBuf> =
-        std::env::split_paths(&current).collect();
+    let mut existing: Vec<std::path::PathBuf> = std::env::split_paths(&current).collect();
     if existing.first().is_some_and(|p| p == dir) {
         return;
     }

--- a/crates/soldr-cli/src/main_tests.rs
+++ b/crates/soldr-cli/src/main_tests.rs
@@ -691,14 +691,8 @@ fn pick_cross_subcommand_musl_returns_zigbuild() {
 #[cfg(target_os = "linux")]
 fn pick_cross_subcommand_legacy_xwin_returns_none() {
     let _g = ENV_LOCK.lock().unwrap();
-    std::env::set_var(
-        crate::blessed_build::USE_LEGACY_XWIN_ENV_VAR,
-        "1",
-    );
-    assert_eq!(
-        pick_cross_subcommand("x86_64-pc-windows-msvc"),
-        None,
-    );
+    std::env::set_var(crate::blessed_build::USE_LEGACY_XWIN_ENV_VAR, "1");
+    assert_eq!(pick_cross_subcommand("x86_64-pc-windows-msvc"), None,);
     std::env::remove_var(crate::blessed_build::USE_LEGACY_XWIN_ENV_VAR);
 }
 
@@ -706,17 +700,9 @@ fn pick_cross_subcommand_legacy_xwin_returns_none() {
 #[cfg(target_os = "linux")]
 fn pick_cross_subcommand_legacy_zigbuild_returns_none() {
     let _g = ENV_LOCK.lock().unwrap();
-    std::env::set_var(
-        crate::blessed_build::USE_LEGACY_ZIGBUILD_ENV_VAR,
-        "1",
-    );
-    assert_eq!(
-        pick_cross_subcommand("aarch64-apple-darwin"),
-        None,
-    );
-    std::env::remove_var(
-        crate::blessed_build::USE_LEGACY_ZIGBUILD_ENV_VAR,
-    );
+    std::env::set_var(crate::blessed_build::USE_LEGACY_ZIGBUILD_ENV_VAR, "1");
+    assert_eq!(pick_cross_subcommand("aarch64-apple-darwin"), None,);
+    std::env::remove_var(crate::blessed_build::USE_LEGACY_ZIGBUILD_ENV_VAR);
 }
 
 #[test]

--- a/crates/soldr-cli/src/prepare_cmd.rs
+++ b/crates/soldr-cli/src/prepare_cmd.rs
@@ -272,9 +272,7 @@ pub async fn run(
                 match ensure_llvm_toolchain(&paths).await {
                     Ok(p) => Ok::<PathBuf, SoldrError>(p),
                     Err(SoldrError::UnsupportedPlatform(m)) => {
-                        eprintln!(
-                            "soldr prepare: LLVM auto-bootstrap not supported on host: {m}"
-                        );
+                        eprintln!("soldr prepare: LLVM auto-bootstrap not supported on host: {m}");
                         Ok(PathBuf::new())
                     }
                     Err(e) => Err(e),
@@ -290,8 +288,7 @@ pub async fn run(
             // Darwin cross-compile path: needs zig + Apple SDK; export SDKROOT.
             // Both fetches independent — race them.
             eprintln!("soldr prepare: dispatch=zigbuild+apple-sdk (parallel)");
-            let (zig_dir, sdk) =
-                tokio::try_join!(ensure_zig(&paths), ensure_apple_sdk(&paths))?;
+            let (zig_dir, sdk) = tokio::try_join!(ensure_zig(&paths), ensure_apple_sdk(&paths))?;
             eprintln!("soldr prepare: zig at {}", zig_dir.display());
             eprintln!("soldr prepare: Apple SDK at {}", sdk.display());
             let sdk_str = sdk.to_string_lossy();

--- a/crates/soldr-cli/src/pyo3_detect.rs
+++ b/crates/soldr-cli/src/pyo3_detect.rs
@@ -126,7 +126,10 @@ fn detect_uncached(workspace_root: &Path) -> bool {
 /// Returns an empty map iff PyO3 detection found nothing OR the
 /// target equals the host (no cross-compile, native Python in
 /// the rustc-default toolchain works).
-pub fn cross_env_for_target(workspace_root: &Path, target: &str) -> std::collections::BTreeMap<String, String> {
+pub fn cross_env_for_target(
+    workspace_root: &Path,
+    target: &str,
+) -> std::collections::BTreeMap<String, String> {
     let mut env = std::collections::BTreeMap::new();
     if target.is_empty() || !workspace_uses_pyo3(workspace_root) {
         return env;
@@ -154,9 +157,17 @@ fn host_triple() -> &'static str {
         "x86_64-apple-darwin"
     } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
         "aarch64-apple-darwin"
-    } else if cfg!(all(target_os = "linux", target_arch = "x86_64", target_env = "musl")) {
+    } else if cfg!(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        target_env = "musl"
+    )) {
         "x86_64-unknown-linux-musl"
-    } else if cfg!(all(target_os = "linux", target_arch = "aarch64", target_env = "musl")) {
+    } else if cfg!(all(
+        target_os = "linux",
+        target_arch = "aarch64",
+        target_env = "musl"
+    )) {
         "aarch64-unknown-linux-musl"
     } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
         "x86_64-unknown-linux-gnu"

--- a/crates/soldr-cli/src/target_alias.rs
+++ b/crates/soldr-cli/src/target_alias.rs
@@ -109,10 +109,7 @@ pub enum AliasError {
         "soldr build --target `{input}`: not a known alias or Rust triple. \
          Did you mean `{suggestion}`?"
     )]
-    Unknown {
-        input: String,
-        suggestion: String,
-    },
+    Unknown { input: String, suggestion: String },
     #[error(
         "soldr build --target `{input}`: ambiguous — could mean ARM32 \
          (not supported) or ARM64. Use `{disambiguated}` explicitly."
@@ -125,10 +122,7 @@ pub enum AliasError {
         "soldr build --target `{input}`: 32-bit targets are not in soldr's \
          supported set. Did you mean `{suggestion}`?"
     )]
-    Thirty2Bit {
-        input: String,
-        suggestion: String,
-    },
+    Thirty2Bit { input: String, suggestion: String },
     #[error(
         "soldr build --target `all` is only valid for `soldr prepare --target all`; \
          expand explicitly for `soldr build`."
@@ -309,9 +303,17 @@ fn host_triple() -> &'static str {
         "x86_64-apple-darwin"
     } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
         "aarch64-apple-darwin"
-    } else if cfg!(all(target_os = "linux", target_arch = "x86_64", target_env = "musl")) {
+    } else if cfg!(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        target_env = "musl"
+    )) {
         "x86_64-unknown-linux-musl"
-    } else if cfg!(all(target_os = "linux", target_arch = "aarch64", target_env = "musl")) {
+    } else if cfg!(all(
+        target_os = "linux",
+        target_arch = "aarch64",
+        target_env = "musl"
+    )) {
         "aarch64-unknown-linux-musl"
     } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
         "x86_64-unknown-linux-gnu"

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -330,10 +330,9 @@ fn is_compile_env_var(name: &str) -> bool {
         "ZCCACHE_", // ZCCACHE_CACHE_DIR, ZCCACHE_PATH_REMAP, ZCCACHE_SESSION_ID
         "CC_",      // cc-rs cc_PROFILE_TARGET style
         "CXX_",     // ditto for C++
-        "AR_",
-        "LD_",      // LD_LIBRARY_PATH, LD_PRELOAD — both meaningful to subprocesses
-        "DEP_",     // build-script-emitted DEP_<pkg>_<key> env vars
-        "OUT_",     // OUT_DIR (build script working dir)
+        "AR_", "LD_",  // LD_LIBRARY_PATH, LD_PRELOAD — both meaningful to subprocesses
+        "DEP_", // build-script-emitted DEP_<pkg>_<key> env vars
+        "OUT_", // OUT_DIR (build script working dir)
     ];
     if PREFIXES.iter().any(|p| name.starts_with(p)) {
         return true;
@@ -429,67 +428,68 @@ fn compile_via_daemon(effective_args: &[String]) -> Result<i32, SoldrError> {
     // stdout/stderr as chunk frames arrive, so the IPC layer never
     // holds the whole rustc output buffered in memory.
     let first = client::compile_streaming(&sock, req.clone(), std::io::stdout(), std::io::stderr());
-    let done = match first {
-        Ok(info) => info,
-        Err(_) => {
-            // Spawn the daemon, then retry up to ~30 s. The spawn
-            // returns before the socket is bound. On cold WSL2 starts
-            // (or fresh container layers) the daemon's embedded
-            // zccache service can take a couple of seconds to come up
-            // before it accepts IPC.
-            let spawn_result = crate::daemon::lifecycle::try_spawn_detached();
-            if let Err(e) = &spawn_result {
-                eprintln!("soldr: try_spawn_detached returned err: {e:?}");
-            }
-            let mut last_err = None;
-            let mut done = None;
-            // 30 s retry window — embedded zccache cold-start (redb
-            // open, cache root init, depgraph load) can take several
-            // seconds on first-ever boot in a container.
-            for attempt in 0..300 {
-                std::thread::sleep(std::time::Duration::from_millis(100));
-                match client::compile_streaming(
-                    &sock,
-                    req.clone(),
-                    std::io::stdout(),
-                    std::io::stderr(),
-                ) {
-                    Ok(info) => {
-                        done = Some(info);
-                        break;
-                    }
-                    Err(e) => last_err = Some((attempt, e)),
+    let done =
+        match first {
+            Ok(info) => info,
+            Err(_) => {
+                // Spawn the daemon, then retry up to ~30 s. The spawn
+                // returns before the socket is bound. On cold WSL2 starts
+                // (or fresh container layers) the daemon's embedded
+                // zccache service can take a couple of seconds to come up
+                // before it accepts IPC.
+                let spawn_result = crate::daemon::lifecycle::try_spawn_detached();
+                if let Err(e) = &spawn_result {
+                    eprintln!("soldr: try_spawn_detached returned err: {e:?}");
                 }
-            }
-            match done {
-                Some(info) => info,
-                None => {
-                    // Diagnose: report whether the daemon binary even
-                    // exists at the expected sibling path, the PID
-                    // file presence, and the tail of the daemon's
-                    // spawn log (the daemon's stderr redirected by
-                    // spawn_detached_inner). Concrete place to look.
-                    let bin_diag = std::env::current_exe()
-                        .ok()
-                        .map(|p| crate::daemon::service_definition::sibling_daemon_binary(&p))
-                        .map(|p| (p.exists(), p.display().to_string()))
-                        .unwrap_or((false, "<unknown>".into()));
-                    let log_tail = SoldrPaths::new()
-                        .ok()
-                        .map(|p| p.root.join("daemon-spawn.log"))
-                        .and_then(|p| std::fs::read_to_string(&p).ok())
-                        .map(|s| {
-                            s.lines()
-                                .rev()
-                                .take(20)
-                                .collect::<Vec<_>>()
-                                .into_iter()
-                                .rev()
-                                .collect::<Vec<_>>()
-                                .join("\n")
-                        })
-                        .unwrap_or_else(|| "<no spawn log>".into());
-                    return Err(SoldrError::Other(format!(
+                let mut last_err = None;
+                let mut done = None;
+                // 30 s retry window — embedded zccache cold-start (redb
+                // open, cache root init, depgraph load) can take several
+                // seconds on first-ever boot in a container.
+                for attempt in 0..300 {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    match client::compile_streaming(
+                        &sock,
+                        req.clone(),
+                        std::io::stdout(),
+                        std::io::stderr(),
+                    ) {
+                        Ok(info) => {
+                            done = Some(info);
+                            break;
+                        }
+                        Err(e) => last_err = Some((attempt, e)),
+                    }
+                }
+                match done {
+                    Some(info) => info,
+                    None => {
+                        // Diagnose: report whether the daemon binary even
+                        // exists at the expected sibling path, the PID
+                        // file presence, and the tail of the daemon's
+                        // spawn log (the daemon's stderr redirected by
+                        // spawn_detached_inner). Concrete place to look.
+                        let bin_diag = std::env::current_exe()
+                            .ok()
+                            .map(|p| crate::daemon::service_definition::sibling_daemon_binary(&p))
+                            .map(|p| (p.exists(), p.display().to_string()))
+                            .unwrap_or((false, "<unknown>".into()));
+                        let log_tail = SoldrPaths::new()
+                            .ok()
+                            .map(|p| p.root.join("daemon-spawn.log"))
+                            .and_then(|p| std::fs::read_to_string(&p).ok())
+                            .map(|s| {
+                                s.lines()
+                                    .rev()
+                                    .take(20)
+                                    .collect::<Vec<_>>()
+                                    .into_iter()
+                                    .rev()
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
+                            })
+                            .unwrap_or_else(|| "<no spawn log>".into());
+                        return Err(SoldrError::Other(format!(
                         "soldr daemon embedded compile dispatch failed after spawn + 30s retry: \
                          {:?}. daemon_binary=({}, exists={}) spawn_result={:?} sock={}.\n\
                          daemon-spawn.log tail:\n{}\n\
@@ -500,10 +500,10 @@ fn compile_via_daemon(effective_args: &[String]) -> Result<i32, SoldrError> {
                         sock.display(),
                         log_tail,
                     )));
+                    }
                 }
             }
-        }
-    };
+        };
 
     Ok(done.exit_code)
 }

--- a/crates/soldr-cli/src/zccache_embedded.rs
+++ b/crates/soldr-cli/src/zccache_embedded.rs
@@ -60,8 +60,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use blake3::Hasher;
-use zccache::core::NormalizedPath;
 use zccache::audit::AuditMode;
+use zccache::core::NormalizedPath;
 use zccache::embedded::{
     AuditConfig, AuditContext, CacheOutcome, CompileRequest as ZccacheCompileRequest, HostIdentity,
     RuntimeHooks, ServiceLimits, ShutdownMode, ZccacheConfig, ZccacheService,

--- a/crates/soldr-cli/tests/cli_build_alias_parity.rs
+++ b/crates/soldr-cli/tests/cli_build_alias_parity.rs
@@ -53,9 +53,7 @@ fn soldr_build_alias_resolves_via_clap_not_external() {
     );
     // Must reference the build verb's own docstring or `--target`.
     assert!(
-        combined.contains("build")
-            || combined.contains("--target")
-            || combined.contains("blessed"),
+        combined.contains("build") || combined.contains("--target") || combined.contains("blessed"),
         "soldr build --help should produce build-verb help text:\n{combined}"
     );
 }
@@ -115,7 +113,9 @@ fn soldr_build_invokes_real_cargo_build() {
         ("soldr cargo build", &cargo_stderr),
     ] {
         assert!(
-            stderr.contains("manifest") || stderr.contains("Cargo.toml") || stderr.contains("nonexistent"),
+            stderr.contains("manifest")
+                || stderr.contains("Cargo.toml")
+                || stderr.contains("nonexistent"),
             "{name} did not reach cargo's manifest-handling path; stderr was:\n{stderr}"
         );
         assert!(
@@ -144,7 +144,9 @@ fn soldr_build_help_documents_blessed_surface() {
     );
 
     assert!(
-        combined.contains("blessed") || combined.contains("cross-compile") || combined.contains("Build the workspace"),
+        combined.contains("blessed")
+            || combined.contains("cross-compile")
+            || combined.contains("Build the workspace"),
         "soldr build --help is missing the blessed-surface contract language:\n{combined}"
     );
 }

--- a/crates/soldr-cli/tests/cli_daemon_builds.rs
+++ b/crates/soldr-cli/tests/cli_daemon_builds.rs
@@ -16,7 +16,6 @@ use soldr_cli::daemon::db;
 use soldr_cli::daemon::protocol::BuildRecord;
 mod common;
 
-
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
+++ b/crates/soldr-cli/tests/cli_daemon_lifecycle.rs
@@ -16,7 +16,6 @@ use serde_json::Value;
 use soldr_cli::core::SoldrPaths;
 mod common;
 
-
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 struct EnvScope {

--- a/crates/soldr-cli/tests/cli_daemon_target_touch.rs
+++ b/crates/soldr-cli/tests/cli_daemon_target_touch.rs
@@ -15,7 +15,6 @@ use soldr_cli::daemon::lifecycle;
 use soldr_cli::daemon::protocol::Request;
 mod common;
 
-
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
+++ b/crates/soldr-cli/tests/cli_daemon_zccache_link.rs
@@ -19,7 +19,6 @@ use soldr_cli::daemon::{client, db};
 use soldr_cli::timed_test;
 mod common;
 
-
 fn unique_temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/soldr-cli/tests/daemon_cook_index.rs
+++ b/crates/soldr-cli/tests/daemon_cook_index.rs
@@ -417,7 +417,6 @@ timed_test!(
             panic!("expected mac hit")
         };
 
-
         assert_eq!(linux_sha, [0xAAu8; 32]);
         assert_eq!(linux_size, 100);
         assert_eq!(mac_sha, [0xBBu8; 32]);


### PR DESCRIPTION
## Summary

Unblocks the `cargo fmt --all -- --check` step that has been failing on every cross-build lane on `main` for 30+ consecutive CI runs.

Three small changes:

1. **Format rebase** across `soldr-cli` (`cargo fmt -p soldr-cli`) — 33 files of mechanical whitespace/line-break diffs that newer rustfmt wants, no semantic edits.
2. **Workflow scope** `cargo fmt -p soldr-cli -- --check` (instead of `--all`) in `_ci-cross-build-linux.yml` and `ci.yml`. `--all` walks the path-dep submodule at `_vender/zccache` (despite `workspace.exclude`) and flags drift in code we don't own.
3. **Restore checkout after `setup-soldr`'s cook hydration** in `_ci-cross-build-linux.yml`. `prebuild-deps: soldr-cook` runs cargo-chef under the hood, which replaces every workspace crate's `main.rs` / `build.rs` with `fn main() {}` stubs. Without `git restore --worktree -- .`, the subsequent fmt check sees the stubs and fails. The `lint` job in `ci.yml` already has this pattern.
4. **`--github-env "$GITHUB_ENV"`** for `soldr prepare` (was passing the flag without a value, which now errors — `soldr#939` made the value mandatory).

Closes #1066.

## What this does NOT fix

`#1066` was scoped to the fmt failure that masked every other CI signal. Once fmt unblocks, several pre-existing cross-cc workflow issues become visible:
- linux musl/gnu cross link errors (duplicate `_start` from zig+rustc dueling crt1.o)
- linux gnu clippy needs `aarch64-linux-gnu-gcc`
- darwin jemalloc `sys/syscall.h` include path
- windows-msvc `cargo nextest archive` bypasses cargo-xwin's MSVC env setup

Each of those is its own bug. They're tracked under #1068 with concrete fix paths. Trying to bundle them into this PR ballooned the diff and exposed deeper architectural issues that warrant dedicated PRs.

## Test plan

- [x] `soldr cargo fmt -p soldr-cli -- --check` exits 0 locally
- [x] `soldr cargo check -p soldr-cli --lib` clean
- [ ] Cross-build lane CI on this PR: fmt step passes (the fix's actual proof — downstream cross-cc lane failures are #1068's scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)