### PR TITLE
fix(cache+gc): checkpoint embedded zccache state before archiving; run auto-GC at build end (#1286)

### DIFF
--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -585,18 +585,17 @@ jobs:
 
           # scenario -> "fail" or "warn".
           #
-          # TEMPORARY (soldr#1148): cold-tar-untar-warm is demoted from
-          # `fail` to `warn` while soldr#1146 is being investigated.
-          # Speedup has been stable at ~1.20x on GHA linux/medium since
-          # the embed-zccache migration (#977/#980), vs the 3.0x floor.
-          # The number is still surfaced in the ::warning:: line and the
-          # summary table so regressions are visible; the workflow just
-          # doesn't hard-fail on it. RE-PROMOTE to `fail` as part of the
-          # #1146 root-cause fix — leaving this on `warn` permanently
-          # loses the regression signal we care about most.
+          # cold-tar-untar-warm re-promoted to `fail` (#1286, closing
+          # out the #1146/#1148 demotion): the ~1.20x plateau was the
+          # embedded zccache's artifact index + depgraph being
+          # memory-only in soldr-daemon when `soldr save` archived the
+          # cache tree — the restored cache served zero rustc hits.
+          # `soldr save` / `cache flush` / `cache shutdown` now
+          # checkpoint the embedded state (Request::FlushCaches), so a
+          # sub-threshold speedup here is a real regression again.
           mode_for() {
             case "$1" in
-              cold-tar-untar-warm) echo "warn" ;;
+              cold-tar-untar-warm) echo "fail" ;;
               worktree-share|touch-no-change|build-then-check) echo "warn" ;;
               *) echo "warn" ;;
             esac

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.12.11"
+version = "1.12.12"
 dependencies = [
  "arc-swap",
  "bincode",

--- a/crates/soldr-cli/src/cache/session.rs
+++ b/crates/soldr-cli/src/cache/session.rs
@@ -411,6 +411,25 @@ pub(crate) async fn run_cache_shutdown_command(
         notes.push("polling disabled via --no-wait; daemon exit not confirmed".into());
     }
 
+    // Step 5 (#1286 F1): the steps above only quiesce the MANAGED
+    // zccache daemon (the C/C++ side). The rustc side lives in the
+    // soldr-daemon's embedded zccache service, whose artifact index +
+    // depgraph were memory-only until a graceful daemon exit — the
+    // exact same zero-warm-hit archive race soldr#383 fixed for the
+    // managed daemon, one layer up. FlushCaches is synchronous: when
+    // it returns, the embedded state is durable and a following
+    // `soldr save` / tar sees a complete cache tree.
+    {
+        let sock = crate::daemon::server::server_sock_path(&paths);
+        match crate::daemon::client::flush_caches(&sock) {
+            Ok(()) => notes.push("embedded zccache state flushed via soldr-daemon".into()),
+            Err(err) => notes.push(format!(
+                "soldr-daemon embedded flush unavailable ({err:?}); on-disk \
+                 state is whatever the daemon last persisted"
+            )),
+        }
+    }
+
     output.notes = notes;
 
     let timed_out = polled_for_exit && !output.daemon_exited;
@@ -472,6 +491,24 @@ pub(crate) async fn run_cache_flush_command(json: bool) -> Result<(), SoldrError
         stats: None,
         notes: Vec::new(),
     };
