### PR TITLE
chore(fmt): run cargo fmt on soldr-cli

### DIFF
--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -193,7 +193,8 @@ pub async fn prepare(paths: &SoldrPaths, target_triple: &str) -> Result<BlessedP
                     "clang++ --target={clang_arch_target} -isysroot {sdk_str} -mmacosx-version-min=11.0 -stdlib=libc++"
                 );
                 let cflags = format!("-isysroot {sdk_str} -mmacosx-version-min=11.0");
-                let cxxflags = format!("-isysroot {sdk_str} -mmacosx-version-min=11.0 -stdlib=libc++");
+                let cxxflags =
+                    format!("-isysroot {sdk_str} -mmacosx-version-min=11.0 -stdlib=libc++");
                 let rustflags = format!(
                     "-C link-arg=--target={clang_arch_target} \
                      -C link-arg=-isysroot \
@@ -201,9 +202,9 @@ pub async fn prepare(paths: &SoldrPaths, target_triple: &str) -> Result<BlessedP
                      -C link-arg=-mmacosx-version-min=11.0 \
                      -C link-arg=-fuse-ld=lld"
                 );
-                prep.env.push((format!("CC_{target_u}"), clang_base.clone()));
                 prep.env
-                    .push((format!("CXX_{target_u}"), clangxx_base));
+                    .push((format!("CC_{target_u}"), clang_base.clone()));
+                prep.env.push((format!("CXX_{target_u}"), clangxx_base));
                 prep.env
                     .push((format!("AR_{target_u}"), "llvm-ar".to_string()));
                 prep.env
@@ -214,8 +215,10 @@ pub async fn prepare(paths: &SoldrPaths, target_triple: &str) -> Result<BlessedP
                     format!("CARGO_TARGET_{target_u_upper}_LINKER"),
                     "clang".to_string(),
                 ));
