### PR TITLE
perf(ci): add Swatinem/rust-cache to _bootstrap-e2e.yml (#1232)

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -136,6 +136,16 @@ jobs:
           zccache-seed-strict: true
           linker: platform-default
 
+      # soldr#1232 — cache ~/.cargo/{registry,git} + soldr/target/ so
+      # `Build soldr-cli` doesn't recompile ~700 deps from scratch every
+      # run. Same pattern as #1227 for _ci-cross-build-linux.yml.
+      # `workspaces: soldr` because the checkout lands in a subdir.
+      - name: Restore cargo + target caches
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: bootstrap-e2e-${{ inputs.target }}
+          workspaces: soldr
+
       - name: Reset stale cache fallback artifacts
         if: >-
           ${{


### PR DESCRIPTION
## Summary

- Fixes #1232.
- Add \`Swatinem/rust-cache@e18b497\` (SHA-pinned, same pattern as #1227) after the setup-soldr step in \`_bootstrap-e2e.yml\`.
- \`workspaces: soldr\` — this workflow checks out into a subdir.

## Impact

Cache-hit path: Build soldr-cli 123 s → ~30-50 s. Estimated ~80 s off Bootstrap third-party app job per CI run when cache warm.

## Test plan

- [x] rust-cache pinned at same SHA as #1227.
- [ ] First CI post-merge: cache miss, save populates.
- [ ] Second CI: cache hits, Build soldr-cli drops from 123 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)