### PR TITLE
fix(cross): repair windows-x64 + windows-arm64 cross lanes (xwin bundle case aliases + zlib-ng clang-cl ARM toggles)

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -1271,10 +1271,103 @@ async fn append_subcommand_transitive_bin_dirs(
                     }
                     Err(err) => return Err(err),
                 }
+
+                // zlib-ng's ARM optimizations are unbuildable under
+                // clang-cl — chain a toolchain-file wrapper that turns
+                // them off for the aarch64 lane. See
+                // `ensure_zlib_ng_arm_cmake_wrapper` for the full
+                // root-cause writeup (cross-run 28574600982 fix).
+                if let Some((key, value)) = ensure_zlib_ng_arm_cmake_wrapper(paths, triple)? {
+                    if std::env::var_os(&key).is_none() {
+                        extra_env.push((key, value));
+                    }
+                }
             }
         }
     }
     Ok(())
+}
+
+/// Write the cmake toolchain-file WRAPPER that disables zlib-ng's ARM
+/// optimizations for `aarch64-pc-windows-msvc` cross-compiles, and
+/// return the `(env var, path)` pair to export on the child cargo.
+/// Returns `Ok(None)` for every other triple.
+///
+/// ## Why (run 28574600982, windows-arm lane)
+///
+/// libz-ng-sys builds vendored zlib-ng via cmake. Under clang-cl
+/// (`_MSC_VER` defined, but none of MSVC's compiler intrinsics exist),
+/// zlib-ng's ARM feature detection is self-INCONSISTENT:
+///
+/// * `HAVE_ARMV8_INTRIN` probes `__crc32w` from `<intrin.h>` — an
+///   MSVC-only declaration clang-cl doesn't ship → probe fails. But
+///   the GNU-asm probe `HAVE_ARMV8_INLINE_ASM` passes, so cmake
+///   enables `ARM_CRC32` anyway — and `acle_intrins.h`'s `_MSC_VER`
+///   code path then requires exactly the missing `__crc32b/h/w/d`
+///   intrinsics: `crc32_armv8.c` fails with "call to undeclared
+///   function '__crc32b'".
+/// * The NEON path includes MSVC's `arm64_neon.h`, whose
+///   `vld1q_*_x4` macros expand to `neon_ld1m4_*` compiler magic that
+///   clang-cl neither declares nor lowers. The `NEON_HAS_LD4` probe
+///   dies at link ("undefined symbol: neon_ld1m4_q32"), and the
+///   fallback inline functions zlib-ng then compiles collide with the
+///   still-defined macros ("type specifier missing" in
+///   `adler32_neon.c` via `neon_intrins.h`).
+///
+/// Turning `WITH_NEON` / `WITH_ARMV8` / `WITH_ARMV6` off makes
+/// zlib-ng build its portable C fallbacks — the only combination
+/// clang-cl can actually compile until upstream zlib-ng grows real
+/// clang-cl ARM64 support.
+///
+/// ## How the wrapper reaches cmake
+///
+/// cargo-xwin exports `CMAKE_TOOLCHAIN_FILE_<underscore-triple>` on
+/// the child cargo. The `cmake` crate (used by libz-ng-sys's
+/// build.rs) checks the DASH-triple form of that variable FIRST
+/// (`getenv_target_os` in cmake-rs), so soldr exports
+/// `CMAKE_TOOLCHAIN_FILE_aarch64-pc-windows-msvc` pointing at this
+/// wrapper. The wrapper chain-includes cargo-xwin's real clang-cl
+/// toolchain file via `$ENV{...}` (still present in the build-script
+/// environment) so compiler/linker setup is byte-identical, then
+/// force-caches the three `WITH_*` toggles.
+fn ensure_zlib_ng_arm_cmake_wrapper(
+    paths: &SoldrPaths,
+    triple: &str,
+) -> Result<Option<(String, String)>, SoldrError> {
+    if !(triple.starts_with("aarch64-") && triple.ends_with("-pc-windows-msvc")) {
+        return Ok(None);
+    }
+    let dir = paths.root.join("cmake").join(triple);
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        SoldrError::Other(format!("create cmake wrapper dir {}: {e}", dir.display()))
+    })?;
+    let wrapper = dir.join("clang-cl-arm-toolchain.cmake");
+    let underscore = triple.replace('-', "_");
+    let content = format!(
+        r#"# Written by soldr (cross-run 28574600982 fix) — do not edit; regenerated each run.
+# Chain-include cargo-xwin's generated clang-cl toolchain file (it
+# exports the underscore-form env var on the child cargo) so the
+# compiler/linker setup is unchanged.
+if(DEFINED ENV{{CMAKE_TOOLCHAIN_FILE_{underscore}}})
+    include("$ENV{{CMAKE_TOOLCHAIN_FILE_{underscore}}}")
+endif()
+
+# zlib-ng's ARM optimizations require MSVC-only compiler intrinsics
+# (__crc32*, neon_ld1m4_*) that clang-cl does not implement; its cmake
+# feature detection half-enables them anyway and the build dies in
+# crc32_armv8.c / adler32_neon.c. Force the portable C fallbacks.
+set(WITH_NEON OFF CACHE BOOL "soldr: MSVC-intrinsic-only under clang-cl" FORCE)
+set(WITH_ARMV8 OFF CACHE BOOL "soldr: MSVC-intrinsic-only under clang-cl" FORCE)
+set(WITH_ARMV6 OFF CACHE BOOL "soldr: MSVC-intrinsic-only under clang-cl" FORCE)
+"#
+    );
+    std::fs::write(&wrapper, content).map_err(|e| {
+        SoldrError::Other(format!("write cmake wrapper {}: {e}", wrapper.display()))
+    })?;
+    Ok(Some((
+        format!("CMAKE_TOOLCHAIN_FILE_{triple}"),
+        wrapper.to_string_lossy().into_owned(),
+    )))
 }
 
 fn append_zigbuild_env_overrides(

--- a/crates/soldr-cli/src/cargo_front_door/tests.rs
+++ b/crates/soldr-cli/src/cargo_front_door/tests.rs
@@ -861,3 +861,41 @@ fn non_xwin_subcommand_does_not_inject_anything() {
         "bare cargo build shouldn't inject xwin env: {env:?}"
     );
 }
