### PR TITLE
feat(syslib-fetch): real download + extract for *-sys catalogue (#1064)

### DIFF
--- a/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
@@ -43,17 +43,13 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/bzip2/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("bzip2", version, slug)
 }
 
 pub async fn ensure_bzip2_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no bzip2 sysroot recipe for target {target_triple}; \
@@ -61,12 +57,7 @@ pub async fn ensure_bzip2_sysroot(
             BZIP2_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_BZIP2_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "bzip2 sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/1064"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "bzip2", MANAGED_BZIP2_VERSION, slug).await
 }
 
 #[cfg(test)]
@@ -87,7 +78,7 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_BZIP2_VERSION, "linux-x64-gnu");
-        assert!(u.contains("/deps/bzip2/1.0.8/linux-x64-gnu/"));
+        assert!(u.contains("/bzip2/1.0.8/linux-x64-gnu/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 

--- a/crates/soldr-cli/src/fetch/jemalloc_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/jemalloc_sysroot.rs
@@ -46,17 +46,13 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/jemalloc/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("jemalloc", version, slug)
 }
 
 pub async fn ensure_jemalloc_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no jemalloc sysroot recipe for target {target_triple} \
@@ -64,12 +60,8 @@ pub async fn ensure_jemalloc_sysroot(
             JEMALLOC_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_JEMALLOC_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "jemalloc sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/1064"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "jemalloc", MANAGED_JEMALLOC_VERSION, slug)
+        .await
 }
 
 #[cfg(test)]
@@ -91,7 +83,7 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_JEMALLOC_VERSION, "linux-x64-musl");
-        assert!(u.contains("/deps/jemalloc/5.3.0/linux-x64-musl/"));
+        assert!(u.contains("/jemalloc/5.3.0/linux-x64-musl/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 

--- a/crates/soldr-cli/src/fetch/lzma_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/lzma_sysroot.rs
@@ -45,17 +45,13 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/lzma/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("lzma", version, slug)
 }
 
 pub async fn ensure_lzma_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no lzma sysroot recipe for target {target_triple}; \
@@ -63,12 +59,7 @@ pub async fn ensure_lzma_sysroot(
             LZMA_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_LZMA_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "lzma sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/1064"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "lzma", MANAGED_LZMA_VERSION, slug).await
 }
 
 #[cfg(test)]
@@ -89,7 +80,7 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_LZMA_VERSION, "darwin-arm64");
-        assert!(u.contains("/deps/lzma/5.6.3/darwin-arm64/"));
+        assert!(u.contains("/lzma/5.6.3/darwin-arm64/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 

--- a/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
@@ -41,17 +41,13 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/mimalloc/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("mimalloc", version, slug)
 }
 
 pub async fn ensure_mimalloc_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no mimalloc sysroot recipe for target {target_triple}; \
@@ -59,12 +55,8 @@ pub async fn ensure_mimalloc_sysroot(
             MIMALLOC_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_MIMALLOC_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "mimalloc sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/1064"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "mimalloc", MANAGED_MIMALLOC_VERSION, slug)
+        .await
 }
 
 #[cfg(test)]
@@ -85,7 +77,7 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_MIMALLOC_VERSION, "windows-x64");
-        assert!(u.contains("/deps/mimalloc/3.0.4/windows-x64/"));
+        assert!(u.contains("/mimalloc/3.0.4/windows-x64/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -74,6 +74,10 @@ pub mod jemalloc_sysroot;
 pub mod lzma_sysroot;
 pub mod mimalloc_sysroot;
 pub mod sqlite_sysroot;
+/// soldr#1064 Phase B — shared download + extract for the six
+/// *-sys C library catalogue bundles. The per-lib modules each
+/// call this helper with their own `(lib, version, slug)` tuple.
+pub mod syslib_common;
 pub mod zccache;
 pub mod zccache_install;
 pub mod zccache_runtime;

--- a/crates/soldr-cli/src/fetch/sqlite_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/sqlite_sysroot.rs
@@ -48,17 +48,13 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/sqlite/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("sqlite", version, slug)
 }
 
 pub async fn ensure_sqlite_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no sqlite sysroot recipe for target {target_triple}; \
@@ -66,12 +62,7 @@ pub async fn ensure_sqlite_sysroot(
             SQLITE_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_SQLITE_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "sqlite sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/1064"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "sqlite", MANAGED_SQLITE_VERSION, slug).await
 }
 
 #[cfg(test)]
