### PR TITLE
chore(release): bump 0.7.81 -> 0.7.82 + git restore Cargo.toml before maturin

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -924,13 +924,23 @@ jobs:
           mkdir -p dist
 
           expected="${EXPECTED_VERSION#v}"
-          # v0.7.80 lesson: regex-based version extract from
-          # Cargo.toml kept extracting `4` on Linux gnu lanes
-          # (Cargo.LOCK format version, not Cargo.toml's workspace
-          # version). Stop guessing — use `cargo metadata` which
-          # parses TOML properly and returns the SAME version
-          # maturin will use. Plus full diagnostic on mismatch so
-          # the next regression is self-explaining.
+          # v0.7.81 lesson: the workspace `Cargo.toml` on disk at
+          # this point is a STRIPPED variant (only `[workspace]` +
+          # `[workspace.dependencies]`, missing `[workspace.package]`
+          # entirely). Some prior step in this matrix lane is
+          # replacing the manifest — most likely setup-soldr's
+          # cache restoration normalizing it for cache-key
+          # stability. The result: maturin reads the wrong
+          # manifest, writes wheels tagged with whatever first
+          # `version = "X"` line is in the stripped file (the
+          # first dep version, usually clap's "4"), and downstream
+          # twine aborts the PyPI upload.
+          #
+          # Restore the real manifest tree from git BEFORE
+          # anything reads it. Cheap (just file IO from
+          # .git/objects).
+          git restore -- Cargo.toml Cargo.lock crates/soldr-cli/Cargo.toml || true
+
           echo "=== pre-maturin diagnostic ==="
           echo "pwd: $(pwd)"
           echo "ls Cargo.toml Cargo.lock:"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.81"
+version = "0.7.82"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.81"
+version = "0.7.82"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.81",
+  "version": "0.7.82",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
v0.7.81's diagnostic finally revealed root cause: by the time the wheel-build step runs, `Cargo.toml` on disk is a STRIPPED variant with only `[workspace]` + `[workspace.dependencies]` — no `[workspace.package]`, no `version = "X"` line. Some prior step is overwriting it (likely setup-soldr's cache restoration normalizing for cache-key stability).

The first `^version` line in the stripped file is `version = "4"` from `[workspace.dependencies.clap]` — explains both the recurring `4` extract AND why maturin produced `0.0.1` wheels (couldn't find a workspace version, fell through to its synthetic default).

## Fix

Restore the manifest tree from git BEFORE the version check + maturin run:

```bash
git restore -- Cargo.toml Cargo.lock crates/soldr-cli/Cargo.toml
```

Cheap, idempotent, undoes whatever the cache-restore step did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)