### PR TITLE
perf(ci): cache baseline-zero-deps bootstrap soldr binary (#1160)

### DIFF
--- a/.github/workflows/baseline-zero-deps.yml
+++ b/.github/workflows/baseline-zero-deps.yml
@@ -58,7 +58,20 @@ jobs:
           toolchain: 1.94.1
           targets: ${{ matrix.target }}
 
+      # soldr#1160 — cache the host-side bootstrap soldr binary.
+      # Both matrix jobs (glibc + musl) rebuild the same x86_64-unknown-linux-gnu
+      # release binary here (~305s each) with RUSTC_WRAPPER="", so there is no
+      # zccache to catch it. When crates/**, Cargo.toml, Cargo.lock and
+      # rust-toolchain.toml are unchanged, restore instead of rebuild.
+      - name: Restore cached bootstrap soldr binary
+        id: bootstrap_cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ runner.temp }}/soldr-bin/soldr
+          key: bootstrap-soldr-linux-gnu-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml') }}
+
       - name: Bootstrap soldr from checkout
+        if: steps.bootstrap_cache.outputs.cache-hit != 'true'
         env:
           RUSTC_WRAPPER: ""
         shell: bash
@@ -74,6 +87,15 @@ jobs:
           mkdir -p "$RUNNER_TEMP/soldr-bin"
           cp "$bootstrap_target/x86_64-unknown-linux-gnu/release/soldr" "$RUNNER_TEMP/soldr-bin/soldr"
           chmod +x "$RUNNER_TEMP/soldr-bin/soldr"
+
+      - name: Expose bootstrap soldr on PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x "$RUNNER_TEMP/soldr-bin/soldr" || {
+            echo "bootstrap soldr not present at $RUNNER_TEMP/soldr-bin/soldr" >&2
+            exit 1
+          }
           echo "$RUNNER_TEMP/soldr-bin" >> "$GITHUB_PATH"
           echo "BOOTSTRAP_SOLDR=$RUNNER_TEMP/soldr-bin/soldr" >> "$GITHUB_ENV"
           "$RUNNER_TEMP/soldr-bin/soldr" --version


### PR DESCRIPTION
## Summary

- Fixes #1160.
- Add \`actions/cache\` around the \`Bootstrap soldr from checkout\` step in \`baseline-zero-deps.yml\`.
- Cache key: \`bootstrap-soldr-linux-gnu-\${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml') }}\` — matches perf-matrix.yml's soldr-bin key shape.
- Both matrix jobs (glibc + musl) share the same key because they build the identical host-side \`x86_64-unknown-linux-gnu\` release binary.
- Cache-miss behavior is unchanged (still runs the same cargo build).
- Cache-hit skips the 305 s compile; a small always-run "Expose bootstrap soldr on PATH" step handles the \$GITHUB_PATH / \$GITHUB_ENV export either way.

## Impact

Per issue #1160: latest run rebuilt the same binary twice at ~305 s each. On cache-hit both matrix jobs save ~305 s wallclock in parallel → the whole Baseline Zero-Deps Docker workflow gets ~5 minutes shorter (was ~14 min).

## Test plan

- [x] Local YAML edit sanity — bootstrap step now gated on \`steps.bootstrap_cache.outputs.cache-hit != 'true'\`, exposure step always runs.
- [ ] First push after merge is a cache miss (expected — populates the cache).
- [ ] Second push with no crate changes hits the cache and skips the 305 s bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)