### PR TITLE
ci: pass SOLDR_GITHUB_TOKEN in benchmark-stats.yml (#1322 follow-up)

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -31,6 +31,13 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  # soldr#1322 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN
+  # for authenticated GitHub Releases lookups (5,000/hr) instead of
+  # unauthenticated (60/hr per runner IP). Follow-up to #1319 / #1323 /
+  # #1326 / #1328 / #1329 / #1330.
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
+
 jobs:
   # soldr#1203 + soldr#1213 — perf/benchmark workflows are expensive
   # (build + bench + publish, ~30-60 min). The gate reconciles two


### PR DESCRIPTION
Follow-up to #1319 / #1323 / #1326 / #1328 / #1329 / #1330.

## Summary
Add \`SOLDR_GITHUB_TOKEN\` to \`benchmark-stats.yml\` via a new
workflow-level \`env:\` block.

## Why
benchmark-stats invokes setup-soldr + soldr per matrix cell. Without
the token, soldr's zccache fetch runs unauthenticated (60/hr per
runner IP) and can fall through to \`cargo install zccache\` — ~700 s
of source compile.

Same one-line pattern as prior PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)