### PR TITLE
chore(release): bump 0.7.67 -> 0.7.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.67"
+version = "0.7.68"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.67"
+version = "0.7.68"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.67",
+  "version": "0.7.68",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Triggers the autonomous release workflow once merged. Picks up:

- **#1067** — fmt drift unblock + workflow scope to `-p soldr-cli` + git-restore after cook hydration + `--github-env "\$GITHUB_ENV"`
- **#1069** — cross-cc structural: zig-cc wrappers extended to all zigbuild targets, host clippy, `--target=` filtering, `-C link-self-contained=no`, darwin SDKROOT injection, skip windows nextest archive
- **#1072** — `blessed_build::xwin_msvc_cflags()` `/imsvc<path>` no-space CFLAGS format fix + windows-msvc cross-build via `soldr build` blessed surface (bootstraps fresh soldr + clang-shim) + darwin and aarch64-windows lanes gated pending forge recipes

## CI on main after this train

| Lane | Status |
|---|---|
| aarch64-unknown-linux-gnu | ✅ pass |
| aarch64-unknown-linux-musl | ✅ pass |
| x86_64-unknown-linux-musl | ✅ pass |
| x86_64-pc-windows-msvc | ✅ pass (via `soldr build`) |
| {x86_64,aarch64}-apple-darwin | ⏸ gated — `soldr-toolchain#34` priority 2 (jemalloc-darwin recipes) |
| aarch64-pc-windows-msvc | ⏸ gated — `soldr-toolchain#34` priority 3 (zlib-ng × 8) |

## Test plan

- [x] `soldr cargo check -p soldr-cli --lib` clean locally
- [ ] release-auto workflow auto-publishes v0.7.68 on merge (PyPI + npm + GitHub release + crates.io)

🤖 Generated with [Claude Code](https://claude.com/claude-code)