+
+    // Issue #1286 (F1): also checkpoint the soldr-daemon's EMBEDDED
+    // zccache state (the rustc side). The managed-zccache flush below
+    // only covers the C/C++ daemon; without this, archives taken after
+    // `cache flush` were missing the embedded artifact index + depgraph
+    // and restored with zero rustc hits.
+    {
+        let sock = crate::daemon::server::server_sock_path(&paths);
+        match crate::daemon::client::flush_caches(&sock) {
+            Ok(()) => output
+                .notes
+                .push("embedded zccache state flushed via soldr-daemon".into()),
+            Err(err) => output.notes.push(format!(
+                "soldr-daemon embedded flush unavailable ({err:?}); on-disk \
+                 state is whatever the daemon last persisted"
+            )),
+        }
+    }
 
     let mut lifecycle = linked_private.map(|(lifecycle, _)| lifecycle).or_else(|| {
         fetch

--- a/crates/soldr-cli/src/cargo_front_door/mod.rs
+++ b/crates/soldr-cli/src/cargo_front_door/mod.rs
@@ -608,9 +608,11 @@ pub(crate) async fn run_cargo_front_door(
         // Cargo front door only: keep startup/low-disk warnings off unrelated
         // commands and out of the rustc-wrapper hot path.
         gc::emit_startup_target_warning_if_due();
-        // Best-effort auto-GC trigger (issue #323). Runs on a detached
-        // background thread; never blocks the build.
-        gc::maybe_kick_auto_gc(&paths);
+        // Issue #1286 (F5): the auto-GC trigger moved to build END (see
+        // `gc::maybe_spawn_auto_gc_sweeper` below). Kicking here — right
+        // after `build_active::set(true)` — always deferred with
+        // `reason=build_active`, so the sweep never ran on machines
+        // that only invoke soldr for builds.
     }
     let mut path_dirs: Vec<std::path::PathBuf> = Vec::with_capacity(1 + extra_bin_dirs.len());
     path_dirs.push(cargo_bin_dir);
@@ -774,6 +776,13 @@ pub(crate) async fn run_cargo_front_door(
     // (before `post_cargo_result`) lets the post-build target-GC pass
     // run normally without thinking it's still inside the build.
     crate::cache_lib::build_active::set(false);
+    // Issue #1286 (F5): the build just ended — this is the idle
+    // transition, so fire the auto-GC sweep now, as a detached process
+    // that survives this wrapper's imminent exit. Throttled to once
+    // per 5-minute window by the marker inside.
+    if build_like_cargo {
+        gc::maybe_spawn_auto_gc_sweeper(&paths);
+    }
 
     let post_cargo_result: Result<(), SoldrError> = (|| {
         if status.success() {

--- a/crates/soldr-cli/src/cli_args.rs
+++ b/crates/soldr-cli/src/cli_args.rs
@@ -966,6 +966,12 @@ pub(crate) enum GcSubcommand {
     /// (issue #574). Designed for cross-repo `target/` reclamation —
     /// independent of the per-repo `target/` taxonomy walks above.
     Target(Box<GcTargetArgs>),
+    /// Issue #1286 (F5): run the auto-GC sweep synchronously in this
+    /// process. Internal — the cargo front door spawns this detached at
+    /// build end so the sweep survives the wrapper process exiting; the
+    /// spawner owns the throttle, so this verb runs unconditionally.
+    #[command(name = "auto-sweep", hide = true)]
+    AutoSweep,
 }
 
 #[derive(clap::Args)]

--- a/crates/soldr-cli/src/daemon/client.rs
+++ b/crates/soldr-cli/src/daemon/client.rs
@@ -104,6 +104,20 @@ pub fn shutdown(sock_path: &Path) -> Result<(), ClientError> {
     }
 }
 
+/// Issue #1286 (F1): ask the daemon to checkpoint the embedded zccache
+/// state (artifact index, depgraph snapshot, metadata cache) to disk
+/// without shutting down. Used by `soldr save` / `soldr cache flush`
+/// before archiving the cache tree.
+pub fn flush_caches(sock_path: &Path) -> Result<(), ClientError> {
+    match submit_request(sock_path, &Request::FlushCaches)? {
+        Response::Ack => Ok(()),
+        Response::Error(msg) => Err(ClientError::Protocol(msg)),
+        other => Err(ClientError::Protocol(format!(
+            "unexpected response: {other:?}"
+        ))),
+    }
+}
+
 pub fn list_builds(
     sock_path: &Path,
     limit: u32,

--- a/crates/soldr-cli/src/daemon/protocol.rs
+++ b/crates/soldr-cli/src/daemon/protocol.rs
@@ -47,7 +47,13 @@ use thiserror::Error;
 ///   v6 `CompileResponse` slot is kept on the wire for one release
 ///   cycle so cross-version traffic still errors as a clean version
 ///   mismatch instead of a silent oneof mis-decode.
-pub const PROTOCOL_VERSION: u32 = 7;
+/// * v8 (#1286 F1): adds `Request::FlushCaches` so `soldr save` /
+///   `soldr cache flush` can checkpoint the embedded zccache state
+///   (artifact index, depgraph snapshot, metadata cache) to disk
+///   without shutting the daemon down. Before v8 that state was
+///   memory-only until a graceful daemon exit, so archives taken from
+///   a live daemon restored with zero rustc hits.
+pub const PROTOCOL_VERSION: u32 = 8;
 
 /// Wire-chunk granularity for the streaming Compile reply (#983 Phase
 /// 5b). 64 KiB is the same buffer size cargo's own pipe readers use
@@ -178,6 +184,13 @@ pub enum Request {
     /// embedded-service failure. There is no longer a wrapper-side
     /// fallback to forking `zccache.exe` — embedded is mandatory.
     Compile(CompileRequest),
+    /// Request-response: checkpoint the embedded zccache service's
+    /// in-memory state (artifact index, depgraph snapshot, metadata
+    /// cache, pending writes) to disk WITHOUT shutting down. Issued by
+    /// `soldr save` and `soldr cache flush` before archiving so the
+    /// on-disk cache tree is complete (#1286 F1). Replies with
+    /// [`Response::Ack`].
+    FlushCaches,
 }
 
 /// Body of [`Request::Compile`]. Carries the full `rustc` argv plus the

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -323,6 +323,25 @@ pub async fn run_async(opts: ServerOptions) -> Result<(), ServerError> {
             signal_state.shutdown.notify_waiters();
         }
     });
+    // Issue #1286 (F1): SIGTERM previously killed the daemon without
+    // the graceful-drain path below, silently discarding the embedded
+    // zccache's in-memory artifact index + depgraph — a full cold
+    // cache on the next daemon start. `pkill soldr-daemon`, container
+    // stop, and service managers all send TERM, not INT.
+    #[cfg(unix)]
+    {
+        let term_state = state.clone();
+        tokio::spawn(async move {
+            let Ok(mut term) =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            else {
+                return;
+            };
+            if term.recv().await.is_some() {
+                term_state.shutdown.notify_waiters();
+            }
+        });
+    }
 
     state.shutdown.notified().await;
     accept_handle.abort();
@@ -469,6 +488,20 @@ where
         Request::Shutdown => {
             let _ = write_frame_async(&mut stream, &Response::ShuttingDown).await;
             state.shutdown.notify_waiters();
+        }
+        Request::FlushCaches => {
+            // Issue #1286 (F1): checkpoint the embedded zccache state
+            // (artifact index, depgraph snapshot, metadata cache) to
+            // disk without shutting down. `soldr save` / `soldr cache
+            // flush` call this before archiving — otherwise the state
+            // is memory-only until a graceful daemon exit and archives
+            // taken from a live daemon restore with zero rustc hits.
+            state.event_batcher.flush().await;
+            let response = match state.compile_service.flush().await {
+                Ok(_) => Response::Ack,
+                Err(err) => Response::Error(format!("embedded zccache flush failed: {err}")),
+            };
+            let _ = write_frame_async(&mut stream, &response).await;
         }
         Request::BuildSessionStart {
             session_id,

--- a/crates/soldr-cli/src/daemon/wire.proto
+++ b/crates/soldr-cli/src/daemon/wire.proto
@@ -40,6 +40,10 @@ message WireRequest {
     // zccache service to run a rustc invocation instead of forking
     // zccache.exe. v6 protocol.
     WireCompileRequest compile = 13;
+    // #1286 F1 — checkpoint the embedded zccache state (artifact
+    // index, depgraph snapshot, metadata cache) to disk without
+    // shutting down. Replies with ack. v8 protocol.
+    WireUnit flush_caches = 14;
   }
 }
 

--- a/crates/soldr-cli/src/daemon/wire.rs
+++ b/crates/soldr-cli/src/daemon/wire.rs
@@ -45,7 +45,7 @@ pub mod proto {
 
     #[derive(Clone, PartialEq, Message)]
     pub struct WireRequest {
-        #[prost(oneof = "WireRequestKind", tags = "1,2,3,4,5,6,7,8,9,10,11,12,13")]
+        #[prost(oneof = "WireRequestKind", tags = "1,2,3,4,5,6,7,8,9,10,11,12,13,14")]
         pub kind: Option<WireRequestKind>,
     }
 
@@ -78,6 +78,9 @@ pub mod proto {
         /// #977 Phase 5 / #980 L1 — wrapper-to-daemon Compile dispatch.
         #[prost(message, tag = "13")]
         Compile(WireCompileRequest),
+        /// #1286 F1 — checkpoint embedded zccache state to disk.
+        #[prost(message, tag = "14")]
+        FlushCaches(WireUnit),
     }
 
     #[derive(Clone, PartialEq, Message)]
@@ -686,6 +689,7 @@ impl From<&Request> for proto::WireRequest {
             }
             Request::Status => proto::WireRequestKind::Status(proto::WireUnit {}),
             Request::Shutdown => proto::WireRequestKind::Shutdown(proto::WireUnit {}),
+            Request::FlushCaches => proto::WireRequestKind::FlushCaches(proto::WireUnit {}),
             Request::BuildSessionStart {
                 session_id,
                 repo_root,
@@ -823,6 +827,7 @@ impl TryFrom<proto::WireRequest> for Request {
             },
             proto::WireRequestKind::Status(_) => Request::Status,
             proto::WireRequestKind::Shutdown(_) => Request::Shutdown,
+            proto::WireRequestKind::FlushCaches(_) => Request::FlushCaches,
             proto::WireRequestKind::BuildSessionStart(m) => Request::BuildSessionStart {
                 session_id: m.session_id,
                 repo_root: m.repo_root,
@@ -1047,6 +1052,14 @@ mod tests {
         assert!(matches!(
             decode_request(&bytes).expect("decode"),
             Request::Status
+        ));
+    });
+
+    crate::timed_test!(flush_caches_request_round_trips, {
+        let bytes = encode_request(&Request::FlushCaches);
+        assert!(matches!(
+            decode_request(&bytes).expect("decode"),
+            Request::FlushCaches
         ));
     });
 

--- a/crates/soldr-cli/src/gc/auto.rs
+++ b/crates/soldr-cli/src/gc/auto.rs
@@ -28,7 +28,24 @@ const AUTO_GC_DISABLE_ENV_VAR: &str = "SOLDR_AUTO_GC_DISABLED";
 /// dropped by the Tier-0 step of `run_auto_gc_background`.
 const DAEMON_EVENT_TTL_MS: i64 = 30 * 24 * 60 * 60 * 1000;
 
-pub(crate) fn maybe_kick_auto_gc(paths: &SoldrPaths) {
+/// Issue #1286 (F5): spawn the auto-GC sweep as a DETACHED PROCESS at
+/// build end instead of an in-process thread at build start.
+///
+/// The previous design (`maybe_kick_auto_gc`, a detached thread kicked
+/// from the front door right after `build_active::set(true)`) could
+/// never actually sweep: the thread woke up inside an active build,
+/// deferred with `reason=build_active`, and re-armed the marker — on a
+/// machine where soldr only runs during builds, the log showed days of
+/// continuous deferrals and a 36 GB cache. A post-build thread doesn't
+/// work either: the wrapper process exits right after cargo does,
+/// killing the sweep mid-flight. A detached `soldr gc auto-sweep`
+/// child survives the wrapper's exit and starts with
+/// `build_active == false` in its own process.
+///
+/// The 5-minute throttle marker still bounds the spawn frequency, so
+/// steady-state builds pay one `stat` here and at most one process
+/// spawn per throttle window.
+pub(crate) fn maybe_spawn_auto_gc_sweeper(paths: &SoldrPaths) {
     if auto_gc_env_disabled() {
         return;
     }
@@ -42,17 +59,38 @@ pub(crate) fn maybe_kick_auto_gc(paths: &SoldrPaths) {
     if !auto_gc_throttle_expired(&marker, AUTO_GC_THROTTLE_SECONDS) {
         return;
     }
-    // Touch the marker before spawning so a crashing background thread
-    // doesn't cause us to immediately rerun on the next invocation.
+    // Touch the marker before spawning so a crashing sweeper doesn't
+    // cause us to immediately rerun on the next invocation.
     let _ = touch_auto_gc_marker(&marker);
 
-    let log_path = crate::cache_lib::auto_gc_log_path(paths);
-    let paths_root = paths.root.clone();
-    let _ = std::thread::Builder::new()
-        .name("soldr-auto-gc".to_string())
-        .spawn(move || {
-            run_auto_gc_background(paths_root, log_path);
-        });
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let mut cmd = std::process::Command::new(exe);
+    cmd.args(["gc", "auto-sweep"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS | CREATE_NO_WINDOW —
+        // same detach semantics as daemon::lifecycle::spawn_detached_inner.
+        const FLAGS: u32 = 0x0000_0200 | 0x0000_0008 | 0x0800_0000;
+        cmd.creation_flags(FLAGS);
+    }
+    let _ = cmd.spawn();
+}
+
+/// Issue #1286 (F5): synchronous entry point behind the hidden
+/// `soldr gc auto-sweep` verb. The spawner above already consumed the
+/// throttle marker, so this runs the sweep unconditionally (the
+/// `build_active` preamble check still applies inside).
+pub(crate) fn run_gc_auto_sweep_command() -> Result<(), crate::core::SoldrError> {
+    let paths = SoldrPaths::new()?;
+    let log_path = crate::cache_lib::auto_gc_log_path(&paths);
+    run_auto_gc_background(paths.root.clone(), log_path);
+    Ok(())
 }
 
 fn auto_gc_env_disabled() -> bool {
@@ -115,6 +153,13 @@ fn run_auto_gc_background(paths_root: std::path::PathBuf, log_path: std::path::P
         rearm_auto_gc_marker(&paths);
         return;
     }
+
+    // Issue #1286 (F5): record that a sweep actually STARTED. Before
+    // this line the log could only ever contain deferrals and tier
+    // actions, so "GC ran but found nothing to do" and "GC never ran"
+    // were indistinguishable — which is how days of silent starvation
+    // went unnoticed.
+    let _ = append_auto_gc_log_line(&log_path, "auto-gc status=run stage=start");
 
     // Tier-0 (Phase 2): prune `daemon_events` rows older than 30 days
     // before any disk-pressure tiers run. Bounded, cheap, runs even when

--- a/crates/soldr-cli/src/gc/mod.rs
+++ b/crates/soldr-cli/src/gc/mod.rs
@@ -28,7 +28,7 @@ mod walks;
 
 // Re-export the public CLI surface so `crate::gc::*` keeps matching
 // the call sites in `main.rs` and `cargo_front_door.rs`.
-pub(crate) use auto::maybe_kick_auto_gc;
+pub(crate) use auto::{maybe_spawn_auto_gc_sweeper, run_gc_auto_sweep_command};
 pub(crate) use cargo_native::{
     run_gc_cargo_command, run_gc_locations_command, run_gc_sweep_command,
 };

--- a/crates/soldr-cli/src/main.rs
+++ b/crates/soldr-cli/src/main.rs
@@ -845,6 +845,10 @@ async fn run_cli(cli: Cli) -> Result<(), SoldrError> {
                     gc::run_gc_target_command(*args)?;
                     return Ok(());
                 }
+                Some(GcSubcommand::AutoSweep) => {
+                    gc::run_gc_auto_sweep_command()?;
+                    return Ok(());
+                }
                 None => gc::GcInvocation {
                     mode: gc::GcMode::Summary,
                     older_than,

--- a/crates/soldr-cli/src/save_load.rs
+++ b/crates/soldr-cli/src/save_load.rs
@@ -116,6 +116,24 @@ pub struct LoadArgs {
     pub auto_defender_exclude: bool,
 }
 
+/// Issue #1286 (F1): before archiving a cache tree, ask the ambient
+/// soldr-daemon to checkpoint its embedded zccache state (artifact
+/// index, depgraph snapshot, metadata cache) to disk. Without this,
+/// `soldr save` taken while the daemon is alive archives a tree whose
+/// rustc-side index is memory-only — the restored cache then serves
+/// zero rustc hits (the cold-tar-untar-warm 1.00x-speedup bug).
+/// Best-effort: an unreachable daemon means disk state is already the
+/// best available.
+fn flush_embedded_state_before_save() {
+    let Ok(paths) = crate::core::SoldrPaths::new() else {
+        return;
+    };
+    let sock = crate::daemon::server::server_sock_path(&paths);
+    if crate::daemon::client::flush_caches(&sock).is_ok() {
+        eprintln!("soldr save: embedded zccache state flushed via soldr-daemon");
+    }
+}
+
 pub fn run_save(args: SaveArgs) -> i32 {
     let args = match apply_private_session_cache_dir_default(
         args,
@@ -128,6 +146,9 @@ pub fn run_save(args: SaveArgs) -> i32 {
             return 1;
         }
     };
+    if args.cache_dir.is_some() {
+        flush_embedded_state_before_save();
+    }
     if let Some(base_manifest_path) = args.delta_from_manifest.as_deref() {
         let Some(cache_dir) = args.cache_dir.as_deref() else {
             eprintln!("soldr save: --delta-from-manifest requires --cache-dir");

--- a/crates/soldr-cli/tests/cli_daemon_flush_caches.rs
+++ b/crates/soldr-cli/tests/cli_daemon_flush_caches.rs
@@ -1,0 +1,153 @@
+//! Issue #1286 (F1): `soldr cache flush` must checkpoint the
+//! soldr-daemon's EMBEDDED zccache state (artifact index, depgraph
+//! snapshot, metadata cache) to disk via `Request::FlushCaches`.
+//!
+//! Before the fix, `cache flush` / `cache shutdown` only quiesced the
+//! managed zccache daemon (the C/C++ side); the embedded rustc-side
+//! state stayed memory-only until a graceful daemon exit, so `soldr
+//! save` archives taken from a live daemon restored with zero rustc
+//! hits (the cold-tar-untar-warm 1.00x-speedup bug).
+
+#![allow(clippy::print_stdout)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use soldr_cli::timed_test;
+
+mod common;
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("soldr-{label}-{nanos}"));
+    std::fs::create_dir_all(&dir).expect("failed to create temp dir");
+    dir
+}
+
+fn soldr_daemon_bin() -> PathBuf {
+    let soldr = common::soldr_bin();
+    let parent = soldr.parent().expect("parent");
+    let stem = if cfg!(windows) {
+        "soldr-daemon.exe"
+    } else {
+        "soldr-daemon"
+    };
+    parent.join(stem)
+}
+
+fn run_soldr(args: &[&str], cache_root: &Path, home_root: &Path) -> std::process::Output {
+    let mut cmd = Command::new(common::soldr_bin());
+    cmd.args(args)
+        .env("SOLDR_CACHE_DIR", cache_root)
+        .env("HOME", home_root)
+        .env("USERPROFILE", home_root)
+        .env_remove("RUSTC_WRAPPER");
+    cmd.output().expect("run soldr")
+}
+
+struct DaemonProc {
+    child: Option<Child>,
+    cache_root: PathBuf,
+    home_root: PathBuf,
+}
+
+impl DaemonProc {
+    fn spawn(cache_root: &Path, home_root: &Path) -> Self {
+        let mut cmd = Command::new(soldr_daemon_bin());
+        cmd.args(["--foreground", "--idle-timeout-secs", "60"])
+            .env("SOLDR_CACHE_DIR", cache_root)
+            .env("HOME", home_root)
+            .env("USERPROFILE", home_root)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = cmd.spawn().expect("spawn soldr-daemon");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let pid_file = cache_root
+            .join("cache")
+            .join("soldr-daemon")
+            .join("daemon.pid");
+        while Instant::now() < deadline {
+            if pid_file.exists() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        Self {
+            child: Some(child),
+            cache_root: cache_root.to_path_buf(),
+            home_root: home_root.to_path_buf(),
+        }
+    }
+}
+
+impl Drop for DaemonProc {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = run_soldr(&["daemon", "stop"], &self.cache_root, &self.home_root);
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while Instant::now() < deadline {
+                if let Ok(Some(_)) = child.try_wait() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn find_file(dir: &Path, name: &str) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(found) = find_file(&path, name) {
+                return Some(found);
+            }
+        } else if path.file_name().and_then(|n| n.to_str()) == Some(name) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+timed_test!(
+    cache_flush_checkpoints_embedded_state,
+    Duration::from_secs(120),
+    {
+        let cache_root = unique_temp_dir("flush-caches-cache");
+        let home_root = unique_temp_dir("flush-caches-home");
+        let daemon = DaemonProc::spawn(&cache_root, &home_root);
+
+        let out = run_soldr(&["cache", "flush", "--json"], &cache_root, &home_root);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            out.status.success(),
+            "cache flush must exit 0; stdout: {stdout}; stderr: {stderr}"
+        );
+        assert!(
+            stdout.contains("embedded zccache state flushed"),
+            "cache flush notes must confirm the embedded checkpoint ran \
+             (Request::FlushCaches -> Ack); stdout: {stdout}"
+        );
+
+        // The checkpoint must leave the embedded depgraph snapshot
+        // durable on disk — this is the file whose absence made
+        // archives restore with zero rustc hits.
+        let zccache_root = cache_root.join("cache").join("zccache");
+        assert!(
+            find_file(&zccache_root, "depgraph.bin").is_some(),
+            "embedded depgraph snapshot must exist under {} after flush",
+            zccache_root.display()
+        );
+
+        drop(daemon);
+    }
+);

--- a/crates/soldr-cli/tests/cli_gc_auto_sweep.rs
+++ b/crates/soldr-cli/tests/cli_gc_auto_sweep.rs
@@ -1,0 +1,48 @@
+//! Issue #1286 (F5): regression coverage for the auto-GC starvation fix.
+//!
+//! Before the fix, the auto-GC orchestrator was kicked at build START —
+//! microseconds after `build_active::set(true)` — so every tick
+//! deferred with `reason=build_active` and the sweep never executed on
+//! machines that only invoke soldr for builds (observed locally: days
+//! of continuous deferrals and a 36 GB cache). The fix spawns a
+//! detached `soldr gc auto-sweep` process at build END, and the sweep
+//! itself now records an `auto-gc status=run stage=start` line so
+//! "ran but found nothing" and "never ran" are distinguishable.
+
+use std::process::Command;
+
+use soldr_cli::timed_test;
+
+mod common;
+
+timed_test!(gc_auto_sweep_runs_and_logs_start_line, {
+    let cache_root = tempfile::tempdir().expect("cache tempdir");
+    let home_root = tempfile::tempdir().expect("home tempdir");
+
+    let out = Command::new(common::soldr_bin())
+        .args(["gc", "auto-sweep"])
+        .env("SOLDR_CACHE_DIR", cache_root.path())
+        .env("HOME", home_root.path())
+        .env("USERPROFILE", home_root.path())
+        .env_remove("RUSTC_WRAPPER")
+        .output()
+        .expect("run soldr gc auto-sweep");
+    assert!(
+        out.status.success(),
+        "auto-sweep must exit 0; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let log = cache_root.path().join("logs").join("auto-gc.log");
+    let content = std::fs::read_to_string(&log).unwrap_or_default();
+    assert!(
+        content.contains("status=run stage=start"),
+        "auto-gc.log must record that the sweep STARTED (not just \
+         deferrals); log content: {content:?}"
+    );
+    assert!(
+        !content.contains("reason=build_active"),
+        "a standalone auto-sweep process must not consider a build \
+         active; log content: {content:?}"
+    );
+});

--- a/docker/cook-shared-cache/Dockerfile
+++ b/docker/cook-shared-cache/Dockerfile
@@ -41,6 +41,10 @@ RUN apt-get update \
        git \
        ca-certificates \
        curl \
+       cmake \
+       ninja-build \
+       jq \
+       zstd \
     && rm -rf /var/lib/apt/lists/*
 
 # soldr's `cargo test` jobs check the system rustc version; pin it here


### PR DESCRIPTION
Closes #1286.

## What this fixes

### F1 — cold-tar-untar-warm at 1.00x speedup despite '100% hit rate' (also the #1146 mystery)

Root cause (validated in the docker-linux harness): the embedded zccache service inside soldr-daemon kept its artifact index, depgraph snapshot, and metadata cache **memory-only** until a graceful daemon exit. `soldr cache flush` / `cache shutdown` only quiesced the **managed** zccache daemon (the C/C++ build-script side), so `soldr save` archived a cache tree whose rustc-side index did not exist on disk. The restored cache served **zero rustc hits** while session stats — which only count the managed daemon's ~30 `cc` compiles — reported 'hit rate 100%'.

Evidence (medium fixture, docker linux):

| flow | warm build |
|---|---|
| same cache dir, daemon alive | 3.0s (cold 107s) |
| save/load or even a full `cp -a` of the cache dir | ~70s ≈ cold |
| graceful `soldr daemon stop`, then archive | 12–15s |
| **with this PR (save/flush checkpoint)** | **12.2s (cold 116s, ~9.5x)** |

Changes:
- **Protocol v8**: `Request::FlushCaches` — checkpoint embedded state to disk without shutting down (replies `Ack`); wire tag 14, `.proto` doc, round-trip test.
- `soldr save` best-effort-flushes the ambient daemon before walking the cache tree; `soldr cache flush` / `cache shutdown` gain an embedded-checkpoint step (the same zero-warm-hit archive race #383 fixed for the managed daemon, one layer up).
- soldr-daemon handles **SIGTERM** via the graceful-drain path on unix (TERM previously discarded the in-memory index — every `pkill`/container-stop was a full cold cache).
- perf-matrix: `cold-tar-untar-warm` Evaluate gate **re-promoted warn → fail**, closing out the #1146/#1148 demotion exactly as its TEMPORARY comment instructed.

### F5 — auto-GC never ran (days of `reason=build_active` deferrals, 36 GB cache)

The GC kick fired at build START, microseconds after `build_active::set(true)` — every tick deferred and re-armed. Now the front door spawns a detached `soldr gc auto-sweep` process at build END (survives the wrapper's exit; 5-min throttle marker unchanged), and the sweep logs `status=run stage=start` so 'ran but idle' vs 'never ran' is distinguishable.

### F2 — embedded compile journal (via zccache#950 / 1.12.12)

Submodule bumped to the merged zccache fix: the embedded backend now writes `compile_journal.jsonl` with the same outcome + `miss_reason` attribution as the daemon IPC path. rustc hit/miss telemetry exists again on dev machines.

### Harness

`docker/cook-shared-cache` image gains cmake/ninja-build (new transitive build deps) and jq/zstd (perf scenario prerequisites).

## Validation (all in the docker-linux harness, per the #1105 rule — no raw-host runs)

- Scenario replica: cold 116.4s → save 1.2s → load 0.7s → `cargo clean` → **warm 12.2s, 30/30 hits** (pre-fix: 75s, 1.00x).
- `cli_daemon_flush_caches` (new): real daemon + `soldr cache flush --json` → embedded-checkpoint note + durable `depgraph.bin`.
- `cli_gc_auto_sweep` (new): sweep runs, logs `status=run`, no `build_active` deferral.
- wire round-trip tests (19) green; `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` green.

## Follow-ups (deliberately not in this PR)

- `soldr save --ci` minimal-profile archive (owner requirement: don't blow GH runner cache limits) — the current fix does not grow the archive (~77 MB for the medium fixture), but an explicit minimal/CI mode + setup-soldr knob deserves its own issue.
- `MANAGED_ZCCACHE_VERSION` 1.12.12 pin bump lands as a follow-up commit on this PR once the zccache Auto-Release publishes binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)