### PR TITLE
ci: pass SOLDR_GITHUB_TOKEN in perf-matrix.yml (#1322 follow-up)

### DIFF
--- a/.github/workflows/perf-matrix.yml
+++ b/.github/workflows/perf-matrix.yml
@@ -84,6 +84,14 @@ on:
 permissions:
   contents: read
 
+env:
+  # soldr#1322 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN
+  # for authenticated GitHub Releases lookups (5,000/hr) instead of
+  # unauthenticated (60/hr per runner IP). Follow-up to #1319 / #1323 /
+  # #1326 / #1328 / #1329. Every step in this perf harness that
+  # invokes soldr (build-soldr, benchmark, evaluate) inherits it.
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
+
 concurrency:
   # Never cancel a perf run in flight — every measurement is a data
   # point we want to keep, even if a follow-up push lands before this


### PR DESCRIPTION
Follow-up to #1319 / #1323 / #1326 / #1328 / #1329.

## Summary
Add a workflow-level \`env:\` block with \`SOLDR_GITHUB_TOKEN\` to
\`perf-matrix.yml\`.

## Why
perf-matrix.yml runs on nightly cron + push:main + workflow_dispatch,
and every soldr-invoking step (build-soldr, benchmark, evaluate)
inherits workflow-level env. Without the token, soldr's zccache fetch
runs unauthenticated (60/hr per runner IP) and can fall through to
\`cargo install zccache\` — ~700 s of source compile.

Same one-line pattern as prior PRs.

## Test plan
- [ ] Lint stays green.
- [ ] Next perf-matrix run doesn't hit rate-limit fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)