### PR TITLE
chore(release): bump 0.7.91 → 0.7.92 + inject SDKROOT lib path for zig-cc libiconv

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -736,6 +736,21 @@ jobs:
           # musl, gnu, windows) still builds fine with bare cargo.
           target='${{ matrix.target }}'
           if [[ "$target" == *-apple-darwin && "$RUNNER_OS" = "Linux" ]]; then
+            # soldr#1140/#1202 followup: zig-cc's bundled Apple stubs
+            # don't include a standalone libiconv, so `-liconv` (emitted
+            # by ureq / ring / etc.) fails at link:
+            #   error: unable to find dynamic system library 'iconv'
+            # The Apple SDK we fetched has `libiconv.tbd` under
+            # `$SDKROOT/usr/lib` — add that to the linker search path
+            # via RUSTFLAGS so zig-cc finds it. Same reason -F for
+            # Frameworks. SDKROOT lives in $GITHUB_ENV via the
+            # `Prepare Apple SDK` step so it's already exported here.
+            if [ -z "${SDKROOT:-}" ]; then
+              echo "ERROR: SDKROOT is unset — Prepare Apple SDK step should have set it" >&2
+              exit 1
+            fi
+            export RUSTFLAGS="-C link-arg=-L${SDKROOT}/usr/lib -C link-arg=-F${SDKROOT}/System/Library/Frameworks${RUSTFLAGS:+ ${RUSTFLAGS}}"
+            echo "RUSTFLAGS=$RUSTFLAGS"
             cargo zigbuild \
               --release \
               --manifest-path "$work_dir/Cargo.toml" \
@@ -802,10 +817,17 @@ jobs:
           # Same zigbuild switch as the crgx step above: bare `cargo
           # build` fails at link time for Linux → x86_64-apple-darwin
           # (libiconv not findable in the sysroot). Route the Apple x64
-          # cross through cargo-zigbuild; everything else stays on bare
-          # cargo. See the crgx step comment for the full rationale.
+          # cross through cargo-zigbuild + inject SDKROOT into linker
+          # search path so zig-cc can find libiconv.tbd. See the crgx
+          # step comment for the full rationale.
           target='${{ matrix.target }}'
           if [[ "$target" == *-apple-darwin && "$RUNNER_OS" = "Linux" ]]; then
+            if [ -z "${SDKROOT:-}" ]; then
+              echo "ERROR: SDKROOT is unset — Prepare Apple SDK step should have set it" >&2
+              exit 1
+            fi
+            export RUSTFLAGS="-C link-arg=-L${SDKROOT}/usr/lib -C link-arg=-F${SDKROOT}/System/Library/Frameworks${RUSTFLAGS:+ ${RUSTFLAGS}}"
+            echo "RUSTFLAGS=$RUSTFLAGS"
             cargo zigbuild \
               --release \
               --manifest-path "$work_dir/Cargo.toml" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.91"
+version = "0.7.92"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.91"
+version = "0.7.92"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.91",
+  "version": "0.7.92",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Cuts **v0.7.92** and fixes the second-order libiconv failure on the macOS x64 lane.

v0.7.91 (soldr#1223) routed crgx + cargo-chef through cargo-zigbuild on the Linux → x86_64-apple-darwin lane, which got past the first-order LINKER-env drop. But zig-cc's bundled Apple stubs don't ship a standalone libiconv, so \`-liconv\` (emitted by transitive deps in crgx and cargo-chef — ureq, ring, and a handful of others) still fails at link:

\`\`\`
ld.lld: error: unable to find dynamic system library 'iconv' using strategy 'paths_first'
\`\`\`

## Fix

The Apple SDK we fetch under \`\$SDKROOT\` does have \`libiconv.tbd\` at \`\$SDKROOT/usr/lib\`. Adding that directory to the linker search path via RUSTFLAGS lets zig-cc find it:

\`\`\`bash
export RUSTFLAGS=\"-C link-arg=-L\${SDKROOT}/usr/lib -C link-arg=-F\${SDKROOT}/System/Library/Frameworks\${RUSTFLAGS:+ \${RUSTFLAGS}}\"
\`\`\`

Applied to both \`Build crgx from pinned source\` and \`Build cargo-chef from pinned source\` steps, gated on the same \`*-apple-darwin && \$RUNNER_OS = Linux\` check that #1223 added. Native darwin / musl / gnu / windows lanes are unchanged.

## Release chain context

- **0.7.87** — shipped a stub binary (stripped Cargo.toml). Fixed in soldr#1187.
- **0.7.89** — macOS x64 Apple SDK step: \`--github-env\` missing FILE. Fixed in soldr#1220.
- **0.7.90** — macOS x64 crgx cross-compile: libiconv not findable (bare cargo build). Fixed in soldr#1223 (zigbuild route).
- **0.7.91** — macOS x64 crgx cross-compile: libiconv still not findable in zig-cc's Apple stubs. **This PR.**

## Version bump

Lockstep bump (Cargo.toml + package.json + Cargo.lock). \`crates/soldr-cli/tests/version_lockstep.rs\` — 1/1 pass locally.

## Test plan

- [x] Diff scoped to release-auto.yml (two build steps) + Cargo.{toml,lock} + package.json.
- [x] Local lockstep guard passes.
- [ ] Post-merge: v0.7.92 Autonomous Release completes macOS x64 lane end-to-end, all 6 PyPI wheels land, Verify step succeeds.