### PR TITLE
perf(ci): add Swatinem/rust-cache to baseline-zero-deps.yml (#1235)

### DIFF
--- a/.github/workflows/baseline-zero-deps.yml
+++ b/.github/workflows/baseline-zero-deps.yml
@@ -58,6 +58,18 @@ jobs:
           toolchain: 1.94.1
           targets: ${{ matrix.target }}
 
+      # soldr#1235 — cache ~/.cargo/{registry,git} + target/ so the
+      # `Build soldr-cli via soldr cargo zigbuild` step below doesn't
+      # recompile ~700 crate deps from scratch on every run. Same
+      # SHA-pinned action already in #1228/#1233. The workflow's zero-
+      # deps mandate covers only the DOCKER CONTAINER (used by the
+      # Bootstrap test acceptance jobs); runner-side compile is a
+      # normal build with no such constraint.
+      - name: Restore cargo + target caches
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: baseline-zero-deps-${{ matrix.target }}
+
       # soldr#1160 — cache the host-side bootstrap soldr binary.
       # Both matrix jobs (glibc + musl) rebuild the same x86_64-unknown-linux-gnu
       # release binary here (~305s each) with RUSTC_WRAPPER="", so there is no


### PR DESCRIPTION
## Summary

- Fixes #1235.
- Add \`Swatinem/rust-cache@e18b497\` (SHA-pinned, same as #1228/#1233) after the toolchain install in \`baseline-zero-deps.yml\`.
- Caches \`~/.cargo/{registry,git}\` and workspace \`target/\` — covers the \`Build soldr-cli via soldr cargo zigbuild\` step.

## Impact

Cache-hit path (musl variant): Build soldr-cli 493 s → ~120-200 s. Similar on glibc.

## Zero-deps mandate preserved

The workflow's zero-deps mandate applies to the DOCKER CONTAINER used by the \`Bootstrap test (glibc/musl)\` acceptance jobs. \`Build soldr for X\` jobs run on the runner and can use normal caching without breaking that contract.

The Bootstrap step's \`\$RUNNER_TEMP/soldr-bootstrap-target\` custom \`--target-dir\` is untouched by rust-cache; its binary-level cache from #1160 remains as-is.

## Test plan

- [x] rust-cache pinned at same SHA as prior PRs.
- [ ] First CI post-merge: cache miss, save populates.
- [ ] Second CI: cache hits, Build soldr-cli drops from 493 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)