### PR TITLE
perf(scenarios): use --no-wait on end-of-scenario shutdowns (closes #1150)

### DIFF
--- a/perf/scenarios/build-then-check/run.sh
+++ b/perf/scenarios/build-then-check/run.sh
@@ -92,7 +92,7 @@ warm_misses="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" mi
 warm_hit_rate="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hit_rate)"
 
 SOLDR_CACHE_DIR="${CACHE}" soldr cache shutdown \
-    --shutdown-timeout-seconds 5 --json >"${WORKDIR}/build-then-check-shutdown.json" || true
+    --no-wait --json >"${WORKDIR}/build-then-check-shutdown.json" || true
 
 cache_bytes="$(measure::cache_bytes "${CACHE}")"
 

--- a/perf/scenarios/cold-tar-untar-warm/run.sh
+++ b/perf/scenarios/cold-tar-untar-warm/run.sh
@@ -122,7 +122,7 @@ warm_hit_rate="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" 
 warm_stats_source="cache-report"
 
 SOLDR_CACHE_DIR="${CACHE_WARM}" soldr cache shutdown \
-    --shutdown-timeout-seconds 5 --json >"${WORKDIR}/warm-shutdown.json" || true
+    --no-wait --json >"${WORKDIR}/warm-shutdown.json" || true
 
 warm_cache_bytes="$(measure::cache_bytes "${CACHE_WARM}")"
 

--- a/perf/scenarios/touch-no-change/run.sh
+++ b/perf/scenarios/touch-no-change/run.sh
@@ -70,7 +70,7 @@ warm_misses="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" mi
 warm_hit_rate="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hit_rate)"
 
 SOLDR_CACHE_DIR="${CACHE}" soldr cache shutdown \
-    --shutdown-timeout-seconds 5 --json >"${WORKDIR}/touch-shutdown.json" || true
+    --no-wait --json >"${WORKDIR}/touch-shutdown.json" || true
 
 cache_bytes="$(measure::cache_bytes "${CACHE}")"
 

--- a/perf/scenarios/worktree-share/run.sh
+++ b/perf/scenarios/worktree-share/run.sh
@@ -75,7 +75,7 @@ b_misses="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" misse
 b_hit_rate="$(measure::cache_report_stat "${WORKDIR}/warm-cache-report.json" hit_rate)"
 
 SOLDR_CACHE_DIR="${CACHE}" soldr cache shutdown \
-    --shutdown-timeout-seconds 5 --json >"${WORKDIR}/worktree-shutdown.json" || true
+    --no-wait --json >"${WORKDIR}/worktree-shutdown.json" || true
 
 cache_after_b_bytes="$(measure::cache_bytes "${CACHE}")"
 


### PR DESCRIPTION
See #1150. Switches four end-of-scenario `soldr cache shutdown` calls to `--no-wait` so we don't stall 5s waiting on a daemon that will never gracefully exit within that window. The mid-scenario shutdown in cold-tar-untar-warm (which feeds `soldr save` on the next line) still waits with `--shutdown-timeout-seconds 5`. Saves ~40 s / Perf Matrix run.

Closes #1150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)