### PR TITLE
ci(cross-build): drop llvm-dev from clang-stack apt install (#1279)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -121,8 +121,14 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
+          # soldr#1279 — dropped llvm-dev. It pulled ~150 MB of libLLVM
+          # headers + shared library, but no crate in the dep tree links
+          # against libLLVM (grep -R llvm-sys Cargo.lock is empty).
+          # llvm-ar / llvm-ranlib come from `llvm` alone. libclang-dev
+          # stays because zccache's `clang` crate needs libclang.so at
+          # build time.
           sudo apt-get install -y --no-install-recommends \
-            clang lld llvm llvm-dev libclang-dev
+            clang lld llvm libclang-dev
 
       # zig + cargo-zigbuild — required for musl and aarch64-linux-gnu
       # cross-builds. Darwin is intentionally EXCLUDED: since soldr#1081


### PR DESCRIPTION
Fixes #1279.

## Summary
- Remove \`llvm-dev\` from the \`Install apt deps (clang stack for MSVC/darwin)\` step.
- Keep \`clang lld llvm libclang-dev\`.

## Why
No crate in the dep tree links against libLLVM:

    $ grep -RE 'llvm-sys|llvm_sys' Cargo.lock
    # empty

Only zccache's \`clang\` crate dep needs a shared library — \`libclang.so\`
from \`libclang-dev\`. \`llvm-ar\` / \`llvm-ranlib\` come from \`llvm\` alone.

Expected saving: ~3-5 s of apt install time per darwin/MSVC lane.

## Test plan
- [ ] Lint stays green.
- [ ] darwin/MSVC cross-build lanes still compile end-to-end.
- [ ] \`Install apt deps (clang stack)\` step wallclock trends down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)