### PR TITLE
feat(ci): dogfood soldr cargo zigbuild on musl + aarch64-linux-gnu lanes (#1207)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -322,7 +322,15 @@ jobs:
               --package soldr-cli --bin soldr
           elif [[ "$target" == *-unknown-linux-musl ]] \
                || [[ "$target" == aarch64-unknown-linux-gnu ]]; then
-            cargo zigbuild --release --target "$target" \
+            # soldr#1207 — dogfood: route zigbuild through soldr so
+            # RUSTC_WRAPPER=zccache lands on host-side build.rs +
+            # proc-macro compiles. Cross-target rustc calls still
+            # miss the seed (different rustc inputs), but the
+            # HOST-triple compilation surface picks up hits. soldr
+            # defers to the PATH-installed cargo-zigbuild@0.23.0 by
+            # default so the underlying binary is identical to
+            # bare-cargo mode.
+            soldr cargo zigbuild --release --target "$target" \
               --package soldr-cli --bin soldr
           else
             cargo build --release --target "$target" \


### PR DESCRIPTION
## Summary

- Fixes #1207.
- Change the musl + aarch64-linux-gnu branch of \`Cross-build release binary\` from bare \`cargo zigbuild\` to \`soldr cargo zigbuild\` (using setup-soldr's pinned v0.7.42).
- soldr defers to the same PATH-installed \`cargo-zigbuild@0.23.0\` underneath — just injects \`RUSTC_WRAPPER=zccache\` on top.

## Impact

Host-side compile surface (build.rs outputs, proc-macros — all HOST triple) picks up hits from the setup-soldr zccache seed. Cross-target rustc calls still miss (different rustc inputs), which is unchanged.

Estimated: 10-30% speedup per lane on \`Cross-build release binary\` for the 3 zigbuild lanes. Musl x86_64 baseline ~491 s → target ~350-420 s.

## Continues goal thread

Follows on from #1194/#1195 (bootstrap dogfood). Same rationale — pinned known-working soldr wraps the compile so zccache can help.

## Test plan

- [x] setup-soldr v0.7.42 supports \`soldr cargo zigbuild\` (registered in \`known_tools\`).
- [x] soldr defers to PATH cargo-zigbuild by default — same binary as bare cargo mode.
- [ ] First CI post-merge: musl + gnu-aarch64 cross-build steps drop 10-30%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)