### PR TITLE
release: bump version to 0.7.97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.96"
+version = "0.7.97"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.96"
+version = "0.7.97"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Release PR per the publishing rules: bumps `[workspace.package].version`, `package.json`, and the `soldr-cli` row in `Cargo.lock` in lockstep to **0.7.97** (unpublished — PyPI/npm/tags all at 0.7.96). `version_lockstep` test green.

Merging this triggers the Autonomous Release pipeline. Highlights shipping in 0.7.97:

- **PEP 517 backend dogfooding + hardening** (#1264 / #1269): `build-backend = "soldr"`, toolchain-pinned `soldr maturin` dispatch (`CARGO`, sibling `RUSTC`, `CARGO_BUILD_TARGET`, managed cmake/ninja env), and the manual uv-provisioned maturin fallback (`SOLDR_MATURIN_PROVISIONER`, uv 0.11.26 from the toolchain archive).
- **Managed cmake + ninja for blessed builds** (#1257): `CMAKE` / `CMAKE_GENERATOR=Ninja` from catalogue bundles instead of whatever the system PATH serves.

Once published, fully-isolated `pip install soldr` / `pip install .` builds route through soldr's own backend end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)