### PR TITLE
perf(scenarios): cold-tar-untar-warm mid-scenario shutdown --no-wait (closes #1152)

### DIFF
--- a/perf/scenarios/cold-tar-untar-warm/run.sh
+++ b/perf/scenarios/cold-tar-untar-warm/run.sh
@@ -54,7 +54,7 @@ measure::write_cache_report "${CACHE_COLD}" "${WORKDIR}/cold-cache-report.json"
 # Flush + shutdown so the depgraph snapshot is durable before tar.
 SOLDR_CACHE_DIR="${CACHE_COLD}" soldr cache flush --json >/dev/null 2>&1 || true
 SOLDR_CACHE_DIR="${CACHE_COLD}" soldr cache shutdown \
-    --shutdown-timeout-seconds 5 --json >"${WORKDIR}/cold-shutdown.json" || true
+    --no-wait --json >"${WORKDIR}/cold-shutdown.json" || true
 
 # Copy zccache's per-session logs out of the cache tree (daemon is
 # now gone) so the upload-artifact glob picks them up.


### PR DESCRIPTION
See #1152. The explicit `soldr cache flush` on line 55 already writes depgraph + journal to disk before the shutdown; shutdown's remaining work doesn't change the on-disk state that `soldr save` reads next. Waiting is defensive but redundant. Saves ~10 s / Perf Matrix run.

Closes #1152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)