### PR TITLE
[codex] activate safe syslib catalogue bundles

### DIFF
--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -268,7 +268,7 @@ async fn inject_sys_library_overrides(
         Ok(sysroot) => {
             prep.env
                 .push(("ZSTD_SYS_USE_PKG_CONFIG".to_string(), "1".to_string()));
-            prepend_pkg_config_path(prep, &sysroot);
+            prepend_pkg_config_path(prep, target_triple, &sysroot);
         }
         Err(e) => log_sys_unavailable("zstd", target_triple, &e),
     }
@@ -278,76 +278,62 @@ async fn inject_sys_library_overrides(
         Ok(sysroot) => {
             prep.env
                 .push(("LIBSQLITE3_SYS_USE_PKG_CONFIG".to_string(), "1".to_string()));
-            prepend_pkg_config_path(prep, &sysroot);
+            prepend_pkg_config_path(prep, target_triple, &sysroot);
         }
         Err(e) => log_sys_unavailable("sqlite", target_triple, &e),
     }
 
-    // tikv-jemalloc-sys → JEMALLOC_OVERRIDE=<lib>/libjemalloc.a
-    match crate::fetch::jemalloc_sysroot::ensure_jemalloc_sysroot(paths, target_triple).await {
-        Ok(sysroot) => {
-            let lib = sysroot.join("lib").join("libjemalloc.a");
-            prep.env.push((
-                "JEMALLOC_OVERRIDE".to_string(),
-                lib.to_string_lossy().into_owned(),
-            ));
-        }
-        Err(e) => log_sys_unavailable("jemalloc", target_triple, &e),
-    }
-
-    // libmimalloc-sys → MIMALLOC_OVERRIDE=<lib>/libmimalloc.a
-    match crate::fetch::mimalloc_sysroot::ensure_mimalloc_sysroot(paths, target_triple).await {
-        Ok(sysroot) => {
-            let lib = sysroot.join("lib").join("libmimalloc.a");
-            prep.env.push((
-                "MIMALLOC_OVERRIDE".to_string(),
-                lib.to_string_lossy().into_owned(),
-            ));
-        }
-        Err(e) => log_sys_unavailable("mimalloc", target_triple, &e),
-    }
-
-    // libz-ng-sys → PKG_CONFIG_PATH (pkg-config-only contract)
-    match crate::fetch::zlib_ng_sysroot::ensure_zlib_ng_sysroot(paths, target_triple).await {
-        Ok(sysroot) => prepend_pkg_config_path(prep, &sysroot),
-        Err(e) => log_sys_unavailable("zlib-ng", target_triple, &e),
-    }
-
-    // lzma-sys → LZMA_API_STATIC=1 + PKG_CONFIG_PATH
-    match crate::fetch::lzma_sysroot::ensure_lzma_sysroot(paths, target_triple).await {
-        Ok(sysroot) => {
-            prep.env
-                .push(("LZMA_API_STATIC".to_string(), "1".to_string()));
-            prepend_pkg_config_path(prep, &sysroot);
-        }
-        Err(e) => log_sys_unavailable("lzma", target_triple, &e),
-    }
-
-    // bzip2-sys → PKG_CONFIG_PATH (pkg-config-only contract)
-    match crate::fetch::bzip2_sysroot::ensure_bzip2_sysroot(paths, target_triple).await {
-        Ok(sysroot) => prepend_pkg_config_path(prep, &sysroot),
-        Err(e) => log_sys_unavailable("bzip2", target_triple, &e),
-    }
+    // Currently not wired:
+    // - jemalloc: recipe version differs from tikv-jemalloc-sys' vendored lib.
+    // - mimalloc and zlib-ng: current sys crates do not expose valid hooks.
+    // - lzma: LZMA_API_STATIC selects the vendored path today.
+    // - bzip2: pkg-config behavior is partial and not all-target safe.
 }
 
 /// Prepend `<sysroot>/lib/pkgconfig` to whatever `PKG_CONFIG_PATH`
