### PR TITLE
fix(msvc-host): auto-discover Windows VS install (closes #1079)

### DIFF
--- a/crates/soldr-cli/src/lib.rs
+++ b/crates/soldr-cli/src/lib.rs
@@ -18,6 +18,13 @@
 /// `Commands::Build` for canonical target triples. Coordinates the
 /// xwin-cache materialization + clang-shim install + env var setup.
 pub mod blessed_build;
+/// soldr#1079 — Windows MSVC host-toolchain auto-discovery. Probes
+/// vswhere + the Windows SDK and synthesizes LIB/INCLUDE/PATH/LIBPATH
+/// onto the current process so `soldr cargo build` / `soldr cargo test`
+/// succeed from a plain PowerShell without the downstream `$env:LIB`
+/// workaround. Detect-host now; managed-catalogue fallback is a
+/// follow-up in the same issue.
+pub mod msvc_host;
 pub mod cache_lib;
 pub mod cargo_metadata_soldr;
 pub mod core;

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -34,6 +34,10 @@ mod fuzzy_match;
 mod gc;
 mod install_shims;
 mod linker;
+/// soldr#1079 — Windows MSVC host-toolchain auto-discovery. Runs
+/// before cargo for MSVC targets so `link.exe` + `LIB` are set
+/// without the user touching `$env:LIB`.
+mod msvc_host;
 mod native_cc;
 mod optimize;
 mod optimize_detect;
@@ -310,6 +314,15 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 }
             }
 
+            // soldr#1079: ensure native Windows MSVC builds get LIB /
+            // INCLUDE / PATH (link.exe) injected from the host VS
+            // install, so users invoking `soldr build` from a plain
+            // PowerShell don't have to set `$env:LIB` themselves.
+            // No-op when not on Windows, when the user opted out via
+            // `SOLDR_MSVC_DISCOVERY=off`, when LIB is already set, or
+            // when the resolved target is non-MSVC.
+            ensure_msvc_host_env_for_native(&full_args);
+
             std::process::exit(
                 cargo_front_door::run_cargo_front_door(
                     &full_args,
@@ -321,6 +334,11 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             );
         }
         Commands::Cargo { args } => {
+            // soldr#1079: same MSVC host env injection that
+            // `Commands::Build` does, so `soldr cargo build` /
+            // `soldr cargo test` on a native Windows MSVC target also
+            // succeed from a plain PowerShell without `$env:LIB`.
+            ensure_msvc_host_env_for_native(&args);
             std::process::exit(
                 cargo_front_door::run_cargo_front_door(
                     &args,
@@ -1068,6 +1086,50 @@ fn rewrite_build_args_for_subcommand(mut args: Vec<String>, subcmd: &str) -> Vec
             args
         }
         _ => args,
+    }
+}
+
+/// soldr#1079 — bridge between the cargo dispatcher and the MSVC
+/// host-discovery module. Resolves the target triple (explicit
+/// `--target` first, then `TargetTriple::detect()` for the implicit
+/// native default) and asks [`crate::msvc_host`] to inject the
+/// vcvars-equivalent env vars when relevant.
+///
+/// All branches are silent on success / no-op. Discovery errors are
+/// printed as a single warning line so the user gets a hint about
+/// `SOLDR_MSVC_DISCOVERY=off` if the auto-probe trips on an unusual
+/// install — the underlying cargo invocation still runs and emits
+/// its own (better) error if it actually needs the env.
+fn ensure_msvc_host_env_for_native(args: &[String]) {
+    if !cfg!(target_os = "windows") {
+        return;
+    }
+    let target = match extract_target_from_args(args) {
+        Some(t) => t,
+        None => match crate::core::TargetTriple::detect() {
+            Ok(t) => t.triple(),
+            Err(_) => return,
+        },
+    };
+    match crate::msvc_host::ensure_msvc_env_for_native(&target) {
+        Ok(true) => {
+            tracing::debug!(
+                target: "soldr::msvc_host",
+                target_triple = %target,
+                "injected host MSVC env (LIB/INCLUDE/PATH/LIBPATH) for native build"
+            );
+        }
+        Ok(false) => {
+            // Skipped — non-windows, non-msvc, opt-out, or already-set.
+            // Nothing to log; this is the steady-state branch in dev
+            // command prompts.
+        }
+        Err(err) => {
+            eprintln!(
+                "soldr: MSVC host discovery failed for {target}: {err}\n\
+                 soldr: cargo will still run; set SOLDR_MSVC_DISCOVERY=off to silence this probe."
+            );
+        }
     }
 }
 

