### PR TITLE
chore(release): bump 0.7.95 → 0.7.96 + idempotent Pre-create tag step

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -1552,16 +1552,34 @@ jobs:
       # creating the tag first lets the subsequent release-create see an
       # existing tag and skip the implicit-tag-creation that was the
       # source of the 403.
+      #
+      # soldr#1252: both endpoints started returning 403 for v0.7.95 even
+      # on push runs. Owner may need to pre-populate the tag out-of-band
+      # with a PAT. Make the step idempotent: check if the tag already
+      # exists first (owner may have pre-populated it), skip if so, else
+      # attempt the create. The check-first flow also makes reruns after
+      # a partial success safe.
       - name: Pre-create release tag
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
-            -X POST \
-            -f "ref=refs/tags/${{ needs.prepare.outputs.version }}" \
-            -f "sha=${{ needs.prepare.outputs.commit_sha }}"
+          tag='${{ needs.prepare.outputs.version }}'
+          sha='${{ needs.prepare.outputs.commit_sha }}'
+          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}" >/dev/null 2>&1; then
+              echo "tag ${tag} already exists — skipping create"
+              exit 0
+          fi
+          if ! gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -X POST \
+              -f "ref=refs/tags/${tag}" \
+              -f "sha=${sha}"; then
+              echo "::warning::GITHUB_TOKEN could not create tag ${tag} via /git/refs — the repo owner must pre-create the tag out-of-band. See soldr#1252."
+              echo "Repro from a local shell with owner PAT:"
+              echo "  gh api repos/${GITHUB_REPOSITORY}/git/refs -X POST -f ref=refs/tags/${tag} -f sha=${sha}"
+              exit 1
+          fi
 
       - name: Create draft GitHub Release
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.95"
+version = "0.7.96"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.95"
+version = "0.7.96"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
## Summary

Cuts **v0.7.96** and makes the \`Pre-create release tag\` step idempotent so an out-of-band pre-populated tag (via owner PAT) unblocks the publish job.

## What v0.7.95 hit

v0.7.95's Autonomous Release [run 28564020184](https://github.com/zackees/soldr/actions/runs/28564020184) build lanes all succeeded (7/7 — no macOS x64 by design). But the \`Attest and publish release assets\` job failed at \`Pre-create release tag\`:

\`\`\`
gh: Resource not accessible by integration (HTTP 403)
{\"message\":\"Resource not accessible by integration\", \"status\":\"403\"}
\`\`\`

Workflow-level \`permissions: contents: write\` is declared, so the GITHUB_TOKEN SHOULD be able to POST to \`/git/refs\`. Prior releases (v0.7.87, v0.7.89) that used the same step succeeded — something about GHA's GITHUB_TOKEN → /git/refs plumbing regressed in the last several hours, or there's an org-level tightening. Owner-side PAT still works (verified manually — the v0.7.95 tag was created out-of-band as a test).

## Fix in this PR

Make the step **idempotent**:

- Check if the tag already exists via \`GET /git/refs/tags/<tag>\` first; skip the POST if so.
- Owner can pre-populate the tag with a PAT before/after merge; the workflow then no-ops on the check-first branch.
- Rerunning after partial success is safe.
- When the POST fails, emit an actionable \`::warning::\` naming the exact owner-side repro command.

## Pre-merge action needed

Owner must pre-create the tag for this bump BEFORE (or right after) merge:

\`\`\`bash
gh api repos/zackees/soldr/git/refs -X POST \
  -f \"ref=refs/tags/v0.7.96\" \
  -f \"sha=<merge-commit-sha>\"
\`\`\`

The idempotent step above will then see the tag and skip the POST, unblocking Attest + PyPI + npm publish.

## Not addressed (follow-up)

Root-cause the GITHUB_TOKEN /git/refs 403. Options:

- Switch to a repo secret PAT (\`RELEASE_PAT\`) for this one step.
- Reconfigure the workflow to let \`gh release create --target <sha>\` create the tag implicitly (though the pre-existing comment says that also 403s).

Filing separately.

## Test plan

- [x] Cargo.lock refreshed; \`version_lockstep\` — 1/1 pass.
- [x] Diff scoped to release-auto.yml (Pre-create step body only) + Cargo.{toml,lock} + package.json.
- [ ] Post-merge: owner pre-creates the tag, v0.7.96 Autonomous Release publishes cleanly.

## Release chain

- **0.7.87** — stub binary. Fixed in soldr#1187.
- **0.7.89–0.7.94** — macOS x64 saga. Ended by dropping the target in soldr#1250.
- **0.7.95** — GITHUB_TOKEN /git/refs 403. **This PR** makes the step idempotent so out-of-band tag pre-population works.