### PR TITLE
ci(bootstrap-e2e): remove dead 'save_cache' input (#1307)

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -12,10 +12,6 @@ on:
       binary_name:
         required: true
         type: string
-      save_cache:
-        required: false
-        type: boolean
-        default: false
       source_ref:
         required: true
         type: string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,6 @@ jobs:
       runner: ubuntu-24.04
       target: x86_64-unknown-linux-gnu
       binary_name: soldr
-      save_cache: ${{ github.event_name == 'push' }}
       source_ref: ${{ github.sha }}
 
   # soldr#1051 / #1038: all cross-builds go through the consolidated


### PR DESCRIPTION
Fixes #1307.

## Summary
- Remove \`save_cache\` input from \`_bootstrap-e2e.yml\`.
- Drop the \`save_cache: \${{ github.event_name == 'push' }}\` line from
  \`ci.yml\`'s call to it.

## Why
\`inputs.save_cache\` is never referenced inside the workflow — the
input was a no-op the whole time. Same cleanup class as #1293 /
#1305.

## Test plan
- [ ] Lint stays green.
- [ ] \`e2e-linux-x64\` (build) job still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)