--- a/crates/soldr-cli/src/msvc_host.rs
+++ b/crates/soldr-cli/src/msvc_host.rs
@@ -1,0 +1,545 @@
+//! Windows MSVC host-toolchain auto-discovery (issue #1079).
+//!
+//! Synthesizes the env vars (`LIB`, `INCLUDE`, `PATH`, `LIBPATH`) that
+//! `vcvars64.bat` sets up, by probing the host's Visual Studio install
+//! via `vswhere.exe` and the Windows 10/11 SDK via filesystem
+//! enumeration. Lets soldr-managed `cargo build` / `cargo test`
+//! invocations succeed from a plain PowerShell, eliminating the
+//! downstream `$env:LIB` workaround documented in issue #1079.
+//!
+//! ## Detect-then-download (issue #1079 comment thread)
+//!
+//! This module covers the **detect-host** half. The download-fallback
+//! half (synthesize the same env from a soldr-managed MSVC catalogue
+//! when no host VS is installed) is tracked in #1079 as a follow-up
+//! and is not implemented here — the immediate user-blocking symptom
+//! is satisfied by host detection alone, which is the 99% case on
+//! developer machines.
+//!
+//! ## Behavior contract
+//!
+//! - On non-Windows hosts: every function is a no-op.
+//! - On Windows with `SOLDR_MSVC_DISCOVERY=off` (or `0` / `false`):
+//!   no-op. Lets users force-disable the auto-injection.
+//! - On Windows where `LIB` is already set AND `link.exe` is already
+//!   on `PATH` (caller is in a Developer Command Prompt or has run
+//!   vcvars manually): no-op. soldr respects an existing env rather
+//!   than clobbering it.
+//! - Otherwise: probe vswhere → resolve VS install + tools version →
+//!   probe SDK → write `LIB`/`INCLUDE`/`PATH`/`LIBPATH` onto the
+//!   current process env.
+
+use std::path::{Path, PathBuf};
+
+/// Env var that opts out of MSVC host discovery. Accepts `off`, `0`,
+/// or `false`. Any other value (including unset) keeps discovery on.
+pub const SOLDR_MSVC_DISCOVERY_ENV_VAR: &str = "SOLDR_MSVC_DISCOVERY";
+
+/// Override path to `vswhere.exe`. Useful in tests and for unusual
+/// installs. When unset, [`vswhere_path`] uses the canonical
+/// `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`
+/// location that ships with every VS 2017+ install.
+pub const SOLDR_VSWHERE_ENV_VAR: &str = "SOLDR_VSWHERE";
+
+/// Override path to the Windows SDK root (e.g. `C:\Program Files (x86)\Windows Kits\10`).
+/// When unset, [`probe_windows_sdk`] enumerates the standard locations.
+pub const SOLDR_WINDOWS_SDK_ROOT_ENV_VAR: &str = "SOLDR_WINDOWS_SDK_ROOT";
+
+/// The four env vars [`ensure_msvc_env_for_native`] writes when it
+/// successfully detects a host MSVC install. `PATH` is the only
+/// existing-value-respected one (we *prepend* tool dirs); the others
+/// are full replacements.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MsvcHostEnv {
+    pub lib: String,
+    pub include: String,
+    /// Semicolon-joined list of directories to **prepend** to `PATH`.
+    pub path_prepend: String,
+    pub libpath: String,
+}
+
+/// Resolved MSVC + Windows SDK layout. Constructed by
+/// [`discover_msvc_layout`] from the host filesystem; transformed
+/// into [`MsvcHostEnv`] via [`MsvcHostLayout::synthesize_env_x64`] —
+/// no I/O in the synthesis step so the pure transformation is unit-
+/// testable without a real VS install.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MsvcHostLayout {
+    pub vs_install: PathBuf,
+    pub vc_tools_version: String,
+    pub sdk_root: PathBuf,
+    pub sdk_version: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MsvcDetectionError {
+    #[error("vswhere.exe not found at expected location: {0}")]
+    VswhereNotFound(PathBuf),
+    #[error("vswhere.exe returned non-zero: {0}")]
+    VswhereFailed(String),
+    #[error("vswhere.exe found no Visual Studio install with the VC++ x86/x64 tools component")]
+    NoVsInstall,
+    #[error("MSVC tools version file missing or empty: {0}")]
+    NoToolsVersion(PathBuf),
+    #[error("Windows 10/11 SDK install not found in any standard location")]
+    NoSdkRoot,
+    #[error("Windows SDK at {0} has no usable version directory under Include/")]
+    NoSdkVersion(PathBuf),
+    #[error("io error during MSVC discovery: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl MsvcHostLayout {
+    /// Pure transformation from a discovered layout to the env vars
+    /// `vcvars64.bat` writes for an x64 host targeting x64. No
+    /// filesystem access — fully unit-testable.
+    pub fn synthesize_env_x64(&self) -> MsvcHostEnv {
+        let msvc = self
+            .vs_install
+            .join("VC")
+            .join("Tools")
+            .join("MSVC")
+            .join(&self.vc_tools_version);
+        let sdk_inc = self.sdk_root.join("Include").join(&self.sdk_version);
+        let sdk_lib = self.sdk_root.join("Lib").join(&self.sdk_version);
+
+        let lib = vec![
+            msvc.join("lib").join("x64"),
+            msvc.join("ATLMFC").join("lib").join("x64"),
+            sdk_lib.join("um").join("x64"),
+            sdk_lib.join("ucrt").join("x64"),
+        ];
+        let include = vec![
+            msvc.join("include"),
+            msvc.join("ATLMFC").join("include"),
+            sdk_inc.join("ucrt"),
+            sdk_inc.join("shared"),
+            sdk_inc.join("um"),
+            sdk_inc.join("winrt"),
+            sdk_inc.join("cppwinrt"),
+        ];
+        let path_prepend = vec![
+            msvc.join("bin").join("Hostx64").join("x64"),
+            self.sdk_root.join("bin").join(&self.sdk_version).join("x64"),
+            msvc.join("bin").join("Hostx64").join("x86"),
+        ];
+        let libpath = vec![
+            msvc.join("lib").join("x64"),
+            msvc.join("ATLMFC").join("lib").join("x64"),
+        ];
+
+        MsvcHostEnv {
+            lib: join_semicolons(&lib),
+            include: join_semicolons(&include),
+            path_prepend: join_semicolons(&path_prepend),
+            libpath: join_semicolons(&libpath),
+        }
+    }
+}
+
+fn join_semicolons(parts: &[PathBuf]) -> String {
+    parts
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+/// Returns `true` when the env was injected, `false` when discovery
+/// was skipped (non-Windows, opted out, already in a vcvars env, or
+/// target is not MSVC). Returns `Err` only when discovery was
+/// attempted and failed in a way the caller should know about — most
+/// commonly "no VS install with VC++ tools".
+pub fn ensure_msvc_env_for_native(target_triple: &str) -> Result<bool, MsvcDetectionError> {
+    if !cfg!(target_os = "windows") {
+        return Ok(false);
+    }
+    if !target_triple.ends_with("-pc-windows-msvc") {
+        return Ok(false);
+    }
+    if opted_out() {
+        return Ok(false);
+    }
+    if already_in_msvc_env() {
+        return Ok(false);
+    }
+    let layout = discover_msvc_layout()?;
+    let env = layout.synthesize_env_x64();
+    apply_to_process(&env);
+    Ok(true)
+}
+
+/// Returns `true` if `SOLDR_MSVC_DISCOVERY` is set to `off`, `0`, or
+/// `false`. Anything else (including missing) keeps discovery on.
+pub fn opted_out() -> bool {
+    match std::env::var(SOLDR_MSVC_DISCOVERY_ENV_VAR) {
+        Ok(v) => {
+            let lower = v.trim().to_lowercase();
+            matches!(lower.as_str(), "off" | "0" | "false" | "no")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Heuristic for "user already has a working MSVC env loaded".
+/// Conservative on purpose: we only skip when BOTH `LIB` is set
+/// AND `link.exe` is findable on PATH. A half-loaded env (LIB without
+/// link.exe, or vice versa) still triggers discovery so we end up in
+/// a consistent state.
+pub fn already_in_msvc_env() -> bool {
+    let lib_set = std::env::var_os("LIB")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let link_on_path = which_on_path("link.exe").is_some();
+    lib_set && link_on_path
+}
+
+/// Look up an executable on the current process's `PATH`. Returns
+/// the first match, or `None`. Kept dep-free (no `which` crate)
+/// because we only need bare-name lookup with `.is_file()`.
+pub fn which_on_path(name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// End-to-end host probe: vswhere → VS install → tools version →
+/// Windows SDK root + version. Returns the resolved layout or a
+/// structured error for the missing step.
+pub fn discover_msvc_layout() -> Result<MsvcHostLayout, MsvcDetectionError> {
+    let vswhere = vswhere_path();
+    if !vswhere.is_file() {
+        return Err(MsvcDetectionError::VswhereNotFound(vswhere));
+    }
+    let install = run_vswhere_install_path(&vswhere)?;
+    let vc_tools_version = read_vc_tools_version(&install)?;
+    let (sdk_root, sdk_version) = probe_windows_sdk()?;
+    Ok(MsvcHostLayout {
+        vs_install: install,
+        vc_tools_version,
+        sdk_root,
+        sdk_version,
+    })
+}
+
+/// Resolves the location of `vswhere.exe`. Honors
+/// [`SOLDR_VSWHERE_ENV_VAR`] for overrides; otherwise points at the
+/// canonical install path that ships with every VS 2017+ installer.
+pub fn vswhere_path() -> PathBuf {
+    if let Some(p) = std::env::var_os(SOLDR_VSWHERE_ENV_VAR) {
+        return PathBuf::from(p);
+    }
+    let pf86 = std::env::var_os("ProgramFiles(x86)")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\Program Files (x86)"));
+    pf86.join("Microsoft Visual Studio")
+        .join("Installer")
+        .join("vswhere.exe")
+}
+
+fn run_vswhere_install_path(vswhere: &Path) -> Result<PathBuf, MsvcDetectionError> {
+    let out = std::process::Command::new(vswhere)
+        .args([
+            "-latest",
+            "-products",
+            "*",
+            "-requires",
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "-property",
+            "installationPath",
+            "-format",
+            "value",
+            "-utf8",
+        ])
+        .output()?;
+    if !out.status.success() {
+        return Err(MsvcDetectionError::VswhereFailed(format!(
+            "status={:?} stderr={}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if path.is_empty() {
+        return Err(MsvcDetectionError::NoVsInstall);
+    }
+    Ok(PathBuf::from(path))
+}
+
+fn read_vc_tools_version(install: &Path) -> Result<String, MsvcDetectionError> {
+    let f = install
+        .join("VC")
+        .join("Auxiliary")
+        .join("Build")
+        .join("Microsoft.VCToolsVersion.default.txt");
+    let s =
+        std::fs::read_to_string(&f).map_err(|_| MsvcDetectionError::NoToolsVersion(f.clone()))?;
+    let v = s.trim().to_string();
+    if v.is_empty() {
+        return Err(MsvcDetectionError::NoToolsVersion(f));
+    }
+    Ok(v)
+}
+
+fn probe_windows_sdk() -> Result<(PathBuf, String), MsvcDetectionError> {
+    if let Some(root_override) = std::env::var_os(SOLDR_WINDOWS_SDK_ROOT_ENV_VAR) {
+        let root = PathBuf::from(root_override);
+        let version = pick_highest_sdk_version(&root)?;
+        return Ok((root, version));
+    }
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    for env_name in ["ProgramFiles(x86)", "ProgramFiles"] {
+        if let Some(pf) = std::env::var_os(env_name) {
+            candidates.push(PathBuf::from(pf).join("Windows Kits").join("10"));
+        }
+    }
+    for root in candidates {
+        if root.is_dir() {
+            let version = pick_highest_sdk_version(&root)?;
+            return Ok((root, version));
+        }
+    }
+    Err(MsvcDetectionError::NoSdkRoot)
+}
+
+/// Enumerate `<root>/Include/<version>/` directories and return the
+/// lexically-largest one that has the canonical `um/` + `ucrt/`
+/// subdirs (filters out half-installed SDKs). Lexical ordering works
+/// because Windows SDK versions are `10.0.NNNNN.N` with the build
+/// number padded to a fixed width.
+pub fn pick_highest_sdk_version(root: &Path) -> Result<String, MsvcDetectionError> {
+    let include = root.join("Include");
+    let mut versions = Vec::new();
+    if include.is_dir() {
+        for entry in std::fs::read_dir(&include)? {
+            let entry = entry?;
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !name.starts_with("10.") {
+                continue;
+            }
+            let p = entry.path();
+            if p.join("um").is_dir() && p.join("ucrt").is_dir() {
+                versions.push(name);
+            }
+        }
+    }
+    if versions.is_empty() {
+        return Err(MsvcDetectionError::NoSdkVersion(include));
+    }
+    versions.sort();
+    Ok(versions.pop().expect("non-empty"))
+}
+
+fn apply_to_process(env: &MsvcHostEnv) {
+    std::env::set_var("LIB", &env.lib);
+    std::env::set_var("INCLUDE", &env.include);
+    std::env::set_var("LIBPATH", &env.libpath);
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut new_path = std::ffi::OsString::new();
+    new_path.push(&env.path_prepend);
+    if !env.path_prepend.ends_with(';') {
+        new_path.push(";");
+    }
+    new_path.push(&existing);
+    std::env::set_var("PATH", new_path);
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the issue #1079 MSVC host discovery.
+    //!
+    //! Pure-function tests (no real VS / SDK install required) run on
+    //! every platform. The `discover_msvc_layout` end-to-end probe is
+    //! gated to `cfg(target_os = "windows")` and skips gracefully when
+    //! vswhere isn't present (CI without VS), so the same source
+    //! compiles + tests on Linux CI lanes too.
+    //!
+    //! The acceptance test for the issue is in
+    //! `tests/msvc_host_discovery_windows.rs` (separate integration
+    //! binary so the env-mutation it does cannot race other tests).
+
+    use super::*;
+    use crate::timed_test;
+    use std::time::Duration;
+
+    timed_test!(synthesize_env_x64_builds_canonical_paths, Duration::from_secs(5), {
+        let layout = MsvcHostLayout {
+            vs_install: PathBuf::from(
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community",
+            ),
+            vc_tools_version: "14.29.30133".into(),
+            sdk_root: PathBuf::from(r"C:\Program Files (x86)\Windows Kits\10"),
+            sdk_version: "10.0.22621.0".into(),
+        };
+        let env = layout.synthesize_env_x64();
+
+        assert!(
+            env.lib.contains(r"VC\Tools\MSVC\14.29.30133\lib\x64"),
+            "lib should contain canonical MSVC x64 libs path: {}",
+            env.lib
+        );
+        assert!(
+            env.lib.contains(r"Windows Kits\10\Lib\10.0.22621.0\ucrt\x64"),
+            "lib should contain ucrt x64 path: {}",
+            env.lib
+        );
+        assert!(
+            env.include.contains(r"VC\Tools\MSVC\14.29.30133\include"),
+            "include should contain MSVC include path: {}",
+            env.include
+        );
+        assert!(
+            env.path_prepend
+                .contains(r"VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64"),
+            "path_prepend should contain x64 host tools (link.exe lives here): {}",
+            env.path_prepend
+        );
+    });
+
+    timed_test!(vswhere_path_honors_override_env_var, Duration::from_secs(5), {
+        // Mutate env: ok because we read-then-restore. Run serially
+        // would be ideal but a single set/clear pair is atomic enough
+        // for cargo test's default parallelism — and no other tests
+        // touch SOLDR_VSWHERE.
+        let prior = std::env::var_os(SOLDR_VSWHERE_ENV_VAR);
+        std::env::set_var(SOLDR_VSWHERE_ENV_VAR, r"D:\custom\vswhere.exe");
+        let p = vswhere_path();
+        match prior {
+            Some(v) => std::env::set_var(SOLDR_VSWHERE_ENV_VAR, v),
+            None => std::env::remove_var(SOLDR_VSWHERE_ENV_VAR),
+        }
+        assert_eq!(p, PathBuf::from(r"D:\custom\vswhere.exe"));
+    });
+
+    timed_test!(opted_out_recognizes_off_zero_false, Duration::from_secs(5), {
+        let prior = std::env::var_os(SOLDR_MSVC_DISCOVERY_ENV_VAR);
+        for v in ["off", "OFF", "0", "false", "FALSE", "no", "  off  "] {
+            std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v);
+            assert!(opted_out(), "value `{v}` should opt out");
+        }
+        for v in ["on", "1", "true", "auto", ""] {
+            std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v);
+            assert!(!opted_out(), "value `{v}` should NOT opt out");
+        }
+        match prior {
+            Some(v) => std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v),
+            None => std::env::remove_var(SOLDR_MSVC_DISCOVERY_ENV_VAR),
+        }
+    });
+
+    timed_test!(pick_highest_sdk_version_skips_partial_installs, Duration::from_secs(10), {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inc = tmp.path().join("Include");
+        // 10.0.19041.0 — half-installed, missing ucrt/
+        std::fs::create_dir_all(inc.join("10.0.19041.0").join("um")).unwrap();
+        // 10.0.22621.0 — fully installed
+        std::fs::create_dir_all(inc.join("10.0.22621.0").join("um")).unwrap();
+        std::fs::create_dir_all(inc.join("10.0.22621.0").join("ucrt")).unwrap();
+        // 10.0.20348.0 — also fully installed but older
+        std::fs::create_dir_all(inc.join("10.0.20348.0").join("um")).unwrap();
+        std::fs::create_dir_all(inc.join("10.0.20348.0").join("ucrt")).unwrap();
+
+        let picked = pick_highest_sdk_version(tmp.path()).expect("should find a version");
+        assert_eq!(
+            picked, "10.0.22621.0",
+            "should pick the highest fully-installed version, skipping the partial 10.0.19041.0"
+        );
+    });
+
+    timed_test!(pick_highest_sdk_version_errors_on_empty_install, Duration::from_secs(10), {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Only Include/ exists, but no version subdirs with um+ucrt.
+        std::fs::create_dir_all(tmp.path().join("Include")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("Include").join("10.0.0.0").join("um")).unwrap();
+        // missing ucrt → should not qualify
+        let err = pick_highest_sdk_version(tmp.path()).expect_err("should fail");
+        assert!(matches!(err, MsvcDetectionError::NoSdkVersion(_)));
+    });
+
+    timed_test!(ensure_msvc_env_for_native_is_noop_on_non_msvc_target, Duration::from_secs(5), {
+        // This test runs on every platform and proves the early-out
+        // for non-MSVC targets. Even on Windows, asking for a
+        // non-MSVC target must skip discovery.
+        let applied = ensure_msvc_env_for_native("x86_64-unknown-linux-gnu")
+            .expect("noop should not error");
+        assert!(!applied, "linux-gnu target must not trigger MSVC discovery");
+    });
+
+    #[cfg(not(target_os = "windows"))]
+    timed_test!(ensure_msvc_env_for_native_is_noop_on_non_windows_host, Duration::from_secs(5), {
+        let applied = ensure_msvc_env_for_native("x86_64-pc-windows-msvc")
+            .expect("noop should not error");
+        assert!(
+            !applied,
+            "non-windows host must not attempt MSVC discovery"
+        );
+    });
+
+    // -------------------------------------------------------------------
+    // Windows-only end-to-end probe. Skips gracefully on hosts without
+    // a VS install (CI lanes without VC++ workload).
+    // -------------------------------------------------------------------
+    #[cfg(target_os = "windows")]
+    timed_test!(discover_msvc_layout_on_developer_machine_finds_real_link_exe, Duration::from_secs(30), {
+        let v = vswhere_path();
+        if !v.is_file() {
+            eprintln!(
+                "msvc_host: skipping discovery test — vswhere not present at {}",
+                v.display()
+            );
+            return;
+        }
+        let layout = match discover_msvc_layout() {
+            Ok(l) => l,
+            Err(MsvcDetectionError::NoVsInstall) => {
+                eprintln!("msvc_host: skipping — vswhere installed but no VS with C++ tools");
+                return;
+            }
+            Err(MsvcDetectionError::NoSdkRoot | MsvcDetectionError::NoSdkVersion(_)) => {
+                eprintln!("msvc_host: skipping — no Windows 10/11 SDK on host");
+                return;
+            }
+            Err(e) => panic!("unexpected discovery error: {e}"),
+        };
+
+        // The whole point of discovery is to produce a layout that
+        // resolves to a real link.exe. If this asserts, the layout
+        // is wrong and the env we'd inject would not fix the
+        // "linker `link.exe` not found" symptom.
+        let link_exe = layout
+            .vs_install
+            .join("VC")
+            .join("Tools")
+            .join("MSVC")
+            .join(&layout.vc_tools_version)
+            .join("bin")
+            .join("Hostx64")
+            .join("x64")
+            .join("link.exe");
+        assert!(
+            link_exe.is_file(),
+            "expected discovered layout to point at a real link.exe — got {}",
+            link_exe.display()
+        );
+
+        let env = layout.synthesize_env_x64();
+        assert!(
+            env.lib.contains(r"VC\Tools\MSVC"),
+            "lib should contain VC\\Tools\\MSVC: {}",
+            env.lib
+        );
+        assert!(
+            env.path_prepend.contains(r"VC\Tools\MSVC"),
+            "path_prepend should contain VC\\Tools\\MSVC: {}",
+            env.path_prepend
+        );
+    });
+}

--- a/crates/soldr-cli/tests/msvc_host_discovery_windows.rs
+++ b/crates/soldr-cli/tests/msvc_host_discovery_windows.rs
@@ -1,0 +1,177 @@
+//! End-to-end TDD acceptance test for issue #1079.
+//!
+//! Proves the contract: from a Windows shell with NO MSVC env vars
+//! loaded (no vcvars, no Developer Command Prompt), calling
+//! `msvc_host::ensure_msvc_env_for_native("x86_64-pc-windows-msvc")`
+//! produces a process env where `link.exe` is findable on `PATH` and
+//! `LIB` is populated — i.e. the user no longer needs the
+//! `$env:LIB = '...'` workaround documented in the issue.
+//!
+//! ## Why a separate integration binary
+//!
+//! cargo runs unit tests in parallel by default, so any test that
+//! mutates process-global env vars can race other tests. Integration
+//! tests under `tests/` each compile to their own binary with their
+//! own process — mutation here cannot leak into the lib `cargo test`
+//! workers. We put exactly ONE test in this file and accept the
+//! single-test cost of a fresh binary in exchange for safety.
+//!
+//! ## Skip behavior
+//!
+//! - Non-Windows: the whole file is `cfg(target_os = "windows")` — it
+//!   compiles to an empty test binary on Linux/macOS lanes.
+//! - Windows without VS C++ tools: the test skips with a clear stderr
+//!   message instead of failing. CI Windows runners without the VC++
+//!   workload (rare but possible) shouldn't fail this gate; the
+//!   per-PR perf-matrix runners that DO have the workload will.
+
+#![cfg(target_os = "windows")]
+
+use soldr_cli::msvc_host::{
+    discover_msvc_layout, ensure_msvc_env_for_native, vswhere_path, which_on_path,
+    MsvcDetectionError, SOLDR_MSVC_DISCOVERY_ENV_VAR,
+};
+use soldr_cli::timed_test;
+use std::time::Duration;
+
+timed_test!(ensure_msvc_env_for_native_makes_link_exe_findable_on_plain_powershell, Duration::from_secs(30), {
+    // ----- Skip gracefully on hosts without VS C++ tooling. -----
+    if !vswhere_path().is_file() {
+        eprintln!(
+            "msvc_host integration test: skipping — vswhere not present at {}",
+            vswhere_path().display()
+        );
+        return;
+    }
+    match discover_msvc_layout() {
+        Ok(_) => {}
+        Err(MsvcDetectionError::NoVsInstall) => {
+            eprintln!("msvc_host: skipping — vswhere installed but no VS with C++ tools");
+            return;
+        }
+        Err(MsvcDetectionError::NoSdkRoot | MsvcDetectionError::NoSdkVersion(_)) => {
+            eprintln!("msvc_host: skipping — no Windows 10/11 SDK on host");
+            return;
+        }
+        Err(MsvcDetectionError::NoToolsVersion(_)) => {
+            eprintln!("msvc_host: skipping — VS install missing VCToolsVersion file");
+            return;
+        }
+        Err(e) => {
+            panic!("unexpected discovery error setting up the test: {e}");
+        }
+    }
+
+    // ----- Save the env we're about to mutate. -----
+    let saved_lib = std::env::var_os("LIB");
+    let saved_include = std::env::var_os("INCLUDE");
+    let saved_libpath = std::env::var_os("LIBPATH");
+    let saved_path = std::env::var_os("PATH");
+    let saved_optout = std::env::var_os(SOLDR_MSVC_DISCOVERY_ENV_VAR);
+
+    // ----- Sanitize: simulate a plain PowerShell with no vcvars. -----
+    // Remove LIB / INCLUDE / LIBPATH entirely.
+    std::env::remove_var("LIB");
+    std::env::remove_var("INCLUDE");
+    std::env::remove_var("LIBPATH");
+    // Make sure the opt-out var isn't set to a disabling value left
+    // over from earlier tests in this process.
+    std::env::remove_var(SOLDR_MSVC_DISCOVERY_ENV_VAR);
+    // Strip any PATH entries that contain a `link.exe` so the test
+    // really proves *our* injection put it back. We rebuild PATH
+    // from only directories that DON'T already resolve link.exe.
+    if let Some(orig_path) = saved_path.as_ref() {
+        let cleaned: Vec<std::path::PathBuf> = std::env::split_paths(orig_path)
+            .filter(|d| !d.join("link.exe").is_file())
+            .collect();
+        let joined = std::env::join_paths(cleaned).expect("clean PATH");
+        std::env::set_var("PATH", joined);
+    }
+
+    // ----- RED check: confirm sanitization actually removed link.exe. -----
+    let link_before = which_on_path("link.exe");
+    let lib_before = std::env::var_os("LIB");
+    assert!(
+        link_before.is_none(),
+        "test setup bug: link.exe still on PATH after sanitization at {}",
+        link_before.map(|p| p.display().to_string()).unwrap_or_default()
+    );
+    assert!(
+        lib_before.is_none(),
+        "test setup bug: LIB still set after sanitization"
+    );
+
+    // ----- The contract under test. -----
+    let applied = ensure_msvc_env_for_native("x86_64-pc-windows-msvc")
+        .expect("discovery should succeed on a Windows host with VS installed");
+
+    // ----- GREEN check: env is now usable. -----
+    // Snapshot results BEFORE restoring saved env so failure messages
+    // describe the state we actually care about.
+    let applied_was_true = applied;
+    let link_after = which_on_path("link.exe");
+    let lib_after = std::env::var_os("LIB");
+    let include_after = std::env::var_os("INCLUDE");
+    let libpath_after = std::env::var_os("LIBPATH");
+
+    // ----- Restore. -----
+    match saved_lib {
+        Some(v) => std::env::set_var("LIB", v),
+        None => std::env::remove_var("LIB"),
+    }
+    match saved_include {
+        Some(v) => std::env::set_var("INCLUDE", v),
+        None => std::env::remove_var("INCLUDE"),
+    }
+    match saved_libpath {
+        Some(v) => std::env::set_var("LIBPATH", v),
+        None => std::env::remove_var("LIBPATH"),
+    }
+    match saved_path {
+        Some(v) => std::env::set_var("PATH", v),
+        None => std::env::remove_var("PATH"),
+    }
+    match saved_optout {
+        Some(v) => std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v),
+        None => std::env::remove_var(SOLDR_MSVC_DISCOVERY_ENV_VAR),
+    }
+
+    // ----- Now assert (after restoration is safely done). -----
+    assert!(
+        applied_was_true,
+        "ensure_msvc_env_for_native should report it injected env (returned false)"
+    );
+    let link_resolved = link_after.expect(
+        "issue #1079 contract broken: link.exe NOT findable after \
+         ensure_msvc_env_for_native — soldr is failing to put the MSVC \
+         bin directory on PATH",
+    );
+    assert!(
+        link_resolved
+            .to_string_lossy()
+            .to_lowercase()
+            .contains(r"\vc\tools\msvc\"),
+        "link.exe resolved at {} but doesn't look like a VC\\Tools\\MSVC binary",
+        link_resolved.display()
+    );
+    let lib = lib_after.expect("LIB env was not set by ensure_msvc_env_for_native");
+    let lib_str = lib.to_string_lossy();
+    assert!(
+        lib_str.contains(r"\VC\Tools\MSVC\"),
+        "LIB env should contain VC\\Tools\\MSVC: {lib_str}"
+    );
+    assert!(
+        lib_str.to_lowercase().contains(r"\ucrt\x64"),
+        "LIB env should contain \\ucrt\\x64 (Windows SDK ucrt libs): {lib_str}"
+    );
+    let inc = include_after.expect("INCLUDE env was not set");
+    let inc_str = inc.to_string_lossy();
+    assert!(
+        inc_str.contains(r"\VC\Tools\MSVC\"),
+        "INCLUDE env should contain VC\\Tools\\MSVC: {inc_str}"
+    );
+    assert!(
+        libpath_after.is_some(),
+        "LIBPATH env was not set by ensure_msvc_env_for_native"
+    );
+});


### PR DESCRIPTION
## Summary

Closes #1079 by adding a Windows MSVC host-toolchain auto-discovery module (`crates/soldr-cli/src/msvc_host.rs`) and wiring it into the `Commands::Cargo` and `Commands::Build` dispatch arms so the user no longer has to do this:

\`\`\`powershell
\$env:LIB = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\ATLMFC\lib\x64;...'
soldr cargo test ...
\`\`\`

before invoking soldr from a plain PowerShell.

## What it does

On every \`soldr cargo ...\` and \`soldr build ...\` invocation on a Windows host targeting MSVC:

1. Probe \`vswhere.exe\` at \`%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\\`. Resolve the latest VS install that has the VC++ x86/x64 component.
2. Read the active toolset version from \`<install>\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt\`.
3. Enumerate \`<Windows Kits 10>\Include\<version>\\` for the highest fully-installed Windows SDK (requires both \`um/\` and \`ucrt/\` subdirs — filters out half-installed SDKs).
4. Synthesize the env vars vcvars64.bat sets: \`LIB\` / \`INCLUDE\` / \`LIBPATH\` (replace) + \`PATH\` (prepend \`<msvc>\bin\Hostx64\x64\\` so link.exe is findable).
5. Inject them onto the current process so the child cargo invocation and downstream rustc + linker inherit them.

## Detect-then-download contract

Per the #1079 comment thread, soldr must follow detect-then-download:

- **First**: probe the host. If VS is present → use it. (This PR.)
- **If host VS absent** → fall back to soldr-managed MSVC catalogue (xwin-style). This PR does **not** implement that fallback — tracked in #1079 as a follow-up. The host-detect path alone covers the 99% case (developer machines with VS installed) and is what the user-reported regression was blocking.

## Skips and escape hatches

- Non-Windows host: no-op.
- Target ≠ \`*-pc-windows-msvc\`: no-op.
- \`SOLDR_MSVC_DISCOVERY=off\` (also accepts \`0\`, \`false\`, \`no\`): no-op.
- \`LIB\` already set AND \`link.exe\` already on \`PATH\`: no-op — caller is in a Developer Command Prompt, we don't clobber.
- \`SOLDR_VSWHERE\` overrides the vswhere path (useful for unusual installs).
- \`SOLDR_WINDOWS_SDK_ROOT\` overrides the SDK root probe.

Discovery errors are surfaced as a one-line stderr warning; cargo still runs. The next layer's error (the linker's) is more actionable than ours.

## Tests (TDD RED → GREEN)

**7 unit tests** in \`src/msvc_host.rs\`:

| Test | What it covers |
|---|---|
| \`synthesize_env_x64_builds_canonical_paths\` | Pure synthesis — no I/O, runs on every platform |
| \`vswhere_path_honors_override_env_var\` | \`SOLDR_VSWHERE\` env override |
| \`opted_out_recognizes_off_zero_false\` | Opt-out parsing (case + whitespace insensitive) |
| \`pick_highest_sdk_version_skips_partial_installs\` | Tempdir-based fixture: half-installed SDK 10.0.19041.0 (missing ucrt/) is correctly skipped in favor of fully-installed 10.0.22621.0 |
| \`pick_highest_sdk_version_errors_on_empty_install\` | Tempdir fixture: returns \`NoSdkVersion\` when nothing qualifies |
| \`ensure_msvc_env_for_native_is_noop_on_non_msvc_target\` | Linux-target early-out on every platform |
| \`discover_msvc_layout_on_developer_machine_finds_real_link_exe\` | **Windows-only end-to-end**: real vswhere probe → assert the discovered layout points at a real \`link.exe\` |

**1 integration acceptance test** in \`tests/msvc_host_discovery_windows.rs\` (separate binary so its env-mutation cannot race the parallel unit-test workers):

- Sanitizes the current process env: removes \`LIB\`/\`INCLUDE\`/\`LIBPATH\`, strips any PATH entry containing \`link.exe\` (proves a plain-PowerShell state).
- RED check: asserts \`link.exe\` is now NOT findable on PATH and \`LIB\` is NOT set (test-setup sanity).
- Calls \`ensure_msvc_env_for_native(\"x86_64-pc-windows-msvc\")\`.
- GREEN check: \`link.exe\` is findable on PATH (and resolves to a \`\VC\Tools\MSVC\\` binary); \`LIB\` contains \`\VC\Tools\MSVC\\` and \`\ucrt\x64\`; \`INCLUDE\` contains \`\VC\Tools\MSVC\\`; \`LIBPATH\` is set.
- Restores the env (BEFORE asserting) so a partial failure doesn't leak mutated env into other test binaries.

This is the test that directly proves the issue's contract: the user no longer needs the \`\$env:LIB\` workaround.

**All 8 tests pass** on a Windows host with VS 2019 BuildTools + Windows SDK 10.0.22621.0.

\`\`\`
running 7 tests
test msvc_host::tests::ensure_msvc_env_for_native_is_noop_on_non_msvc_target ... ok
test msvc_host::tests::vswhere_path_honors_override_env_var ... ok
test msvc_host::tests::synthesize_env_x64_builds_canonical_paths ... ok
test msvc_host::tests::opted_out_recognizes_off_zero_false ... ok
test msvc_host::tests::pick_highest_sdk_version_errors_on_empty_install ... ok
test msvc_host::tests::pick_highest_sdk_version_skips_partial_installs ... ok
test msvc_host::tests::discover_msvc_layout_on_developer_machine_finds_real_link_exe ... ok
test result: ok. 7 passed; 0 failed

running 1 test
test ensure_msvc_env_for_native_makes_link_exe_findable_on_plain_powershell ... ok
test result: ok. 1 passed; 0 failed
\`\`\`

## Note on local end-to-end validation

Verifying \"use freshly-built soldr from plain PowerShell\" on the dev machine is blocked by an **orthogonal** shipping bug uncovered during this work: managed \`zccache-1.12.11/\` only contains \`zccache-daemon.exe\` and \`zccache-fp.exe\` — the standalone \`zccache.exe\` was dropped when the daemon embedded zccache, but older installed soldr versions still try to spawn it as RUSTC_WRAPPER. Workaround: \`soldr --no-cache cargo ...\` bypasses RUSTC_WRAPPER entirely. **That orthogonal bug will be filed as a separate issue** — needs a zccache-soldr shim binary that forwards rustc-wrapper calls into the soldr-daemon's embedded service. Not in scope here.

The in-repo unit + integration tests added in this PR are the regression guard; downstream verification (fbuild / pip install) lands once this is merged.

## Test plan
- [x] \`soldr --no-cache cargo check -p soldr-cli --tests\` — clean
- [x] \`soldr --no-cache cargo test -p soldr-cli --lib msvc_host\` — 7/7 pass
- [x] \`soldr --no-cache cargo test -p soldr-cli --test msvc_host_discovery_windows\` — 1/1 pass
- [x] Real-vswhere probe asserted to resolve to an actual link.exe on the dev machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)