### PR TITLE
perf(ci): drop dead 'Restore checkout after soldr-cook' step (#1254)

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -108,9 +108,10 @@ jobs:
           "CARGO_PROFILE_DEV_DEBUG=line-tables-only" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CARGO_PROFILE_TEST_DEBUG=line-tables-only" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Restore checkout after soldr-cook
-        shell: pwsh
-        run: git restore --worktree -- .
+      # soldr#1254 — removed the "Restore checkout after soldr-cook"
+      # step. Same failure pattern as #1252: setup-soldr's `cache: false`
+      # (#1083) disables cook, so nothing rewrites the workspace and
+      # `git restore --worktree -- .` was 4-7 s of dead code.
 
       # soldr#1252 — removed the "Reset stale cache fallback artifacts"
       # step. Same rationale as the sibling in _bootstrap-e2e.yml:


### PR DESCRIPTION
## Summary

Fixes #1254. Same failure pattern as #1252 — a workaround for soldr-cook that outlived cook itself.

- Remove the \`Restore checkout after soldr-cook\` step from \`_build-and-test.yml\`. Setup-soldr's \`cache: false\` (set in #1083 to disable cook) means nothing rewrites the workspace, so \`git restore --worktree -- .\` was 4-7 s of pure dead code.
- \`_bootstrap-e2e.yml\` doesn't have this step (already cleaned).
- The Setup Soldr Action workflow keeps it (that one intentionally exercises \`prebuild-deps: soldr-cook\`).

## Impact

- Linux x64 lane: ~6 s per CI run.

## Test plan

- [x] Only remove from \`_build-and-test.yml\` (verified other consumers).
- [ ] First CI run post-merge: no "Restore checkout after soldr-cook" step in the Linux x64 lane's job history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)