### PR TITLE
perf(ci): pre-build test binaries in Linux x64 Build workspace step (#1176)

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -140,16 +140,22 @@ jobs:
             rustup component add $component
           }
 
-      - name: Build workspace
+      # soldr#1176 — build workspace bins AND test binaries in one pass.
+      # Downstream `Run library tests` / `Run CLI smoke tests` steps then
+      # find every artifact fresh in target/deps and skip rustc entirely
+      # (cargo's freshness check hits, no compile). Saves the redundant
+      # test-mode compile that used to happen twice (once here in non-
+      # test mode, once again in each test step in test mode).
+      - name: Build workspace + tests
         shell: pwsh
         run: |
           $timer = [Diagnostics.Stopwatch]::StartNew()
-          soldr cargo build --workspace --locked --target ${{ inputs.target }}
+          soldr cargo build --workspace --tests --bins --locked --target ${{ inputs.target }}
           $exitCode = $LASTEXITCODE
           $timer.Stop()
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
             [Globalization.CultureInfo]::InvariantCulture,
-            "- **${{ inputs.target }} / Build workspace**: {0:F3}s",
+            "- **${{ inputs.target }} / Build workspace + tests**: {0:F3}s",
             $timer.Elapsed.TotalSeconds
           ))
           exit $exitCode


### PR DESCRIPTION
## Summary

- Fixes #1176.
- Change \`_build-and-test.yml\`'s \`Build workspace\` step to \`cargo build --workspace --tests --bins\` so downstream \`Run library tests\` + \`Run CLI smoke tests\` steps run against pre-built artifacts.
- No behavior change for the tests themselves; the isolated SOLDR_CACHE_DIR / ZCCACHE_CACHE_DIR envvars still apply to spawned soldr subprocesses.

## Impact

Linux x64 lane's three cargo steps totaled 353 s (139 + 98 + 116). After: ~200 s estimated (Build step longer since it now compiles test bins too; the two test steps drop to test-run-only wallclock).

## Test plan

- [x] \`--bins\` preserves the debug soldr binary at \`target/<t>/debug/soldr\` (LOCAL_SOLDR reference intact).
- [x] \`--tests\` compiles all integration test binaries needed by \`Run CLI smoke tests\`.
- [ ] First CI run post-merge: Run library tests + Run CLI smoke tests drop to a few seconds each (no rustc calls, just execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)