### PR TITLE
chore(release): bump 0.7.90 → 0.7.91 + fix crgx/cargo-chef darwin-x64 cross

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -722,19 +722,40 @@ jobs:
           # cargo toolchain is shared with the soldr build step above,
           # so no extra setup-uv / install-musl / install-rust is
           # needed here.
-          cargo build \
-            --release \
-            --manifest-path "$work_dir/Cargo.toml" \
-            --target "${{ matrix.target }}" \
-            --locked
+          #
+          # soldr#1140/#1202 aftermath: on Linux → x86_64-apple-darwin
+          # cross-build, bare `cargo build` fails at link time —
+          # `unable to find dynamic system library 'iconv'` — because
+          # the elaborate SDK cross-env (CC_*, CXX_*, AR_*, CFLAGS_*,
+          # CARGO_TARGET_*_LINKER, ...) set by the soldr build step is
+          # step-scoped and doesn't persist here. Route through
+          # cargo-zigbuild for the darwin-on-Linux lane — zig-cc
+          # handles the sysroot / linker plumbing internally and picks
+          # up SDKROOT from $GITHUB_ENV (populated by the
+          # `Prepare Apple SDK` step). Everything else (native darwin,
+          # musl, gnu, windows) still builds fine with bare cargo.
+          target='${{ matrix.target }}'
+          if [[ "$target" == *-apple-darwin && "$RUNNER_OS" = "Linux" ]]; then
+            cargo zigbuild \
+              --release \
+              --manifest-path "$work_dir/Cargo.toml" \
+              --target "$target" \
+              --locked
+          else
+            cargo build \
+              --release \
+              --manifest-path "$work_dir/Cargo.toml" \
+              --target "$target" \
+              --locked
+          fi
 
           suffix=""
-          case "${{ matrix.target }}" in *-pc-windows-msvc) suffix=".exe" ;; esac
+          case "$target" in *-pc-windows-msvc) suffix=".exe" ;; esac
 
-          built="$work_dir/target/${{ matrix.target }}/release/crgx${suffix}"
+          built="$work_dir/target/$target/release/crgx${suffix}"
           if [ ! -f "$built" ]; then
             echo "crgx not built at expected path: $built" >&2
-            ls -la "$work_dir/target/${{ matrix.target }}/release/" >&2 || true
+            ls -la "$work_dir/target/$target/release/" >&2 || true
             exit 1
           fi
           file "$built" || true
@@ -778,20 +799,35 @@ jobs:
           echo "cargo_chef_commit=$cargo_chef_commit"
           echo "CARGO_CHEF_SOURCE_COMMIT=$cargo_chef_commit" >> "$GITHUB_ENV"
 
-          cargo build \
-            --release \
-            --manifest-path "$work_dir/Cargo.toml" \
-            --target "${{ matrix.target }}" \
-            --locked \
-            --bin cargo-chef
+          # Same zigbuild switch as the crgx step above: bare `cargo
+          # build` fails at link time for Linux → x86_64-apple-darwin
+          # (libiconv not findable in the sysroot). Route the Apple x64
+          # cross through cargo-zigbuild; everything else stays on bare
+          # cargo. See the crgx step comment for the full rationale.
+          target='${{ matrix.target }}'
+          if [[ "$target" == *-apple-darwin && "$RUNNER_OS" = "Linux" ]]; then
+            cargo zigbuild \
+              --release \
+              --manifest-path "$work_dir/Cargo.toml" \
+              --target "$target" \
+              --locked \
+              --bin cargo-chef
+          else
+            cargo build \
+              --release \
+              --manifest-path "$work_dir/Cargo.toml" \
+              --target "$target" \
+              --locked \
+              --bin cargo-chef
+          fi
 
           suffix=""
-          case "${{ matrix.target }}" in *-pc-windows-msvc) suffix=".exe" ;; esac
+          case "$target" in *-pc-windows-msvc) suffix=".exe" ;; esac
 
-          built="$work_dir/target/${{ matrix.target }}/release/cargo-chef${suffix}"
+          built="$work_dir/target/$target/release/cargo-chef${suffix}"
           if [ ! -f "$built" ]; then
             echo "cargo-chef not built at expected path: $built" >&2
-            ls -la "$work_dir/target/${{ matrix.target }}/release/" >&2 || true
+            ls -la "$work_dir/target/$target/release/" >&2 || true
             exit 1
           fi
           file "$built" || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.90"
+version = "0.7.91"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.90"
+version = "0.7.91"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.90",
+  "version": "0.7.91",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Cuts **v0.7.91** and fixes the second release-blocker for the macOS x64 lane. v0.7.90 got past \`Prepare Apple SDK\` (thanks to soldr#1220's fix), but then failed at \`Build crgx from pinned source\`:

\`\`\`
error: unable to find dynamic system library 'iconv' using strategy 'paths_first'
error: could not compile crgx (bin \"crgx\") due to 1 previous error
Process completed with exit code 101.
\`\`\`

Same failure would recur at \`Build cargo-chef from pinned source\`.

## Root cause

On the Linux → x86_64-apple-darwin lane, the earlier \`Build release binary\` step sets up an elaborate Apple SDK cross-env inline (\`CC_x86_64_apple_darwin\`, \`CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER\`, \`CFLAGS_x86_64_apple_darwin\`, …) via \`export\`. GHA steps run in fresh shells, so those env vars don't persist to the subsequent \`Build crgx\` / \`Build cargo-chef\` steps. Those bare \`cargo build\` invocations then had no SDK cross-env, and rustc's linker probe couldn't find \`libiconv\` in the sysroot.

## Fix

Route the two source-build steps through **cargo-zigbuild** on the darwin-on-Linux lane; zig-cc handles sysroot / linker plumbing internally and reads \`SDKROOT\` (which the \`Prepare Apple SDK\` step already writes to \`\$GITHUB_ENV\` since 0.7.90's fix). Everything else — native darwin, musl, gnu, windows — stays on bare \`cargo build\` unchanged.

\`\`\`bash
target='\${{ matrix.target }}'
if [[ \"\$target\" == *-apple-darwin && \"\$RUNNER_OS\" = \"Linux\" ]]; then
  cargo zigbuild --release --manifest-path \"\$work_dir/Cargo.toml\" --target \"\$target\" --locked
else
  cargo build   --release --manifest-path \"\$work_dir/Cargo.toml\" --target \"\$target\" --locked
fi
\`\`\`

## Version bump

Lockstep (Cargo.toml + package.json + Cargo.lock refreshed via \`soldr cargo build\`). \`crates/soldr-cli/tests/version_lockstep.rs\` passes.

## Test plan

- [x] Local script logic sanity: both branches of the if fire as expected.
- [x] \`soldr cargo test -p soldr-cli --test version_lockstep\` — 1/1 pass.
- [x] Diff scoped to release-auto.yml (crgx + cargo-chef steps) + Cargo.{toml,lock} + package.json.
- [ ] Post-merge: v0.7.91 Autonomous Release completes macOS x64 lane end-to-end, all 6 PyPI wheels land, Verify step succeeds.

## Release chain context

- 0.7.87 → stub-binary bug (bad Cargo.toml at build time). Fixed by soldr#1187.
- 0.7.89 → macOS x64 Apple SDK step: \`--github-env\` missing FILE. Fixed by soldr#1220.
- 0.7.90 → macOS x64 crgx + cargo-chef cross-compile: libiconv missing. **This PR.**