### PR TITLE
perf(ci): cache Apple SDK for darwin cross-build lanes (#1246)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -166,6 +166,17 @@ jobs:
           path: ${{ runner.temp }}/setup-soldr-soldr/sdk/${{ inputs.target }}/xwin/2026-06-22
           key: soldr-xwin-cache-${{ inputs.target }}-cargo-xwin-0.18.6-v2026-06-22
 
+      # soldr#1246 — cache the Apple SDK v11.3 fetched by soldr's
+      # blessed_build::prepare on darwin targets. Same pattern as
+      # the xwin-cache above. soldr's ensure_apple_sdk sees the
+      # extracted dir on next run and skips the download.
+      - name: Cache Apple SDK
+        if: contains(inputs.target, 'apple-darwin')
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ runner.temp }}/setup-soldr-soldr/bin/apple-sdk/11.3
+          key: soldr-apple-sdk-11.3-v1
+
       # soldr#1227 — cache target/ + ~/.cargo/{registry,git} across runs.
       # Bootstrap (host x86_64-linux-gnu) + Cross-build (target subtree)
       # both live under target/ and share Cargo.lock-keyed rlibs. Keyed on


### PR DESCRIPTION
## Summary

- Fixes #1246.
- Add \`actions/cache@0400d5f644\` (SHA-pinned) around the Apple SDK v11.3 dir, gated on \`apple-darwin\` targets.

## Impact

Cache-hit path: soldr's \`ensure_apple_sdk\` sees the extracted dir + skips the ~5 s download. Two darwin lanes → ~10 s cumulative, ~5 s off critical path.

## Test plan

- [x] Same SHA-pinned action as prior caching PRs (#1175 xwin-cache, #1245 zigbuild-toolchain).
- [x] Cache key embeds SDK version so bumps invalidate.
- [ ] First CI post-merge: cache miss, save populates.
- [ ] Second CI: cache hits, Apple SDK download skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)