+
+crate::timed_test!(zlib_ng_arm_wrapper_written_only_for_aarch64_msvc, {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = SoldrPaths::with_root(dir.path().join("soldr"));
+
+    // Non-arm / non-msvc triples: no wrapper, no env.
+    for triple in [
+        "x86_64-pc-windows-msvc",
+        "aarch64-unknown-linux-musl",
+        "aarch64-apple-darwin",
+    ] {
+        let got = ensure_zlib_ng_arm_cmake_wrapper(&paths, triple).unwrap();
+        assert!(got.is_none(), "{triple} must not get the wrapper");
+    }
+
+    // The arm-msvc lane gets the DASH-triple env var (the form the
+    // cmake crate checks before cargo-xwin's underscore form) plus a
+    // wrapper that chain-includes cargo-xwin's file and disables the
+    // clang-cl-incompatible zlib-ng ARM toggles.
+    let (key, value) = ensure_zlib_ng_arm_cmake_wrapper(&paths, "aarch64-pc-windows-msvc")
+        .unwrap()
+        .expect("aarch64-pc-windows-msvc gets the wrapper");
+    assert_eq!(key, "CMAKE_TOOLCHAIN_FILE_aarch64-pc-windows-msvc");
+    let body = std::fs::read_to_string(&value).expect("wrapper file exists");
+    assert!(
+        body.contains("$ENV{CMAKE_TOOLCHAIN_FILE_aarch64_pc_windows_msvc}"),
+        "wrapper must chain-include cargo-xwin's underscore-form toolchain file: {body}"
+    );
+    for toggle in ["WITH_NEON OFF", "WITH_ARMV8 OFF", "WITH_ARMV6 OFF"] {
+        assert!(body.contains(toggle), "wrapper must force {toggle}: {body}");
+    }
+
+    // Idempotent: second call rewrites the same path.
+    let (key2, value2) = ensure_zlib_ng_arm_cmake_wrapper(&paths, "aarch64-pc-windows-msvc")
+        .unwrap()
+        .expect("second call still yields the wrapper");
+    assert_eq!((key, value), (key2, value2));
+});

