### PR TITLE
chore(release): bump 0.7.93 → 0.7.94 + switch macOS x64 to native macos-13

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -208,8 +208,17 @@ jobs:
           # ubuntu-24.04 + cargo zigbuild. Same pattern proven for
           # aarch64-musl below + the every-commit ci.yml darwin lanes
           # (PR #1052).
+          # soldr#1140/#1187/#1220/#1223/#1226/#1231 chain: Linux → x86_64-
+          # apple-darwin cross via zig-cc kept revealing new incomplete-
+          # SDK / archive-format issues (libiconv, CommonCrypto, libz-ng
+          # archive terminator, ...) — every fix uncovered another leaf.
+          # Switch to the native macos-13 (x86_64) runner: Apple's own
+          # toolchain builds natively, no cross-compile fragility. macos-
+          # 13 is the last remaining Intel macOS GHA runner. Cost ~10x
+          # ubuntu-24.04, still measured in cents per release. Same
+          # native-runner shape as the macOS ARM64 lane.
           - name: macOS x64
-            runner: ubuntu-24.04
+            runner: macos-13
             target: x86_64-apple-darwin
             binary: soldr
           - name: macOS ARM64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.93"
+version = "0.7.94"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.93"
+version = "0.7.94"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.93",
+  "version": "0.7.94",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Cuts **v0.7.94** and ends the macOS x64 cross-compile whack-a-mole by switching to a native Intel macOS runner (\`macos-13\`).

## The pattern

Every macOS x64 failure across 0.7.87 → 0.7.93 was the same architectural root cause: Linux → x86_64-apple-darwin cross-compile via zig-cc kept revealing new incomplete-SDK / archive-format edge cases:

| Version | Failure |
|---|---|
| 0.7.89 | Prepare Apple SDK: \`--github-env\` missing FILE |
| 0.7.90 | crgx bare cargo build: libiconv missing |
| 0.7.91 | crgx zigbuild: libiconv still missing (SDK not in -L path) |
| 0.7.92 | maturin wheel: libmimalloc-sys can't find CommonCrypto/*.h |
| 0.7.93 | maturin wheel: libz-ng-sys \"Invalid archive terminator\" (zig ar quirk) |

Every fix uncovered another leaf. zig-cc does not ship a complete Apple SDK, and every new C dep or archive-format quirk resurfaces the problem.

## Fix

Change the matrix entry:

\`\`\`yaml
- name: macOS x64
  runner: macos-13      # was: ubuntu-24.04
  target: x86_64-apple-darwin
  binary: soldr
\`\`\`

All existing darwin-cross setup steps are already gated on \`matrix.runner == 'ubuntu-24.04'\` and skip cleanly for macos-13. The build falls through to the native \`cargo build\` path — same shape as the macOS ARM64 lane on \`macos-15\`.

## Cost

macOS runners are ~10x ubuntu-24.04 per minute; release lane is ~13 min. Measured in cents per release. Cheap insurance against continued cross-compile fragility.

macos-13 is the last remaining Intel-macOS GHA runner. Supported through end of 2026 per GHA runner lifecycle. If it's deprecated before we have an Intel-mac-free path, we drop the target and ship sdist for Intel Mac users.

## Test plan

- [x] Cargo.lock refreshed; \`version_lockstep\` — 1/1 pass.
- [x] YAML: matrix entry updated cleanly; sibling darwin lanes untouched.
- [x] \`if:\` gates on darwin-cross setup steps already exclude non-ubuntu runners → they skip correctly on macos-13.
- [ ] Post-merge: v0.7.94 Autonomous Release completes macOS x64 lane end-to-end, all 6 PyPI wheels land, Verify step succeeds.