### PR TITLE
ci(cross-build): bump rust-cache shared-key to v2 to pick up ci-bootstrap subdir (#1287)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -203,7 +203,13 @@ jobs:
       - name: Restore cargo + target caches
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          shared-key: cross-build-${{ inputs.target }}
+          # soldr#1287 — v2 suffix bumped after #1283 added
+          # [profile.ci-bootstrap]. Swatinem/rust-cache keys on Cargo.lock,
+          # not Cargo.toml — the pre-#1283 primary key still HIT and served
+          # stale (release-only) cache, and Swatinem never re-saves once the
+          # primary key exists. Bumping the shared-key forces a MISS →
+          # fresh save with the ci-bootstrap/ subdir included.
+          shared-key: cross-build-${{ inputs.target }}-v2
 
       # Bootstrap soldr from the current checkout. Darwin uses it to
       # drive `soldr prepare --target ... --github-env`. Windows MSVC


### PR DESCRIPTION
Fixes #1287.

## Summary
- Bump \`Restore cargo + target caches\` shared-key from
  \`cross-build-<target>\` to \`cross-build-<target>-v2\`.

## Why
PR #1283 added \`[profile.ci-bootstrap]\` but the rust-cache primary key
never changed (Swatinem keys on Cargo.lock, not Cargo.toml). The cache
kept restoring stale (release-only) contents and Swatinem never
re-saves once the primary key exists. Bootstrap step recompiled from
scratch on every run.

Bumping the shared-key forces a MISS on the first post-merge run →
fresh save with target/<host>/ci-bootstrap/ included. Subsequent runs
HIT the new key and get Fresh cargo hits for ci-bootstrap deps.

## Expected impact
- Bootstrap step: ~289 s → ~30-60 s once warm.
- CI critical path: ~568 s → ~300-350 s.

## Test plan
- [ ] Lint stays green.
- [ ] First post-merge run: fresh save (\`Cache saved with key ... -v2\`).
- [ ] Second post-merge run: Fresh cargo hits on ci-bootstrap deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)