### PR TITLE
ci: pass SOLDR_GITHUB_TOKEN in cache-delta-experiment.yml (#1322 follow-up)

### DIFF
--- a/.github/workflows/cache-delta-experiment.yml
+++ b/.github/workflows/cache-delta-experiment.yml
@@ -33,6 +33,13 @@ on:
 permissions:
   contents: read
 
+env:
+  # soldr#1322 — soldr's zccache/crgx fetch reads SOLDR_GITHUB_TOKEN
+  # for authenticated GitHub Releases lookups (5,000/hr) instead of
+  # unauthenticated (60/hr per runner IP). Follow-up to #1319 / #1323 /
+  # #1326 / #1328 / #1329 / #1330 / #1332.
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
+
 jobs:
   delta:
     name: Linux x64 (delta-cache)


### PR DESCRIPTION
Follow-up to #1319 / #1323 / #1326 / #1328 / #1329 / #1330 / #1332.

## Summary
Add \`SOLDR_GITHUB_TOKEN\` to \`cache-delta-experiment.yml\` via a new
workflow-level \`env:\` block.

## Why
cache-delta-experiment invokes soldr at 10 call sites for delta-cache
measurements. Without the token, soldr's zccache fetch runs
unauthenticated (60/hr per runner IP) — same rate-limit fallback risk
as prior workflows.

Same one-line pattern.

## Closing note
This closes out the SOLDR_GITHUB_TOKEN sweep for workflows that
actually invoke soldr. Remaining workflows without the token
(\`vendor-state.yml\`, \`vcpkg-windows-refresh.yml\`, \`_ci-target-run.yml\`)
don't call soldr and don't need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)