### PR TITLE
release: bump version to 0.7.98

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.97"
+version = "0.7.98"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.97"
+version = "0.7.98"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Release PR (three-file lockstep, `version_lockstep` green). 0.7.98 is the first fully-published release of the PEP 517 backend era — see the commit message for the complete change roster (#1257 #1269 #1273 #1276 #1277 #1278 #1281 #1284 #1285 #1289).

Merge is gated on the in-flight `cross-compile-all-targets` run 28580822202 proving 7/7 lanes green on main.

v0.7.97 note: tag-only (publish stranded by the GH-release 403 that #1281 now degrades); PyPI/npm skip straight from 0.7.96 to 0.7.98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)