### PR TITLE
revert(ci): #1208 soldr cargo zigbuild dogfood — broke aarch64 (#1215)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -322,15 +322,7 @@ jobs:
               --package soldr-cli --bin soldr
           elif [[ "$target" == *-unknown-linux-musl ]] \
                || [[ "$target" == aarch64-unknown-linux-gnu ]]; then
-            # soldr#1207 — dogfood: route zigbuild through soldr so
-            # RUSTC_WRAPPER=zccache lands on host-side build.rs +
-            # proc-macro compiles. Cross-target rustc calls still
-            # miss the seed (different rustc inputs), but the
-            # HOST-triple compilation surface picks up hits. soldr
-            # defers to the PATH-installed cargo-zigbuild@0.23.0 by
-            # default so the underlying binary is identical to
-            # bare-cargo mode.
-            soldr cargo zigbuild --release --target "$target" \
+            cargo zigbuild --release --target "$target" \
               --package soldr-cli --bin soldr
           else
             cargo build --release --target "$target" \


### PR DESCRIPTION
## Summary

Fixes #1215. Straight revert of #1208 (commit 4ed3aa3).

PR #1208 aimed to dogfood \`soldr cargo zigbuild\` on musl + aarch64-linux-gnu cross-build lanes so host-side build.rs + proc-macro compiles could hit the zccache seed. In practice it broke both aarch64 lanes with a target/host arch mismatch at link time:

\`\`\`
ld.lld: error: /.../target/aarch64-.../release/deps/rustccw5vFO/symbols.o
                is incompatible with elf64-x86-64
ld.lld: error: /.../sevenz_rust-*.rlib is incompatible with elf64-x86-64
\`\`\`

Per #1215's root-cause: the linker was invoked as host \`clang\` targeting \`elf64-x86-64\` instead of \`aarch64-linux-gnu\` via zig-cc. \`soldr cargo zigbuild\` through setup-soldr's pinned v0.7.42 appears to drop \`CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER\` when preparing the child environment. \`x86_64-linux-musl\` works only because host arch is x86_64.

Reverting to bare \`cargo zigbuild\` on both lanes. Root-cause investigation of the LINKER-env drop is out of scope for the rollback — the ~10-30% host-side compile-hit win #1208 aimed for is not worth broken aarch64 CI.

## Test plan

- [x] Diff is one line: \`soldr cargo zigbuild\` → \`cargo zigbuild\` in the musl/aarch64 branch of \`_ci-cross-build-linux.yml\`.
- [x] No other files changed.
- [ ] Post-merge: next cross-build run on aarch64-unknown-linux-{gnu,musl} succeeds again.

Not addressed here: the underlying LINKER-env drop in soldr's cargo front-door + setup-soldr's v0.7.42. That warrants a separate investigation once someone can reproduce the LINKER-drop locally.