### PR TITLE
chore(release): bump 0.7.74 -> 0.7.75 + narrow dist-wipe regression fix

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -874,15 +874,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # soldr#1083 follow-up: wipe dist/ before maturin runs so a
-          # stale wheel restored from setup-soldr's target/ cache
-          # (or left over from a prior maturin invocation in the same
-          # workspace) cannot leak into the upload set. Without this,
-          # lanes whose target/ cache included an old `dist/` from a
-          # pre-version-bump build silently re-upload e.g.
-          # `soldr-0.0.1-py3-none-manylinux_2_34_x86_64.whl` and twine
-          # aborts the whole PyPI publish on the first 400.
-          rm -rf dist target/wheels
+          # soldr#1083 follow-up: wipe stale wheels before maturin
+          # runs so a leftover .whl restored from setup-soldr's
+          # target/ cache (or maturin's internal staging dir) cannot
+          # leak into the upload set. Without this, lanes whose
+          # target/ cache included an old `dist/` from a pre-version-
+          # bump build silently re-upload e.g.
+          # `soldr-0.0.1-py3-none-manylinux_2_34_x86_64.whl` and
+          # twine aborts the whole PyPI publish on the first 400.
+          #
+          # NOTE: surgical wipe of `dist/*.whl` ONLY — `rm -rf dist`
+          # would also delete `dist/soldr-v$VERSION-$TARGET.tar.zst`
+          # which the `Package combined archive` step above created
+          # and the `Smoke test combined tar.zst archive` step below
+          # reads. The v0.7.73 release on the Linux ARM64 lane
+          # demonstrated this regression (run 28422788167).
+          rm -f dist/*.whl
+          rm -rf target/wheels
           mkdir -p dist
           uv tool install "maturin>=1.7,<2"
           maturin build \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.74"
+version = "0.7.75"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.74"
+version = "0.7.75"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.74",
+  "version": "0.7.75",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Why 0.7.75

v0.7.73's release run regressed Linux ARM64 + macOS ARM64 lanes because the wheel-build step's \`rm -rf dist target/wheels\` also nuked the **release tarball** that the earlier \`Package combined archive\` step had created at \`dist/soldr-v\$VERSION-\$T.tar.zst\`. The downstream \`Smoke test combined tar.zst archive\` step then failed with file-not-found.

Step ordering in release-auto.yml:

| Line | Step | Effect |
|---|---|---|
| 843 | Package combined archive | creates \`dist/soldr-v\$VERSION-\$T.tar.zst\` |
| 872 | Build hardened wheel | my buggy \`rm -rf dist\` — DELETED the tarball |
| 1032 | Smoke test combined tar.zst archive | tried to read deleted file → FAIL |

v0.7.74 carried the same bug. I cancelled run \`28422992114\` before it could waste CI time.

## Fix

Surgical wipe:

\`\`\`bash
rm -f dist/*.whl          # only stale wheels (the actual leak source)
rm -rf target/wheels      # maturin's internal staging dir
mkdir -p dist             # idempotent
\`\`\`

The release tarball at \`dist/soldr-v\$VERSION-\$T.tar.zst\` is preserved.

## What v0.7.75 includes (cumulative since v0.7.72 / PyPI's latest 0.7.71)

- #1078 daemon-side cancellation when wrapper disconnects
- #1080 Windows MSVC auto-discovery (closes #1079)
- #1082 zccache-soldr shim + shared compile_dispatch
- #1084 wheel-version lint (catches 0.0.1-stub regressions before twine)
- #1085 darwin-cross blessed env wired into release-auto.yml; \`continue-on-error\` dropped from darwin lanes
- **THIS PR**: dist-wipe fix so Linux ARM64 + macOS ARM64 + macOS x64 wheel-producing lanes don't lose their release tarball

## Expected outcome

- 8/8 build lanes ✅ for the first time since the embedded-zccache transition
- v0.7.75 to PyPI + npm + GitHub Releases
- If darwin x64 still fails (the structural fix from #1084 may have edge cases I can't validate without docker), the failure is now LOUD and diagnosable, not silently masked

## Test plan
- [x] Workspace version bumped in lockstep across Cargo.toml + Cargo.lock + package.json
- [x] v0.7.74 release run cancelled to avoid wasting CI runners
- [ ] Release workflow run validates the full 8/8 matrix (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)