-/// value is already queued on `prep.env`. Multiple sysroots stack via
-/// repeated calls (last-wins lookup order = first-pushed sysroot).
-fn prepend_pkg_config_path(prep: &mut BlessedPrep, sysroot: &std::path::Path) {
+/// value is already queued on `prep.env`, and also expose the same
+/// path through pkg-config-rs' target-scoped variable.
+fn prepend_pkg_config_path(prep: &mut BlessedPrep, target_triple: &str, sysroot: &std::path::Path) {
     let pkgconfig_dir = sysroot.join("lib").join("pkgconfig");
     let new_entry = pkgconfig_dir.to_string_lossy().into_owned();
+    upsert_path_env(prep, "PKG_CONFIG_PATH", &new_entry);
+    upsert_path_env(
+        prep,
+        &format!("PKG_CONFIG_PATH_{}", target_triple.replace('-', "_")),
+        &new_entry,
+    );
+    upsert_env(prep, "PKG_CONFIG_ALLOW_CROSS", "1");
+}
+
+fn upsert_path_env(prep: &mut BlessedPrep, name: &str, new_entry: &str) {
     // If a prior call already pushed a PKG_CONFIG_PATH entry, prepend
     // to it rather than clobbering. cargo + the child cargo will see
     // the final composed value at child-process spawn time.
     if let Some(existing) = prep
         .env
         .iter_mut()
-        .find(|(name, _)| name == "PKG_CONFIG_PATH")
+        .find(|(existing_name, _)| existing_name == name)
     {
         let sep = if cfg!(windows) { ';' } else { ':' };
-        existing.1 = format!("{new_entry}{sep}{}", existing.1);
+        if existing.1.is_empty() {
+            existing.1 = new_entry.to_string();
+        } else {
+            existing.1 = format!("{new_entry}{sep}{}", existing.1);
+        }
     } else {
-        prep.env.push(("PKG_CONFIG_PATH".to_string(), new_entry));
+        prep.env.push((name.to_string(), new_entry.to_string()));
+    }
+}
+
+fn upsert_env(prep: &mut BlessedPrep, name: &str, value: &str) {
+    if let Some(existing) = prep
+        .env
+        .iter_mut()
+        .find(|(existing_name, _)| existing_name == name)
+    {
+        existing.1 = value.to_string();
+    } else {
+        prep.env.push((name.to_string(), value.to_string()));
     }
 }
 
@@ -558,13 +544,41 @@ mod tests {
     crate::timed_test!(linux_targets_get_no_prep, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let prev = std::env::var_os(USE_LEGACY_VENDORED_SYS_ENV_VAR);
+        std::env::set_var(USE_LEGACY_VENDORED_SYS_ENV_VAR, "1");
         let prep = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(prepare(&paths, "x86_64-unknown-linux-musl"))
             .expect("linux musl target should not error");
+        match prev {
+            Some(v) => std::env::set_var(USE_LEGACY_VENDORED_SYS_ENV_VAR, v),
+            None => std::env::remove_var(USE_LEGACY_VENDORED_SYS_ENV_VAR),
+        }
         assert!(prep.xwin_cache_dir.is_none());
         assert!(prep.sdkroot.is_none());
         assert!(prep.env.is_empty());
+    });
+
+    crate::timed_test!(pkg_config_env_is_global_target_scoped_and_cross_enabled, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let sysroot = tmp.path().join("zstd");
+        let mut prep = BlessedPrep::default();
+        prepend_pkg_config_path(&mut prep, "x86_64-unknown-linux-musl", &sysroot);
+
+        let value_for = |name: &str| {
+            prep.env
+                .iter()
+                .find(|(env_name, _)| env_name == name)
+                .map(|(_, value)| value.as_str())
+        };
+        let pkgconfig = sysroot.join("lib").join("pkgconfig");
+        let pkgconfig = pkgconfig.to_string_lossy();
+        assert_eq!(value_for("PKG_CONFIG_PATH"), Some(pkgconfig.as_ref()));
+        assert_eq!(
+            value_for("PKG_CONFIG_PATH_x86_64_unknown_linux_musl"),
+            Some(pkgconfig.as_ref())
+        );
+        assert_eq!(value_for("PKG_CONFIG_ALLOW_CROSS"), Some("1"));
     });
 
     crate::timed_test!(xwin_cflags_emits_imsvc_for_present_dirs, {

--- a/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
@@ -1,4 +1,4 @@
-//! bzip2 (libbz2) sysroot fetcher — soldr#1064 Phase B.
+//! bzip2 (libbz2) sysroot fetcher placeholder for soldr#1064 Phase B.
 //!
 //! Consumes the soldr-toolchain `recipes/bzip2-<platform>/` catalogue
 //! rows. Each row ships:
@@ -9,14 +9,10 @@
 //! include/bzlib.h
 //! ```
 //!
-//! When `bzip2-sys` is in the transitive deps and the catalogue row is
-//! ingested, the blessed path exports `PKG_CONFIG_PATH` pointing at the
-//! materialized `lib/pkgconfig/` directory so `bzip2-sys`' build.rs
-//! uses pkg-config to locate the precompiled libbz2 instead of
-//! recompiling the in-tree bzip2 sources (1-3s).
-//!
-//! Lowest-cost crate in the in-scope list — included for completeness
-//! since the recipe pattern is identical.
+//! This module is intentionally disabled for now. `bzip2-sys` only has
+//! partial pkg-config behavior across the target set, and
+//! `BZIP2_NO_PKG_CONFIG=0` is not a valid enable contract for the
+//! all-target blessed-build path tracked by soldr#1064.
 
 use std::path::PathBuf;
 
@@ -43,10 +39,7 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/bzip2/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_bundle::asset_url_for("bzip2", version, slug)
 }
 
 pub async fn ensure_bzip2_sysroot(
@@ -56,15 +49,15 @@ pub async fn ensure_bzip2_sysroot(
     let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
-            "no bzip2 sysroot recipe for target {target_triple}; \
-             supported: {:?}",
+            "no bzip2 sysroot recipe for target {target_triple}; supported: {:?}",
             BZIP2_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
     let url = asset_url_for(MANAGED_BZIP2_VERSION, slug);
     Err(SoldrError::Other(format!(
-        "bzip2 sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
+        "bzip2 sysroot for {target_triple} ({slug}) is disabled: current bzip2-sys \
+         does not expose a valid all-target catalogue override. Current expected \
+         URL: {url}\n\
          Tracking: https://github.com/zackees/soldr/issues/1064"
     )))
 }
@@ -87,17 +80,18 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_BZIP2_VERSION, "linux-x64-gnu");
-        assert!(u.contains("/deps/bzip2/1.0.8/linux-x64-gnu/"));
+        assert!(u.contains("/bzip2/1.0.8/linux-x64-gnu/"));
+        assert!(!u.contains("/deps/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_bzip2_sysroot_returns_not_yet_ingested, {
+    crate::timed_test!(ensure_bzip2_sysroot_returns_disabled_error, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
         let result = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(ensure_bzip2_sysroot(&paths, "x86_64-unknown-linux-gnu"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
+        let err = result.expect_err("must error while disabled");
+        assert!(err.to_string().contains("disabled"));
     });
 }

--- a/crates/soldr-cli/src/fetch/jemalloc_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/jemalloc_sysroot.rs
@@ -16,6 +16,11 @@
 //!
 //! tikv-jemalloc-sys' build.rs short-circuits the 20-40s autotools
 //! build entirely when this env var points at a static archive.
+//!
+//! This module stays disabled until the recipe version is aligned with
+//! the current Cargo.lock entry: tikv-jemalloc-sys 0.7.1 vendors
+//! jemalloc 5.3.1, while the merged soldr-toolchain recipe currently
+//! builds 5.3.0.
 
 use std::path::PathBuf;
 
@@ -46,10 +51,7 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/jemalloc/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_bundle::asset_url_for("jemalloc", version, slug)
 }
 
 pub async fn ensure_jemalloc_sysroot(
@@ -66,8 +68,9 @@ pub async fn ensure_jemalloc_sysroot(
     })?;
     let url = asset_url_for(MANAGED_JEMALLOC_VERSION, slug);
     Err(SoldrError::Other(format!(
-        "jemalloc sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
+        "jemalloc sysroot for {target_triple} ({slug}) is disabled until \
+         the catalogue recipe version is aligned with tikv-jemalloc-sys' \
+         vendored jemalloc 5.3.1. Current expected URL: {url}\n\
          Tracking: https://github.com/zackees/soldr/issues/1064"
     )))
 }
@@ -91,18 +94,19 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_JEMALLOC_VERSION, "linux-x64-musl");
-        assert!(u.contains("/deps/jemalloc/5.3.0/linux-x64-musl/"));
+        assert!(u.contains("/jemalloc/5.3.0/linux-x64-musl/"));
+        assert!(!u.contains("/deps/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_jemalloc_sysroot_returns_not_yet_ingested, {
+    crate::timed_test!(ensure_jemalloc_sysroot_returns_disabled_error, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
         let result = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(ensure_jemalloc_sysroot(&paths, "x86_64-unknown-linux-musl"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
+        let err = result.expect_err("must error while disabled");
+        assert!(err.to_string().contains("disabled"));
     });
 
     crate::timed_test!(ensure_jemalloc_rejects_windows, {

--- a/crates/soldr-cli/src/fetch/lzma_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/lzma_sysroot.rs
@@ -10,15 +10,10 @@
 //! include/lzma/*.h
 //! ```
 //!
-//! When `lzma-sys` is in the transitive deps and the catalogue row is
-//! ingested, the blessed path exports:
-//!
-//!   * `LZMA_API_STATIC=1`
-//!   * `PKG_CONFIG_PATH=<sysroot>/lib/pkgconfig:$PKG_CONFIG_PATH`
-//!
-//! so `lzma-sys`' build.rs uses pkg-config to locate the precompiled
-//! liblzma static archive instead of recompiling its in-tree xz copy
-//! (5-10s).
+//! This module is intentionally disabled for now. In the current
+//! `lzma-sys` build script, `LZMA_API_STATIC=1` selects the vendored
+//! static build path instead of forcing pkg-config. Blessed builds must
+//! not inject this sysroot until the upstream contract is proven.
 
 use std::path::PathBuf;
 
@@ -45,10 +40,7 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/lzma/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_bundle::asset_url_for("lzma", version, slug)
 }
 
 pub async fn ensure_lzma_sysroot(
@@ -65,8 +57,9 @@ pub async fn ensure_lzma_sysroot(
     })?;
     let url = asset_url_for(MANAGED_LZMA_VERSION, slug);
     Err(SoldrError::Other(format!(
-        "lzma sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
+        "lzma sysroot for {target_triple} ({slug}) is disabled: current lzma-sys \
+         does not expose the static pkg-config override described in the issue. \
+         Current expected URL: {url}\n\
          Tracking: https://github.com/zackees/soldr/issues/1064"
     )))
 }
@@ -89,17 +82,18 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_LZMA_VERSION, "darwin-arm64");
-        assert!(u.contains("/deps/lzma/5.6.3/darwin-arm64/"));
+        assert!(u.contains("/lzma/5.6.3/darwin-arm64/"));
+        assert!(!u.contains("/deps/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_lzma_sysroot_returns_not_yet_ingested, {
+    crate::timed_test!(ensure_lzma_sysroot_returns_disabled_error, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
         let result = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(ensure_lzma_sysroot(&paths, "aarch64-apple-darwin"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
+        let err = result.expect_err("must error while disabled");
+        assert!(err.to_string().contains("disabled"));
     });
 }

--- a/crates/soldr-cli/src/fetch/manifest_lookup.rs
+++ b/crates/soldr-cli/src/fetch/manifest_lookup.rs
@@ -161,6 +161,13 @@ impl ManifestIndex {
             .find(|e| e.owner == owner && e.repo == repo && e.tag == tag && e.asset == asset)
     }
 
+    /// Look up a catalogue entry by exact download URL. This is needed
+    /// for soldr-toolchain local assets that intentionally reuse generic
+    /// filenames like `bundle.tar.zst` under distinct platform paths.
+    pub fn lookup_url(&self, url: &str) -> Option<&ManifestEntry> {
+        self.entries.iter().find(|e| e.url == url)
+    }
+
     /// Look up by `(owner, repo, tag)` only, ignoring the asset filter.
     /// Useful when the caller already knows the platform-matched asset
     /// name and just wants to round-trip the URL + sha256 for that one
@@ -472,9 +479,20 @@ mod tests {
             .is_none());
     });
 
+    crate::timed_test!(lookup_url_finds_exact_url_match, {
+        let idx = ManifestIndex::from_json(sample_json()).unwrap();
+        let url = "https://github.com/zackees/zccache/releases/download/1.12.9/zccache-x86_64-pc-windows-msvc.zip";
+        let hit = idx.lookup_url(url).expect("should hit exact URL");
+        assert_eq!(hit.asset, "zccache-x86_64-pc-windows-msvc.zip");
+        assert!(idx
+            .lookup_url("https://example.invalid/miss.tar.zst")
+            .is_none());
+    });
+
     crate::timed_test!(empty_index_lookup_always_misses, {
         let idx = ManifestIndex::empty();
         assert!(idx.lookup("a", "b", "c", "d").is_none());
+        assert!(idx.lookup_url("https://example.invalid/nope").is_none());
         assert!(idx.lookup_release("a", "b", "c").is_empty());
     });
 

--- a/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
@@ -8,13 +8,11 @@
 //! include/mimalloc.h
 //! ```
 //!
-//! When `libmimalloc-sys` is in the transitive deps and the catalogue
-//! row is ingested, the blessed path exports:
-//!
-//!   * `MIMALLOC_OVERRIDE=<sysroot>/lib/libmimalloc.a`
-//!
-//! `libmimalloc-sys`' build.rs (v0.1.49+) honors `MIMALLOC_OVERRIDE`
-//! and skips its cmake compile entirely.
+//! This module is intentionally disabled for now. The current
+//! `libmimalloc-sys` build script does not expose a
+//! `MIMALLOC_OVERRIDE` contract, and its bundled mimalloc version does
+//! not match the merged catalogue recipe. Do not wire this into
+//! blessed builds until the upstream hook and version are aligned.
 
 use std::path::PathBuf;
 
@@ -41,10 +39,7 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/mimalloc/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_bundle::asset_url_for("mimalloc", version, slug)
 }
 
 pub async fn ensure_mimalloc_sysroot(
@@ -61,8 +56,9 @@ pub async fn ensure_mimalloc_sysroot(
     })?;
     let url = asset_url_for(MANAGED_MIMALLOC_VERSION, slug);
     Err(SoldrError::Other(format!(
-        "mimalloc sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
+        "mimalloc sysroot for {target_triple} ({slug}) is disabled: current \
+         libmimalloc-sys does not expose a MIMALLOC_OVERRIDE hook and the \
+         catalogue recipe version is not aligned. Current expected URL: {url}\n\
          Tracking: https://github.com/zackees/soldr/issues/1064"
     )))
 }
