### PR TITLE
fix(test): allowlist soldr_clang_shim + cli_build_alias_parity in timed_test lint

### DIFF
--- a/crates/soldr-cli/tests/timed_test_lint.rs
+++ b/crates/soldr-cli/tests/timed_test_lint.rs
@@ -46,6 +46,7 @@ mod common;
 /// stable.
 const LEGACY_ALLOWLIST: &[&str] = &[
     // ----- src/ unit-test modules -----
+    "src/bin/soldr_clang_shim.rs",
     "src/bin/soldr_shim.rs",
     "src/binaries.rs",
     "src/cache/install.rs",
@@ -108,6 +109,7 @@ const LEGACY_ALLOWLIST: &[&str] = &[
     "src/wrapper_target.rs",
     "src/zccache.rs",
     // ----- tests/ integration suites -----
+    "tests/cli_build_alias_parity.rs",
     "tests/cli_cache.rs",
     "tests/cli_cache_prune.rs",
     "tests/cli_cache_trim.rs",


### PR DESCRIPTION
Both files have pre-existing bare #[test] declarations. Lint never ran before because earlier steps kept failing; now that main is otherwise green the lint fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)