### PR TITLE
fix(ci): point cargo-xwin cache at the real XWIN_CACHE_DIR path (#1174)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -137,19 +137,23 @@ jobs:
         with:
           tool: cargo-nextest
 
-      # soldr#1172 — cargo-xwin re-downloads the ~1 GB MSVC CRT+SDK
-      # every run (~8 min 20 s) even though soldr's blessed_build
-      # extracts an xwin-cache and exports XWIN_CACHE_DIR. The
-      # XWIN_CACHE_DIR handoff isn't being honored (unverified — either
-      # tarball layout mismatch or version-invalidation). Until the
-      # structural fix lands, cache cargo-xwin's own default cache dir
-      # so only the FIRST run per xwin version pays the download.
-      - name: Cache cargo-xwin SDK download
+      # soldr#1172 + soldr#1174 — cargo-xwin re-downloads the MSVC CRT+SDK
+      # (~8-13 min) every run even though soldr's blessed_build extracts
+      # an xwin-cache and exports XWIN_CACHE_DIR. cargo-xwin honors
+      # XWIN_CACHE_DIR and writes to it, but the pre-shipped soldr-toolchain
+      # tarball's layout doesn't match cargo-xwin's expectations, so it
+      # re-populates the same dir. Cache the whole XWIN_CACHE_DIR parent
+      # (soldr's `.complete` stamp + cargo-xwin's downloaded CRT/SDK) so
+      # the second run and beyond skips the download entirely.
+      #
+      # Cache key embeds MANAGED_XWIN_CACHE_VERSION (2026-06-22 today —
+      # bump when crates/soldr-cli/src/fetch/xwin_cache.rs changes).
+      - name: Cache cargo-xwin MSVC CRT+SDK (via XWIN_CACHE_DIR)
         if: contains(inputs.target, 'pc-windows-msvc')
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
-          path: ~/.cache/cargo-xwin
-          key: cargo-xwin-0.18.6-crt-sdk-v1
+          path: ${{ runner.temp }}/setup-soldr-soldr/sdk/${{ inputs.target }}/xwin/2026-06-22
+          key: soldr-xwin-cache-${{ inputs.target }}-cargo-xwin-0.18.6-v2026-06-22
 
       # Bootstrap soldr from the current checkout. Darwin uses it to
       # drive `soldr prepare --target ... --github-env`. Windows MSVC


### PR DESCRIPTION
## Summary

- Fixes #1174.
- PR #1173 pointed \`actions/cache\` at \`~/.cache/cargo-xwin\` but that path never gets populated — cargo-xwin writes to the \`XWIN_CACHE_DIR\` env var that soldr's \`blessed_build::prepare()\` exports, which is \`\$RUNNER_TEMP/setup-soldr-soldr/sdk/<target>/xwin/2026-06-22/xwin\`.
- Update the cache path to that actual location. Cache-save now succeeds; next run hits the cache and cargo-xwin skips the 8-13 min MSVC CRT download.

## Evidence

Run [28522910559](https://github.com/zackees/soldr/actions/runs/28522910559) after #1173 landed:

\`\`\`
[warning]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
\`\`\`

Meanwhile MSVC CRT downloaded for 12m 41s that run — exactly the pattern #1173 was supposed to fix.

## Cache-hit behavior

On restore, the whole \`xwin/2026-06-22\` dir comes back including soldr's \`.complete\` stamp. soldr's \`ensure_xwin_cache\` sees the stamp and skips its own extract; cargo-xwin sees CRT+SDK already present and skips its download.

## Cache key

Embeds \`inputs.target\` (soldr's xwin cache is per-target) and \`MANAGED_XWIN_CACHE_VERSION\` (2026-06-22 today). Bump the version in the workflow when \`crates/soldr-cli/src/fetch/xwin_cache.rs\` changes it.

## Test plan

- [x] Path matches the one soldr's \`fetch::xwin_cache\` writes to (\`sdk/<t>/xwin/<version>\`).
- [ ] First CI post-merge: cache miss, save succeeds this time (no "path does not exist" warning).
- [ ] Second CI post-merge: cache hits, MSVC CRT download skipped, MSVC lane drops ~7-12 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)