@@ -85,17 +81,18 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_MIMALLOC_VERSION, "windows-x64");
-        assert!(u.contains("/deps/mimalloc/3.0.4/windows-x64/"));
+        assert!(u.contains("/mimalloc/3.0.4/windows-x64/"));
+        assert!(!u.contains("/deps/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_mimalloc_sysroot_returns_not_yet_ingested, {
+    crate::timed_test!(ensure_mimalloc_sysroot_returns_disabled_error, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
         let result = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(ensure_mimalloc_sysroot(&paths, "aarch64-apple-darwin"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
+        let err = result.expect_err("must error while disabled");
+        assert!(err.to_string().contains("disabled"));
     });
 }

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -60,15 +60,14 @@ pub mod openssl_sysroot;
 /// soldr#997 Phase A — Python sysroot bundle for PyO3 cross-compile
 /// (closes parts of #931, #932, #933).
 pub mod python_sysroot;
+pub(crate) mod syslib_bundle;
 /// soldr#1012 PR 5 — xwin-cache catalogue materialization for the
 /// blessed `*-pc-windows-msvc` cross-compile path.
 pub mod xwin_cache;
-// soldr#1064 Phase B — *-sys C library catalogue distribution.
-// Each module is a stub-until-ingested consumer modeled on
-// openssl_sysroot.rs. Once the soldr-toolchain forge dispatches
-// land the assets, blessed_build::prepare wires the corresponding
-// _SYSTEM / _OVERRIDE env vars onto the child cargo invocation so
-// the *-sys crate's build.rs skips its vendored compile.
+// soldr#1064 Phase B: *-sys C library catalogue distribution.
+// zstd/sqlite are active consumers; the other modules preserve the
+// target/version tables but return disabled errors until their crate
+// hooks and bundled versions are safe to override.
 pub mod bzip2_sysroot;
 pub mod jemalloc_sysroot;
 pub mod lzma_sysroot;

--- a/crates/soldr-cli/src/fetch/sqlite_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/sqlite_sysroot.rs
@@ -16,8 +16,9 @@
 //!   * `PKG_CONFIG_PATH=<sysroot>/lib/pkgconfig:$PKG_CONFIG_PATH`
 //!
 //! This is the highest-cost crate in the in-scope list (35-47s per
-//! lane for the SQLite amalgamation compile). Mirrors
-//! [`super::openssl_sysroot`]'s stub-until-ingested shape.
+//! lane for the SQLite amalgamation compile). Once a target row is
+//! present in `catalogue.v1.json`, `ensure_sqlite_sysroot` downloads,
+//! sha-verifies, extracts, and returns the local package root.
 
 use std::path::PathBuf;
 
@@ -48,17 +49,13 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/sqlite/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_bundle::asset_url_for("sqlite", version, slug)
 }
 
 pub async fn ensure_sqlite_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no sqlite sysroot recipe for target {target_triple}; \
@@ -66,12 +63,15 @@ pub async fn ensure_sqlite_sysroot(
             SQLITE_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_SQLITE_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "sqlite sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/1064"
-    )))
+    super::syslib_bundle::ensure_syslib_bundle(
+        paths,
+        target_triple,
+        "sqlite",
+        MANAGED_SQLITE_VERSION,
+        slug,
+        &["include/sqlite3.h", "lib/pkgconfig/sqlite3.pc"],
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -92,17 +92,21 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_SQLITE_VERSION, "linux-arm64-musl");
-        assert!(u.contains("/deps/sqlite/3.46.0/linux-arm64-musl/"));
+        assert!(u.contains("/sqlite/3.46.0/linux-arm64-musl/"));
+        assert!(!u.contains("/deps/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_sqlite_sysroot_returns_not_yet_ingested, {
-        let tmp = tempfile::tempdir().expect("tmpdir");
-        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
-        let result = tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(ensure_sqlite_sysroot(&paths, "x86_64-unknown-linux-musl"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
-    });
+    crate::timed_test!(
+        ensure_sqlite_sysroot_rejects_unsupported_target_without_network,
+        {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+            let result = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(ensure_sqlite_sysroot(&paths, "wasm32-unknown-unknown"));
+            let err = result.expect_err("unsupported target must error before catalogue fetch");
+            assert!(matches!(err, SoldrError::UnsupportedPlatform(_)));
+        }
+    );
 }

--- a/crates/soldr-cli/src/fetch/syslib_bundle.rs
+++ b/crates/soldr-cli/src/fetch/syslib_bundle.rs
@@ -1,0 +1,236 @@
+//! Shared materializer for soldr-toolchain syslib bundles.
+//!
+//! The forge ingest path publishes rows like
+//! `zstd/1.5.7/linux-x64-musl/bundle.tar.zst` into the flat v1
+//! catalogue. Those rows intentionally reuse the same asset filename
+//! (`bundle.tar.zst`) across target shapes, so consumers must resolve
+//! them by exact URL rather than `(owner, repo, tag, asset)`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{SoldrError, SoldrPaths};
+
+use super::github::http_client;
+use super::manifest_lookup;
+use super::trust;
+
+const TOOLCHAIN_ASSETS_BASE_URL: &str =
+    "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets";
+const SYSROOT_ASSET_NAME: &str = "bundle.tar.zst";
+
+pub(crate) fn asset_url_for(tool: &str, version: &str, slug: &str) -> String {
+    format!("{TOOLCHAIN_ASSETS_BASE_URL}/{tool}/{version}/{slug}/{SYSROOT_ASSET_NAME}")
+}
+
+pub(crate) async fn ensure_syslib_bundle(
+    paths: &SoldrPaths,
+    target_triple: &str,
+    tool: &str,
+    version: &str,
+    slug: &str,
+    expected_files: &[&str],
+) -> Result<PathBuf, SoldrError> {
+    let url = asset_url_for(tool, version, slug);
+    let manifest = manifest_lookup::get_or_fetch().await;
+    let entry = manifest.lookup_url(&url).ok_or_else(|| {
+        SoldrError::Other(format!(
+            "{tool} sysroot for {target_triple} ({slug}) is not yet ingested into the \
+             soldr-toolchain catalogue. Expected URL: {url}\n\
+             Tracking: https://github.com/zackees/soldr/issues/1064"
+        ))
+    })?;
+    let expected_sha256 = entry.sha256.trim().to_ascii_lowercase();
+    let entry_url = entry.url.clone();
+
+    paths.ensure_dirs()?;
+    let install_dir = install_dir_for(paths, target_triple, tool, version, slug);
+    let stamp = install_dir.join(".complete");
+    let sysroot = package_root_for(&install_dir);
+
+    if stamp_matches(&stamp, &expected_sha256) && expected_files_present(&sysroot, expected_files) {
+        return Ok(sysroot);
+    }
+
+    eprintln!("soldr: fetching {tool} sysroot v{version} for {target_triple} from {entry_url}...");
+    let client = http_client()?;
+    let resp = client
+        .get(&entry_url)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(SoldrError::Network(format!(
+            "{tool} sysroot download failed: HTTP {}",
+            resp.status()
+        )));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    let digest = trust::sha256_of(&bytes);
+    if digest != expected_sha256 {
+        return Err(SoldrError::Other(format!(
+            "{tool} sysroot sha256 mismatch for {target_triple}: expected {expected_sha256}, \
+             got {digest} (catalogue blob may have been replaced; refusing to extract)"
+        )));
+    }
+    eprintln!(
+        "soldr: trust: manifest-verified {tool} sysroot v{version} for {target_triple} sha256={digest}"
+    );
+
+    if install_dir.exists() {
+        std::fs::remove_dir_all(&install_dir)?;
+    }
+    std::fs::create_dir_all(&install_dir)?;
+    extract_tar_zst_tree(&bytes, &install_dir)?;
+
+    let sysroot = package_root_for(&install_dir);
+    ensure_expected_files(&sysroot, expected_files, tool, target_triple)?;
+    write_stamp(&stamp, version, &entry_url, &expected_sha256)?;
+    eprintln!(
+        "soldr: extracted {tool} sysroot for {target_triple} to {}",
+        sysroot.display()
+    );
+    Ok(sysroot)
+}
+
+fn install_dir_for(
+    paths: &SoldrPaths,
+    target_triple: &str,
+    tool: &str,
+    version: &str,
+    slug: &str,
+) -> PathBuf {
+    paths
+        .root
+        .join("sdk")
+        .join(target_triple)
+        .join(tool)
+        .join(version)
+        .join(slug)
+}
+
+fn package_root_for(install_dir: &Path) -> PathBuf {
+    let package = install_dir.join("package");
+    if package.is_dir() {
+        package
+    } else {
+        install_dir.to_path_buf()
+    }
+}
+
+fn expected_files_present(sysroot: &Path, expected_files: &[&str]) -> bool {
+    expected_files.iter().all(|rel| sysroot.join(rel).is_file())
+}
+
+fn ensure_expected_files(
+    sysroot: &Path,
+    expected_files: &[&str],
+    tool: &str,
+    target_triple: &str,
+) -> Result<(), SoldrError> {
+    let missing = expected_files
+        .iter()
+        .filter(|rel| !sysroot.join(rel).is_file())
+        .copied()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(SoldrError::Archive(format!(
+        "{tool} sysroot extract for {target_triple} is missing expected files under {}: {}",
+        sysroot.display(),
+        missing.join(", ")
+    )))
+}
+
+fn stamp_matches(stamp: &Path, expected_sha256: &str) -> bool {
+    std::fs::read_to_string(stamp)
+        .map(|text| {
+            text.lines()
+                .any(|line| line == format!("sha256={expected_sha256}"))
+        })
+        .unwrap_or(false)
+}
+
+fn write_stamp(stamp: &Path, version: &str, url: &str, sha256: &str) -> Result<(), SoldrError> {
+    std::fs::write(
+        stamp,
+        format!("version={version}\nurl={url}\nsha256={sha256}\n"),
+    )?;
+    Ok(())
+}
+
+fn extract_tar_zst_tree(data: &[u8], dest: &Path) -> Result<(), SoldrError> {
+    let reader = std::io::Cursor::new(data);
+    let zst = zstd::stream::read::Decoder::new(reader)
+        .map_err(|e| SoldrError::Archive(format!("zstd decoder init: {e}")))?;
+    let mut archive = tar::Archive::new(zst);
+    archive
+        .unpack(dest)
+        .map_err(|e| SoldrError::Archive(format!("tar.zst unpack: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(asset_url_uses_top_level_tool_layout, {
+        let url = asset_url_for("zstd", "1.5.7", "linux-x64-musl");
+        assert_eq!(
+            url,
+            "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/zstd/1.5.7/linux-x64-musl/bundle.tar.zst"
+        );
+        assert!(!url.contains("/deps/"));
+    });
+
+    crate::timed_test!(package_root_prefers_inner_package_dir, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let root = tmp.path().join("install");
+        std::fs::create_dir_all(root.join("package")).expect("mkdir");
+        assert_eq!(package_root_for(&root), root.join("package"));
+    });
+
+    crate::timed_test!(cache_hit_requires_matching_stamp_and_expected_files, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let install = install_dir_for(
+            &paths,
+            "x86_64-unknown-linux-musl",
+            "zstd",
+            "1.5.7",
+            "linux-x64-musl",
+        );
+        let sysroot = install.join("package");
+        std::fs::create_dir_all(sysroot.join("include")).expect("include");
+        std::fs::create_dir_all(sysroot.join("lib").join("pkgconfig")).expect("pkgconfig");
+        std::fs::write(sysroot.join("include").join("zstd.h"), b"").expect("zstd.h");
+        std::fs::write(
+            sysroot.join("lib").join("pkgconfig").join("libzstd.pc"),
+            b"",
+        )
+        .expect("pc");
+        let stamp = install.join(".complete");
+        let sha = "0".repeat(64);
+        write_stamp(
+            &stamp,
+            "1.5.7",
+            "https://example.invalid/bundle.tar.zst",
+            &sha,
+        )
+        .expect("stamp");
+
+        assert!(stamp_matches(&stamp, &sha));
+        assert!(expected_files_present(
+            &package_root_for(&install),
+            &["include/zstd.h", "lib/pkgconfig/libzstd.pc"]
+        ));
+        assert!(!expected_files_present(
+            &package_root_for(&install),
+            &["include/zstd.h", "lib/pkgconfig/missing.pc"]
+        ));
+    });
+}

