### PR TITLE
docs: pyproject example for building with soldr instead of maturin

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,45 @@ soldr cargo-dylint check
 soldr rustfmt src/main.rs
 ```
 
+## Use soldr as your PEP 517 build backend (instead of maturin)
+
+For Rust+Python packages, point `pyproject.toml` at soldr instead of
+maturin and `pip install .` / `uv pip install .` route the whole build
+through soldr:
+
+```toml
+[build-system]
+requires = ["soldr"]
+build-backend = "soldr"
+
+# Your existing [tool.maturin] section stays exactly as it is —
+# soldr drives a pinned maturin under the hood, so all maturin
+# configuration keeps working unchanged.
+[tool.maturin]
+manifest-path = "crates/my-crate/Cargo.toml"
+module-name = "my_pkg._native"
+python-source = "src"
+```
+
+That is the entire change — no `maturin` entry in `requires`, no other
+files touched. What you get over `build-backend = "maturin"`:
+
+- **Pinned maturin, fetched on demand** — soldr downloads a pinned
+  maturin binary (or provisions the PyPI wheel in an isolated
+  uv-managed env if the binary fetch misses). Reproducible across
+  machines; nothing to add to your dependencies.
+- **Toolchain pinning** — the build uses the rustup toolchain your
+  `rust-toolchain.toml` declares (MSVC on Windows), even when a stray
+  GNU cargo or mingw shadows it on `PATH`.
+- **Managed cmake + ninja** — cmake-based `*-sys` crates
+  (`libz-ng-sys`, `zstd-sys`, ...) configure with pinned tools from the
+  soldr toolchain archive instead of whatever `cmake`/`make` your
+  `PATH` happens to serve.
+- **Compilation caching** — rustc invocations run under soldr's
+  `RUSTC_WRAPPER`, so repeat builds hit the cache.
+
+soldr's own wheel is built this way (see this repo's `pyproject.toml`).
+
 ## How it works
 
 soldr is a **chameleon binary**: one executable that picks its role from `argv[1]` on every invocation. Three roles:

--- a/docs/API.md
+++ b/docs/API.md
@@ -131,6 +131,35 @@ soldr cargo clean              # explicitly route `clean` to cargo (NOT soldr's 
 soldr cargo config get profile.dev
 ```
 
+### PEP 517 Build Backend
+
+soldr ships a PEP 517 build backend (`src/soldr/__init__.py` in the
+wheel), so Rust+Python packages can build through soldr instead of
+raw maturin:
+
+```toml
+[build-system]
+requires = ["soldr"]
+build-backend = "soldr"
+```
+
+The existing `[tool.maturin]` configuration is honored unchanged — the
+backend delegates to `soldr maturin pep517 <hook>` with a pinned
+maturin. The dispatch pins the child's toolchain before exec:
+
+| Pin | Effect |
+|---|---|
+| `CARGO` / `RUSTC` | rustup-resolved cargo + its sibling rustc — `rust-toolchain.toml` wins over PATH-shadowing standalones (chocolatey/scoop GNU installs). |
+| `CARGO_BUILD_TARGET` | runtime MSVC-default triple on Windows (same policy as the cargo front door). |
+| `CMAKE` / `CMAKE_GENERATOR=Ninja` | managed cmake + ninja from the soldr toolchain archive for cmake-based `*-sys` crates. |
+| `RUSTC_WRAPPER=soldr` | compilation caching (set by the Python backend). |
+
+Every pin defers to a pre-set user env var. Maturin acquisition is a
+ladder controlled by `SOLDR_MATURIN_PROVISIONER` (`auto` default:
+pinned prebuilt binary from GitHub Releases, falling back to the PyPI
+maturin wheel provisioned into an isolated uv-managed env under
+`~/.soldr/bin/maturin-uv-<ver>/`; `binary` and `uv` force one rung).
+
 ### Mode 3: Internal Wrapper Mode
 
 Wrapper mode is entered when Cargo invokes soldr as the configured `RUSTC_WRAPPER`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@
 # managed cmake/ninja env for cmake-based *-sys deps, and
 # RUSTC_WRAPPER=soldr caching. Direct `maturin build` invocations
 # (release CI) are unaffected — maturin as a CLI ignores [build-system].
+# User-facing walkthrough: README "Use soldr as your PEP 517 build
+# backend" + docs/API.md "PEP 517 Build Backend".
 [build-system]
 requires = ["soldr"]
 build-backend = "soldr"


### PR DESCRIPTION
Adds the user-facing documentation for the PEP 517 backend shipped in #1269/#1273 (issue #1264):

- **README** — new "Use soldr as your PEP 517 build backend (instead of maturin)" section: the two-line `[build-system]` swap, what stays unchanged (`[tool.maturin]`), and what you gain (pinned maturin, toolchain pinning, managed cmake/ninja, caching).
- **docs/API.md** — backend reference: pin table (CARGO/RUSTC/CARGO_BUILD_TARGET/CMAKE/RUSTC_WRAPPER) and the `SOLDR_MATURIN_PROVISIONER` acquisition ladder.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)