### PR TITLE
perf(ci): cache cargo-xwin CRT+SDK download on MSVC cross-build (#1172)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -137,6 +137,20 @@ jobs:
         with:
           tool: cargo-nextest
 
+      # soldr#1172 — cargo-xwin re-downloads the ~1 GB MSVC CRT+SDK
+      # every run (~8 min 20 s) even though soldr's blessed_build
+      # extracts an xwin-cache and exports XWIN_CACHE_DIR. The
+      # XWIN_CACHE_DIR handoff isn't being honored (unverified — either
+      # tarball layout mismatch or version-invalidation). Until the
+      # structural fix lands, cache cargo-xwin's own default cache dir
+      # so only the FIRST run per xwin version pays the download.
+      - name: Cache cargo-xwin SDK download
+        if: contains(inputs.target, 'pc-windows-msvc')
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cache/cargo-xwin
+          key: cargo-xwin-0.18.6-crt-sdk-v1
+
       # Bootstrap soldr from the current checkout. Darwin uses it to
       # drive `soldr prepare --target ... --github-env`. Windows MSVC
       # uses it to drive `soldr build --target X` (the blessed


### PR DESCRIPTION
## Summary

- Fixes #1172 (stopgap; structural follow-up tracked in the issue).
- Wraps \`~/.cache/cargo-xwin\` in \`actions/cache\` on the MSVC cross-build lane.
- Cache key: \`cargo-xwin-0.18.6-crt-sdk-v1\` (bump the suffix when cargo-xwin's pinned version or the xwin manifest changes).

## Why

The MSVC lane's \`Cross-build release binary\` step spends **8 min 20 s downloading the MSVC CRT** on every CI run — even though soldr's \`blessed_build::prepare()\` extracts an xwin-cache and exports \`XWIN_CACHE_DIR\` 3 seconds earlier. cargo-xwin isn't honoring the handoff.

Root-cause investigation is tracked in #1172. This stopgap gets the 8 min back today by caching cargo-xwin's own default cache location — first run per key pays the download, subsequent runs restore in 1-2 s.

## Impact

Latest MSVC lane wallclock: 886 s. Estimated post-cache-hit: ~470 s (~47% reduction). MSVC is the critical-path lane for CI wallclock; the whole workflow wallclock drops proportionally.

## Test plan

- [x] \`if\` gate restricts the cache step to MSVC lanes (musl/darwin/gnu are unaffected).
- [ ] First run post-merge: cache miss, 8 min download populates cache, cache saves on-post.
- [ ] Second run: cache hits, cargo-xwin skips MSVC CRT download, MSVC lane wallclock drops ~7-8 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)