### PR TITLE
perf(ci): drop bootstrap --target-dir override in baseline-zero-deps.yml (#1237)

### DIFF
--- a/.github/workflows/baseline-zero-deps.yml
+++ b/.github/workflows/baseline-zero-deps.yml
@@ -82,6 +82,12 @@ jobs:
           path: ${{ runner.temp }}/soldr-bin/soldr
           key: bootstrap-soldr-linux-gnu-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml') }}
 
+      # soldr#1237 — dropped the custom `--target-dir "$RUNNER_TEMP/
+      # soldr-bootstrap-target"` so cargo writes to workspace `target/`
+      # where rust-cache (added in #1236) saves + restores it. The
+      # subsequent `Build soldr-cli via soldr cargo zigbuild` writes
+      # to `target/<musl-triple>/release/` — different subtree, no
+      # conflict.
       - name: Bootstrap soldr from checkout
         if: steps.bootstrap_cache.outputs.cache-hit != 'true'
         env:
@@ -89,15 +95,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bootstrap_target="$RUNNER_TEMP/soldr-bootstrap-target"
           "$CARGO_HOME/bin/cargo" build \
             --package soldr-cli \
             --release \
             --locked \
-            --target x86_64-unknown-linux-gnu \
-            --target-dir "$bootstrap_target"
+            --target x86_64-unknown-linux-gnu
           mkdir -p "$RUNNER_TEMP/soldr-bin"
-          cp "$bootstrap_target/x86_64-unknown-linux-gnu/release/soldr" "$RUNNER_TEMP/soldr-bin/soldr"
+          cp target/x86_64-unknown-linux-gnu/release/soldr "$RUNNER_TEMP/soldr-bin/soldr"
           chmod +x "$RUNNER_TEMP/soldr-bin/soldr"
 
       - name: Expose bootstrap soldr on PATH


### PR DESCRIPTION
## Summary

- Fixes #1237.
- Drop the \`--target-dir "\$RUNNER_TEMP/soldr-bootstrap-target"\` override in \`baseline-zero-deps.yml\`'s Bootstrap step. cargo now writes to workspace \`target/x86_64-unknown-linux-gnu/release/\` where rust-cache (added in #1236) saves + restores.

## Impact

Cache-hit path: Bootstrap 299 s → ~50-100 s. ~200 s per matrix variant (glibc + musl) per Baseline Docker run when cache warm.

## Safety

- Sibling \`Build soldr-cli via soldr cargo zigbuild\` step writes to \`target/<musl-triple>/release/\` — different subtree, no conflict.
- \`Restore cached bootstrap soldr binary\` (#1160) still short-circuits when \`crates/**\` unchanged.

## Test plan

- [x] cp source path updated to \`target/x86_64-unknown-linux-gnu/release/soldr\` (matches workspace target/).
- [ ] First CI post-merge: cache miss, save populates.
- [ ] Second CI: cache hits, Bootstrap drops from 299 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)