### PR TITLE
Revert #1185: awalsh128/cache-apt-pkgs-action uses unpinned nested actions

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -98,16 +98,16 @@ jobs:
         shell: bash
         run: rustup target add ${{ inputs.target }}
 
-      # soldr#1184 — cache the .deb files so first run per key downloads
-      # + saves, subsequent runs restore in ~3-5 s regardless of Azure
-      # mirror weather. Same fix pattern as #1166 for benchmark-stats,
-      # which had spiked to 15 min on Azure mirror. Latest 1170 s spike
-      # observed on run 28530360106 aarch64-linux-gnu lane.
       - name: Install apt deps
-        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad # v1.5.1
-        with:
-          packages: build-essential pkg-config file jq xz-utils bzip2 zip unzip ca-certificates curl git musl-tools cmake perl clang lld llvm llvm-dev libclang-dev
-          version: soldr-ci-v1
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config file jq xz-utils bzip2 zip unzip \
+            ca-certificates curl git \
+            musl-tools cmake perl \
+            clang lld llvm llvm-dev libclang-dev
 
       # zig + cargo-zigbuild — required for musl, darwin, and aarch64
       # gnu cross-builds.


### PR DESCRIPTION
## Summary

Reverts #1185 (\`perf(ci): cache apt deps via awalsh128/cache-apt-pkgs-action\`) because it broke every cross-build lane:

\`\`\`
##[error]The actions actions/cache/restore@v4 and actions/upload-artifact@v3 are not allowed in zackees/soldr because all actions must be pinned to a full-length commit SHA.
\`\`\`

soldr's actions policy requires every action (INCLUDING nested actions inside third-party wrappers) be pinned to a full commit SHA. \`awalsh128/cache-apt-pkgs-action@v1.5.1\` calls \`actions/cache/restore@v4\` and \`actions/upload-artifact@v3\` internally with version tags, violating the policy.

Runs affected: [28533929310](https://github.com/zackees/soldr/actions/runs/28533929310), [28533484850](https://github.com/zackees/soldr/actions/runs/28533484850).

## Follow-up

Filed as follow-up on #1184: implement apt caching using SHA-pinned actions/cache@v4.2.4 directly, wrapped around a copy of the .deb archive dir (since \`/var/cache/apt/archives\` is root-owned). Not blocking — the Azure mirror spike (1170 s on aarch64-linux-gnu) is rare and CI-green is more important than tail-latency elimination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)