### PR TITLE
fix(test): expect 4 probes in toolchain doctor JSON schema test (#1203)

### DIFF
--- a/crates/soldr-cli/tests/cli_toolchain_doctor.rs
+++ b/crates/soldr-cli/tests/cli_toolchain_doctor.rs
@@ -50,11 +50,13 @@ timed_test!(
         assert!(host["libc"].is_string());
         // Probes array contains all expected probe names in stable order.
         // soldr#1059 added the `cargo-on-path-shadowing` row.
+        // soldr#1188 added the `rustlib-integrity` row.
         let probes = parsed["probes"].as_array().expect("probes array");
-        assert_eq!(probes.len(), 3, "expected 3 probes, got {}", probes.len());
+        assert_eq!(probes.len(), 4, "expected 4 probes, got {}", probes.len());
         assert_eq!(probes[0]["name"], Value::from("musl-cc"));
         assert_eq!(probes[1]["name"], Value::from("shared-target-warning"));
         assert_eq!(probes[2]["name"], Value::from("cargo-on-path-shadowing"));
+        assert_eq!(probes[3]["name"], Value::from("rustlib-integrity"));
         // Each probe MUST carry an `ok` boolean and a `details` object.
         for probe in probes {
             assert!(probe["ok"].is_boolean(), "probe.ok must be bool: {probe}");


### PR DESCRIPTION
## Summary

- Fixes #1203.
- PR #1188 added a fourth probe (\`rustlib-integrity\`) to \`run_toolchain_doctor()\` but didn't update \`cli_toolchain_doctor.rs\`. Every \`Linux x64\` + \`target-run *-linux-*\` lane has been red on main since.
- Bump the test's \`assert_eq!(probes.len(), 3, ...)\` to 4 and assert the new probe name at index 3.

## Impact

Unblocks CI. Multiple auto-loop iterations have been failing to get past required checks since #1188 landed.

## Test plan

- [x] Update matches the actual probe order in \`toolchain_doctor.rs:37-42\`.
- [ ] First CI run post-merge: Linux x64 + target-run linux lanes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)