### PR TITLE
perf(profile): add dwarf call-graph knob + bound the perf-script fold

### DIFF
--- a/ci/docker/profile/README.md
+++ b/ci/docker/profile/README.md
@@ -92,6 +92,8 @@ Leaf frames are normalized (address offsets stripped so `foo+0x12` and
 | `SOLDR_PROFILE_HZ` | `99` | `perf record -F` rate. Higher = finer-grained but bigger `perf.data` |
 | `SOLDR_PROFILE_SCENARIOS` | `cold-tar-untar-warm worktree-share touch-no-change build-then-check` | Space-separated scenario list. Drop tokens to skip cases. |
 | `SOLDR_PROFILE_FIXTURE_NAME` | `medium` | Fixture name (extracted via `perf/lib/extract.sh`) |
+| `SOLDR_PROFILE_CALL_GRAPH` | `fp` | On-CPU unwind method. `fp` = frame pointers (soldr is built with `-C force-frame-pointers`; fast fold, but leaves soldr's own Rust frames as `[soldr]`). `dwarf` = `.debug_frame` unwind, which resolves soldr's function symbols — **but the `perf script` fold is very heavy on large captures and can take ~1 h+ on WSL2**, so use it only on a capable runner (and see `SOLDR_PROFILE_FOLD_TIMEOUT`). |
+| `SOLDR_PROFILE_FOLD_TIMEOUT` | `600` | Seconds the on-CPU `perf script` fold may run before it is killed and that scenario's chart is skipped (a slow fold degrades gracefully instead of hanging the whole harness). `0` disables the bound. |
 
 The fixture defaults to `perf/fixtures/medium` (the same one the Perf
 Matrix uses), so the profile data lines up with the gate-workflow numbers.

--- a/ci/docker/profile/scripts/run_scenario.sh
+++ b/ci/docker/profile/scripts/run_scenario.sh
@@ -26,6 +26,13 @@ FIXTURE_DIR="$2"
 OUT_DIR="$3"
 
 SAMPLE_HZ=${SOLDR_PROFILE_HZ:-99}
+# Call-graph unwind method for the on-CPU sampler. Default `fp` (frame
+# pointers — soldr is built with -C force-frame-pointers). Set
+# `SOLDR_PROFILE_CALL_GRAPH=dwarf` to unwind via .debug_frame instead,
+# which resolves soldr's own Rust frames (the `[soldr]` leaves that FP
+# unwinds leave unresolved) at the cost of larger perf.data + slower
+# folding. `dwarf,<N>` sets the stack-dump size (default 8192).
+CALL_GRAPH=${SOLDR_PROFILE_CALL_GRAPH:-fp}
 SCENARIO_SCRIPT="/work/perf/scenarios/${SCENARIO_NAME}/run.sh"
 
 if [[ ! -x "${SCENARIO_SCRIPT}" ]] && [[ ! -f "${SCENARIO_SCRIPT}" ]]; then
@@ -81,7 +88,8 @@ sleep 2
 
 # On-CPU sampler — perf record wrapping the scenario invocation.
 log "==> starting on-CPU sampler wrapping ${SCENARIO_SCRIPT}"
-perf record -F "${SAMPLE_HZ}" -g --call-graph fp \
+log "on-CPU call-graph : ${CALL_GRAPH}"
+perf record -F "${SAMPLE_HZ}" -g --call-graph "${CALL_GRAPH}" \
     -o "/tmp/perf-${SCENARIO_NAME}.data" \
     -- bash "${SCENARIO_SCRIPT}" "${FIXTURE_DIR}" \
     > "${OUT_DIR}/scenario.stdout.log" 2> "${OUT_DIR}/scenario.stderr.log" || true
@@ -101,10 +109,23 @@ sleep 2
 [[ -s "/tmp/perf-sched-${SCENARIO_NAME}.data" ]] && cp "/tmp/perf-sched-${SCENARIO_NAME}.data" "${OUT_DIR}/perf-sched.data"
 
 # --- on-CPU flame chart --------------------------------------------
-log "==> rendering on-CPU flame chart"
+# `perf script` unwinding a DWARF capture (SOLDR_PROFILE_CALL_GRAPH=dwarf)
+# can take enormous time/memory on large captures — on WSL2 it has been
+# observed to churn for ~1 h on a single scenario without finishing.
+# Bound it so a slow fold degrades to "no on-CPU chart for this scenario"
+# instead of hanging the whole harness. Override with
+# SOLDR_PROFILE_FOLD_TIMEOUT (seconds; 0 disables the bound).
+FOLD_TIMEOUT=${SOLDR_PROFILE_FOLD_TIMEOUT:-600}
+if [[ "${FOLD_TIMEOUT}" -gt 0 ]]; then
+    FOLD_GUARD=(timeout --signal=KILL "${FOLD_TIMEOUT}")
+else
+    FOLD_GUARD=()
+fi
+log "==> rendering on-CPU flame chart (fold timeout: ${FOLD_TIMEOUT}s)"
 if [[ -s "${OUT_DIR}/perf.data" ]]; then
-    perf script -i "${OUT_DIR}/perf.data" > "/tmp/perf-${SCENARIO_NAME}.script" \
-        2>> "${OUT_DIR}/perf.log" || log "warn: perf script failed"
+    "${FOLD_GUARD[@]}" perf script -i "${OUT_DIR}/perf.data" > "/tmp/perf-${SCENARIO_NAME}.script" \
+        2>> "${OUT_DIR}/perf.log" \
+        || log "warn: perf script failed or timed out after ${FOLD_TIMEOUT}s (try SOLDR_PROFILE_CALL_GRAPH=fp, or a longer SOLDR_PROFILE_FOLD_TIMEOUT)"
     stackcollapse-perf.pl "/tmp/perf-${SCENARIO_NAME}.script" > "${OUT_DIR}/oncpu.folded" \
         2>> "${OUT_DIR}/perf.log" || log "warn: collapse failed"
     flamegraph.pl --title "soldr on-CPU (${SCENARIO_NAME})" \


### PR DESCRIPTION
Two harness improvements to `ci/docker/profile`, found while profiling soldr for the perf loop.

## 1. `SOLDR_PROFILE_CALL_GRAPH` (default `fp`, opt-in `dwarf`)

Under `fp`, soldr's own frames unwind as unresolved `[soldr]` leaves, so the on-CPU flame graph can't attribute soldr's CPU to real functions. `dwarf` unwinds via `.debug_frame` and resolves the symbols. Default unchanged.

## 2. `SOLDR_PROFILE_FOLD_TIMEOUT` (default 600s)

Wraps the on-CPU `perf script` fold in `timeout`. A DWARF capture folded on WSL2 was observed to churn **~1 hour on a single scenario** without finishing — perf's DWARF unwind is O(huge) on big captures. Now a slow fold is killed and that scenario's chart skipped, so the harness degrades gracefully instead of hanging. `0` disables the bound. This also makes the new `dwarf` knob safe to use anywhere.

## Validation

A single-scenario `fp` run still produces ~12.5k folded stacks with the timeout wrapper in the shared code path (no regression to the default path), and the `fold timeout: 600s` log line confirms the guard is active.

Context: iteration 1 (#1327) fixed the harness's `CARGO_TARGET_DIR` clobber that was leaving all scenarios empty; with that fixed, the cache hit rates land at 100% exactly where expected (cold→warm, worktree-share, touch-no-change) and soldr's on-CPU cost is thin relative to rustc — these knobs support the deeper (DWARF-resolved / off-CPU) slowdown hunting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)