### PR TITLE
ci: pass SOLDR_GITHUB_TOKEN in build-all-from-linux.yml (#1322 follow-up)

### DIFF
--- a/.github/workflows/build-all-from-linux.yml
+++ b/.github/workflows/build-all-from-linux.yml
@@ -39,6 +39,11 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # soldr#1322 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN
+  # for authenticated GitHub Releases lookups (5,000/hr) instead of
+  # unauthenticated (60/hr per runner IP). Follow-up to #1319 / #1323 /
+  # #1326 / #1328.
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
   build-all:


### PR DESCRIPTION
Follow-up to #1319 / #1323 / #1326 / #1328.

## Summary
Add \`SOLDR_GITHUB_TOKEN: \${{ github.token }}\` to
\`build-all-from-linux.yml\`'s workflow-level \`env:\` block.

## Why
This workflow runs soldr for every matrix target. Without the token,
soldr's zccache fetch runs unauthenticated (60/hr per runner IP) and
can fall through to \`cargo install zccache\` on a busy CI window.

Same one-line pattern as prior PRs.

## Test plan
- [ ] Lint stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)