--- a/crates/soldr-cli/src/fetch/xwin_cache.rs
+++ b/crates/soldr-cli/src/fetch/xwin_cache.rs
@@ -31,6 +31,7 @@
 //! at runtime, but the immediate goal of this PR is "win-arm64
 //! works"; hardcoded sha256s are the minimum-blast-radius first cut.
 
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::core::{SoldrError, SoldrPaths};
@@ -103,6 +104,13 @@ pub async fn ensure_xwin_cache(
     let cache_dir = install_dir.join("xwin");
 
     if stamp.is_file() && cache_dir.is_dir() {
+        // Repair pass for caches extracted by older soldr versions (or
+        // restored from a CI cache) that predate the case-alias fix —
+        // idempotent and cheap once the aliases exist (cross-run 28574600982 fix).
+        let aliases = ensure_xwin_case_aliases(&cache_dir)?;
+        if aliases > 0 {
+            eprintln!("soldr: added {aliases} xwin-cache case aliases");
+        }
         return Ok(cache_dir);
     }
 
@@ -153,12 +161,262 @@ pub async fn ensure_xwin_cache(
         )));
     }
 
+    // Case-sensitivity repair (cross-run 28574600982 fix): the catalogue bundle ships
+    // one file per header with whatever casing the recipe splatted, but
+    // Windows SDK headers cross-reference each other with inconsistent
+    // casing (`kernelspecs.h` does `#include "DriverSpecs.h"` while the
+    // file on disk is `driverspecs.h`). On the case-sensitive Linux CI
+    // filesystems that include fails fatally. Materialize the aliases
+    // both directions before declaring the cache usable.
+    let aliases = ensure_xwin_case_aliases(&cache_dir)?;
+    if aliases > 0 {
+        eprintln!("soldr: added {aliases} xwin-cache case aliases");
+    }
+
     std::fs::write(&stamp, MANAGED_XWIN_CACHE_VERSION)?;
     eprintln!(
         "soldr: extracted xwin-cache to {} (set XWIN_CACHE_DIR there)",
         cache_dir.display()
     );
     Ok(cache_dir)
