### PR TITLE
feat(build): provision managed cmake + ninja on demand for blessed builds

### DIFF
--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -52,6 +52,11 @@ pub struct BlessedPrep {
     /// Directory to prepend to `PATH` so the soldr-clang-shim wins
     /// when cc-rs (or ring) does a bare `which("clang")` lookup.
     pub shim_path_dir: Option<PathBuf>,
+    /// Additional directories to prepend to `PATH` on the child cargo
+    /// invocation (after `shim_path_dir`). Used for the managed
+    /// cmake/ninja `bin/` dirs so CMake's Ninja generator resolves the
+    /// managed ninja instead of whatever the system PATH serves.
+    pub path_dirs: Vec<PathBuf>,
     /// Per-target env-var tuples to set on the child cargo
     /// invocation: `[(NAME, VALUE), ...]`. Includes `CC_<t>`,
     /// `CXX_<t>`, `AR_<t>`, `CARGO_TARGET_<T>_LINKER` for MSVC
@@ -258,7 +263,113 @@ pub async fn prepare(paths: &SoldrPaths, target_triple: &str) -> Result<BlessedP
         inject_sys_library_overrides(paths, target_triple, &mut prep).await;
     }
 
+    // ----------------------- managed cmake + ninja ---------------------------
+    // Host-side tooling, independent of the compile target: cmake-based
+    // *-sys build scripts (libz-ng-sys, zstd-sys, ...) must run a
+    // known-good cmake with a sane generator, not whatever the system
+    // PATH resolves. See inject_cmake_tooling for the full contract.
+    inject_cmake_tooling(paths, &mut prep).await;
+
     Ok(prep)
+}
+
+/// Env var that opts out of the managed cmake/ninja injection and
+/// leaves cmake resolution to the system PATH. Set to any non-empty
+/// value (other than `"0"`) to trigger. Mirrors the
+/// `SOLDR_USE_LEGACY_*` env-var contract.
+pub const USE_SYSTEM_CMAKE_ENV_VAR: &str = "SOLDR_USE_SYSTEM_CMAKE";
+
+fn system_cmake_opt_out() -> bool {
+    std::env::var(USE_SYSTEM_CMAKE_ENV_VAR)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+}
+
+/// Inject the managed CMake + Ninja tooling env onto the prep.
+///
+/// What gets set (all only on success — every failure logs and falls
+/// through to system cmake, stub-until-ingested style):
+///
+/// * `CMAKE=<bundle>/bin/cmake` — the cmake-rs crate (used by every
+///   cmake-based *-sys build script) resolves the cmake binary from
+///   this env var before falling back to PATH.
+/// * `CMAKE_GENERATOR=Ninja` — cmake-rs forwards this as `-G`;
+///   only set when the managed ninja materialized. Ninja is immune
+///   to the "MSYS Makefiles + mangled MSVC flags" failure mode that
+///   a stray GNU make on PATH produces, and it needs no VS generator
+///   registry probing.
+/// * `prep.path_dirs` gets both bundles' `bin/` dirs — CMake's Ninja
+///   generator discovers `ninja` via PATH (there is no env-var
+///   equivalent of the `CMAKE_MAKE_PROGRAM` cache variable).
+///
+/// Skips (with no log noise) when the caller already set `CMAKE` or
+/// `CMAKE_GENERATOR` — explicit user env always wins — and when
+/// [`USE_SYSTEM_CMAKE_ENV_VAR`] opts out.
+pub async fn inject_cmake_tooling(paths: &SoldrPaths, prep: &mut BlessedPrep) {
+    if system_cmake_opt_out() {
+        return;
+    }
+    // Respect explicit user config: a pre-set CMAKE or CMAKE_GENERATOR
+    // means someone already made this decision.
+    for user_var in ["CMAKE", "CMAKE_GENERATOR"] {
+        if std::env::var_os(user_var).is_some_and(|v| !v.is_empty()) {
+            return;
+        }
+    }
+
+    let host = crate::fetch::cmake_tools::current_host_triple();
+
+    let cmake_root = match crate::fetch::cmake_tools::ensure_cmake_bundle(paths, host).await {
+        Ok(root) => root,
+        Err(e) => {
+            log_cmake_unavailable("cmake", host, &e);
+            return;
+        }
+    };
+    let cmake_bin = crate::fetch::cmake_tools::cmake_exe(&cmake_root);
+    if !cmake_bin.is_file() {
+        eprintln!(
+            "soldr build: managed cmake bundle at {} has no {} — \
+             falling back to system cmake",
+            cmake_root.display(),
+            cmake_bin.display()
+        );
+        return;
+    }
+
+    prep.env.push((
+        "CMAKE".to_string(),
+        cmake_bin.to_string_lossy().into_owned(),
+    ));
+    prep.path_dirs.push(cmake_root.join("bin"));
+
+    // Ninja is the generator upgrade, but the managed cmake alone is
+    // already a win — don't tie the two together. Without ninja we
+    // leave the generator choice to cmake-rs (Visual Studio on MSVC
+    // hosts, Unix Makefiles elsewhere).
+    match crate::fetch::cmake_tools::ensure_ninja_bundle(paths, host).await {
+        Ok(ninja_root) => {
+            let ninja_bin = crate::fetch::cmake_tools::ninja_exe(&ninja_root);
+            if ninja_bin.is_file() {
+                prep.env
+                    .push(("CMAKE_GENERATOR".to_string(), "Ninja".to_string()));
+                prep.path_dirs.push(ninja_root.join("bin"));
+            } else {
+                eprintln!(
+                    "soldr build: managed ninja bundle at {} has no {} — \
+                     keeping cmake's default generator",
+                    ninja_root.display(),
+                    ninja_bin.display()
+                );
+            }
+        }
+        Err(e) => log_cmake_unavailable("ninja", host, &e),
+    }
+}
+
+fn log_cmake_unavailable(tool: &str, host: &str, err: &SoldrError) {
+    eprintln!("soldr build: managed {tool} unavailable for host {host}: {err}");
+    eprintln!("soldr build: continuing with system {tool} from PATH");
 }
 
 /// Env var that opts out of the entire `*-sys` catalogue-substitution
