### PR TITLE
fix(ci): rustfmt PR #1114 + #1115 fallout (unblock main)

### DIFF
--- a/crates/soldr-cli/src/cargo_path_check.rs
+++ b/crates/soldr-cli/src/cargo_path_check.rs
@@ -146,9 +146,7 @@ pub fn classify_cargo_path(path: &Path) -> CargoOnPathFinding {
     let classification = if lower.contains("/.cargo/bin/") || lower.contains("/cargo/bin/") {
         // Rustup proxy lives under CARGO_HOME/bin (default `~/.cargo/bin`).
         CargoClassification::Rustup
-    } else if lower.contains("/.rustup/toolchains/")
-        || lower.contains("/rustup/toolchains/")
-    {
+    } else if lower.contains("/.rustup/toolchains/") || lower.contains("/rustup/toolchains/") {
         CargoClassification::RustupToolchainBin
     } else if lower.contains("/chocolatey/") {
         CargoClassification::Chocolatey
@@ -165,7 +163,10 @@ pub fn classify_cargo_path(path: &Path) -> CargoOnPathFinding {
         CargoClassification::Unknown
     };
 
-    let honors = matches!(classification, CargoClassification::Rustup | CargoClassification::SoldrShim);
+    let honors = matches!(
+        classification,
+        CargoClassification::Rustup | CargoClassification::SoldrShim
+    );
 
     CargoOnPathFinding {
         resolved: path.to_path_buf(),
@@ -240,14 +241,20 @@ mod tests {
         assert!(f.honors_rust_toolchain_toml);
     });
 
-    timed_test!(classify_rustup_toolchain_bin_is_warned, Duration::from_secs(5), {
-        // Direct toolchain bin path — pinned to ONE channel, ignores
-        // per-crate overrides. Warn.
-        let p = PathBuf::from("/home/me/.rustup/toolchains/1.94.1-x86_64-pc-windows-msvc/bin/cargo");
-        let f = classify_cargo_path(&p);
-        assert_eq!(f.classification, CargoClassification::RustupToolchainBin);
-        assert!(!f.honors_rust_toolchain_toml);
-    });
+    timed_test!(
+        classify_rustup_toolchain_bin_is_warned,
+        Duration::from_secs(5),
+        {
+            // Direct toolchain bin path — pinned to ONE channel, ignores
+            // per-crate overrides. Warn.
+            let p = PathBuf::from(
+                "/home/me/.rustup/toolchains/1.94.1-x86_64-pc-windows-msvc/bin/cargo",
+            );
+            let f = classify_cargo_path(&p);
+            assert_eq!(f.classification, CargoClassification::RustupToolchainBin);
+            assert!(!f.honors_rust_toolchain_toml);
+        }
+    );
 
     timed_test!(classify_system_package_linux, Duration::from_secs(5), {
         let p = PathBuf::from("/usr/bin/cargo");
@@ -264,31 +271,35 @@ mod tests {
         assert!(warning_for(&f).is_some());
     });
 
-    timed_test!(detect_cargo_on_path_respects_synth_env, Duration::from_secs(10), {
-        // Build an isolated PATH and a fake cargo binary; verify the
-        // detector finds it. Restore PATH at the end so we don't
-        // pollute downstream tests.
-        let tmp = tempfile::tempdir().expect("tmpdir");
-        let bin = tmp.path().join("scoop").join("shims");
-        std::fs::create_dir_all(&bin).unwrap();
-        let exe_name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
-        let exe = bin.join(exe_name);
-        std::fs::write(&exe, b"#!/bin/sh\n").unwrap();
-        #[cfg(unix)]
+    timed_test!(
+        detect_cargo_on_path_respects_synth_env,
+        Duration::from_secs(10),
         {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(&exe).unwrap().permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&exe, perms).unwrap();
+            // Build an isolated PATH and a fake cargo binary; verify the
+            // detector finds it. Restore PATH at the end so we don't
+            // pollute downstream tests.
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let bin = tmp.path().join("scoop").join("shims");
+            std::fs::create_dir_all(&bin).unwrap();
+            let exe_name = if cfg!(windows) { "cargo.exe" } else { "cargo" };
+            let exe = bin.join(exe_name);
+            std::fs::write(&exe, b"#!/bin/sh\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = std::fs::metadata(&exe).unwrap().permissions();
+                perms.set_mode(0o755);
+                std::fs::set_permissions(&exe, perms).unwrap();
+            }
+            let prior = std::env::var_os("PATH");
+            std::env::set_var("PATH", &bin);
+            let found = detect_cargo_on_path();
+            match prior {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+            let found = found.expect("detector should find the fake cargo");
+            assert_eq!(found.classification, CargoClassification::Scoop);
         }
-        let prior = std::env::var_os("PATH");
-        std::env::set_var("PATH", &bin);
-        let found = detect_cargo_on_path();
-        match prior {
-            Some(v) => std::env::set_var("PATH", v),
-            None => std::env::remove_var("PATH"),
-        }
-        let found = found.expect("detector should find the fake cargo");
-        assert_eq!(found.classification, CargoClassification::Scoop);
-    });
+    );
 }

--- a/crates/soldr-cli/src/exec_cmd.rs
+++ b/crates/soldr-cli/src/exec_cmd.rs
@@ -84,10 +84,7 @@ pub fn path_with_prepend(prepend_dir: &Path) -> std::ffi::OsString {
 
 /// Pure-function form of [`path_with_prepend`] — takes the base PATH
 /// value explicitly so tests don't race on the process env.
-pub fn path_with_prepend_using(
-    prepend_dir: &Path,
-    base: &std::ffi::OsStr,
-) -> std::ffi::OsString {
+pub fn path_with_prepend_using(prepend_dir: &Path, base: &std::ffi::OsStr) -> std::ffi::OsString {
     let mut entries: Vec<PathBuf> = std::env::split_paths(base)
         .filter(|p| p != prepend_dir)
         .collect();
@@ -99,7 +96,11 @@ pub fn path_with_prepend_using(
 /// Used so `soldr exec` resolves the command against its own
 /// PATH-prepended view rather than the unmodified process PATH.
 pub fn find_on_path(name: &str, path_value: &std::ffi::OsStr) -> Option<PathBuf> {
-    let exts: &[&str] = if cfg!(windows) { &["", ".exe", ".cmd", ".bat"] } else { &[""] };
+    let exts: &[&str] = if cfg!(windows) {
+        &["", ".exe", ".cmd", ".bat"]
+    } else {
+        &[""]
+    };
     // If the user gave a path-like argument (contains a separator), no
     // PATH lookup — just trust it.
     if name.contains('/') || name.contains('\\') {
@@ -138,24 +139,29 @@ pub fn find_on_path(name: &str, path_value: &std::ffi::OsStr) -> Option<PathBuf>
 /// knows whether to install rustup or set `RUSTUP_HOME`.
 fn resolve_rustup_cargo() -> Result<PathBuf, SoldrError> {
     if let Some(home) = std::env::var_os("CARGO_HOME") {
-        let candidate = PathBuf::from(home)
-            .join("bin")
-            .join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
+        let candidate =
+            PathBuf::from(home)
+                .join("bin")
+                .join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
         if candidate.is_file() {
             return Ok(candidate);
         }
     }
     if let Some(home) = dirs_home_dir() {
-        let candidate = home
-            .join(".cargo")
-            .join("bin")
-            .join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
+        let candidate =
+            home.join(".cargo")
+                .join("bin")
+                .join(if cfg!(windows) { "cargo.exe" } else { "cargo" });
         if candidate.is_file() {
             return Ok(candidate);
         }
     }
     // Fallback to `rustup which cargo`.
-    let rustup = if cfg!(windows) { "rustup.exe" } else { "rustup" };
+    let rustup = if cfg!(windows) {
+        "rustup.exe"
+    } else {
+        "rustup"
+    };
     let mut command = Command::new(rustup);
     command.args(["which", "cargo"]);
     suppress_windows_console_window(&mut command);
@@ -208,38 +214,54 @@ mod tests {
     use crate::timed_test;
     use std::time::Duration;
 
-    timed_test!(path_with_prepend_inserts_dir_first, Duration::from_secs(5), {
-        // Pure-function form — no env mutation, no race with sibling
-        // tests under parallel `cargo test`.
-        let sep = if cfg!(windows) { ";" } else { ":" };
-        let base: std::ffi::OsString = format!("/a/b{sep}/c/d").into();
-        let prepended = path_with_prepend_using(Path::new("/x/y"), base.as_os_str());
-        let entries: Vec<PathBuf> = std::env::split_paths(&prepended).collect();
-        assert_eq!(entries.first().map(|p| p.as_path()), Some(Path::new("/x/y")));
-        assert!(
-            entries.iter().any(|p| p == Path::new("/a/b")),
-            "missing /a/b in {entries:?}",
-        );
-        assert!(
-            entries.iter().any(|p| p == Path::new("/c/d")),
-            "missing /c/d in {entries:?}",
-        );
-    });
+    timed_test!(
+        path_with_prepend_inserts_dir_first,
+        Duration::from_secs(5),
+        {
+            // Pure-function form — no env mutation, no race with sibling
+            // tests under parallel `cargo test`.
+            let sep = if cfg!(windows) { ";" } else { ":" };
+            let base: std::ffi::OsString = format!("/a/b{sep}/c/d").into();
+            let prepended = path_with_prepend_using(Path::new("/x/y"), base.as_os_str());
+            let entries: Vec<PathBuf> = std::env::split_paths(&prepended).collect();
+            assert_eq!(
+                entries.first().map(|p| p.as_path()),
+                Some(Path::new("/x/y"))
+            );
+            assert!(
+                entries.iter().any(|p| p == Path::new("/a/b")),
+                "missing /a/b in {entries:?}",
+            );
+            assert!(
+                entries.iter().any(|p| p == Path::new("/c/d")),
+                "missing /c/d in {entries:?}",
+            );
+        }
+    );
 
-    timed_test!(path_with_prepend_deduplicates_existing, Duration::from_secs(5), {
-        let sep = if cfg!(windows) { ";" } else { ":" };
-        let base: std::ffi::OsString = format!("/x/y{sep}/a/b").into();
-        let prepended = path_with_prepend_using(Path::new("/x/y"), base.as_os_str());
-        let entries: Vec<PathBuf> = std::env::split_paths(&prepended).collect();
-        // `/x/y` should appear exactly once — the duplicate should have
-        // been dropped before we prepended.
-        let count = entries.iter().filter(|p| p == &Path::new("/x/y")).count();
-        assert_eq!(count, 1, "expected exactly one /x/y entry, got {count} in {entries:?}");
-    });
+    timed_test!(
+        path_with_prepend_deduplicates_existing,
+        Duration::from_secs(5),
+        {
+            let sep = if cfg!(windows) { ";" } else { ":" };
+            let base: std::ffi::OsString = format!("/x/y{sep}/a/b").into();
+            let prepended = path_with_prepend_using(Path::new("/x/y"), base.as_os_str());
+            let entries: Vec<PathBuf> = std::env::split_paths(&prepended).collect();
+            // `/x/y` should appear exactly once — the duplicate should have
+            // been dropped before we prepended.
+            let count = entries.iter().filter(|p| p == &Path::new("/x/y")).count();
+            assert_eq!(
+                count, 1,
+                "expected exactly one /x/y entry, got {count} in {entries:?}"
+            );
+        }
+    );
 
     timed_test!(find_on_path_locates_executable, Duration::from_secs(5), {
         let tmp = tempfile::tempdir().expect("tmpdir");
-        let exe = tmp.path().join(if cfg!(windows) { "myexe.exe" } else { "myexe" });
+        let exe = tmp
+            .path()
+            .join(if cfg!(windows) { "myexe.exe" } else { "myexe" });
         std::fs::write(&exe, b"x").unwrap();
         #[cfg(unix)]
         {
@@ -248,18 +270,25 @@ mod tests {
             perms.set_mode(0o755);
             std::fs::set_permissions(&exe, perms).unwrap();
         }
-        let path_value: std::ffi::OsString = std::env::join_paths(std::iter::once(tmp.path()))
-            .unwrap();
-        let resolved = find_on_path("myexe", path_value.as_os_str())
-            .expect("should find the fake executable");
+        let path_value: std::ffi::OsString =
+            std::env::join_paths(std::iter::once(tmp.path())).unwrap();
+        let resolved =
+            find_on_path("myexe", path_value.as_os_str()).expect("should find the fake executable");
         assert_eq!(resolved, exe);
     });
 
-    timed_test!(find_on_path_passthrough_for_explicit_path, Duration::from_secs(5), {
-        // When the name already contains a separator, treat it as a
-        // direct path and skip PATH lookup.
-        let path_value: std::ffi::OsString = "/this/does/not/exist".into();
-        let resolved = find_on_path("/explicit/path/binary", path_value.as_os_str());
-        assert_eq!(resolved.as_deref(), Some(Path::new("/explicit/path/binary")));
-    });
+    timed_test!(
+        find_on_path_passthrough_for_explicit_path,
+        Duration::from_secs(5),
+        {
+            // When the name already contains a separator, treat it as a
+            // direct path and skip PATH lookup.
+            let path_value: std::ffi::OsString = "/this/does/not/exist".into();
+            let resolved = find_on_path("/explicit/path/binary", path_value.as_os_str());
+            assert_eq!(
+                resolved.as_deref(),
+                Some(Path::new("/explicit/path/binary"))
+            );
+        }
+    );
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -19,7 +19,6 @@ mod cache_lib;
 mod cargo_diagnostics;
 mod cargo_front_door;
 mod cargo_metadata_soldr;
-mod cli_args;
 /// soldr#1081 — shared `Request::Compile` dispatch with hang-safe
 /// retry budget. Used by `wrapper.rs` and the `zccache-soldr` bin.
 /// soldr#1059 — classify the `cargo` binary that `which cargo` would
@@ -27,6 +26,7 @@ mod cli_args;
 /// when a Chocolatey-style standalone shadows rustup's proxy, defeating
 /// per-crate `rust-toolchain.toml` overrides for subprocess invocations.
 mod cargo_path_check;
+mod cli_args;
 mod compile_dispatch;
 mod cook;
 mod core;

--- a/crates/soldr-cli/tests/version_lockstep.rs
+++ b/crates/soldr-cli/tests/version_lockstep.rs
@@ -28,8 +28,8 @@ use std::time::Duration;
 /// `CARGO_MANIFEST_DIR` points at `<repo>/crates/soldr-cli`; we want
 /// `<repo>/`.
 fn repo_root() -> PathBuf {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-        .expect("CARGO_MANIFEST_DIR set by cargo at test time");
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo at test time");
     PathBuf::from(manifest_dir)
         .parent()
         .and_then(|p| p.parent())


### PR DESCRIPTION
## Summary

Same pattern as PR #1113. PRs #1114 (\`fix(toolchain): detect Chocolatey-cargo shadow + add \`soldr exec\`\`) and #1115 (\`docs+test: lockstep guard\`) merged with unformatted code, breaking fmt-check on main. Four files needed reformatting:

- \`crates/soldr-cli/src/cargo_path_check.rs\` (4 hunks: \`matches!()\` expand, if-else collapse, two \`timed_test!\` expands)
- \`crates/soldr-cli/src/exec_cmd.rs\` (7 hunks: signature collapse, if-cfg expands, path-chain rewraps)
- \`crates/soldr-cli/src/main.rs\` (2 trivial hunks)
- \`crates/soldr-cli/tests/version_lockstep.rs\` (2 trivial hunks)

Pure formatting. No behavior change. Generated by \`cargo fmt -p soldr-cli\`; verified clean with \`cargo fmt -p soldr-cli -- --check\` locally.

## Process note

Same drift has now landed in 3 consecutive merges (#1111, #1114, #1115). Each fix is mechanical, but it should never hit main. Recommend making Lint a required status check on PRs to main — separate concern, not in this PR's scope.

## Test plan

- [ ] This PR's CI passes (Lint + cross-builds)
- [ ] Main's next CI run goes green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)