--- a/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
@@ -9,11 +9,11 @@
 //! include/zlib-ng.h
 //! ```
 //!
-//! When `libz-ng-sys` is in the transitive deps and the catalogue row
-//! is ingested, the blessed path exports `PKG_CONFIG_PATH` pointing at
-//! the materialized `lib/pkgconfig/` directory so `libz-ng-sys`'
-//! build.rs uses pkg-config to locate the precompiled libz-ng instead
-//! of triggering its cmake build (10-20s).
+//! This module is intentionally disabled for now. The current
+//! `libz-ng-sys` version does not expose a reliable system-library
+//! override for these catalogue bundles, and its vendored zlib-ng
+//! version does not match the merged recipe. Blessed builds must not
+//! inject this sysroot until that contract is real.
 
 use std::path::PathBuf;
 
@@ -40,10 +40,7 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/zlib-ng/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_bundle::asset_url_for("zlib-ng", version, slug)
 }
 
 pub async fn ensure_zlib_ng_sysroot(
@@ -60,8 +57,9 @@ pub async fn ensure_zlib_ng_sysroot(
     })?;
     let url = asset_url_for(MANAGED_ZLIB_NG_VERSION, slug);
     Err(SoldrError::Other(format!(
-        "zlib-ng sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
+        "zlib-ng sysroot for {target_triple} ({slug}) is disabled: current \
+         libz-ng-sys does not expose a reliable catalogue override and the \
+         catalogue recipe version is not aligned. Current expected URL: {url}\n\
          Tracking: https://github.com/zackees/soldr/issues/1064"
     )))
 }