@@ -613,19 +724,59 @@ mod tests {
         // soldr#1064 Phase B: syslib catalogue overrides may populate
         // prep.env even on linux targets. The invariant we still want to
         // assert is "linux gets no Windows-xwin and no Apple-SDK prep" —
-        // opt out of catalogue injection to keep this test hermetic.
+        // opt out of catalogue injection (and the managed cmake/ninja
+        // injection, which is host-side and target-independent) to keep
+        // this test hermetic.
         std::env::set_var(USE_LEGACY_VENDORED_SYS_ENV_VAR, "1");
+        std::env::set_var(USE_SYSTEM_CMAKE_ENV_VAR, "1");
         let tmp = tempfile::tempdir().expect("tmpdir");
         let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
         let result = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(prepare(&paths, "x86_64-unknown-linux-musl"));
         std::env::remove_var(USE_LEGACY_VENDORED_SYS_ENV_VAR);
+        std::env::remove_var(USE_SYSTEM_CMAKE_ENV_VAR);
         let prep = result.expect("linux musl target should not error");
         assert!(prep.xwin_cache_dir.is_none());
         assert!(prep.sdkroot.is_none());
         assert!(prep.env.is_empty());
         assert!(prep.cargo_args.is_empty());
+    });
+
+    crate::timed_test!(cmake_injection_respects_system_opt_out, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let mut prep = BlessedPrep::default();
+
+        std::env::set_var(USE_SYSTEM_CMAKE_ENV_VAR, "1");
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(inject_cmake_tooling(&paths, &mut prep));
+        std::env::remove_var(USE_SYSTEM_CMAKE_ENV_VAR);
+
+        assert!(prep.env.is_empty(), "opt-out must inject nothing");
+        assert!(prep.path_dirs.is_empty());
+    });
+
+    crate::timed_test!(cmake_injection_defers_to_user_cmake_env, {
+        // A caller-provided CMAKE (or CMAKE_GENERATOR) means the user
+        // already decided; the managed injection must stand down
+        // entirely — no fetch attempt, no env, no PATH dirs.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        for user_var in ["CMAKE", "CMAKE_GENERATOR"] {
+            let mut prep = BlessedPrep::default();
+            std::env::set_var(user_var, "user-choice");
+            rt.block_on(inject_cmake_tooling(&paths, &mut prep));
+            std::env::remove_var(user_var);
+            assert!(
+                prep.env.is_empty(),
+                "pre-set {user_var} must suppress injection"
+            );
+            assert!(prep.path_dirs.is_empty());
+        }
     });
 
     crate::timed_test!(mimalloc_build_script_override_uses_target_config, {

--- a/crates/soldr-cli/src/fetch/cmake_tools.rs
+++ b/crates/soldr-cli/src/fetch/cmake_tools.rs
@@ -1,0 +1,235 @@
+//! Managed CMake + Ninja bundle fetchers — soldr's answer to "use
+//! whatever cmake/make happens to be on PATH".
+//!
+//! Motivation (2026-07-01): a `pip install soldr` build on a Windows
+//! dev box died inside `libz-ng-sys`'s cmake configure step because
+//! the system PATH resolved `cmake` to a pip-installed wheel and
+//! `make` to the MSYS-flavored binary bundled by an unrelated pip
+//! package (`zcmds_win32`). CMake picked the "MSYS Makefiles"
+//! generator, the MSYS make path-mangled MSVC flags (`/nologo` →
+//! `C:\Program Files\Git\nologo.obj`), and the try-compile exploded.
+//! None of that is soldr's PATH to fix — but soldr builds should
+//! never have been at its mercy in the first place.
+//!
+//! These fetchers pull pinned upstream-official binaries (Kitware
+//! CMake, ninja-build ninja) repackaged as soldr-toolchain catalogue
+//! bundles, so the blessed `soldr build` path can export a known-good
+//! `CMAKE` + `CMAKE_GENERATOR=Ninja` combination to every cmake-based
+//! `*-sys` build script (libz-ng-sys, zstd-sys, ...) instead of
+//! trusting the machine. See `blessed_build::inject_cmake_tooling`
+//! for the env-injection side.
+//!
+//! Bundle layout (forge recipes `cmake-<shape>` / `ninja-<shape>` on
+//! zackees/soldr-toolchain):
+//!
+//! ```text
+//! cmake bundle: bin/cmake(.exe) bin/ctest(.exe) bin/cpack(.exe)
+//!               share/cmake-<major.minor>/...   ← module tree
+//! ninja bundle: bin/ninja(.exe)
+//! ```
+//!
+//! Stub-until-ingested: like every other catalogue consumer, when the
+//! catalogue has no row for (tool, version, slug) the ensure fns error
+//! and the caller falls through to system cmake — nothing breaks
+//! before the assets land.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{SoldrError, SoldrPaths};
+
+/// CMake version pinned by the soldr-toolchain `cmake-<shape>` recipes.
+pub const MANAGED_CMAKE_VERSION: &str = "4.3.4";
+
+/// Ninja version pinned by the soldr-toolchain `ninja-<shape>` recipes.
+pub const MANAGED_NINJA_VERSION: &str = "1.13.2";
+
+/// Host triple → catalogue shape slug. cmake + ninja are HOST tools
+/// (they run on the build machine regardless of the compile target),
+/// so the table keys on the host, not the `--target`.
+///
+/// musl hosts are deliberately absent: the upstream Kitware / ninja
+/// linux binaries are glibc-linked. Alpine-style hosts fall through
+/// to system cmake.
+pub const CMAKE_TOOL_HOSTS: &[(&str, &str)] = &[
+    ("x86_64-pc-windows-msvc", "windows-x64"),
+    ("aarch64-pc-windows-msvc", "windows-arm64"),
+    ("x86_64-apple-darwin", "darwin-x64"),
+    ("aarch64-apple-darwin", "darwin-arm64"),
+    ("x86_64-unknown-linux-gnu", "linux-x64-gnu"),
+    ("aarch64-unknown-linux-gnu", "linux-arm64-gnu"),
+];
+
+/// Catalogue slug for a host triple, if the host is supported.
+pub fn host_slug_for(host_triple: &str) -> Option<&'static str> {
+    CMAKE_TOOL_HOSTS
+        .iter()
+        .find(|(rust, _)| *rust == host_triple)
+        .map(|(_, slug)| *slug)
+}
+
+/// The running binary's host triple, cfg-resolved. Mirrors the
+/// supported-host set of [`CMAKE_TOOL_HOSTS`] plus musl (which then
+/// misses the slug lookup and falls through — the miss is the
+/// mechanism, not an error path we need to special-case).
+pub fn current_host_triple() -> &'static str {
+    if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        "x86_64-pc-windows-msvc"
+    } else if cfg!(all(target_os = "windows", target_arch = "aarch64")) {
+        "aarch64-pc-windows-msvc"
+    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+        "x86_64-apple-darwin"
+    } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        "aarch64-apple-darwin"
+    } else if cfg!(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        target_env = "musl"
+    )) {
+        "x86_64-unknown-linux-musl"
+    } else if cfg!(all(
+        target_os = "linux",
+        target_arch = "aarch64",
+        target_env = "musl"
+    )) {
+        "aarch64-unknown-linux-musl"
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        "x86_64-unknown-linux-gnu"
+    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+        "aarch64-unknown-linux-gnu"
+    } else {
+        "unsupported-host"
+    }
+}
+
+/// Assets-branch URL for the cmake bundle. Catalogue layout:
+/// `cmake/<version>/<slug>/bundle.tar.zst`.
+pub fn cmake_asset_url_for(version: &str, slug: &str) -> String {
+    super::syslib_common::asset_url_for("cmake", version, slug)
+}
+
+/// Assets-branch URL for the ninja bundle. Catalogue layout:
+/// `ninja/<version>/<slug>/bundle.tar.zst`.
+pub fn ninja_asset_url_for(version: &str, slug: &str) -> String {
+    super::syslib_common::asset_url_for("ninja", version, slug)
+}
+
+/// Materialize the managed CMake bundle for `host_triple`. Returns
+/// the bundle root (contains `bin/` + `share/`).
+pub async fn ensure_cmake_bundle(
+    paths: &SoldrPaths,
+    host_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let slug = host_slug_for(host_triple).ok_or_else(|| unsupported_host("cmake", host_triple))?;
+    super::syslib_common::ensure_syslib_bundle(paths, "cmake", MANAGED_CMAKE_VERSION, slug).await
+}
+
+/// Materialize the managed Ninja bundle for `host_triple`. Returns
+/// the bundle root (contains `bin/`).
+pub async fn ensure_ninja_bundle(
+    paths: &SoldrPaths,
+    host_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let slug = host_slug_for(host_triple).ok_or_else(|| unsupported_host("ninja", host_triple))?;
+    super::syslib_common::ensure_syslib_bundle(paths, "ninja", MANAGED_NINJA_VERSION, slug).await
+}
+
+fn unsupported_host(tool: &str, host_triple: &str) -> SoldrError {
+    SoldrError::UnsupportedPlatform(format!(
+        "no managed {tool} bundle for host {host_triple}; supported: {:?}",
+        CMAKE_TOOL_HOSTS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+    ))
+}
+
+/// Path to the cmake executable inside a materialized bundle root.
+pub fn cmake_exe(bundle_root: &Path) -> PathBuf {
+    bundle_root.join("bin").join(exe_name("cmake"))
+}
+
+/// Path to the ninja executable inside a materialized bundle root.
+pub fn ninja_exe(bundle_root: &Path) -> PathBuf {
+    bundle_root.join("bin").join(exe_name("ninja"))
+}
+
+fn exe_name(base: &str) -> String {
+    if cfg!(windows) {
+        format!("{base}.exe")
+    } else {
+        base.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(host_slug_for_supported_triples, {
+        assert_eq!(host_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
+        assert_eq!(host_slug_for("aarch64-apple-darwin"), Some("darwin-arm64"));
+        assert_eq!(
+            host_slug_for("x86_64-unknown-linux-gnu"),
+            Some("linux-x64-gnu")
+        );
+        // musl hosts intentionally unsupported — glibc-linked upstream
+        // binaries. The miss routes callers to system cmake.
+        assert_eq!(host_slug_for("x86_64-unknown-linux-musl"), None);
+        assert_eq!(host_slug_for("wasm32-unknown-unknown"), None);
+    });
+
+    crate::timed_test!(asset_url_layout_matches_catalogue, {
+        let c = cmake_asset_url_for(MANAGED_CMAKE_VERSION, "windows-x64");
+        assert!(c.starts_with("https://media.githubusercontent.com/media/"));
+        assert!(c.contains("/cmake/4.3.4/windows-x64/"));
+        assert!(c.ends_with("/bundle.tar.zst"));
+
+        let n = ninja_asset_url_for(MANAGED_NINJA_VERSION, "linux-arm64-gnu");
+        assert!(n.contains("/ninja/1.13.2/linux-arm64-gnu/"));
+        assert!(n.ends_with("/bundle.tar.zst"));
+    });
+
+    crate::timed_test!(version_constants_well_formed, {
+        for v in [MANAGED_CMAKE_VERSION, MANAGED_NINJA_VERSION] {
+            let parts: Vec<&str> = v.split('.').collect();
+            assert_eq!(parts.len(), 3, "expected MAJOR.MINOR.PATCH, got {v}");
+            for p in parts {
+                assert!(p.chars().all(|c| c.is_ascii_digit()), "non-digit in {v}");
+            }
+        }
+    });
+
+    crate::timed_test!(current_host_triple_is_in_known_set_or_musl, {
+        let host = current_host_triple();
+        let known = CMAKE_TOOL_HOSTS.iter().any(|(t, _)| *t == host);
+        let musl = host.ends_with("-unknown-linux-musl");
+        assert!(
+            known || musl,
+            "host {host} neither a supported cmake host nor musl"
+        );
+    });
+
+    crate::timed_test!(exe_paths_are_platform_correct, {
+        let root = Path::new("root");
+        let cmake = cmake_exe(root);
+        let ninja = ninja_exe(root);
+        if cfg!(windows) {
+            assert!(cmake.ends_with("bin/cmake.exe") || cmake.ends_with("bin\\cmake.exe"));
+            assert!(ninja.ends_with("bin/ninja.exe") || ninja.ends_with("bin\\ninja.exe"));
+        } else {
+            assert!(cmake.ends_with("bin/cmake"));
+            assert!(ninja.ends_with("bin/ninja"));
+        }
+    });
+
+    crate::timed_test!(ensure_bundles_reject_unsupported_host, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt
+            .block_on(ensure_cmake_bundle(&paths, "wasm32-unknown-unknown"))
+            .expect_err("unsupported host must error");
+        assert!(matches!(err, SoldrError::UnsupportedPlatform(_)));
+        let err = rt
+            .block_on(ensure_ninja_bundle(&paths, "x86_64-unknown-linux-musl"))
+            .expect_err("musl host must error");
+        assert!(matches!(err, SoldrError::UnsupportedPlatform(_)));
+    });
+}

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -70,6 +70,11 @@ pub mod xwin_cache;
 // _SYSTEM / _OVERRIDE env vars onto the child cargo invocation so
 // the *-sys crate's build.rs skips its vendored compile.
 pub mod bzip2_sysroot;
+/// Managed CMake + Ninja host-tool bundles — blessed builds export
+/// `CMAKE` / `CMAKE_GENERATOR=Ninja` from these instead of trusting
+/// whatever cmake/make the system PATH resolves. Stub-until-ingested
+/// consumer like the *-sys sysroots below.
+pub mod cmake_tools;
 pub mod lzma_sysroot;
 pub mod mimalloc_sysroot;
 pub mod sqlite_sysroot;

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -302,7 +302,8 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
 
             // Try to recognize a target from argv so we can prep
             // before invoking cargo. If the user didn't pass `--target`,
-            // blessed prep is a no-op and we forward unchanged.
+            // only the host-side prep (managed cmake/ninja) runs and we
+            // forward otherwise unchanged.
             if let Some(target_triple) = extract_target_from_args(&full_args) {
                 let paths = crate::core::SoldrPaths::new()?;
                 let prep = crate::blessed_build::prepare(&paths, &target_triple).await?;
@@ -315,6 +316,9 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                 }
                 if let Some(shim_dir) = prep.shim_path_dir.as_ref() {
                     prepend_to_path_env(shim_dir);
+                }
+                for dir in &prep.path_dirs {
+                    prepend_to_path_env(dir);
                 }
 
                 // soldr#882: auto-dispatch cargo subcommand based on
@@ -330,6 +334,24 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                     full_args = rewrite_build_args_for_subcommand(full_args, subcmd);
                 }
                 full_args = insert_cargo_config_args(full_args, &cargo_args);
