### PR TITLE
chore(release): bump 0.7.73 -> 0.7.74 + wire darwin-cross blessed env (no more cargo zigbuild)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -168,12 +168,15 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.should_release == 'true'
     runs-on: ${{ matrix.runner }}
-    # darwin cross-build via zigbuild hits tikv-jemalloc-sys's
-    # sys/syscall.h cross-compile bug. Tracked in soldr-toolchain#34
-    # priority 2 (jemalloc-darwin forge recipes). Until that lands,
-    # ship releases without darwin binaries rather than block every
-    # patch release on a structural toolchain gap.
-    continue-on-error: ${{ contains(matrix.target, 'apple-darwin') }}
+    # soldr#1083 follow-up: darwin lanes are no longer marked
+    # continue-on-error. The structural cross-compile gap (zig's
+    # minimal darwin sysroot missing `sys/syscall.h` macros jemalloc
+    # configure probes) is fixed by `blessed_build.rs`'s apple-darwin
+    # arm, which surfaces the COMPLETE Apple SDK to cc-rs + rustc's
+    # linker. The `Build release binary` step now goes through
+    # `soldr build --target $T`, which uses the blessed env on
+    # darwin. If darwin cross-compile breaks the workflow, that's a
+    # real regression we want to surface — not silently skip.
     strategy:
       fail-fast: false
       matrix:
@@ -358,20 +361,23 @@ jobs:
         env:
           CARGO_PROFILE_RELEASE_DEBUG: ${{ contains(matrix.target, 'pc-windows-msvc') && 'line-tables-only' || '0' }}
         run: |
-          # soldr#1029 + soldr#917: aarch64-musl and both apple-darwin
-          # lanes route through cargo zigbuild for a hermetic cross-
-          # compile from linux. All other lanes use plain cargo build
-          # on their native runner.
+          # soldr#1083 follow-up: all build lanes go through `soldr
+          # build --target $T` so soldr owns the cross-compile env
+          # decision end-to-end. blessed_build.rs (apple-darwin arm)
+          # surfaces the COMPLETE Apple SDK to cc-rs's per-target
+          # CC/CXX/AR + rustc's linker — the structural fix for the
+          # tikv-jemalloc-sys `sys/syscall.h` cross-compile failure
+          # that was masked by `continue-on-error` on the darwin
+          # lanes. Internally soldr dispatches to:
+          #   * plain `cargo build` for darwin (with the blessed env)
+          #   * `cargo zigbuild` for `aarch64-unknown-linux-musl` via
+          #     `pick_cross_subcommand` — zig's bundled musl IS
+          #     complete and works fine; only the surface goes through
+          #     soldr instead of being called directly here
+          #   * plain `cargo build` for native lanes
+          # The workflow no longer invokes `cargo zigbuild` directly.
           target='${{ matrix.target }}'
-          # Use cargo zigbuild only when cross-compiling from a linux
-          # host. Native macOS runners (aarch64-apple-darwin on
-          # macos-15) use plain cargo build.
-          if [ "$target" = "aarch64-unknown-linux-musl" ] \
-             || { [[ "$target" == *-apple-darwin ]] && [ "$RUNNER_OS" = "Linux" ]; }; then
-            cargo zigbuild --package soldr-cli --release --locked --target "$target"
-          else
-            cargo build --package soldr-cli --release --locked --target "$target"
-          fi
+          soldr build --target "$target" --release --locked --package soldr-cli
 
       - name: Install zstd
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.73"
+version = "0.7.74"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.73"
+version = "0.7.74"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Activates the darwin-cross fix from #1084 by switching release-auto.yml's build step from \`cargo zigbuild\` / \`cargo build\` to a single \`soldr build --target \$T\` entry point. Drops \`continue-on-error\` on the darwin lanes so failures are now real failures, not silent skips.

## Why

The macOS x64 lane has been failing every release for weeks because \`cargo zigbuild --target x86_64-apple-darwin\` from ubuntu-24.04 hits tikv-jemalloc-sys's \`sys/syscall.h\` configure probe against zig's intentionally-minimal darwin sysroot. We landed the structural fix (\`blessed_build.rs\` apple-darwin arm that surfaces the COMPLETE Apple SDK to cc-rs + rustc's linker) in #1084 but never wired it into the workflow. This PR does the wiring.

## Changes

### \`release-auto.yml\` — single entry point for every build lane

Replace the cargo zigbuild/build conditional with:

\`\`\`bash
soldr build --target \$target --release --locked --package soldr-cli
\`\`\`

\`soldr build\` owns cross-compile orchestration via \`blessed_build.rs\`:
| Target | What soldr build dispatches to |
|---|---|
| \`*-apple-darwin\` | plain \`cargo build\` with the blessed env (clang + Apple SDK + clang+lld linker) |
| \`aarch64-unknown-linux-musl\` | \`cargo zigbuild\` internally via \`pick_cross_subcommand\` (zig's bundled musl IS complete; only the entry point changes) |
| Native lanes (Windows MSVC native, macOS ARM64 native, Linux native) | plain \`cargo build\` |

The workflow no longer invokes \`cargo zigbuild\` directly. soldr is the sole orchestrator.

### \`release-auto.yml\` — drop \`continue-on-error\` on darwin

Lines 171-176 used to mark \`apple-darwin\` rows as non-blocking while waiting for soldr-toolchain#34 (jemalloc-darwin forge recipes). The structural fix landed in #1084 + is now activated. Darwin failures are real regressions worth blocking on.

### Bump 0.7.73 → 0.7.74

Per CLAUDE.md release rules — fresh version triggers a clean re-run across all surfaces.

## Expected outcome

**If the blessed env block works** (cargo build + Apple SDK headers compile tikv-jemalloc-sys + ring + every other C dep):
- All 8 build lanes ✅ for the first time since the embedded-zccache transition
- v0.7.74 to PyPI + npm + GitHub Releases
- macOS x64 binary is back on the wire

**If darwin x64 still fails**:
- The lane is no longer continue-on-error, so the release is marked failed
- Linux + Windows + macOS-ARM64 lanes are independent matrix rows and still ship
- Diagnostic is exact (specific cargo step) instead of being masked by the silent skip

The wheel-version lint added in #1084 keeps the previous PyPI failure mode from recurring regardless of darwin's outcome.

## Test plan
- [x] Confirmed \`Commands::Build\` arg shape: \`soldr build --target X --release --locked --package soldr-cli\` becomes \`cargo build --target X --release --locked --package soldr-cli\` after blessed prep
- [x] Workspace version bumped in lockstep across Cargo.toml + Cargo.lock + package.json
- [ ] Release workflow run validates darwin x64 cross-compile end-to-end (validated post-merge by the autonomous release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)