### PR TITLE
chore(release): bump 0.7.79 -> 0.7.80 + fix version-parser awk quoting bug

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -924,11 +924,21 @@ jobs:
           mkdir -p dist
 
           expected="${EXPECTED_VERSION#v}"
-          cargo_version="$(grep '^version' Cargo.toml | head -1 | awk -F'"' '{print $2}')"
+          # sed-based extract (the prior awk -F'"' attempt produced
+          # `4` instead of the version string in the v0.7.78 run on
+          # Linux gnu lanes — likely a YAML/bash quoting interaction
+          # specific to those runners). sed with a literal
+          # single-quoted pattern is unambiguous.
+          cargo_version="$(sed -n 's/^version *= *"\([^"]*\)".*/\1/p' Cargo.toml | head -1)"
           echo "Cargo.toml [workspace.package].version = $cargo_version"
           echo "Expected (from prepare.outputs.version) = $expected"
+          if [ -z "$cargo_version" ]; then
+              echo "ERROR: failed to extract version from Cargo.toml. Top of file:" >&2
+              head -30 Cargo.toml >&2
+              exit 1
+          fi
           if [ "$cargo_version" != "$expected" ]; then
-              echo "ERROR: Cargo.toml workspace version mismatch — possible cache contamination" >&2
+              echo "ERROR: Cargo.toml workspace version ($cargo_version) does not match prepare.outputs.version ($expected) — possible cache contamination" >&2
               exit 1
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.79"
+version = "0.7.80"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.79"
+version = "0.7.80"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
v0.7.78 (and the as-yet-unstarted v0.7.79) hit a pre-maturin abort:

```
Cargo.toml [workspace.package].version = 4
ERROR: Cargo.toml workspace version mismatch — possible cache contamination
Expected (from prepare.outputs.version) = 0.7.78
```

The actual file had `version = "0.7.78"` correctly — the bug was in my YAML-embedded `awk -F'"' '{print $2}'` extraction. Some YAML/bash quoting interaction on Linux runners (macOS + Windows were fine) caused `4` to come out. False positive that aborted the build before maturin ever ran.

## Fix

Replace awk with sed using literal single-quoted patterns (no ambiguous quote chars inside the YAML run-block):

```bash
cargo_version="$(sed -n 's/^version *= *"\([^"]*\)".*/\1/p' Cargo.toml | head -1)"
```

Plus a fallback that prints `head -30 Cargo.toml` to stderr if extraction returns empty, so any future regression is self-diagnostic.

## Carries forward

- v0.7.79's --no-trampoline on darwin soldr build (the cargo_front_door workspace trampoline opt-out)
- v0.7.78's aggressive wheel-cache bust + cargo clean -p soldr-cli
- All cumulative fixes from v0.7.72

🤖 Generated with [Claude Code](https://claude.com/claude-code)