### PR TITLE
perf(scenarios): drop redundant flush in worktree-share + touch-no-change (closes #1156)

### DIFF
--- a/perf/scenarios/touch-no-change/run.sh
+++ b/perf/scenarios/touch-no-change/run.sh
@@ -39,7 +39,10 @@ cold_start_ms="$(measure::now_ms)"
 )
 cold_elapsed_ms="$(measure::elapsed_ms "${cold_start_ms}")"
 
-SOLDR_CACHE_DIR="${CACHE}" soldr cache flush --json >/dev/null 2>&1 || true
+# No `soldr cache flush` between cold and warm — the daemon stays
+# alive for the very next `soldr cargo build --release` in the same
+# session, so its in-memory depgraph serves the hits directly.
+# See soldr#1156 (and the equivalent #1154 fix for build-then-check).
 
 # --- Touch every source file without changing content --------------
 

--- a/perf/scenarios/worktree-share/run.sh
+++ b/perf/scenarios/worktree-share/run.sh
@@ -53,7 +53,11 @@ a_start_ms="$(measure::now_ms)"
 )
 a_elapsed_ms="$(measure::elapsed_ms "${a_start_ms}")"
 
-SOLDR_CACHE_DIR="${CACHE}" soldr cache flush --json >/dev/null 2>&1 || true
+# No `soldr cache flush` between A and B — the daemon stays alive for
+# the very next `soldr cargo build` in WORKTREE_B (same SOLDR_CACHE_DIR),
+# so its in-memory depgraph serves the hits directly. On-disk
+# durability is not required for the next command in the same session.
+# See soldr#1156 (and the equivalent #1154 fix for build-then-check).
 
 cache_after_a_bytes="$(measure::cache_bytes "${CACHE}")"
 


### PR DESCRIPTION
See #1156. Same pattern as #1154 — the daemon stays alive through the next `soldr cargo build` in the same session, so an inter-build `soldr cache flush` is redundant. Kept cold-tar-untar-warm's flush (feeds `soldr save`).

Closes #1156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)