### PR TITLE
fix(test): raise watchdog fast-path timeout from 1ms to 500ms

### DIFF
--- a/crates/soldr-cli/src/test_util.rs
+++ b/crates/soldr-cli/src/test_util.rs
@@ -339,10 +339,19 @@ mod tests {
 
     #[test]
     fn watchdog_returns_for_very_short_timeout_when_body_is_instant() {
-        // 1ms timeout, instantaneous body. Verifies we don't false-fire
+        // 500ms timeout, instantaneous body. Verifies we don't false-fire
         // on legitimately quick work — the channel send/recv path must
         // beat the timer for noop bodies.
-        run_with_watchdog("instant_body", Duration::from_millis(1), || {});
+        //
+        // Was 1ms originally, but that races on shared GHA ubuntu-24.04
+        // runners under parallel test load: worker-thread spawn +
+        // channel setup + first `send` can easily take >1ms when the
+        // scheduler is busy, tripping the watchdog and calling
+        // std::process::abort() on a noop-body test which then bring
+        // the whole test binary down (signal 6 SIGABRT). 500ms still
+        // catches a real hang — the point of this test is "the fast
+        // path exists at all", not µs-precision.
+        run_with_watchdog("instant_body", Duration::from_millis(500), || {});
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

\`watchdog_returns_for_very_short_timeout_when_body_is_instant\` used \`Duration::from_millis(1)\` as its timeout for a noop body. Locally that beats the timer easily; on shared GHA ubuntu-24.04 runners under parallel test load it races — worker-thread spawn + channel setup + first \`send\` can exceed 1ms when the scheduler is busy, tripping the watchdog on an instant body and calling \`std::process::abort()\`, which brings the whole lib test binary down as SIGABRT (signal 6).

That was the pattern behind every \`Linux x64\` failure on main since the Lint gate started passing (df06536 onward). Bumping to 500ms preserves the "fast path exists" intent — the test still verifies send/recv can beat a short timer — while giving the scheduler headroom on noisy runners.

## Test plan

- [x] Local: \`soldr cargo test -p soldr-cli --lib watchdog_returns\` passes
- [x] Local: \`soldr cargo fmt --check\` clean
- [ ] CI on this PR + main to confirm the SIGABRT is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)