### PR TITLE
ci: pass SOLDR_GITHUB_TOKEN in remaining soldr-invoking workflows (#1322)

### DIFF
--- a/.github/workflows/parent-cache-bench.yml
+++ b/.github/workflows/parent-cache-bench.yml
@@ -54,6 +54,10 @@ jobs:
     env:
       TARGET: ${{ inputs.target || 'self' }}
       THRESHOLD: ${{ inputs.threshold_ratio || '5' }}
+      # soldr#1322 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN
+      # for authenticated GitHub Releases lookups (5,000/hr) instead of
+      # unauthenticated (60/hr per runner IP). Follow-up to #1319 / #1323.
+      SOLDR_GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/perf-cold-warm.yml
+++ b/.github/workflows/perf-cold-warm.yml
@@ -69,6 +69,10 @@ env:
   # cache restore/save and the `soldr cargo build` step have to
   # agree on this path.
   SOLDR_CACHE_ROOT: ${{ github.workspace }}/.soldr-perf
+  # soldr#1322 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN
+  # for authenticated GitHub Releases lookups (5,000/hr) instead of
+  # unauthenticated (60/hr per runner IP). Follow-up to #1319 / #1323.
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
   build-soldr:

--- a/.github/workflows/thin-v2-verify.yml
+++ b/.github/workflows/thin-v2-verify.yml
@@ -64,6 +64,10 @@ jobs:
     env:
       SOLDR_TARGET_CACHE_PROFILE: thin-v2
       CARGO_TERM_COLOR: never
+      # soldr#1322 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN
+      # for authenticated GitHub Releases lookups (5,000/hr) instead of
+      # unauthenticated (60/hr per runner IP). Follow-up to #1319 / #1323.
+      SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Follow-up to #1319 (_ci-cross-build-linux.yml) and #1323
(cross-compile-all-targets.yml). Closes the remaining items in #1322.

## Summary
Add \`SOLDR_GITHUB_TOKEN: \${{ github.token }}\` to three more workflows
that call soldr:

- perf-cold-warm.yml
- parent-cache-bench.yml
- thin-v2-verify.yml

## Why
Without the token, soldr's GitHub Releases fetch of zccache runs
unauthenticated (60/hr per runner IP). A busy CI window pushes the
lane into \`cargo install zccache\` — ~700 s of source compile.

## Test plan
- [ ] Lint stays green.
- [ ] Workflows still triggerable (no YAML syntax break).

## Non-goals
Not touching perf-matrix.yml (has multiple step-level env blocks — needs
per-step care; separate PR). Not touching benchmark-stats,
cache-delta-experiment, vcpkg-windows-refresh (low frequency, can wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)