### PR TITLE
ci: pass SOLDR_GITHUB_TOKEN in cross-compile-all-targets.yml (#1322)

### DIFF
--- a/.github/workflows/cross-compile-all-targets.yml
+++ b/.github/workflows/cross-compile-all-targets.yml
@@ -50,6 +50,12 @@ env:
   FORCE_COLOR: "1"
   CLICOLOR_FORCE: "1"
   PY_COLORS: "1"
+  # soldr#1322 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN for
+  # authenticated GitHub Releases lookups (5,000/hr) instead of
+  # unauthenticated (60/hr per runner IP). Without this a busy CI window
+  # pushes a lane into the `cargo install zccache` fallback (~700 s of
+  # source compile). See soldr#1319 for the CI-lane fix.
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
   bootstrap-and-linux-x86:


### PR DESCRIPTION
Fixes #1322 (partial — cross-compile-all-targets.yml only).

## Summary
- Add \`SOLDR_GITHUB_TOKEN: \${{ github.token }}\` to
  \`cross-compile-all-targets.yml\`'s workflow-level \`env:\` block.

## Why
Follow-up to #1319 which added the token to \`_ci-cross-build-linux.yml\`.
This workflow is the next-most-important soldr-invoking workflow
missing the token — production release cross-compile.

Without the token, any lane whose zccache fetch hits the unauthenticated
GitHub rate limit falls to \`cargo install zccache\` — ~700 s of source
compile per lane.

## Follow-up
Remaining workflows (perf-*, benchmark-stats, cache-delta-experiment,
etc.) tracked in #1322 will follow.

## Test plan
- [ ] Lint stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)