### PR TITLE
ci(cross-build): pass SOLDR_GITHUB_TOKEN so soldr's fetch is authenticated (#1319)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -49,6 +49,12 @@ jobs:
       # run (and fall back to vendored compile if it fails). Required
       # after PR #1111 expanded the transitive *-sys dep tree.
       PKG_CONFIG_ALLOW_CROSS: "1"
+      # soldr#1319 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN
+      # for authenticated GitHub Releases lookups (5,000/hr) instead of
+      # unauthenticated (60/hr per runner IP). Without this a busy CI
+      # window can push a lane into the `cargo install zccache` fallback
+      # (~700 s of source compile) — observed in run 28731872479.
+      SOLDR_GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Fixes #1319.

## Summary
- Add \`SOLDR_GITHUB_TOKEN: \${{ github.token }}\` to
  \`_ci-cross-build-linux.yml\`'s job \`env:\` block.

## Why
Empirical: run 28731872479 darwin-x86_64 hit unauthenticated GitHub
API rate limit (60/hr per runner IP), retried 4 times, then fell
through to \`cargo install zccache\` — 929 s cross-build vs ~200 s
baseline.

Every OTHER workflow-that-runs-soldr exports SOLDR_GITHUB_TOKEN. Only
this one was missing it. Grep-verified.

## Expected impact
- Eliminates the rate-limit fallback path on cross-build lanes.
- Removes the outlier where a lane blows to 1000+ s.
- Zero cost when rate isn't at issue.

## Test plan
- [ ] Lint stays green.
- [ ] Cross-build lanes stay at baseline wallclock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)