### PR TITLE
ci(build-and-test): combine 'Run library tests' + 'Run CLI smoke tests' (#1324)

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -136,7 +136,13 @@ jobs:
       - name: Stop setup-soldr builder cache before tests
         uses: zackees/setup-soldr/cleanup@cca74625e75e70b56f1805fa6eeee9069f945d48
 
-      - name: Run library tests
+      # soldr#1324 — combined `Run library tests` + `Run CLI smoke tests`
+      # into one cargo invocation. Workspace has one member (soldr-cli),
+      # so `--workspace --lib` ≡ `-p soldr-cli --lib`. Merging with
+      # `--tests` lets cargo's libtest scheduler interleave lib-tests
+      # and integration binaries — no wasted cargo-startup +
+      # freshness-check pass between the two former steps.
+      - name: Run library + CLI smoke tests
         shell: pwsh
         env:
           SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}
@@ -147,31 +153,12 @@ jobs:
           Write-Host "Using isolated test SOLDR_CACHE_DIR=$env:SOLDR_CACHE_DIR"
           Write-Host "Using isolated test ZCCACHE_CACHE_DIR=$env:ZCCACHE_CACHE_DIR"
           $timer = [Diagnostics.Stopwatch]::StartNew()
-          & $env:LOCAL_SOLDR cargo test --workspace --lib --locked --target ${{ inputs.target }}
+          & $env:LOCAL_SOLDR cargo test -p soldr-cli --lib --tests --locked --target ${{ inputs.target }}
           $exitCode = $LASTEXITCODE
           $timer.Stop()
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
             [Globalization.CultureInfo]::InvariantCulture,
-            "- **${{ inputs.target }} / Library tests**: {0:F3}s",
-            $timer.Elapsed.TotalSeconds
-          ))
-          exit $exitCode
-
-      - name: Run CLI smoke tests
-        shell: pwsh
-        env:
-          SOLDR_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}
-          SOLDR_CACHE_LIFECYCLE: command
-          SOLDR_CACHE_SHUTDOWN_TIMEOUT_SECS: "30"
-          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/soldr-self-tests/${{ inputs.target }}/cache/zccache
-        run: |
-          $timer = [Diagnostics.Stopwatch]::StartNew()
-          & $env:LOCAL_SOLDR cargo test -p soldr-cli --tests --locked --target ${{ inputs.target }}
-          $exitCode = $LASTEXITCODE
-          $timer.Stop()
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ([string]::Format(
-            [Globalization.CultureInfo]::InvariantCulture,
-            "- **${{ inputs.target }} / CLI smoke tests**: {0:F3}s",
+            "- **${{ inputs.target }} / Library + smoke tests**: {0:F3}s",
             $timer.Elapsed.TotalSeconds
           ))
           exit $exitCode


### PR DESCRIPTION
Fixes #1324.

## Summary
Merge \`Run library tests\` (\`cargo test --workspace --lib\`) and
\`Run CLI smoke tests\` (\`cargo test -p soldr-cli --tests\`) into one
\`cargo test -p soldr-cli --lib --tests\` invocation.

## Why
Workspace has one member (soldr-cli), so \`--workspace --lib\` ≡
\`-p soldr-cli --lib\`. Merging skips duplicate cargo startup +
freshness-check pass and lets one libtest scheduler interleave lib
tests and integration binaries.

Empirical baseline (Linux x64 job, post-#1323):
- Run library tests: 95 s
- Run CLI smoke tests: 118 s

Expected combined: 200-208 s (5-15 s wallclock trim).

## Test plan
- [ ] Lint stays green.
- [ ] Linux x64 job runs \`Run library + smoke tests\` step and it passes.
- [ ] Same test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)