### PR TITLE
ci(cross-build): route bootstrap through zccache instead of bare rustc (#1270)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -224,7 +224,13 @@ jobs:
         if: (contains(inputs.target, 'apple-darwin') || contains(inputs.target, 'pc-windows-msvc')) && steps.bootstrap_cache.outputs.cache-hit != 'true'
         shell: bash
         env:
-          RUSTC_WRAPPER: ""
+          # soldr#1270 — route bootstrap through zccache so unchanged
+          # deps hit the cache seeded by setup-soldr instead of
+          # recompiling from scratch on every crates/** change.
+          # zccache is a separate binary from soldr, so there is no
+          # circular dependency here — the old `RUSTC_WRAPPER: ""` was
+          # a wrong-shape defensive from the pre-zccache workflow.
+          RUSTC_WRAPPER: zccache
         run: |
           set -euo pipefail
           cargo build --release --locked --package soldr-cli \


### PR DESCRIPTION
Fixes #1270.

## Summary
- Change \`Bootstrap soldr for SDK / blessed-build prep\` step's env from
  \`RUSTC_WRAPPER: \"\"\` to \`RUSTC_WRAPPER: zccache\`.
- Rely on setup-soldr's pinned zccache + seeded ZCCACHE_CACHE_DIR (already
  wired earlier in the workflow) for the cache lookup.

## Why
When any PR touches \`crates/**\`, the bootstrap-cache primary key changes
and this step runs cold. Run 28571290523 darwin-x86_64: 276 s of pure
recompile, 183 crates.

zccache is a separate binary from soldr, so there is no circular
dependency here — the old \`RUSTC_WRAPPER: \"\"\` was a defensive from
the pre-zccache workflow.

Expected saving: ~200 s per darwin/MSVC lane on repeat runs. Worst case
(zccache 0-hit residual — soldr#400) is same-as-today behavior.

## Test plan
- [ ] Lint stays green.
- [ ] Next run's darwin/MSVC Bootstrap step reports zccache hits > 0.
- [ ] Cross-build lane wallclock trends down from ~530 s toward ~350 s once
      the cache warms up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)