### PR TITLE
fix(release): reject stub-wheel releases (soldr#1140)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -1134,19 +1134,84 @@ jobs:
                   raise SystemExit(
                       f"`{script_entry}` in {wheels[0].name} is empty"
                   )
+              # soldr#1140: v0.7.87 shipped 118 KB stubs on
+              # win_amd64 + Linux gnu lanes. Both wheels had every
+              # `.data/scripts/*` entry at ~118 KB / ~332 KB — real
+              # release binaries are 4+ MB. Enforce a floor so the
+              # stub bug can never ship again. On macOS lanes, maturin
+              # uses delocate-style repair: the `.data/scripts/*`
+              # entries are ~450-byte Python launcher stubs that exec
+              # the real binaries under `soldr.scripts/`. We validate
+              # both possible locations and require ONE of them ships
+              # a payload larger than the floor.
+              #
+              # Floor derived from win_arm64 (a known-good release):
+              #   soldr.exe          15074816  ← main CLI
+              #   soldr-daemon.exe    4700672
+              #   soldr-clang-shim    226304
+              #   soldr-shim          226304
+              #   zccache-soldr       945664
+              # Pick 2 MB as the floor for the primary bin (soldr /
+              # soldr.exe). Anything below that means the actual
+              # crate code did not get compiled in.
+              MIN_PRIMARY_BIN_BYTES = 2 * 1024 * 1024
+              soldr_scripts_entry = f"soldr.scripts/{binary_name}"
+              candidates = [
+                  (script_entry, info.file_size),
+              ]
+              if soldr_scripts_entry in names:
+                  candidates.append(
+                      (soldr_scripts_entry, wheel.getinfo(soldr_scripts_entry).file_size)
+                  )
+              largest = max(sz for _, sz in candidates)
+              if largest < MIN_PRIMARY_BIN_BYTES:
+                  layout = "\n".join(
+                      f"  {p}: {sz} bytes" for p, sz in candidates
+                  )
+                  raise SystemExit(
+                      f"wheel ships {binary_name!r} at {largest} bytes across "
+                      f"{len(candidates)} candidate path(s):\n{layout}\n"
+                      f"expected ≥ {MIN_PRIMARY_BIN_BYTES} bytes (2 MiB) — a "
+                      f"real soldr binary compiled from crates/soldr-cli is "
+                      f"~15 MB. Anything below this floor means the crate's "
+                      f"main.rs did not get compiled into the shipped bin "
+                      f"(soldr#1140 — v0.7.87 stub regression). Do NOT ship "
+                      f"this wheel; investigate the maturin cargo invocation."
+                  )
+              # Dump all script entries so post-mortems can see per-bin sizes
+              # even when the assertion above passes.
+              print("=== wheel scripts/ layout ===")
+              for n in sorted(names):
+                  if ".data/scripts/" in n or n.startswith("soldr.scripts/"):
+                      print(f"  {wheel.getinfo(n).file_size:>10}  {n}")
 
           print(
               f"{wheels[0].name} ships {binary_name} at `{script_entry}` "
-              f"({info.file_size} bytes)"
+              f"({info.file_size} bytes); primary-bin payload ≥ "
+              f"{MIN_PRIMARY_BIN_BYTES} bytes OK"
           )
 
       - name: Smoke test wheel
         if: ${{ !contains(matrix.target, 'musl') }}
         shell: bash
         run: |
+          set -euo pipefail
           uv venv .venv
           uv pip install --python .venv dist/*.whl
-          .venv/bin/soldr --version || .venv/Scripts/soldr.exe --version
+          # soldr#1140: previously this step only checked exit code. A
+          # stub bin that silently exits 0 (as v0.7.87 shipped on
+          # win_amd64) trivially passed. Capture stdout and require it
+          # to start with "soldr " so a stub can never sneak through.
+          if [ -x .venv/bin/soldr ]; then
+              out="$(.venv/bin/soldr --version)"
+          else
+              out="$(.venv/Scripts/soldr.exe --version)"
+          fi
+          printf 'wheel smoke test — soldr --version output: %s\n' "$out"
+          case "$out" in
+              "soldr "*) ;;
+              *) echo "ERROR: 'soldr --version' output did not start with 'soldr ' — likely shipping a stub binary (soldr#1140)." >&2; exit 1 ;;
+          esac
 
       - name: Smoke test standalone musl binary
         # The wheel smoke test above is unreachable for musl rows (the


### PR DESCRIPTION
Closes #1140.

## Context

`v0.7.87` shipped 118 KB stub binaries in the `win_amd64`, `manylinux_x86_64`, and `manylinux_aarch64` PyPI wheels. Every `pip install soldr` on those platforms produces a `soldr` binary that silently exits 0 for every invocation — including `soldr --version`, `soldr cargo build`, `soldr cargo test`. Downstream tooling (fbuild, CI-driven build wrappers) that enforce `soldr cargo …` end up doing nothing while reporting success.

The `win_arm64` and `macosx_11_0_arm64` wheels shipped **correct** binaries in the same release (soldr.exe = 15 MB, mac soldr = 12.5 MB). So the stub bug is per-runner, not per-source.

Full evidence in #1140 — including hashes, wheel structure comparisons, and disassembly showing the stub binaries have zero soldr code strings.

## Why root cause is not fixed here

The CI `Check` steps that were **supposed** to catch this before publish had two independent gaps:

1. `Verify wheel ships the bin script at the spec path` — asserted only `file_size != 0`. A 118 KB stub trivially passed.
2. `Smoke test wheel` — ran `soldr --version` but only checked exit code. A stub that exits 0 with no output silently passed.

The maturin `cargo rustc --bin soldr` invocation is doing something wrong on those runners (returning cached-empty artifacts? broken RUSTC_WRAPPER? host-toolchain interaction?), but I can't reproduce it locally — my Windows box hits an unrelated MSVC library setup issue during the soldr build. **What we CAN do immediately is guarantee the next occurrence of the stub bug fails CI cleanly with a clear diagnostic instead of shipping to PyPI.**

## What this PR changes

`.github/workflows/release-auto.yml`:

### `Verify wheel ships the bin script` — new 2 MiB floor + macOS fallback

- Assert the primary bin (`soldr` / `soldr.exe`) is ≥ 2 MiB. Derived from `win_arm64`'s known-good release where `soldr.exe = 15 MB`. Anything below 2 MiB is definitively a stub — a real Rust binary compiled from `crates/soldr-cli/src/main.rs` cannot be that small.
- Handle the macOS `--auditwheel repair` layout: on darwin, maturin's delocate moves real binaries to `soldr.scripts/<binary>` and leaves ~450-byte Python launcher stubs in `.data/scripts/`. Check both locations; the larger of the two wins.
- Dump per-bin sizes for every `.data/scripts/` + `soldr.scripts/` entry as diagnostic output so post-mortems can see the full wheel layout without re-downloading.

### `Smoke test wheel` — capture output, require `soldr ` prefix

- Capture stdout of `soldr --version` into a variable.
- `case "$out" in "soldr "*) ;; *) exit 1 ;; esac` — a stub can't fake this.
- Cross-platform-safe the venv path probe with `-x` (was `.venv/bin/soldr || .venv/Scripts/soldr.exe`; the `||` masked the real error on Windows when the linux path errored first).
- Add `set -euo pipefail`.

## Local verification

Fed the actual v0.7.87 wheels (both stub + good) through the new logic:

```
✓  soldr-0.7.87-py3-none-win_amd64.whl        want=FAIL  got=FAIL  (118272 bytes — rejected)
✓  soldr-0.7.87-py3-none-win_arm64.whl        want=PASS  got=PASS  (15074816 bytes — accepted)
✓  soldr-0.7.87-py3-none-macosx_11_0_arm64.whl want=PASS got=PASS  (soldr.scripts/soldr 12.5 MB — accepted)
✓  soldr-0.7.87-py3-none-manylinux_...x86_64.whl want=FAIL got=FAIL (332704 bytes — rejected)
```

## Follow-up

Someone with access to the win_amd64 + linux gnu release runners needs to investigate WHY `cargo rustc --bin soldr` is producing 118 KB stubs on those specific runners while win_arm64 and macos produce real binaries from the same source tree. Likely suspects:

- setup-soldr's `zccache-seed-strict: true` returning cached-empty artifacts on those platforms
- `RUSTC_WRAPPER` set to a broken value on those runners specifically
- Host toolchain interference (rustup default-host vs `--target` mismatch)

This PR ensures the investigation happens on a red CI signal, not on an incident report from downstream consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)