### PR TITLE
chore(release): bump 0.7.92 → 0.7.93 + bake SDKROOT into zig-cc wrappers

### DIFF
--- a/.github/scripts/make_zig_cc_wrappers.sh
+++ b/.github/scripts/make_zig_cc_wrappers.sh
@@ -80,6 +80,26 @@ cxx_path="$out_dir/${target}-c++"
 ar_path="$out_dir/${target}-ar"
 linker_path="$out_dir/${target}-linker"
 
+# soldr#1140/#1202 chain: for *-apple-darwin targets, zig-cc's bundled
+# stubs don't include Apple system frameworks (CommonCrypto, Foundation,
+# Security, etc.) that transitive deps (libmimalloc-sys on darwin,
+# rusty-ssl, and friends) `#include`. Bake an `-isysroot $SDKROOT`
+# (and Frameworks -F) into the wrapper so any consumer of these
+# wrappers picks it up automatically at runtime. $SDKROOT is populated
+# by the `Prepare Apple SDK` step and persisted via $GITHUB_ENV, so it's
+# in the environment by the time this generator runs AND when the
+# wrappers execute.
+darwin_prelude=""
+case "$target" in
+    *-apple-darwin)
+        if [ -n "${SDKROOT:-}" ]; then
+            darwin_prelude="-isysroot \"$SDKROOT\" -F\"$SDKROOT/System/Library/Frameworks\" -iframework \"$SDKROOT/System/Library/Frameworks\""
+        else
+            echo "warning: SDKROOT unset for apple-darwin target $target — wrappers may fail on Foundation/CommonCrypto includes" >&2
+        fi
+        ;;
+esac
+
 cat > "$cc_path" <<EOF
 #!/usr/bin/env bash
 # Auto-generated persistent zig-cc wrapper for $target (soldr#1043).
@@ -94,7 +114,7 @@ for arg in "\$@"; do
         *) filtered+=("\$arg") ;;
     esac
 done
-exec zig cc -target $zig_target "\${filtered[@]}"
+exec zig cc -target $zig_target $darwin_prelude "\${filtered[@]}"
 EOF
 chmod +x "$cc_path"
 
@@ -109,7 +129,7 @@ for arg in "\$@"; do
         *) filtered+=("\$arg") ;;
     esac
 done
-exec zig c++ -target $zig_target "\${filtered[@]}"
+exec zig c++ -target $zig_target $darwin_prelude "\${filtered[@]}"
 EOF
 chmod +x "$cxx_path"
 
@@ -135,7 +155,7 @@ for arg in "\$@"; do
         *) filtered+=("\$arg") ;;
     esac
 done
-exec zig cc -target $zig_target "\${filtered[@]}"
+exec zig cc -target $zig_target $darwin_prelude "\${filtered[@]}"
 EOF
 chmod +x "$linker_path"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.92"
+version = "0.7.93"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.92"
+version = "0.7.93"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.92",
+  "version": "0.7.93",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Cuts **v0.7.93** and fixes the fourth-order macOS x64 wheel-build failure: maturin's cargo run needed the Apple SDK's Framework headers, and the zig-cc wrappers weren't passing \`-isysroot \$SDKROOT\`.

v0.7.92's fix (RUSTFLAGS \`-L \$SDKROOT/usr/lib\` in the crgx / cargo-chef steps) got the *linker* to see libiconv. But the maturin wheel build's *compiler* side (libmimalloc-sys build.rs) failed:

\`\`\`
fatal error: 'CommonCrypto/CommonCryptoError.h' file not found
\`\`\`

Root cause: the persistent zig-cc wrappers written by \`.github/scripts/make_zig_cc_wrappers.sh\` don't pass \`-isysroot \$SDKROOT\`. zig-cc's bundled Apple stubs don't include the CommonCrypto / Foundation / Security framework headers that darwin-only build.rs scripts include — those live only in the Apple SDK we fetched.

The soldr \`Build release binary\` step got past this because it inline-exports its own CC/CXX with \`-isysroot \$SDKROOT\`, overriding the wrappers within its step. But the maturin build step later inherits only the *persistent* wrappers via \`\$GITHUB_ENV\` — no \`-isysroot\`.

## Fix

Modify \`make_zig_cc_wrappers.sh\`: for \`*-apple-darwin\` targets when \`SDKROOT\` is set at wrapper-generation time, bake

\`\`\`
-isysroot \"\$SDKROOT\"
-F\"\$SDKROOT/System/Library/Frameworks\"
-iframework \"\$SDKROOT/System/Library/Frameworks\"
\`\`\`

into the CC / CXX / linker wrapper templates, right after \`-target x86_64-macos\`. Any downstream consumer of these wrappers (maturin build, ad-hoc cargo build in any subsequent step) now automatically sees the SDK.

Non-darwin targets are unchanged (empty prelude).

## Release chain context

- **0.7.87** — shipped a stub binary. Fixed in soldr#1187.
- **0.7.89** — macOS x64: \`--github-env\` missing FILE. Fixed in soldr#1220.
- **0.7.90** — macOS x64 crgx: bare cargo build. Fixed in soldr#1223 (zigbuild).
- **0.7.91** — macOS x64 crgx: libiconv missing. Fixed in soldr#1226 (RUSTFLAGS -L).
- **0.7.92** — macOS x64 maturin wheel: CommonCrypto framework headers missing. **This PR.**

## Test plan

- [x] Cargo.lock refreshed; \`soldr cargo test -p soldr-cli --test version_lockstep\` — 1/1 pass.
- [x] Wrapper generator: darwin_prelude is empty for non-darwin targets, populated for apple-darwin.
- [x] Diff scoped to \`make_zig_cc_wrappers.sh\` + version-bump trio.
- [ ] Post-merge: v0.7.93 Autonomous Release macOS x64 lane completes end-to-end, all 6 PyPI wheels land.