### PR TITLE
fix(ci): remove hostile 'Reset stale cache fallback artifacts' step (#1252)

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -146,29 +146,14 @@ jobs:
           shared-key: bootstrap-e2e-${{ inputs.target }}
           workspaces: soldr
 
-      - name: Reset stale cache fallback artifacts
-        if: >-
-          ${{
-            steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit' ||
-            steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'
-          }}
-        shell: pwsh
-        working-directory: soldr
-        run: |
-          Write-Host "Disabling target-cache for later steps after a fallback setup-soldr restore."
-          "SOLDR_TARGET_CACHE_MODE=off" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-          $targetTripleDir = Join-Path "target" "${{ inputs.target }}"
-          if (Test-Path -LiteralPath $targetTripleDir) {
-            Write-Host "Removing restored target artifacts from $targetTripleDir"
-            Remove-Item -LiteralPath $targetTripleDir -Recurse -Force
-          }
-
-          $artifactDir = Join-Path $env:ZCCACHE_CACHE_DIR "artifacts"
-          if (Test-Path -LiteralPath $artifactDir) {
-            Write-Host "Removing restored zccache artifacts from $artifactDir"
-            Remove-Item -LiteralPath $artifactDir -Recurse -Force
-          }
+      # soldr#1252 — removed the "Reset stale cache fallback artifacts"
+      # step. It guarded on `setup_soldr.outputs.*-cache-restore-status
+      # != 'exact-hit'`, but with setup-soldr's `cache: false` (set in
+      # #1083 to disable soldr-cook), that condition trips EVERY run —
+      # so the step was deleting `target/<triple>/` right after
+      # Swatinem/rust-cache (added in #1233) restored it, nuking all
+      # rust-cache benefit. rust-cache's own restore is authoritative
+      # now; no separate "fallback reset" is needed.
 
       - name: Build soldr-cli
         shell: pwsh

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -112,28 +112,12 @@ jobs:
         shell: pwsh
         run: git restore --worktree -- .
 
-      - name: Reset stale cache fallback artifacts
-        if: >-
-          ${{
-            steps.setup_soldr.outputs.build-cache-restore-status != 'exact-hit' ||
-            steps.setup_soldr.outputs.target-cache-restore-status != 'exact-hit'
-          }}
-        shell: pwsh
-        run: |
-          Write-Host "Disabling target-cache for later steps after a fallback setup-soldr restore."
-          "SOLDR_TARGET_CACHE_MODE=off" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-          $targetTripleDir = Join-Path "target" "${{ inputs.target }}"
-          if (Test-Path -LiteralPath $targetTripleDir) {
-            Write-Host "Removing restored target artifacts from $targetTripleDir"
-            Remove-Item -LiteralPath $targetTripleDir -Recurse -Force
-          }
-
-          $artifactDir = Join-Path $env:ZCCACHE_CACHE_DIR "artifacts"
-          if (Test-Path -LiteralPath $artifactDir) {
-            Write-Host "Removing restored zccache artifacts from $artifactDir"
-            Remove-Item -LiteralPath $artifactDir -Recurse -Force
-          }
+      # soldr#1252 — removed the "Reset stale cache fallback artifacts"
+      # step. Same rationale as the sibling in _bootstrap-e2e.yml:
+      # setup-soldr's `cache: false` (#1083) makes its restore-status
+      # never `exact-hit`, so the guard tripped every run and the step
+      # deleted `target/<triple>/` right after Swatinem/rust-cache
+      # (#1242) restored it. rust-cache's own restore is authoritative.
 
       - name: Install requested Rust components
         if: inputs.install_components != ''


### PR DESCRIPTION
## Summary

Fixes #1252. **This is a big deal** — every Linux x64 + bootstrap-e2e CI run since #1233 landed has been silently throwing away its rust-cache target/ restore.

Latest CI [run 28561934659](https://github.com/zackees/soldr/actions/runs/28561934659) log from build/Bootstrap third-party app:

\`\`\`
Disabling target-cache for later steps after a fallback setup-soldr restore.
Removing restored target artifacts from target/x86_64-unknown-linux-gnu
\`\`\`

Root cause: the \`Reset stale cache fallback artifacts\` step in \`_build-and-test.yml\` and \`_bootstrap-e2e.yml\` guarded on \`setup_soldr.outputs.*-cache-restore-status != 'exact-hit'\`. With setup-soldr's \`cache: false\` (set in #1083 to disable soldr-cook), those outputs are always \`disabled\` — the guard trips every run — target/ gets deleted right after rust-cache restored it.

## Fix

Delete the step from both files. Its purpose (guard against soldr-cook stub artifacts) is moot when \`cache: false\` disables cook entirely. rust-cache's own restore is authoritative.

## Impact

- Linux x64's \`Build workspace + tests\`: 138 s → ~40-80 s.
- bootstrap-e2e's \`Build soldr-cli\`: 111 s → ~30-50 s.
- Also drops the 9 s cost of the Remove-Item itself from both lanes.
- ~60-100 s off the CI critical path (both jobs run in parallel).

## Test plan

- [x] Removed from both workflows.
- [ ] First CI run post-merge: no "Removing restored target artifacts from ..." log line.
- [ ] Second CI: Build workspace + tests + Build soldr-cli drop meaningfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)