### PR TITLE
chore(release): bump 0.7.70 -> 0.7.71 — actually move aarch64-darwin to macos-15

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -213,7 +213,7 @@ jobs:
             target: x86_64-apple-darwin
             binary: soldr
           - name: macOS ARM64
-            runner: ubuntu-24.04
+            runner: macos-15
             target: aarch64-apple-darwin
             binary: soldr
           - name: Windows x64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.70"
+version = "0.7.71"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.70"
+version = "0.7.71"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.70",
+  "version": "0.7.71",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
0.7.70 had the per-step `if:` conditions gating on `matrix.runner == 'ubuntu-24.04'` but the matrix runner value for macOS ARM64 stayed on `ubuntu-24.04` — the workflow YAML change landed partially. This commit corrects the matrix entry to `runner: macos-15` (native arm64 mac) so aarch64-apple-darwin runs plain `cargo build` natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)