### PR TITLE
perf(ci): gate Benchmark Stats + Perf Matrix on 24h quiet window

### DIFF
--- a/.github/scripts/perf_gate.py
+++ b/.github/scripts/perf_gate.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Skip perf / benchmark workflows if a real user push landed on main recently.
+
+The perf-matrix and benchmark-stats workflows are expensive (build + bench +
+publish, ~30-60 min a piece). Running them on every push to main during
+active development bursts eats CI capacity that PR pipelines could use, and
+produces no useful signal — the per-commit noise dominates the between-day
+trend the benchmarks are meant to track.
+
+This gate looks at recent main commits and skips the run when the most
+recent NON-BOT commit is younger than `--hours` (default 24). The idea is
+that perf-heavy workflows fire only during quiet periods — one benchmark
+run per day of quiet — while active dev bursts stay lean.
+
+The signal is deliberately "commit author is a human", not "the current
+push is from a human" — if a bot pushed 20 minutes ago but the last actual
+person-driven change was 30h ago, we still want the perf run.
+
+## Bot classifiers
+
+An author email counts as bot-authored when it matches any of:
+    * `github-actions[bot]@...` — the default GHA identity for
+      `${{ secrets.GITHUB_TOKEN }}` pushes.
+    * `actions@github.com` — legacy GHA push identity.
+    * `noreply@github.com` — used by some Squash/Merge web flows and by
+      programmatic pushes via the GitHub API.
+    * `renovate[bot]` / `dependabot[bot]` — dependency-update bots.
+    * `soldr-release-bot` — hypothetical future release automation
+      identity.
+
+`noreply@anthropic.com` (Claude's co-author trailer) is NOT classified as
+bot: it appears only in the co-author trailer of commits whose primary
+author is a real user, and `git log --format=%ae` reports the AUTHOR
+email, not co-author trailers.
+
+## Usage
+
+    python3 .github/scripts/perf_gate.py --hours 24
+
+Writes `should_run=<true|false>` and `reason=<text>` to `$GITHUB_OUTPUT`
+when running under GHA. Also prints the reason to stdout so `gh run view`
+lines up with the gate decision. Always exits 0.
+
+## Bypass rules baked in the caller
+
+This script is only invoked when the workflow's own YAML has decided the
+event might be gate-eligible (e.g. `push` to `main`). Workflow_dispatch
+runs, `perf/**` branch pushes, and `evaluate/**` branch pushes should
+bypass the gate entirely — those are explicit human requests to run.
+Callers wire that bypass in with a plain shell check before invoking the
+script; the script assumes it's being called in a gate-eligible context.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from typing import Iterable
+
+BOT_EMAIL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^github-actions\[bot\]@", re.IGNORECASE),
+    re.compile(r"^actions@github\.com$", re.IGNORECASE),
+    re.compile(r"^noreply@github\.com$", re.IGNORECASE),
+    re.compile(r"renovate\[bot\]", re.IGNORECASE),
+    re.compile(r"dependabot\[bot\]", re.IGNORECASE),
+    re.compile(r"soldr-release-bot", re.IGNORECASE),
+)
+
+
+def is_bot(email: str) -> bool:
+    email = email.strip()
+    return any(p.search(email) for p in BOT_EMAIL_PATTERNS)
+
+
+def walk_main_commits(limit: int, ref: str) -> Iterable[tuple[int, str]]:
+    """Yield `(unix_ts, author_email)` for the most recent `limit` commits on `ref`."""
+    proc = subprocess.run(
+        ["git", "log", f"-n{limit}", "--format=%at|%ae", ref],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    for line in proc.stdout.splitlines():
+        ts_str, sep, email = line.partition("|")
+        if not sep:
+            continue
+        try:
+            yield int(ts_str), email
+        except ValueError:
+            continue
+
+
+def emit_output(should_run: bool, reason: str) -> None:
+    print(reason)
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    with open(out_path, "a", encoding="utf-8") as fh:
+        fh.write(f"should_run={'true' if should_run else 'false'}\n")
+        # Escape newlines defensively; the reason is a single line by construction.
+        fh.write(f"reason={reason}\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    ap.add_argument(
+        "--hours",
+        type=int,
+        default=24,
+        help="Skip if the last non-bot commit is younger than this many hours.",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Number of recent commits to walk (bounds the git log call).",
+    )
+    ap.add_argument(
+        "--ref",
+        default="HEAD",
+        help="Git ref to walk. Defaults to HEAD (which is `main` when the "
+        "workflow triggered on push:main).",
+    )
+    args = ap.parse_args()
+
+    now = int(time.time())
+    cutoff_ts = now - args.hours * 3600
+
+    latest_human_ts: int | None = None
+    latest_human_email: str | None = None
+    for ts, email in walk_main_commits(args.limit, args.ref):
+        if is_bot(email):
+            continue
+        latest_human_ts = ts
+        latest_human_email = email
+        break
+
+    if latest_human_ts is None:
+        # No non-bot commit in the walk window. Extremely unlikely in
+        # practice; if it happens, treat as "quiet enough to run" so we
+        # don't silently kill perf runs when the bot-detection heuristic
+        # accidentally overmatches.
+        emit_output(
+            True,
+            f"No non-bot commit in the last {args.limit} main commits — proceeding.",
+        )
+        return 0
+
+    hours_ago = (now - latest_human_ts) // 3600
+    if latest_human_ts >= cutoff_ts:
+        emit_output(
+            False,
+            f"Last non-bot commit was {hours_ago}h ago ({latest_human_email}); "
+            f"< {args.hours}h. Skipping perf run to preserve CI capacity for "
+            "active dev.",
+        )
+        return 0
+
+    emit_output(
+        True,
+        f"Last non-bot commit was {hours_ago}h ago ({latest_human_email}); "
+        f">= {args.hours}h. Proceeding with perf run.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -25,8 +25,44 @@ permissions:
   id-token: write
 
 jobs:
+  # soldr#1203 — perf/benchmark workflows are expensive (build + bench +
+  # publish, ~30-60 min) and produce noise when they fire on every merge
+  # during active development bursts. This gate skips the benchmark run
+  # unless the most recent non-bot commit on main is >=24h old, so we
+  # get one benchmark per quiet day instead of one per PR merge.
+  #
+  # Bypassed entirely for `workflow_dispatch` — that's an explicit human
+  # request to run.
+  gate:
+    name: Skip if recent human push
+    runs-on: ubuntu-24.04
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      reason:     ${{ steps.check.outputs.reason }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # perf_gate.py walks up to 200 commits back. Fetch that much so
+          # the check has data to work with. Well above the default
+          # shallow depth of 1.
+          fetch-depth: 250
+      - name: Evaluate quiet-window gate
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "push" ]; then
+              echo "Event is ${{ github.event_name }} (not push) — bypassing gate; run unconditionally."
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              echo "reason=bypass: event=${{ github.event_name }}" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
+          python3 .github/scripts/perf_gate.py --hours 24
+
   benchmark:
     name: Generate + publish benchmark stats
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:

--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -85,6 +85,51 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # soldr#1203 — Perf Matrix on push:main is expensive (~30-60 min per
+  # cell × several cells) and produces per-commit noise that swamps the
+  # between-day trend the matrix is meant to track. This gate skips the
+  # full sweep unless the most recent non-bot commit on main is >=24h
+  # old, so we get one perf sweep per quiet day instead of one per PR
+  # merge.
+  #
+  # Bypassed for `workflow_dispatch` (explicit human request) and for
+  # `perf/**` / `evaluate/**` branch pushes (feature branches where the
+  # dev is iterating and expects every push to run).
+  gate:
+    name: Skip if recent human push (main only)
+    runs-on: ubuntu-24.04
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      reason:     ${{ steps.check.outputs.reason }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 250
+      - name: Evaluate quiet-window gate
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Bypass 1: any non-push event (workflow_dispatch).
+          if [ "${{ github.event_name }}" != "push" ]; then
+              echo "Event is ${{ github.event_name }} (not push) — bypassing gate; run unconditionally."
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              echo "reason=bypass: event=${{ github.event_name }}" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
+          # Bypass 2: perf/** or evaluate/** feature-branch pushes. The
+          # dev is iterating and wants every push to run.
+          ref='${{ github.ref }}'
+          case "$ref" in
+            refs/heads/perf/*|refs/heads/evaluate/*)
+              echo "Ref is $ref — perf/eval feature branch bypasses gate; run unconditionally."
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              echo "reason=bypass: feature-branch ref=$ref" >> "$GITHUB_OUTPUT"
+              exit 0 ;;
+          esac
+          # Main-branch push: consult the quiet-window gate.
+          python3 .github/scripts/perf_gate.py --hours 24
+
   setup:
     # Resolve the effective (platforms, fixtures, scenarios) scope
     # once and pipe the result to every downstream gate via job
@@ -98,6 +143,8 @@ jobs:
     #    `::notice::` so the dev still gets useful data while
     #    iterating on a feature branch.
     name: setup
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-24.04
     outputs:
       platforms: ${{ steps.parse.outputs.platforms }}


### PR DESCRIPTION
## Summary

Benchmark Stats and Perf Matrix fire on every push to main and each take ~30-60 minutes. During active-dev bursts (several PR merges per hour, as seen this afternoon) they consume CI capacity that PR pipelines need, and produce per-commit noise that swamps the between-day trend the benchmarks are actually meant to track.

This PR adds a `gate` job at the head of each workflow that:

1. Bypasses entirely for `workflow_dispatch` (explicit human request).
2. For perf-matrix, also bypasses `perf/**` and `evaluate/**` branch pushes (feature-branch iteration).
3. For `push:main`, invokes `.github/scripts/perf_gate.py --hours 24`. The script walks up to 200 recent commits on the checked-out ref and finds the newest whose author email is NOT a bot pattern (`github-actions[bot]@`, `noreply@github.com`, `renovate[bot]`, `dependabot[bot]`, `soldr-release-bot`). If that commit is younger than 24h, the gate sets `should_run=false` and downstream jobs skip.

Downstream `needs: gate` + `if: needs.gate.outputs.should_run == 'true'` propagates the skip through the whole graph via the existing `needs` chains.

## Local test

```
$ uv run --no-project python .github/scripts/perf_gate.py --hours 24
Last non-bot commit was 0h ago (zachvorhies@protonmail.com); < 24h. Skipping perf run to preserve CI capacity for active dev.
$ uv run --no-project python .github/scripts/perf_gate.py --hours 0
Last non-bot commit was 0h ago (zachvorhies@protonmail.com); >= 0h. Proceeding with perf run.
```

Both YAML files re-parse cleanly with `pyyaml.safe_load` and the job graph is:

- `benchmark-stats.yml`: `gate` → `benchmark` → `deploy-pages`
- `perf-matrix.yml`: `gate` → `setup` → `build-soldr` → `bench` → `evaluate`

## Signal design

The check is "author of the last main commit is a human", NOT "the CURRENT push is a human". If a bot pushed 20 minutes ago but the last person-driven change was 30h ago, we still run — the goal is to capture a real quiet-window trend point.

`noreply@anthropic.com` (Claude's co-author trailer) is intentionally NOT classified as bot: `git log --format=%ae` reports the author email, and Claude only ever appears as a co-author of commits whose primary author is a human.

## Non-scope

- `thin-v2-verify`, `cook-size-gate`, `cache-delta-experiment` are already path-scoped to a small handful of files and don't fire on typical main pushes. No gate needed.
- `parent-cache-bench` and `perf-cold-warm` are workflow_dispatch only. No automatic triggers to gate.
- `release-auto` is intentionally push-triggered — release cadence must NOT be delayed by a quiet-window heuristic.

## Test plan

- [x] Local script test on quiet-window rules (both true and false branches).
- [x] YAML parse + job graph inspection.
- [x] Bot-pattern regex covers the identities we care about; author (not co-author) email is the input.
- [ ] Post-merge: next push to main should fire the workflow with the gate job showing `should_run=false` in the log (since main is very active right now). A `workflow_dispatch` should still run through to the full sweep.