### PR TITLE
feat(ci): dogfood pinned setup-soldr into bootstrap compile (#1194)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -187,14 +187,21 @@ jobs:
           path: ${{ runner.temp }}/soldr-bin
           key: bootstrap-soldr-blessed-linux-gnu-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml') }}
 
+      # soldr#1194 — dogfood: use the pinned setup-soldr `soldr` (v0.7.42
+       # today, resolved via `zackees/setup-soldr@cca74625`) to drive the
+       # bootstrap compile. The pinned soldr auto-injects RUSTC_WRAPPER=
+       # zccache, so bootstrap gets seed hits on shared crates instead of
+       # rebuilding ~700 crates from scratch each cache-miss run.
+      # `soldr cargo build` is a plain passthrough that v0.7.42 already
+      # supports; it does not require the `soldr build` subcommand (which
+      # arrived later — that's what THIS bootstrap step is producing for
+      # the downstream Cross-build release binary step).
       - name: Bootstrap soldr for SDK / blessed-build prep
         if: (contains(inputs.target, 'apple-darwin') || contains(inputs.target, 'pc-windows-msvc')) && steps.bootstrap_cache.outputs.cache-hit != 'true'
         shell: bash
-        env:
-          RUSTC_WRAPPER: ""
         run: |
           set -euo pipefail
-          cargo build --release --locked --package soldr-cli \
+          soldr cargo build --release --locked --package soldr-cli \
             --bin soldr --bin soldr-clang-shim \
             --target x86_64-unknown-linux-gnu
           mkdir -p "$RUNNER_TEMP/soldr-bin"


### PR DESCRIPTION
## Summary

- Fixes #1194.
- The \`Bootstrap soldr for SDK / blessed-build prep\` step in \`_ci-cross-build-linux.yml\` now runs \`soldr cargo build\` (via setup-soldr's pinned v0.7.42) instead of bare \`cargo build\` with \`RUSTC_WRAPPER=""\`.
- Bootstrapping through pinned soldr → zccache in the loop → seed hits on shared crates → faster cache-miss bootstrap.

## Ordering

The setup-soldr's pinned soldr sits on PATH by this step. After the following \`Expose bootstrap soldr on PATH\` step, the freshly-built HEAD soldr takes precedence for the downstream \`Cross-build release binary\` step (which needs the newer \`soldr build\` subcommand v0.7.42 doesn't have).

## Verification

- \`soldr cargo build\` in v0.7.42 is a plain passthrough — it doesn't require any newer soldr subcommands.
- Cache-hit path (from #1162) short-circuits this step entirely — this PR only affects cache-miss runs.
- Downstream MSVC + darwin lanes' \`Cross-build release binary\` (using \`soldr build --target X\`) still receive the fresh HEAD-built soldr via the "Expose bootstrap soldr on PATH" step.

## Test plan

- [ ] First CI post-merge: bootstrap step still produces working \`soldr\` + \`soldr-clang-shim\` binaries.
- [ ] Subsequent \`Cross-build release binary\` step succeeds on MSVC and darwin lanes.
- [ ] Bootstrap step wallclock drops on cache-miss runs (zccache seed hits on shared crates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)