### PR TITLE
perf(ci): drop duplicate dtolnay toolchain install in _build-and-test + _bootstrap-e2e (#1178)

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -71,11 +71,10 @@ jobs:
           ref: ${{ inputs.third_party_ref }}
           path: ${{ inputs.third_party_path }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.94.1
-          targets: ${{ inputs.target }}
+      # soldr#1178 — dropped dtolnay/rust-toolchain: setup-soldr below
+      # installs the same 1.94.1 toolchain via the `toolchain-file:
+      # rust-toolchain.ci.toml` input (which declares the target too),
+      # so running dtolnay first duplicated ~6-8 s of install work.
 
       - name: Install musl tools
         if: contains(inputs.target, 'musl')

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -76,13 +76,13 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.94.1
-          targets: ${{ inputs.target }}
-          components: ${{ inputs.install_components }}
-
+      # soldr#1178 — dropped the dtolnay/rust-toolchain step: setup-soldr
+      # below installs the same 1.94.1 toolchain, so running dtolnay
+      # first duplicated ~8 s of install work per CI run. The host target
+      # (x86_64-unknown-linux-gnu) is rustup's default so no explicit
+      # `rustup target add` is required. Components are installed further
+      # down via the "Install requested Rust components" step.
+      #
       # soldr#1083 follow-up: cache + soldr-cook disabled. Cook
       # rewrites the workspace manifest in ways incompatible with
       # cross-compile lanes; save cost no longer justifies. Pure


### PR DESCRIPTION
## Summary

- Fixes #1178.
- Both \`_build-and-test.yml\` and \`_bootstrap-e2e.yml\` ran \`dtolnay/rust-toolchain\` right before a \`setup-soldr\` step that installs the same toolchain. Removed the dtolnay step from both.
- setup-soldr's \`toolchain:\` / \`toolchain-file:\` inputs already handle install + target install.

## Impact

- \`_build-and-test.yml\` (Linux x64 lane): ~8 s per CI run.
- \`_bootstrap-e2e.yml\` (Bootstrap third-party app job): ~6-8 s per CI run.
- Both run in parallel on the CI critical path — ~8 s off overall CI wallclock.

## Test plan

- [x] \`_build-and-test.yml\`'s target is the host (x86_64-unknown-linux-gnu) so no explicit target-add is needed.
- [x] \`_bootstrap-e2e.yml\`'s \`rust-toolchain.ci.toml\` declares \`targets = ["${{ inputs.target }}"]\` so setup-soldr installs the target via that file.
- [ ] First CI run post-merge: no "target not found" errors from cargo; \`Install Rust toolchain\` step absent from job step list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)