### PR TITLE
ci: pass SOLDR_GITHUB_TOKEN in release-auto.yml (#1322 follow-up)

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -22,6 +22,11 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  # soldr#1322 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN
+  # for authenticated GitHub Releases lookups (5,000/hr) instead of
+  # unauthenticated (60/hr per runner IP). Follow-up to #1319 / #1323 /
+  # #1326.
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
 concurrency:
   group: release-auto-${{ github.ref_name }}


### PR DESCRIPTION
Follow-up to #1319 / #1323 / #1326.

## Summary
Add \`SOLDR_GITHUB_TOKEN: \${{ github.token }}\` to
\`release-auto.yml\`'s workflow-level \`env:\` block.

## Why
release-auto.yml runs on every release-version-bump PR (frequent).
Without the token, soldr's zccache fetch runs unauthenticated (60/hr
per runner IP) and can fall through to \`cargo install zccache\` — 700 s
of source compile per lane.

Same one-line pattern as #1319 / #1323 / #1326.

## Test plan
- [ ] Lint stays green.
- [ ] release-auto still triggers on release PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)