### PR TITLE
Revert #1195: bootstrap dogfood is net-negative (0% zccache hit, +45s overhead) (#1224)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -187,21 +187,14 @@ jobs:
           path: ${{ runner.temp }}/soldr-bin
           key: bootstrap-soldr-blessed-linux-gnu-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml') }}
 
-      # soldr#1194 — dogfood: use the pinned setup-soldr `soldr` (v0.7.42
-       # today, resolved via `zackees/setup-soldr@cca74625`) to drive the
-       # bootstrap compile. The pinned soldr auto-injects RUSTC_WRAPPER=
-       # zccache, so bootstrap gets seed hits on shared crates instead of
-       # rebuilding ~700 crates from scratch each cache-miss run.
-      # `soldr cargo build` is a plain passthrough that v0.7.42 already
-      # supports; it does not require the `soldr build` subcommand (which
-      # arrived later — that's what THIS bootstrap step is producing for
-      # the downstream Cross-build release binary step).
       - name: Bootstrap soldr for SDK / blessed-build prep
         if: (contains(inputs.target, 'apple-darwin') || contains(inputs.target, 'pc-windows-msvc')) && steps.bootstrap_cache.outputs.cache-hit != 'true'
         shell: bash
+        env:
+          RUSTC_WRAPPER: ""
         run: |
           set -euo pipefail
-          soldr cargo build --release --locked --package soldr-cli \
+          cargo build --release --locked --package soldr-cli \
             --bin soldr --bin soldr-clang-shim \
             --target x86_64-unknown-linux-gnu
           mkdir -p "$RUNNER_TEMP/soldr-bin"


### PR DESCRIPTION
Reverts #1195. See #1224 — zccache seed doesn't align with soldr HEAD Cargo.lock, so hit_rate=0.0% and interception overhead adds ~45s per bootstrap. Restores bare-cargo baseline (~295s).