### PR TITLE
fix(soldr-cli): silence clippy::manual_contains + doc_lazy_continuation

### DIFF
--- a/crates/soldr-cli/src/core/canonical_targets.rs
+++ b/crates/soldr-cli/src/core/canonical_targets.rs
@@ -54,7 +54,7 @@ pub fn canonical_targets() -> &'static [&'static str] {
 /// Returns `true` iff `triple` is in [`CANONICAL_TARGETS`].
 /// Cheap linear scan over 8 entries.
 pub fn is_canonical(triple: &str) -> bool {
-    CANONICAL_TARGETS.iter().any(|t| *t == triple)
+    CANONICAL_TARGETS.contains(&triple)
 }
 
 #[cfg(test)]

--- a/crates/soldr-cli/src/fetch/manifest_lookup.rs
+++ b/crates/soldr-cli/src/fetch/manifest_lookup.rs
@@ -48,7 +48,7 @@
 //!   resolver builds `{origin}/catalogue.v1.json`). See Phase 2.
 //! * `SOLDR_TOOLCHAIN_CATALOGUE_URL` — override the full URL (testing
 //!   + air-gapped mirrors). When set takes precedence over
-//!   `SOLDR_TOOLCHAIN_ORIGIN`.
+//!     `SOLDR_TOOLCHAIN_ORIGIN`.
 //! * `SOLDR_MANIFEST_DISABLE=1` — skip the catalogue lookup entirely;
 //!   the resolver falls through to the live GitHub Releases API.
 //!


### PR DESCRIPTION
## Summary

Follow-up to the fmt fix that landed at fcd06864 (PR #1100 / #1099). The Lint job on the post-fmt-fix main ([run 28455998640](https://github.com/zackees/soldr/actions/runs/28455998640)) is still red — now on `Run clippy` instead of `Check formatting`:

1. **`clippy::manual_contains`** in `crates/soldr-cli/src/core/canonical_targets.rs:57`
   `CANONICAL_TARGETS.iter().any(|t| *t == triple)` -> `CANONICAL_TARGETS.contains(&triple)`
2. **`clippy::doc_lazy_continuation`** in `crates/soldr-cli/src/fetch/manifest_lookup.rs:51`
   third line of the `SOLDR_TOOLCHAIN_CATALOGUE_URL` bullet needed 2 more spaces of indentation so rustdoc keeps it as a list-item continuation rather than starting a new paragraph.

Both are mechanical applications of the clippy `help:` text. No behavior change.

## Test plan

- [x] `rustup run 1.94.1 cargo fmt -p soldr-cli -- --check` still passes
- [ ] CI Lint `Run clippy` step green (local clippy can't run cleanly without `soldr cargo` wrapping the build-script crate resolution; deferred to CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)