### PR TITLE
fix(test): scrub outer env in integration tests via isolated_soldr_command

### DIFF
--- a/crates/soldr-cli/tests/cli_cache.rs
+++ b/crates/soldr-cli/tests/cli_cache.rs
@@ -22,7 +22,7 @@ fn status_reports_cache_control_defaults() {
     // a stale host pin would otherwise leak into the test as a fetched
     // binary and break the "not fetched yet" assertion below.
     let home_root = unique_temp_dir("status-home");
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .arg("status")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -62,7 +62,7 @@ fn status_json_reports_stable_machine_fields() {
     // discovery so the developer's host-side pin (issue #426) can't leak
     // into the test as a "binary already fetched" signal.
     let home_root = unique_temp_dir("status-json-home");
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["status", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &home_root)
@@ -153,7 +153,7 @@ fn cache_command_reports_managed_zccache_status() {
     )
     .expect("failed to seed session stats");
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .arg("cache")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -223,7 +223,7 @@ fn cache_json_reports_managed_zccache_status() {
     )
     .expect("failed to seed session stats");
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cache", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -271,7 +271,7 @@ fn cache_json_reports_managed_zccache_status() {
 fn cache_report_json_emits_stable_schema_when_files_missing() {
     let cache_root = unique_temp_dir("cache-report-empty");
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cache", "report", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -322,7 +322,7 @@ fn cache_report_json_surfaces_persisted_session_stats() {
     )
     .expect("failed to seed session stats");
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cache", "report", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -367,7 +367,7 @@ fn cache_report_json_passes_through_unknown_session_stat_fields() {
     )
     .expect("failed to seed session stats");
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cache", "report", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -405,7 +405,7 @@ fn clean_clears_managed_zccache_and_state_dir() {
         .expect("failed to create journal dir");
     fs::write(&journal, "{\"event\":\"hit\"}\n").expect("failed to seed journal");
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .arg("clean")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("HOME", &user_home)
@@ -457,7 +457,7 @@ fn purge_removes_soldr_artifact_dirs_and_keeps_config() {
         .expect("failed to seed zccache state");
     fs::write(&config_file, "cache = true\n").expect("failed to seed config");
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .arg("purge")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -497,7 +497,7 @@ fn purge_reports_empty_cache_without_creating_dirs() {
     let bin_dir = cache_root.join("bin");
     let cache_dir = cache_root.join("cache");
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .arg("purge")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -530,7 +530,7 @@ fn purge_removes_corrupt_artifact_paths() {
     fs::write(&bin_path, "not a dir").expect("failed to seed corrupt bin path");
     fs::write(&cache_path, "not a dir").expect("failed to seed corrupt cache path");
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .arg("purge")
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -561,7 +561,7 @@ fn purge_removes_corrupt_artifact_paths() {
 
 #[test]
 fn purge_rejects_json_flag() {
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["purge", "--json"])
         .output()
         .expect("failed to run soldr purge --json");
@@ -580,7 +580,7 @@ fn purge_rejects_json_flag() {
 
 #[test]
 fn clean_rejects_json_flag() {
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["clean", "--json"])
         .output()
         .expect("failed to run soldr clean --json");
@@ -606,7 +606,7 @@ fn cache_flush_emits_zccache_stats_on_success() {
     let log_path = cache_root.join("tool.log");
     let (_, _, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cache", "flush", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -644,7 +644,7 @@ fn cache_flush_handles_unsupported_zccache_gracefully() {
     let log_path = cache_root.join("tool.log");
     let (_, _, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cache", "flush", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -681,7 +681,7 @@ fn cache_flush_falls_back_when_json_flag_is_unsupported() {
     let log_path = cache_root.join("tool.log");
     let (_, _, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cache", "flush", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -726,7 +726,7 @@ fn cache_shutdown_waits_for_daemon_to_exit() {
     // Sanity: the marker must not exist before stop runs.
     assert!(!down_marker.exists());
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cache", "shutdown", "--json"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_ZCCACHE_BIN", &zccache)
@@ -775,7 +775,7 @@ fn cache_shutdown_times_out_when_daemon_does_not_exit() {
     // Deliberately omit SOLDR_TEST_ZCCACHE_DAEMON_DOWN_MARKER, so the
     // fake `status` always reports the daemon as up. The shutdown
     // poll then has to give up after the deadline.
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args([
             "cache",
             "shutdown",
@@ -812,7 +812,7 @@ fn cache_shutdown_no_wait_skips_polling() {
 
     // Daemon never goes down — without the poll this would hang.
     let start = std::time::Instant::now();
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args([
             "cache",
             "shutdown",

--- a/crates/soldr-cli/tests/cli_cargo_basic.rs
+++ b/crates/soldr-cli/tests/cli_cargo_basic.rs
@@ -15,7 +15,7 @@ use std::{
 #[test]
 fn cargo_front_door_runs_real_cargo() {
     let cache_root = unique_temp_dir("cargo-version");
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["--no-cache", "cargo", "--version"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -38,7 +38,7 @@ fn cargo_front_door_runs_real_cargo() {
 #[test]
 fn cargo_front_door_consumes_no_cache_flag() {
     let cache_root = unique_temp_dir("cargo-no-cache");
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["--no-cache", "cargo", "--version"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -69,7 +69,7 @@ fn cargo_build_warns_when_disk_space_is_low() {
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["--no-cache", "cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -105,7 +105,7 @@ fn cargo_build_ignores_disk_space_detection_failures() {
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["--no-cache", "cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -134,7 +134,7 @@ fn cargo_build_ignores_disk_space_detection_failures() {
 #[test]
 fn cargo_subcommand_rejects_no_cache_flag() {
     let cache_root = unique_temp_dir("cargo-subcommand-no-cache");
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "--no-cache", "--version"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .output()
@@ -169,7 +169,7 @@ fn cargo_front_door_uses_soldr_wrapper_and_managed_zccache_by_default() {
     // shells out to the fake cargo for `cargo metadata`, gets back `{}`,
     // and fails with "missing field `packages`". Every fake-toolchain
     // test below clears these the same way for the same reason.
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -273,7 +273,7 @@ fn cargo_front_door_recovers_when_session_start_loses_daemon() {
     let log_path = cache_root.join("tool.log");
     let lost_marker = cache_root.join("session-start-lost");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -323,7 +323,7 @@ fn command_lifetime_cache_stops_zccache_after_successful_cargo() {
     let log_path = cache_root.join("tool.log");
     let down_marker = cache_root.join("zccache-down");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_CACHE_LIFECYCLE", "command")
@@ -370,7 +370,7 @@ fn command_lifetime_cache_stops_zccache_after_failing_cargo() {
     write_fake_script(&rustc, &fake_rustc_script(&log_path));
     write_fake_script(&zccache, &fake_zccache_script(&log_path));
 
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_CACHE_LIFECYCLE", "command")
@@ -479,7 +479,7 @@ fn cargo_front_door_defaults_dev_debug_off_and_warns_once_per_repo() {
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
     let cargo_home = cache_root.join("cargo-home");
 
-    let first = Command::new(common::soldr_bin())
+    let first = common::isolated_soldr_command()
         .args(["cargo", "build"])
         .current_dir(&repo)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -500,7 +500,7 @@ fn cargo_front_door_defaults_dev_debug_off_and_warns_once_per_repo() {
         String::from_utf8_lossy(&first.stderr)
     );
 
-    let second = Command::new(common::soldr_bin())
+    let second = common::isolated_soldr_command()
         .args(["cargo", "build"])
         .current_dir(&repo)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -558,7 +558,7 @@ fn cargo_front_door_respects_dev_debug_in_cargo_config_toml() {
 
     let log_path = cache_root.join("tool.log");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "build"])
         .current_dir(&repo)
         .env("SOLDR_CACHE_DIR", &cache_root)

--- a/crates/soldr-cli/tests/cli_rust_plan.rs
+++ b/crates/soldr-cli/tests/cli_rust_plan.rs
@@ -70,7 +70,7 @@ fn cargo_front_door_invokes_zccache_rust_plan_when_target_cache_enabled() {
         .expect("write metadata fixture");
 
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "build", "--locked"])
         .current_dir(&workspace)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -174,7 +174,7 @@ fn cargo_front_door_warns_when_rust_plan_restore_is_partial() {
         .expect("write metadata fixture");
 
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "build", "--locked"])
         .current_dir(&workspace)
         .env("SOLDR_CACHE_DIR", &cache_root)
@@ -217,7 +217,7 @@ fn cargo_front_door_recovers_from_stale_zccache_daemon_start() {
     let log_path = cache_root.join("tool.log");
     let stale_marker = cache_root.join("stale-zccache-start");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("SOLDR_TEST_CARGO_BIN", &cargo)
@@ -265,7 +265,7 @@ fn cargo_front_door_removes_stale_zccache_daemon_lock_before_retry() {
     let log_path = cache_root.join("tool.log");
     let stale_marker = cache_root.join("stale-zccache-lock");
     let (cargo, rustc, zccache) = install_fake_toolchain(&log_path);
-    let output = Command::new(common::soldr_bin())
+    let output = common::isolated_soldr_command()
         .args(["cargo", "build"])
         .env("SOLDR_CACHE_DIR", &cache_root)
         .env("ZCCACHE_CACHE_DIR", &zccache_session_dir)


### PR DESCRIPTION
Bulk-migrate direct `Command::new(common::soldr_bin())` calls in 5 integration test files to use `common::isolated_soldr_command()`, which scrubs RUSTC_WRAPPER + ZCCACHE_PATH_REMAP + ZCCACHE_WORKTREE_ROOT + CARGO_TARGET_* + RUSTFLAGS from the spawned soldr's env.

Root cause of the whack-a-mole failure pattern: setup-soldr exports these env vars in every CI job. Tests using the direct Command::new pattern inherited them and the child soldr took its "user already set the wrapper" branch, skipping the zccache-wrapper injection the assertions expect. isolated_soldr_command has been the right pattern all along; some tests just didn't use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)