@@ -84,17 +82,18 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_ZLIB_NG_VERSION, "linux-x64-gnu");
-        assert!(u.contains("/deps/zlib-ng/2.2.5/linux-x64-gnu/"));
+        assert!(u.contains("/zlib-ng/2.2.5/linux-x64-gnu/"));
+        assert!(!u.contains("/deps/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_zlib_ng_sysroot_returns_not_yet_ingested, {
+    crate::timed_test!(ensure_zlib_ng_sysroot_returns_disabled_error, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
         let result = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(ensure_zlib_ng_sysroot(&paths, "x86_64-unknown-linux-gnu"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
+        let err = result.expect_err("must error while disabled");
+        assert!(err.to_string().contains("disabled"));
     });
 }

--- a/crates/soldr-cli/src/fetch/zstd_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/zstd_sysroot.rs
@@ -19,11 +19,10 @@
 //! so `zstd-sys`' build script links against the precompiled libzstd
 //! instead of recompiling 11-15s of C source on every fresh checkout.
 //!
-//! Mirrors [`super::openssl_sysroot`]'s stub-until-ingested shape.
-//! Asset population happens via the soldr-toolchain forge pipeline;
-//! until those rows land, `ensure_zstd_sysroot` returns the
-//! "not yet ingested" error and the caller falls through to the
-//! crate's vendored compile.
+//! Asset population happens via the soldr-toolchain forge pipeline.
+//! Once a target row is present in `catalogue.v1.json`,
+//! `ensure_zstd_sysroot` downloads, sha-verifies, extracts, and returns
+//! the local package root.
 
 use std::path::PathBuf;
 
@@ -53,21 +52,14 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
         .map(|(_, slug)| *slug)
 }
 
-/// Construct the expected `assets`-branch URL.
-///
-///     deps/zstd/<version>/<slug>/bundle.tar.zst
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/zstd/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_bundle::asset_url_for("zstd", version, slug)
 }
 
 pub async fn ensure_zstd_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no zstd sysroot recipe for target {target_triple}; \
