### PR TITLE
fix(profile): stop the perf harness clobbering its own soldr binary

### DIFF
--- a/ci/docker/profile/run_profile.sh
+++ b/ci/docker/profile/run_profile.sh
@@ -73,8 +73,30 @@ if [[ ! -x "${SOLDR_BIN}" ]]; then
 fi
 log "soldr binary : ${SOLDR_BIN}"
 
-# Ensure soldr is on PATH so its env-detection wins over any host soldr.
-export PATH="/tmp/soldr-target/release:${PATH}"
+# Install soldr + soldr-daemon into a stable PATH location that is NOT
+# under CARGO_TARGET_DIR. Previously the harness put the binary's own
+# dir (/tmp/soldr-target/release) on PATH, but CARGO_TARGET_DIR was
+# also /tmp/soldr-target and got INHERITED by the scenario builds — so
+# the first `soldr cargo build <fixture>` rebuilt an unrelated
+# workspace into that shared target dir and cargo deleted the soldr
+# binary. The warm build (and every subsequent scenario) then died
+# with "soldr: command not found" / "No such file or directory",
+# leaving the flamegraphs + hit-rate data empty. Copying the binaries
+# out to /usr/local/bin decouples the driver from fixture target-dir
+# churn.
+install -m 0755 "${SOLDR_BIN}" /usr/local/bin/soldr
+install -m 0755 /tmp/soldr-target/release/soldr-daemon /usr/local/bin/soldr-daemon 2>/dev/null || true
+SOLDR_BIN=/usr/local/bin/soldr
+log "soldr installed to : ${SOLDR_BIN} ($("${SOLDR_BIN}" --version 2>/dev/null | head -1))"
+
+# CRITICAL: stop exporting CARGO_TARGET_DIR into the scenarios. It was
+# only needed to build the soldr driver above (already done). If the
+# scenarios inherit it, every fixture builds into ONE shared target
+# dir — which both clobbers the soldr binary (above) AND destroys the
+# cold/warm isolation the hit-rate measurements depend on (scenario 2's
+# "cold" build would reuse scenario 1's artifacts). Each scenario must
+# build its fixture into its own default (fixture-local) target dir.
+unset CARGO_TARGET_DIR
 
 log "rustc        : $(command -v rustc) ($(rustc --version))"
 log "cargo        : $(command -v cargo) ($(cargo --version))"


### PR DESCRIPTION
## The bug

The Linux profile harness (`ci/docker/profile/run_profile.sh`) exports `CARGO_TARGET_DIR=/tmp/soldr-target` to build the soldr driver, then puts `/tmp/soldr-target/release` on PATH — but **never unsets `CARGO_TARGET_DIR` before the scenario loop**. The perf-matrix scenarios inherit it, so the first `soldr cargo build <fixture>` rebuilds an unrelated workspace into that shared target dir and **cargo removes the soldr binary**. Cold's warm build then fails with `No such file or directory`, and scenarios 2-4 die with `soldr: command not found`.

Effect: 3.5 of 4 scenarios never actually run. The flamegraphs are empty (`oncpu.folded` = 0 lines), the top-5 is pure kernel `__schedule`/`[unknown]` noise, and there are **no real hit/miss numbers**. Every prior profiling artifact was garbage.

## The fix

1. `install` soldr + soldr-daemon into `/usr/local/bin` — a stable PATH location **outside** any fixture target dir — and drive from there.
2. `unset CARGO_TARGET_DIR` before the scenario loop, so each scenario builds its fixture into its own default target dir. This also restores the cold/warm isolation the hit-rate measurements depend on (previously every scenario shared one target dir, so a "cold" build would reuse a prior scenario's artifacts).

## Validation (in-container, this branch)

All 4 scenarios now run; `oncpu.folded` has ~12-13k real stacks each (was 0); and the hit rates land exactly where expected:

| Scenario | Hit rate |
|---|---|
| cold-tar-untar-warm | cold 0% → warm **100%** |
| worktree-share | **100%** (path-remap cross-worktree) |
| touch-no-change | **100%** (content-hash freshness) |
| build-then-check | **100%** (cross-verb reuse) |

So soldr's cache is correct — the earlier 0%/missing data was purely this harness bug. The now-real flamegraphs unblock actual slowdown-hunting (rustc interning + allocator dominate, as expected for a thin wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)