+            } else {
+                // Native host build (no --target): the cross-compile
+                // sysroot prep doesn't apply, but the managed cmake +
+                // ninja injection does — cmake-based *-sys build
+                // scripts run on the host regardless of target, and
+                // "use whatever cmake/make PATH serves" is exactly the
+                // failure mode soldr exists to remove (a pip-installed
+                // MSYS make + "MSYS Makefiles" generator broke native
+                // libz-ng-sys builds — see fetch::cmake_tools).
+                let paths = crate::core::SoldrPaths::new()?;
+                let mut prep = crate::blessed_build::BlessedPrep::default();
+                crate::blessed_build::inject_cmake_tooling(&paths, &mut prep).await;
+                for (k, v) in &prep.env {
+                    std::env::set_var(k, v);
+                }
+                for dir in &prep.path_dirs {
+                    prepend_to_path_env(dir);
+                }
             }
 
             // soldr#1079: ensure native Windows MSVC builds get LIB /


### PR DESCRIPTION
## Motivation

`pip install soldr` (maturin → cargo → `libz-ng-sys`) exploded on a real dev box because the build trusted whatever cmake/make the system PATH served:

- PATH `cmake` was a pip wheel (cmake 4.1.0 in `python13\Scripts`), PATH `make` was an MSYS-flavored binary bundled by the unrelated pip package `zcmds_win32`.
- CMake picked the **"MSYS Makefiles"** generator; MSYS make path-mangled MSVC flags (`/nologo` → `C:\Program Files\Git\nologo.obj`, `LNK1181`) and failed `CreateProcess` on POSIX-style compiler paths.
- Chocolatey's GNU rust (`C:\ProgramData\chocolatey\bin\cargo`) shadowing rustup compounded it by flipping the host target to `x86_64-pc-windows-gnu`.

