### PR TITLE
fix(cross): darwin lanes — rustc cannot find libobjc (SDKROOT dropped by wrapper env filter + cargo-zigbuild --sysroot -L doubling on zig 0.14)

### DIFF
--- a/crates/soldr-cli/src/cargo_front_door/zig_shim.rs
+++ b/crates/soldr-cli/src/cargo_front_door/zig_shim.rs
@@ -31,8 +31,9 @@ pub(super) fn ensure_zig_wrappers(
     let ar = dir.join(format!("ar{ext}"));
     let ranlib = dir.join(format!("ranlib{ext}"));
 
-    write_wrapper(&cc, &render_cc_wrapper("cc", zig_target))?;
-    write_wrapper(&cxx, &render_cc_wrapper("c++", zig_target))?;
+    let is_darwin = triple.ends_with("-apple-darwin");
+    write_wrapper(&cc, &render_cc_wrapper("cc", zig_target, is_darwin))?;
+    write_wrapper(&cxx, &render_cc_wrapper("c++", zig_target, is_darwin))?;
     write_wrapper(&ar, &render_tool_wrapper("ar"))?;
     write_wrapper(&ranlib, &render_tool_wrapper("ranlib"))?;
 
@@ -58,11 +59,74 @@ fn rust_target_to_zig_target(triple: &str) -> Result<&'static str, SoldrError> {
     }
 }
 
-fn render_cc_wrapper(subcommand: &str, zig_target: &str) -> String {
+fn render_cc_wrapper(subcommand: &str, zig_target: &str, is_darwin: bool) -> String {
+    if is_darwin {
+        return render_darwin_cc_wrapper(subcommand, zig_target);
+    }
     if cfg!(windows) {
         format!("@echo off\r\ncargo-zigbuild zig {subcommand} -- -target {zig_target} %*\r\n",)
     } else {
         format!("#!/bin/sh\nexec cargo-zigbuild zig {subcommand} -- -target {zig_target} \"$@\"\n",)
+    }
+}
+
+/// Darwin cc/c++ wrapper — sidesteps cargo-zigbuild's broken
+/// `--sysroot` handling on zig < 0.15 (darwin lanes of run 28574600982).
+///
+/// When `SDKROOT` is set, cargo-zigbuild's `zig cc` proxy (v0.23.0,
+/// zig < 0.15 branch of `add_macos_specific_args`) passes BOTH
+/// `--sysroot=$SDKROOT` and absolute `-L$SDKROOT/usr/lib` /
+/// `-F$SDKROOT/System/Library/Frameworks` args. zig 0.14's Mach-O
+/// linker interprets every `-L` path as *relative to the sysroot*, so
+/// each search dir doubles up (`$SDKROOT$SDKROOT/usr/lib`,
+/// `$SDKROOT/<build-out-dir>`, …) and no system library resolves:
+///
+///   error: unable to find dynamic system library 'objc'
+///           using strategy 'paths_first'. searched paths: none
+///
+/// cargo-zigbuild's own fix only engages on zig >= 0.15 (SDKROOT env
+/// var instead of `--sysroot`). Since soldr pins zig 0.14.1, the shim
+/// clears `SDKROOT` before exec'ing cargo-zigbuild (so it never adds
+/// `--sysroot`) and passes the SDK include/library/framework search
+/// paths explicitly — the exact arg shape cargo-zigbuild's zig >= 0.15
+/// branch would produce. Non-darwin targets keep the plain wrapper.
+fn render_darwin_cc_wrapper(subcommand: &str, zig_target: &str) -> String {
+    if cfg!(windows) {
+        format!(
+            "@echo off\r\n\
+             setlocal\r\n\
+             set \"SOLDR_APPLE_SDK=%SDKROOT%\"\r\n\
+             set \"SDKROOT=\"\r\n\
+             if defined SOLDR_APPLE_SDK (\r\n\
+               cargo-zigbuild zig {subcommand} -- -target {zig_target} \
+             -isystem \"%SOLDR_APPLE_SDK%\\usr\\include\" \
+             \"-L%SOLDR_APPLE_SDK%\\usr\\lib\" \
+             \"-F%SOLDR_APPLE_SDK%\\System\\Library\\Frameworks\" \
+             -iframework \"%SOLDR_APPLE_SDK%\\System\\Library\\Frameworks\" \
+             -DTARGET_OS_IPHONE=0 %*\r\n\
+             ) else (\r\n\
+               cargo-zigbuild zig {subcommand} -- -target {zig_target} %*\r\n\
+             )\r\n"
+        )
+    } else {
+        format!(
+            "#!/bin/sh\n\
+             # soldr zig shim (darwin): see zig_shim.rs — clears SDKROOT so\n\
+             # cargo-zigbuild (zig < 0.15) does not emit --sysroot, which\n\
+             # makes zig resolve every -L path relative to the SDK. The SDK\n\
+             # search paths are passed explicitly instead.\n\
+             if [ -n \"${{SDKROOT:-}}\" ]; then\n\
+               SOLDR_APPLE_SDK=\"$SDKROOT\"\n\
+               unset SDKROOT\n\
+               exec cargo-zigbuild zig {subcommand} -- -target {zig_target} \\\n\
+                 -isystem \"$SOLDR_APPLE_SDK/usr/include\" \\\n\
+                 \"-L$SOLDR_APPLE_SDK/usr/lib\" \\\n\
+                 \"-F$SOLDR_APPLE_SDK/System/Library/Frameworks\" \\\n\
+                 -iframework \"$SOLDR_APPLE_SDK/System/Library/Frameworks\" \\\n\
+                 -DTARGET_OS_IPHONE=0 \"$@\"\n\
+             fi\n\
+             exec cargo-zigbuild zig {subcommand} -- -target {zig_target} \"$@\"\n"
+        )
     }
 }
 
@@ -119,11 +183,39 @@ mod tests {
         if cfg!(windows) {
             return;
         }
-        let body = render_cc_wrapper("cc", "aarch64-linux-musl");
+        let body = render_cc_wrapper("cc", "aarch64-linux-musl", false);
         assert!(body.starts_with("#!/bin/sh\n"));
         assert!(body.contains("cargo-zigbuild zig cc -- -target aarch64-linux-musl"));
         assert!(body.contains("\"$@\""));
+        // Non-darwin wrappers must NOT carry the SDKROOT workaround.
+        assert!(!body.contains("SDKROOT"));
     });
