### PR TITLE
fix(soldr-cli): drop unused imports in tests/common/mod.rs

### DIFF
--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -4,14 +4,12 @@
 //! per-binary basis without sprinkling allows over individual helpers.
 #![allow(dead_code)]
 
-use serde_json::Value;
-use std::io::Write;
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     fs,
     path::{Path, PathBuf},
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);


### PR DESCRIPTION
Third lint failure on the original goal (CI run 28439879982 chain). Post-fmt + manual_contains/doc_lazy fixes, Lint [run 28456594537](https://github.com/zackees/soldr/actions/runs/28456594537) still red — `-D warnings` flagged unused imports in `crates/soldr-cli/tests/common/mod.rs`:

- line 7: `use serde_json::Value;`
- line 8: `use std::io::Write;`
- line 14: `Duration` and `Instant` (from `time::{...}`)

Surgical removal; remaining imports in the same blocks are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)