### PR TITLE
feat(release+pep517): manylinux_2_17 wheels + stable PEP 517 target dir (fbuild ingestion)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -326,8 +326,19 @@ jobs:
       # for both darwin lanes (cross-compile from linux replaces
       # macos-runner builds). Same pinned versions as the every-commit
       # _ci-cross-build-linux.yml workflow.
-      - name: Setup zig (zigbuild lanes)
-        if: matrix.target == 'aarch64-unknown-linux-musl' || (contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04')
+      # soldr#1005 / fbuild ingestion: zig is ALSO needed on the two
+      # linux-gnu lanes so `maturin build --zig` can link the wheel's
+      # embedded soldr binary against a glibc 2.17 floor and tag the
+      # wheel manylinux_2_17. Without zig, maturin links against the
+      # runner's glibc (2.39 on ubuntu-24.04) and auto-tags
+      # manylinux_2_39 — pip on any older glibc (ubuntu-22.04 CI,
+      # enterprise containers) then falls back to the ancient 0.1.0
+      # placeholder sdist, breaking soldr as a PEP 517
+      # `requires=["soldr"]` backend org-wide. Same glibc-floor pattern
+      # as FastLED/fbuild's .github/workflows/template_native_build.yml
+      # (`cargo zigbuild --target <arch>-unknown-linux-gnu.2.17`).
+      - name: Setup zig (zigbuild + manylinux_2_17 wheel lanes)
+        if: matrix.target == 'aarch64-unknown-linux-musl' || contains(matrix.target, 'unknown-linux-gnu') || (contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04')
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.15.2
@@ -1125,10 +1136,32 @@ jobs:
           fi
 
           uv tool install "maturin>=1.7,<2"
+
+          # soldr#1005 / fbuild ingestion: on the linux-gnu lanes,
+          # build the wheel with maturin's zig integration so the
+          # embedded soldr binary links against a glibc 2.17 floor and
+          # the wheel is tagged manylinux_2_17. `--compatibility pypi`
+          # alone lets maturin auto-tag from the runner glibc
+          # (manylinux_2_39 on ubuntu-24.04), which excludes every
+          # glibc<2.39 consumer and triggers pip's fallback to the
+          # 0.1.0 placeholder sdist. Reference implementation:
+          # FastLED/fbuild .github/workflows/template_native_build.yml
+          # (`cargo zigbuild --target <arch>-unknown-linux-gnu.2.17`);
+          # maturin --zig routes through the same cargo-zigbuild
+          # machinery (zig cc as linker + TARGET_CC for cc-rs build
+          # scripts) internally. macOS / Windows lanes keep
+          # `--compatibility pypi` untouched.
+          compat_args=(--compatibility pypi)
+          case "${{ matrix.target }}" in
+            *-unknown-linux-gnu)
+              compat_args=(--zig --compatibility manylinux_2_17)
+              ;;
+          esac
+
           maturin build \
             --release \
             --locked \
-            --compatibility pypi \
+            "${compat_args[@]}" \
             --auditwheel repair \
             --target "${{ matrix.target }}" \
             --target-dir target \
@@ -1185,6 +1218,49 @@ jobs:
           print(
               f"wheel version lint OK: {len(wheels)} wheel(s) all tagged {expected!r}:"
           )
+          for w in wheels:
+              print(f"  - {w.name}")
+
+      - name: Assert linux-gnu wheels are tagged manylinux_2_17
+        if: contains(matrix.target, 'unknown-linux-gnu')
+        shell: python
+        run: |
+          # soldr#1005 / fbuild ingestion: hard assertion-gate in the
+          # spirit of FastLED/fbuild's `NO CHEATING` artifact gates
+          # (cf. fbuild ci/docker-mac-cross/build.sh:77-84, where
+          # file(1) must report Mach-O for every cross-built artifact
+          # or the lane fails loudly — a silently host-linked binary
+          # must never ship). Here the equivalent silent failure mode
+          # is maturin quietly falling back to the runner glibc and
+          # tagging manylinux_2_39: the wheel still builds, still
+          # smoke-tests on the 2.39 runner, and only breaks downstream
+          # when pip on glibc<2.39 skips it and installs the 0.1.0
+          # placeholder sdist instead. Fail the lane at build time if
+          # any linux wheel filename is not manylinux_2_17-tagged.
+          import sys
+          from pathlib import Path
+
+          wheels = sorted(Path("dist").glob("*.whl"))
+          if not wheels:
+              sys.exit("no wheels in dist/ — maturin produced nothing?")
+          bad = [w.name for w in wheels if "manylinux_2_17" not in w.name]
+          if bad:
+              msg = ["manylinux_2_17 tag assertion FAILED:"]
+              for name in bad:
+                  msg.append(f"  - {name}")
+              msg.append("")
+              msg.append(
+                  "Every linux-gnu wheel must carry the manylinux_2_17 "
+                  "platform tag (glibc 2.17 floor via `maturin build "
+                  "--zig --compatibility manylinux_2_17`). A higher tag "
+                  "(e.g. manylinux_2_39 from the runner glibc) makes "
+                  "`pip install soldr` on older glibc fall back to the "
+                  "0.1.0 placeholder sdist — the soldr#1005 trap. Check "
+                  "that zig is on PATH and the maturin invocation kept "
+                  "the --zig/--compatibility args for this lane."
+              )
+              sys.exit("\n".join(msg))
+          print(f"manylinux_2_17 tag assertion OK: {len(wheels)} wheel(s):")
           for w in wheels:
               print(f"  - {w.name}")
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -160,6 +160,14 @@ pinned prebuilt binary from GitHub Releases, falling back to the PyPI
 maturin wheel provisioned into an isolated uv-managed env under
 `~/.soldr/bin/maturin-uv-<ver>/`; `binary` and `uv` force one rung).
 