+}
+
+/// Create the case-variant file aliases that make an xwin splat usable
+/// on a case-sensitive filesystem. Returns the number of aliases
+/// created (0 on a case-insensitive filesystem or when everything is
+/// already materialized — the pass is idempotent).
+///
+/// Two passes:
+///
+/// 1. **Lowercase aliases** — for every mixed-case file under
+///    `crt/{include,lib}` + `sdk/{include,lib}`, hardlink a lowercase
+///    sibling (`Kernel32.Lib` → `kernel32.lib`). Covers lowercase
+///    `#include <windows.h>` / `-lkernel32`-style references to
+///    mixed-case files.
+/// 2. **Include-referenced aliases** (cross-run 28574600982 fix) — scan every file
+///    under the include trees for `#include` directives and, for each
+///    referenced name that only matches an on-disk file
+///    case-INsensitively, hardlink an alias with the referenced casing
+///    (`driverspecs.h` → `DriverSpecs.h`, referenced by
+///    `kernelspecs.h` which winnt.h pulls into every `windows.h`
+///    compile). This is the reverse direction of pass 1 and is what
+///    xwin's own `--symlinks` mode does at splat time.
+pub fn ensure_xwin_case_aliases(xwin_dir: &Path) -> Result<usize, SoldrError> {
+    let roots = [
+        xwin_dir.join("crt").join("include"),
+        xwin_dir.join("crt").join("lib"),
+        xwin_dir.join("sdk").join("include"),
+        xwin_dir.join("sdk").join("lib"),
+    ];
+
+    let mut created = 0;
+    for root in roots {
+        if root.is_dir() {
+            created += ensure_lowercase_file_aliases(&root)?;
+        }
+    }
+    created += ensure_include_referenced_aliases(xwin_dir)?;
+    Ok(created)
+}
+
+fn ensure_lowercase_file_aliases(dir: &Path) -> Result<usize, SoldrError> {
+    let mut created = 0;
+    for entry in std::fs::read_dir(dir)
+        .map_err(|e| SoldrError::Other(format!("read xwin cache dir {}: {e}", dir.display())))?
+    {
+        let entry = entry.map_err(|e| {
+            SoldrError::Other(format!(
+                "read xwin cache entry under {}: {e}",
+                dir.display()
+            ))
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|e| {
+            SoldrError::Other(format!("stat xwin cache entry {}: {e}", path.display()))
+        })?;
+
+        if file_type.is_dir() {
+            created += ensure_lowercase_file_aliases(&path)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let lower = name.to_ascii_lowercase();
+        if lower == name {
+            continue;
+        }
+
+        let alias = path.with_file_name(lower);
+        if alias.exists() {
+            continue;
+        }
+
+        create_xwin_file_alias(&path, &alias)?;
+        created += 1;
+    }
+    Ok(created)
+}
+
+/// Pass 2 of [`ensure_xwin_case_aliases`]: alias every include-directive
+/// referenced name whose on-disk file only matches case-insensitively.
+fn ensure_include_referenced_aliases(xwin_dir: &Path) -> Result<usize, SoldrError> {
+    let include_roots = [
+        xwin_dir.join("crt").join("include"),
+        xwin_dir.join("sdk").join("include"),
+    ];
+
+    // (dir, lowercase-name → actual-name) per directory, plus the set
+    // of basenames referenced by any `#include` directive anywhere in
+    // the splat. Quoted includes resolve relative to the includer's
+    // directory and angle includes against every `/imsvc` root, so an
+    // alias is created in EVERY directory holding a case-insensitive
+    // match — a superset of what resolution needs, and harmless.
+    let mut dir_maps: Vec<(PathBuf, HashMap<String, String>)> = Vec::new();
+    let mut referenced: HashSet<String> = HashSet::new();
+    for root in &include_roots {
+        if root.is_dir() {
+            collect_names_and_includes(root, &mut dir_maps, &mut referenced)?;
+        }
+    }
+
+    let mut created = 0;
+    for (dir, names) in &dir_maps {
+        for reference in &referenced {
+            let Some(actual) = names.get(&reference.to_ascii_lowercase()) else {
+                continue;
+            };
+            if actual == reference {
+                continue;
+            }
+            let alias = dir.join(reference);
+            // `exists()` is the case-insensitive-filesystem guard: on
+            // such filesystems the alias name already resolves to the
+            // actual file, so nothing needs materializing.
+            if alias.exists() {
+                continue;
+            }
+            create_xwin_file_alias(&dir.join(actual), &alias)?;
+            created += 1;
+        }
+    }
+    Ok(created)
+}
+
+fn collect_names_and_includes(
+    dir: &Path,
+    dir_maps: &mut Vec<(PathBuf, HashMap<String, String>)>,
+    referenced: &mut HashSet<String>,
+) -> Result<(), SoldrError> {
+    let mut names: HashMap<String, String> = HashMap::new();
+    for entry in std::fs::read_dir(dir)
+        .map_err(|e| SoldrError::Other(format!("read xwin include dir {}: {e}", dir.display())))?
+    {
+        let entry = entry.map_err(|e| {
+            SoldrError::Other(format!(
+                "read xwin include entry under {}: {e}",
+                dir.display()
+            ))
+        })?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|e| {
+            SoldrError::Other(format!("stat xwin include entry {}: {e}", path.display()))
+        })?;
+
+        if file_type.is_dir() {
+            collect_names_and_includes(&path, dir_maps, referenced)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue; // non-UTF8 names can't appear in #include directives
+        };
+        // First name wins on case-insensitive filesystems where two
+        // casings can't coexist anyway; on case-sensitive filesystems
+        // duplicates only differ by case and either works as a source.
+        names.entry(name.to_ascii_lowercase()).or_insert(name);
+
+        // Every file under the include trees is a text header (SDK
+        // headers, MSVC STL extensionless headers, .inl bodies). Scan
+        // them all rather than maintaining an extension allowlist.
+        if let Ok(content) = std::fs::read(&path) {
+            scan_include_directives(&content, referenced);
+        }
+    }
+    dir_maps.push((dir.to_path_buf(), names));
+    Ok(())
+}
+
+/// Collect the basename of every `#include "..."` / `#include <...>`
+/// directive in `content` into `referenced`. Tolerant line-oriented
+/// parse — a false positive only risks creating an unnecessary alias.
+fn scan_include_directives(content: &[u8], referenced: &mut HashSet<String>) {
+    for line in content.split(|&b| b == b'\n') {
+        let s = trim_ascii_start(line);
+        let Some(s) = s.strip_prefix(b"#") else {
+            continue;
+        };
+        let s = trim_ascii_start(s);
+        let Some(s) = s.strip_prefix(b"include") else {
+            continue;
+        };
+        let s = trim_ascii_start(s);
+        let close = match s.first() {
+            Some(b'"') => b'"',
+            Some(b'<') => b'>',
+            _ => continue,
+        };
+        let inner = &s[1..];
+        let Some(end) = inner.iter().position(|&b| b == close) else {
+            continue;
+        };
+        let name = &inner[..end];
+        let base = name
+            .rsplit(|&b| b == b'/' || b == b'\\')
+            .next()
+            .unwrap_or(name);
+        if base.is_empty() {
+            continue;
+        }
+        if let Ok(base) = std::str::from_utf8(base) {
+            referenced.insert(base.to_string());
+        }
+    }
+}
+
+fn trim_ascii_start(mut s: &[u8]) -> &[u8] {
+    while let Some((first, rest)) = s.split_first() {
+        if first.is_ascii_whitespace() {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    s
+}
+
+fn create_xwin_file_alias(src: &Path, alias: &Path) -> Result<(), SoldrError> {
+    match std::fs::hard_link(src, alias) {
+        Ok(()) => Ok(()),
+        Err(hardlink_err) => {
+            if alias.exists() {
+                return Ok(());
+            }
+            std::fs::copy(src, alias).map(|_| ()).map_err(|copy_err| {
+                SoldrError::Other(format!(
+                    "create xwin cache case alias {} -> {}: \
+                     hardlink failed: {hardlink_err}; copy failed: {copy_err}",
+                    alias.display(),
+                    src.display()
+                ))
+            })
+        }
+    }
 }
 
 fn extract_tar_zst_tree(data: &[u8], dest: &Path) -> Result<(), SoldrError> {
@@ -213,6 +471,92 @@ mod tests {
         assert!(
             msg.contains("not yet ingested") || msg.contains("TBD"),
             "expected 'not yet ingested' or 'TBD' in error, got: {msg}"
+        );
+    });
+
+    /// Probe whether `dir`'s filesystem resolves names case-insensitively
+    /// (macOS APFS default, Windows NTFS). On such filesystems no aliases
+    /// are needed (or creatable) — tests adjust expectations accordingly.
+    fn is_case_insensitive_fs(dir: &Path) -> bool {
+        let probe = dir.join("CaseProbe");
+        std::fs::write(&probe, b"").expect("write case probe");
+        let insensitive = dir.join("caseprobe").exists();
+        std::fs::remove_file(&probe).ok();
+        insensitive
+    }
+
+    crate::timed_test!(include_referenced_case_alias_materializes_driverspecs, {
+        // cross-run 28574600982 regression fixture: the catalogue xwin bundle ships
+        // `driverspecs.h` (lowercase) while `kernelspecs.h` references
+        // `#include "DriverSpecs.h"` — every `windows.h` compile on a
+        // case-sensitive filesystem died with "file not found".
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let xwin = tmp.path().join("xwin");
+        let shared = xwin.join("sdk").join("include").join("shared");
+        std::fs::create_dir_all(&shared).expect("mkdir shared");
+        std::fs::write(
+            shared.join("kernelspecs.h"),
+            b"#pragma once\n#include \"DriverSpecs.h\"\n",
+        )
+        .expect("write kernelspecs");
+        std::fs::write(shared.join("driverspecs.h"), b"#pragma once\n").expect("write driverspecs");
+
+        let case_insensitive = is_case_insensitive_fs(tmp.path());
+        let created = ensure_xwin_case_aliases(&xwin).expect("aliases");
+        let expected = if case_insensitive { 0 } else { 1 };
+        assert_eq!(created, expected, "DriverSpecs.h alias count");
+        // Resolvable under the referenced casing either way.
+        assert!(shared.join("DriverSpecs.h").is_file());
+
+        // Idempotent on re-run.
+        let again = ensure_xwin_case_aliases(&xwin).expect("aliases again");
+        assert_eq!(again, 0);
+    });
+
+    crate::timed_test!(include_scan_handles_angle_subdir_and_whitespace, {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let xwin = tmp.path().join("xwin");
+        let um = xwin.join("sdk").join("include").join("um");
+        std::fs::create_dir_all(&um).expect("mkdir um");
+        // Angle include, subdir-qualified reference, and whitespace
+        // between `#` and `include` — all must resolve to basenames.
+        std::fs::write(
+            um.join("consumer.h"),
+            b"  #  include <foo/BarBaz.h>\n#include \"QuuxThing.h\"\nint x;\n",
+        )
+        .expect("write consumer");
+        std::fs::write(um.join("barbaz.h"), b"x").expect("write barbaz");
+        std::fs::write(um.join("quuxthing.h"), b"y").expect("write quuxthing");
+
+        let case_insensitive = is_case_insensitive_fs(tmp.path());
+        let created = ensure_xwin_case_aliases(&xwin).expect("aliases");
+        let expected = if case_insensitive { 0 } else { 2 };
+        assert_eq!(created, expected);
+        assert!(um.join("BarBaz.h").is_file());
+        assert!(um.join("QuuxThing.h").is_file());
+    });
+
+    crate::timed_test!(scan_include_directives_parses_directive_shapes, {
+        let mut refs = HashSet::new();
+        scan_include_directives(
+            b"#include <a/b/Name.h>\n\
+              # include \"Other.H\"\n\
+              #include<NoSpace.h>\n\
+              // #include commented is still fine to over-collect\n\
+              #define X 1\n\
+              #include \"backslash\\Sub\\Deep.h\"\n\
+              #include \"\"\n\
+              #include <unclosed\n",
+            &mut refs,
+        );
+        assert!(refs.contains("Name.h"), "{refs:?}");
+        assert!(refs.contains("Other.H"), "{refs:?}");
+        assert!(refs.contains("NoSpace.h"), "{refs:?}");
+        assert!(refs.contains("Deep.h"), "{refs:?}");
+        assert!(!refs.contains(""), "empty names must be dropped: {refs:?}");
+        assert!(
+            !refs.iter().any(|r| r.contains("unclosed")),
+            "unclosed directives must be ignored: {refs:?}"
         );
     });
 

--- a/crates/soldr-cli/src/prepare_cmd.rs
+++ b/crates/soldr-cli/src/prepare_cmd.rs
@@ -170,83 +170,14 @@ async fn ensure_xwin_cache() -> Result<PathBuf, SoldrError> {
     Ok(xwin_dir)
 }
 
-fn ensure_xwin_case_aliases(xwin_dir: &Path) -> Result<usize, SoldrError> {
-    let roots = [
-        xwin_dir.join("crt").join("include"),
-        xwin_dir.join("crt").join("lib"),
-        xwin_dir.join("sdk").join("include"),
-        xwin_dir.join("sdk").join("lib"),
-    ];
-
-    let mut created = 0;
-    for root in roots {
-        if root.is_dir() {
-            created += ensure_lowercase_file_aliases(&root)?;
-        }
-    }
-    Ok(created)
-}
-
-fn ensure_lowercase_file_aliases(dir: &Path) -> Result<usize, SoldrError> {
-    let mut created = 0;
-    for entry in std::fs::read_dir(dir)
-        .map_err(|e| SoldrError::Other(format!("read xwin cache dir {}: {e}", dir.display())))?
-    {
-        let entry = entry.map_err(|e| {
-            SoldrError::Other(format!(
-                "read xwin cache entry under {}: {e}",
-                dir.display()
-            ))
-        })?;
-        let path = entry.path();
-        let file_type = entry.file_type().map_err(|e| {
-            SoldrError::Other(format!("stat xwin cache entry {}: {e}", path.display()))
-        })?;
-
-        if file_type.is_dir() {
-            created += ensure_lowercase_file_aliases(&path)?;
-            continue;
-        }
-        if !file_type.is_file() {
-            continue;
-        }
-
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        let lower = name.to_ascii_lowercase();
-        if lower == name {
-            continue;
-        }
-
-        let alias = path.with_file_name(lower);
-        if alias.exists() {
-            continue;
-        }
-
-        create_xwin_file_alias(&path, &alias)?;
-        created += 1;
-    }
-    Ok(created)
-}
-
-fn create_xwin_file_alias(src: &Path, alias: &Path) -> Result<(), SoldrError> {
-    match std::fs::hard_link(src, alias) {
-        Ok(()) => Ok(()),
-        Err(hardlink_err) => {
-            if alias.exists() {
-                return Ok(());
-            }
-            std::fs::copy(src, alias).map(|_| ()).map_err(|copy_err| {
-                SoldrError::Other(format!(
-                    "create lowercase xwin cache alias {} -> {}: \
-                     hardlink failed: {hardlink_err}; copy failed: {copy_err}",
-                    alias.display(),
-                    src.display()
-                ))
-            })
-        }
-    }
-}
+/// Case-alias materialization is shared with the blessed
+/// `fetch::xwin_cache` path — same bundle shape, same case-sensitivity
+/// problem, one implementation (cross-run 28574600982 fix). Covers both the lowercase
+/// pass (`Kernel32.Lib` → `kernel32.lib`) and the include-referenced
+/// pass (`driverspecs.h` → `DriverSpecs.h`, which `kernelspecs.h`
+/// references as `#include "DriverSpecs.h"` from every `windows.h`
+/// compile).
+use crate::fetch::xwin_cache::ensure_xwin_case_aliases;
 
 /// Parse the `--target` argument into a list of triples.
 ///


### PR DESCRIPTION
Fixes the two failing `*-pc-windows-msvc` lanes of `cross-compile-all-targets.yml` from run [28574600982](https://github.com/zackees/soldr/actions/runs/28574600982) (jobs 84721100570 windows-x86, 84721100572 windows-arm).

## Root cause 1 — `DriverSpecs.h` case miss (both windows lanes)

The xwin-cache URL migration to the soldr-toolchain catalogue (`c65a650`) swapped the bundle from `zackees/soldr@manifest .../2026-06-22b` (88.4 MB) to `zackees/soldr-toolchain@assets .../2026-06-22` (84.7 MB). The new bundle ships `sdk/include/shared/driverspecs.h` **lowercase only**, but `kernelspecs.h` line 36 references `#include "DriverSpecs.h"` — and `winnt.h:101` pulls `kernelspecs.h` into **every** `windows.h` compile. On the case-sensitive runner filesystem that's a fatal "file not found":

* windows-x86: `zstd-sys` (zstdmt `threading.c` / `zstdmt_compress.c` include `windows.h`)
* windows-arm: zlib-ng's `arm_features.c` (same chain)

`soldr prepare`'s existing alias pass only creates **mixed-case → lowercase** aliases (`Kernel32.Lib` → `kernel32.lib`) — the wrong direction for this reference.

**Fix:** a second, include-referenced alias pass (what `xwin --symlinks` does at splat time): scan the splat's include trees for `#include` directives and hardlink an alias with the referenced casing next to any file that only matches case-insensitively (`driverspecs.h` → `DriverSpecs.h`; 1495 aliases on the current bundle). Implementation moved to `fetch::xwin_cache::ensure_xwin_case_aliases`, shared by `soldr prepare` (the legacy `soldr cargo xwin` lanes) and the blessed `ensure_xwin_cache` path — including a repair pass for already-extracted / CI-cache-restored splats.

## Root cause 2 — zlib-ng ARM intrinsics under clang-cl (windows-arm lane)

`libz-ng-sys v1.1.29` entered the dependency graph since the last green run (2026-06-22; `flate2` with `zlib-ng`). Its vendored zlib-ng cmake feature detection is self-inconsistent under clang-cl (which defines `_MSC_VER` but implements none of MSVC's compiler intrinsics):

* `HAVE_ARMV8_INTRIN` probes `__crc32w` from `<intrin.h>` — MSVC-only, clang-cl's builtin `intrin.h`/`arm64intr.h` don't declare it → probe fails. But the GNU-inline-asm probe `HAVE_ARMV8_INLINE_ASM` **passes** (clang-cl accepts GCC asm + honors `-march=armv8-a+crc`), so cmake enables `ARM_CRC32` anyway — and `acle_intrins.h`'s `_MSC_VER` branch (`#include <intrin.h>`, asm fallback gated on `!defined(_MSC_VER)`) then needs exactly the missing `__crc32b/h/w/d`: `crc32_armv8.c` fails with *call to undeclared function '__crc32b'*.
* The NEON path includes MSVC's `arm64_neon.h`, whose `vld1q_*_x4` macros expand to `neon_ld1m4_*` compiler intrinsics clang-cl neither declares nor lowers. The `NEON_HAS_LD4` probe dies at link (`undefined symbol: neon_ld1m4_q32` — captured in the docker repro's CMakeConfigureLog), so zlib-ng compiles its fallback inline functions, which collide with the still-defined macros (*type specifier missing* in `adler32_neon.c` via `neon_intrins.h`).

**Fix:** for `aarch64-pc-windows-msvc`, the `soldr cargo xwin` front door writes a toolchain-file **wrapper** and exports it as `CMAKE_TOOLCHAIN_FILE_aarch64-pc-windows-msvc` — the dash-triple form, which the `cmake` crate checks **before** cargo-xwin's underscore form (`getenv_target_os` in cmake-rs 0.1.58). The wrapper chain-includes cargo-xwin's real clang-cl toolchain file via `$ENV{CMAKE_TOOLCHAIN_FILE_aarch64_pc_windows_msvc}` (compiler/linker setup unchanged) and force-caches `WITH_NEON`/`WITH_ARMV8`/`WITH_ARMV6` OFF, so zlib-ng builds its portable C fallbacks — the only combination clang-cl can compile until upstream zlib-ng grows real clang-cl ARM64 support. User-set env always wins (injection is gated on `var_os().is_none()`).

## Evidence

Reproduced + validated end-to-end in a case-sensitive docker harness mirroring the CI lanes (ubuntu 24.04, rust 1.94.1, cargo-xwin 0.23.0, managed LLVM 21.1.5, the exact catalogue bundle + `soldr prepare` lowercase-alias seeding, `CC_<t>=clang-cl` etc.), building a crate that depends on `libz-ng-sys =1.1.29` + `zstd 0.13 (zstdmt)`:

| target | baseline | with fixes |
|---|---|---|
| `aarch64-pc-windows-msvc` | `crc32_armv8.c` `__crc32b` undeclared + `adler32_neon.c` macro collision + `arm_features.c` DriverSpecs.h (identical to job 84721100572) | **exit 0** |
| `x86_64-pc-windows-msvc` | `zstdmt_compress.c` → `kernelspecs.h(36,10): fatal error: 'DriverSpecs.h' file not found` (identical to job 84721100570) | **exit 0** |

Also verified locally against the managed clang-cl 21.1.5: clang's `arm_acle.h`/`intrin.h` declaration behavior, the cmake-rs dash-vs-underscore env precedence, and that the NEON `ld4` probe failure is a **link**-stage failure (undefined `neon_ld1m4_q32`), not a compile-stage one.

Unit tests added: include-referenced alias materialization (DriverSpecs fixture), directive-parser shapes (angle/quoted/subdir/whitespace/unclosed), and wrapper generation gating (aarch64-msvc only, dash-form env var, chain-include + `WITH_* OFF` content, idempotence). `cargo test --lib`, targeted bin tests, `timed_test_lint`/`monocrate_guard`/`version_lockstep`, `clippy --all-targets -- -D warnings`, and `fmt --check` all pass.

A `workflow_dispatch` of `cross-compile-all-targets.yml` on this branch is linked in the PR comments as the direct pre-merge proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
