### PR TITLE
fix(ci): perf-matrix — checkout submodules recursively (closes #1142)

### DIFF
--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -227,6 +227,8 @@ jobs:
       - name: Checkout
         if: steps.gate.outputs.selected == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
 
       - name: Install Rust toolchain
         if: steps.gate.outputs.selected == 'true'
@@ -330,6 +332,8 @@ jobs:
       - name: Checkout
         if: steps.gate.outputs.selected == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
 
       - name: Install Rust toolchain
         if: steps.gate.outputs.selected == 'true'


### PR DESCRIPTION
See #1142 for the failure trace. Every Perf Matrix run on main has been red at build-soldr(linux) since the zccache path-dep landed; both checkout steps in the workflow were missing `with: submodules: recursive`. One-line addition to each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)