### PR TITLE
chore(release): bump 0.7.71 -> 0.7.72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.71"
+version = "0.7.72"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.71"
+version = "0.7.72"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Bumps workspace version 0.7.71 → 0.7.72 to trigger the autonomous release workflow. Contents over v0.7.71:

- **feat(daemon): cancel inflight compile instantly when wrapper disconnects (#1078).** Daemon-side \`select!\` between the compile future and a 1-byte EOF probe on the IPC stream — when cargo ctrl-c kills the wrapper, the in-flight rustc is dropped at the select boundary instead of grinding to completion. Watchdog-bounded TDD test (1-hour fake compile cancelled within <500 ms) proves the contract.

- **fix(msvc-host): auto-discover Windows VS install (#1080, closes #1079).** Windows users no longer need \`\$env:LIB = '...'\` before running \`soldr cargo build\` / \`soldr cargo test\`. vswhere-based probe synthesizes LIB / INCLUDE / PATH / LIBPATH from the host's installed Visual Studio + Windows SDK; opt-out via \`SOLDR_MSVC_DISCOVERY=off\`. Skips cleanly when already in a Developer Command Prompt or on non-Windows hosts.

- **feat(shim): zccache-soldr RUSTC_WRAPPER shim binary + shared compile_dispatch (#1082, refs #1081).** New dedicated wrapper binary that the RUSTC_WRAPPER slot can point at, plus a lifted \`compile_dispatch\` module both the existing soldr-as-wrapper hot path AND the new shim binary call. Honors a per-process retry budget (\`SOLDR_DAEMON_SPAWN_RETRY_BUDGET_MS\`, default 30s, clamped to ≥100ms) so the daemon-spawn loop never wedges. Hang-safety contract proved by a dead-socket TDD test.

## Dogfood validation

A freshly-built soldr 0.7.71-HEAD from a **clean Windows shell with no vcvars loaded** successfully built the whole soldr-cli workspace in **19.84 s (exit 0)**, proving the MSVC auto-discovery + the daemon embedded-zccache path end-to-end with **no \`\$env:LIB\` workaround**. See https://github.com/zackees/soldr/issues/1081#issuecomment-4839798840 for the full validation transcript.

## Release surface check (per CLAUDE.md "Release Publishing Rules")

- \`Cargo.toml\` \`[workspace.package].version\` → 0.7.72 ✅ (not on PyPI / npm / git tags)
- \`package.json\` \`"version"\` → 0.7.72 ✅ (lockstep)
- \`Cargo.lock\` \`soldr-cli\` version → 0.7.72 ✅
- \`v0.7.72\` git tag → does not exist (\`git ls-remote --tags origin v0.7.7\` shows only v0.7 / v0.7.71)
- PyPI \`soldr\` latest → 0.7.71 (0.7.72 not published)
- npm \`@zackees/soldr\` latest → 0.7.71 (0.7.72 not published)

Merging this PR triggers the \`autonomous-release\` workflow's prepare job, which sets \`should_release=true\` because the bumped version is not yet on a remote tag.

## Test plan
- [x] \`soldr --no-cache cargo check -p soldr-cli --tests --bins\` — clean on Windows
- [x] All 57 daemon tests + 6 compile_dispatch + 7 msvc_host + 5 wrapper_target — GREEN
- [x] Dogfood: fresh soldr binary from plain PowerShell builds full soldr workspace in 19.84 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)