### PR TITLE
perf(ci): add Swatinem/rust-cache to Lint job (#1239)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,15 @@ jobs:
           cache: false
           zccache-seed-strict: true
 
+      # soldr#1239 — cache ~/.cargo/{registry,git} + target/ so `cargo
+      # clippy --workspace --all-targets` doesn't recompile ~700 deps
+      # from scratch every CI run. Same SHA-pinned action as #1228/
+      # #1233/#1236/#1238.
+      - name: Restore cargo + target caches
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: lint
+
       - name: Install Rust components
         run: rustup component add rustfmt clippy
 


### PR DESCRIPTION
## Summary

- Fixes #1239.
- Add \`Swatinem/rust-cache@e18b497\` (SHA-pinned, same as prior PRs) after setup-soldr in the Lint job.
- Caches \`~/.cargo/{registry,git}\` + workspace \`target/\`.

## Impact

Lint's \`Run clippy\` step: 102 s → ~30-50 s cache-hit. Lint is a required status check on the CI critical path.

## Test plan

- [x] Rust-cache pinned at same SHA as prior PRs.
- [ ] First CI post-merge: cache miss, save populates.
- [ ] Second CI: cache hits, clippy step drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)