### PR TITLE
release: 0.7.99 — managed zccache 1.12.12 pin + protocol-v8 test repair (#1286 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.98"
+version = "0.7.99"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.98"
+version = "0.7.99"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/contracts/zccache-runtime.v1.json
+++ b/contracts/zccache-runtime.v1.json
@@ -18,7 +18,7 @@
     "linux_zccache_target_libc": "musl"
   },
   "zccache": {
-    "managed_version": "1.12.11",
+    "managed_version": "1.12.12",
     "local_dir_env": "SOLDR_ZCCACHE_LOCAL_DIR",
     "cache_dir_env": "ZCCACHE_CACHE_DIR",
     "required_binaries": [

--- a/crates/soldr-cli/src/daemon/protocol.rs
+++ b/crates/soldr-cli/src/daemon/protocol.rs
@@ -366,11 +366,12 @@ pub struct BuildRecord {
 mod tests {
     use super::*;
 
-    crate::timed_test!(protocol_version_is_v7_after_streaming_compile, {
-        // Bumped from 6 → 7 in #983 Phase 5b when the daemon switched
-        // from a single-frame Response::Compile to streaming
-        // CompileStdoutChunk / CompileStderrChunk / CompileDone.
-        assert_eq!(PROTOCOL_VERSION, 7);
+    crate::timed_test!(protocol_version_is_v8_after_flush_caches, {
+        // Bumped from 7 → 8 in #1286 F1 when Request::FlushCaches was
+        // added so `soldr save` / `cache flush` can checkpoint the
+        // embedded zccache state without a daemon shutdown. (7 came
+        // from #983 Phase 5b's streaming Compile reply.)
+        assert_eq!(PROTOCOL_VERSION, 8);
     });
 
     crate::timed_test!(chunk_bytes_is_64_kib, {

--- a/crates/soldr-cli/src/fetch/mod.rs
+++ b/crates/soldr-cli/src/fetch/mod.rs
@@ -153,7 +153,7 @@ pub struct FetchResult {
     pub cached: bool,
 }
 
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.11";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.12";
 
 /// The soldr version segment used by per-version `~/.soldr/v<X.Y.Z>/**`
 /// state. Source of truth for `SoldrPaths::versioned_root` and

--- a/crates/soldr-cli/src/zccache.rs
+++ b/crates/soldr-cli/src/zccache.rs
@@ -1356,13 +1356,13 @@ mod tests {
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.12.11/zccache"),
+                std::path::Path::new("/tmp/cache-cold/bin/zccache-1.12.12/zccache"),
                 std::path::Path::new("/tmp/cache-cold/cache/zccache"),
             ),
             resolve_private_zccache_daemon_name(
                 None,
                 std::path::Path::new("/repo/target/debug/soldr"),
-                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.12.11/zccache"),
+                std::path::Path::new("/tmp/cache-warm/bin/zccache-1.12.12/zccache"),
                 std::path::Path::new("/tmp/cache-warm/cache/zccache"),
             ),
             "managed zccache binaries under different SOLDR_CACHE_DIR roots must hash by runtime identity, not absolute path",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Two commits stranded when #1295 was merged mid-push:

1. **test repair (unbreaks main)**: #1295 landed `PROTOCOL_VERSION = 8` (`Request::FlushCaches`) but the squash happened before the matching pin-test update was pushed — `daemon::protocol::tests::protocol_version_is_v7_after_streaming_compile` now fails on main's target-run lanes. This updates the pin test to v8.
2. **release bump**: soldr 0.7.98 → 0.7.99 (Cargo.toml + package.json + Cargo.lock lockstep) and `MANAGED_ZCCACHE_VERSION` 1.12.11 → 1.12.12 (fetch/mod.rs + `contracts/zccache-runtime.v1.json` + zccache.rs fixtures) pulling in the embedded-journal release ([zccache#950](https://github.com/zackees/zccache/pull/950), published with 15 assets). Merging ships #1286's FlushCaches checkpoint + auto-GC fix as a release.

## Validation (docker-linux harness)

- `version_lockstep` + zccache contract tests green with the bump.
- Full lib suite 555/555 green.
- Same-tree release build succeeds (`soldr-cli v0.7.99`).

Part of #1286 (already closed by #1295 — this completes the release story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)