@@ -75,12 +67,15 @@ pub async fn ensure_zstd_sysroot(
             ZSTD_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_ZSTD_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "zstd sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/1064"
-    )))
+    super::syslib_bundle::ensure_syslib_bundle(
+        paths,
+        target_triple,
+        "zstd",
+        MANAGED_ZSTD_VERSION,
+        slug,
+        &["include/zstd.h", "lib/pkgconfig/libzstd.pc"],
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -125,21 +120,21 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_ZSTD_VERSION, "linux-x64-musl");
-        assert!(u.contains("/deps/zstd/1.5.7/linux-x64-musl/"));
+        assert!(u.contains("/zstd/1.5.7/linux-x64-musl/"));
+        assert!(!u.contains("/deps/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_zstd_sysroot_returns_not_yet_ingested, {
-        let tmp = tempfile::tempdir().expect("tmpdir");
-        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
-        let result = tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(ensure_zstd_sysroot(&paths, "x86_64-unknown-linux-musl"));
-        let err = result.expect_err("must error until catalogue row lands");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("not yet ingested"),
-            "expected 'not yet ingested' marker in error, got: {msg}"
-        );
-    });
+    crate::timed_test!(
+        ensure_zstd_sysroot_rejects_unsupported_target_without_network,
+        {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+            let result = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(ensure_zstd_sysroot(&paths, "wasm32-unknown-unknown"));
+            let err = result.expect_err("unsupported target must error before catalogue fetch");
+            assert!(matches!(err, SoldrError::UnsupportedPlatform(_)));
+        }
+    );
 }


