### PR TITLE
perf(daemon): wire opt-in tokio-console into soldr-daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,6 +3028,7 @@ version = "0.7.100"
 dependencies = [
  "blake3",
  "clap",
+ "console-subscriber",
  "filetime",
  "flate2",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+# Opt-in tokio-console support for soldr-daemon (only active under a
+# `--cfg tokio_unstable` build; a no-op otherwise). See
+# `daemon::server::run`.
+console-subscriber = "0.5"
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/ci/docker/profile/README.md
+++ b/ci/docker/profile/README.md
@@ -20,9 +20,15 @@ The four authoritative perf-matrix scenarios against `perf/fixtures/medium`:
 Each scenario is invoked as `bash perf/scenarios/<name>/run.sh <fixture-dir>`
 inside the container, wrapped by `scripts/run_scenario.sh`.
 
-Tokio-events profiling is deliberately out of scope for this iteration;
-soldr-daemon has zero `console-subscriber` wiring today. Adding it is a
-separate follow-up (mirror the pattern in `_vender/zccache/crates/zccache/src/bin/zccache-daemon.rs`).
+This on/off-CPU flame-graph harness does not itself drive tokio-console.
+soldr-daemon now supports it directly, though: set
+`SOLDR_DAEMON_TOKIO_CONSOLE=1` and build the daemon with
+`RUSTFLAGS="--cfg tokio_unstable"`, then attach with `tokio-console`
+(default `127.0.0.1:6669`) to inspect per-task poll/idle time and worker
+behaviour — the async-task view needed to pin down the daemon-worker
+`sched_yield` spin (soldr#1334). Without `--cfg tokio_unstable` the env
+var degrades to a one-line hint and the daemon runs normally. See
+`daemon::server::maybe_init_tokio_console`.
 
 ## How to run
 

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+console-subscriber = { workspace = true }
 url = { workspace = true }
 walkdir = { workspace = true }
 wait-timeout = { workspace = true }

--- a/crates/soldr-cli/src/daemon/server.rs
+++ b/crates/soldr-cli/src/daemon/server.rs
@@ -209,7 +209,56 @@ async fn shutdown_compile_service(state: &Arc<State>) {
 /// Synchronous entry point used by both the `soldr-daemon` bin target
 /// and `soldr daemon start --foreground`. Builds a tokio runtime and
 /// blocks until the daemon exits.
+/// Env var that turns on the tokio-console layer for the daemon:
+/// `SOLDR_DAEMON_TOKIO_CONSOLE=1`. Only functional when the daemon is
+/// built with `RUSTFLAGS="--cfg tokio_unstable"`; otherwise it degrades
+/// to a warning (see [`maybe_init_tokio_console`]).
+pub const TOKIO_CONSOLE_ENV_VAR: &str = "SOLDR_DAEMON_TOKIO_CONSOLE";
+
+/// Install the tokio-console subscriber layer when
+/// [`TOKIO_CONSOLE_ENV_VAR`] is truthy, so `tokio-console` can attach to
+/// the daemon's runtime and expose per-task poll/idle time and worker
+/// behaviour — the tooling needed to pin down the daemon-worker
+/// `sched_yield` spin from soldr#1334 at the async-task level.
+///
+/// `console_subscriber::spawn()` panics unless the crate was compiled
+/// with `--cfg tokio_unstable` (the tokio task instrumentation is
+/// otherwise absent). We `catch_unwind` that so a normal release build
+/// simply logs a hint instead of crashing the daemon. Mirrors the
+/// established `zccache-daemon` pattern. No-op (and no subscriber
+/// installed — daemon stays silent as before) when the env var is unset.
+fn maybe_init_tokio_console() {
+    let enabled = std::env::var(TOKIO_CONSOLE_ENV_VAR)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false);
+    if !enabled {
+        return;
+    }
+    match std::panic::catch_unwind(console_subscriber::spawn) {
+        Ok(console_layer) => {
+            use tracing_subscriber::prelude::*;
+            let _ = tracing_subscriber::registry()
+                .with(console_layer)
+                .try_init();
+            tracing::info!(
+                "tokio-console enabled for soldr-daemon; connect with `tokio-console` \
+                 (default 127.0.0.1:6669)"
+            );
+        }
+        Err(_) => {
+            eprintln!(
+                "soldr-daemon: {TOKIO_CONSOLE_ENV_VAR} set but console-subscriber is \
+                 inert — rebuild with RUSTFLAGS=\"--cfg tokio_unstable\" to use tokio-console"
+            );
+        }
+    }
+}
+
 pub fn run(opts: ServerOptions) -> Result<(), ServerError> {
+    // Opt-in async-runtime instrumentation. Must run before the runtime
+    // is built so console-subscriber's aggregator is in place.
+    maybe_init_tokio_console();
+
     // L6 (soldr#980): cap the daemon Tokio runtime to a small fixed
     // worker count so it doesn't oversubscribe the CPU during cargo
     // builds. The daemon handles IPC + bookkeeping; rustc is the CPU


### PR DESCRIPTION
The Linux profile harness captures on/off-CPU flame graphs, but the **async-task view (tokio-console)** was missing — soldr-daemon had no `console-subscriber` wiring, so its `[soldr-daemon]` off-CPU frames (notably the worker `sched_yield` spin in #1334) couldn't be attributed to specific tasks or poll-vs-idle time.

## Change

- Add `console-subscriber` 0.5 (already used by the vendored zccache workspace).
- New opt-in `daemon::server::maybe_init_tokio_console`: `SOLDR_DAEMON_TOKIO_CONSOLE=1` installs the console layer before the runtime is built.
- `console_subscriber::spawn` panics unless compiled with `RUSTFLAGS="--cfg tokio_unstable"`, so the call is `catch_unwind`-guarded and degrades to a one-line hint on a normal build (mirrors the established `zccache-daemon` pattern).
- **Default behaviour unchanged**: no env var → no subscriber installed → daemon stays silent as before.
- README: document how to attach (`tokio-console` on `127.0.0.1:6669`).

## Validation

- Compiles clean; clippy/fmt/timed_test-lint pass.
- Smoke-tested on a non-`tokio_unstable` build: `SOLDR_DAEMON_TOKIO_CONSOLE=1` prints the inert hint and the daemon runs + exits cleanly (the `catch_unwind` swallows the console-subscriber panic).

## Why (perf loop context)

Across the profiling iterations, soldr's cache hits land at 100% everywhere expected (medium **and** the C-heavy sqlite-link fixture) and its CPU is thin relative to rustc. The one soldr-side off-CPU hotspot is the daemon's idle Tokio workers spinning on `sched_yield` (#1334) — a known #980 L6 tradeoff whose safe fix needs async-task-level data. This wires up exactly that tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)