### PR TITLE
perf(ci): nightly cron fires perf/bench when the day had activity (#1213)

### DIFF
--- a/.github/scripts/perf_gate.py
+++ b/.github/scripts/perf_gate.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python3
-"""Skip perf / benchmark workflows if a real user push landed on main recently.
+"""Perf/benchmark workflow gate — two modes, one check on recent main activity.
 
 The perf-matrix and benchmark-stats workflows are expensive (build + bench +
-publish, ~30-60 min a piece). Running them on every push to main during
-active development bursts eats CI capacity that PR pipelines could use, and
-produces no useful signal — the per-commit noise dominates the between-day
-trend the benchmarks are meant to track.
+publish, ~30-60 min a piece). Firing them on every push to main during
+active development produces per-commit noise that swamps the between-day
+trend they're meant to track. Never firing them on quiet-only days means we
+miss the trend entirely. This gate reconciles the two.
 
-This gate looks at recent main commits and skips the run when the most
-recent NON-BOT commit is younger than `--hours` (default 24). The idea is
-that perf-heavy workflows fire only during quiet periods — one benchmark
-run per day of quiet — while active dev bursts stay lean.
+## Modes
 
-The signal is deliberately "commit author is a human", not "the current
-push is from a human" — if a bot pushed 20 minutes ago but the last actual
-person-driven change was 30h ago, we still want the perf run.
+* `push` (default): skip when the last non-bot commit on main is
+  YOUNGER than `--hours` (default 24). Rationale: a busy day is
+  already producing benchmark noise; suppress the per-merge triggers
+  and let the nightly cron capture the day's cumulative trend.
+* `schedule`: run when there WAS at least one non-bot commit on main
+  in the last `--hours`. Rationale: on a day that had activity there
+  is something new to benchmark, so the nightly cron fires; on a
+  quiet day, skip cleanly.
+
+The two modes read the same signal (age of the newest non-bot commit)
+and simply invert its interpretation. Both write `should_run=<bool>` and
+`reason=<text>` to `$GITHUB_OUTPUT`.
 
 ## Bot classifiers
 
@@ -35,20 +41,20 @@ email, not co-author trailers.
 
 ## Usage
 
-    python3 .github/scripts/perf_gate.py --hours 24
+    python3 .github/scripts/perf_gate.py --mode push     --hours 24
+    python3 .github/scripts/perf_gate.py --mode schedule --hours 24
 
-Writes `should_run=<true|false>` and `reason=<text>` to `$GITHUB_OUTPUT`
-when running under GHA. Also prints the reason to stdout so `gh run view`
-lines up with the gate decision. Always exits 0.
+Always exits 0.
 
 ## Bypass rules baked in the caller
 
