### PR TITLE
Use Cargo config for mimalloc syslib override

### DIFF
--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -57,6 +57,11 @@ pub struct BlessedPrep {
     /// `CXX_<t>`, `AR_<t>`, `CARGO_TARGET_<T>_LINKER` for MSVC
     /// targets.
     pub env: Vec<(String, String)>,
+    /// Extra cargo CLI args to inject into the `soldr build` cargo
+    /// invocation. Used for target-scoped Cargo config that has no
+    /// environment-variable equivalent, such as build-script overrides
+    /// for crates with `links = "..."`
+    pub cargo_args: Vec<String>,
 }
 
 /// Prepare the blessed sysroot for `target`. Returns `Ok(prep)` on
@@ -311,12 +316,14 @@ async fn inject_sys_library_overrides(
         Err(e) => log_sys_unavailable("sqlite", target_triple, &e),
     }
 
-    // libmimalloc-sys → MIMALLOC_OVERRIDE (NOT target-scoped by
-    // libmimalloc-sys upstream; leaving disabled — mimalloc's
-    // vendored compile is fast enough and works everywhere).
-    // Catalogue mimalloc sysroot fetcher kept for future use if
-    // upstream gains target-scoped env-var support.
-    let _ = crate::fetch::mimalloc_sysroot::catalogue_slug_for(target_triple);
+    // libmimalloc-sys has `links = "mimalloc"` but no target-scoped
+    // env hook. Use Cargo's build-script override config instead;
+    // that skips libmimalloc-sys/build.rs entirely and supplies the
+    // link metadata directly.
+    match crate::fetch::mimalloc_sysroot::ensure_mimalloc_sysroot(paths, target_triple).await {
+        Ok(sysroot) => add_mimalloc_build_script_override(prep, target_triple, &sysroot),
+        Err(e) => log_sys_unavailable("mimalloc", target_triple, &e),
+    }
 
     // libz-ng-sys → PKG_CONFIG_PATH_<triple>
     match crate::fetch::zlib_ng_sysroot::ensure_zlib_ng_sysroot(paths, target_triple).await {
@@ -355,6 +362,47 @@ fn prepend_pkg_config_path_for_target(
     } else {
         prep.env.push((var_name, new_entry));
     }
+}
+
+fn add_mimalloc_build_script_override(
+    prep: &mut BlessedPrep,
+    target_triple: &str,
+    sysroot: &std::path::Path,
+) {
+    let table = format!("target.{target_triple}.mimalloc");
+    let lib_dir = sysroot.join("lib");
+    let include_dir = sysroot.join("include");
+    prep.cargo_args.extend([
+        "--config".to_string(),
+        format!("{table}.rustc-link-lib=[\"static=mimalloc\"]"),
+        "--config".to_string(),
+        format!(
+            "{table}.rustc-link-search=[{}]",
+            toml_string(&lib_dir.to_string_lossy())
+        ),
+        "--config".to_string(),
+        format!(
+            "{table}.metadata_include_dir={}",
+            toml_string(&include_dir.to_string_lossy())
+        ),
+    ]);
+}
+
+fn toml_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 fn log_sys_unavailable(lib_name: &str, target_triple: &str, err: &SoldrError) {
@@ -577,6 +625,29 @@ mod tests {
         assert!(prep.xwin_cache_dir.is_none());
         assert!(prep.sdkroot.is_none());
         assert!(prep.env.is_empty());
+        assert!(prep.cargo_args.is_empty());
+    });
+
+    crate::timed_test!(mimalloc_build_script_override_uses_target_config, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let sysroot = tmp.path().join("mimalloc sysroot");
+        let mut prep = BlessedPrep::default();
+
+        add_mimalloc_build_script_override(&mut prep, "x86_64-unknown-linux-gnu", &sysroot);
+
+        assert_eq!(prep.cargo_args.len(), 6);
+        assert_eq!(prep.cargo_args[0], "--config");
+        assert_eq!(
+            prep.cargo_args[1],
+            "target.x86_64-unknown-linux-gnu.mimalloc.rustc-link-lib=[\"static=mimalloc\"]"
+        );
+        assert_eq!(prep.cargo_args[2], "--config");
+        assert!(prep.cargo_args[3]
+            .starts_with("target.x86_64-unknown-linux-gnu.mimalloc.rustc-link-search=[\""));
+        assert!(prep.cargo_args[3].contains("mimalloc sysroot"));
+        assert_eq!(prep.cargo_args[4], "--config");
+        assert!(prep.cargo_args[5]
+            .starts_with("target.x86_64-unknown-linux-gnu.mimalloc.metadata_include_dir=\""));
     });
 
     crate::timed_test!(xwin_cflags_emits_imsvc_for_present_dirs, {

--- a/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
+++ b/crates/soldr-cli/src/fetch/mimalloc_sysroot.rs
@@ -9,18 +9,25 @@
 //! ```
 //!
 //! When `libmimalloc-sys` is in the transitive deps and the catalogue
-//! row is ingested, the blessed path exports:
+//! row is ingested, the blessed path injects Cargo build-script
+//! override config for `links = "mimalloc"`:
 //!
-//!   * `MIMALLOC_OVERRIDE=<sysroot>/lib/libmimalloc.a`
+//!   * `target.<triple>.mimalloc.rustc-link-lib=["static=mimalloc"]`
+//!   * `target.<triple>.mimalloc.rustc-link-search=["<sysroot>/lib"]`
+//!   * `target.<triple>.mimalloc.metadata_include_dir="<sysroot>/include"`
 //!
-//! `libmimalloc-sys`' build.rs (v0.1.49+) honors `MIMALLOC_OVERRIDE`
-//! and skips its cmake compile entirely.
+//! That target-scoped Cargo config skips `libmimalloc-sys`' build.rs
+//! entirely. This is deliberately not an environment variable:
+//! `libmimalloc-sys` v0.1.49 has no `MIMALLOC_OVERRIDE` hook.
 
 use std::path::PathBuf;
 
 use crate::core::{SoldrError, SoldrPaths};
 
-pub const MANAGED_MIMALLOC_VERSION: &str = "3.0.4";
+/// Pinned mimalloc version vendored by `libmimalloc-sys` 0.1.49.
+/// `c_src/mimalloc/v3/include/mimalloc.h` reports MI_MALLOC_VERSION
+/// 30302, i.e. upstream mimalloc 3.3.2.
+pub const MANAGED_MIMALLOC_VERSION: &str = "3.3.2";
 
 pub const MIMALLOC_TARGETS: &[(&str, &str)] = &[
     ("x86_64-pc-windows-msvc", "windows-x64"),
@@ -77,17 +84,12 @@ mod tests {
 
     crate::timed_test!(asset_url_layout_matches_catalogue, {
         let u = asset_url_for(MANAGED_MIMALLOC_VERSION, "windows-x64");
-        assert!(u.contains("/mimalloc/3.0.4/windows-x64/"));
+        assert!(u.contains("/mimalloc/3.3.2/windows-x64/"));
         assert!(u.ends_with("/bundle.tar.zst"));
     });
 
-    crate::timed_test!(ensure_mimalloc_sysroot_returns_not_yet_ingested, {
-        let tmp = tempfile::tempdir().expect("tmpdir");
-        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
-        let result = tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(ensure_mimalloc_sysroot(&paths, "aarch64-apple-darwin"));
-        let err = result.expect_err("must error until catalogue row lands");
-        assert!(err.to_string().contains("not yet ingested"));
-    });
+    // No live "not yet ingested" assertion here: mimalloc rows are
+    // expected to appear in the catalogue as part of soldr#1064.
+    // Once they do, ensure_mimalloc_sysroot returns a real sysroot or a
+    // network error, neither of which is a stable unit-test signal.
 }

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -306,6 +306,7 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             if let Some(target_triple) = extract_target_from_args(&full_args) {
                 let paths = crate::core::SoldrPaths::new()?;
                 let prep = crate::blessed_build::prepare(&paths, &target_triple).await?;
+                let cargo_args = prep.cargo_args.clone();
                 // Apply prep env onto the current process env so the
                 // child cargo invocation (and its sub-rustc + build
                 // scripts) inherit them.
@@ -328,6 +329,7 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 if let Some(subcmd) = pick_cross_subcommand(&target_triple) {
                     full_args = rewrite_build_args_for_subcommand(full_args, subcmd);
                 }
+                full_args = insert_cargo_config_args(full_args, &cargo_args);
             }
 
             // soldr#1079: ensure native Windows MSVC builds get LIB /
@@ -1151,6 +1153,24 @@ fn rewrite_build_args_for_subcommand(mut args: Vec<String>, subcmd: &str) -> Vec
         }
         _ => args,
     }
+}
+
+fn insert_cargo_config_args(mut args: Vec<String>, cargo_config_args: &[String]) -> Vec<String> {
+    if cargo_config_args.is_empty() {
+        return args;
+    }
+
+    let insert_at = if args.first().is_some_and(|arg| arg == "xwin")
+        && args.get(1).is_some_and(|arg| arg == "build")
+    {
+        2
+    } else if args.is_empty() {
+        0
+    } else {
+        1
+    };
+    args.splice(insert_at..insert_at, cargo_config_args.iter().cloned());
+    args
 }
 
 /// soldr#1079 — bridge between the cargo dispatcher and the MSVC