-                prep.env
-                    .push((format!("CARGO_TARGET_{target_u_upper}_RUSTFLAGS"), rustflags));
+                prep.env.push((
+                    format!("CARGO_TARGET_{target_u_upper}_RUSTFLAGS"),
+                    rustflags,
+                ));
             }
             Err(e) => {
                 eprintln!("soldr build: apple SDK unavailable for {target_triple}: {e}");

--- a/crates/soldr-cli/src/compile_dispatch.rs
+++ b/crates/soldr-cli/src/compile_dispatch.rs
@@ -42,8 +42,7 @@ use crate::daemon::protocol::CompileRequest;
 /// set this to a sub-second value so the wait-for-daemon loop fails
 /// fast against a known-absent socket instead of wedging the test
 /// runner.
-pub const SOLDR_DAEMON_SPAWN_RETRY_BUDGET_MS_ENV_VAR: &str =
-    "SOLDR_DAEMON_SPAWN_RETRY_BUDGET_MS";
+pub const SOLDR_DAEMON_SPAWN_RETRY_BUDGET_MS_ENV_VAR: &str = "SOLDR_DAEMON_SPAWN_RETRY_BUDGET_MS";
 
 /// Default 30-second budget for the daemon-spawn + retry loop.
 ///
@@ -196,9 +195,7 @@ where
     let req = build_compile_request(rustc_argv);
 
     // First try — daemon may already be running.
-    if let Ok(done) =
-        client::compile_streaming(&sock, req.clone(), &mut stdout, &mut stderr)
-    {
+    if let Ok(done) = client::compile_streaming(&sock, req.clone(), &mut stdout, &mut stderr) {
         return Ok(done.exit_code);
     }
 
@@ -318,62 +315,82 @@ mod tests {
         }
     }
 
-    timed_test!(is_compile_env_var_recognizes_msvc_link_vars, Duration::from_secs(5), {
-        // Issue #1079 — the MSVC discovery sets LIB / INCLUDE / LIBPATH
-        // on the wrapper process. The dispatch's env filter must
-        // forward them to the daemon so the embedded rustc invocation
-        // gets the same env. Regression-test that explicitly.
-        for v in ["LIB", "INCLUDE", "LIBPATH", "PATH"] {
-            assert!(is_compile_env_var(v), "{v} must be forwarded to daemon");
+    timed_test!(
+        is_compile_env_var_recognizes_msvc_link_vars,
+        Duration::from_secs(5),
+        {
+            // Issue #1079 — the MSVC discovery sets LIB / INCLUDE / LIBPATH
+            // on the wrapper process. The dispatch's env filter must
+            // forward them to the daemon so the embedded rustc invocation
+            // gets the same env. Regression-test that explicitly.
+            for v in ["LIB", "INCLUDE", "LIBPATH", "PATH"] {
+                assert!(is_compile_env_var(v), "{v} must be forwarded to daemon");
+            }
         }
-    });
+    );
 
-    timed_test!(is_compile_env_var_drops_common_noise, Duration::from_secs(5), {
-        for v in [
-            "PROMPT",
-            "PSModulePath",
-            "ChocolateyInstall",
-            "WSL_DISTRO_NAME",
-        ] {
-            assert!(!is_compile_env_var(v), "{v} should be dropped");
+    timed_test!(
+        is_compile_env_var_drops_common_noise,
+        Duration::from_secs(5),
+        {
+            for v in [
+                "PROMPT",
+                "PSModulePath",
+                "ChocolateyInstall",
+                "WSL_DISTRO_NAME",
+            ] {
+                assert!(!is_compile_env_var(v), "{v} should be dropped");
+            }
         }
-    });
+    );
 
-    timed_test!(build_compile_request_filters_env_and_carries_args, Duration::from_secs(5), {
-        std::env::set_var("CARGO_PKG_NAME_TEST_DISPATCH", "soldr-cli-test");
-        let argv = vec!["rustc".to_string(), "--version".to_string()];
-        let req = build_compile_request(&argv);
-        std::env::remove_var("CARGO_PKG_NAME_TEST_DISPATCH");
+    timed_test!(
+        build_compile_request_filters_env_and_carries_args,
+        Duration::from_secs(5),
+        {
+            std::env::set_var("CARGO_PKG_NAME_TEST_DISPATCH", "soldr-cli-test");
+            let argv = vec!["rustc".to_string(), "--version".to_string()];
+            let req = build_compile_request(&argv);
+            std::env::remove_var("CARGO_PKG_NAME_TEST_DISPATCH");
 
-        assert_eq!(req.args, argv);
-        assert!(
-            req.env
-                .iter()
-                .any(|(k, _)| k == "CARGO_PKG_NAME_TEST_DISPATCH"),
-            "CARGO_*-prefixed env var must survive the filter"
-        );
-    });
+            assert_eq!(req.args, argv);
+            assert!(
+                req.env
+                    .iter()
+                    .any(|(k, _)| k == "CARGO_PKG_NAME_TEST_DISPATCH"),
+                "CARGO_*-prefixed env var must survive the filter"
+            );
+        }
+    );
 
-    timed_test!(resolved_spawn_retry_budget_respects_override, Duration::from_secs(5), {
-        let g = BudgetEnvGuard::acquire();
-        g.set("250");
-        let budget = resolved_spawn_retry_budget();
-        drop(g);
-        assert_eq!(budget, Duration::from_millis(250));
-    });
+    timed_test!(
+        resolved_spawn_retry_budget_respects_override,
+        Duration::from_secs(5),
+        {
+            let g = BudgetEnvGuard::acquire();
+            g.set("250");
+            let budget = resolved_spawn_retry_budget();
+            drop(g);
+            assert_eq!(budget, Duration::from_millis(250));
+        }
+    );
 
-    timed_test!(resolved_spawn_retry_budget_clamps_to_min_100ms, Duration::from_secs(5), {
-        // Defense in depth: no caller can disable retries entirely
-        // by passing 0 — the loop must still get at least one shot.
-        let g = BudgetEnvGuard::acquire();
-        g.set("0");
-        let budget = resolved_spawn_retry_budget();
-        drop(g);
-        assert!(
-            budget >= Duration::from_millis(100),
-            "budget {budget:?} must be clamped to at least 100ms"
-        );
-    });
+    timed_test!(
+        resolved_spawn_retry_budget_clamps_to_min_100ms,
+        Duration::from_secs(5),
+        {
+            // Defense in depth: no caller can disable retries entirely
+            // by passing 0 — the loop must still get at least one shot.
+            let g = BudgetEnvGuard::acquire();
+            g.set("0");
+            let budget = resolved_spawn_retry_budget();
+            drop(g);
+            assert!(
+                budget >= Duration::from_millis(100),
+                "budget {budget:?} must be clamped to at least 100ms"
+            );
+        }
+    );
 
     // The TDD acceptance test for the no-hang contract: point dispatch
     // at a socket path that cannot possibly accept, set the budget to
@@ -381,45 +398,49 @@ mod tests {
     // The `timed_test!` 10-second deadline is the belt-and-suspenders —
     // if a regression makes the dispatch ignore the budget, the test
     // hangs there and the watchdog fires.
-    timed_test!(dispatch_compile_with_sock_fails_within_budget_on_dead_socket, Duration::from_secs(15), {
-        let g = BudgetEnvGuard::acquire();
-        // 250 ms budget; we expect dispatch to fail-fast.
-        g.set("250");
+    timed_test!(
+        dispatch_compile_with_sock_fails_within_budget_on_dead_socket,
+        Duration::from_secs(15),
+        {
+            let g = BudgetEnvGuard::acquire();
+            // 250 ms budget; we expect dispatch to fail-fast.
+            g.set("250");
 
-        // A path that cannot resolve to a live socket / pipe on any
-        // platform. On Windows the leading `\\.\pipe\` prefix is
-        // mandatory for named pipes, so a Unix-style path under TMP
-        // cannot accept; on Unix the path simply does not exist.
-        let dead = if cfg!(windows) {
-            PathBuf::from(r"\\.\pipe\soldr-test-no-such-pipe-12345")
-        } else {
-            std::env::temp_dir().join("soldr-test-no-such-sock-12345")
-        };
-        // Make sure no leftover artifact from a prior test is on disk.
-        let _ = std::fs::remove_file(&dead);
+            // A path that cannot resolve to a live socket / pipe on any
+            // platform. On Windows the leading `\\.\pipe\` prefix is
+            // mandatory for named pipes, so a Unix-style path under TMP
+            // cannot accept; on Unix the path simply does not exist.
+            let dead = if cfg!(windows) {
+                PathBuf::from(r"\\.\pipe\soldr-test-no-such-pipe-12345")
+            } else {
+                std::env::temp_dir().join("soldr-test-no-such-sock-12345")
+            };
+            // Make sure no leftover artifact from a prior test is on disk.
+            let _ = std::fs::remove_file(&dead);
 
-        let argv = vec!["rustc".to_string(), "--version".to_string()];
-        let mut stdout: Vec<u8> = Vec::new();
-        let mut stderr: Vec<u8> = Vec::new();
+            let argv = vec!["rustc".to_string(), "--version".to_string()];
+            let mut stdout: Vec<u8> = Vec::new();
+            let mut stderr: Vec<u8> = Vec::new();
 
-        let start = Instant::now();
-        let result = dispatch_compile_with_sock(&dead, &argv, &mut stdout, &mut stderr);
-        let elapsed = start.elapsed();
-        drop(g);
+            let start = Instant::now();
+            let result = dispatch_compile_with_sock(&dead, &argv, &mut stdout, &mut stderr);
+            let elapsed = start.elapsed();
+            drop(g);
 
-        assert!(result.is_err(), "dispatch should error on dead socket");
-        // Windows runtime spawn overhead per attempt can push elapsed
-        // well past the configured budget. The contract is "the loop
-        // honors the budget" — i.e. we don't sit at the 30 s default —
-        // not a tight stopwatch on absolute time. A 5 s ceiling is
-        // generous enough to absorb tokio runtime startup while still
-        // catching a regression that ignores the budget entirely.
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "dispatch took {elapsed:?} on a dead socket with a 250 ms budget — \
+            assert!(result.is_err(), "dispatch should error on dead socket");
+            // Windows runtime spawn overhead per attempt can push elapsed
+            // well past the configured budget. The contract is "the loop
+            // honors the budget" — i.e. we don't sit at the 30 s default —
+            // not a tight stopwatch on absolute time. A 5 s ceiling is
+            // generous enough to absorb tokio runtime startup while still
+            // catching a regression that ignores the budget entirely.
+            assert!(
+                elapsed < Duration::from_secs(5),
+                "dispatch took {elapsed:?} on a dead socket with a 250 ms budget — \
              this is the no-hang contract: the retry loop MUST honor the \
              SOLDR_DAEMON_SPAWN_RETRY_BUDGET_MS budget instead of waiting \
              out the 30s default"
-        );
-    });
+            );
+        }
+    );
 }

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -943,7 +943,10 @@ pub(crate) enum DispatchOutcome<T> {
 /// compile-future are ready in the same poll tick, prefer the
 /// disconnect branch so we don't accidentally write a response into a
 /// half-closed pipe.
-pub(crate) async fn race_against_disconnect<R, F>(reader: &mut R, fut: F) -> DispatchOutcome<F::Output>
+pub(crate) async fn race_against_disconnect<R, F>(
+    reader: &mut R,
+    fut: F,
+) -> DispatchOutcome<F::Output>
 where
     R: tokio::io::AsyncRead + Unpin,
     F: std::future::Future,

--- a/crates/soldr-cli/src/lib.rs
+++ b/crates/soldr-cli/src/lib.rs
@@ -18,20 +18,13 @@
 /// `Commands::Build` for canonical target triples. Coordinates the
 /// xwin-cache materialization + clang-shim install + env var setup.
 pub mod blessed_build;
+pub mod cache_lib;
+pub mod cargo_metadata_soldr;
 /// soldr#1081 — Shared `Request::Compile` dispatch logic used by both
 /// the soldr-as-RUSTC_WRAPPER hot path (`wrapper.rs`) and the dedicated
 /// `zccache-soldr` shim binary (`bin/zccache_soldr.rs`). Owns the
 /// hang-safe retry budget contract.
 pub mod compile_dispatch;
-/// soldr#1079 — Windows MSVC host-toolchain auto-discovery. Probes
-/// vswhere + the Windows SDK and synthesizes LIB/INCLUDE/PATH/LIBPATH
-/// onto the current process so `soldr cargo build` / `soldr cargo test`
-/// succeed from a plain PowerShell without the downstream `$env:LIB`
-/// workaround. Detect-host now; managed-catalogue fallback is a
-/// follow-up in the same issue.
-pub mod msvc_host;
-pub mod cache_lib;
-pub mod cargo_metadata_soldr;
 pub mod core;
 pub mod daemon;
 pub mod defender;
@@ -40,6 +33,13 @@ pub mod defender;
 /// via `cargo test --lib`.
 pub mod env_cmd;
 pub mod fetch;
+/// soldr#1079 — Windows MSVC host-toolchain auto-discovery. Probes
+/// vswhere + the Windows SDK and synthesizes LIB/INCLUDE/PATH/LIBPATH
+/// onto the current process so `soldr cargo build` / `soldr cargo test`
+/// succeed from a plain PowerShell without the downstream `$env:LIB`
+/// workaround. Detect-host now; managed-catalogue fallback is a
+/// follow-up in the same issue.
+pub mod msvc_host;
 /// soldr#939 — PyO3 auto-detection via cargo metadata.
 pub mod pyo3_detect;
 pub mod release_sidecar;

--- a/crates/soldr-cli/src/msvc_host.rs
+++ b/crates/soldr-cli/src/msvc_host.rs
@@ -120,7 +120,10 @@ impl MsvcHostLayout {
         ];
         let path_prepend = vec![
             msvc.join("bin").join("Hostx64").join("x64"),
-            self.sdk_root.join("bin").join(&self.sdk_version).join("x64"),
+            self.sdk_root
+                .join("bin")
+                .join(&self.sdk_version)
+                .join("x64"),
             msvc.join("bin").join("Hostx64").join("x86"),
         ];
         let libpath = vec![
@@ -370,176 +373,207 @@ mod tests {
     use crate::timed_test;
     use std::time::Duration;
 
-    timed_test!(synthesize_env_x64_builds_canonical_paths, Duration::from_secs(5), {
-        let layout = MsvcHostLayout {
-            vs_install: PathBuf::from(
-                r"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community",
-            ),
-            vc_tools_version: "14.29.30133".into(),
-            sdk_root: PathBuf::from(r"C:\Program Files (x86)\Windows Kits\10"),
-            sdk_version: "10.0.22621.0".into(),
-        };
-        let env = layout.synthesize_env_x64();
+    timed_test!(
+        synthesize_env_x64_builds_canonical_paths,
+        Duration::from_secs(5),
+        {
+            let layout = MsvcHostLayout {
+                vs_install: PathBuf::from(
+                    r"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community",
+                ),
+                vc_tools_version: "14.29.30133".into(),
+                sdk_root: PathBuf::from(r"C:\Program Files (x86)\Windows Kits\10"),
+                sdk_version: "10.0.22621.0".into(),
+            };
+            let env = layout.synthesize_env_x64();
 
-        assert!(
-            env.lib.contains(r"VC\Tools\MSVC\14.29.30133\lib\x64"),
-            "lib should contain canonical MSVC x64 libs path: {}",
-            env.lib
-        );
-        assert!(
-            env.lib.contains(r"Windows Kits\10\Lib\10.0.22621.0\ucrt\x64"),
-            "lib should contain ucrt x64 path: {}",
-            env.lib
-        );
-        assert!(
-            env.include.contains(r"VC\Tools\MSVC\14.29.30133\include"),
-            "include should contain MSVC include path: {}",
-            env.include
-        );
-        assert!(
-            env.path_prepend
-                .contains(r"VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64"),
-            "path_prepend should contain x64 host tools (link.exe lives here): {}",
-            env.path_prepend
-        );
-    });
-
-    timed_test!(vswhere_path_honors_override_env_var, Duration::from_secs(5), {
-        // Mutate env: ok because we read-then-restore. Run serially
-        // would be ideal but a single set/clear pair is atomic enough
-        // for cargo test's default parallelism — and no other tests
-        // touch SOLDR_VSWHERE.
-        let prior = std::env::var_os(SOLDR_VSWHERE_ENV_VAR);
-        std::env::set_var(SOLDR_VSWHERE_ENV_VAR, r"D:\custom\vswhere.exe");
-        let p = vswhere_path();
-        match prior {
-            Some(v) => std::env::set_var(SOLDR_VSWHERE_ENV_VAR, v),
-            None => std::env::remove_var(SOLDR_VSWHERE_ENV_VAR),
+            assert!(
+                env.lib.contains(r"VC\Tools\MSVC\14.29.30133\lib\x64"),
+                "lib should contain canonical MSVC x64 libs path: {}",
+                env.lib
+            );
+            assert!(
+                env.lib
+                    .contains(r"Windows Kits\10\Lib\10.0.22621.0\ucrt\x64"),
+                "lib should contain ucrt x64 path: {}",
+                env.lib
+            );
+            assert!(
+                env.include.contains(r"VC\Tools\MSVC\14.29.30133\include"),
+                "include should contain MSVC include path: {}",
+                env.include
+            );
+            assert!(
+                env.path_prepend
+                    .contains(r"VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64"),
+                "path_prepend should contain x64 host tools (link.exe lives here): {}",
+                env.path_prepend
+            );
         }
-        assert_eq!(p, PathBuf::from(r"D:\custom\vswhere.exe"));
-    });
+    );
 
-    timed_test!(opted_out_recognizes_off_zero_false, Duration::from_secs(5), {
-        let prior = std::env::var_os(SOLDR_MSVC_DISCOVERY_ENV_VAR);
-        for v in ["off", "OFF", "0", "false", "FALSE", "no", "  off  "] {
-            std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v);
-            assert!(opted_out(), "value `{v}` should opt out");
+    timed_test!(
+        vswhere_path_honors_override_env_var,
+        Duration::from_secs(5),
+        {
+            // Mutate env: ok because we read-then-restore. Run serially
+            // would be ideal but a single set/clear pair is atomic enough
+            // for cargo test's default parallelism — and no other tests
+            // touch SOLDR_VSWHERE.
+            let prior = std::env::var_os(SOLDR_VSWHERE_ENV_VAR);
+            std::env::set_var(SOLDR_VSWHERE_ENV_VAR, r"D:\custom\vswhere.exe");
+            let p = vswhere_path();
+            match prior {
+                Some(v) => std::env::set_var(SOLDR_VSWHERE_ENV_VAR, v),
+                None => std::env::remove_var(SOLDR_VSWHERE_ENV_VAR),
+            }
+            assert_eq!(p, PathBuf::from(r"D:\custom\vswhere.exe"));
         }
-        for v in ["on", "1", "true", "auto", ""] {
-            std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v);
-            assert!(!opted_out(), "value `{v}` should NOT opt out");
-        }
-        match prior {
-            Some(v) => std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v),
-            None => std::env::remove_var(SOLDR_MSVC_DISCOVERY_ENV_VAR),
-        }
-    });
+    );
 
-    timed_test!(pick_highest_sdk_version_skips_partial_installs, Duration::from_secs(10), {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let inc = tmp.path().join("Include");
-        // 10.0.19041.0 — half-installed, missing ucrt/
-        std::fs::create_dir_all(inc.join("10.0.19041.0").join("um")).unwrap();
-        // 10.0.22621.0 — fully installed
-        std::fs::create_dir_all(inc.join("10.0.22621.0").join("um")).unwrap();
-        std::fs::create_dir_all(inc.join("10.0.22621.0").join("ucrt")).unwrap();
-        // 10.0.20348.0 — also fully installed but older
-        std::fs::create_dir_all(inc.join("10.0.20348.0").join("um")).unwrap();
-        std::fs::create_dir_all(inc.join("10.0.20348.0").join("ucrt")).unwrap();
+    timed_test!(
+        opted_out_recognizes_off_zero_false,
+        Duration::from_secs(5),
+        {
+            let prior = std::env::var_os(SOLDR_MSVC_DISCOVERY_ENV_VAR);
+            for v in ["off", "OFF", "0", "false", "FALSE", "no", "  off  "] {
+                std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v);
+                assert!(opted_out(), "value `{v}` should opt out");
+            }
+            for v in ["on", "1", "true", "auto", ""] {
+                std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v);
+                assert!(!opted_out(), "value `{v}` should NOT opt out");
+            }
+            match prior {
+                Some(v) => std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v),
+                None => std::env::remove_var(SOLDR_MSVC_DISCOVERY_ENV_VAR),
+            }
+        }
+    );
 
-        let picked = pick_highest_sdk_version(tmp.path()).expect("should find a version");
-        assert_eq!(
+    timed_test!(
+        pick_highest_sdk_version_skips_partial_installs,
+        Duration::from_secs(10),
+        {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let inc = tmp.path().join("Include");
+            // 10.0.19041.0 — half-installed, missing ucrt/
+            std::fs::create_dir_all(inc.join("10.0.19041.0").join("um")).unwrap();
+            // 10.0.22621.0 — fully installed
+            std::fs::create_dir_all(inc.join("10.0.22621.0").join("um")).unwrap();
+            std::fs::create_dir_all(inc.join("10.0.22621.0").join("ucrt")).unwrap();
+            // 10.0.20348.0 — also fully installed but older
+            std::fs::create_dir_all(inc.join("10.0.20348.0").join("um")).unwrap();
+            std::fs::create_dir_all(inc.join("10.0.20348.0").join("ucrt")).unwrap();
+
+            let picked = pick_highest_sdk_version(tmp.path()).expect("should find a version");
+            assert_eq!(
             picked, "10.0.22621.0",
             "should pick the highest fully-installed version, skipping the partial 10.0.19041.0"
         );
-    });
+        }
+    );
 
-    timed_test!(pick_highest_sdk_version_errors_on_empty_install, Duration::from_secs(10), {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        // Only Include/ exists, but no version subdirs with um+ucrt.
-        std::fs::create_dir_all(tmp.path().join("Include")).unwrap();
-        std::fs::create_dir_all(tmp.path().join("Include").join("10.0.0.0").join("um")).unwrap();
-        // missing ucrt → should not qualify
-        let err = pick_highest_sdk_version(tmp.path()).expect_err("should fail");
-        assert!(matches!(err, MsvcDetectionError::NoSdkVersion(_)));
-    });
+    timed_test!(
+        pick_highest_sdk_version_errors_on_empty_install,
+        Duration::from_secs(10),
+        {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            // Only Include/ exists, but no version subdirs with um+ucrt.
+            std::fs::create_dir_all(tmp.path().join("Include")).unwrap();
+            std::fs::create_dir_all(tmp.path().join("Include").join("10.0.0.0").join("um"))
+                .unwrap();
+            // missing ucrt → should not qualify
+            let err = pick_highest_sdk_version(tmp.path()).expect_err("should fail");
+            assert!(matches!(err, MsvcDetectionError::NoSdkVersion(_)));
+        }
+    );
 
-    timed_test!(ensure_msvc_env_for_native_is_noop_on_non_msvc_target, Duration::from_secs(5), {
-        // This test runs on every platform and proves the early-out
-        // for non-MSVC targets. Even on Windows, asking for a
-        // non-MSVC target must skip discovery.
-        let applied = ensure_msvc_env_for_native("x86_64-unknown-linux-gnu")
-            .expect("noop should not error");
-        assert!(!applied, "linux-gnu target must not trigger MSVC discovery");
-    });
+    timed_test!(
+        ensure_msvc_env_for_native_is_noop_on_non_msvc_target,
+        Duration::from_secs(5),
+        {
+            // This test runs on every platform and proves the early-out
+            // for non-MSVC targets. Even on Windows, asking for a
+            // non-MSVC target must skip discovery.
+            let applied = ensure_msvc_env_for_native("x86_64-unknown-linux-gnu")
+                .expect("noop should not error");
+            assert!(!applied, "linux-gnu target must not trigger MSVC discovery");
+        }
+    );
 
     #[cfg(not(target_os = "windows"))]
-    timed_test!(ensure_msvc_env_for_native_is_noop_on_non_windows_host, Duration::from_secs(5), {
-        let applied = ensure_msvc_env_for_native("x86_64-pc-windows-msvc")
-            .expect("noop should not error");
-        assert!(
-            !applied,
-            "non-windows host must not attempt MSVC discovery"
-        );
-    });
+    timed_test!(
+        ensure_msvc_env_for_native_is_noop_on_non_windows_host,
+        Duration::from_secs(5),
+        {
+            let applied = ensure_msvc_env_for_native("x86_64-pc-windows-msvc")
+                .expect("noop should not error");
+            assert!(!applied, "non-windows host must not attempt MSVC discovery");
+        }
+    );
 
     // -------------------------------------------------------------------
     // Windows-only end-to-end probe. Skips gracefully on hosts without
     // a VS install (CI lanes without VC++ workload).
     // -------------------------------------------------------------------
     #[cfg(target_os = "windows")]
-    timed_test!(discover_msvc_layout_on_developer_machine_finds_real_link_exe, Duration::from_secs(30), {
-        let v = vswhere_path();
-        if !v.is_file() {
-            eprintln!(
-                "msvc_host: skipping discovery test — vswhere not present at {}",
-                v.display()
+    timed_test!(
+        discover_msvc_layout_on_developer_machine_finds_real_link_exe,
+        Duration::from_secs(30),
+        {
+            let v = vswhere_path();
+            if !v.is_file() {
+                eprintln!(
+                    "msvc_host: skipping discovery test — vswhere not present at {}",
+                    v.display()
+                );
+                return;
+            }
+            let layout = match discover_msvc_layout() {
+                Ok(l) => l,
+                Err(MsvcDetectionError::NoVsInstall) => {
+                    eprintln!("msvc_host: skipping — vswhere installed but no VS with C++ tools");
+                    return;
+                }
+                Err(MsvcDetectionError::NoSdkRoot | MsvcDetectionError::NoSdkVersion(_)) => {
+                    eprintln!("msvc_host: skipping — no Windows 10/11 SDK on host");
+                    return;
+                }
+                Err(e) => panic!("unexpected discovery error: {e}"),
+            };
+
+            // The whole point of discovery is to produce a layout that
+            // resolves to a real link.exe. If this asserts, the layout
+            // is wrong and the env we'd inject would not fix the
+            // "linker `link.exe` not found" symptom.
+            let link_exe = layout
+                .vs_install
+                .join("VC")
+                .join("Tools")
+                .join("MSVC")
+                .join(&layout.vc_tools_version)
+                .join("bin")
+                .join("Hostx64")
+                .join("x64")
+                .join("link.exe");
+            assert!(
+                link_exe.is_file(),
+                "expected discovered layout to point at a real link.exe — got {}",
+                link_exe.display()
             );
-            return;
+
+            let env = layout.synthesize_env_x64();
+            assert!(
+                env.lib.contains(r"VC\Tools\MSVC"),
+                "lib should contain VC\\Tools\\MSVC: {}",
+                env.lib
+            );
+            assert!(
+                env.path_prepend.contains(r"VC\Tools\MSVC"),
+                "path_prepend should contain VC\\Tools\\MSVC: {}",
+                env.path_prepend
+            );
         }
-        let layout = match discover_msvc_layout() {
-            Ok(l) => l,
-            Err(MsvcDetectionError::NoVsInstall) => {
-                eprintln!("msvc_host: skipping — vswhere installed but no VS with C++ tools");
-                return;
-            }
-            Err(MsvcDetectionError::NoSdkRoot | MsvcDetectionError::NoSdkVersion(_)) => {
-                eprintln!("msvc_host: skipping — no Windows 10/11 SDK on host");
-                return;
-            }
-            Err(e) => panic!("unexpected discovery error: {e}"),
-        };
-
-        // The whole point of discovery is to produce a layout that
-        // resolves to a real link.exe. If this asserts, the layout
-        // is wrong and the env we'd inject would not fix the
-        // "linker `link.exe` not found" symptom.
-        let link_exe = layout
-            .vs_install
-            .join("VC")
-            .join("Tools")
-            .join("MSVC")
-            .join(&layout.vc_tools_version)
-            .join("bin")
-            .join("Hostx64")
-            .join("x64")
-            .join("link.exe");
-        assert!(
-            link_exe.is_file(),
-            "expected discovered layout to point at a real link.exe — got {}",
-            link_exe.display()
-        );
-
-        let env = layout.synthesize_env_x64();
-        assert!(
-            env.lib.contains(r"VC\Tools\MSVC"),
-            "lib should contain VC\\Tools\\MSVC: {}",
-            env.lib
-        );
-        assert!(
-            env.path_prepend.contains(r"VC\Tools\MSVC"),
-            "path_prepend should contain VC\\Tools\\MSVC: {}",
-            env.path_prepend
-        );
-    });
+    );
 }

--- a/crates/soldr-cli/tests/msvc_host_discovery_windows.rs
+++ b/crates/soldr-cli/tests/msvc_host_discovery_windows.rs
@@ -34,144 +34,150 @@ use soldr_cli::msvc_host::{
 use soldr_cli::timed_test;
 use std::time::Duration;
 
-timed_test!(ensure_msvc_env_for_native_makes_link_exe_findable_on_plain_powershell, Duration::from_secs(30), {
-    // ----- Skip gracefully on hosts without VS C++ tooling. -----
-    if !vswhere_path().is_file() {
-        eprintln!(
-            "msvc_host integration test: skipping — vswhere not present at {}",
-            vswhere_path().display()
+timed_test!(
+    ensure_msvc_env_for_native_makes_link_exe_findable_on_plain_powershell,
+    Duration::from_secs(30),
+    {
+        // ----- Skip gracefully on hosts without VS C++ tooling. -----
+        if !vswhere_path().is_file() {
+            eprintln!(
+                "msvc_host integration test: skipping — vswhere not present at {}",
+                vswhere_path().display()
+            );
+            return;
+        }
+        match discover_msvc_layout() {
+            Ok(_) => {}
+            Err(MsvcDetectionError::NoVsInstall) => {
+                eprintln!("msvc_host: skipping — vswhere installed but no VS with C++ tools");
+                return;
+            }
+            Err(MsvcDetectionError::NoSdkRoot | MsvcDetectionError::NoSdkVersion(_)) => {
+                eprintln!("msvc_host: skipping — no Windows 10/11 SDK on host");
+                return;
+            }
+            Err(MsvcDetectionError::NoToolsVersion(_)) => {
+                eprintln!("msvc_host: skipping — VS install missing VCToolsVersion file");
+                return;
+            }
+            Err(e) => {
+                panic!("unexpected discovery error setting up the test: {e}");
+            }
+        }
+
+        // ----- Save the env we're about to mutate. -----
+        let saved_lib = std::env::var_os("LIB");
+        let saved_include = std::env::var_os("INCLUDE");
+        let saved_libpath = std::env::var_os("LIBPATH");
+        let saved_path = std::env::var_os("PATH");
+        let saved_optout = std::env::var_os(SOLDR_MSVC_DISCOVERY_ENV_VAR);
+
+        // ----- Sanitize: simulate a plain PowerShell with no vcvars. -----
+        // Remove LIB / INCLUDE / LIBPATH entirely.
+        std::env::remove_var("LIB");
+        std::env::remove_var("INCLUDE");
+        std::env::remove_var("LIBPATH");
+        // Make sure the opt-out var isn't set to a disabling value left
+        // over from earlier tests in this process.
+        std::env::remove_var(SOLDR_MSVC_DISCOVERY_ENV_VAR);
+        // Strip any PATH entries that contain a `link.exe` so the test
+        // really proves *our* injection put it back. We rebuild PATH
+        // from only directories that DON'T already resolve link.exe.
+        if let Some(orig_path) = saved_path.as_ref() {
+            let cleaned: Vec<std::path::PathBuf> = std::env::split_paths(orig_path)
+                .filter(|d| !d.join("link.exe").is_file())
+                .collect();
+            let joined = std::env::join_paths(cleaned).expect("clean PATH");
+            std::env::set_var("PATH", joined);
+        }
+
+        // ----- RED check: confirm sanitization actually removed link.exe. -----
+        let link_before = which_on_path("link.exe");
+        let lib_before = std::env::var_os("LIB");
+        assert!(
+            link_before.is_none(),
+            "test setup bug: link.exe still on PATH after sanitization at {}",
+            link_before
+                .map(|p| p.display().to_string())
+                .unwrap_or_default()
         );
-        return;
-    }
-    match discover_msvc_layout() {
-        Ok(_) => {}
-        Err(MsvcDetectionError::NoVsInstall) => {
-            eprintln!("msvc_host: skipping — vswhere installed but no VS with C++ tools");
-            return;
+        assert!(
+            lib_before.is_none(),
+            "test setup bug: LIB still set after sanitization"
+        );
+
+        // ----- The contract under test. -----
+        let applied = ensure_msvc_env_for_native("x86_64-pc-windows-msvc")
+            .expect("discovery should succeed on a Windows host with VS installed");
+
+        // ----- GREEN check: env is now usable. -----
+        // Snapshot results BEFORE restoring saved env so failure messages
+        // describe the state we actually care about.
+        let applied_was_true = applied;
+        let link_after = which_on_path("link.exe");
+        let lib_after = std::env::var_os("LIB");
+        let include_after = std::env::var_os("INCLUDE");
+        let libpath_after = std::env::var_os("LIBPATH");
+
+        // ----- Restore. -----
+        match saved_lib {
+            Some(v) => std::env::set_var("LIB", v),
+            None => std::env::remove_var("LIB"),
         }
-        Err(MsvcDetectionError::NoSdkRoot | MsvcDetectionError::NoSdkVersion(_)) => {
-            eprintln!("msvc_host: skipping — no Windows 10/11 SDK on host");
-            return;
+        match saved_include {
+            Some(v) => std::env::set_var("INCLUDE", v),
+            None => std::env::remove_var("INCLUDE"),
         }
-        Err(MsvcDetectionError::NoToolsVersion(_)) => {
-            eprintln!("msvc_host: skipping — VS install missing VCToolsVersion file");
-            return;
+        match saved_libpath {
+            Some(v) => std::env::set_var("LIBPATH", v),
+            None => std::env::remove_var("LIBPATH"),
         }
-        Err(e) => {
-            panic!("unexpected discovery error setting up the test: {e}");
+        match saved_path {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
         }
-    }
+        match saved_optout {
+            Some(v) => std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v),
+            None => std::env::remove_var(SOLDR_MSVC_DISCOVERY_ENV_VAR),
+        }
 
-    // ----- Save the env we're about to mutate. -----
-    let saved_lib = std::env::var_os("LIB");
-    let saved_include = std::env::var_os("INCLUDE");
-    let saved_libpath = std::env::var_os("LIBPATH");
-    let saved_path = std::env::var_os("PATH");
-    let saved_optout = std::env::var_os(SOLDR_MSVC_DISCOVERY_ENV_VAR);
-
-    // ----- Sanitize: simulate a plain PowerShell with no vcvars. -----
-    // Remove LIB / INCLUDE / LIBPATH entirely.
-    std::env::remove_var("LIB");
-    std::env::remove_var("INCLUDE");
-    std::env::remove_var("LIBPATH");
-    // Make sure the opt-out var isn't set to a disabling value left
-    // over from earlier tests in this process.
-    std::env::remove_var(SOLDR_MSVC_DISCOVERY_ENV_VAR);
-    // Strip any PATH entries that contain a `link.exe` so the test
-    // really proves *our* injection put it back. We rebuild PATH
-    // from only directories that DON'T already resolve link.exe.
-    if let Some(orig_path) = saved_path.as_ref() {
-        let cleaned: Vec<std::path::PathBuf> = std::env::split_paths(orig_path)
-            .filter(|d| !d.join("link.exe").is_file())
-            .collect();
-        let joined = std::env::join_paths(cleaned).expect("clean PATH");
-        std::env::set_var("PATH", joined);
-    }
-
-    // ----- RED check: confirm sanitization actually removed link.exe. -----
-    let link_before = which_on_path("link.exe");
-    let lib_before = std::env::var_os("LIB");
-    assert!(
-        link_before.is_none(),
-        "test setup bug: link.exe still on PATH after sanitization at {}",
-        link_before.map(|p| p.display().to_string()).unwrap_or_default()
-    );
-    assert!(
-        lib_before.is_none(),
-        "test setup bug: LIB still set after sanitization"
-    );
-
-    // ----- The contract under test. -----
-    let applied = ensure_msvc_env_for_native("x86_64-pc-windows-msvc")
-        .expect("discovery should succeed on a Windows host with VS installed");
-
-    // ----- GREEN check: env is now usable. -----
-    // Snapshot results BEFORE restoring saved env so failure messages
-    // describe the state we actually care about.
-    let applied_was_true = applied;
-    let link_after = which_on_path("link.exe");
-    let lib_after = std::env::var_os("LIB");
-    let include_after = std::env::var_os("INCLUDE");
-    let libpath_after = std::env::var_os("LIBPATH");
-
-    // ----- Restore. -----
-    match saved_lib {
-        Some(v) => std::env::set_var("LIB", v),
-        None => std::env::remove_var("LIB"),
-    }
-    match saved_include {
-        Some(v) => std::env::set_var("INCLUDE", v),
-        None => std::env::remove_var("INCLUDE"),
-    }
-    match saved_libpath {
-        Some(v) => std::env::set_var("LIBPATH", v),
-        None => std::env::remove_var("LIBPATH"),
-    }
-    match saved_path {
-        Some(v) => std::env::set_var("PATH", v),
-        None => std::env::remove_var("PATH"),
-    }
-    match saved_optout {
-        Some(v) => std::env::set_var(SOLDR_MSVC_DISCOVERY_ENV_VAR, v),
-        None => std::env::remove_var(SOLDR_MSVC_DISCOVERY_ENV_VAR),
-    }
-
-    // ----- Now assert (after restoration is safely done). -----
-    assert!(
-        applied_was_true,
-        "ensure_msvc_env_for_native should report it injected env (returned false)"
-    );
-    let link_resolved = link_after.expect(
-        "issue #1079 contract broken: link.exe NOT findable after \
+        // ----- Now assert (after restoration is safely done). -----
+        assert!(
+            applied_was_true,
+            "ensure_msvc_env_for_native should report it injected env (returned false)"
+        );
+        let link_resolved = link_after.expect(
+            "issue #1079 contract broken: link.exe NOT findable after \
          ensure_msvc_env_for_native — soldr is failing to put the MSVC \
          bin directory on PATH",
-    );
-    assert!(
-        link_resolved
-            .to_string_lossy()
-            .to_lowercase()
-            .contains(r"\vc\tools\msvc\"),
-        "link.exe resolved at {} but doesn't look like a VC\\Tools\\MSVC binary",
-        link_resolved.display()
-    );
-    let lib = lib_after.expect("LIB env was not set by ensure_msvc_env_for_native");
-    let lib_str = lib.to_string_lossy();
-    assert!(
-        lib_str.contains(r"\VC\Tools\MSVC\"),
-        "LIB env should contain VC\\Tools\\MSVC: {lib_str}"
-    );
-    assert!(
-        lib_str.to_lowercase().contains(r"\ucrt\x64"),
-        "LIB env should contain \\ucrt\\x64 (Windows SDK ucrt libs): {lib_str}"
-    );
-    let inc = include_after.expect("INCLUDE env was not set");
-    let inc_str = inc.to_string_lossy();
-    assert!(
-        inc_str.contains(r"\VC\Tools\MSVC\"),
-        "INCLUDE env should contain VC\\Tools\\MSVC: {inc_str}"
-    );
-    assert!(
-        libpath_after.is_some(),
-        "LIBPATH env was not set by ensure_msvc_env_for_native"
-    );
-});
+        );
+        assert!(
+            link_resolved
+                .to_string_lossy()
+                .to_lowercase()
+                .contains(r"\vc\tools\msvc\"),
+            "link.exe resolved at {} but doesn't look like a VC\\Tools\\MSVC binary",
+            link_resolved.display()
+        );
+        let lib = lib_after.expect("LIB env was not set by ensure_msvc_env_for_native");
+        let lib_str = lib.to_string_lossy();
+        assert!(
+            lib_str.contains(r"\VC\Tools\MSVC\"),
+            "LIB env should contain VC\\Tools\\MSVC: {lib_str}"
+        );
+        assert!(
+            lib_str.to_lowercase().contains(r"\ucrt\x64"),
+            "LIB env should contain \\ucrt\\x64 (Windows SDK ucrt libs): {lib_str}"
+        );
+        let inc = include_after.expect("INCLUDE env was not set");
+        let inc_str = inc.to_string_lossy();
+        assert!(
+            inc_str.contains(r"\VC\Tools\MSVC\"),
+            "INCLUDE env should contain VC\\Tools\\MSVC: {inc_str}"
+        );
+        assert!(
+            libpath_after.is_some(),
+            "LIBPATH env was not set by ensure_msvc_env_for_native"
+        );
+    }
+);


### PR DESCRIPTION
## Summary

Fixes the lint failure in [CI run 28439879982](https://github.com/zackees/soldr/actions/runs/28439879982) (push of 0.7.87 release bump, commit 805b633). Six soldr-cli source files drifted from rustfmt's canonical layout — pure whitespace / line-wrap differences flagged by `soldr cargo fmt -p soldr-cli -- --check`. No behavioral change.

Affected files (rustfmt from toolchain 1.94.1):
- `crates/soldr-cli/src/blessed_build.rs`
- `crates/soldr-cli/src/compile_dispatch.rs`
- `crates/soldr-cli/src/daemon/server.rs`
- `crates/soldr-cli/src/lib.rs`
- `crates/soldr-cli/src/msvc_host.rs`
- `crates/soldr-cli/tests/msvc_host_discovery_windows.rs`

## Test plan

- [x] `rustup run 1.94.1 cargo fmt -p soldr-cli -- --check` passes locally
- [ ] CI Lint job (`Check formatting`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)