### PR TITLE
fix(test): handle case-insensitive FS in xwin_cache_case_aliases test (#1229)

### DIFF
--- a/crates/soldr-cli/src/prepare_cmd.rs
+++ b/crates/soldr-cli/src/prepare_cmd.rs
@@ -1028,9 +1028,28 @@ mod tests {
         std::fs::write(lib.join("UserEnv.Lib"), b"userenv").expect("write userenv");
         std::fs::write(include.join("Windows.h"), b"windows").expect("write windows.h");
 
+        // soldr#1229 — probe filesystem case-sensitivity. macOS APFS
+        // is case-insensitive by default: `Kernel32.Lib` and
+        // `kernel32.lib` resolve to the same inode, so
+        // `ensure_lowercase_file_aliases`'s `alias.exists()` guard
+        // trips and no aliases are created. That's CORRECT behavior
+        // (aliases aren't needed on case-insensitive FS) — the test
+        // just needs to adjust its expectation.
+        let probe = tmp.path().join("CaseProbe");
+        std::fs::write(&probe, b"").expect("write case probe");
+        let case_insensitive = tmp.path().join("caseprobe").exists();
+        std::fs::remove_file(&probe).ok();
+
         let created = ensure_xwin_case_aliases(&xwin).expect("aliases");
-        let expected_created = if cfg!(windows) { 0 } else { 3 };
+        let expected_created = if cfg!(windows) || case_insensitive {
+            0
+        } else {
+            3
+        };
         assert_eq!(created, expected_created);
+        // These assertions pass on both case-sensitive (real aliases
+        // created) and case-insensitive (same file resolvable under any
+        // case) filesystems.
         assert!(lib.join("kernel32.lib").is_file());
         assert!(lib.join("userenv.lib").is_file());
         assert!(include.join("windows.h").is_file());


### PR DESCRIPTION
## Summary

- Fixes #1229.
- The \`xwin_cache_case_aliases_mixed_case_sdk_files\` test at \`prepare_cmd.rs:1020\` was failing on macOS APFS default (case-insensitive) — \`Kernel32.Lib\` and \`kernel32.lib\` resolve to the same inode, so \`ensure_lowercase_file_aliases\` correctly returns 0, but the test hard-coded \`expected_created = 3\`.
- Probe filesystem case-sensitivity at test time and adjust the expectation.

## Impact

Unblocks the Setup Soldr Action macOS job — has been red for months.

## Test plan

- [x] Case-insensitive probe: create \`CaseProbe\`, check \`caseprobe\` resolves.
- [x] Expected count: \`windows || case-insensitive => 0\`, else 3.
- [x] File-exists assertions pass on both filesystems (same inode under case-insensitive).
- [ ] First macOS run post-merge: Setup Soldr Action macOS job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)