### PR TITLE
ci(cross-build): revert bootstrap zccache wrapping — 0 hits + 35s overhead (#1274)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -224,13 +224,12 @@ jobs:
         if: (contains(inputs.target, 'apple-darwin') || contains(inputs.target, 'pc-windows-msvc')) && steps.bootstrap_cache.outputs.cache-hit != 'true'
         shell: bash
         env:
-          # soldr#1270 — route bootstrap through zccache so unchanged
-          # deps hit the cache seeded by setup-soldr instead of
-          # recompiling from scratch on every crates/** change.
-          # zccache is a separate binary from soldr, so there is no
-          # circular dependency here — the old `RUSTC_WRAPPER: ""` was
-          # a wrong-shape defensive from the pre-zccache workflow.
-          RUSTC_WRAPPER: zccache
+          # soldr#1274 reverts soldr#1270: routing bootstrap through
+          # zccache 1.11.6 added ~35 s/lane of per-invocation overhead
+          # AND still reported 0 hits (the 0-hit residual — soldr#400
+          # — is real and bites here). Back to bare rustc until zccache
+          # actually delivers hits on this call pattern.
+          RUSTC_WRAPPER: ""
         run: |
           set -euo pipefail
           cargo build --release --locked --package soldr-cli \


### PR DESCRIPTION
Fixes #1274.

## Summary
- Revert #1271. Bootstrap step returns to \`RUSTC_WRAPPER: \"\"\`.

## Why
Empirical post-#1271 numbers show every darwin/MSVC lane is ~35 s
SLOWER, with zccache reporting 0 hits / 56 misses on both post-merge
runs. The 0-hit residual (soldr#400) is still real in zccache 1.11.6
for this call pattern, and two zccache-daemon PIDs at shutdown show
bootstrap and cross-build run in separate cache namespaces anyway.

## Test plan
- [ ] Lint stays green.
- [ ] Next run's Bootstrap step returns to ~272 s.
- [ ] No zccache daemon spawned for the bootstrap step.

## Follow-up
A proper fix — sharing the setup-soldr cache dir between bootstrap
and cross-build, OR upstream zccache — is a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)