### PR TITLE
ci(cross-build): bump rust-cache shared-key v2 → v3 to purge libz-ng-sys corruption (#1315)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -205,13 +205,14 @@ jobs:
       - name: Restore cargo + target caches
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          # soldr#1287 — v2 suffix bumped after #1283 added
-          # [profile.ci-bootstrap]. Swatinem/rust-cache keys on Cargo.lock,
-          # not Cargo.toml — the pre-#1283 primary key still HIT and served
-          # stale (release-only) cache, and Swatinem never re-saves once the
-          # primary key exists. Bumping the shared-key forces a MISS →
-          # fresh save with the ci-bootstrap/ subdir included.
-          shared-key: cross-build-${{ inputs.target }}-v2
+          # soldr#1287 → v2 forced a fresh save with the ci-bootstrap/
+          # subdir; soldr#1315 → v3 forces another fresh save because
+          # the v2 primary key stuck with a cargo registry snapshot
+          # where libz-ng-sys-1.1.29's src/zlib-ng was missing
+          # zlib-ng.map.in + test/. Every darwin run inherited that
+          # broken extraction (rust-cache only saves on primary-key
+          # miss). Bumping to v3 forces a clean re-fetch.
+          shared-key: cross-build-${{ inputs.target }}-v3
 
       # Bootstrap soldr from the current checkout. Darwin uses it to
       # drive `soldr prepare --target ... --github-env`. Windows MSVC


### PR DESCRIPTION
Fixes #1315.

## Summary
Bump \`Restore cargo + target caches\` shared-key from
\`cross-build-<target>-v2\` to \`cross-build-<target>-v3\`.

## Why
Main is red on darwin cross-build lanes:

    CMake Error: File .../libz-ng-sys-1.1.29/src/zlib-ng/zlib-ng.map.in
    does not exist.
    error: failed to run custom build command for \`libz-ng-sys v1.1.29\`

The v2 cache HITS full match but the extracted crate source is missing
\`.map.in\` + \`test/\`. Same class of stale-cache issue as #1287 — Swatinem
only saves on primary-key MISS, so once the v2 key stuck with a broken
libz-ng-sys extraction, every darwin run inherits it.

Bumping to v3 forces a fresh save on the first post-merge run with a
clean cargo registry. Subsequent runs HIT with clean state.

## Test plan
- [ ] Lint stays green.
- [ ] Darwin cross-build lanes pass after this lands.
- [ ] First post-merge run is slower (fresh compile); second run
      back to normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)