### PR TITLE
chore(release): bump 0.7.85 -> 0.7.86 + fix darwin Apple SDK URL

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -386,18 +386,29 @@ jobs:
             sudo ln -sf /usr/bin/llvm-ar-18 /usr/bin/llvm-ar
             sudo ln -sf /usr/bin/lld-18 /usr/bin/ld.lld
 
-            APPLE_SDK_URL="https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/apple-sdk/MacOSX11.3.sdk.tar.xz"
+            # Same URL apple_sdk.rs uses in production (see
+            # MANAGED_APPLE_SDK_URL in fetch/apple_sdk.rs). v0.7.85
+            # used the wrong URL + wrong extension (.tar.xz) and
+            # 404'd — corrected to soldr/manifest deps/mac/sdk.tar.zstd.
+            APPLE_SDK_URL="https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/mac/sdk.tar.zstd"
             mkdir -p "$RUNNER_TEMP/apple-sdk"
-            if [ ! -d "$RUNNER_TEMP/apple-sdk/MacOSX11.3.sdk" ]; then
+            if ! ls "$RUNNER_TEMP/apple-sdk/"MacOSX*.sdk 1>/dev/null 2>&1; then
                 echo "fetching Apple SDK from $APPLE_SDK_URL ..."
-                curl -fsSL "$APPLE_SDK_URL" -o /tmp/MacOSX11.3.sdk.tar.xz
-                tar -xJ -C "$RUNNER_TEMP/apple-sdk" -f /tmp/MacOSX11.3.sdk.tar.xz
-                rm /tmp/MacOSX11.3.sdk.tar.xz
+                sudo apt-get update -qq && sudo apt-get install -y -qq zstd
+                curl -fsSL "$APPLE_SDK_URL" -o /tmp/sdk.tar.zstd
+                zstd -dc /tmp/sdk.tar.zstd | tar -xf - -C "$RUNNER_TEMP/apple-sdk"
+                rm /tmp/sdk.tar.zstd
             fi
-            export SDKROOT="$RUNNER_TEMP/apple-sdk/MacOSX11.3.sdk"
-            if [ ! -f "$SDKROOT/usr/include/sys/syscall.h" ]; then
+            # Discover whatever MacOSXXX.X.sdk dir landed (the
+            # tarball's top-level name is the SDK version).
+            SDKROOT="$(ls -d "$RUNNER_TEMP/apple-sdk/"MacOSX*.sdk 2>/dev/null | head -1)"
+            export SDKROOT
+            echo "resolved SDKROOT=$SDKROOT"
+            if [ -z "$SDKROOT" ] || [ ! -f "$SDKROOT/usr/include/sys/syscall.h" ]; then
                 echo "ERROR: Apple SDK did not contain usr/include/sys/syscall.h" >&2
-                find "$SDKROOT" -maxdepth 3 -type d | head -20 >&2
+                echo "RUNNER_TEMP/apple-sdk contents:" >&2
+                ls -la "$RUNNER_TEMP/apple-sdk" >&2 || true
+                find "$RUNNER_TEMP/apple-sdk" -maxdepth 4 -type d | head -30 >&2
                 exit 1
             fi
             target_u="${target//-/_}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.85"
+version = "0.7.86"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.85"
+version = "0.7.86"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.85",
+  "version": "0.7.86",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
v0.7.85 macOS x64 lane curl'd a 404 — wrong URL + wrong extension. Corrected to the SAME URL apple_sdk.rs uses in production: `https://media.githubusercontent.com/media/zackees/soldr/manifest/deps/mac/sdk.tar.zstd`. Pipe through `zstd -dc | tar -xf` instead of `tar -xJ`. Auto-discover `MacOSX*.sdk` from the extracted tree so a future SDK-version bump in the manifest doesn't require touching this script.

Carries forward all v0.7.85 fixes (which finally shipped to PyPI + npm + GitHub Release — first PyPI release since v0.7.71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)