### PR TITLE
fix(release): git restore Cargo.toml before Build release binary + bump 0.7.88

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -361,6 +361,33 @@ jobs:
         env:
           CARGO_PROFILE_RELEASE_DEBUG: ${{ contains(matrix.target, 'pc-windows-msvc') && 'line-tables-only' || '0' }}
         run: |
+          # soldr#1140 root-cause fix: restore Cargo.toml + Cargo.lock
+          # + crates/soldr-cli/Cargo.toml BEFORE cargo runs.
+          #
+          # setup-soldr's `cook` step (which fires before this one on any
+          # cache-hit lane) strips [workspace.package] from Cargo.toml
+          # for cache-key stability and compiles soldr-cli as v0.0.1 into
+          # target/. Without a restore + clean here, the subsequent
+          # `cargo build --release` sees a stub target/ + a stripped
+          # manifest, does not detect a version change, and links a
+          # v0.0.1 stub binary (~118K on Windows, ~332K on Linux gnu)
+          # that ships to PyPI as the release binary. Symptom: every
+          # soldr invocation from `pip install soldr` silently exits 0
+          # — see soldr#1140 and the FastLED-side fallback in
+          # FastLED/FastLED#3523 for the downstream impact.
+          #
+          # `git restore` is the same incantation the wheel-build step
+          # below already uses (v0.7.81 lesson); this just moves the
+          # rescue earlier so the tar.zst archive + wheel both start
+          # from the correct workspace.package version.
+          #
+          # `cargo clean -p soldr-cli` purges cook's stub soldr-cli
+          # artifacts specifically; the 200+ transitive deps keep their
+          # cached object code so cold recompile stays ~30-60s, not
+          # multi-minute.
+          git restore -- Cargo.toml Cargo.lock crates/soldr-cli/Cargo.toml || true
+          cargo clean -p soldr-cli --target "${{ matrix.target }}" --release 2>/dev/null || true
+
           # Dispatch matrix:
           # 1. Darwin Linux-host cross — `soldr build --target $T`.
           #    The `Bootstrap soldr for Apple SDK prep` step above

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.87"
+version = "0.7.88"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.87"
+version = "0.7.88"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.87",
+  "version": "0.7.88",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Closes #1140. Downstream: FastLED/FastLED#3523.

## Root cause

setup-soldr's `cook` pre-step strips `[workspace.package]` from Cargo.toml and compiles soldr-cli as v0.0.1 into target/. Subsequent `cargo build --release` sees a stub target/ + stripped manifest, detects no version change, links a v0.0.1 stub binary that ships to PyPI as the release binary (332 KB on Linux gnu, 118 KB on win_amd64). The win_arm64 + mac_arm64 lanes were fine because cook-cache missed there.

Log evidence, Linux x64 lane, run 28439879878:
```
11:20:50  Compiling soldr-cli v0.0.1  ← cook, stripped manifest
11:22:57  Compiling soldr-cli v0.0.1  ← Build release binary, still stubbed
11:24:49  -rwxr-xr-x runner  332720  soldr
11:26:36+ Compiling soldr-cli v0.7.87 ← maturin (already too late)
```

## Fix

Move `git restore -- Cargo.toml Cargo.lock crates/soldr-cli/Cargo.toml` + `cargo clean -p soldr-cli --target $T --release` from the wheel-build step up into the Build release binary step so the tar.zst archive + wheel both start from the correct workspace.package version. Same incantations already applied downstream (v0.7.81 lesson comment).

## Version bump

0.7.87 → 0.7.88 in lockstep across Cargo.toml, package.json, Cargo.lock (version_lockstep guard).

The #1141 wheel-size guard remains as belt-and-suspenders. If this fix is wrong, release fails cleanly instead of shipping more stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)