### PR TITLE
perf(ci): add Swatinem/rust-cache to _build-and-test.yml (#1241)

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -92,6 +92,15 @@ jobs:
           cache: false
           zccache-seed-strict: true
 
+      # soldr#1241 — cache ~/.cargo/{registry,git} + target/ so
+      # `Build workspace + tests`, `Run library tests`, `Run CLI
+      # smoke tests` don't recompile ~700 deps from scratch every
+      # run. Same SHA-pinned action as #1228/#1233/#1236/#1238/#1240.
+      - name: Restore cargo + target caches
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: build-and-test-${{ inputs.target }}
+
       - name: Enable Windows line-table debug symbols
         if: runner.os == 'Windows'
         shell: pwsh


### PR DESCRIPTION
## Summary

- Fixes #1241.
- Add \`Swatinem/rust-cache@e18b497\` after setup-soldr in \`_build-and-test.yml\`. Same SHA-pinned pattern as prior PRs.

## Impact

Linux x64 lane's cargo compile time drops significantly on cache-hit runs:
- Build workspace + tests: 154 s → ~40-80 s
- Run library tests: 75 s → ~40 s
- Run CLI smoke tests: 93 s → ~50 s

~100-150 s off Linux x64 per CI run when cache warm.

## Test plan

- [x] Rust-cache pinned at same SHA as prior PRs.
- [ ] First CI post-merge: cache miss, save populates.
- [ ] Second CI: cache hits, cargo compile steps drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)