### PR TITLE
perf(ci): install matplotlib+Pillow via PyPI wheels in Benchmark Stats (#1166)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -48,17 +48,31 @@ jobs:
         working-directory: soldr
         run: bash bench/run_canaries.sh
 
-      - name: Install benchmark rendering and comparison tools
-        # Issues #785/#790: README embeds zccache-style comparison JPGs
-        # rendered with Pillow, and the comparison runner measures a pinned
-        # apt sccache package.
+      # soldr#1166 — the previous "one big apt install" step spent ~15 min
+      # here because Azure's Ubuntu mirror ran at ~62 kB/s and python3-
+      # matplotlib pulled in scipy + numpy + blas + lapack + friends
+      # (~55 MB of debs). Split into two steps: matplotlib/Pillow come
+      # from PyPI wheels via uv (~30 s), sccache stays apt-pinned for
+      # measurement-reproducibility per #785/#790.
+      - name: Install pinned sccache (apt)
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --allow-downgrades --no-install-recommends \
-            python3-matplotlib \
-            python3-pil \
             sccache=0.7.7-2ubuntu0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+        with:
+          enable-cache: false
+
+      - name: Install benchmark rendering deps (matplotlib + Pillow) via uv
+        run: |
+          set -euo pipefail
+          # Ubuntu 24.04's system python is PEP 668 "externally managed";
+          # --break-system-packages is required for --system installs.
+          # An ephemeral runner is safe to modify system Python.
+          uv pip install --system --break-system-packages matplotlib Pillow
 
       - name: Run comparison benchmarks
         working-directory: soldr

--- a/bench/render_benchmark_trend.py
+++ b/bench/render_benchmark_trend.py
@@ -8,7 +8,8 @@ Reads:  ./benchmark-stats/history.jsonl
 Writes: ./benchmark-stats/benchmark-trend.png
 
 stdlib + matplotlib only. matplotlib is installed in the workflow via
-`apt-get install -y python3-matplotlib` (small + fast).
+`uv pip install --system --break-system-packages matplotlib Pillow`
+(PyPI wheels — see soldr#1166 for why we no longer apt-install it).
 """
 
 import json


### PR DESCRIPTION
## Summary

- Fixes #1166.
- Benchmark Stats' \`Install benchmark rendering and comparison tools\` step was ~909 s (Azure Ubuntu apt mirror at ~62 kB/s pulling matplotlib + its scipy/numpy/blas/lapack dep chain).
- Split into: \`sccache\` from apt (preserves version pin), \`uv\` via setup-uv, and matplotlib + Pillow via \`uv pip install\`.
- Updates \`bench/render_benchmark_trend.py\` docstring to point at the new install path.

## Impact

Estimated wallclock: 909 s → 30-60 s per Benchmark Stats run. Roughly halves the whole Benchmark Stats workflow (was ~1 260 s).

## Test plan

- [x] sccache stays apt-pinned (\`sccache=0.7.7-2ubuntu0.1\`) per #785/#790 measurement-reproducibility notes.
- [x] matplotlib + Pillow come from PyPI wheels — no scipy/numpy/blas/lapack apt install.
- [x] uv installed via \`astral-sh/setup-uv@v5\` (same pin release-auto.yml already uses).
- [ ] First run post-merge: \`Run comparison benchmarks\` step still finds sccache; render scripts still find matplotlib + Pillow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)