--- a/crates/soldr-cli/src/main_tests.rs
+++ b/crates/soldr-cli/src/main_tests.rs
@@ -769,3 +769,68 @@ fn rewrite_build_args_unknown_subcmd_is_noop() {
     let out = rewrite_build_args_for_subcommand(args.clone(), "gibberish");
     assert_eq!(out, args);
 }
+
+#[test]
+fn insert_cargo_config_args_after_plain_build_verb() {
+    let args = vec![
+        "build".to_string(),
+        "--target".to_string(),
+        "x86_64-unknown-linux-gnu".to_string(),
+    ];
+    let config = vec!["--config".to_string(), "target.x.foo.bar=1".to_string()];
+    let out = insert_cargo_config_args(args, &config);
+    assert_eq!(
+        out,
+        vec![
+            "build",
+            "--config",
+            "target.x.foo.bar=1",
+            "--target",
+            "x86_64-unknown-linux-gnu",
+        ]
+    );
+}
+
+#[test]
+fn insert_cargo_config_args_after_zigbuild_verb() {
+    let args = vec![
+        "zigbuild".to_string(),
+        "--target".to_string(),
+        "x86_64-unknown-linux-musl".to_string(),
+    ];
+    let config = vec!["--config".to_string(), "target.x.foo.bar=1".to_string()];
+    let out = insert_cargo_config_args(args, &config);
+    assert_eq!(
+        out,
+        vec![
+            "zigbuild",
+            "--config",
+            "target.x.foo.bar=1",
+            "--target",
+            "x86_64-unknown-linux-musl",
+        ]
+    );
+}
+
+#[test]
+fn insert_cargo_config_args_after_xwin_build_pair() {
+    let args = vec![
+        "xwin".to_string(),
+        "build".to_string(),
+        "--target".to_string(),
+        "x86_64-pc-windows-msvc".to_string(),
+    ];
+    let config = vec!["--config".to_string(), "target.x.foo.bar=1".to_string()];
+    let out = insert_cargo_config_args(args, &config);
+    assert_eq!(
+        out,
+        vec![
+            "xwin",
+            "build",
+            "--config",
+            "target.x.foo.bar=1",
+            "--target",
+            "x86_64-pc-windows-msvc",
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- activate mimalloc syslib consumption via Cargo's `links = mimalloc` build-script override config
- pass generated `--config` args through `soldr build` for plain cargo, cargo-zigbuild, and cargo-xwin forms
- pin the mimalloc fetcher to libmimalloc-sys 0.1.49's vendored upstream version, 3.3.2

## Verification
- `cargo check -p soldr-cli --bins --tests` with rustup-managed 1.94.1 MSVC toolchain
- `cargo test -p soldr-cli --bin soldr mimalloc_build_script_override_uses_target_config`
- `cargo test -p soldr-cli --bin soldr insert_cargo_config_args`
- `cargo test -p soldr-cli --bin soldr mimalloc_sysroot`
- temp-crate smoke: Cargo config override checked `libmimalloc-sys` without running build.rs

Depends on zackees/soldr-toolchain#41.
Refs #1064.