### PR TITLE
fix(ci): unblock main — syslib tests, target-run checkout, zstd-sys cross

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -50,6 +50,12 @@ jobs:
     name: cross-build ${{ inputs.target }} (linux host)
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    env:
+      # zstd-sys' build.rs probes pkg-config; pkg-config-rs refuses
+      # cross-compile probes by default. Setting this 1 lets the probe
+      # run (and fall back to vendored compile if it fails). Required
+      # after PR #1111 expanded the transitive *-sys dep tree.
+      PKG_CONFIG_ALLOW_CROSS: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/_ci-target-run.yml
+++ b/.github/workflows/_ci-target-run.yml
@@ -44,9 +44,14 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 30
     steps:
-      # No source checkout — the artifact carries everything we need.
-      # If individual tests want to fall back to MANIFEST_DIR, they
-      # short-circuit via SOLDR_TEST_SKIP_SOURCE_TREE.
+      # nextest's `run --archive-file` needs the workspace Cargo.toml
+      # present (per the `--workspace-remap` docs) even when all binaries
+      # come from the archive. Shallow checkout is enough; we don't run
+      # cargo build here.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          submodules: recursive
 
       - name: Download cross-build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v6

--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -555,13 +555,19 @@ mod tests {
         }
     });
 
-    crate::timed_test!(linux_targets_get_no_prep, {
+    crate::timed_test!(linux_targets_get_no_xwin_or_sdk_prep, {
+        // soldr#1064 Phase B: syslib catalogue overrides may populate
+        // prep.env even on linux targets. The invariant we still want to
+        // assert is "linux gets no Windows-xwin and no Apple-SDK prep" —
+        // opt out of catalogue injection to keep this test hermetic.
+        std::env::set_var(USE_LEGACY_VENDORED_SYS_ENV_VAR, "1");
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
-        let prep = tokio::runtime::Runtime::new()
+        let result = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(prepare(&paths, "x86_64-unknown-linux-musl"))
-            .expect("linux musl target should not error");
+            .block_on(prepare(&paths, "x86_64-unknown-linux-musl"));
+        std::env::remove_var(USE_LEGACY_VENDORED_SYS_ENV_VAR);
+        let prep = result.expect("linux musl target should not error");
         assert!(prep.xwin_cache_dir.is_none());
         assert!(prep.sdkroot.is_none());
         assert!(prep.env.is_empty());

--- a/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/bzip2_sysroot.rs
@@ -82,13 +82,13 @@ mod tests {
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_bzip2_sysroot_returns_not_yet_ingested, {
+    crate::timed_test!(ensure_bzip2_sysroot_rejects_unknown_target, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
         let result = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(ensure_bzip2_sysroot(&paths, "x86_64-unknown-linux-gnu"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
+            .block_on(ensure_bzip2_sysroot(&paths, "wasm32-unknown-unknown"));
+        let err = result.expect_err("unsupported target must error");
+        assert!(matches!(err, SoldrError::UnsupportedPlatform(_)));
     });
 }

--- a/crates/soldr-cli/src/fetch/lzma_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/lzma_sysroot.rs
@@ -84,13 +84,13 @@ mod tests {
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_lzma_sysroot_returns_not_yet_ingested, {
+    crate::timed_test!(ensure_lzma_sysroot_rejects_unknown_target, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
         let result = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(ensure_lzma_sysroot(&paths, "aarch64-apple-darwin"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
+            .block_on(ensure_lzma_sysroot(&paths, "wasm32-unknown-unknown"));
+        let err = result.expect_err("unsupported target must error");
+        assert!(matches!(err, SoldrError::UnsupportedPlatform(_)));
     });
 }

--- a/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/zlib_ng_sysroot.rs
@@ -80,13 +80,13 @@ mod tests {
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_zlib_ng_sysroot_returns_not_yet_ingested, {
+    crate::timed_test!(ensure_zlib_ng_sysroot_rejects_unknown_target, {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
         let result = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(ensure_zlib_ng_sysroot(&paths, "x86_64-unknown-linux-gnu"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
+            .block_on(ensure_zlib_ng_sysroot(&paths, "wasm32-unknown-unknown"));
+        let err = result.expect_err("unsupported target must error");
+        assert!(matches!(err, SoldrError::UnsupportedPlatform(_)));
     });
 }


### PR DESCRIPTION
## Summary

Three independent CI failures introduced when PR #1111 (\`feat(syslib-fetch): real download + extract for *-sys catalogue\`) landed on main. Each is small and unrelated to the others; bundled here because they all block the same CI runs.

### Cluster A — stale syslib unit tests
PR #1111 swapped \`ensure_bzip2_sysroot\`/\`lzma\`/\`zlib_ng\` from stubs that always returned \`Err(NotYetIngested)\` to real downloads that succeed. Tests still called \`.expect_err(\"must error until catalogue row lands\")\` → panic. Rewritten as \`rejects_unknown_target\` (same hermetic shape, just with a guaranteed-unsupported wasm32 target). \`blessed_build::linux_targets_get_no_prep\` asserted \`prep.env.is_empty()\` which is no longer true on linux; renamed + set \`SOLDR_USE_LEGACY_VENDORED_SYS=1\` to capture the meaningful invariant.

### Cluster B — target-run jobs missing workspace source
\`_ci-target-run.yml\` downloaded the test archive but never \`actions/checkout\`-ed the repo. \`cargo nextest run --archive-file\` needs the workspace \`Cargo.toml\` present. Added a shallow checkout step before the nextest run.

### Cluster C — zstd-sys cross-compile to Windows MSVC
zstd-sys' build.rs probes pkg-config; pkg-config-rs refuses cross-compile by default. Set job-level \`PKG_CONFIG_ALLOW_CROSS=1\` in \`_ci-cross-build-linux.yml\`. Probe is now allowed and falls back to vendored compile on failure (the desired behavior).

## Test plan

- [x] Locally verified Cluster A: \`soldr cargo test -p soldr-cli --lib sysroot\` and \`... linux_targets\` both pass; 514 lib tests still green
- [ ] CI on this PR confirms B + C (workflow-only, can't verify locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)