### PR TITLE
fix(cross): linux-arm-musl lane — wrapper env allowlist dropped crgx's cargo:rustc-env CRGX_TARGET

### DIFF
--- a/crates/soldr-cli/src/compile_dispatch.rs
+++ b/crates/soldr-cli/src/compile_dispatch.rs
@@ -6,8 +6,9 @@
 //!
 //! 1. Build a `CompileRequest` from the rustc-style argv they were
 //!    invoked with.
-//! 2. Filter the current process env down to the compile-relevant
-//!    subset (see [`is_compile_env_var`]).
+//! 2. Forward the current process env minus known session noise
+//!    (see [`is_compile_env_var`]) — build-script-emitted
+//!    `cargo:rustc-env` vars have arbitrary names and MUST survive.
 //! 3. Connect to the soldr-daemon IPC socket / Windows named pipe.
 //! 4. On failure to connect, spawn the daemon detached and retry
 //!    within a configurable budget (default 30s for production —
@@ -56,79 +57,75 @@ pub const DEFAULT_SPAWN_RETRY_BUDGET_MS: u64 = 30_000;
 /// socket starts accepting.
 const RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Predicate for the env-var filter (Phase 5c from #981). Returns
-/// `true` for env vars that rustc, cargo build scripts (cc-rs /
-/// bindgen / proc-macro setup), or zccache's internal machinery
-/// actually read. Everything else is dropped from the
-/// `Request::Compile` payload to keep the daemon's tokio runtime out
-/// of prost serialization of ~10-50 KB of useless `CARGO_PKG_*`
-/// metadata per compile.
+/// Predicate for the env-var filter (Phase 5c from #981, reworked for
+/// correctness after the `cargo:rustc-env` regression that broke the
+/// linux-arm-musl cross-compile lane — run 28574600982).
+///
+/// Returns `true` for env vars that must be forwarded in the
+/// `Request::Compile` payload so the daemon-spawned rustc sees the
+/// same environment cargo gave the wrapper process.
+///
+/// ## Why this is a noise DENYLIST, not an allowlist
+///
+/// Cargo forwards `cargo:rustc-env=<NAME>=<value>` lines emitted by a
+/// crate's build script as environment variables **on the rustc
+/// invocation only** — and `<NAME>` is arbitrary (crgx sets
+/// `CRGX_TARGET`, vergen sets `VERGEN_*`, shadow-rs sets `SHADOW_*`,
+/// ...). The crate then reads them back with `env!()` at compile
+/// time. An allowlist can never enumerate those names, and dropping
+/// one turns into a hard `error: environment variable ... not defined
+/// at compile time` inside the daemon-spawned rustc. That is exactly
+/// what broke the `linux-arm-musl` cross-compile lane: the crgx
+/// source-build fallback died on `env!("CRGX_TARGET")` because the
+/// old allowlist filtered the var out of the compile request.
+///
+/// So the filter now drops only *known* interactive-session noise
+/// (shell prompt state, desktop-session plumbing) that no compiler,
+/// build script, or proc-macro legitimately reads. Everything else —
+/// including vars we have never heard of — is forwarded. The
+/// standalone zccache wrapper client forwards its **entire** env
+/// (see `_vender/zccache/crates/zccache/src/cli/commands/wrap/env.rs`),
+/// so this keeps the embedded-daemon path consistent with the managed
+/// binary path. The Phase 5c payload-size concern is preserved by the
+/// denylist (session noise still never crosses the wire) and by the
+/// fact that zccache's fingerprint only hashes `CARGO_*` vars, so the
+/// extra forwarded vars do not churn cache keys.
 pub fn is_compile_env_var(name: &str) -> bool {
-    // Prefix matches first — order roughly by hit rate so the common
-    // case short-circuits early on the per-call hot path.
-    const PREFIXES: &[&str] = &[
-        "CARGO_",   // CARGO_PKG_*, CARGO_CFG_*, CARGO_MANIFEST_DIR, etc.
-        "RUSTC_",   // RUSTC, RUSTC_WRAPPER, RUSTC_BOOTSTRAP, ...
-        "RUST",     // RUSTFLAGS, RUSTDOC*, RUSTFMT, RUSTUP*, RUST_BACKTRACE
-        "SOLDR_",   // SOLDR_ZCCACHE_BIN, SOLDR_CACHE_*, SOLDR_BUILD_SESSION_*
-        "ZCCACHE_", // ZCCACHE_CACHE_DIR, ZCCACHE_PATH_REMAP, ZCCACHE_SESSION_ID
-        "CC_",      // cc-rs cc_PROFILE_TARGET style
-        "CXX_",     // ditto for C++
-        "AR_", "LD_",  // LD_LIBRARY_PATH, LD_PRELOAD — both meaningful to subprocesses
-        "DEP_", // build-script-emitted DEP_<pkg>_<key> env vars
-        "OUT_", // OUT_DIR (build script working dir)
+    // Desktop / login-session plumbing. Prefix matches.
+    const NOISE_PREFIXES: &[&str] = &[
+        "XDG_",     // XDG_SESSION_TYPE, XDG_RUNTIME_DIR, ...
+        "GNOME_",   // GNOME_TERMINAL_SERVICE, ...
+        "GDM",      // GDM_LANG, GDMSESSION
+        "DESKTOP_", // DESKTOP_SESSION-adjacent
     ];
-    if PREFIXES.iter().any(|p| name.starts_with(p)) {
-        return true;
+    if NOISE_PREFIXES.iter().any(|p| name.starts_with(p)) {
+        return false;
     }
-    // Exact matches for shorter vars rustc / cc-rs / linker need.
-    matches!(
+    // Shell-prompt / terminal-session state. Exact matches.
+    !matches!(
         name,
-        "HOME"
-            | "USER"
-            | "PATH"
-            | "LANG"
-            | "LC_ALL"
-            | "TARGET"
-            | "HOST"
-            | "TMPDIR"
-            | "TMP"
-            | "TEMP"
-            | "USERPROFILE"
-            | "APPDATA"
-            | "LOCALAPPDATA"
-            | "PROGRAMFILES"
-            | "PROGRAMDATA"
-            | "WINDIR"
-            | "SYSTEMROOT"
-            | "SYSTEMDRIVE"
-            | "COMSPEC"
-            | "PATHEXT"
-            | "TERM"
-            | "RUSTUP_HOME"
-            | "RUSTUP_TOOLCHAIN"
-            | "CARGO"
-            | "CARGO_HOME"
-            | "CC"
-            | "CXX"
-            | "AR"
-            | "LD"
-            | "NM"
-            | "OBJCOPY"
-            | "OBJDUMP"
-            | "STRIP"
-            | "RANLIB"
-            | "CFLAGS"
-            | "CXXFLAGS"
-            | "LDFLAGS"
-            | "MSYSTEM"
-            | "VCINSTALLDIR"
-            | "VSINSTALLDIR"
-            | "VCToolsInstallDir"
-            | "WindowsSdkDir"
-            | "INCLUDE"
-            | "LIB"
-            | "LIBPATH"
+        "PROMPT"
+            | "PS1"
+            | "PS2"
+            | "PS4"
+            | "OLDPWD"
+            | "SHLVL"
+            | "DISPLAY"
+            | "WAYLAND_DISPLAY"
+            | "DBUS_SESSION_BUS_ADDRESS"
+            | "SESSION_MANAGER"
+            | "LS_COLORS"
+            | "LSCOLORS"
+            | "PSModulePath"
+            | "ChocolateyInstall"
+            | "ChocolateyLastPathUpdate"
+            | "WSL_DISTRO_NAME"
+            | "WSL_INTEROP"
+            | "WT_SESSION"
+            | "WT_PROFILE_ID"
+            | "WINDOWID"
+            | "COLORTERM"
+            | "VTE_VERSION"
     )
 }
 
@@ -325,6 +322,35 @@ mod tests {
             // gets the same env. Regression-test that explicitly.
             for v in ["LIB", "INCLUDE", "LIBPATH", "PATH"] {
                 assert!(is_compile_env_var(v), "{v} must be forwarded to daemon");
+            }
+        }
+    );
+
+    timed_test!(
+        is_compile_env_var_forwards_build_script_rustc_env_vars,
+        Duration::from_secs(5),
+        {
+            // Regression test for the linux-arm-musl cross-compile lane
+            // failure (run 28574600982): crgx's build.rs emits
+            // `cargo:rustc-env=CRGX_TARGET=<triple>` and reads it back
+            // with `env!("CRGX_TARGET")`. Cargo sets such vars only on
+            // the rustc process env; if the dispatch filter drops them,
+            // the daemon-spawned rustc fails with `error: environment
+            // variable ... not defined at compile time`. The names are
+            // arbitrary, so the filter must be a noise denylist that
+            // forwards anything it does not recognize.
+            for v in [
+                "CRGX_TARGET",
+                "VERGEN_GIT_SHA",
+                "SHADOW_RS",
+                "SOME_CRATE_CUSTOM_COMPILE_TIME_VAR",
+            ] {
+                assert!(
+                    is_compile_env_var(v),
+                    "{v} must be forwarded to the daemon — build-script \
+                     `cargo:rustc-env` vars have arbitrary names and dropping \
+                     them breaks `env!()` in daemon-spawned rustc"
+                );
             }
         }
     );

--- a/crates/soldr-cli/src/wrapper.rs
+++ b/crates/soldr-cli/src/wrapper.rs
@@ -355,7 +355,7 @@ pub(crate) use crate::wrapper_target::{record_target_dir_in_registry, TargetTouc
 // =========================================================================
 //
 // As of issue #1081 the `compile_via_daemon` body and the
-// `is_compile_env_var` allowlist were lifted into
+// `is_compile_env_var` env filter were lifted into
 // `crate::compile_dispatch` so the new `zccache-soldr` shim binary
 // can share them. The wrapper-entry dispatch site above now calls
 // `compile_dispatch::compile_via_daemon` directly. Nothing remains in

--- a/crates/soldr-cli/tests/phase5_contract.rs
+++ b/crates/soldr-cli/tests/phase5_contract.rs
@@ -12,12 +12,13 @@
 //!     versions.
 //!
 //!   * **Phase 5c — env filter.** `compile_dispatch::is_compile_env_var`
-//!     keeps the rustc / cc-rs / zccache / MSVC-host (soldr#1079) env
-//!     vars and drops the noisy `CARGO_PKG_*` / `PROMPT` / etc. set.
-//!     The Cold flame chart in #981 measured the daemon's tokio
-//!     runtime burning 10–13% on prost-encoding ~20–50 KB of useless
-//!     env per compile; the filter must keep the per-compile payload
-//!     under ~5 KB for representative workloads.
+//!     forwards the compile-relevant env (rustc / cc-rs / zccache /
+//!     MSVC-host (soldr#1079) vars AND arbitrary build-script
+//!     `cargo:rustc-env` vars — see the linux-arm-musl crgx
+//!     regression) while dropping known interactive-session noise
+//!     (`PROMPT`, `DISPLAY`, `XDG_*`, ...). It is a noise DENYLIST:
+//!     an allowlist can never enumerate `cargo:rustc-env` names, and
+//!     dropping one hard-fails `env!()` in the daemon-spawned rustc.
 //!
 //!   * **Phase 5d — dispatch parallelism contract.** The IPC server
 //!     accepts each connection with a per-connection `tokio::spawn`
@@ -183,26 +184,27 @@ timed_test!(
     is_compile_env_var_drops_cargo_pkg_noise,
     Duration::from_secs(5),
     {
-        // Soldr#981's Phase 5c profile showed CARGO_PKG_* metadata
-        // was ~10-50 KB per compile of useless prost serialization.
-        // The filter must drop the description / authors / homepage
-        // /readme / license set while keeping CARGO_PKG_NAME and
-        // CARGO_PKG_VERSION (cargo treats these as build-script
-        // contract).
+        // The filter must keep cargo's compile contract vars (and, per
+        // the linux-arm-musl crgx regression, any build-script-emitted
+        // `cargo:rustc-env` var — arbitrary names, so the filter is a
+        // noise denylist) while still dropping interactive-session
+        // noise from the per-compile prost payload.
         use soldr_cli::compile_dispatch::is_compile_env_var;
         for kept in [
             "CARGO_PKG_NAME",
             "CARGO_PKG_VERSION",
             "CARGO_CFG_TARGET_ARCH",
+            // build-script `cargo:rustc-env` vars — names are arbitrary
+            "CRGX_TARGET",
+            "VERGEN_GIT_SHA",
         ] {
             assert!(
                 is_compile_env_var(kept),
-                "{kept} must be forwarded (cargo build-script contract)"
+                "{kept} must be forwarded (cargo compile contract / \
+                 build-script rustc-env)"
             );
         }
-        // These CARGO_* vars ARE kept today because the filter is
-        // prefix-based — but the IMPORTANT invariant is that totally
-        // unrelated env doesn't slip through.
+        // Known session-noise vars must stay out of the payload.
         for dropped in [
             "PROMPT",
             "PS1",


### PR DESCRIPTION
## Root cause

The `linux-arm-musl (--release aarch64-unknown-linux-musl)` lane of `cross-compile-all-targets.yml` (run 28574600982, job 84721100531) failed source-building crgx with:

```
error: environment variable `CRGX_TARGET` not defined at compile time
  --> src/config.rs:70:9
```

crgx's `build.rs` emits `cargo:rustc-env=CRGX_TARGET=<triple>` and reads it back with `env!()`. Cargo sets such variables **only on the rustc process env**. Since #977/#980/#1081, managed `soldr cargo ...` puts soldr itself in the `RUSTC_WRAPPER` slot and brokers every compile to the soldr-daemon's embedded zccache. The forwarded env is filtered by `compile_dispatch::is_compile_env_var` (Phase 5c of #981) — an **allowlist** that `CRGX_TARGET` matched neither by prefix nor by name. The embedded zccache `env_clear()`s and replays only the request env, so rustc ran without the var and `env!()` hard-failed.

- Any crate using a custom `cargo:rustc-env` name (crgx, vergen, shadow-rs, ...) fails the same way under the managed wrapper.
- Only this lane trips because aarch64-musl is the sole target with a crgx catalogue miss, forcing the source-build fallback (`fetch_or_build_tool.sh`). The same crgx commit (`fbf0a69`) built fine on 2026-06-22 under soldr 0.7.58, where compiles still went through the standalone zccache binary — whose wrapper client forwards its **entire** env.
- The tell-tale `compilations: 0` zccache session summary in the failing step confirms the managed zccache binary never saw the compiles — they went through the soldr-daemon embedded path.
- Not related to the cmake generator sweep (#1278): that touches only `blessed_build.rs`.

## Fix

`cargo:rustc-env` names are arbitrary, so an allowlist can never be complete. Invert `is_compile_env_var` into a noise **denylist**: forward everything except known interactive-session vars (`PROMPT`, `PS1`, `DISPLAY`, `DBUS_SESSION_BUS_ADDRESS`, `XDG_*`, `PSModulePath`, `WT_SESSION`, ...). This:

- matches the standalone zccache wrapper client (forwards full env), keeping both wrapper paths consistent;
- keeps every existing Phase 5c assertion green (the noise vars those tests require dropped are still dropped);
- does not churn cache keys — zccache's request fingerprint hashes only `CARGO_*` vars from the client env.

New regression test `is_compile_env_var_forwards_build_script_rustc_env_vars` locks in forwarding of `CRGX_TARGET`-style names; `phase5_contract.rs` comments updated to the denylist semantics.

## Validation

- Reproduced in `ci/docker-aarch64-musl-cross`: released soldr 0.7.96 fails a minimal `cargo:rustc-env` + `env!()` crate with the exact CI error (including the `compilations: 0` signature).
- `soldr cargo test -p soldr-cli --lib` (552 passed), `--test phase5_contract` (7 passed), clippy `-D warnings` clean, `fmt --check` clean.
- **Final lane validation is deferred to a post-merge `cross-compile-all-targets` re-dispatch** (coordinator runs it).

Note: the windows/macos lane failures in the same run are a separate xwin-SDK issue (`DriverSpecs.h` not found in zstd-sys build) and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)