### PR TITLE
perf(ci): split apt install; clang stack only for MSVC/darwin (#1189)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -98,15 +98,26 @@ jobs:
         shell: bash
         run: rustup target add ${{ inputs.target }}
 
-      - name: Install apt deps
+      # soldr#1189 — split apt install per target. The clang stack
+      # (clang lld llvm llvm-dev libclang-dev) is only needed by MSVC
+      # (cargo-xwin) and darwin (blessed_build). Skipping it on musl
+      # + linux-gnu lanes saves ~15-20 s of apt fetch per lane.
+      - name: Install apt deps (baseline)
         shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential pkg-config file jq xz-utils bzip2 zip unzip \
-            ca-certificates curl git \
-            musl-tools cmake perl \
+            ca-certificates curl git cmake perl \
+            musl-tools
+
+      - name: Install apt deps (clang stack for MSVC/darwin)
+        if: contains(inputs.target, 'pc-windows-msvc') || contains(inputs.target, 'apple-darwin')
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y --no-install-recommends \
             clang lld llvm llvm-dev libclang-dev
 
       # zig + cargo-zigbuild — required for musl, darwin, and aarch64


### PR DESCRIPTION
## Summary

- Fixes #1189.
- Split \`Install apt deps\` in \`_ci-cross-build-linux.yml\` into two conditional steps: baseline (every lane) + clang stack (\`clang lld llvm llvm-dev libclang-dev\`, only for MSVC + darwin lanes).
- Musl + aarch64-linux-gnu lanes use zigbuild (zig cc replaces system clang), so they didn't need the ~40-50 MB clang stack.

## Impact

Estimated savings: ~15-20 s per lane × 3 non-clang lanes (musl x86_64, musl aarch64, gnu aarch64) = 45-60 s cumulative + 15-20 s off the slowest non-clang lane's wallclock.

## SHA-pinning policy

Uses raw \`apt-get\` — no third-party actions. Unlike #1185 (reverted), this doesn't drag in unpinned nested actions.

## Test plan

- [x] Musl + aarch64-linux-gnu targets skip the clang stack step (gated by \`if:\` clause).
- [ ] First CI post-merge: musl + linux-gnu lanes' apt step shrinks; MSVC + darwin lanes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)