### PR TITLE
fix(soldr-cli): swap manual clamp pattern for .clamp(1, 4)

### DIFF
--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -484,7 +484,7 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             let cpu_cap = std::thread::available_parallelism()
                 .map(|n| n.get())
                 .unwrap_or(2);
-            let concurrency = cpu_cap.min(targets.len()).min(4).max(1);
+            let concurrency = cpu_cap.min(targets.len()).clamp(1, 4);
             if targets.len() > 1 {
                 eprintln!(
                     "soldr prepare: parallelizing {} targets with {} workers (soldr#940)",


### PR DESCRIPTION
Fourth lint issue in the run-28439879982 chain. Lint [run 28457195556](https://github.com/zackees/soldr/actions/runs/28457195556) flagged `clippy::manual_clamp` in `crates/soldr-cli/src/main.rs:487`:

```rust
let concurrency = cpu_cap.min(targets.len()).min(4).max(1);
// ->
let concurrency = cpu_cap.min(targets.len()).clamp(1, 4);
```

`clamp` panics if `max < min`; here `1 < 4` is a compile-time constant so it's safe. Semantics identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)