### PR TITLE
fix(ci): sudo -E for uv pip install in benchmark-stats (#1170)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -71,8 +71,11 @@ jobs:
           set -euo pipefail
           # Ubuntu 24.04's system python is PEP 668 "externally managed";
           # --break-system-packages is required for --system installs.
-          # An ephemeral runner is safe to modify system Python.
-          uv pip install --system --break-system-packages matplotlib Pillow
+          # sudo -E preserves PATH so sudo finds uv on the hostedtoolcache
+          # (soldr#1170 — plain `uv pip install --system` hit a permission
+          # error because /usr/local/lib/python3.12/dist-packages is
+          # root-owned). Ephemeral runners are safe to modify system Python.
+          sudo -E env "PATH=$PATH" uv pip install --system --break-system-packages matplotlib Pillow
 
       - name: Run comparison benchmarks
         working-directory: soldr


### PR DESCRIPTION
## Summary

- Fixes #1170.
- Wrap the \`uv pip install\` command from #1167 with \`sudo -E env "PATH=$PATH"\` so it can write to \`/usr/local/lib/python3.12/dist-packages\`.
- Preserves the ~15 min win from #1167 while making the install actually succeed.

## Why sudo is needed

\`--break-system-packages\` handles PEP 668 (externally-managed marker) but not filesystem ACLs. The dist-packages dir is root-owned on ubuntu-24.04. \`sudo -E env "PATH=$PATH"\` runs the install as root while preserving PATH so the hostedtoolcache-installed \`uv\` binary is still resolved.

## Test plan

- [x] \`sudo -E\` is passwordless on GHA hosted runners (matches how \`sudo apt-get\` is already called in sibling steps).
- [x] \`env "PATH=$PATH"\` preserves the astral-sh/setup-uv-populated PATH through sudo.
- [ ] First main run post-merge: Benchmark Stats no longer fails on the install step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)