### PR TITLE
fix(blessed_build): preserve source mtime on soldr-clang-shim install (#1265)

### DIFF
--- a/crates/soldr-cli/src/blessed_build.rs
+++ b/crates/soldr-cli/src/blessed_build.rs
@@ -556,6 +556,20 @@ fn install_clang_shim(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
     // released install, it's at `<exe-dir>/soldr-clang-shim(.exe)`.
     let shim_src = locate_shim_binary()?;
 
+    // soldr#1265 — preserve the source binary's mtime on the installed
+    // shim. cc-rs uses the CC binary's mtime in some build-script paths;
+    // without preservation every `soldr build` invocation looked like a
+    // fresh compiler → cargo invalidated cc-rs-touched deps on darwin/
+    // MSVC CI lanes. Preserving mtime keeps the shim's timestamp aligned
+    // with the source (stable when bootstrap cache HITs).
+    let src_mtime = std::fs::metadata(&shim_src)
+        .and_then(|meta| meta.modified())
+        .map_err(|e| {
+            SoldrError::Other(format!(
+                "failed to read source mtime for soldr-clang-shim: {e}"
+            ))
+        })?;
+
     for name in clang_shim_names() {
         let dst = shim_dir.join(&name);
         // Best-effort remove first; ignore errors (file may not exist).
@@ -569,6 +583,18 @@ fn install_clang_shim(paths: &SoldrPaths) -> Result<PathBuf, SoldrError> {
                 dst.display()
             ))
         })?;
+
+        // Preserve source mtime — see block comment above the loop.
+        std::fs::File::options()
+            .write(true)
+            .open(&dst)
+            .and_then(|f| f.set_modified(src_mtime))
+            .map_err(|e| {
+                SoldrError::Other(format!(
+                    "failed to preserve mtime on installed soldr-clang-shim {}: {e}",
+                    dst.display()
+                ))
+            })?;
 
         #[cfg(unix)]
         {


### PR DESCRIPTION
Fixes #1265.

## Summary
- \`install_clang_shim\` did \`remove_file\` + \`fs::copy\` on every
  \`soldr build\` invocation. \`fs::copy\` sets fresh mtime, and cc-rs uses
  the CC binary's mtime in build-script fingerprint paths.
- Preserve source mtime via \`File::set_modified\` (stable Rust 1.75+).

## Why this matters
CI cross-build lanes routing through \`soldr build\` (MSVC + both darwin)
show rust-cache primary-key HITs but 0 cargo Fresh hits — 150–184 crates
recompile per lane. Musl / linux-gnu lanes using plain \`cargo zigbuild\`
show clean Fresh behavior on the same cache key format. The shim install
pattern is the delta.

## Expected impact
- Best case: ~200 s off darwin/MSVC lanes on the second run after this
  merges (once the cache save reflects the stable-mtime state).
- Worst case: no improvement, no regression. \`remove + fresh-mtime copy\`
  is objectively wasteful either way.

## Test plan
- [ ] All existing tests pass — this is a pure I/O behavior tweak.
- [ ] Lint stays green.
- [ ] Next CI run's darwin/MSVC lane 'Compiling' count drops toward the
      musl baseline (~4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)