### PR TITLE
fix(release): replace U+2265 with ASCII >= in Verify wheel step

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -1198,7 +1198,7 @@ jobs:
                   raise SystemExit(
                       f"wheel ships {binary_name!r} at {largest} bytes across "
                       f"{len(candidates)} candidate path(s):\n{layout}\n"
-                      f"expected ≥ {MIN_PRIMARY_BIN_BYTES} bytes (2 MiB) — a "
+                      f"expected >= {MIN_PRIMARY_BIN_BYTES} bytes (2 MiB) — a "
                       f"real soldr binary compiled from crates/soldr-cli is "
                       f"~15 MB. Anything below this floor means the crate's "
                       f"main.rs did not get compiled into the shipped bin "
@@ -1214,7 +1214,7 @@ jobs:
 
           print(
               f"{wheels[0].name} ships {binary_name} at `{script_entry}` "
-              f"({info.file_size} bytes); primary-bin payload ≥ "
+              f"({info.file_size} bytes); primary-bin payload >="
               f"{MIN_PRIMARY_BIN_BYTES} bytes OK"
           )
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.88"
+version = "0.7.89"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.88"
+version = "0.7.89"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.88",
+  "version": "0.7.89",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Windows GH runners default Python stdout to cp1252 which cannot encode U+2265. The Verify-wheel step (added in #1141) printed 'primary-bin payload >= 2097152 bytes OK' on the success path and raised UnicodeEncodeError, failing the job.

Symptom: soldr#1187 release-auto run 28535571428, Windows ARM64:

    UnicodeEncodeError: 'charmap' codec can't encode character in position 131
    ##[error]Process completed with exit code 1.

The wheel was fine (15 MB); only the diagnostic line failed. Windows ARM64 was continue-on-error so did not block, but Windows x64 (in-flight now) is not continue-on-error.

Fix: replace both U+2265 with ASCII >=. No behavioral change; the size guard still enforces the 2 MiB floor.

Generated with Claude Code