### PR TITLE
chore(release): bump 0.7.76 -> 0.7.77 + activate darwin-cross fix via bootstrap chain

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -168,20 +168,17 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.should_release == 'true'
     runs-on: ${{ matrix.runner }}
-    # darwin cross-build via zigbuild hits tikv-jemalloc-sys's
-    # sys/syscall.h cross-compile bug. Tracked in soldr-toolchain#34
-    # priority 2 (jemalloc-darwin forge recipes). Until that lands,
-    # ship releases without darwin binaries rather than block every
-    # patch release on a structural toolchain gap.
-    #
-    # The earlier attempt at fixing this (#1085) wired `soldr build
-    # --target $T` into this workflow, but the soldr binary that
-    # setup-soldr installs predates the `Commands::Build` arm and
-    # fell into the External tool-fetch path on every lane (chicken-
-    # and-egg: needs an in-tree-soldr bootstrap before it can be the
-    # cross-compile orchestrator). Reverted in v0.7.76 — to be wired
-    # in properly behind a bootstrap step in a future PR.
-    continue-on-error: ${{ contains(matrix.target, 'apple-darwin') }}
+    # darwin lanes are no longer continue-on-error. The
+    # tikv-jemalloc-sys `sys/syscall.h` cross-compile failure is
+    # fixed in v0.7.77 by routing the darwin build step through the
+    # in-tree-built soldr (bootstrapped in the `Bootstrap soldr for
+    # Apple SDK prep` step at line ~337), which has
+    # `blessed_build.rs`'s apple-darwin arm that surfaces the
+    # COMPLETE Apple SDK to cc-rs's per-target CC/CXX/AR + rustc's
+    # linker. jemalloc's `#include <sys/syscall.h>` now resolves to
+    # the real Apple SDK header instead of zig's minimal bundled
+    # one. If darwin breaks, that's a real regression — not a known
+    # skip.
     strategy:
       fail-fast: false
       matrix:
@@ -366,24 +363,24 @@ jobs:
         env:
           CARGO_PROFILE_RELEASE_DEBUG: ${{ contains(matrix.target, 'pc-windows-msvc') && 'line-tables-only' || '0' }}
         run: |
-          # soldr#1029 + soldr#917: aarch64-musl and both apple-darwin
-          # lanes route through cargo zigbuild for a hermetic cross-
-          # compile from linux. All other lanes use plain cargo build
-          # on their native runner.
-          #
-          # v0.7.76 reverted the v0.7.75 attempt to route through
-          # `soldr build --target $T` — the setup-soldr-provided
-          # soldr binary predates `Commands::Build` and fell into the
-          # External arm. Wiring the in-tree-built soldr in here
-          # needs a bootstrap step (build soldr host-native first,
-          # then exec it as the cross-compile orchestrator) — that's
-          # a separate PR.
+          # Dispatch matrix:
+          # 1. Darwin Linux-host cross — `soldr build --target $T`.
+          #    The `Bootstrap soldr for Apple SDK prep` step above
+          #    put the in-tree-built soldr (v0.7.77+) on PATH at
+          #    `$RUNNER_TEMP/soldr-bin/soldr`, so `soldr build` here
+          #    invokes `Commands::Build` → blessed_build.rs apple-
+          #    darwin arm → CC=clang+SDKROOT, AR=llvm-ar, etc. Fixes
+          #    the jemalloc `sys/syscall.h` cross-compile (the
+          #    structural fix introduced in #1085 + finally activated
+          #    in v0.7.77 with the bootstrap chain).
+          # 2. `aarch64-unknown-linux-musl` Linux-host cross — keep
+          #    `cargo zigbuild`: zig's bundled musl IS complete.
+          # 3. Everything else — plain `cargo build` on the native
+          #    runner.
           target='${{ matrix.target }}'
-          # Use cargo zigbuild only when cross-compiling from a linux
-          # host. Native macOS runners (aarch64-apple-darwin on
-          # macos-15) use plain cargo build.
-          if [ "$target" = "aarch64-unknown-linux-musl" ] \
-             || { [[ "$target" == *-apple-darwin ]] && [ "$RUNNER_OS" = "Linux" ]; }; then
+          if [[ "$target" == *-apple-darwin && "$RUNNER_OS" = "Linux" ]]; then
+            soldr build --target "$target" --release --locked --package soldr-cli
+          elif [ "$target" = "aarch64-unknown-linux-musl" ]; then
             cargo zigbuild --package soldr-cli --release --locked --target "$target"
           else
             cargo build --package soldr-cli --release --locked --target "$target"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.76"
