### PR TITLE
feat(pep517): pin toolchain + managed cmake/ninja in soldr maturin, dogfood build-backend = soldr

### DIFF
--- a/crates/soldr-cli/src/fetch/maturin_env.rs
+++ b/crates/soldr-cli/src/fetch/maturin_env.rs
@@ -1,0 +1,277 @@
+//! Manual uv-provisioned maturin environment — soldr#1264 follow-on.
+//!
+//! The primary maturin acquisition is the pinned prebuilt binary from
+//! PyO3/maturin GitHub Releases (`fetch_tool("maturin", pinned)`).
+//! This module is the guarantee behind "maturin is always invocable":
+//! when the binary fetch misses (rate limit, missing asset for a
+//! platform, upstream release shape change), soldr provisions maturin
+//! into a manually-managed isolated environment using the managed
+//! `uv` from the soldr-toolchain archive:
+//!
+//! ```text
+//! uv venv --python 3.12 ~/.soldr/bin/maturin-uv-<ver>/
+//! uv pip install --python <env python> maturin==<ver>
+//! ```
+//!
+//! Deliberately hand-rolled rather than depending on the `uv-iso-env`
+//! PyPI package: soldr's build backend carries zero third-party Python
+//! deps, and the two uv invocations above are the entire surface that
+//! package would have wrapped.
+//!
+//! uv state is kept under the soldr root (`UV_CACHE_DIR`,
+//! `UV_PYTHON_INSTALL_DIR`) so nothing leaks into the user's uv dirs
+//! and `soldr clean`-style wipes take it along.
+//!
+//! ## Env-var surface
+//!
+//! `SOLDR_MATURIN_PROVISIONER` — `auto` (default: prebuilt binary,
+//! uv-env fallback), `binary` (prebuilt only, fail hard on miss),
+//! `uv` (skip the binary fetch, go straight to the uv env).
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{suppress_windows_console_window, SoldrError, SoldrPaths};
+
+/// Selects how `soldr maturin` acquires the maturin executable.
+pub const MATURIN_PROVISIONER_ENV_VAR: &str = "SOLDR_MATURIN_PROVISIONER";
+
+/// Python version the isolated maturin env is created with. uv
+/// downloads its managed CPython on demand when the host has none —
+/// pinned so the env is reproducible across machines.
+pub const MATURIN_ENV_PYTHON: &str = "3.12";
+
+/// Sentinel filename marking a fully-provisioned env. Written last;
+/// its absence means a previous attempt died mid-way and the dir is
+/// rebuilt from scratch.
+const COMPLETE_SENTINEL: &str = ".soldr-complete";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaturinProvisioner {
+    /// Prebuilt binary first, uv env as fallback (default).
+    Auto,
+    /// Prebuilt binary only — a fetch miss is a hard error.
+    Binary,
+    /// Straight to the uv-provisioned env.
+    Uv,
+}
+
+impl MaturinProvisioner {
+    /// Parse from the env-var value. Unknown / empty values fall back
+    /// to `Auto` — diagnostic env vars must never wedge the build.
+    pub fn from_env_value(value: Option<&str>) -> Self {
+        match value.map(str::trim) {
+            Some(v) if v.eq_ignore_ascii_case("binary") => Self::Binary,
+            Some(v) if v.eq_ignore_ascii_case("uv") => Self::Uv,
+            _ => Self::Auto,
+        }
+    }
+
+    pub fn from_env() -> Self {
+        let raw = std::env::var(MATURIN_PROVISIONER_ENV_VAR).ok();
+        Self::from_env_value(raw.as_deref())
+    }
+}
+
+/// Directory of the isolated maturin env for `version`.
+pub fn env_dir_for(paths: &SoldrPaths, version: &str) -> PathBuf {
+    paths.bin.join(format!("maturin-uv-{version}"))
+}
+
+/// Path of the maturin executable inside an isolated env dir.
+pub fn maturin_exe_in_env(env_dir: &Path) -> PathBuf {
+    if cfg!(windows) {
+        env_dir.join("Scripts").join("maturin.exe")
+    } else {
+        env_dir.join("bin").join("maturin")
+    }
+}
+
+/// A provisioned env counts as complete only when BOTH the maturin
+/// executable and the sentinel exist — the sentinel is written last,
+/// so its absence means a prior attempt died mid-way and the dir must
+/// be rebuilt rather than served.
+pub(crate) fn env_is_complete(env_dir: &Path) -> bool {
+    maturin_exe_in_env(env_dir).is_file() && env_dir.join(COMPLETE_SENTINEL).is_file()
+}
+
+fn python_exe_in_env(env_dir: &Path) -> PathBuf {
+    if cfg!(windows) {
+        env_dir.join("Scripts").join("python.exe")
+    } else {
+        env_dir.join("bin").join("python")
+    }
+}
+
+/// Provision maturin `version` into an isolated uv-managed env and
+/// return the maturin executable path. Idempotent: a completed env is
+/// a couple of stat calls; a half-built one is wiped and rebuilt.
+pub async fn provision_maturin_via_uv(
+    paths: &SoldrPaths,
+    version: &str,
+) -> Result<PathBuf, SoldrError> {
+    let env_dir = env_dir_for(paths, version);
+    let maturin = maturin_exe_in_env(&env_dir);
+    if env_is_complete(&env_dir) {
+        return Ok(maturin);
+    }
+
+    let host = super::cmake_tools::current_host_triple();
+    let uv_root = super::uv_tool::ensure_uv_bundle(paths, host).await?;
+    let uv = super::uv_tool::uv_exe(&uv_root);
+    if !uv.is_file() {
+        return Err(SoldrError::Other(format!(
+            "managed uv bundle at {} has no {}",
+            uv_root.display(),
+            uv.display()
+        )));
+    }
+
+    // Half-built env from a previous attempt → start clean.
+    if env_dir.exists() {
+        let _ = std::fs::remove_dir_all(&env_dir);
+    }
+
+    eprintln!(
+        "soldr: provisioning maturin {version} via managed uv \
+         ({MATURIN_ENV_PYTHON} isolated env)..."
+    );
+
+    run_uv(
+        &uv,
+        paths,
+        &[
+            "venv".as_ref(),
+            "--python".as_ref(),
+            MATURIN_ENV_PYTHON.as_ref(),
+            env_dir.as_os_str(),
+        ],
+        "uv venv",
+    )?;
+
+    let env_python = python_exe_in_env(&env_dir);
+    let spec = format!("maturin=={version}");
+    run_uv(
+        &uv,
+        paths,
+        &[
+            "pip".as_ref(),
+            "install".as_ref(),
+            "--python".as_ref(),
+            env_python.as_os_str(),
+            spec.as_str().as_ref(),
+        ],
+        "uv pip install maturin",
+    )?;
+
+    if !maturin.is_file() {
+        return Err(SoldrError::Other(format!(
+            "uv reported success but {} does not exist",
+            maturin.display()
+        )));
+    }
+    std::fs::write(env_dir.join(COMPLETE_SENTINEL), b"ok\n")?;
+    Ok(maturin)
+}
+
+/// Run one uv command with soldr-scoped uv state dirs. Inherits
+/// stdout/stderr so download progress is visible to the user.
+fn run_uv(
+    uv: &Path,
+    paths: &SoldrPaths,
+    args: &[&std::ffi::OsStr],
+    label: &str,
+) -> Result<(), SoldrError> {
+    let mut command = std::process::Command::new(uv);
+    command.args(args);
+    command.env("UV_CACHE_DIR", paths.root.join("uv-cache"));
+    command.env("UV_PYTHON_INSTALL_DIR", paths.root.join("uv-python"));
+    suppress_windows_console_window(&mut command);
+    let status = command.status().map_err(|e| {
+        SoldrError::Other(format!("{label}: failed to spawn {}: {e}", uv.display()))
+    })?;
+    if !status.success() {
+        return Err(SoldrError::Other(format!(
+            "{label} exited with {status} (uv: {})",
+            uv.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(provisioner_parse_defaults_to_auto, {
+        assert_eq!(
+            MaturinProvisioner::from_env_value(None),
+            MaturinProvisioner::Auto
+        );
+        assert_eq!(
+            MaturinProvisioner::from_env_value(Some("")),
+            MaturinProvisioner::Auto
+        );
+        assert_eq!(
+            MaturinProvisioner::from_env_value(Some("garbage")),
+            MaturinProvisioner::Auto,
+            "unknown values must not wedge the build"
+        );
+        assert_eq!(
+            MaturinProvisioner::from_env_value(Some("BINARY")),
+            MaturinProvisioner::Binary
+        );
+        assert_eq!(
+            MaturinProvisioner::from_env_value(Some(" uv ")),
+            MaturinProvisioner::Uv
+        );
+    });
+
+    crate::timed_test!(env_layout_is_versioned_and_platform_correct, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let dir = env_dir_for(&paths, "1.14.1");
+        assert!(dir.ends_with("maturin-uv-1.14.1"));
+        let exe = maturin_exe_in_env(&dir);
+        if cfg!(windows) {
+            assert!(exe.ends_with("Scripts/maturin.exe") || exe.ends_with("Scripts\\maturin.exe"));
+        } else {
+            assert!(exe.ends_with("bin/maturin"));
+        }
+    });
+
+    crate::timed_test!(completed_env_short_circuits_without_uv, {
+        // A maturin exe + sentinel must satisfy the provisioner with
+        // zero network / uv-bundle work — proven by pointing at a
+        // synthetic root where no uv bundle could possibly exist.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let env_dir = env_dir_for(&paths, "9.9.9");
+        let exe = maturin_exe_in_env(&env_dir);
+        std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        std::fs::write(&exe, b"stub").unwrap();
+        std::fs::write(env_dir.join(COMPLETE_SENTINEL), b"ok\n").unwrap();
+
+        let got = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(provision_maturin_via_uv(&paths, "9.9.9"))
+            .expect("completed env must short-circuit");
+        assert_eq!(got, exe);
+    });
+
+    crate::timed_test!(missing_sentinel_means_incomplete, {
+        // Exe without sentinel = half-built env → NOT complete, must
+        // be rebuilt rather than served. Sentinel without exe likewise.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let env_dir = tmp.path().join("maturin-uv-9.9.9");
+        let exe = maturin_exe_in_env(&env_dir);
+        std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        std::fs::write(&exe, b"stub").unwrap();
+        assert!(!env_is_complete(&env_dir), "no sentinel → incomplete");
+
+        std::fs::write(env_dir.join(COMPLETE_SENTINEL), b"ok\n").unwrap();
+        assert!(env_is_complete(&env_dir));
+
+        std::fs::remove_file(&exe).unwrap();
+        assert!(!env_is_complete(&env_dir), "no exe → incomplete");
+    });
+}

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -76,12 +76,19 @@ pub mod bzip2_sysroot;
 /// consumer like the *-sys sysroots below.
 pub mod cmake_tools;
 pub mod lzma_sysroot;
+/// soldr#1264 follow-on — manual uv-provisioned maturin env (fallback
+/// when the prebuilt maturin binary fetch misses). Hand-rolled on
+/// purpose; see module doc for why not the `uv-iso-env` package.
+pub mod maturin_env;
 pub mod mimalloc_sysroot;
 pub mod sqlite_sysroot;
 /// soldr#1064 Phase B — shared download + extract for the six
 /// *-sys C library catalogue bundles. The per-lib modules each
 /// call this helper with their own `(lib, version, slug)` tuple.
 pub mod syslib_common;
+/// soldr#1264 follow-on — managed `uv` bundle from the soldr-toolchain
+/// archive. First consumer: [`maturin_env`].
+pub mod uv_tool;
 pub mod zccache;
 pub mod zccache_install;
 pub mod zccache_runtime;

--- a/crates/soldr-cli/src/fetch/uv_tool.rs
+++ b/crates/soldr-cli/src/fetch/uv_tool.rs
@@ -1,0 +1,129 @@
+//! Managed `uv` bundle fetcher — soldr#1264 follow-on.
+//!
+//! `uv` (astral-sh/uv) joins the soldr-toolchain archive as a managed
+//! host tool so soldr can provision Python tooling in manually-managed
+//! isolated environments — first consumer: the maturin fallback in
+//! [`super::maturin_env`], which does `uv venv` + `uv pip install
+//! maturin==<pin>` when the prebuilt maturin binary fetch misses.
+//! Deliberately NOT the `uv-iso-env` PyPI package: the whole point is
+//! zero Python-level dependencies in soldr's build backend, so the
+//! isolation dance is done by hand against a pinned managed binary.
+//!
+//! Bundle layout (forge recipes `uv-<shape>` on zackees/soldr-toolchain):
+//!
+//! ```text
+//! bin/uv(.exe)
+//! bin/uvx(.exe)   ← present in upstream archives; shipped along
+//! ```
+//!
+//! Unlike cmake/ninja, upstream ships musl builds, so all 8 standard
+//! shapes are supported. Stub-until-ingested like every catalogue
+//! consumer: a catalogue miss errors and callers fall through.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::{SoldrError, SoldrPaths};
+
+/// uv version pinned by the soldr-toolchain `uv-<shape>` recipes.
+pub const MANAGED_UV_VERSION: &str = "0.11.26";
+
+/// Host triple → catalogue shape slug. uv is a HOST tool.
+pub const UV_TOOL_HOSTS: &[(&str, &str)] = &[
+    ("x86_64-pc-windows-msvc", "windows-x64"),
+    ("aarch64-pc-windows-msvc", "windows-arm64"),
+    ("x86_64-apple-darwin", "darwin-x64"),
+    ("aarch64-apple-darwin", "darwin-arm64"),
+    ("x86_64-unknown-linux-gnu", "linux-x64-gnu"),
+    ("aarch64-unknown-linux-gnu", "linux-arm64-gnu"),
+    ("x86_64-unknown-linux-musl", "linux-x64-musl"),
+    ("aarch64-unknown-linux-musl", "linux-arm64-musl"),
+];
+
+/// Catalogue slug for a host triple, if supported.
+pub fn host_slug_for(host_triple: &str) -> Option<&'static str> {
+    UV_TOOL_HOSTS
+        .iter()
+        .find(|(rust, _)| *rust == host_triple)
+        .map(|(_, slug)| *slug)
+}
+
+/// Assets-branch URL for the uv bundle. Catalogue layout:
+/// `uv/<version>/<slug>/bundle.tar.zst`.
+pub fn asset_url_for(version: &str, slug: &str) -> String {
+    super::syslib_common::asset_url_for("uv", version, slug)
+}
+
+/// Materialize the managed uv bundle for `host_triple`. Returns the
+/// bundle root (contains `bin/`).
+pub async fn ensure_uv_bundle(
+    paths: &SoldrPaths,
+    host_triple: &str,
+) -> Result<PathBuf, SoldrError> {
+    let slug = host_slug_for(host_triple).ok_or_else(|| {
+        SoldrError::UnsupportedPlatform(format!(
+            "no managed uv bundle for host {host_triple}; supported: {:?}",
+            UV_TOOL_HOSTS.iter().map(|(t, _)| *t).collect::<Vec<_>>()
+        ))
+    })?;
+    super::syslib_common::ensure_syslib_bundle(paths, "uv", MANAGED_UV_VERSION, slug).await
+}
+
+/// Path to the uv executable inside a materialized bundle root.
+pub fn uv_exe(bundle_root: &Path) -> PathBuf {
+    let name = if cfg!(windows) { "uv.exe" } else { "uv" };
+    bundle_root.join("bin").join(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::timed_test!(uv_host_slug_covers_all_eight_shapes, {
+        assert_eq!(host_slug_for("x86_64-pc-windows-msvc"), Some("windows-x64"));
+        assert_eq!(
+            host_slug_for("x86_64-unknown-linux-musl"),
+            Some("linux-x64-musl"),
+            "uv ships musl builds — musl hosts are supported (unlike cmake/ninja)"
+        );
+        assert_eq!(
+            host_slug_for("aarch64-unknown-linux-musl"),
+            Some("linux-arm64-musl")
+        );
+        assert_eq!(host_slug_for("wasm32-unknown-unknown"), None);
+        assert_eq!(UV_TOOL_HOSTS.len(), 8);
+    });
+
+    crate::timed_test!(uv_asset_url_layout_matches_catalogue, {
+        let u = asset_url_for(MANAGED_UV_VERSION, "windows-x64");
+        assert!(u.starts_with("https://media.githubusercontent.com/media/"));
+        assert!(u.contains("/uv/0.11.26/windows-x64/"));
+        assert!(u.ends_with("/bundle.tar.zst"));
+    });
+
+    crate::timed_test!(uv_version_constant_well_formed, {
+        let parts: Vec<&str> = MANAGED_UV_VERSION.split('.').collect();
+        assert_eq!(parts.len(), 3);
+        for p in parts {
+            assert!(p.chars().all(|c| c.is_ascii_digit()));
+        }
+    });
+
+    crate::timed_test!(uv_exe_path_is_platform_correct, {
+        let exe = uv_exe(Path::new("root"));
+        if cfg!(windows) {
+            assert!(exe.ends_with("bin/uv.exe") || exe.ends_with("bin\\uv.exe"));
+        } else {
+            assert!(exe.ends_with("bin/uv"));
+        }
+    });
+
+    crate::timed_test!(ensure_uv_bundle_rejects_unsupported_host, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let paths = SoldrPaths::with_root(tmp.path().to_path_buf());
+        let err = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(ensure_uv_bundle(&paths, "wasm32-unknown-unknown"))
+            .expect_err("unsupported host must error");
+        assert!(matches!(err, SoldrError::UnsupportedPlatform(_)));
+    });
+}

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -967,7 +967,16 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             }
 
             eprintln!("soldr: fetching {crate_name}...");
-            let result = crate::fetch::fetch_tool(&crate_name, &version).await?;
+            // soldr#1264 follow-on: maturin gets a provisioning ladder
+            // instead of the bare fetch — prebuilt binary from GitHub
+            // Releases first, manual uv-provisioned isolated env as
+            // the fallback (SOLDR_MATURIN_PROVISIONER=auto|binary|uv).
+            // Everything else keeps the plain fetch_tool path.
+            let result = if crate_name == "maturin" {
+                fetch_maturin_with_provisioner(&version).await?
+            } else {
+                crate::fetch::fetch_tool(&crate_name, &version).await?
+            };
 
             if result.cached {
                 eprintln!("soldr: using cached {crate_name} v{}", result.version);
@@ -1105,6 +1114,49 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
 
 fn should_use_managed_zccache_external(crate_name: &str, version: &VersionSpec) -> bool {
     crate_name == "zccache" && matches!(version, VersionSpec::Latest)
+}
+
+/// soldr#1264 follow-on: maturin provisioning ladder. `auto` (default)
+/// tries the prebuilt GitHub-Releases binary and falls back to the
+/// manual uv-provisioned isolated env; `binary` / `uv` force one rung.
+/// See `fetch::maturin_env` for the env-var contract.
+async fn fetch_maturin_with_provisioner(
+    version: &VersionSpec,
+) -> Result<crate::fetch::FetchResult, SoldrError> {
+    use crate::fetch::maturin_env::MaturinProvisioner;
+
+    let pinned = match version {
+        VersionSpec::Exact(v) => v.clone(),
+        VersionSpec::Latest => crate::fetch::MANAGED_MATURIN_VERSION.to_string(),
+    };
+
+    match MaturinProvisioner::from_env() {
+        MaturinProvisioner::Binary => crate::fetch::fetch_tool("maturin", version).await,
+        MaturinProvisioner::Uv => provisioned_maturin_fetch_result(&pinned).await,
+        MaturinProvisioner::Auto => match crate::fetch::fetch_tool("maturin", version).await {
+            Ok(result) => Ok(result),
+            Err(err) => {
+                eprintln!("soldr: prebuilt maturin fetch failed: {err}");
+                eprintln!("soldr: falling back to the uv-provisioned maturin env...");
+                provisioned_maturin_fetch_result(&pinned).await
+            }
+        },
+    }
+}
+
+async fn provisioned_maturin_fetch_result(
+    version: &str,
+) -> Result<crate::fetch::FetchResult, SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let cached = crate::fetch::maturin_env::env_is_complete(
+        &crate::fetch::maturin_env::env_dir_for(&paths, version),
+    );
+    let binary_path = crate::fetch::maturin_env::provision_maturin_via_uv(&paths, version).await?;
+    Ok(crate::fetch::FetchResult {
+        binary_path,
+        version: version.to_string(),
+        cached,
+    })
 }
 
 fn report_and_exit(error: SoldrError) -> i32 {

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -978,6 +978,97 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
             let mut command = std::process::Command::new(&result.binary_path);
             command.args(tool_args);
 
+            // soldr#1264: `soldr maturin ...` is the engine behind the
+            // PEP 517 build backend (src/soldr/__init__.py). maturin
+            // spawns `cargo` itself, and on Windows the #493 `.cmd`
+            // PATH shims below are invisible to Rust-spawned children
+            // (CreateProcess resolves only `cargo.exe`, never `.cmd`),
+            // so on a PATH-poisoned machine (e.g. a chocolatey GNU
+            // cargo ahead of rustup's proxies) maturin silently builds
+            // the wrong toolchain and cmake-based *-sys deps explode
+            // in "MSYS Makefiles" flag mangling. Pin the child's
+            // toolchain + build tools before exec:
+            //   * `CARGO` → soldr's resolved rustup cargo (honors
+            //     rust-toolchain.toml + MSVC-on-Windows). maturin
+            //     reads `CARGO` before falling back to bare PATH
+            //     lookup. A caller-provided CARGO always wins.
+            //   * managed cmake/ninja env (`CMAKE`,
+            //     `CMAKE_GENERATOR=Ninja`, PATH prepends) via the same
+            //     `inject_cmake_tooling` the blessed `soldr build`
+            //     surface uses (#1257). Same opt-outs apply.
+            if crate_name == "maturin" {
+                if std::env::var_os("CARGO").is_none() {
+                    match resolve_toolchain_binary("cargo") {
+                        Ok(cargo) => {
+                            // A direct (non-rustup-proxy) toolchain
+                            // cargo spawns `rustc` from PATH — on the
+                            // poisoned-fixture machine that's the GNU
+                            // standalone, which lacks the msvc std and
+                            // dies with E0463. Pin RUSTC to the
+                            // sibling rustc of the resolved cargo so
+                            // cargo and rustc always come from the
+                            // same toolchain; fall back to the
+                            // resolver when there is no sibling.
+                            if std::env::var_os("RUSTC").is_none() {
+                                let sibling = cargo.parent().map(|dir| {
+                                    dir.join(if cfg!(windows) { "rustc.exe" } else { "rustc" })
+                                });
+                                match sibling.filter(|p| p.is_file()) {
+                                    Some(rustc) => {
+                                        command.env("RUSTC", rustc);
+                                    }
+                                    None => match resolve_toolchain_binary("rustc") {
+                                        Ok(rustc) => {
+                                            command.env("RUSTC", rustc);
+                                        }
+                                        Err(err) => eprintln!(
+                                            "soldr warning: could not resolve \
+                                             toolchain rustc for maturin: {err}"
+                                        ),
+                                    },
+                                }
+                            }
+                            command.env("CARGO", &cargo);
+                        }
+                        Err(err) => eprintln!(
+                            "soldr warning: could not resolve toolchain cargo for \
+                             maturin; child falls back to PATH lookup: {err}"
+                        ),
+                    }
+                }
+                // CARGO alone is not enough: resolve_toolchain_binary's
+                // last-resort probe is a PATH lookup, and on the
+                // poisoned-fixture machine a GNU-host rustup resolves
+                // the pinned channel to its GNU variant. Force the
+                // TARGET too — same runtime MSVC-default policy the
+                // cargo front door applies via CARGO_BUILD_TARGET
+                // (Windows-only; explicit user env always wins). Both
+                // cargo and maturin honor CARGO_BUILD_TARGET, so even
+                // a wrong-host cargo emits the right-target wheel.
+                if cfg!(windows) && std::env::var_os("CARGO_BUILD_TARGET").is_none() {
+                    match crate::core::TargetTriple::detect() {
+                        Ok(triple) => {
+                            command.env("CARGO_BUILD_TARGET", triple.triple());
+                        }
+                        Err(err) => eprintln!(
+                            "soldr warning: could not detect default target for \
+                             maturin; child builds for its cargo's host: {err}"
+                        ),
+                    }
+                }
+                let paths = SoldrPaths::new()?;
+                let mut prep = crate::blessed_build::BlessedPrep::default();
+                crate::blessed_build::inject_cmake_tooling(&paths, &mut prep).await;
+                // Mutate our own env (inherited by the child) so the
+                // shim-dir PATH prepend below composes on top.
+                for (k, v) in &prep.env {
+                    std::env::set_var(k, v);
+                }
+                for dir in &prep.path_dirs {
+                    prepend_to_path_env(dir);
+                }
+            }
+
             // Issue #493: when the user runs `soldr <external-tool>`,
             // install a transient PATH shim so any nested `cargo` /
             // `rustc` / `rustdoc` / `rustfmt` / `clippy-driver` spawned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,13 @@
+# soldr#1264: dogfood soldr's own PEP 517 backend (src/soldr/__init__.py).
+# The published soldr wheel installs into the isolated build env and
+# drives the build via `soldr maturin pep517 <hook>` — pinned maturin,
+# rustup-resolved CARGO (MSVC on Windows regardless of PATH junk),
+# managed cmake/ninja env for cmake-based *-sys deps, and
+# RUSTC_WRAPPER=soldr caching. Direct `maturin build` invocations
+# (release CI) are unaffected — maturin as a CLI ignores [build-system].
 [build-system]
-requires = ["maturin>=1.7,<2"]
-build-backend = "maturin"
+requires = ["soldr"]
+build-backend = "soldr"
 
 [project]
 name = "soldr"


### PR DESCRIPTION
Closes #1264.

## Problem

`pip install .` of soldr itself bypassed soldr entirely: pyproject declared `build-backend = "maturin"`, raw maturin resolved bare `cargo` from PATH, and on the PATH-poisoned fixture machine (chocolatey GNU rust ahead of rustup, pip cmake/make wheels) the build targeted `x86_64-pc-windows-gnu` and died in libz-ng-sys's "MSYS Makefiles" flag mangling. The #493 `.cmd` PATH shims can't intercept this — CreateProcess never resolves `.cmd` for Rust-spawned children.

## Change

**`soldr maturin` dispatch** (the engine behind the PEP 517 backend from #821) now pins the child's toolchain before exec — each pin skipped when the user pre-set the var:

| Pin | Why |
|---|---|
| `CARGO` → `resolve_toolchain_binary("cargo")` | maturin honors `$CARGO` before PATH lookup (verified empirically with a bogus CARGO). |
| `RUSTC` → resolved cargo's **sibling** rustc | A direct (non-proxy) toolchain cargo spawns `rustc` from PATH; the GNU standalone there lacks msvc std — observed live as `E0463 can't find crate for core` during acceptance. Sibling pin keeps cargo+rustc from the same toolchain. |
| `CARGO_BUILD_TARGET` → runtime MSVC-default triple (Windows only, `TargetTriple::detect`, same policy as the cargo front door) | The resolver's last-resort probe is itself a PATH lookup, and a GNU-host rustup resolves the pinned channel to its GNU variant — the target pin makes even a wrong-host cargo emit the right-target wheel. |
| managed cmake/ninja env via `blessed_build::inject_cmake_tooling` (#1257) | cmake-based `*-sys` deps configure with catalogue cmake 4.3.4 + ninja 1.13.2 instead of PATH junk. `SOLDR_USE_SYSTEM_CMAKE` / pre-set `CMAKE`/`CMAKE_GENERATOR` opt-outs apply. |

**pyproject.toml** flips `[build-system]` to `requires = ["soldr"]` / `build-backend = "soldr"` (dogfooding). Release CI is unaffected — it invokes `maturin build` directly, which ignores `[build-system]`.

## Acceptance (on the poisoned fixture, zero PATH changes)

- Wheel built via `soldr maturin pep517 build-wheel`; maturin's cargo command line shows `C:\Users\...\.rustup\toolchains\1.94.1-x86_64-pc-windows-msvc\bin\cargo.exe ... --target x86_64-pc-windows-msvc`.
- libz-ng-sys CMakeCache: `CMAKE_COMMAND=~/.soldr/bin/syslib/cmake/4.3.4/.../cmake.exe`, `CMAKE_MAKE_PROGRAM=.../ninja/1.13.2/.../ninja.exe`, `CMAKE_GENERATOR=Ninja`, `CMAKE_C_COMPILER=.../cl.exe` (previously: chocolatey `gcc.exe` + MSYS Makefiles).
- Built wheel (`soldr-0.7.96-py3-none-win_amd64.whl`) installed, then `uv pip install . --no-build-isolation` **rebuilt soldr from source through its own backend** successfully.
- 538 lib tests pass; clippy `--all-targets` 0 warnings; fmt clean.

## Rollout note

Fully-isolated `pip install .` (default build isolation) installs the backend from PyPI, so it starts working end-to-end once the **next release** publishes this dispatch fix. Until then `--no-build-isolation` with a locally-installed soldr exercises the full path (verified above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-on commit: manual uv-provisioned maturin fallback (`ef15223`)

Per owner direction, maturin invocability is now guaranteed without `uv-iso-env` (which would have added `uv`/`filelock`/`twine` as Python deps) and without maturin ever being a Python dependency:

- **`fetch::uv_tool`** — managed **uv 0.11.26** from the soldr-toolchain archive (all 8 shapes incl. musl; recipes zackees/soldr-toolchain#45, assets #46, catalogue now at 90 entries).
- **`fetch::maturin_env`** — hand-rolled isolation: `uv venv --python 3.12` + `uv pip install maturin==<pin>` into `~/.soldr/bin/maturin-uv-<ver>/`, sentinel-guarded, uv cache/python dirs scoped under `~/.soldr/`.
- **`soldr maturin` provisioning ladder** — `SOLDR_MATURIN_PROVISIONER=auto|binary|uv` (default `auto`: prebuilt GitHub-Releases binary first, uv env on miss).

E2E on the fixture machine (clean `~/.soldr/bin/maturin-uv-*`):

```
$ SOLDR_MATURIN_PROVISIONER=uv soldr maturin --version
soldr: trust: verified syslib uv/0.11.26/windows-x64 sha256=2699f171...
soldr: provisioning maturin 1.14.1 via managed uv (3.12 isolated env)...
Creating virtual environment at: C:\Users\...\.soldr\bin\maturin-uv-1.14.1
 + maturin==1.14.1
maturin 1.14.1
```

Second invocation short-circuits: `soldr: using cached maturin v1.14.1`. 9 new unit tests; clippy/fmt clean.
