### PR TITLE
ci: remove dead 'id: setup_soldr' left in two workflows (#1338)

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -122,7 +122,6 @@ jobs:
       # ways incompatible with cross-compile lanes. Save cost no
       # longer offsets savings. Toolchain install only.
       - name: Setup soldr build cache
-        id: setup_soldr
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         env:
           ACTION_WORKSPACE: ${{ github.workspace }}/soldr

--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -68,7 +68,6 @@ jobs:
       # cross-compile lanes; save cost no longer justifies. Pure
       # toolchain install via setup-soldr.
       - name: Setup soldr build cache
-        id: setup_soldr
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:
           toolchain: 1.94.1


### PR DESCRIPTION
Fixes #1338.

## Summary
Delete two \`id: setup_soldr\` lines that no step references:
- \`_build-and-test.yml\`
- \`_bootstrap-e2e.yml\`

## Why
The id used to be consumed by "Reset stale cache fallback artifacts"
steps that gated on
\`setup_soldr.outputs.*-cache-restore-status != 'exact-hit'\`. Those
steps were removed in #1252 / #1253 but the \`id:\` was left orphaned.

Same cleanup class as #1293 / #1305 / #1307 / #1313 / #1335.

## Test plan
- [ ] Lint stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)