### PR TITLE
chore(release): bump 0.7.69 -> 0.7.70 + aarch64-darwin native macos-15 runner

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -310,13 +310,13 @@ jobs:
       # macos-runner builds). Same pinned versions as the every-commit
       # _ci-cross-build-linux.yml workflow.
       - name: Setup zig (zigbuild lanes)
-        if: matrix.target == 'aarch64-unknown-linux-musl' || contains(matrix.target, 'apple-darwin')
+        if: matrix.target == 'aarch64-unknown-linux-musl' || (contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04')
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.15.2
 
       - name: Install cargo-zigbuild (zigbuild lanes)
-        if: matrix.target == 'aarch64-unknown-linux-musl' || contains(matrix.target, 'apple-darwin')
+        if: matrix.target == 'aarch64-unknown-linux-musl' || (contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04')
         uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
         with:
           tool: cargo-zigbuild@0.23.0
@@ -327,7 +327,7 @@ jobs:
       # Mirrors the proven pattern in _ci-cross-build-linux.yml (PR
       # #1052). Darwin-only — no SDK fetch needed for other lanes.
       - name: Bootstrap soldr for Apple SDK prep (darwin only)
-        if: contains(matrix.target, 'apple-darwin')
+        if: contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04'
         shell: bash
         env:
           RUSTC_WRAPPER: ""
@@ -341,12 +341,12 @@ jobs:
           echo "$RUNNER_TEMP/soldr-bin" >> "$GITHUB_PATH"
 
       - name: Prepare Apple SDK (darwin only)
-        if: contains(matrix.target, 'apple-darwin')
+        if: contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04'
         shell: bash
         run: soldr prepare --target ${{ matrix.target }} --github-env
 
       - name: Setup persistent zig-cc wrappers (darwin only)
-        if: contains(matrix.target, 'apple-darwin')
+        if: contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04'
         shell: bash
         run: bash .github/scripts/make_zig_cc_wrappers.sh "${{ matrix.target }}"
 
@@ -363,7 +363,11 @@ jobs:
           # compile from linux. All other lanes use plain cargo build
           # on their native runner.
           target='${{ matrix.target }}'
-          if [ "$target" = "aarch64-unknown-linux-musl" ] || [[ "$target" == *-apple-darwin ]]; then
+          # Use cargo zigbuild only when cross-compiling from a linux
+          # host. Native macOS runners (aarch64-apple-darwin on
+          # macos-15) use plain cargo build.
+          if [ "$target" = "aarch64-unknown-linux-musl" ] \
+             || { [[ "$target" == *-apple-darwin ]] && [ "$RUNNER_OS" = "Linux" ]; }; then
             cargo zigbuild --package soldr-cli --release --locked --target "$target"
           else
             cargo build --package soldr-cli --release --locked --target "$target"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.69"
+version = "0.7.70"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.69"
+version = "0.7.70"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Per user direction: aarch64-apple-darwin should NOT be skipped.

Reverts soldr#917 / #1053 only for aarch64-apple-darwin — moves it back to a native `macos-15` runner so `cargo build` runs naturally on darwin with the SDK headers present. The linux-host zigbuild path fails at `tikv-jemalloc-sys`'s `sys/syscall.h` cross-compile.

x86_64-apple-darwin stays on linux-host zigbuild + continue-on-error for now; same forge libjemalloc.a recipe (soldr-toolchain#34 priority 2) eventually unblocks both lanes.

## Changes

- aarch64-apple-darwin matrix runner: `ubuntu-24.04` → `macos-15`
- `continue-on-error` gated only on `x86_64-apple-darwin` (not aarch64)
- Setup zig / cargo-zigbuild / Bootstrap soldr SDK prep / Apple SDK / zig-cc wrappers steps gate on `runner.os == 'Linux'` so native macos runner skips cross-compile prep
- Build dispatch: aarch64-darwin on macos uses plain `cargo build`; linux-host darwin still uses `cargo zigbuild`

Cargo.toml + package.json bumped to 0.7.70 to retrigger release-auto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
