### PR TITLE
fix(toolchain): detect Chocolatey-cargo shadow + add `soldr exec` (#1059)

### DIFF
--- a/crates/soldr-cli/src/cargo_path_check.rs
+++ b/crates/soldr-cli/src/cargo_path_check.rs
@@ -1,0 +1,294 @@
+//! Detect when a standalone (Chocolatey/scoop/manual) `cargo` shadows
+//! rustup's proxy on PATH — issue #1059.
+//!
+//! ## What this catches
+//!
+//! When a Windows host has both a Chocolatey-installed standalone Rust
+//! and a rustup-managed toolchain, `~/.cargo/bin/` may be missing a
+//! `cargo.exe` proxy (rustup ships one but the package can be removed,
+//! corrupted, or simply absent on a Chocolatey-first setup). In that
+//! state, `PATH` resolves bare `cargo` to
+//! `C:\ProgramData\chocolatey\bin\cargo.exe` — a standalone 1.94.1
+//! cargo that IGNORES per-crate `rust-toolchain.toml` overrides.
+//!
+//! soldr's own bash/PowerShell hook refuses bare `cargo` from the user
+//! and routes through `soldr cargo ...`. But it cannot catch
+//! subprocess invocations from already-built tools (`cargo-dylint`,
+//! `cargo-binstall`, `cargo-make`, etc.) that hard-code `"cargo"` and
+//! find the Chocolatey shim themselves. The user-visible symptom is
+//! a `cargo-dylint` subprocess failing with `E0554` /
+//! `can't find crate for rustc_driver` because the nightly switch
+//! from `dylints/X/rust-toolchain.toml` never happened.
+//!
+//! This module:
+//!
+//!   * Resolves the first `cargo` on PATH.
+//!   * Decides whether that path is a Chocolatey/scoop/standalone shim
+//!     that doesn't honor `rust-toolchain.toml`.
+//!   * Emits a structured [`CargoOnPathFinding`] consumed by
+//!     `toolchain_doctor` (probe row) and `toolchain_ensure`
+//!     (one-line warning).
+//!
+//! ## Why not "fix" PATH automatically
+//!
+//! The fix is genuinely user-side: either uninstall the standalone
+//! Rust (`choco uninstall rust`) or prepend `~/.cargo/bin` to PATH so
+//! the rustup proxy wins. soldr can't reorder system PATH safely. The
+//! best soldr can do is *flag the problem clearly* + offer a
+//! subprocess-safe escape hatch (`soldr exec <cmd>`).
+
+use std::path::{Path, PathBuf};
+
+/// A `cargo` binary found on PATH plus a classification of whether it
+/// will honor `rust-toolchain.toml` overrides for subprocesses that
+/// hard-code `"cargo"`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CargoOnPathFinding {
+    /// Absolute path that `which cargo` (or PowerShell `Get-Command
+    /// cargo`) would resolve to today.
+    pub resolved: PathBuf,
+    /// `true` when the resolved path is a rustup proxy (or behaves
+    /// equivalently — i.e. respects per-crate channel overrides).
+    /// `false` when the resolved path is a standalone shim that
+    /// ignores them.
+    pub honors_rust_toolchain_toml: bool,
+    /// Origin classification — drives the warning message and the
+    /// machine-facing probe payload.
+    pub classification: CargoClassification,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CargoClassification {
+    /// Path matches a known Chocolatey install layout (e.g.
+    /// `C:\ProgramData\chocolatey\bin\cargo.exe` or
+    /// `C:\ProgramData\chocolatey\lib\rust\...\cargo.exe`).
+    Chocolatey,
+    /// Path matches a Scoop shim layout
+    /// (`~/scoop/shims/cargo.exe` or `C:\scoop\shims\cargo.exe`).
+    Scoop,
+    /// Path matches a rustup-managed install (`~/.cargo/bin/cargo[.exe]`
+    /// or `CARGO_HOME/bin/cargo[.exe]`). These ARE rustup proxies and
+    /// honor per-crate channel overrides.
+    Rustup,
+    /// Path lives directly under a rustup toolchain dir
+    /// (`~/.rustup/toolchains/<channel>/bin/cargo[.exe]`). Honors the
+    /// channel that toolchain represents, but NOT per-crate overrides
+    /// — flagged with `honors_rust_toolchain_toml = false`.
+    RustupToolchainBin,
+    /// Path is one of the soldr-installed shims
+    /// (`<shim-dir>/cargo[.exe]`) — they re-exec into soldr so they
+    /// inherit soldr's own channel-resolution logic.
+    SoldrShim,
+    /// Path matches a system package manager that ships a standalone
+    /// cargo (apt, dnf, etc.). On Linux/macOS this is usually fine
+    /// because the same package supplies the rustc/cargo pair
+    /// consistently, but it does not honor `rust-toolchain.toml`.
+    SystemPackage,
+    /// Path doesn't match any known layout. Conservatively assumed to
+    /// NOT honor `rust-toolchain.toml` overrides — that's the
+    /// failure mode users hit.
+    Unknown,
+}
+
+impl CargoClassification {
+    /// Human-readable label for the warning / probe details.
+    pub fn label(&self) -> &'static str {
+        match self {
+            CargoClassification::Chocolatey => "chocolatey",
+            CargoClassification::Scoop => "scoop",
+            CargoClassification::Rustup => "rustup",
+            CargoClassification::RustupToolchainBin => "rustup-toolchain-bin",
+            CargoClassification::SoldrShim => "soldr-shim",
+            CargoClassification::SystemPackage => "system-package",
+            CargoClassification::Unknown => "unknown",
+        }
+    }
+}
+
+/// Probe PATH for the first `cargo` binary and classify it. Returns
+/// `None` when no `cargo` is anywhere on PATH.
+pub fn detect_cargo_on_path() -> Option<CargoOnPathFinding> {
+    let path = std::env::var_os("PATH")?;
+    let exts: &[&str] = if cfg!(windows) { &["", ".exe"] } else { &[""] };
+    for dir in std::env::split_paths(&path) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        for ext in exts {
+            let candidate: PathBuf = if ext.is_empty() {
+                dir.join("cargo")
+            } else {
+                dir.join(format!("cargo{ext}"))
+            };
+            if candidate.is_file() {
+                return Some(classify_cargo_path(&candidate));
+            }
+        }
+    }
+    None
+}
+
+/// Pure-function classifier. Linux-testable by handing in a synthetic
+/// path. Looks for substrings characteristic of each install layout —
+/// the prefixes are stable enough that substring matching beats trying
+/// to chase canonical paths on every platform.
+pub fn classify_cargo_path(path: &Path) -> CargoOnPathFinding {
+    let raw = path.to_string_lossy();
+    // Normalize separators before substring checks so the same patterns
+    // catch both `C:\ProgramData\chocolatey\...` and the bash-shell
+    // form `/c/ProgramData/chocolatey/...`.
+    let lower = raw.to_ascii_lowercase().replace('\\', "/");
+
+    // Order matters: rustup paths typically also contain `.cargo/bin`
+    // so we have to check rustup before the more general "standalone"
+    // heuristics.
+    let classification = if lower.contains("/.cargo/bin/") || lower.contains("/cargo/bin/") {
+        // Rustup proxy lives under CARGO_HOME/bin (default `~/.cargo/bin`).
+        CargoClassification::Rustup
+    } else if lower.contains("/.rustup/toolchains/")
+        || lower.contains("/rustup/toolchains/")
+    {
+        CargoClassification::RustupToolchainBin
+    } else if lower.contains("/chocolatey/") {
+        CargoClassification::Chocolatey
+    } else if lower.contains("/scoop/") {
+        CargoClassification::Scoop
+    } else if lower.contains("/soldr-shim")
+        || lower.contains("/soldr/bin/")
+        || lower.contains("\\soldr\\bin\\")
+    {
+        CargoClassification::SoldrShim
+    } else if lower.starts_with("/usr/") || lower.starts_with("/opt/") {
+        CargoClassification::SystemPackage
+    } else {
+        CargoClassification::Unknown
+    };
+
+    let honors = matches!(classification, CargoClassification::Rustup | CargoClassification::SoldrShim);
+
+    CargoOnPathFinding {
+        resolved: path.to_path_buf(),
+        honors_rust_toolchain_toml: honors,
+        classification,
+    }
+}
+
+/// Render the user-actionable warning for a shadowing finding. Returns
+/// `None` when the finding does NOT warrant a warning (rustup or
+/// soldr-shim).
+pub fn warning_for(finding: &CargoOnPathFinding) -> Option<String> {
+    if finding.honors_rust_toolchain_toml {
+        return None;
+    }
+    let label = finding.classification.label();
+    let path = finding.resolved.display();
+    Some(format!(
+        "soldr: warning: `cargo` on PATH resolves to a {label} install at {path}\n\
+         soldr: this binary does NOT honor per-crate `rust-toolchain.toml` overrides.\n\
+         soldr: subprocesses launched by cargo extensions (cargo-dylint, cargo-binstall, ...)\n\
+         soldr: will use the WRONG channel and may fail with E0554 / E0463.\n\
+         soldr: see https://github.com/zackees/soldr/issues/1059 for the fix.\n\
+         soldr: workarounds:\n\
+         soldr:   (a) uninstall the standalone Rust (e.g. `choco uninstall rust`), OR\n\
+         soldr:   (b) prepend `~/.cargo/bin` to PATH so the rustup proxy wins, OR\n\
+         soldr:   (c) wrap subprocess-y commands in `soldr exec <command...>`."
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timed_test;
+    use std::time::Duration;
+
+    timed_test!(classify_chocolatey_windows_path, Duration::from_secs(5), {
+        let p = PathBuf::from(r"C:\ProgramData\chocolatey\bin\cargo.exe");
+        let f = classify_cargo_path(&p);
+        assert_eq!(f.classification, CargoClassification::Chocolatey);
+        assert!(!f.honors_rust_toolchain_toml);
+        assert!(warning_for(&f).is_some());
+    });
+
+    timed_test!(classify_chocolatey_msys_form, Duration::from_secs(5), {
+        // The MSYS / git-for-windows bash form of the same path.
+        let p = PathBuf::from("/c/ProgramData/chocolatey/bin/cargo");
+        let f = classify_cargo_path(&p);
+        assert_eq!(f.classification, CargoClassification::Chocolatey);
+        assert!(!f.honors_rust_toolchain_toml);
+    });
+
+    timed_test!(classify_scoop_path, Duration::from_secs(5), {
+        let p = PathBuf::from(r"C:\Users\me\scoop\shims\cargo.exe");
+        let f = classify_cargo_path(&p);
+        assert_eq!(f.classification, CargoClassification::Scoop);
+        assert!(!f.honors_rust_toolchain_toml);
+    });
+
+    timed_test!(classify_rustup_cargo_home, Duration::from_secs(5), {
+        let p = PathBuf::from(r"C:\Users\me\.cargo\bin\cargo.exe");
+        let f = classify_cargo_path(&p);
+        assert_eq!(f.classification, CargoClassification::Rustup);
+        assert!(f.honors_rust_toolchain_toml);
+        assert!(warning_for(&f).is_none());
+    });
+
+    timed_test!(classify_rustup_cargo_home_linux, Duration::from_secs(5), {
+        let p = PathBuf::from("/home/me/.cargo/bin/cargo");
+        let f = classify_cargo_path(&p);
+        assert_eq!(f.classification, CargoClassification::Rustup);
+        assert!(f.honors_rust_toolchain_toml);
+    });
+
+    timed_test!(classify_rustup_toolchain_bin_is_warned, Duration::from_secs(5), {
+        // Direct toolchain bin path — pinned to ONE channel, ignores
+        // per-crate overrides. Warn.
+        let p = PathBuf::from("/home/me/.rustup/toolchains/1.94.1-x86_64-pc-windows-msvc/bin/cargo");
+        let f = classify_cargo_path(&p);
+        assert_eq!(f.classification, CargoClassification::RustupToolchainBin);
+        assert!(!f.honors_rust_toolchain_toml);
+    });
+
+    timed_test!(classify_system_package_linux, Duration::from_secs(5), {
+        let p = PathBuf::from("/usr/bin/cargo");
+        let f = classify_cargo_path(&p);
+        assert_eq!(f.classification, CargoClassification::SystemPackage);
+        assert!(!f.honors_rust_toolchain_toml);
+    });
+
+    timed_test!(classify_unknown_falls_through, Duration::from_secs(5), {
+        let p = PathBuf::from("/tmp/random/cargo");
+        let f = classify_cargo_path(&p);
+        assert_eq!(f.classification, CargoClassification::Unknown);
+        assert!(!f.honors_rust_toolchain_toml);
+        assert!(warning_for(&f).is_some());
+    });
+
+    timed_test!(detect_cargo_on_path_respects_synth_env, Duration::from_secs(10), {
+        // Build an isolated PATH and a fake cargo binary; verify the
+        // detector finds it. Restore PATH at the end so we don't
+        // pollute downstream tests.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let bin = tmp.path().join("scoop").join("shims");
+        std::fs::create_dir_all(&bin).unwrap();
+        let exe_name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+        let exe = bin.join(exe_name);
+        std::fs::write(&exe, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&exe).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&exe, perms).unwrap();
+        }
+        let prior = std::env::var_os("PATH");
+        std::env::set_var("PATH", &bin);
+        let found = detect_cargo_on_path();
+        match prior {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+        let found = found.expect("detector should find the fake cargo");
+        assert_eq!(found.classification, CargoClassification::Scoop);
+    });
+}

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -188,6 +188,8 @@ pub(crate) const SOLDR_BUILTIN_VERBS: &[&str] = &[
     "build",
     "cargo",
     "cook",
+    // soldr#1059 — PATH-prepending escape hatch for cargo extensions.
+    "exec",
     "rustc",
     "rustfmt",
     "clippy-driver",
@@ -258,6 +260,24 @@ pub(crate) enum Commands {
     /// Run cargo through soldr (cached, pinned toolchain)
     Cargo {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run an arbitrary command with rustup's toolchain bin dir prepended to PATH (#1059)
+    ///
+    /// Workaround for Windows hosts where a Chocolatey-installed
+    /// standalone Rust shadows rustup's `cargo` proxy. Cargo extensions
+    /// like `cargo-dylint` / `cargo-binstall` invoke `"cargo"` directly
+    /// (not through soldr), find the Chocolatey shim on PATH, and fail
+    /// to honor per-crate `rust-toolchain.toml` overrides.
+    ///
+    /// `soldr exec <cmd> [args...]` resolves rustup's cargo via
+    /// `rustup which cargo`, prepends its containing directory to PATH
+    /// for the child process, and execs `<cmd>` unchanged. Any
+    /// subprocess `<cmd>` spawns will then see rustup's proxy first.
+    ///
+    /// Example: `soldr exec cargo-dylint dylint --all`
+    Exec {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
         args: Vec<String>,
     },
     /// Compile Rust source via the pinned toolchain

--- a/crates/soldr-cli/src/exec_cmd.rs
+++ b/crates/soldr-cli/src/exec_cmd.rs
@@ -1,0 +1,265 @@
+//! `soldr exec <cmd>` — issue #1059 escape hatch.
+//!
+//! Runs an arbitrary command with rustup's toolchain bin dir prepended
+//! to PATH, so any subprocess the command spawns finds rustup's
+//! `cargo` (and therefore the rustup proxy, which DOES honor per-crate
+//! `rust-toolchain.toml` overrides) before any Chocolatey/scoop/
+//! standalone shim that may also be on PATH.
+//!
+//! Resolution flow:
+//!
+//!   1. Resolve `cargo` via the shared `resolve_toolchain_binary`
+//!      helper. This either calls `rustup which cargo` or hits one of
+//!      the direct-probe shortcuts in `binaries.rs`.
+//!   2. Take its containing directory (the rustup toolchain `bin/`).
+//!   3. Build a new `PATH` value with that dir prepended.
+//!   4. Resolve the user-supplied `<cmd>` against the new PATH so
+//!      `soldr exec cargo-dylint ...` works even when `cargo-dylint`
+//!      lives under `~/.cargo/bin/`.
+//!   5. Spawn the resolved binary with the new PATH and the remaining
+//!      args, forwarding stdout / stderr unchanged.
+//!
+//! The wrapped command inherits the current process env otherwise. We
+//! deliberately don't set `RUSTUP_TOOLCHAIN` or `CARGO` — those wouldn't
+//! help against the very subprocess-y `cargo-dylint` style hardcoded
+//! `"cargo"` invocations the issue is about. The PATH-prepend is the
+//! load-bearing change.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::core::{suppress_windows_console_window, SoldrError};
+
+/// Implementation of `soldr exec`. Returns the child process exit code
+/// (or 127 on spawn failure, matching the POSIX "command not found"
+/// convention).
+pub fn run_exec(args: &[String]) -> Result<i32, SoldrError> {
+    if args.is_empty() {
+        return Err(SoldrError::Other(
+            "soldr exec: missing command — usage: soldr exec <cmd> [args...]".to_string(),
+        ));
+    }
+
+    let cargo = resolve_rustup_cargo()?;
+    let rustup_bin_dir = cargo.parent().ok_or_else(|| {
+        SoldrError::Other(format!(
+            "soldr exec: resolved cargo has no parent dir: {}",
+            cargo.display()
+        ))
+    })?;
+
+    let new_path = path_with_prepend(rustup_bin_dir);
+
+    let (cmd, cmd_args) = args.split_first().expect("non-empty checked above");
+    // Resolve `cmd` against the NEW path so the rustup-bin lookup wins.
+    let resolved_cmd = find_on_path(cmd, &new_path).unwrap_or_else(|| PathBuf::from(cmd));
+
+    eprintln!(
+        "soldr exec: PATH prefix {} | running {} {}",
+        rustup_bin_dir.display(),
+        resolved_cmd.display(),
+        shell_quote(cmd_args)
+    );
+
+    let mut command = Command::new(&resolved_cmd);
+    command.args(cmd_args);
+    command.env("PATH", &new_path);
+    suppress_windows_console_window(&mut command);
+
+    let status = command.status().map_err(|e| {
+        SoldrError::Other(format!(
+            "soldr exec: failed to spawn {}: {e}",
+            resolved_cmd.display()
+        ))
+    })?;
+    Ok(status.code().unwrap_or(127))
+}
+
+/// Build a new PATH-style env var value with `prepend_dir` placed first
+/// (and de-duplicated against an existing copy in the rest of PATH).
+pub fn path_with_prepend(prepend_dir: &Path) -> std::ffi::OsString {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    path_with_prepend_using(prepend_dir, current.as_os_str())
+}
+
+/// Pure-function form of [`path_with_prepend`] — takes the base PATH
+/// value explicitly so tests don't race on the process env.
+pub fn path_with_prepend_using(
+    prepend_dir: &Path,
+    base: &std::ffi::OsStr,
+) -> std::ffi::OsString {
+    let mut entries: Vec<PathBuf> = std::env::split_paths(base)
+        .filter(|p| p != prepend_dir)
+        .collect();
+    entries.insert(0, prepend_dir.to_path_buf());
+    std::env::join_paths(entries).unwrap_or_else(|_| base.to_os_string())
+}
+
+/// Look up `name` against a PATH-shape value (NOT the process env).
+/// Used so `soldr exec` resolves the command against its own
+/// PATH-prepended view rather than the unmodified process PATH.
+pub fn find_on_path(name: &str, path_value: &std::ffi::OsStr) -> Option<PathBuf> {
+    let exts: &[&str] = if cfg!(windows) { &["", ".exe", ".cmd", ".bat"] } else { &[""] };
+    // If the user gave a path-like argument (contains a separator), no
+    // PATH lookup — just trust it.
+    if name.contains('/') || name.contains('\\') {
+        return Some(PathBuf::from(name));
+    }
+    for dir in std::env::split_paths(path_value) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        for ext in exts {
+            let candidate: PathBuf = if ext.is_empty() {
+                dir.join(name)
+            } else {
+                dir.join(format!("{name}{ext}"))
+            };
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Resolve the path of rustup's `cargo` binary. soldr#1059's escape
+/// hatch is specifically for hosts where `which cargo` returns a
+/// shadowing standalone — we deliberately DO NOT consult PATH here.
+/// Lookup order:
+///
+///   1. `RUSTUP_HOME` / default rustup home → `<home>/bin/cargo[.exe]`
+///      (the rustup proxy).
+///   2. `rustup which cargo` shelled out (covers the case where
+///      rustup is on PATH under a non-standard home).
+///
+/// Returns a `SoldrError` when neither resolution path produces a
+/// real file. The error message names both attempts so the user
+/// knows whether to install rustup or set `RUSTUP_HOME`.
+fn resolve_rustup_cargo() -> Result<PathBuf, SoldrError> {
+    if let Some(home) = std::env::var_os("CARGO_HOME") {
+        let candidate = PathBuf::from(home)
+            .join("bin")
+            .join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    if let Some(home) = dirs_home_dir() {
+        let candidate = home
+            .join(".cargo")
+            .join("bin")
+            .join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    // Fallback to `rustup which cargo`.
+    let rustup = if cfg!(windows) { "rustup.exe" } else { "rustup" };
+    let mut command = Command::new(rustup);
+    command.args(["which", "cargo"]);
+    suppress_windows_console_window(&mut command);
+    if let Ok(out) = command.output() {
+        if out.status.success() {
+            let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !path.is_empty() {
+                let pb = PathBuf::from(path);
+                if pb.is_file() {
+                    return Ok(pb);
+                }
+            }
+        }
+    }
+    Err(SoldrError::Other(
+        "soldr exec: could not resolve rustup's cargo binary; \
+         tried $CARGO_HOME/bin, ~/.cargo/bin, and `rustup which cargo`. \
+         Install rustup or set CARGO_HOME to a rustup install."
+            .to_string(),
+    ))
+}
+
+fn dirs_home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        std::env::var_os("USERPROFILE").map(PathBuf::from)
+    }
+    #[cfg(not(windows))]
+    {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+}
+
+fn shell_quote(args: &[String]) -> String {
+    args.iter()
+        .map(|a| {
+            if a.contains(' ') || a.contains('"') {
+                format!("{a:?}")
+            } else {
+                a.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timed_test;
+    use std::time::Duration;
+
+    timed_test!(path_with_prepend_inserts_dir_first, Duration::from_secs(5), {
+        // Pure-function form — no env mutation, no race with sibling
+        // tests under parallel `cargo test`.
+        let sep = if cfg!(windows) { ";" } else { ":" };
+        let base: std::ffi::OsString = format!("/a/b{sep}/c/d").into();
+        let prepended = path_with_prepend_using(Path::new("/x/y"), base.as_os_str());
+        let entries: Vec<PathBuf> = std::env::split_paths(&prepended).collect();
+        assert_eq!(entries.first().map(|p| p.as_path()), Some(Path::new("/x/y")));
+        assert!(
+            entries.iter().any(|p| p == Path::new("/a/b")),
+            "missing /a/b in {entries:?}",
+        );
+        assert!(
+            entries.iter().any(|p| p == Path::new("/c/d")),
+            "missing /c/d in {entries:?}",
+        );
+    });
+
+    timed_test!(path_with_prepend_deduplicates_existing, Duration::from_secs(5), {
+        let sep = if cfg!(windows) { ";" } else { ":" };
+        let base: std::ffi::OsString = format!("/x/y{sep}/a/b").into();
+        let prepended = path_with_prepend_using(Path::new("/x/y"), base.as_os_str());
+        let entries: Vec<PathBuf> = std::env::split_paths(&prepended).collect();
+        // `/x/y` should appear exactly once — the duplicate should have
+        // been dropped before we prepended.
+        let count = entries.iter().filter(|p| p == &Path::new("/x/y")).count();
+        assert_eq!(count, 1, "expected exactly one /x/y entry, got {count} in {entries:?}");
+    });
+
+    timed_test!(find_on_path_locates_executable, Duration::from_secs(5), {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let exe = tmp.path().join(if cfg!(windows) { "myexe.exe" } else { "myexe" });
+        std::fs::write(&exe, b"x").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&exe).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&exe, perms).unwrap();
+        }
+        let path_value: std::ffi::OsString = std::env::join_paths(std::iter::once(tmp.path()))
+            .unwrap();
+        let resolved = find_on_path("myexe", path_value.as_os_str())
+            .expect("should find the fake executable");
+        assert_eq!(resolved, exe);
+    });
+
+    timed_test!(find_on_path_passthrough_for_explicit_path, Duration::from_secs(5), {
+        // When the name already contains a separator, treat it as a
+        // direct path and skip PATH lookup.
+        let path_value: std::ffi::OsString = "/this/does/not/exist".into();
+        let resolved = find_on_path("/explicit/path/binary", path_value.as_os_str());
+        assert_eq!(resolved.as_deref(), Some(Path::new("/explicit/path/binary")));
+    });
+}

--- a/crates/soldr-cli/src/lib.rs
+++ b/crates/soldr-cli/src/lib.rs
@@ -20,6 +20,10 @@
 pub mod blessed_build;
 pub mod cache_lib;
 pub mod cargo_metadata_soldr;
+/// soldr#1059 — classify the `cargo` binary that `which cargo`
+/// resolves to. Lib-side declaration mirrors `main.rs` so integration
+/// tests can exercise the classifier directly.
+pub mod cargo_path_check;
 /// soldr#1081 — Shared `Request::Compile` dispatch logic used by both
 /// the soldr-as-RUSTC_WRAPPER hot path (`wrapper.rs`) and the dedicated
 /// `zccache-soldr` shim binary (`bin/zccache_soldr.rs`). Owns the
@@ -32,6 +36,10 @@ pub mod defender;
 /// Declared from both lib and bin so the unit tests are reachable
 /// via `cargo test --lib`.
 pub mod env_cmd;
+/// soldr#1059 — `soldr exec <cmd>` PATH-prepend wrapper. Lib-side
+/// declaration mirrors `main.rs` so the unit tests are reachable via
+/// `cargo test --lib`.
+pub mod exec_cmd;
 pub mod fetch;
 /// soldr#1079 — Windows MSVC host-toolchain auto-discovery. Probes
 /// vswhere + the Windows SDK and synthesizes LIB/INCLUDE/PATH/LIBPATH

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -22,6 +22,11 @@ mod cargo_metadata_soldr;
 mod cli_args;
 /// soldr#1081 — shared `Request::Compile` dispatch with hang-safe
 /// retry budget. Used by `wrapper.rs` and the `zccache-soldr` bin.
+/// soldr#1059 — classify the `cargo` binary that `which cargo` would
+/// resolve to. Used by `toolchain doctor` / `toolchain ensure` to warn
+/// when a Chocolatey-style standalone shadows rustup's proxy, defeating
+/// per-crate `rust-toolchain.toml` overrides for subprocess invocations.
+mod cargo_path_check;
 mod compile_dispatch;
 mod cook;
 mod core;
@@ -32,6 +37,10 @@ mod doctor;
 /// soldr#938 — `soldr env --target` subcommand. Prints shell-eval /
 /// shell-export / JSON env block for the given target.
 mod env_cmd;
+/// soldr#1059 — `soldr exec <cmd>` escape hatch for cargo extensions
+/// like cargo-dylint that hard-code `"cargo"` and would otherwise pick
+/// up a Chocolatey/scoop standalone instead of rustup's proxy.
+mod exec_cmd;
 mod fetch;
 mod fuzzy_match;
 mod gc;
@@ -354,6 +363,9 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
         }
         Commands::Cook { args } => {
             std::process::exit(cook::run_cook(&args, cache_enabled, zccache_source).await?);
+        }
+        Commands::Exec { args } => {
+            std::process::exit(exec_cmd::run_exec(&args)?);
         }
         Commands::Rustc { args } => {
             std::process::exit(toolchain::run_toolchain_passthrough("rustc", &args)?);

--- a/crates/soldr-cli/src/toolchain_doctor.rs
+++ b/crates/soldr-cli/src/toolchain_doctor.rs
@@ -37,6 +37,7 @@ pub(crate) fn run_toolchain_doctor(json: bool) -> Result<i32, SoldrError> {
     let probes = vec![
         probe_musl_cc(&host),
         probe_shared_target_warning(&workspace),
+        probe_cargo_on_path_shadowing(),
     ];
 
     let all_ok = probes.iter().all(|p| p.ok);
@@ -119,6 +120,8 @@ pub(crate) const PROBE_MUSL_CC: &str = "musl-cc";
 /// Probe name for the pre-populated-target warning (ports
 /// `detect-shared-target-warning.ts`).
 pub(crate) const PROBE_SHARED_TARGET_WARNING: &str = "shared-target-warning";
+/// Probe name for the soldr#1059 Chocolatey-cargo-shadowing detector.
+pub(crate) const PROBE_CARGO_ON_PATH_SHADOWING: &str = "cargo-on-path-shadowing";
 
 /// Detect availability of a musl C compiler on PATH. On non-Linux
 /// hosts the probe is skipped (ok=true, details=`{"skipped": "not-linux"}`)
@@ -198,6 +201,37 @@ pub(crate) fn probe_shared_target_warning(workspace: &Path) -> ProbeResult {
 }
 
 /// PATH lookup helper. Mirrors setup-soldr's `findOnPathSync`.
+/// soldr#1059 — probe the first `cargo` on PATH and classify whether
+/// it honors per-crate `rust-toolchain.toml` overrides. The probe
+/// returns `ok = true` even when the resolved cargo is a shadowing
+/// shim — the diagnosis itself succeeded; the *finding* (in
+/// `details.honors_rust_toolchain_toml`) tells the caller whether to
+/// act on it. Mirrors how `probe_shared_target_warning` already
+/// reports `would_warn: true` with `ok: true`.
+pub(crate) fn probe_cargo_on_path_shadowing() -> ProbeResult {
+    let Some(finding) = crate::cargo_path_check::detect_cargo_on_path() else {
+        return ProbeResult {
+            name: PROBE_CARGO_ON_PATH_SHADOWING.to_string(),
+            ok: true,
+            details: json!({
+                "cargo_on_path": null,
+                "found": false,
+            }),
+        };
+    };
+    let warning = crate::cargo_path_check::warning_for(&finding);
+    ProbeResult {
+        name: PROBE_CARGO_ON_PATH_SHADOWING.to_string(),
+        ok: true,
+        details: json!({
+            "cargo_on_path": finding.resolved.display().to_string(),
+            "classification": finding.classification.label(),
+            "honors_rust_toolchain_toml": finding.honors_rust_toolchain_toml,
+            "would_warn": warning.is_some(),
+        }),
+    }
+}
+
 fn find_on_path(cmd: &str) -> Option<PathBuf> {
     let path = std::env::var_os("PATH")?;
     let exts: &[&str] = if cfg!(windows) { &["", ".exe"] } else { &[""] };

--- a/crates/soldr-cli/src/toolchain_ensure.rs
+++ b/crates/soldr-cli/src/toolchain_ensure.rs
@@ -119,6 +119,18 @@ pub(crate) async fn run_toolchain_ensure(json: bool) -> Result<i32, SoldrError> 
         emit_human(&output);
     }
 
+    // soldr#1059 — flag a shadowing standalone `cargo` on PATH. JSON
+    // callers (setup-soldr#133) already pick this up through the
+    // doctor probe; the warning here is for the human surface only,
+    // emitted to stderr so JSON consumers ignore it.
+    if !json {
+        if let Some(finding) = crate::cargo_path_check::detect_cargo_on_path() {
+            if let Some(msg) = crate::cargo_path_check::warning_for(&finding) {
+                eprintln!("{msg}");
+            }
+        }
+    }
+
     if smoke_ok {
         Ok(0)
     } else {

--- a/crates/soldr-cli/tests/cli_toolchain_doctor.rs
+++ b/crates/soldr-cli/tests/cli_toolchain_doctor.rs
@@ -48,11 +48,13 @@ timed_test!(
         assert!(host["os"].is_string());
         assert!(host["arch"].is_string());
         assert!(host["libc"].is_string());
-        // Probes array contains both expected probe names in stable order.
+        // Probes array contains all expected probe names in stable order.
+        // soldr#1059 added the `cargo-on-path-shadowing` row.
         let probes = parsed["probes"].as_array().expect("probes array");
-        assert_eq!(probes.len(), 2, "expected 2 probes, got {}", probes.len());
+        assert_eq!(probes.len(), 3, "expected 3 probes, got {}", probes.len());
         assert_eq!(probes[0]["name"], Value::from("musl-cc"));
         assert_eq!(probes[1]["name"], Value::from("shared-target-warning"));
+        assert_eq!(probes[2]["name"], Value::from("cargo-on-path-shadowing"));
         // Each probe MUST carry an `ok` boolean and a `details` object.
         for probe in probes {
             assert!(probe["ok"].is_boolean(), "probe.ok must be bool: {probe}");


### PR DESCRIPTION
Closes #1059.

## Problem

When a Windows host has both a Chocolatey-installed standalone Rust and a rustup-managed toolchain, third-party `cargo-*` extensions that invoke `cargo` as a subprocess (`cargo-dylint`, `cargo-binstall`, `cargo-make`, etc.) find the Chocolatey shim on PATH (`C:\ProgramData\chocolatey\bin\cargo.exe`) and fail to honor per-crate `rust-toolchain.toml` overrides. The user-visible symptom is a `cargo-dylint` subprocess failing with `E0554` / `can't find crate for rustc_driver` because the nightly switch from `dylints/X/rust-toolchain.toml` never happened.

soldr's existing bash/PowerShell hook refuses bare `cargo` from the user but cannot intercept subprocess invocations from already-built tools.

## Fix

Two complementary additions:

### 1. `cargo_path_check` — detection + warning

Pure-function classifier for the first `cargo` on PATH. Detects:

- **Chocolatey** — `C:\ProgramData\chocolatey\...\cargo.exe` (does NOT honor `rust-toolchain.toml`)
- **Scoop** — `~/scoop/shims/cargo.exe` (does NOT honor)
- **rustup-toolchain-bin** — `~/.rustup/toolchains/<channel>/bin/cargo` (pinned to one channel, does NOT honor per-crate overrides)
- **system-package** — `/usr/bin/cargo` (does NOT honor)
- **rustup proxy** — `~/.cargo/bin/cargo` (DOES honor; no warning)
- **soldr-shim** — soldr-managed shim (DOES honor; no warning)
- **unknown** — fall-through; conservatively assumed not to honor

Wired into:

- **`soldr toolchain doctor`** — new `cargo-on-path-shadowing` probe row in the schema-v1 JSON payload. Carries `classification`, `honors_rust_toolchain_toml`, `would_warn`, and `cargo_on_path` fields.
- **`soldr toolchain ensure`** — emits a multi-line stderr warning when the classifier flags a shadowing shim. JSON consumers see the same finding through the doctor probe; the warning is human-mode only so it doesn't pollute setup-soldr#133's JSON parse.

Warning format (single emission, multi-line):

```
soldr: warning: \`cargo\` on PATH resolves to a chocolatey install at C:\ProgramData\chocolatey\bin\cargo.exe
soldr: this binary does NOT honor per-crate \`rust-toolchain.toml\` overrides.
soldr: subprocesses launched by cargo extensions (cargo-dylint, cargo-binstall, ...)
soldr: will use the WRONG channel and may fail with E0554 / E0463.
soldr: see https://github.com/zackees/soldr/issues/1059 for the fix.
soldr: workarounds:
soldr:   (a) uninstall the standalone Rust (e.g. \`choco uninstall rust\`), OR
soldr:   (b) prepend \`~/.cargo/bin\` to PATH so the rustup proxy wins, OR
soldr:   (c) wrap subprocess-y commands in \`soldr exec <command...>\`.
```

### 2. `soldr exec <cmd>` — escape hatch

Resolves rustup's `cargo` via `CARGO_HOME/bin` (falling back to `~/.cargo/bin` then `rustup which`), prepends its containing directory to PATH, then execs `<cmd>` with that PATH. Lets users wrap subprocess-y commands:

```
soldr exec cargo-dylint dylint --all
```

The wrapped child sees rustup's `cargo` first regardless of what's on the parent shell's PATH, so its internal `cargo build` resolves the rustup proxy + the per-crate channel switch works.

## Test plan

- [x] 13 new `timed_test!` cases (9 classifier + 4 PATH-prepend) — all pass under Docker rust:1.94 via `scripts/test_msvc_host_linux.sh`.
- [x] `cargo clippy -p soldr-cli --lib --bins --tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Integration test `tests/cli_toolchain_doctor.rs` updated for the new probe row (3 probes, was 2).
- [x] `SOLDR_BUILTIN_VERBS` extended with `exec` — the existing `soldr_builtin_verbs_match_clap_subcommands_and_aliases` regression test verifies the const stays in sync with the Commands enum.
- [ ] Manual Windows host reproduction (out-of-band): with Chocolatey Rust installed + rustup, run `soldr toolchain ensure` → should emit the new warning. Run `soldr exec cargo-dylint dylint --all` in a project pinning rust-lld nightly → should succeed where bare `cargo-dylint` failed.

## Notes

- The fix is two layers because neither alone suffices: detection (1) gives users a clear diagnostic; the escape hatch (2) gives them an immediate path forward without waiting for them to uninstall/reorder PATH. The issue's proposed mitigation list ranked these as (1) + (3); both landed.
- Per CLAUDE.md "Agent Development Environment Rule" (soldr#1107), this fix was developed and validated entirely under the Linux Docker harness before any Windows verification. The end-to-end Windows-host gate stays a manual repro step until a Windows CI lane lands a Chocolatey-Rust fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)