### PR TITLE
chore(release): bump 0.7.78 -> 0.7.79 + --no-trampoline on darwin soldr build

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -379,7 +379,18 @@ jobs:
           #    runner.
           target='${{ matrix.target }}'
           if [[ "$target" == *-apple-darwin && "$RUNNER_OS" = "Linux" ]]; then
-            soldr build --target "$target" --release --locked --package soldr-cli
+            # --no-trampoline: opt out of cargo_front_door's
+            # workspace trampoline (soldr#354). The trampoline
+            # short-circuits `build` / `check` / `clippy` with
+            # "exit 0, no on-disk changes" when a sidecar from a
+            # prior build says everything is up-to-date. Because
+            # the bootstrap step already built soldr for
+            # `x86_64-unknown-linux-gnu`, the sidecar there can
+            # mis-match for `--target x86_64-apple-darwin` and
+            # cause this step to exit 0 without ever producing
+            # `target/x86_64-apple-darwin/release/soldr` (see
+            # the v0.7.78 macOS x64 failure trace).
+            soldr build --target "$target" --release --locked --package soldr-cli --no-trampoline
           elif [ "$target" = "aarch64-unknown-linux-musl" ]; then
             cargo zigbuild --package soldr-cli --release --locked --target "$target"
           else

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.78"
+version = "0.7.79"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.78"
+version = "0.7.79"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
v0.7.78 macOS x64 failed silently. `soldr build --target x86_64-apple-darwin` exited 0 without producing the binary. Next step's `cp` failed.

## Root cause

`cargo_front_door::run_cargo_front_door` has a workspace trampoline (soldr#354) that short-circuits `build` / `check` / `clippy` with "exit 0, no on-disk changes" when a sidecar from a prior build says everything is up-to-date. The Bootstrap step compiles soldr for `x86_64-unknown-linux-gnu` BEFORE the darwin build step runs — leaving a sidecar that incorrectly matches the `--target x86_64-apple-darwin` invocation. Trampoline returns success without ever invoking cargo.

## Fix

Pass `--no-trampoline` to the darwin `soldr build` invocation. Documented opt-out, stripped from the arg list before forwarding to cargo per `cargo_front_door/mod.rs:369`. The trampoline is correct for normal users (skipping no-op builds is the point); just wrong for the release workflow where we explicitly need cargo to emit the binary.

## Carries forward from v0.7.78

- Aggressive wheel-cache bust + cargo clean -p soldr-cli + pre-maturin version verify
- Wheel-version lint
- Darwin-cross-via-bootstrap (`soldr build` for darwin Linux-host)
- `continue-on-error` dropped from darwin lanes
- All cumulative fixes from v0.7.72

## Expected outcome

- 8/8 build lanes ✅
- v0.7.79 to PyPI + npm + GitHub Releases
- macOS x64 binary on the wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)