### PR TITLE
revert(ci): nextest --cargo-profile release regression (#1197 / reverts #1183)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -310,40 +310,25 @@ jobs:
       # headers (darwin). The target-run lane falls back to a
       # `soldr --version` smoke test for these targets. Tracked as
       # #1068 (windows) and the post-#1112 mimalloc dep tree (darwin).
-      # soldr#1168 kept for reference (previous dev-profile config).
-      # soldr#1182 — nextest archive now uses --cargo-profile release
-      # (see command below). Release profile already has debug=false
-      # from Cargo.toml defaults, so the archive is naturally small
-      # without needing CARGO_PROFILE_TEST_DEBUG overrides. Not
-      # setting any CARGO_PROFILE_RELEASE_* overrides here — that
-      # would invalidate the release rlibs the previous step just
-      # cached in target/<t>/release/deps/ (cargo hashes profile
-      # config for freshness).
-      # Test failures still surface the assertion source location
-      # (panic! macro bakes in `file!` / `line!`); only the multi-
-      # frame backtrace loses filenames. Acceptable trade for
-      # eliminating 150 s of dep-recompile per lane.
       - name: Build nextest archive
         if: inputs.build_test_archive && !contains(inputs.target, 'pc-windows-msvc') && !contains(inputs.target, 'apple-darwin')
         shell: bash
+        env:
+          # soldr#1168 — drop full DWARF from test binaries so the
+          # tar.zst archive shrinks from ~3.4 GB to ~1 GB. `line-tables-
+          # only` keeps enough info for backtraces to show file:line in
+          # the target-run lane, which is the main triage need there.
+          # Env-scoped to this step so local `cargo test` still gets
+          # full debuginfo.
+          CARGO_PROFILE_TEST_DEBUG: line-tables-only
         run: |
           set -euo pipefail
           mkdir -p dist
           target='${{ inputs.target }}'
           archive="dist/${{ inputs.artifact_name }}-tests.tar.zst"
-          # soldr#1182 — --cargo-profile release lets nextest reuse the
-          # release-mode dep artifacts already sitting in target/<t>/
-          # release/deps/ from the `Cross-build release binary` step.
-          # Cargo's freshness check hits on every dep; only soldr-cli's
-          # test-mode lib + its integration test binaries actually get
-          # compiled. Cuts the archive step from ~200 s to ~50-80 s on
-          # linux cross-build lanes. Tests still run — release-mode
-          # tests are safe because soldr-cli has zero debug_assert! or
-          # cfg(debug_assertions) usage (grep-verified).
           cargo nextest archive \
             --target "$target" \
             --workspace \
-            --cargo-profile release \
             --archive-file "$archive" \
             --archive-format tar-zst
           ls -la "$archive"


### PR DESCRIPTION
## Summary

Fixes #1197. Straight revert of #1183.

The `--cargo-profile release` swap on `Build nextest archive` shipped on the theory that release-profile deps built by the previous `Cross-build release binary` step would be reused. In practice deps DON'T share:

- `cargo zigbuild --release` sets `CC_<target>` / `CXX_<target>` / `AR_<target>` / `CARGO_TARGET_<T>_LINKER` pointing at zig-cc wrappers. Cargo hashes the whole compile fingerprint including env-affecting build-script inputs — zigbuild-release fingerprints differ from plain-cargo-release fingerprints.
- Release profile is `lto = "thin"` + `codegen-units = 1` + `opt-level = 3`. Test binaries + workspace crates get all that heavy optimization. Dev (previous default) is opt-level=0, no LTO, incremental — 3-5× faster to compile.

## Measured impact (musl x86_64 lane, from #1197)

| step | before #1183 | after #1183 |
|---|---|---|
| Cross-build release binary | 491 s | 500 s |
| Build nextest archive | 206 s | **553 s** |
| **Lane total** | **794 s** | **1122 s** |

## What the revert restores

- Drops `--cargo-profile release` from the archive step.
- Restores `CARGO_PROFILE_TEST_DEBUG: line-tables-only` env override (originally from #1168) that #1183 dropped as unnecessary — that override keeps the tar.zst archive ~1 GB instead of ~3.4 GB.

## Test plan

- [x] Diff scoped to `.github/workflows/_ci-cross-build-linux.yml` — one revert, no drift.
- [ ] CI Linux cross-lanes still fail on the same pre-existing unpinned-actions policy issue (out of scope), but the fix would only be observable there.
- [ ] Once merged, next Linux cross-build lane run should return to the pre-#1183 wallclock (~200 s archive, ~800 s lane total).

## Non-scope

Investigating whether zigbuild-release and cargo-build-release CAN share deps is a real follow-up but not this PR. The naive profile swap is the wrong lever regardless.