### PR TITLE
perf(ci): add Swatinem/rust-cache to cross-build lanes (#1227)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -166,6 +166,19 @@ jobs:
           path: ${{ runner.temp }}/setup-soldr-soldr/sdk/${{ inputs.target }}/xwin/2026-06-22
           key: soldr-xwin-cache-${{ inputs.target }}-cargo-xwin-0.18.6-v2026-06-22
 
+      # soldr#1227 — cache target/ + ~/.cargo/{registry,git} across runs.
+      # Bootstrap (host x86_64-linux-gnu) + Cross-build (target subtree)
+      # both live under target/ and share Cargo.lock-keyed rlibs. Keyed on
+      # Cargo.lock + rustc + toolchain by Swatinem/rust-cache so a hit
+      # happens even when source code changes (deps stable).
+      #
+      # Setup-soldr's `cache: false` covers only its own zccache seeding;
+      # rust-cache handles the cargo target-dir surface on top.
+      - name: Restore cargo + target caches
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: cross-build-${{ inputs.target }}
+
       # Bootstrap soldr from the current checkout. Darwin uses it to
       # drive `soldr prepare --target ... --github-env`. Windows MSVC
       # uses it to drive `soldr build --target X` (the blessed


### PR DESCRIPTION
## Summary

- Fixes #1227.
- Add \`Swatinem/rust-cache@e18b497\` (SHA-pinned, already used elsewhere in the repo) to \`_ci-cross-build-linux.yml\`. Keyed on Cargo.lock + rustc + toolchain so hits are common even when source code changes.
- Restores \`~/.cargo/registry/\`, \`~/.cargo/git/\`, and the whole \`target/\` dir (both host bootstrap subtree AND the cross-target subtree share the same key).

## Impact

Cache-hit path estimates (MSVC lane example, latest run 726 s cargo compile total):
- Bootstrap: 353 s → ~30-60 s (workspace crates + bins only)
- Cross-build: 373 s → ~120-200 s (workspace crates + bins only)

Cumulative: ~1500-2000 s off cross-build lanes per CI run when cache warm. Cache-miss runs behave the same as today.

## Safety

- Swatinem/rust-cache is SHA-pinned and already trusted in \`perf-matrix.yml\`, \`perf-cold-warm.yml\`, \`parent-cache-bench.yml\`.
- \`Setup soldr build cache (Rust toolchain only)\`'s \`cache: false\` covers only its own zccache seeding surface; rust-cache handles cargo target-dir on top with no overlap.
- Zero runtime behavior change — cache is purely additive.

## Test plan

- [x] rust-cache pinned at same SHA as the perf-* workflows.
- [ ] First CI post-merge: cache miss, save populates on-post.
- [ ] Second CI: cache hits, bootstrap + cross-build drop by hundreds of seconds each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)