### PR TITLE
docs+test: lockstep guard for Cargo.toml / Cargo.lock / package.json (#1026)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,22 @@ This rule was set during the #1105 fix: the `rust-lld` LIB-injection feature was
 - uv for Python dependency management
 - Workspace dependencies shared in root `Cargo.toml`
 
+## Bumping soldr's own version (release PRs)
+
+When opening a release PR, **three files must be bumped in lockstep** or every CI lane fails immediately with `error: cannot update the lock file because --locked was passed to prevent this` (the v0.7.65 trap from #1024 / #1025):
+
+1. `Cargo.toml` — `[workspace.package].version`.
+2. `package.json` — top-level `"version"`.
+3. `Cargo.lock` — the `soldr-cli` package's `version` field. Refresh with a no-op build (`soldr cargo build -p soldr-cli`) AFTER bumping `Cargo.toml`, then `git add Cargo.lock` so the new version is committed alongside the other two.
+
+The regression guard at `crates/soldr-cli/tests/version_lockstep.rs` reads all three files and asserts they match — `soldr cargo test -p soldr-cli --test version_lockstep` (or any full `cargo test` run) fails the build if any of the three drifts. The same test runs on every PR via the `Lint` job.
+
+A pre-merge `cargo metadata --frozen` would also catch the trap (it refuses to run when the lockfile is stale relative to manifests) but adds a separate workflow. The in-tree test covers the same ground with no CI plumbing.
+
+### Why a separate checklist for this
+
+The 'Bumping managed_zccache_version' section below documents the four-file lockstep for the *zccache* pin (`MANAGED_ZCCACHE_VERSION` + the contract file + a cosmetic test fixture + the `zccache = { git = ... }` rev). That's an internal dependency pin — orthogonal to soldr's own release version. Both lockstep checklists live in this file because both have surfaced bugs in the past, and both need to be in front of an agent's eyes when it goes to open a PR that touches versions.
+
 ## Bumping managed_zccache_version
 
 When pulling in a new managed zccache release, **four files must be updated in lockstep** or `zccache_runtime_contract_matches_rust_constants` (or a `./test` run) will fail:

--- a/crates/soldr-cli/tests/version_lockstep.rs
+++ b/crates/soldr-cli/tests/version_lockstep.rs
@@ -1,0 +1,147 @@
+//! Regression test for soldr#1026 — the v0.7.65 release trap.
+//!
+//! A release PR bumps `Cargo.toml`'s `[workspace.package].version`,
+//! `package.json`'s top-level `"version"`, and `Cargo.lock`'s
+//! `soldr-cli` `version` in lockstep. If any of the three drifts —
+//! historically `Cargo.lock` was the one a human contributor forgot —
+//! the CI lanes that pass `--locked` fail immediately with
+//!
+//!     error: cannot update the lock file because --locked was passed
+//!     to prevent this
+//!
+//! That kills the whole release matrix before any code compiles. The
+//! v0.7.65 run (#28338586417) burned for ~10 minutes diagnosing this
+//! on a Friday afternoon — exactly the failure shape this test
+//! prevents.
+//!
+//! The test is a single integration binary (lives under `tests/` so it
+//! gets its own process, no race with other lib tests touching env)
+//! and runs on every `cargo test` invocation.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use soldr_cli::timed_test;
+use std::time::Duration;
+
+/// Locate the soldr repo root from the CARGO_MANIFEST_DIR convention.
+/// `CARGO_MANIFEST_DIR` points at `<repo>/crates/soldr-cli`; we want
+/// `<repo>/`.
+fn repo_root() -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR set by cargo at test time");
+    PathBuf::from(manifest_dir)
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("crates/soldr-cli must live two levels under repo root")
+        .to_path_buf()
+}
+
+/// Extract `[workspace.package] version = "..."` from the repo's
+/// root `Cargo.toml`. Hand-parsed (no `toml` crate dep here) because
+/// the file shape is stable and we only need one field.
+fn read_cargo_toml_version(root: &Path) -> String {
+    let s = fs::read_to_string(root.join("Cargo.toml")).expect("read Cargo.toml");
+    let mut in_section = false;
+    for raw in s.lines() {
+        let line = raw.trim();
+        if line.starts_with('[') {
+            in_section = line == "[workspace.package]";
+            continue;
+        }
+        if in_section {
+            if let Some(rest) = line.strip_prefix("version") {
+                let rest = rest.trim_start_matches([' ', '=']);
+                let rest = rest.trim();
+                if let Some(stripped) = rest.strip_prefix('"') {
+                    if let Some(end) = stripped.find('"') {
+                        return stripped[..end].to_string();
+                    }
+                }
+            }
+        }
+    }
+    panic!("could not find [workspace.package].version in Cargo.toml");
+}
+
+/// Extract `name = "soldr-cli"` package's `version` from Cargo.lock.
+/// Walks each `[[package]]` block until name matches, then reads the
+/// adjacent `version = "..."` line. The lockfile shape is set by
+/// cargo and stable across Rust 1.x.
+fn read_cargo_lock_version(root: &Path) -> String {
+    let s = fs::read_to_string(root.join("Cargo.lock")).expect("read Cargo.lock");
+    let mut current_name: Option<String> = None;
+    for raw in s.lines() {
+        let line = raw.trim();
+        if line == "[[package]]" {
+            current_name = None;
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("name") {
+            let rest = rest.trim_start_matches([' ', '=']).trim();
+            if let Some(stripped) = rest.strip_prefix('"') {
+                if let Some(end) = stripped.find('"') {
+                    current_name = Some(stripped[..end].to_string());
+                }
+            }
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("version") {
+            if current_name.as_deref() == Some("soldr-cli") {
+                let rest = rest.trim_start_matches([' ', '=']).trim();
+                if let Some(stripped) = rest.strip_prefix('"') {
+                    if let Some(end) = stripped.find('"') {
+                        return stripped[..end].to_string();
+                    }
+                }
+            }
+        }
+    }
+    panic!("could not find soldr-cli's version entry in Cargo.lock");
+}
+
+/// Extract the top-level `"version"` field from package.json. Same
+/// rationale as the Cargo.toml parser: shape is stable, no need to
+/// pull in a JSON crate.
+fn read_package_json_version(root: &Path) -> String {
+    let s = fs::read_to_string(root.join("package.json")).expect("read package.json");
+    for raw in s.lines() {
+        let line = raw.trim();
+        if let Some(rest) = line.strip_prefix("\"version\"") {
+            let rest = rest.trim_start_matches([' ', ':']).trim();
+            if let Some(stripped) = rest.strip_prefix('"') {
+                if let Some(end) = stripped.find('"') {
+                    return stripped[..end].to_string();
+                }
+            }
+        }
+    }
+    panic!("could not find top-level \"version\" in package.json");
+}
+
+timed_test!(
+    cargo_toml_cargo_lock_and_package_json_share_one_version,
+    Duration::from_secs(15),
+    {
+        let root = repo_root();
+        let cargo_toml = read_cargo_toml_version(&root);
+        let cargo_lock = read_cargo_lock_version(&root);
+        let package_json = read_package_json_version(&root);
+
+        assert_eq!(
+            cargo_toml, cargo_lock,
+            "soldr#1026 v0.7.65 trap: Cargo.toml says {cargo_toml}, Cargo.lock says \
+             {cargo_lock}. CI runs `cargo build --locked` and will fail with `cannot update \
+             the lock file` until you refresh Cargo.lock (run `cargo build -p soldr-cli` \
+             after bumping Cargo.toml and `git add Cargo.lock`). See CLAUDE.md \
+             'Bumping soldr's own version (release PRs)'."
+        );
+        assert_eq!(
+            cargo_toml, package_json,
+            "soldr#1026 lockstep drift: Cargo.toml says {cargo_toml}, package.json says \
+             {package_json}. The release pipeline reads BOTH — the npm-side wrapper bumps off \
+             package.json and the crate bumps off Cargo.toml. Update package.json's top-level \
+             \"version\" to match."
+        );
+    }
+);


### PR DESCRIPTION
Closes #1026.

## Problem

The v0.7.65 release matrix ([run #28338586417](https://github.com/zackees/soldr/actions/runs/28338586417)) burned every lane immediately with:

\`\`\`
error: cannot update the lock file because --locked was passed to prevent this
\`\`\`

PR #1024 bumped \`Cargo.toml\`'s workspace version and \`package.json\` but forgot to refresh \`Cargo.lock\`. Every CI lane uses \`cargo build --locked\` and refused to fix the lockfile itself. Fixed reactively in #1025.

## Fix

Two complementary additions:

### 1. CLAUDE.md — new lockstep checklist

A "Bumping soldr's own version (release PRs)" section that names all three files in lockstep and explains the v0.7.65 trap. Mirrors the existing "Bumping managed_zccache_version" checklist style so release-PR-writing agents see both checklists in the same eye-sweep.

### 2. Integration test — \`tests/version_lockstep.rs\`

Reads:
- \`Cargo.toml\`'s \`[workspace.package].version\`
- \`Cargo.lock\`'s \`soldr-cli\` package entry version
- \`package.json\`'s top-level \`"version"\`

Asserts all three are equal. Standalone integration binary (own \`cargo test\` process — can't be wedged by a sibling lib test). Hand-parsed (no toml / serde_json dep here) — the three file shapes are stable.

If the test fails, the error message names the right CLAUDE.md section and the exact command to fix it (\`cargo build -p soldr-cli\` then \`git add Cargo.lock\`).

## Test plan

- [x] \`cargo test -p soldr-cli --test version_lockstep\` under Docker rust:1.94 — passes on the current 0.7.87 lockstep.
- [x] Manual drift simulation: editing Cargo.toml to \`0.7.88\` while keeping Cargo.lock at \`0.7.87\` makes the test fail with the directive message naming CLAUDE.md.
- [ ] Next release PR — this test should catch the trap automatically before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)