### PR TITLE
chore(release): bump 0.7.83 -> 0.7.84 + bypass soldr build for darwin (inline env)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -376,22 +376,41 @@ jobs:
           #    runner.
           target='${{ matrix.target }}'
           if [[ "$target" == *-apple-darwin && "$RUNNER_OS" = "Linux" ]]; then
-            # v0.7.79 added --no-trampoline but the v0.7.82 macOS
-            # x64 trace still showed silent-skip — `--no-trampoline`
-            # opts out of the cargo-run trampoline, not the
-            # workspace trampoline at cargo_front_door:394. The
-            # workspace trampoline IS suppressed by
-            # `SOLDR_REAL_CARGO=<path>` per the
-            # `workspace_trampoline_suppressed_for_tests` check at
-            # cargo_front_door:974 — set it to any real cargo path
-            # to force soldr build to actually invoke cargo.
+            # v0.7.83's --no-trampoline + SOLDR_REAL_CARGO did not
+            # suppress the workspace trampoline in CI (target dir
+            # never created → soldr build exited 0 with no work).
+            # Bypass soldr entirely for darwin: inline the same env
+            # block blessed_build.rs would have set (clang +
+            # Apple SDK + clang+lld linker) and call plain cargo
+            # build. SDKROOT was already exported by the earlier
+            # `soldr prepare --target X --github-env` step.
             #
-            # Also run `ls target/<triple>/release/` after the
-            # build so the diagnostic captures whether the binary
-            # was actually produced (vs. the cp-failure-only
-            # symptom from prior runs).
-            SOLDR_REAL_CARGO="$(command -v cargo)" \
-              soldr build --target "$target" --release --locked --package soldr-cli --no-trampoline
+            # Apt install ensures clang-18 + llvm-18 (for llvm-ar
+            # + lld). ubuntu-24.04 ships clang-18 by default but
+            # not always the llvm-* CLI tools.
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq clang-18 llvm-18 lld-18
+            sudo ln -sf /usr/bin/llvm-ar-18 /usr/bin/llvm-ar
+            sudo ln -sf /usr/bin/lld-18 /usr/bin/ld.lld
+            : "${SDKROOT:?SDKROOT must be set by Prepare Apple SDK step}"
+            target_u="${target//-/_}"
+            target_u_upper="$(echo "$target_u" | tr '[:lower:]' '[:upper:]')"
+            case "$target" in
+              x86_64-apple-darwin)   clang_arch=x86_64-apple-darwin ;;
+              aarch64-apple-darwin)  clang_arch=arm64-apple-darwin ;;
+              *) echo "unsupported darwin target: $target" >&2 ; exit 1 ;;
+            esac
+            export "CC_${target_u}=clang --target=${clang_arch} -isysroot ${SDKROOT} -mmacosx-version-min=11.0"
+            export "CXX_${target_u}=clang++ --target=${clang_arch} -isysroot ${SDKROOT} -mmacosx-version-min=11.0 -stdlib=libc++"
+            export "AR_${target_u}=llvm-ar"
+            export "CFLAGS_${target_u}=-isysroot ${SDKROOT} -mmacosx-version-min=11.0"
+            export "CXXFLAGS_${target_u}=-isysroot ${SDKROOT} -mmacosx-version-min=11.0 -stdlib=libc++"
+            export "CARGO_TARGET_${target_u_upper}_LINKER=clang"
+            export "CARGO_TARGET_${target_u_upper}_RUSTFLAGS=-C link-arg=--target=${clang_arch} -C link-arg=-isysroot -C link-arg=${SDKROOT} -C link-arg=-mmacosx-version-min=11.0 -C link-arg=-fuse-ld=lld"
+            echo "=== inline darwin env ==="
+            env | grep -E "^(SDKROOT|CC_|CXX_|AR_|CFLAGS_|CARGO_TARGET_)" | grep -E "${target_u}|${target_u_upper}|SDKROOT" | sort
+            echo "========================="
+            cargo build --package soldr-cli --release --locked --target "$target"
             echo "=== post-build diagnostic: target/$target/release/ ==="
             ls -la "target/$target/release/" 2>&1 | head -20 || true
             echo "==================================================="

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.83"
+version = "0.7.84"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.83"
+version = "0.7.84"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.83",
+  "version": "0.7.84",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
v0.7.83's diagnostic confirmed --no-trampoline + SOLDR_REAL_CARGO did NOT suppress the workspace trampoline on CI (`target/x86_64-apple-darwin/release/` never created). Bypassing soldr entirely for darwin: inline the same env block blessed_build.rs would have set + plain cargo build.

```bash
apt install clang-18 llvm-18 lld-18
export CC_x86_64_apple_darwin='clang --target=x86_64-apple-darwin -isysroot $SDKROOT -mmacosx-version-min=11.0'
# ... AR/CFLAGS/CARGO_TARGET_..._LINKER/RUSTFLAGS
cargo build --target $target --release --locked --package soldr-cli
```

SDKROOT is already exported by the earlier `soldr prepare --target X --github-env` step. No soldr in the cargo invocation = no trampoline interference.

continue-on-error on darwin stays as belt-and-suspenders. Drops in v0.7.85 if this works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)