### PR TITLE
feat(fetch): wire python/nodelib/openssl/llvm-tools to syslib_common (#1010)

### DIFF
--- a/crates/soldr-cli/src/fetch/llvm_tools_bundle.rs
+++ b/crates/soldr-cli/src/fetch/llvm_tools_bundle.rs
@@ -53,27 +53,17 @@ pub fn host_slug_for(host_triple: &str) -> Option<&'static str> {
 }
 
 /// Construct the expected `assets`-branch URL for the LLVM-tools
-/// bundle. Catalogue layout:
-///
-///     deps/llvm-tools/<version>/<slug>/bundle.tar.zst
+/// bundle. Catalogue layout: `llvm-tools/<version>/<slug>/bundle.tar.zst`.
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/llvm-tools/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("llvm-tools", version, slug)
 }
 
 /// Ensure the LLVM-tools bundle is materialized for the given driver
 /// host. Returns the directory containing `bin/` + `lib/` + `include/`.
-///
-/// **Status (as of this PR):** catalogue ingest pending — see
-/// [`crate::fetch::python_sysroot::ensure_python_sysroot`] for the
-/// pattern.
 pub async fn ensure_llvm_tools_bundle(
     paths: &SoldrPaths,
     host_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = host_slug_for(host_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no llvm-tools bundle for host {host_triple}; \
@@ -81,12 +71,8 @@ pub async fn ensure_llvm_tools_bundle(
             LLVM_TOOLS_HOSTS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_LLVM_TOOLS_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "llvm-tools bundle for {host_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/997"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "llvm-tools", MANAGED_LLVM_TOOLS_VERSION, slug)
+        .await
 }
 
 #[cfg(test)]
@@ -101,7 +87,7 @@ mod tests {
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_LLVM_TOOLS_VERSION, "linux-x64");
         assert!(u.starts_with("https://media.githubusercontent.com/media/"));
-        assert!(u.contains("/deps/llvm-tools/18.1.8/linux-x64/"));
+        assert!(u.contains("/llvm-tools/18.1.8/linux-x64/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 

--- a/crates/soldr-cli/src/fetch/nodelib.rs
+++ b/crates/soldr-cli/src/fetch/nodelib.rs
@@ -7,7 +7,7 @@
 //! Node.js dist `headers.tar.gz` + the matching per-arch `node.lib`,
 //! and the soldr-toolchain ingest pipeline republishes them under
 //!
-//!     deps/nodelib/<node-version>/<slug>/bundle.tar.zst
+//!     nodelib/<node-version>/<slug>/bundle.tar.zst
 //!
 //! This module's `ensure_nodelib_sysroot` materializes the bundle and
 //! returns the directory containing `include/` + `lib/node.lib`. The
@@ -45,10 +45,7 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 }
 
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/nodelib/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("nodelib", version, slug)
 }
 
 pub fn resolve_node_version() -> String {
@@ -65,7 +62,6 @@ pub async fn ensure_nodelib_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no nodelib recipe for target {target_triple}; \
@@ -74,12 +70,7 @@ pub async fn ensure_nodelib_sysroot(
         ))
     })?;
     let version = resolve_node_version();
-    let url = asset_url_for(&version, slug);
-    Err(SoldrError::Other(format!(
-        "nodelib bundle for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/997"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "nodelib", &version, slug).await
 }
 
 #[cfg(test)]
@@ -100,7 +91,7 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_NODE_VERSION, "windows-x64");
-        assert!(u.contains("/deps/nodelib/22.10.0/windows-x64/"));
+        assert!(u.contains("/nodelib/22.10.0/windows-x64/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 

--- a/crates/soldr-cli/src/fetch/openssl_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/openssl_sysroot.rs
@@ -44,21 +44,17 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
         .map(|(_, slug)| *slug)
 }
 
-/// Construct the expected `assets`-branch URL.
-///
-///     deps/openssl/<version>/<slug>/bundle.tar.zst
+/// Construct the expected `assets`-branch URL via the shared
+/// `syslib_common` helper. Layout:
+/// `https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/openssl/<version>/<slug>/bundle.tar.zst`.
 pub fn asset_url_for(version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/openssl/{version}/{slug}/bundle.tar.zst"
-    )
+    super::syslib_common::asset_url_for("openssl", version, slug)
 }
 
 pub async fn ensure_openssl_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no openssl sysroot recipe for target {target_triple}; \
@@ -66,12 +62,8 @@ pub async fn ensure_openssl_sysroot(
             OPENSSL_TARGETS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
         ))
     })?;