soldr can't fix arbitrary PATHs, but soldr builds should never have been at their mercy. Per the #1010 blessed-surface direction: provision the tool on demand from the toolchain catalogue.

## What this does

- **New `fetch::cmake_tools`** — catalogue consumer for pinned upstream-official binaries: Kitware **CMake 4.3.4** + **ninja 1.13.2**, host-keyed (`windows-x64/arm64`, `darwin-x64/arm64`, `linux-x64/arm64-gnu`; musl falls through — upstream binaries are glibc-linked). Same stub-until-ingested shape as the `*-sys` sysroot consumers.
- **`blessed_build::inject_cmake_tooling`** — exports `CMAKE=<managed cmake>`, `CMAKE_GENERATOR=Ninja` (only when ninja materialized), and prepends the bundle `bin/` dirs to PATH (Ninja generator discovers `ninja` via PATH; there is no env equivalent of the `CMAKE_MAKE_PROGRAM` cache var). cmake-rs reads `CMAKE`/`CMAKE_GENERATOR` natively, so every cmake-based `*-sys` build script (libz-ng-sys, zstd-sys, …) picks this up with zero crate-side changes.
- **Runs for both `soldr build --target X` and native `soldr build`** — cmake/ninja are host tools, target-independent, so the native path gets a minimal host-side prep where full blessed prep previously no-op'd.
- **Escape hatches**: pre-set `CMAKE` or `CMAKE_GENERATOR` env suppresses injection entirely (explicit user config wins); `SOLDR_USE_SYSTEM_CMAKE=1` opts out wholesale. Catalogue misses log + fall through to system cmake.

## Rollout

Safe to land now: until the `cmake`/`ninja` recipes on zackees/soldr-toolchain are dispatched + ingested (companion PR adds them), every fetch misses the catalogue and behavior is unchanged. Once the assets land, blessed builds silently switch to the managed tools.

## Testing

- 8 new unit tests (slug tables, URL layout, exe paths, unsupported-host errors, opt-out + user-env-respect injection guards); `blessed_build` suite green; `cargo fmt` + `clippy --all-targets` clean; `timed_test_lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)