### PR TITLE
perf(ci): drop 'needs: lint' from build-linux-x64 to parallelize (#1258)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,11 @@ jobs:
 
   build-linux-x64:
     name: Linux x64
-    needs: lint
+    # soldr#1258 — dropped `needs: lint`. Every cross-build lane runs in
+    # parallel with Lint; the sequential gate here was inconsistent and
+    # added ~130 s to the CI critical path. Lint remains a required
+    # status check via branch protection, so a Lint failure still blocks
+    # merge — the `needs:` clause was purely a wallclock cost.
     if: github.ref_name == 'main'
     uses: ./.github/workflows/_build-and-test.yml
     with:


### PR DESCRIPTION
## Summary

Fixes #1258.

- Remove \`needs: lint\` from \`build-linux-x64\` in \`ci.yml\`.
- Every cross-build lane already runs in parallel with Lint; the sequential gate on Linux x64 was inconsistent.

## Impact

- Linux x64 lane finishes at ~355 s (parallel with Lint) instead of ~480 s (sequential after Lint).
- CI wallclock is now capped by cross-build lanes (~400 s) instead of Linux x64.
- **~80 s off the CI critical path** on every push to main.

## Correctness

Lint remains a required status check via branch protection. A Lint failure still blocks merge — the workflow \`needs:\` clause was purely a wallclock cost, not a correctness gate.

## Trade-off

- Wallclock: -80 s per CI run.
- Runner minutes on Lint failure: Linux x64 now runs a few seconds before being cancelled. Negligible.

## Test plan

- [x] Remove \`needs: lint\` line + preserve \`if: github.ref_name == 'main'\`.
- [ ] First CI run post-merge: Linux x64 lane starts in parallel with Lint (visible in job timing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)