### PR TITLE
fix(ci): rustfmt syslib_common.rs (unblocks main CI)

### DIFF
--- a/crates/soldr-cli/src/fetch/syslib_common.rs
+++ b/crates/soldr-cli/src/fetch/syslib_common.rs
@@ -62,12 +62,7 @@ pub async fn ensure_syslib_bundle(
     paths.ensure_dirs()?;
     let url = asset_url_for(lib, version, slug);
 
-    let install_root = paths
-        .bin
-        .join("syslib")
-        .join(lib)
-        .join(version)
-        .join(slug);
+    let install_root = paths.bin.join("syslib").join(lib).join(version).join(slug);
     let sysroot = install_root.join("package");
     let stamp = install_root.join(".complete");
 
@@ -113,9 +108,7 @@ pub async fn ensure_syslib_bundle(
              expected {expected_sha256}, got {digest}"
         )));
     }
-    eprintln!(
-        "soldr: trust: verified syslib {lib}/{version}/{slug} sha256={digest}"
-    );
+    eprintln!("soldr: trust: verified syslib {lib}/{version}/{slug} sha256={digest}");
 
     if install_root.exists() {
         std::fs::remove_dir_all(&install_root)?;
@@ -142,9 +135,7 @@ pub async fn ensure_syslib_bundle(
 /// so we filter by URL substring instead. Returns `None` when the
 /// catalogue is empty (network failure / disabled) or the URL hasn't
 /// been ingested yet.
-async fn catalogue_entry_for_url(
-    url: &str,
-) -> Option<manifest_lookup::ManifestEntry> {
+async fn catalogue_entry_for_url(url: &str) -> Option<manifest_lookup::ManifestEntry> {
     let index = manifest_lookup::get_or_fetch().await;
     index.entries.iter().find(|e| e.url == url).cloned()
 }
@@ -168,7 +159,10 @@ mod tests {
 
     timed_test!(asset_url_layout, Duration::from_secs(5), {
         let u = asset_url_for("zstd", "1.5.7", "linux-x64-gnu");
-        assert!(u.contains("/zstd/1.5.7/linux-x64-gnu/bundle.tar.zst"), "{u}");
+        assert!(
+            u.contains("/zstd/1.5.7/linux-x64-gnu/bundle.tar.zst"),
+            "{u}"
+        );
         assert!(u.starts_with("https://media.githubusercontent.com/"));
     });
 


### PR DESCRIPTION
## Summary

PR [#1111](https://github.com/zackees/soldr/pull/1111) (\`feat(syslib-fetch): real download + extract for *-sys catalogue\`) merged with unformatted code in \`crates/soldr-cli/src/fetch/syslib_common.rs\`, breaking \`cargo fmt --check\` on main.

The Lint job in [CI run 28464854054](https://github.com/zackees/soldr/actions/runs/28464854054) failed and, by extension, all four cross-build jobs that depend on Lint also failed (red badge). This PR is the minimal fmt fix to unblock main.

## Changes

Four hunks rustfmt wanted, applied verbatim from the CI diff:
- collapse a multi-line \`paths.bin.join(...).join(...)...\` chain to one line
- collapse a multi-line \`eprintln!(...)\` to one line
- collapse a multi-line \`async fn catalogue_entry_for_url(url: &str)\` signature
- expand an over-width \`assert!(..., "{u}")\` to three lines

Pure formatting. No behavior change.

## How this slipped past PR #1111's own CI

The most likely cause is that the PR was either merged before its own pre-merge CI completed, or fmt wasn't a required check on that PR. Worth a follow-up to make Lint a required status check if it isn't already, but that's a separate concern.

## Test plan

- [ ] This PR's CI passes (Lint + cross-builds)
- [ ] Main's next CI run goes green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)