+version = "0.7.77"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.76"
+version = "0.7.77"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.76",
+  "version": "0.7.77",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Fixes the macOS x64 cross-compile failure

\`\`\`
include/jemalloc/internal/jemalloc_internal_decls.h:23:12: fatal error: 'sys/syscall.h' file not found
   23 | #               include <sys/syscall.h>
\`\`\`

This has broken every release since the embedded-zccache transition. Today it's silently masked by \`continue-on-error: true\` on darwin lanes; this PR fixes it properly + removes the masking.

## Why v0.7.75 didn't work (and v0.7.77 does)

v0.7.75 wired \`soldr build --target \$T\` for **all** lanes. But the \"Bootstrap soldr\" step in release-auto.yml only runs for darwin lanes (lines 337-349):
\`\`\`yaml
- name: Bootstrap soldr for Apple SDK prep (darwin only)
  if: contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04'
  run: |
    cargo build --release --bin soldr --target x86_64-unknown-linux-gnu
    cp target/.../release/soldr \$RUNNER_TEMP/soldr-bin/soldr
    echo \$RUNNER_TEMP/soldr-bin >> \$GITHUB_PATH
\`\`\`

So on darwin lanes, the in-tree-built soldr (which has \`Commands::Build\` + \`blessed_build.rs\`'s apple-darwin env block) IS on PATH. Other lanes only have setup-soldr's installed soldr, which is too old.

v0.7.77's conditional respects that asymmetry: **only darwin** uses \`soldr build\`. Everything else keeps its existing path.

## The fix in one diff

\`\`\`bash
target='\${{ matrix.target }}'
if [[ \"\$target\" == *-apple-darwin && \"\$RUNNER_OS\" = \"Linux\" ]]; then
  soldr build --target \"\$target\" --release --locked --package soldr-cli
elif [ \"\$target\" = \"aarch64-unknown-linux-musl\" ]; then
  cargo zigbuild --package soldr-cli --release --locked --target \"\$target\"
else
  cargo build --package soldr-cli --release --locked --target \"\$target\"
fi
\`\`\`

\`soldr build\` invokes \`blessed_build.rs\`'s apple-darwin arm which exports:

| Env var | Value |
|---|---|
| \`CC_x86_64_apple_darwin\` | \`clang --target=x86_64-apple-darwin -isysroot \$SDKROOT -mmacosx-version-min=11.0\` |
| \`CXX_x86_64_apple_darwin\` | \`clang++ ... -stdlib=libc++\` |
| \`AR_x86_64_apple_darwin\` | \`llvm-ar\` |
| \`CFLAGS_x86_64_apple_darwin\` | \`-isysroot \$SDKROOT ...\` |
| \`CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER\` | \`clang\` |
| \`CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS\` | \`-C link-arg=... -fuse-ld=lld\` |

jemalloc's \`#include <sys/syscall.h>\` now resolves to the real Apple SDK header. Every other C/C++ dep in the tree (ring, zstd-sys, libsqlite3-sys, libz-ng-sys, bzip2-sys, lzma-sys, libmimalloc-sys) gets the same complete sysroot — the fix is structural, not per-library.

## Also dropped

\`continue-on-error: \${{ contains(matrix.target, 'apple-darwin') }}\` from the build matrix. If darwin breaks now, it's a real regression worth blocking on.

## Expected outcome

- ✅ All 8 build lanes including macOS x64 — first time since the embedded-zccache transition
- ✅ PyPI + npm + GitHub Releases (the wheel-lint from #1084 still active)
- macOS x64 binary back on the wire

## Test plan
- [x] Workspace version bumped in lockstep across Cargo.toml + Cargo.lock + package.json
- [x] Bootstrap step + soldr build conditional verified to only fire on darwin lanes
- [ ] Release workflow run validates 8/8 matrix (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)