### PR TITLE
ci(cross-build): skip apt baseline on lanes that don't need musl-tools (#1260)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -98,25 +98,29 @@ jobs:
         shell: bash
         run: rustup target add ${{ inputs.target }}
 
-      # soldr#1189 — split apt install per target. The clang stack
-      # (clang lld llvm llvm-dev libclang-dev) is only needed by MSVC
-      # (cargo-xwin) and darwin (blessed_build). Skipping it on musl
-      # + linux-gnu lanes saves ~15-20 s of apt fetch per lane.
-      - name: Install apt deps (baseline)
+      # soldr#1260 — the previous "Install apt deps (baseline)" step
+      # installed build-essential + pkg-config + file + jq + xz-utils +
+      # bzip2 + zip + unzip + ca-certificates + curl + git + cmake +
+      # perl + musl-tools on every lane. Every package except musl-tools
+      # is already preinstalled on ubuntu-24.04, so the step was ~13 s
+      # of apt fetch producing zero installed packages on gnu/darwin/
+      # msvc lanes. Musl lanes now install only musl-tools; msvc/darwin
+      # fold `apt-get update` into the clang-stack install; linux-gnu
+      # lanes skip apt entirely.
+      - name: Install musl-tools
+        if: contains(inputs.target, 'linux-musl')
         shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config file jq xz-utils bzip2 zip unzip \
-            ca-certificates curl git cmake perl \
-            musl-tools
+          sudo apt-get install -y --no-install-recommends musl-tools
 
       - name: Install apt deps (clang stack for MSVC/darwin)
         if: contains(inputs.target, 'pc-windows-msvc') || contains(inputs.target, 'apple-darwin')
         shell: bash
         run: |
           set -euo pipefail
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             clang lld llvm llvm-dev libclang-dev
 


### PR DESCRIPTION
Fixes #1260.

## Summary
- Every cross-build lane was running `apt-get update` + install of
  `build-essential pkg-config file jq xz-utils bzip2 zip unzip
  ca-certificates curl git cmake perl musl-tools`. Every one of those
  except `musl-tools` is already preinstalled on ubuntu-24.04, so the
  step was ~13 s of apt fetch producing zero installed packages on
  gnu/darwin/msvc lanes.
- Split into: musl lanes install ONLY `musl-tools` (with its own
  `apt-get update`); MSVC/darwin fold `apt-get update` into the
  clang-stack install; linux-gnu native + aarch64 lanes skip apt entirely.

Expected wallclock trim: ~13 s off darwin, MSVC, and both linux-gnu
lanes. Musl unchanged. On the current CI critical path (darwin-x86_64
slowest at ~406 s, MSVC second at ~393 s) that trims ~13 s off CI.

## Test plan
- [ ] `_ci-cross-build-linux.yml` still passes on all six enabled cross
      targets (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`,
      `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`,
      `x86_64-apple-darwin`, `aarch64-apple-darwin`,
      `x86_64-pc-windows-msvc`).
- [ ] darwin/MSVC lanes still fetch clang stack (apt install runs in
      the clang-stack step now with its own `apt-get update`).
- [ ] Lint stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)