@@ -92,17 +83,13 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_SQLITE_VERSION, "linux-arm64-musl");
-        assert!(u.contains("/deps/sqlite/3.46.0/linux-arm64-musl/"));
+        assert!(u.contains("/sqlite/3.46.0/linux-arm64-musl/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_sqlite_sysroot_returns_not_yet_ingested, {
-        let tmp = tempfile::tempdir().expect("tmpdir");
-        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
-        let result = tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(ensure_sqlite_sysroot(&paths, "x86_64-unknown-linux-musl"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
-    });
+    // The original `ensure_sqlite_sysroot_returns_not_yet_ingested` test
+    // was removed in the soldr#1064 phase B follow-up: sqlite 3.46.0 IS
+    // ingested into the live catalogue, so this function now returns a
+    // real sysroot path or a network error. End-to-end coverage runs in
+    // the cross-compile lanes that build against `libsqlite3-sys`.
 }

--- a/crates/soldr-cli/src/fetch/syslib_common.rs
+++ b/crates/soldr-cli/src/fetch/syslib_common.rs
@@ -1,0 +1,180 @@
+//! Shared download + extract for soldr#1064 Phase B `*-sys` C library
+//! catalogue distribution.
+//!
+//! Each `<lib>_sysroot.rs` consumer module calls
+//! [`ensure_syslib_bundle`] with its own `(lib_name, version, slug)`
+//! tuple. The helper:
+//!
+//! 1. Resolves the catalogue URL via [`asset_url_for`].
+//! 2. Looks up the matching `sha256` in the v1 toolchain catalogue
+//!    (already cached process-wide by [`super::manifest_lookup`]).
+//!    If the catalogue doesn't list the URL yet, the helper returns
+//!    the existing "not yet ingested" error so callers fall through
+//!    to the crate's vendored compile, exactly like the original
+//!    `openssl_sysroot.rs` stub did.
+//! 3. Downloads + sha256-verifies + extracts the `tar.zst` bundle
+//!    into `~/.soldr/sdk/syslib/<lib>/<version>/<slug>/` under a
+//!    `.complete` sentinel file. Re-invocations after a successful
+//!    extract are a stat call.
+//! 4. Returns the sysroot root path (the directory containing
+//!    `package/` from the forge artifact, lifted up so callers see
+//!    `lib/` + `include/` + `lib/pkgconfig/` directly).
+//!
+//! Why a shared helper instead of inlining in each consumer module?
+//! The six `*-sys` libs ship the exact same payload shape (forge
+//! produces `package/lib/...`, `package/include/...`,
+//! `package/lib/pkgconfig/...` for every one). Hard-coding the
+//! same flow six times would just be six copies of the same bug
+//! site.
+
+use std::path::{Path, PathBuf};
+
+use super::github::http_client;
+use super::manifest_lookup;
+use super::trust;
+use crate::core::{SoldrError, SoldrPaths};
+
+/// Build the canonical assets-branch URL for a `(lib, version, slug)`
+/// tuple. Mirrors the layout `forge_to_catalogue.py` writes:
+///
+/// ```text
+/// https://media.githubusercontent.com/media/zackees/soldr-toolchain/
+///   assets/<lib>/<version>/<slug>/bundle.tar.zst
+/// ```
+pub fn asset_url_for(lib: &str, version: &str, slug: &str) -> String {
+    format!(
+        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
+         {lib}/{version}/{slug}/bundle.tar.zst"
+    )
+}
+
+/// Materialize a syslib bundle on disk and return the sysroot root.
+///
+/// The returned path is what `blessed_build::prepare`'s env injection
+/// expects: the directory whose children are `lib/`, `include/`, and
+/// (for pkg-config-style libs) `lib/pkgconfig/`.
+pub async fn ensure_syslib_bundle(
+    paths: &SoldrPaths,
+    lib: &str,
+    version: &str,
+    slug: &str,
+) -> Result<PathBuf, SoldrError> {
+    paths.ensure_dirs()?;
+    let url = asset_url_for(lib, version, slug);
+
+    let install_root = paths
+        .bin
+        .join("syslib")
+        .join(lib)
+        .join(version)
+        .join(slug);
+    let sysroot = install_root.join("package");
+    let stamp = install_root.join(".complete");
+
+    if stamp.is_file() && sysroot.is_dir() {
+        return Ok(sysroot);
+    }
+
+    // Resolve sha256 from the toolchain catalogue. The catalogue is
+    // process-cached; the first call inside soldr's run fetches the
+    // document, subsequent ones hit the OnceLock.
+    let entry = catalogue_entry_for_url(&url).await.ok_or_else(|| {
+        SoldrError::Other(format!(
+            "syslib bundle for {lib}/{version}/{slug} not yet ingested into the \
+             soldr-toolchain catalogue. Expected URL: {url}\n\
+             Track: https://github.com/zackees/soldr/issues/1064"
+        ))
+    })?;
+    let expected_sha256 = entry.sha256.clone();
+
+    eprintln!("soldr: fetching syslib {lib}/{version}/{slug} from {url}...");
+
+    let client = http_client()?;
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(SoldrError::Network(format!(
+            "syslib bundle download failed: HTTP {}",
+            resp.status()
+        )));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| SoldrError::Network(e.to_string()))?;
+
+    let digest = trust::sha256_of(&bytes);
+    if digest != expected_sha256 {
+        return Err(SoldrError::Other(format!(
+            "syslib bundle sha256 mismatch for {lib}/{version}/{slug}: \
+             expected {expected_sha256}, got {digest}"
+        )));
+    }
+    eprintln!(
+        "soldr: trust: verified syslib {lib}/{version}/{slug} sha256={digest}"
+    );
+
+    if install_root.exists() {
+        std::fs::remove_dir_all(&install_root)?;
+    }
+    std::fs::create_dir_all(&install_root)?;
+    extract_tar_zst(&bytes, &install_root)?;
+
+    if !sysroot.is_dir() {
+        return Err(SoldrError::Archive(format!(
+            "syslib extract for {lib}/{version}/{slug} did not produce expected \
+             {} (forge artifact layout drift?)",
+            sysroot.display()
+        )));
+    }
+
+    std::fs::write(&stamp, format!("{lib} {version} {slug}"))?;
+    eprintln!("soldr: extracted syslib to {}", sysroot.display());
+    Ok(sysroot)
+}
+
+/// Look up a catalogue entry whose `url` field exactly matches `url`.
+/// The v1 catalogue is keyed by `(owner, repo, tag, asset)` but the
+/// asset names for our bundles collide across libs (`bundle.tar.zst`),
+/// so we filter by URL substring instead. Returns `None` when the
+/// catalogue is empty (network failure / disabled) or the URL hasn't
+/// been ingested yet.
+async fn catalogue_entry_for_url(
+    url: &str,
+) -> Option<manifest_lookup::ManifestEntry> {
+    let index = manifest_lookup::get_or_fetch().await;
+    index.entries.iter().find(|e| e.url == url).cloned()
+}
+
+fn extract_tar_zst(data: &[u8], dest: &Path) -> Result<(), SoldrError> {
+    let reader = std::io::Cursor::new(data);
+    let zst = zstd::stream::read::Decoder::new(reader)
+        .map_err(|e| SoldrError::Archive(format!("zstd decoder init: {e}")))?;
+    let mut archive = tar::Archive::new(zst);
+    archive
+        .unpack(dest)
+        .map_err(|e| SoldrError::Archive(format!("tar.zst unpack: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timed_test;
+    use std::time::Duration;
+
+    timed_test!(asset_url_layout, Duration::from_secs(5), {
+        let u = asset_url_for("zstd", "1.5.7", "linux-x64-gnu");
+        assert!(u.contains("/zstd/1.5.7/linux-x64-gnu/bundle.tar.zst"), "{u}");
+        assert!(u.starts_with("https://media.githubusercontent.com/"));
+    });
+
+    timed_test!(slug_distinct_per_target, Duration::from_secs(5), {
+        let a = asset_url_for("sqlite", "3.46.0", "windows-x64");
+        let b = asset_url_for("sqlite", "3.46.0", "linux-arm64-musl");
+        assert_ne!(a, b);
+    });
+}

--- a/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
@@ -40,17 +40,13 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/zlib-ng/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("zlib-ng", version, slug)
 }
 
 pub async fn ensure_zlib_ng_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no zlib-ng sysroot recipe for target {target_triple}; \
@@ -58,12 +54,8 @@ pub async fn ensure_zlib_ng_sysroot(
             ZLIB_NG_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_ZLIB_NG_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "zlib-ng sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/1064"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "zlib-ng", MANAGED_ZLIB_NG_VERSION, slug)
+        .await
 }
 
 #[cfg(test)]
@@ -84,7 +76,7 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_ZLIB_NG_VERSION, "linux-x64-gnu");
-        assert!(u.contains("/deps/zlib-ng/2.2.5/linux-x64-gnu/"));
+        assert!(u.contains("/zlib-ng/2.2.5/linux-x64-gnu/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 

--- a/crates/soldr-cli/src/fetch/zstd_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/zstd_sysroot.rs
@@ -53,21 +53,17 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
         .map(|(_, slug)| *slug)
 }
 
-/// Construct the expected `assets`-branch URL.
-///
-///     deps/zstd/<version>/<slug>/bundle.tar.zst
+/// Construct the expected `assets`-branch URL. Thin wrapper over
+/// [`super::syslib_common::asset_url_for`] kept for the existing
+/// per-module test contract.
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/zstd/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("zstd", version, slug)
 }
 
 pub async fn ensure_zstd_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no zstd sysroot recipe for target {target_triple}; \
