### PR TITLE
chore(release): bump 0.7.68 -> 0.7.69 + continue-on-error for darwin

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -168,6 +168,12 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.should_release == 'true'
     runs-on: ${{ matrix.runner }}
+    # darwin cross-build via zigbuild hits tikv-jemalloc-sys's
+    # sys/syscall.h cross-compile bug. Tracked in soldr-toolchain#34
+    # priority 2 (jemalloc-darwin forge recipes). Until that lands,
+    # ship releases without darwin binaries rather than block every
+    # patch release on a structural toolchain gap.
+    continue-on-error: ${{ contains(matrix.target, 'apple-darwin') }}
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.68"
+version = "0.7.69"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.68"
+version = "0.7.69"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.68",
+  "version": "0.7.69",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

0.7.68 release-auto run failed because both `apple-darwin` build lanes hit `tikv-jemalloc-sys`'s `sys/syscall.h` cross-compile bug. Same root cause as the darwin lanes already gated off in `ci.yml` since #1072. Proper fix needs a forge libjemalloc.a prebuilt for darwin — tracked in `soldr-toolchain#34` priority 2.

This PR:
1. **Marks darwin builds in `release-auto.yml` as `continue-on-error: true`** so the rest of the matrix publishes cleanly. Releases ship without darwin binaries until the soldr-toolchain catalogue lands them.
2. **Bumps `0.7.68 -> 0.7.69`** to retrigger release-auto.

## Test plan

- [x] `soldr cargo check -p soldr-cli --lib` clean
- [ ] release-auto publishes 0.7.69 with linux/windows artifacts (darwin will fail-but-not-block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)