### PR TITLE
ci(build-and-test): remove dead 'cache_key' input (#1305)

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -24,13 +24,6 @@ on:
         # (e.g. "windows-x86_64-msvc").
         required: true
         type: string
-      cache_key:
-        # Optional extra key segment so two callers on the same
-        # platform (e.g. workspace build vs. lint) don't collide
-        # inside the same shared-key bucket.
-        required: false
-        type: string
-        default: ''
       # soldr#1218 — `run_fetch_test` input removed. It gated a
       # dedicated `cargo test --test fetch_crgx` step that duplicated
       # what `Run CLI smoke tests` already covers via `--tests`. The


### PR DESCRIPTION
Fixes #1305.

## Summary
- Remove \`cache_key\` input from \`_build-and-test.yml\`.

## Why
Nothing references it — no caller passes \`cache_key:\`, and
\`inputs.cache_key\` isn't used inside the workflow. Same cleanup
class as #1293's \`build_test_archive\` removal.

## Test plan
- [ ] Lint stays green.
- [ ] \`build-linux-x64\` job still runs successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)