@@ -75,12 +71,7 @@ pub async fn ensure_zstd_sysroot(
             ZSTD_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_ZSTD_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "zstd sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/1064"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "zstd", MANAGED_ZSTD_VERSION, slug).await
 }
 
 #[cfg(test)]
@@ -125,21 +116,15 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_ZSTD_VERSION, "linux-x64-musl");
-        assert!(u.contains("/deps/zstd/1.5.7/linux-x64-musl/"));
+        assert!(u.contains("/zstd/1.5.7/linux-x64-musl/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_zstd_sysroot_returns_not_yet_ingested, {
-        let tmp = tempfile::tempdir().expect("tmpdir");
-        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
-        let result = tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(ensure_zstd_sysroot(&paths, "x86_64-unknown-linux-musl"));
-        let err = result.expect_err("must error until catalogue row lands");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("not yet ingested"),
-            "expected 'not yet ingested' marker in error, got: {msg}"
-        );
-    });
+    // The original `ensure_zstd_sysroot_returns_not_yet_ingested` unit
+    // test was removed in the soldr#1064 phase B follow-up: now that the
+    // zstd 1.5.7 bundle IS ingested into the live catalogue, this
+    // function returns either a real sysroot path (catalogue reachable)
+    // or a network error (catalogue unreachable). Neither is a stable
+    // unit-test signal. The end-to-end smoke is exercised in the cross-
+    // compile lanes that run `cargo build` against the *-sys crate.
 }


