### PR TITLE
ci(bootstrap): use ci-bootstrap profile (no LTO, cu=16) for host build (#1282)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -238,15 +238,20 @@ jobs:
           RUSTC_WRAPPER: ""
         run: |
           set -euo pipefail
-          cargo build --release --locked --package soldr-cli \
+          # soldr#1282 — --profile ci-bootstrap drops LTO + codegen-units=1
+          # from the throwaway host-side soldr build. The shipped release
+          # binary keeps profile.release; this only affects the bootstrap
+          # binary that lives inside the same lane and is deleted at
+          # post-step cleanup.
+          cargo build --profile ci-bootstrap --locked --package soldr-cli \
             --bin soldr --bin soldr-clang-shim \
             --target x86_64-unknown-linux-gnu
           mkdir -p "$RUNNER_TEMP/soldr-bin"
-          cp target/x86_64-unknown-linux-gnu/release/soldr "$RUNNER_TEMP/soldr-bin/soldr"
+          cp target/x86_64-unknown-linux-gnu/ci-bootstrap/soldr "$RUNNER_TEMP/soldr-bin/soldr"
           # blessed_build::install_clang_shim looks for soldr-clang-shim
           # next to the soldr exe. Without it, `soldr build` errors with
           # "soldr-clang-shim binary not found".
-          cp target/x86_64-unknown-linux-gnu/release/soldr-clang-shim "$RUNNER_TEMP/soldr-bin/soldr-clang-shim"
+          cp target/x86_64-unknown-linux-gnu/ci-bootstrap/soldr-clang-shim "$RUNNER_TEMP/soldr-bin/soldr-clang-shim"
 
       - name: Expose bootstrap soldr on PATH
         if: contains(inputs.target, 'apple-darwin') || contains(inputs.target, 'pc-windows-msvc')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,19 @@ lto = "thin"
 # clean builds further; release-only, so acceptable.
 codegen-units = 1
 
+# soldr#1282 — fast-compile profile for the CI bootstrap step.
+# `Bootstrap soldr for SDK / blessed-build prep` builds a throwaway
+# host-side soldr binary used only inside the same cross-build lane —
+# it never ships to a user, never gets downloaded via setup-soldr, and
+# never survives past post-step cleanup. Optimising it for size buys
+# nothing. Dropping LTO + cu=1 saves ~100–130 s per lane on the three
+# darwin/MSVC lanes where bootstrap dominates the critical path.
+[profile.ci-bootstrap]
+inherits = "release"
+lto = false
+codegen-units = 16
+strip = "none"
+
 [workspace.lints.rust]
 unused_mut = "deny"
 


### PR DESCRIPTION
Fixes #1282.

## Summary
- Add \`[profile.ci-bootstrap]\` in workspace Cargo.toml: inherits \`release\`,
  \`lto = false\`, \`codegen-units = 16\`, \`strip = \"none\"\`.
- Change the \`Bootstrap soldr for SDK / blessed-build prep\` step to use
  \`--profile ci-bootstrap\`; update the \`cp\` paths to \`target/x86_64-unknown-linux-gnu/ci-bootstrap/\`.

## Why
The bootstrap step compiles a throwaway host-side soldr binary used only
inside the same cross-build lane. It never ships to a user, never gets
downloaded via setup-soldr, never survives past post-step cleanup.
Optimising it for size (via LTO + cu=1 on \`profile.release\`) is wasted
work.

Empirical baseline (run 28576445807):
- darwin arm64: 269 s
- darwin x64:   269 s
- MSVC x64:     279 s

Expected saving: ~100–130 s per lane. Since bootstrap is on the critical
path for all three lanes, wallclock trims comparably.

The shipped release binary is untouched — \`profile.release\` still applies
to the cross-build step that produces the consumer artifact.

## Test plan
- [ ] Lint stays green.
- [ ] Next CI run's bootstrap step wallclock < 200 s.
- [ ] Cross-build lanes still produce a working artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)