### PR TITLE
chore(release): bump 0.7.86 -> 0.7.87 + add -fuse-ld=lld to darwin CFLAGS

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -418,11 +418,17 @@ jobs:
               aarch64-apple-darwin)  clang_arch=arm64-apple-darwin ;;
               *) echo "unsupported darwin target: $target" >&2 ; exit 1 ;;
             esac
-            export "CC_${target_u}=clang --target=${clang_arch} -isysroot ${SDKROOT} -mmacosx-version-min=11.0"
-            export "CXX_${target_u}=clang++ --target=${clang_arch} -isysroot ${SDKROOT} -mmacosx-version-min=11.0 -stdlib=libc++"
+            # v0.7.86 lesson: cmake's CMakeTestCCompiler probe
+            # invoked the system /usr/bin/ld (GNU) instead of lld
+            # for the test-link step, hit "unrecognised emulation
+            # mode: llvm". `-fuse-ld=lld` MUST be in CFLAGS/CXXFLAGS
+            # (not just RUSTFLAGS) so any compile-link sequence
+            # cmake-rs runs uses lld and can link Mach-O.
+            export "CC_${target_u}=clang --target=${clang_arch} -isysroot ${SDKROOT} -mmacosx-version-min=11.0 -fuse-ld=lld"
+            export "CXX_${target_u}=clang++ --target=${clang_arch} -isysroot ${SDKROOT} -mmacosx-version-min=11.0 -stdlib=libc++ -fuse-ld=lld"
             export "AR_${target_u}=llvm-ar"
-            export "CFLAGS_${target_u}=-isysroot ${SDKROOT} -mmacosx-version-min=11.0"
-            export "CXXFLAGS_${target_u}=-isysroot ${SDKROOT} -mmacosx-version-min=11.0 -stdlib=libc++"
+            export "CFLAGS_${target_u}=-isysroot ${SDKROOT} -mmacosx-version-min=11.0 -fuse-ld=lld"
+            export "CXXFLAGS_${target_u}=-isysroot ${SDKROOT} -mmacosx-version-min=11.0 -stdlib=libc++ -fuse-ld=lld"
             export "CARGO_TARGET_${target_u_upper}_LINKER=clang"
             export "CARGO_TARGET_${target_u_upper}_RUSTFLAGS=-C link-arg=--target=${clang_arch} -C link-arg=-isysroot -C link-arg=${SDKROOT} -C link-arg=-mmacosx-version-min=11.0 -C link-arg=-fuse-ld=lld"
             echo "=== inline darwin env ==="

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.86"
+version = "0.7.87"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.86"
+version = "0.7.87"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.86",
+  "version": "0.7.87",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
v0.7.86 macOS x64 finally got past the Apple SDK fetch + curl 404. New failure: libz-ng-sys cmake test-compile-link with:

```
/usr/bin/ld: unrecognised emulation mode: llvm
```

cmake invoked GNU `/usr/bin/ld` for the link step instead of lld. `CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS` had `-fuse-ld=lld` but that only applies to rustc's link step, not cmake-rs sub-builds.

Fix: add `-fuse-ld=lld` to CC_/CXX_/CFLAGS_/CXXFLAGS_ so any compile-link cmake-rs (or other build scripts) runs uses lld and can link Mach-O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)