### PR TITLE
ci(cross-build): match nextest install gate to archive step gate (#1291)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -156,9 +156,11 @@ jobs:
         with:
           tool: cargo-xwin@0.18.6
 
-      # nextest — required for the test archive output.
+      # nextest — required for the test archive output. soldr#1291 —
+      # matches the archive step's `if:` so MSVC/darwin lanes (which
+      # skip the archive) don't install a tool they never invoke.
       - name: Install cargo-nextest
-        if: inputs.build_test_archive
+        if: inputs.build_test_archive && !contains(inputs.target, 'pc-windows-msvc') && !contains(inputs.target, 'apple-darwin')
         uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
         with:
           tool: cargo-nextest


### PR DESCRIPTION
Fixes #1291.

## Summary
Match the \`Install cargo-nextest\` step's \`if:\` to the \`Build nextest
archive\` step's \`if:\`. MSVC and darwin lanes already skip the archive;
they shouldn't install the tool.

## Impact
Trivial cleanup. taiki-e/install-action caches cargo-nextest, so
wallclock saving is ~1 s per lane on the three darwin/MSVC lanes.

## Test plan
- [ ] Lint stays green.
- [ ] MSVC/darwin lanes still cross-build successfully.
- [ ] Musl/gnu lanes still install cargo-nextest and archive tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)