### PR TITLE
fix(test): relax embed_lookup_is_fast threshold for GHA musl runners

### DIFF
--- a/crates/soldr-cli/src/fetch/manifest_v6.rs
+++ b/crates/soldr-cli/src/fetch/manifest_v6.rs
@@ -392,8 +392,15 @@ mod tests {
 
     crate::timed_test!(embed_lookup_is_fast, {
         // Cold-start path: zstd decompress + parse + first lookup
-        // must amortize to sub-50ms for 10k lookups, with the
-        // decompression paid exactly once via OnceLock.
+        // must amortize to sub-250ms for 10k lookups (25µs/lookup),
+        // with the decompression paid exactly once via OnceLock.
+        //
+        // Threshold sized for the slowest GHA tier (musl debug builds
+        // on shared ubuntu-24.04 hosted runners can take ~80-180ms).
+        // Tightening below this trades coverage on those runners for
+        // a noisier perf assertion; the test exists to catch O(N)
+        // regressions in lookup, not to gate µs-level perf — that's
+        // what the criterion benches in this crate do.
         let start = std::time::Instant::now();
         let m = embedded_manifest().expect("embedded blob must parse");
         for _ in 0..10_000 {
@@ -401,8 +408,8 @@ mod tests {
         }
         let elapsed = start.elapsed();
         assert!(
-            elapsed < std::time::Duration::from_millis(50),
-            "10k embedded-manifest lookups took {elapsed:?}, expected < 50ms"
+            elapsed < std::time::Duration::from_millis(250),
+            "10k embedded-manifest lookups took {elapsed:?}, expected < 250ms"
         );
     });
 


### PR DESCRIPTION
## Summary

The 50ms 10k-lookup budget in \`fetch::manifest_v6::tests::embed_lookup_is_fast\` was tight enough that musl debug builds on shared GHA ubuntu-24.04 runners blew it on the target-run musl lanes. Bumped to 250ms (25µs per lookup).

Preserves the regression-catching intent: O(N) lookup growth or accidental per-call zstd-decompress would still trip the assertion. µs-level perf is the job of the criterion bench harness in this crate, not this unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)