### PR TITLE
release: bump version to 0.7.100

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "soldr-cli"
-version = "0.7.99"
+version = "0.7.100"
 dependencies = [
  "blake3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.99"
+version = "0.7.100"
 edition = "2021"
 rust-version = "1.94.1"
 license = "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zackees/soldr",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "Instant Rust tools and builds from one command.",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/zackees/soldr",


### PR DESCRIPTION
Publishes the #1309 self-provisioning fix (#1310, merged): `soldr build --target *-apple-darwin` / `*-pc-windows-msvc` now bootstraps the LLVM toolchain (clang / llvm-ar / lld) from **`zackees/clang-tool-chain-bins`** itself, so cross builds require **no host `apt install clang lld llvm`**.

Validated locally via `ci/docker-selfhost-cross/` — a bare image with zero cross toolchain — where `soldr build --target aarch64-apple-darwin` self-fetched LLVM v21.1.5 (sha256-verified) and produced a genuine Mach-O binary; the msvc arm likewise self-fetched LLVM + xwin-cache + cmake/ninja.

Three-file lockstep per CLAUDE.md: `Cargo.toml`, `package.json`, `Cargo.lock` all at 0.7.100.

Once 0.7.100 lands on PyPI it becomes the pinned driver for the remaining #1309 work (build-all-from-Linux workflow + `release-auto.yml` conversion, both pinning 0.7.100 with zero host toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)