### PR TITLE
chore(release): bump 0.7.94 → 0.7.95 + drop macOS x64 from release matrix

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -209,18 +209,23 @@ jobs:
           # aarch64-musl below + the every-commit ci.yml darwin lanes
           # (PR #1052).
           # soldr#1140/#1187/#1220/#1223/#1226/#1231 chain: Linux → x86_64-
-          # apple-darwin cross via zig-cc kept revealing new incomplete-
-          # SDK / archive-format issues (libiconv, CommonCrypto, libz-ng
-          # archive terminator, ...) — every fix uncovered another leaf.
-          # Switch to the native macos-13 (x86_64) runner: Apple's own
-          # toolchain builds natively, no cross-compile fragility. macos-
-          # 13 is the last remaining Intel macOS GHA runner. Cost ~10x
-          # ubuntu-24.04, still measured in cents per release. Same
-          # native-runner shape as the macOS ARM64 lane.
-          - name: macOS x64
-            runner: macos-13
-            target: x86_64-apple-darwin
-            binary: soldr
+          # apple-darwin cross via zig-cc revealed multiple incomplete-SDK
+          # / archive-format issues (libiconv, CommonCrypto, libz-ng archive
+          # terminator, ...). soldr#1234 switched to native `macos-13` to
+          # bypass cross-compile fragility entirely. That worked
+          # correctness-wise but exposed a second issue: GHA's macos-13
+          # Intel runner pool is severely saturated (v0.7.94 release run
+          # 28556957818 sat queued for 3+ hours without ever starting the
+          # macOS x64 job). Every attempt just parks in queue.
+          #
+          # Pragmatic decision: **drop x86_64-apple-darwin from the release
+          # matrix** for the 0.7.9x line. Intel Macs are a shrinking user
+          # segment (Apple stopped shipping them in 2023), and pip users on
+          # Intel Mac can still install via sdist. If/when GHA either
+          # improves macos-13 capacity or provides a hosted Rosetta path
+          # under macos-15, we re-add.
+          #
+          # x86_64-apple-darwin: **intentionally omitted** — see comment above.
           - name: macOS ARM64
             runner: macos-15
             target: aarch64-apple-darwin
@@ -1631,9 +1636,10 @@ jobs:
           # Tag-style version is `vX.Y.Z`; PyPI keys releases by `X.Y.Z`.
           pypi_version="${PYPI_VERSION#v}"
           # Expected wheel count == number of non-musl matrix rows in the
-          # `build` job (the musl rows skip wheel build by design). 6 = 2
-          # linux-gnu + 2 darwin + 2 windows-msvc.
-          expected=6
+          # `build` job (the musl rows skip wheel build by design). 5 = 2
+          # linux-gnu + 1 darwin (aarch64-only per soldr#1237 macos-x64
+          # drop) + 2 windows-msvc.
+          expected=5
           deadline=$(( $(date +%s) + 1800 ))
           attempts=0
           max_attempts=60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.94"
+version = "0.7.95"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.94"
+version = "0.7.95"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Cuts **v0.7.95** and drops \`x86_64-apple-darwin\` from the release matrix. Ships 5 wheels (was 6): 2 linux-gnu + 1 macOS ARM64 + 2 windows-msvc.

## Why we're dropping macOS x64

The 0.7.87 → 0.7.94 macOS x64 saga hit **two orthogonal blockers**:

1. **Cross-compile fragility** (0.7.87 → 0.7.93). Linux → x86_64-apple-darwin via zig-cc kept revealing new incomplete-SDK / archive-format issues — libiconv missing → CommonCrypto headers → libz-ng \"Invalid archive terminator\". Every fix uncovered another leaf.

2. **Native runner scarcity** (0.7.94). Switched to \`macos-13\` (native Intel). Correctness worked, but GHA's macos-13 pool is severely saturated: v0.7.94 release run 28556957818 sat **queued for 3+ hours** without ever starting the macOS x64 job. Every attempt just parks in queue.

The cross-compile path is code-fixable in principle but keeps yielding new failure modes as deps evolve. The native path is blocked on GHA infrastructure we don't control. Both effectively DoS the release lane.

## Impact

Intel Macs are a shrinking user segment (Apple stopped shipping them in 2023). Pip users on Intel Mac can still install via **sdist**. The GitHub Release archive path is unaffected — a savvy Intel Mac user can grab the tar.zst directly.

If/when GHA improves macos-13 capacity or provides a hosted Rosetta path under macos-15, we re-add.

## Changes

- \`.github/workflows/release-auto.yml\`:
  - \`build\` matrix: **remove** \`x86_64-apple-darwin\` entry.
  - \`Verify all wheels visible on PyPI\`: \`expected=6\` → \`expected=5\`.
- Cargo.toml + package.json + Cargo.lock: 0.7.94 → 0.7.95.

## Release chain context

- **0.7.87** — stub binary (unrelated). Fixed in soldr#1187.
- **0.7.89** — macOS x64 Apple SDK step: \`--github-env\` FILE. Fixed in soldr#1220.
- **0.7.90** — macOS x64 crgx cross: libiconv. Fixed in soldr#1223.
- **0.7.91** — macOS x64 crgx cross: libiconv via zigbuild -L path. Fixed in soldr#1226.
- **0.7.92** — macOS x64 maturin: CommonCrypto. Fixed in soldr#1231.
- **0.7.93** — macOS x64 maturin: libz-ng archive terminator (zig ar quirk).
- **0.7.94** — macOS x64 native macos-13: runner pool saturated, 3h+ queue.
- **0.7.95** — **drop x86_64-apple-darwin from matrix.** THIS PR.

## Test plan

- [x] Cargo.lock refreshed; \`version_lockstep\` — 1/1 pass.
- [x] Diff scoped to release-auto.yml (matrix + expected wheel count) + version-bump trio.
- [ ] Post-merge: v0.7.95 Autonomous Release completes with 5 wheels; no macOS x64 lane in the matrix.