### PR TITLE
chore(release): bump 0.7.89 → 0.7.90 + fix Apple SDK --github-env FILE arg

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -346,7 +346,14 @@ jobs:
       - name: Prepare Apple SDK (darwin only)
         if: contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04'
         shell: bash
-        run: soldr prepare --target ${{ matrix.target }} --github-env
+        # `--github-env` takes a FILE path (SDKROOT is appended). Point
+        # at $GITHUB_ENV so downstream steps see the export. The bare
+        # `--github-env` invocation errored `a value is required for
+        # '--github-env <FILE>' but none was supplied` on v0.7.89 and
+        # broke the macOS x64 release lane. See the composite action at
+        # .github/actions/prepare-cross-toolchain/action.yml for the
+        # canonical shape.
+        run: soldr prepare --target ${{ matrix.target }} --github-env "$GITHUB_ENV"
 
       - name: Setup persistent zig-cc wrappers (darwin only)
         if: contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.89"
+version = "0.7.90"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.89"
+version = "0.7.90"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.89",
+  "version": "0.7.90",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Cuts **v0.7.90** and fixes the release-blocker that made v0.7.89's macOS x64 lane fail.

## Version bump (lockstep — CLAUDE.md guard)

| File | Change |
|---|---|
| \`Cargo.toml\` | \`[workspace.package].version\` → 0.7.90 |
| \`package.json\` | \`"version"\` → 0.7.90 |
| \`Cargo.lock\` | \`soldr-cli.version\` → 0.7.90 (refreshed via \`soldr cargo build\`) |

\`crates/soldr-cli/tests/version_lockstep.rs\` verified locally.

## Blocker fix (Prepare Apple SDK)

v0.7.89 Autonomous Release [run 28537699307](https://github.com/zackees/soldr/actions/runs/28537699307) failed on macOS x64 at \`Prepare Apple SDK (darwin only)\`:

\`\`\`
error: a value is required for '--github-env <FILE>' but none was supplied
Process completed with exit code 2.
\`\`\`

Root cause: \`.github/workflows/release-auto.yml:349\` invoked \`soldr prepare --target ... --github-env\` — bare boolean — but the \`--github-env\` flag takes a FILE path (SDKROOT is appended to that file). Fixed to \`--github-env \"\$GITHUB_ENV\"\`, matching the canonical shape at \`.github/actions/prepare-cross-toolchain/action.yml:50\`.

Consequence of v0.7.89's fault: macOS x64 wheel never built, then the "Publish hardened PyPI wheels" job's "Verify all wheels visible on PyPI" step timed out at **5/6 wheels** for soldr==0.7.89. One root cause, both symptoms.

## Test plan

- [x] \`soldr cargo test -p soldr-cli --test version_lockstep\` — 1/1 pass.
- [x] \`soldr cargo build -p soldr-cli --bin soldr\` — clean, Cargo.lock refreshed to 0.7.90.
- [x] Diff scoped to \`release-auto.yml\` (Apple SDK step) + Cargo.toml + Cargo.lock + package.json.
- [ ] Post-merge: Autonomous Release fires for v0.7.90, macOS x64 lane completes, all 6 PyPI wheels land, verify step passes.

## Related

- Root cause for v0.7.89's macOS x64 lane failure.
- Sibling fix already applied to \`prepare-cross-toolchain\` composite action; only the release-auto.yml direct invocation had the wrong shape.