+The backend also pins `CARGO_TARGET_DIR` to the stable per-user path
+`~/.soldr/cargo-target/wheel-build` so PEP 517 isolated builds
+(pip/uv copy the sdist to a throwaway temp dir, discarding `target/`
+after every build) keep cargo's incremental cache hot across
+invocations — ingested from FastLED/fbuild's `setup.py` (fbuild#829).
+A caller-provided `CARGO_TARGET_DIR` always wins, and
+`SOLDR_PEP517_STABLE_TARGET_DIR=0` disables the pin entirely.
+
 ### Mode 3: Internal Wrapper Mode
 
 Wrapper mode is entered when Cargo invokes soldr as the configured `RUSTC_WRAPPER`.
@@ -1303,20 +1311,6 @@ Commands:
   version  Show version
   gc       Review reclaimable Cargo target/ directories; use gc purge to delete
 ```
-
----
-
-## PEP 517 Build Backend
-
-The `soldr` PyPI package doubles as a PEP 517 build backend (`src/soldr/__init__.py`, soldr#1264). Point your `pyproject.toml` at it and soldr fetches a pinned maturin, drives `soldr maturin pep517 <hook>`, and caches every rustc invocation via `RUSTC_WRAPPER=soldr`:
-
-```toml
-[build-system]
-requires = ["soldr"]
-build-backend = "soldr"
-```
-
-The backend pins `CARGO_TARGET_DIR` to the stable per-user path `~/.soldr/cargo-target/wheel-build` so PEP 517 isolated builds (pip/uv copy the sdist to a throwaway temp dir, discarding `target/` after every build) keep cargo's incremental cache hot across invocations — ingested from FastLED/fbuild's `setup.py` (fbuild#829). A caller-provided `CARGO_TARGET_DIR` always wins, and `SOLDR_PEP517_STABLE_TARGET_DIR=0` disables the pin entirely.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1306,6 +1306,20 @@ Commands:
 
 ---
 
+## PEP 517 Build Backend
+
+The `soldr` PyPI package doubles as a PEP 517 build backend (`src/soldr/__init__.py`, soldr#1264). Point your `pyproject.toml` at it and soldr fetches a pinned maturin, drives `soldr maturin pep517 <hook>`, and caches every rustc invocation via `RUSTC_WRAPPER=soldr`:
+
+```toml
+[build-system]
+requires = ["soldr"]
+build-backend = "soldr"
+```
+
+The backend pins `CARGO_TARGET_DIR` to the stable per-user path `~/.soldr/cargo-target/wheel-build` so PEP 517 isolated builds (pip/uv copy the sdist to a throwaway temp dir, discarding `target/` after every build) keep cargo's incremental cache hot across invocations — ingested from FastLED/fbuild's `setup.py` (fbuild#829). A caller-provided `CARGO_TARGET_DIR` always wins, and `SOLDR_PEP517_STABLE_TARGET_DIR=0` disables the pin entirely.
+
+---
+
 ## Environment Variables
 
 | Variable | Purpose | Default |
@@ -1329,6 +1343,7 @@ Commands:
 | `ZCCACHE_PATH_REMAP` | zccache path-remap mode. soldr seeds `auto` on the child cargo for managed-zccache builds so multiple git worktrees of the same repo share cache hits (issue #352, Tier L1.x). Caller-supplied values are preserved. Requires a real `.git/` checkout — tarball/zip checkouts silently fall back to no remap. | unset (soldr injects `auto`) |
 | `SOLDR_PATH_REMAP` | Escape hatch for the default `ZCCACHE_PATH_REMAP=auto` injection. `off` (case-insensitive) suppresses the injection; any other value, or unset, keeps the default behavior. | unset (`auto`) |
 | `SCCACHE_DIR` | sccache cache-root override soldr injects when `SOLDR_RUSTC_WRAPPER=sccache` and the caller has not set it themselves | `~/.soldr/cache/sccache` |
+| `SOLDR_PEP517_STABLE_TARGET_DIR` | PEP 517 backend only: set to `0` / `false` / `no` / `off` to skip pinning `CARGO_TARGET_DIR` to `~/.soldr/cargo-target/wheel-build` for isolated builds (see [PEP 517 Build Backend](#pep-517-build-backend)). A caller-provided `CARGO_TARGET_DIR` always wins regardless. | unset (pin enabled) |
 | `SOLDR_LOG` | Log level | `warn` |
 | `SOLDR_OFFLINE` | Disable network access for tool fetches | `false` |
 | `SOLDR_RUST_PLAN_SKIP_WARM_RESTORE` | Default-on: skip `rust-plan restore` when `target/` is already warm from a prior step in the same GitHub Actions job + attempt (issue #229). Set to a falsy value (`0` / `false` / `no` / `off`) to opt out. | unset (on) |

--- a/src/soldr/__init__.py
+++ b/src/soldr/__init__.py
@@ -30,6 +30,28 @@ def _prep_env() -> "dict[str, str]":
     env = os.environ.copy()
     env.setdefault("RUSTC_WRAPPER", "soldr")
     env.setdefault("ZCCACHE_PATH_REMAP", "auto")
+    # Stable CARGO_TARGET_DIR for PEP 517 isolated builds. When pip/uv
+    # build from an sdist they copy the sources to a throwaway temp dir,
+    # so `<srcdir>/target/` is discarded after every build and cargo
+    # runs cold each time (25-30s+ per `pip install`). Pinning the
+    # target dir to a stable per-user path keeps cargo's incremental
+    # fingerprint cache hot across isolated builds.
+    #
+    # Ingested from FastLED/fbuild's setup.py (`WHEEL_BUILD_TARGET_DIR`,
+    # FastLED/fbuild#829): one shared `wheel-build` dir, deliberately
+    # separate from any dev `<repo>/target/` so `pip install` and the
+    # dev CLI don't invalidate each other's artifacts. Cargo keys
+    # artifacts by package, so sharing one dir across projects is safe.
+    #
+    # Escape hatches: a caller-provided CARGO_TARGET_DIR always wins
+    # (setdefault), and SOLDR_PEP517_STABLE_TARGET_DIR=0 (or false/no/
+    # off) skips the pin entirely.
+    knob = env.get("SOLDR_PEP517_STABLE_TARGET_DIR", "").strip().lower()
+    if knob not in ("0", "false", "no", "off"):
+        env.setdefault(
+            "CARGO_TARGET_DIR",
+            str(Path.home() / ".soldr" / "cargo-target" / "wheel-build"),
+        )
     return env
 
 


### PR DESCRIPTION
Ingests two proven build-system ideas from [FastLED/fbuild](https://github.com/FastLED/fbuild) into soldr.

## 1. manylinux_2_17 Linux wheels — closes the soldr#1005 placeholder-fallback trap

soldr's Linux PyPI wheels were tagged `manylinux_2_39`: the two linux-gnu wheel lanes in `release-auto.yml` run `maturin build --compatibility pypi` on ubuntu-24.04(-arm), and maturin auto-tags from the runner glibc. On any glibc<2.39 host (ubuntu-22.04 CI, older enterprise containers), pip skips the wheel and falls back to the ancient **0.1.0 placeholder sdist** — which silently breaks soldr as a PEP 517 `requires=["soldr"]` backend org-wide (the soldr#1005 trap).

**Fix** (`.github/workflows/release-auto.yml`):
- Both linux-gnu lanes now build with `maturin build --zig --compatibility manylinux_2_17`. maturin's zig integration routes through the same cargo-zigbuild machinery fbuild uses, linking the embedded soldr binary against a glibc **2.17** floor.
- zig 0.15.2 is provisioned on the linux-gnu lanes by extending the existing pinned `mlugg/setup-zig` step (maturin embeds cargo-zigbuild as a library, so no `cargo-zigbuild` binary is needed).
- New hard assertion-gate step fails the lane if any linux wheel filename is not `manylinux_2_17`-tagged — mirroring fbuild's `NO CHEATING` file(1) Mach-O gate (`ci/docker-mac-cross/build.sh:77-84`): the failure mode this guards (maturin silently falling back to the runner glibc) still builds and still smoke-tests on the 2.39 runner, so only a filename assertion catches it at build time.
- macOS and Windows lanes untouched (`--compatibility pypi` preserved); musl lanes were already wheel-exempt.

Reference implementation: fbuild's `.github/workflows/template_native_build.yml` (`cargo zigbuild --target <arch>-unknown-linux-gnu.2.17`, used for exactly this reason — "so manylinux_2_17 wheels actually run on glibc 2.17").

## 2. Stable `CARGO_TARGET_DIR` for PEP 517 isolated builds

When pip/uv build from an sdist they copy the sources to a throwaway temp dir, so `<srcdir>/target/` is discarded after every build and cargo runs cold each time (25-30s+ per install). fbuild solved this in its `setup.py` (`WHEEL_BUILD_TARGET_DIR`, fbuild#829) with one stable shared dir.

**Fix** (`src/soldr/__init__.py::_prep_env`): pin `CARGO_TARGET_DIR` to `~/.soldr/cargo-target/wheel-build` via `setdefault`, exactly fbuild's approach — one shared dir, deliberately separate from any dev `target/` tree; cargo keys artifacts by package so cross-project sharing is safe.

Escape hatches: caller-provided `CARGO_TARGET_DIR` always wins (setdefault), and `SOLDR_PEP517_STABLE_TARGET_DIR=0` (or false/no/off) disables the pin.

Docs: new "PEP 517 Build Backend" section in `docs/API.md` + env-var table row. (Note: the section did not previously exist; added it rather than editing one.)

## Validation

- `uv run --no-project python -m py_compile src/soldr/__init__.py` — OK
- `yaml.safe_load` on `release-auto.yml` — OK
- Behavioral check of `_prep_env`: default pin, `=0` opt-out, and caller-set `CARGO_TARGET_DIR` precedence all verified.
- Rust untouched (YAML + Python + docs only).

Credit: [FastLED/fbuild](https://github.com/FastLED/fbuild) — `template_native_build.yml` (glibc-2.17 zigbuild wheels) and `setup.py` (stable wheel-build target dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)