### PR TITLE
Revert #1208: soldr cargo zigbuild dogfood broke aarch64 lanes (#1215)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -322,15 +322,7 @@ jobs:
               --package soldr-cli --bin soldr
           elif [[ "$target" == *-unknown-linux-musl ]] \
                || [[ "$target" == aarch64-unknown-linux-gnu ]]; then
-            # soldr#1207 — dogfood: route zigbuild through soldr so
-            # RUSTC_WRAPPER=zccache lands on host-side build.rs +
-            # proc-macro compiles. Cross-target rustc calls still
-            # miss the seed (different rustc inputs), but the
-            # HOST-triple compilation surface picks up hits. soldr
-            # defers to the PATH-installed cargo-zigbuild@0.23.0 by
-            # default so the underlying binary is identical to
-            # bare-cargo mode.
-            soldr cargo zigbuild --release --target "$target" \
+            cargo zigbuild --release --target "$target" \
               --package soldr-cli --bin soldr
           else
             cargo build --release --target "$target" \


### PR DESCRIPTION
Reverts #1208. See #1215 — soldr's v0.7.42 apparently drops CARGO_TARGET_<T>_LINKER when preparing the cargo-zigbuild child env, so aarch64 linker fell back to system clang (elf64-x86-64 host default) and blew up linking aarch64 objects.