### PR TITLE
fix(ci): allow unused_imports in tests/common/mod.rs

### DIFF
--- a/crates/soldr-cli/tests/common/mod.rs
+++ b/crates/soldr-cli/tests/common/mod.rs
@@ -1,8 +1,13 @@
 //! Shared helpers for the `cli_*` integration test binaries. Each binary
 //! pulls in `mod common;` and re-exports the helpers it actually uses; the
 //! `#![allow(dead_code)]` on the module silences unused-helper warnings on a
-//! per-binary basis without sprinkling allows over individual helpers.
+//! per-binary basis without sprinkling allows over individual helpers. The
+//! same situation applies to imports: some integration binaries use
+//! `serde_json::Value` / `std::io::Write` / `Duration` / `Instant`, others
+//! don't — `#![allow(unused_imports)]` keeps the common-helpers pattern
+//! working under `-D warnings`.
 #![allow(dead_code)]
+#![allow(unused_imports)]
 
 use serde_json::Value;
 use std::io::Write;


### PR DESCRIPTION
Lint job is red on three pre-existing unused-import errors in `tests/common/mod.rs` (now treated as errors under `-D warnings`). These imports are used by some integration test binaries via `mod common;` but not others — same pattern the existing `#![allow(dead_code)]` already covers. Add `#![allow(unused_imports)]` at the module level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)