+
+    crate::timed_test!(
+        darwin_cc_wrapper_clears_sdkroot_and_adds_explicit_sdk_paths,
+        {
+            if cfg!(windows) {
+                return;
+            }
+            // Run 28574600982: with SDKROOT set, cargo-zigbuild (zig < 0.15)
+            // passes `--sysroot=$SDKROOT` and zig 0.14 then resolves every
+            // -L path relative to the sysroot — no system library resolves.
+            // The darwin wrapper must clear SDKROOT before exec'ing
+            // cargo-zigbuild and pass the SDK search paths explicitly.
+            let body = render_cc_wrapper("cc", "x86_64-macos-none", true);
+            assert!(body.starts_with("#!/bin/sh\n"));
+            assert!(body.contains("unset SDKROOT"));
+            assert!(body.contains("-L$SOLDR_APPLE_SDK/usr/lib"));
+            assert!(body.contains("-F$SOLDR_APPLE_SDK/System/Library/Frameworks"));
+            assert!(body.contains("-isystem \"$SOLDR_APPLE_SDK/usr/include\""));
+            assert!(body.contains("cargo-zigbuild zig cc -- -target x86_64-macos-none"));
+            assert!(body.contains("\"$@\""));
+            // Fallback branch (no SDKROOT in env) keeps the plain invocation.
+            assert!(
+                body.ends_with("exec cargo-zigbuild zig cc -- -target x86_64-macos-none \"$@\"\n")
+            );
+        }
+    );
 
     crate::timed_test!(tool_wrapper_routes_through_cargo_zigbuild, {
         if cfg!(windows) {

--- a/crates/soldr-cli/src/compile_dispatch.rs
+++ b/crates/soldr-cli/src/compile_dispatch.rs
@@ -356,6 +356,26 @@ mod tests {
     );
 
     timed_test!(
+        is_compile_env_var_forwards_apple_sdk_vars,
+        Duration::from_secs(5),
+        {
+            // Regression test for the darwin cross-compile lanes (run
+            // 28574600982). The workflow exports SDKROOT
+            // before `soldr cargo zigbuild --target *-apple-darwin`;
+            // rustc reads it to locate the Apple SDK when linking (it
+            // appends `-isysroot <sdk>` to the cc-style linker), and the
+            // zig-cc linker shim reads it again for the SDK library
+            // search path. The daemon replays the filtered env into
+            // rustc (env_clear + replay), so dropping any of these
+            // makes every `-lobjc` / `-framework` link fail with
+            // "unable to find dynamic system library 'objc'".
+            for v in ["SDKROOT", "DEVELOPER_DIR", "MACOSX_DEPLOYMENT_TARGET"] {
+                assert!(is_compile_env_var(v), "{v} must be forwarded to daemon");
+            }
+        }
+    );
+
+    timed_test!(
         is_compile_env_var_drops_common_noise,
         Duration::from_secs(5),
         {


### PR DESCRIPTION
## Failing jobs

Run [28574600982](https://github.com/zackees/soldr/actions/runs/28574600982) — `macos-x86` (job 84721100576) and `macos-arm` (job 84721100657), both dying at every bin link with:

```
error: unable to find dynamic system library 'objc' using strategy 'paths_first'. searched paths:
    .../target/x86_64-apple-darwin/release/build/<crate>/out/...   (build-script -L dirs only)
    /home/runner/.cache/cargo-zigbuild/0.23.0/deps/libobjc.*       (czb stub dir)
```

plus the tell-tale rustc warning `invoking "xcrun" "--sdk" "macosx" "--show-sdk-path" ... failed` — even though the `Preparing Cross Compile Toolchain` step had exported `SDKROOT=/home/runner/.soldr/bin/apple-sdk/11.3/MacOSX11.3.sdk` and `libobjc.tbd` sits in `$SDKROOT/usr/lib/`.

## Root cause — two stacked regressions since the last green run (2026-06-22, run 27933284058)

**1. `SDKROOT` never reached rustc (fixed on main by #1284).** Since #982 Phase 5c, `soldr`-as-`RUSTC_WRAPPER` brokers every compile to the daemon's embedded zccache, which `env_clear()`s and replays only the request env filtered by `compile_dispatch::is_compile_env_var` — an allowlist that did not include `SDKROOT`. rustc therefore could not locate the Apple SDK (hence the xcrun warning; on Linux there is no xcrun), never appended `-isysroot <sdk>` to the linker line, and the linker child inherited an env without `SDKROOT` too. #1284 (merged today, from the musl lane of the same run) inverted the allowlist into a noise denylist, which restores `SDKROOT` forwarding. This PR adds `is_compile_env_var_forwards_apple_sdk_vars` pinning `SDKROOT` / `DEVELOPER_DIR` / `MACOSX_DEPLOYMENT_TARGET` so the darwin lanes can't regress silently again.

**2. With `SDKROOT` visible again, the lanes would *still* fail — cargo-zigbuild 0.23.0 + zig 0.14.1 `--sysroot` doubling (fixed here).** The green run used zig **0.13.0**; #995 bumped the managed zig to **0.14.1**. cargo-zigbuild's `zig cc` proxy (the `zig < 0.15` branch of `add_macos_specific_args`) passes BOTH `--sysroot=$SDKROOT` and absolute `-L$SDKROOT/usr/lib` / `-F...` args — and zig 0.14's Mach-O linker resolves every `-L` path *relative to the sysroot*, so each search dir doubles up and nothing resolves:

```
warning: unable to open library directory '/opt/apple-sdk/MacOSX11.3.sdk/opt/apple-sdk/MacOSX11.3.sdk/usr/lib': FileNotFound
warning: unable to open library directory '/opt/apple-sdk/MacOSX11.3.sdk/root/.cache/cargo-zigbuild/0.23.0/deps': FileNotFound
error: unable to find dynamic system library 'objc' using strategy 'paths_first'. searched paths: none
```

cargo-zigbuild's own fix for this only engages on zig >= 0.15 (SDKROOT env var instead of `--sysroot`), and soldr pins zig 0.14.1.

## Fix

`cargo_front_door/zig_shim.rs`: the darwin variant of the `zigbuild-shims` cc/cxx wrappers (`CARGO_TARGET_<T>_LINKER` + `CC_<t>`/`CXX_<t>` since #961) now clears `SDKROOT` before exec'ing `cargo-zigbuild zig cc` — so it never emits `--sysroot` — and passes the SDK search paths explicitly: `-isystem <sdk>/usr/include`, `-L<sdk>/usr/lib`, `-F`/`-iframework <sdk>/System/Library/Frameworks`, `-DTARGET_OS_IPHONE=0` (the exact arg shape cargo-zigbuild's zig >= 0.15 branch produces). Non-darwin targets keep the plain wrapper byte-for-byte.

## Evidence (ci/docker-darwin-cross, linux → x86_64-apple-darwin, czb 0.23.0 + zig 0.14.1 + MacOSX11.3.sdk)

| case | result |
|---|---|
| released soldr 0.7.96, `soldr cargo zigbuild --target x86_64-apple-darwin` on a minimal `-lobjc` crate | **exact CI failure** (xcrun warning + czb-stub-only searched paths) |
| bare rustc + shim, SDKROOT set (i.e. what CI becomes after #1284 alone) | **still fails** — doubled `--sysroot` paths, `searched paths: none` |
| bare rustc + patched-shape shim, SDKROOT set (rustc `-isysroot` passthrough included) | links |
| patched soldr, same minimal `-lobjc` + `-framework CoreFoundation` crate | **PASS — Mach-O produced**, no warnings |

Unit tests: `zig_shim` 5/5, `compile_dispatch` 8/8, full `--lib` suite 553 passed / 0 failed; `clippy --all-targets -D warnings` and `fmt --check` clean (all via soldr-wrapped cargo).

End-to-end validation defers to the post-merge `cross-compile-all-targets` re-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)