### PR DESCRIPTION
﻿Refs #1064.

## What changed
- Added shared syslib bundle materialization for soldr-toolchain assets published at `<tool>/<version>/<shape>/bundle.tar.zst`.
- Activated only the verified safe substitutions: `zstd-sys` via `ZSTD_SYS_USE_PKG_CONFIG=1` and `libsqlite3-sys` via `LIBSQLITE3_SYS_USE_PKG_CONFIG=1`.
- Added exact-URL catalogue lookup so repeated asset names like `bundle.tar.zst` resolve by full URL and sha256.
- Added target-scoped `PKG_CONFIG_PATH_<target>` plus `PKG_CONFIG_ALLOW_CROSS=1` for the injected pkg-config sysroots.
- Kept jemalloc, mimalloc, zlib-ng, lzma, and bzip2 disabled with explicit reasons because their current hooks or versions are unsafe/stale.

## Asset state
- soldr-toolchain recipes/catalogue support landed in zackees/soldr-toolchain#35.
- The assets branch now has zstd/sqlite bundles for all eight target shapes at `zackees/soldr-toolchain@a8966c8`.

## Validation
- `uv run --frozen --group dev python scripts\validate_catalogue.py ..\soldr-toolchain-assets\catalogue.v1.json --schema schemas\catalogue.v1.schema.json`
- `uv run --frozen --group dev python scripts\lint_assets.py --assets-dir ..\soldr-toolchain-assets`
- live Pages catalogue reports 21 entries and includes zstd/sqlite rows
- live zstd/sqlite linux-x64-musl blobs sha256-match the catalogue rows
- `cargo fmt --package soldr-cli -- --check` with pinned cargo
- `cargo test -p soldr-cli --target x86_64-pc-windows-msvc --target-dir target\verify-msvc-rustc --lib` with pinned `RUSTC`
- branch-built `soldr 0.7.87 toolchain catalogue`
- branch-built `soldr 0.7.87 cargo dylint --all -- --workspace --all-targets` exits without blocking; dylint reports `No libraries were found.`