### PR DESCRIPTION
## Summary

- Replaces the seven scaffolded `*_sysroot.rs` stubs (zstd, sqlite, jemalloc, mimalloc, zlib-ng, lzma, bzip2) with a working catalogue-backed fetcher.
- Adds `fetch/syslib_common.rs` — shared download + sha256-verify + extract pipeline used by every consumer module.
- Each `<lib>_sysroot.rs` now dispatches to `syslib_common::ensure_syslib_bundle(paths, lib, version, slug)` instead of returning the placeholder \"not yet ingested\" error.
- URL layout fixed: was `/deps/<lib>/<ver>/<slug>/bundle.tar.zst`, now `/<lib>/<ver>/<slug>/bundle.tar.zst` — matches what `forge_to_catalogue.py` writes to the assets branch.

## How it works at runtime

1. `blessed_build::prepare` (unchanged) calls each `ensure_<lib>_sysroot`.
2. The consumer resolves the assets-branch URL + looks up the matching sha256 in the cached v1 catalogue via `manifest_lookup::get_or_fetch`.
3. Catalogue hit → download + sha256-verify + extract under `~/.soldr/sdk/syslib/<lib>/<version>/<slug>/`, gated by a `.complete` sentinel. Re-invocations after success are a stat call.
4. Catalogue miss (lib not yet ingested for this target) → preserves the existing \"not yet ingested\" `SoldrError`, so `blessed_build::prepare` logs + falls through to the crate's vendored compile. Same graceful-degrade contract as before.

## Test plan

- [x] `cargo clippy -p soldr-cli --lib --tests -- -D warnings` under Docker rust:1.94 → clean.
- [x] `cargo check -p soldr-cli --lib` → clean.
- [ ] Cross-build lane verifies a real catalogue fetch for zstd 1.5.7 / sqlite 3.46.0 (both ingested today).
- [ ] Once forge dispatches finish + `forge_to_catalogue.py` ingests the remaining 5 libs, those override paths activate automatically.

## Related

- Phase B of #1064. The five missing libs (jemalloc, mimalloc, zlib-ng, lzma, bzip2) have forge builds in flight via `zackees/soldr-toolchain` PR `feat/dispatch-script-1064` (the dispatch wrapper script).
- Two pre-existing per-lib tests (zstd + sqlite \"ensure_X_returns_not_yet_ingested\") were dropped — they no longer reflect reality now that the live catalogue actually serves those bundles.

Relates to #1064.

🤖 Generated with [Claude Code](https://claude.com/claude-code)