-    let url = asset_url_for(MANAGED_OPENSSL_VERSION, slug);
-    Err(SoldrError::Other(format!(
-        "openssl sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/997"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "openssl", MANAGED_OPENSSL_VERSION, slug)
+        .await
 }
 
 #[cfg(test)]
@@ -92,7 +84,7 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_OPENSSL_VERSION, "windows-arm64");
-        assert!(u.contains("/deps/openssl/3.5.0/windows-arm64/"));
+        assert!(u.contains("/openssl/3.5.0/windows-arm64/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 }

--- a/crates/soldr-cli/src/fetch/python_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/python_sysroot.rs
@@ -83,16 +83,13 @@ pub fn catalogue_slug_for(triple: &str) -> Option<&'static str> {
 /// asset. The catalogue producer pipeline (forge-conan.yml → ingest)
 /// publishes under this layout:
 ///
-///     deps/python/<py-version>/<slug>/sysroot.tar.zst
+///     python/<py-version>/<slug>/bundle.tar.zst
 ///
 /// `media.githubusercontent.com/media/` is used (not `raw`) so LFS-
 /// tracked blobs follow their pointer files to the actual bytes —
 /// matching the apple-sdk fetcher's pattern.
 pub fn asset_url_for(py_version: &str, slug: &str) -> String {
-    format!(
-        "https://media.githubusercontent.com/media/zackees/soldr-toolchain/assets/\
-         deps/python/{py_version}/{slug}/sysroot.tar.zst"
-    )
+    super::syslib_common::asset_url_for("python", py_version, slug)
 }
 
 /// Resolve the Python version soldr should fetch. Precedence:
@@ -128,7 +125,6 @@ pub async fn ensure_python_sysroot(
     paths: &SoldrPaths,
     target_triple: &str,
 ) -> Result<PathBuf, SoldrError> {
-    let _ = paths;
     let slug = catalogue_slug_for(target_triple).ok_or_else(|| {
         SoldrError::UnsupportedPlatform(format!(
             "no python sysroot recipe for target {target_triple}; \
@@ -140,12 +136,7 @@ pub async fn ensure_python_sysroot(
         ))
     })?;
     let version = resolve_python_version();
-    let url = asset_url_for(&version, slug);
-    Err(SoldrError::Other(format!(
-        "python sysroot for {target_triple} ({slug}) not yet ingested into the \
-         soldr-toolchain catalogue. Expected URL: {url}\n\
-         Tracking: https://github.com/zackees/soldr/issues/997"
-    )))
+    super::syslib_common::ensure_syslib_bundle(paths, "python", &version, slug).await
 }
 
 #[cfg(test)]
@@ -171,8 +162,8 @@ mod tests {
         let u = asset_url_for("3.13.0", "windows-x64");
         assert!(u.starts_with("https://media.githubusercontent.com/media/"));
         assert!(u.contains("/zackees/soldr-toolchain/assets/"));
-        assert!(u.contains("/deps/python/3.13.0/windows-x64/"));
-        assert!(u.ends_with("/sysroot.tar.zst"));
+        assert!(u.contains("/python/3.13.0/windows-x64/"));
+        assert!(u.ends_with("/bundle.tar.zst"));
     });
 
     crate::timed_test!(catalogue_slug_for_known_triples, {


### PR DESCRIPTION
Phase 4 of soldr#1010 — replaces the four stubbed fetchers with real catalogue-backed downloads via the existing `syslib_common::ensure_syslib_bundle` helper.

Each module:
- `asset_url_for(version, slug)` now delegates to `syslib_common::asset_url_for(<tool>, version, slug)`, producing `<tool>/<version>/<slug>/bundle.tar.zst` (drops the obsolete `/deps/<tool>/` prefix the scaffolds had).
- `ensure_*` returns the materialized sysroot path via `syslib_common::ensure_syslib_bundle`. The helper handles HTTP fetch, sha256 verification against the catalogue, tar.zst extraction, and the `.complete` sentinel that makes re-invocations a stat call.

Python normalizes `sysroot.tar.zst` → `bundle.tar.zst` to match every other syslib + the `forge_to_catalogue.py` `DEFAULT_ASSET_NAME["python"]` entry that just landed in zackees/soldr-toolchain#38.

Until each tool's catalogue rows land via the ingest pipeline (the running forge dispatches + zackees/soldr-toolchain#40's batch ingest helper extension), `syslib_common::ensure_syslib_bundle` returns the existing `not yet ingested` error and `blessed_build::prepare` falls through to the crate's vendored compile — same graceful-degrade contract as before the refactor.

## Test plan

- [x] `cargo clippy -p soldr-cli --lib --tests -- -D warnings` under Docker rust:1.94 → clean.
- [x] `cargo check -p soldr-cli --lib` → clean.

Refs #1010 phase 4.