### PR TITLE
fix(ci): disable cache + soldr-cook hydration in all setup-soldr callers

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -122,6 +122,10 @@ jobs:
           EOF
           cat rust-toolchain.ci.toml
 
+      # soldr#1083 follow-up: cache + soldr-cook disabled across the
+      # repo. Cook rewrites workspace + per-crate source files in
+      # ways incompatible with cross-compile lanes. Save cost no
+      # longer offsets savings. Toolchain install only.
       - name: Setup soldr build cache
         id: setup_soldr
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
@@ -129,19 +133,9 @@ jobs:
           ACTION_WORKSPACE: ${{ github.workspace }}/soldr
         with:
           toolchain-file: rust-toolchain.ci.toml
-          cache: true
+          cache: false
           zccache-seed-strict: true
           linker: platform-default
-          cache-key-suffix: bootstrap-${{ inputs.target }}-native-cc-v2
-          lockfile: Cargo.lock
-          target-dir: target
-          prebuild-deps: soldr-cook
-          prebuild-deps-flags: "--target ${{ inputs.target }}"
-
-      - name: Restore checkout after soldr-cook
-        shell: pwsh
-        working-directory: soldr
-        run: git restore --worktree -- .
 
       - name: Reset stale cache fallback artifacts
         if: >-

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -83,16 +83,17 @@ jobs:
           targets: ${{ inputs.target }}
           components: ${{ inputs.install_components }}
 
+      # soldr#1083 follow-up: cache + soldr-cook disabled. Cook
+      # rewrites the workspace manifest in ways incompatible with
+      # cross-compile lanes; save cost no longer justifies. Pure
+      # toolchain install via setup-soldr.
       - name: Setup soldr build cache
         id: setup_soldr
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:
           toolchain: 1.94.1
-          cache: true
+          cache: false
           zccache-seed-strict: true
-          cache-key-suffix: build-${{ inputs.shared_key }}-${{ inputs.cache_key }}
-          prebuild-deps: soldr-cook
-          prebuild-deps-flags: "--target ${{ inputs.target }}"
 
       - name: Enable Windows line-table debug symbols
         if: runner.os == 'Windows'

--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -72,26 +72,21 @@ jobs:
       # cc-rs invocations that produced bit-identical outputs to
       # the previous PR. soldr#1061 gap analysis: ~2h/day of CI
       # wallclock burned across the 8-lane matrix.
-      - name: Setup soldr build cache (Rust toolchain + cook hydration)
+      # soldr#1083 follow-up: cache + soldr-cook disabled. Cook's
+      # cargo-chef pass replaces every workspace crate's lib.rs /
+      # main.rs / build.rs with `fn main() {}` stubs AND rewrites
+      # the workspace Cargo.toml to a stripped variant — both
+      # incompatible with cross-compile lanes (wheel-version
+      # extraction broke, formatter saw stub-only files). Save cost
+      # no longer offsets the savings. Pure toolchain install via
+      # setup-soldr; no cook, no cache restore, no
+      # `git restore --worktree` workaround needed.
+      - name: Setup soldr build cache (Rust toolchain only)
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:
           toolchain: 1.94.1
-          cache: true
+          cache: false
           zccache-seed-strict: true
-          cache-key-suffix: ci-cross-${{ inputs.target }}
-          prebuild-deps: soldr-cook
-          prebuild-deps-flags: ""
-
-      # `prebuild-deps: soldr-cook` runs cargo-chef under the hood,
-      # which replaces every workspace crate's main.rs / lib.rs / build.rs
-      # with `fn main() {}` stubs while it cooks dependency layers. The
-      # cook step doesn't restore the originals — soldr#1066. Without
-      # this `git restore` the subsequent `cargo fmt --check` sees the
-      # stubs (missing trailing newlines, lone `fn main() {}` content)
-      # and fails. The ci.yml `lint` job uses the identical pattern.
-      - name: Restore checkout after soldr-cook
-        shell: bash
-        run: git restore --worktree -- .
 
       - name: Add cross-compile target
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,19 +51,20 @@ jobs:
         with:
           submodules: recursive
 
+      # soldr#1083 follow-up: cache + soldr-cook hydration disabled.
+      # Cook hydration was rewriting the workspace Cargo.toml to a
+      # stripped variant (workspace + dependencies, no
+      # [workspace.package]) which broke the release wheel-version
+      # extraction. Cache save cost no longer translates to
+      # measurable speedups on the lint job. Drop both. Restore-from-
+      # git workaround that paired with it is no longer needed
+      # because the manifest is never overwritten.
       - name: Setup soldr build cache
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:
           toolchain: 1.94.1
-          cache: true
+          cache: false
           zccache-seed-strict: true
-          cache-key-suffix: lint-ubuntu
-          prebuild-deps: soldr-cook
-          prebuild-deps-flags: ""
-
-      - name: Restore checkout after soldr-cook
-        shell: pwsh
-        run: git restore --worktree -- .
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -238,15 +238,18 @@ jobs:
       # artifact restore that every-commit CI now uses. Saves the
       # 45-70s/lane that release builds were spending on bit-identical
       # libsqlite3-sys / tikv-jemalloc-sys / zstd-sys / ring rebuilds.
-      - name: Setup soldr build cache (Rust toolchain + cook hydration)
+      # soldr#1083 follow-up: cache + soldr-cook hydration disabled.
+      # Cook rewrites Cargo.toml in ways that don't compose with
+      # cross-compile (stripped [workspace.package], wrong-versioned
+      # wheels). Save cost no longer offsets the savings. Drop both;
+      # rely on cargo's native incremental + zccache for build
+      # acceleration.
+      - name: Setup soldr build cache (Rust toolchain only)
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:
           toolchain: 1.94.1
-          cache: true
+          cache: false
           zccache-seed-strict: true
-          cache-key-suffix: release-${{ matrix.target }}
-          prebuild-deps: soldr-cook
-          prebuild-deps-flags: ""
 
       - name: Add cross-compile target
         shell: bash


### PR DESCRIPTION
Cook hydration (cargo-chef under the hood) does two destructive things to the workspace that don't compose with cross-compile lanes OR with `cargo fmt --check`:

1. **Replaces every workspace crate's lib.rs / main.rs / build.rs with stubs** (`fn main() {}`). Required `git restore --worktree` workarounds in two YAMLs already.

2. **Rewrites the workspace `Cargo.toml` to a stripped variant** (only `[workspace]` + `[workspace.dependencies]`; no `[workspace.package]`, no `version = "X"`). Caused maturin to write wheels tagged `0.0.1` instead of the workspace version on every Linux gnu release lane from v0.7.72 through v0.7.81 — six failed release attempts to diagnose.

Cache save cost no longer translates to measurable speedups either (user observation 2026-06-30).

## Change

Set `cache: false` and remove `prebuild-deps: soldr-cook` in all five workflow files that called setup-soldr with these inputs. Drop the now-redundant `Restore checkout after soldr-cook` workarounds.

Cargo's native incremental + zccache provide the build acceleration; setup-soldr now does just toolchain install + zccache seed.

Upstream issue for the cook hydration's destructive behavior filed against `zackees/setup-soldr` (link in next comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)