### PR TITLE
perf(ci): drop full DWARF from nextest archives (#1168)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -284,6 +284,14 @@ jobs:
       - name: Build nextest archive
         if: inputs.build_test_archive && !contains(inputs.target, 'pc-windows-msvc') && !contains(inputs.target, 'apple-darwin')
         shell: bash
+        env:
+          # soldr#1168 — drop full DWARF from test binaries so the
+          # tar.zst archive shrinks from ~3.4 GB to ~1 GB. `line-tables-
+          # only` keeps enough info for backtraces to show file:line in
+          # the target-run lane, which is the main triage need there.
+          # Env-scoped to this step so local `cargo test` still gets
+          # full debuginfo.
+          CARGO_PROFILE_TEST_DEBUG: line-tables-only
         run: |
           set -euo pipefail
           mkdir -p dist


### PR DESCRIPTION
## Summary

- Fixes #1168.
- Set \`CARGO_PROFILE_TEST_DEBUG=line-tables-only\` on the \`Build nextest archive\` step in \`_ci-cross-build-linux.yml\`.
- Scoped as a step-level env var, so local \`cargo test\` still gets full DWARF for interactive debugging.

## Impact

Cross-build linux nextest archives were ~3.4 GB each (~1,733 tests × full DWARF). Estimated shrink 60-80% → ~1 GB. Wins:
- \`Build nextest archive\` compile time down (~270 s per lane today).
- \`Upload artifact\` down (17-30 s at compression-level 0).
- \`Download cross-build artifact\` down on the downstream \`_ci-target-run.yml\` lanes (81-231 s per lane today).

## Safety

\`line-tables-only\` keeps enough DWARF for backtraces to render \`file:line\`. Test failures on the target-run runner still show location info; only variable inspection is lost, which is not usable on a headless CI runner anyway.

## Test plan

- [x] Env var scoped to the step (does not leak to local cargo test).
- [ ] First CI post-merge: \`Build nextest archive\` step still completes; archive size ~60-80% smaller.
- [ ] target-run lanes still pass all 1,733 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)