-This script is only invoked when the workflow's own YAML has decided the
-event might be gate-eligible (e.g. `push` to `main`). Workflow_dispatch
-runs, `perf/**` branch pushes, and `evaluate/**` branch pushes should
-bypass the gate entirely — those are explicit human requests to run.
-Callers wire that bypass in with a plain shell check before invoking the
-script; the script assumes it's being called in a gate-eligible context.
+The workflow YAML is responsible for the trivial bypasses:
+    * `workflow_dispatch` runs bypass the gate entirely (explicit
+      human request).
+    * On perf-matrix, `perf/**` and `evaluate/**` branch pushes also
+      bypass (feature-branch iteration).
+
+The script only handles the `push:main` and `schedule` code paths.
 """
 
 from __future__ import annotations
@@ -101,17 +107,24 @@ def emit_output(should_run: bool, reason: str) -> None:
         return
     with open(out_path, "a", encoding="utf-8") as fh:
         fh.write(f"should_run={'true' if should_run else 'false'}\n")
-        # Escape newlines defensively; the reason is a single line by construction.
+        # Reason is a single line by construction.
         fh.write(f"reason={reason}\n")
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
     ap.add_argument(
+        "--mode",
+        choices=("push", "schedule"),
+        default="push",
+        help="push (default): skip when there was recent activity. "
+        "schedule: run when there was recent activity.",
+    )
+    ap.add_argument(
         "--hours",
         type=int,
         default=24,
-        help="Skip if the last non-bot commit is younger than this many hours.",
+        help="Size of the recent-activity window.",
     )
     ap.add_argument(
         "--limit",
@@ -123,7 +136,7 @@ def main() -> int:
         "--ref",
         default="HEAD",
         help="Git ref to walk. Defaults to HEAD (which is `main` when the "
-        "workflow triggered on push:main).",
+        "workflow triggered on push:main or schedule with a checkout of main).",
     )
     args = ap.parse_args()
 
@@ -140,31 +153,58 @@ def main() -> int:
         break
 
     if latest_human_ts is None:
-        # No non-bot commit in the walk window. Extremely unlikely in
-        # practice; if it happens, treat as "quiet enough to run" so we
-        # don't silently kill perf runs when the bot-detection heuristic
-        # accidentally overmatches.
-        emit_output(
-            True,
-            f"No non-bot commit in the last {args.limit} main commits — proceeding.",
-        )
+        # No non-bot commit in the walk window — no signal either way.
+        # Push mode: extremely quiet, safe to run.
+        # Schedule mode: nothing new to benchmark, skip.
+        if args.mode == "schedule":
+            emit_output(
+                False,
+                f"No non-bot commit in the last {args.limit} main commits — "
+                "nothing new to benchmark; skipping nightly perf run.",
+            )
+        else:
+            emit_output(
+                True,
+                f"No non-bot commit in the last {args.limit} main commits — "
+                "quiet enough to proceed with perf run.",
+            )
         return 0
 
     hours_ago = (now - latest_human_ts) // 3600
-    if latest_human_ts >= cutoff_ts:
-        emit_output(
-            False,
-            f"Last non-bot commit was {hours_ago}h ago ({latest_human_email}); "
-            f"< {args.hours}h. Skipping perf run to preserve CI capacity for "
-            "active dev.",
-        )
+    had_recent_activity = latest_human_ts >= cutoff_ts
+
+    if args.mode == "schedule":
+        if had_recent_activity:
+            emit_output(
+                True,
+                f"Nightly cron: last non-bot commit was {hours_ago}h ago "
+                f"({latest_human_email}); < {args.hours}h. Day had activity, "
+                "proceeding with perf run.",
+            )
+        else:
+            emit_output(
+                False,
+                f"Nightly cron: last non-bot commit was {hours_ago}h ago "
+                f"({latest_human_email}); >= {args.hours}h. Quiet day, "
+                "nothing new to benchmark; skipping.",
+            )
         return 0
 
-    emit_output(
-        True,
-        f"Last non-bot commit was {hours_ago}h ago ({latest_human_email}); "
-        f">= {args.hours}h. Proceeding with perf run.",
-    )
+    # mode == "push"
+    if had_recent_activity:
+        emit_output(
+            False,
+            f"Push:main: last non-bot commit was {hours_ago}h ago "
+            f"({latest_human_email}); < {args.hours}h. Active burst — "
+            "skipping perf run; the nightly cron will capture today's trend.",
+        )
+    else:
+        emit_output(
+            True,
+            f"Push:main: last non-bot commit was {hours_ago}h ago "
+            f"({latest_human_email}); >= {args.hours}h. Post-quiet window, "
+            "proceeding with perf run.",
+        )
     return 0
 
 

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -12,6 +12,13 @@ on:
     paths-ignore:
       - '*.md'
       - '**/*.md'
+  # soldr#1213 — nightly cron so an active day always produces at least one
+  # benchmark run. The gate below inverts to schedule mode on this trigger:
+  # runs only if there was at least one non-bot commit in the last 24h.
+  # 3:17 UTC deliberately off-hour to avoid the top-of-hour thundering
+  # herd (see the same nudge in .claude cron guidance).
+  schedule:
+    - cron: '17 3 * * *'
 
 concurrency:
   # Only one publish at a time per ref; cancel a stale in-flight when a
@@ -25,16 +32,22 @@ permissions:
   id-token: write
 
 jobs:
-  # soldr#1203 — perf/benchmark workflows are expensive (build + bench +
-  # publish, ~30-60 min) and produce noise when they fire on every merge
-  # during active development bursts. This gate skips the benchmark run
-  # unless the most recent non-bot commit on main is >=24h old, so we
-  # get one benchmark per quiet day instead of one per PR merge.
+  # soldr#1203 + soldr#1213 — perf/benchmark workflows are expensive
+  # (build + bench + publish, ~30-60 min). The gate reconciles two
+  # concerns:
   #
-  # Bypassed entirely for `workflow_dispatch` — that's an explicit human
-  # request to run.
+  #   * push:main — active-dev bursts would fire this on every merge
+  #     and produce per-commit noise. Skip when the last non-bot
+  #     commit is < 24h old (i.e. burst in progress).
+  #   * schedule — nightly cron. Run when there WAS at least one
+  #     non-bot commit in the last 24h (i.e. active day, something
+  #     new to benchmark). Skip on quiet days.
+  #   * workflow_dispatch — explicit human request, always run.
+  #
+  # Net: one benchmark per day of activity, zero per burst, zero on
+  # quiet days.
   gate:
-    name: Skip if recent human push
+    name: Decide whether to run
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -46,18 +59,31 @@ jobs:
           # the check has data to work with. Well above the default
           # shallow depth of 1.
           fetch-depth: 250
-      - name: Evaluate quiet-window gate
+      - name: Evaluate activity gate
         id: check
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" != "push" ]; then
-              echo "Event is ${{ github.event_name }} (not push) — bypassing gate; run unconditionally."
+          case "${{ github.event_name }}" in
+            workflow_dispatch)
+              echo "workflow_dispatch — bypassing gate; run unconditionally."
               echo "should_run=true" >> "$GITHUB_OUTPUT"
-              echo "reason=bypass: event=${{ github.event_name }}" >> "$GITHUB_OUTPUT"
+              echo "reason=bypass: workflow_dispatch" >> "$GITHUB_OUTPUT"
               exit 0
-          fi
-          python3 .github/scripts/perf_gate.py --hours 24
+              ;;
+            schedule)
+              python3 .github/scripts/perf_gate.py --mode schedule --hours 24
+              ;;
+            push)
+              python3 .github/scripts/perf_gate.py --mode push --hours 24
+              ;;
+            *)
+              echo "Unknown event ${{ github.event_name }} — running to be safe."
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              echo "reason=bypass: unknown event=${{ github.event_name }}" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
 
   benchmark:
     name: Generate + publish benchmark stats
@@ -168,7 +194,12 @@ jobs:
   deploy-pages:
     name: Deploy benchmark page
     needs: benchmark
-    if: ${{ needs.benchmark.result == 'success' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    # soldr#1213 — allow nightly schedule to deploy pages too. On
+    # `schedule` GitHub does not populate `github.ref` from a branch push;
+    # scheduled workflows always run against the default branch, so the
+    # ref check still holds implicitly. Skip the branch-format check on
+    # schedule to avoid a false negative.
+    if: ${{ needs.benchmark.result == 'success' && (github.event_name == 'schedule' || (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))) }}
     runs-on: ubuntu-24.04
     environment:
       name: github-pages

--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -73,6 +73,13 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+  # soldr#1213 — nightly cron so an active day always produces at least one
+  # perf sweep. The gate below inverts to schedule mode on this trigger:
+  # runs only if there was at least one non-bot commit on main in the last
+  # 24h. 4:23 UTC deliberately staggered from benchmark-stats' 3:17 slot so
+  # the two nightly runs don't collide on shared runners.
+  schedule:
+    - cron: '23 4 * * *'
 
 permissions:
   contents: read
@@ -85,18 +92,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # soldr#1203 — Perf Matrix on push:main is expensive (~30-60 min per
-  # cell × several cells) and produces per-commit noise that swamps the
-  # between-day trend the matrix is meant to track. This gate skips the
-  # full sweep unless the most recent non-bot commit on main is >=24h
-  # old, so we get one perf sweep per quiet day instead of one per PR
-  # merge.
+  # soldr#1203 + soldr#1213 — Perf Matrix reconciles two concerns:
   #
-  # Bypassed for `workflow_dispatch` (explicit human request) and for
-  # `perf/**` / `evaluate/**` branch pushes (feature branches where the
-  # dev is iterating and expects every push to run).
+  #   * push:main — active-dev bursts would run the full sweep on every
+  #     merge. Skip when the last non-bot commit on main is < 24h old.
+  #   * schedule — nightly cron. Run when there WAS at least one non-bot
+  #     commit on main in the last 24h (active day → benchmark it).
+  #     Skip on quiet days.
+  #   * workflow_dispatch — explicit human request, always run.
+  #   * perf/** / evaluate/** branch pushes — feature-branch iteration,
+  #     always run (dev is watching each push).
+  #
+  # Net: one perf sweep per day of activity on main, plus every dispatch
+  # and every feature-branch push. Zero per burst, zero per quiet day.
   gate:
-    name: Skip if recent human push (main only)
+    name: Decide whether to run
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -105,30 +115,45 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 250
-      - name: Evaluate quiet-window gate
+      - name: Evaluate activity gate
         id: check
         shell: bash
         run: |
           set -euo pipefail
-          # Bypass 1: any non-push event (workflow_dispatch).
-          if [ "${{ github.event_name }}" != "push" ]; then
-              echo "Event is ${{ github.event_name }} (not push) — bypassing gate; run unconditionally."
+          # workflow_dispatch: explicit human request → always run.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "workflow_dispatch — bypassing gate; run unconditionally."
               echo "should_run=true" >> "$GITHUB_OUTPUT"
-              echo "reason=bypass: event=${{ github.event_name }}" >> "$GITHUB_OUTPUT"
+              echo "reason=bypass: workflow_dispatch" >> "$GITHUB_OUTPUT"
               exit 0
           fi
-          # Bypass 2: perf/** or evaluate/** feature-branch pushes. The
-          # dev is iterating and wants every push to run.
+          # perf/** or evaluate/** feature-branch pushes → always run.
+          # (These branches are only reachable via push, so this check
+          # only applies to that event.)
           ref='${{ github.ref }}'
           case "$ref" in
             refs/heads/perf/*|refs/heads/evaluate/*)
               echo "Ref is $ref — perf/eval feature branch bypasses gate; run unconditionally."
               echo "should_run=true" >> "$GITHUB_OUTPUT"
               echo "reason=bypass: feature-branch ref=$ref" >> "$GITHUB_OUTPUT"
-              exit 0 ;;
+              exit 0
+              ;;
           esac
-          # Main-branch push: consult the quiet-window gate.
-          python3 .github/scripts/perf_gate.py --hours 24
+          # Remaining code paths: main-branch push OR nightly schedule.
+          case "${{ github.event_name }}" in
+            schedule)
+              python3 .github/scripts/perf_gate.py --mode schedule --hours 24
+              ;;
+            push)
+              python3 .github/scripts/perf_gate.py --mode push --hours 24
+              ;;
+            *)
+              echo "Unknown event ${{ github.event_name }} — running to be safe."
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
+              echo "reason=bypass: unknown event=${{ github.event_name }}" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
 
   setup:
     # Resolve the effective (platforms, fixtures, scenarios) scope


### PR DESCRIPTION
## Summary

Fixes #1213. Follow-up to #1210.

#1210's push-gate skips Benchmark Stats + Perf Matrix on `push:main` during active-dev bursts. But on typical active days (many merges, none 24h apart), the perf lanes then NEVER run. This PR adds a nightly `schedule:` trigger to both workflows and teaches the gate to invert on that event source: **run when the day had activity, skip when it was quiet**.

## Behavior matrix

| Event | Rule | Effect on active day | Effect on quiet day |
|---|---|---|---|
| `push:main` | skip if < 24h since last non-bot commit | skip (burst in progress) | run (post-quiet trigger) |
| `schedule` (nightly) | run if there WAS a non-bot commit in the last 24h | **run** (captures the day) | skip (nothing new) |
| `workflow_dispatch` | bypass gate | run | run |
| `perf/**` / `evaluate/**` push (perf-matrix only) | bypass gate | run | run |

Net: **one perf/bench sweep per day of activity**, zero per burst, zero per quiet day.

## Implementation

`perf_gate.py` grows a `--mode {push,schedule}` flag. Both modes read the same signal (age of the newest non-bot commit on main) and simply invert its interpretation.

Both workflow YAMLs gain a `schedule:` trigger with cron slots:
- benchmark-stats: `17 3 * * *` (03:17 UTC)
- perf-matrix:     `23 4 * * *` (04:23 UTC)

Deliberately off-minute (avoid top-of-hour thundering herd) and staggered 66 min apart (avoid runner contention).

Also fixes benchmark-stats' `deploy-pages` job whose `if:` previously excluded `schedule`; extended to allow scheduled runs to publish their page.

## Local test

All four expected branches:

```
$ uv run --no-project python .github/scripts/perf_gate.py --mode push     --hours 24
Push:main: last non-bot commit was 0h ago (...); < 24h. Active burst — skipping perf run; the nightly cron will capture today's trend.

$ uv run --no-project python .github/scripts/perf_gate.py --mode schedule --hours 24
Nightly cron: last non-bot commit was 0h ago (...); < 24h. Day had activity, proceeding with perf run.

$ uv run --no-project python .github/scripts/perf_gate.py --mode push     --hours 0
Push:main: last non-bot commit was 0h ago (...); >= 0h. Post-quiet window, proceeding with perf run.

$ uv run --no-project python .github/scripts/perf_gate.py --mode schedule --hours 0
Nightly cron: last non-bot commit was 0h ago (...); >= 0h. Quiet day, nothing new to benchmark; skipping.
```

## Test plan

- [x] Script smoke tests cover push/schedule × recent/quiet.
- [x] YAML parses under `pyyaml.safe_load`; job graph is `gate → benchmark → deploy-pages` and `gate → setup → build-soldr → bench → evaluate`.
- [x] deploy-pages if-condition now allows `schedule`.
- [ ] Post-merge: verify the next scheduled cron fire (03:17 / 04:23 UTC) runs when today had activity; verify a same-day push:main is still skipped by the gate.