### PR TITLE
perf(ci): drop duplicate host clippy from cross-build lanes (#1164)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -229,14 +229,13 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt -p soldr-cli -- --check
 
-      # Host clippy, NOT `--target ${{ inputs.target }}`. Running
-      # clippy against a cross target requires the C cross-toolchain
-      # for every *-sys / ring build script. The cross-build lane below
-      # dispatches to cargo-xwin / cargo-zigbuild for the actual cross-
-      # compile; clippy only needs the host toolchain to catch
-      # source-level lint issues. soldr#1068.
-      - name: cargo clippy (host)
-        run: cargo clippy --workspace --all-targets
+      # Host clippy is intentionally NOT run here. It's already covered by
+      # the top-level `Lint` job in ci.yml (`soldr cargo clippy --workspace
+      # --all-targets --locked -- -D warnings` — a strict superset of what
+      # this file used to run). Duplicating clippy on every cross-build
+      # lane cost ~90 s × 6 lanes for no additional safety. soldr#1164.
+      # See soldr#1068 for the reason clippy must stay HOST-only (never
+      # `--target X`) on cross-build workflows.
 
       # Stage B — release binary build, tool dispatched per target.
       # Windows MSVC + Apple Darwin: `soldr build` (the blessed cross-


### PR DESCRIPTION
## Summary

- Fixes #1164.
- Delete the \`cargo clippy (host)\` step from \`_ci-cross-build-linux.yml\` — it duplicates the required top-level Lint job's clippy check, which is stricter (\`-D warnings\`).
- Preserve context: leave a pointer comment where the step lived so future readers know why cross-build lanes deliberately have no clippy, and keep the reference to soldr#1068 (clippy must stay HOST-only on cross-build workflows).

## Impact

Per issue #1164, every one of the six cross-build lanes ran ~90 s of clippy (~540 s cumulative CPU per CI run). Lanes run in parallel, so each cross-build lane wallclock shrinks by ~90 s.

## Safety

Lint enforces the same clippy check + \`-D warnings\` as a required status check on every push and every PR. If Lint passes, the deleted step is guaranteed to pass. If Lint fails, merges are blocked regardless of what the cross-build lanes report.

## Test plan

- [x] Comment kept referencing soldr#1068 (host-only rule).
- [ ] First CI run post-merge: cross-build lanes should skip clippy but Lint still runs it.
- [ ] Lint continues to gate merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)