### PR TITLE
perf(ci): --cargo-profile release for nextest archive to share release deps (#1182)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -303,21 +303,37 @@ jobs:
         if: inputs.build_test_archive && !contains(inputs.target, 'pc-windows-msvc') && !contains(inputs.target, 'apple-darwin')
         shell: bash
         env:
-          # soldr#1168 — drop full DWARF from test binaries so the
-          # tar.zst archive shrinks from ~3.4 GB to ~1 GB. `line-tables-
-          # only` keeps enough info for backtraces to show file:line in
-          # the target-run lane, which is the main triage need there.
-          # Env-scoped to this step so local `cargo test` still gets
-          # full debuginfo.
-          CARGO_PROFILE_TEST_DEBUG: line-tables-only
+          # soldr#1168 kept for reference (previous dev-profile config).
+          # soldr#1182 — nextest archive now uses --cargo-profile release
+          # (see command below). Release profile already has debug=false
+          # from Cargo.toml defaults, so the archive is naturally small
+          # without needing CARGO_PROFILE_TEST_DEBUG overrides. Not
+          # setting any CARGO_PROFILE_RELEASE_* overrides here — that
+          # would invalidate the release rlibs the previous step just
+          # cached in target/<t>/release/deps/ (cargo hashes profile
+          # config for freshness).
+          # Test failures still surface the assertion source location
+          # (panic! macro bakes in `file!` / `line!`); only the multi-
+          # frame backtrace loses filenames. Acceptable trade for
+          # eliminating 150 s of dep-recompile per lane.
         run: |
           set -euo pipefail
           mkdir -p dist
           target='${{ inputs.target }}'
           archive="dist/${{ inputs.artifact_name }}-tests.tar.zst"
+          # soldr#1182 — --cargo-profile release lets nextest reuse the
+          # release-mode dep artifacts already sitting in target/<t>/
+          # release/deps/ from the `Cross-build release binary` step.
+          # Cargo's freshness check hits on every dep; only soldr-cli's
+          # test-mode lib + its integration test binaries actually get
+          # compiled. Cuts the archive step from ~200 s to ~50-80 s on
+          # linux cross-build lanes. Tests still run — release-mode
+          # tests are safe because soldr-cli has zero debug_assert! or
+          # cfg(debug_assertions) usage (grep-verified).
           cargo nextest archive \
             --target "$target" \
             --workspace \
+            --cargo-profile release \
             --archive-file "$archive" \
             --archive-format tar-zst
           ls -la "$archive"

--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -299,23 +299,22 @@ jobs:
       # headers (darwin). The target-run lane falls back to a
       # `soldr --version` smoke test for these targets. Tracked as
       # #1068 (windows) and the post-#1112 mimalloc dep tree (darwin).
+      # soldr#1168 kept for reference (previous dev-profile config).
+      # soldr#1182 — nextest archive now uses --cargo-profile release
+      # (see command below). Release profile already has debug=false
+      # from Cargo.toml defaults, so the archive is naturally small
+      # without needing CARGO_PROFILE_TEST_DEBUG overrides. Not
+      # setting any CARGO_PROFILE_RELEASE_* overrides here — that
+      # would invalidate the release rlibs the previous step just
+      # cached in target/<t>/release/deps/ (cargo hashes profile
+      # config for freshness).
+      # Test failures still surface the assertion source location
+      # (panic! macro bakes in `file!` / `line!`); only the multi-
+      # frame backtrace loses filenames. Acceptable trade for
+      # eliminating 150 s of dep-recompile per lane.
       - name: Build nextest archive
         if: inputs.build_test_archive && !contains(inputs.target, 'pc-windows-msvc') && !contains(inputs.target, 'apple-darwin')
         shell: bash
-        env:
-          # soldr#1168 kept for reference (previous dev-profile config).
-          # soldr#1182 — nextest archive now uses --cargo-profile release
-          # (see command below). Release profile already has debug=false
-          # from Cargo.toml defaults, so the archive is naturally small
-          # without needing CARGO_PROFILE_TEST_DEBUG overrides. Not
-          # setting any CARGO_PROFILE_RELEASE_* overrides here — that
-          # would invalidate the release rlibs the previous step just
-          # cached in target/<t>/release/deps/ (cargo hashes profile
-          # config for freshness).
-          # Test failures still surface the assertion source location
-          # (panic! macro bakes in `file!` / `line!`); only the multi-
-          # frame backtrace loses filenames. Acceptable trade for
-          # eliminating 150 s of dep-recompile per lane.
         run: |
           set -euo pipefail
           mkdir -p dist


### PR DESCRIPTION
## Summary

- Fixes #1182.
- Add \`--cargo-profile release\` to the \`Build nextest archive\` step so the test-binary build reuses the ~700 release-mode dep artifacts already cached in \`target/<t>/release/deps/\` by the \`Cross-build release binary\` step.
- Removed the previous \`CARGO_PROFILE_TEST_DEBUG=line-tables-only\` override — it wouldn't apply now that the profile in effect is \`release\`, not \`test\`. Deliberately did NOT add \`CARGO_PROFILE_RELEASE_*\` overrides because those would change the profile hash and invalidate the release rlibs the previous step cached (defeating the optimization).

## Impact

Estimated per-lane wallclock for the archive step:

| lane | before | after (est.) |
|---|---|---|
| musl x86_64 | 206 s | 50-80 s |
| musl aarch64 | ~188 s | 50-70 s |
| gnu aarch64 | ~180 s | 50-70 s |

3 linux lanes × parallel → ~40-60 s off CI critical path.

## Safety

- soldr-cli codebase has ZERO uses of \`debug_assert!\` or \`cfg(debug_assertions)\` (grep-verified). Tests don't rely on debug semantics.
- Release-mode tests run under \`opt-level=3\`, LTO thin, single codegen unit. Assertion messages still surface with their source location (via \`panic!\`'s baked-in \`file!\`/\`line!\`).
- Multi-frame backtraces lose filenames (\`debug = false\`). Acceptable for CI test triage — assertion location is the main triage need.

## Test plan

- [x] soldr-cli has no debug-behavior dependencies.
- [ ] First CI run post-merge: \`Build nextest archive\` step drops from ~200 s to under 100 s on linux lanes.
- [ ] target-run lanes still pass all workspace tests (release-mode).

## Rollback

If tests fail under release mode, revert with \`git revert\`. Cargo.toml profiles are unchanged so rollback is a workflow-only edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)