### PR TITLE
ci(build-and-test): pre-cache rustup 1.94.1 in ~/.rustup so setup-soldr skips its install (#1340)

### DIFF
--- a/.github/workflows/_build-and-test.yml
+++ b/.github/workflows/_build-and-test.yml
@@ -67,6 +67,22 @@ jobs:
       # rewrites the workspace manifest in ways incompatible with
       # cross-compile lanes; save cost no longer justifies. Pure
       # toolchain install via setup-soldr.
+      # soldr#1340 — pre-cache the 1.94.1 toolchain in ~/.rustup so
+      # setup-soldr finds it via its "Runner rustup home already
+      # contains toolchain X" check and skips its own 9 s rustup
+      # install. On cache miss (first run at a new key) the install
+      # step runs locally and populates ~/.rustup for the save.
+      - name: Cache rustup 1.94.1 in ~/.rustup
+        id: rustup_cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.rustup/toolchains/1.94.1-x86_64-unknown-linux-gnu
+          key: rustup-1.94.1-linux-x64-v1
+
+      - name: Install rustup 1.94.1 to ~/.rustup (if not cached)
+        if: steps.rustup_cache.outputs.cache-hit != 'true'
+        run: rustup toolchain install 1.94.1 --profile minimal --no-self-update
+
       - name: Setup soldr build cache
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:


### PR DESCRIPTION
Fixes #1340 (partial — _build-and-test.yml as an experiment).

## Summary
Add two steps before setup-soldr in \`_build-and-test.yml\`:
1. \`actions/cache\` for \`~/.rustup/toolchains/1.94.1-x86_64-unknown-linux-gnu\`.
2. \`rustup toolchain install 1.94.1 --profile minimal --no-self-update\` on cache miss.

## Why
Every CI run pays ~9 s inside setup-soldr's rustup install because
1.94.1 isn't preinstalled in the runner's ~/.rustup. setup-soldr
checks $HOME/.rustup first — if 1.94.1 is present there, it uses it
and skips its own install.

Expected saving on cache HIT: ~7 s per lane.

## Experimental scope
Starting with just \`_build-and-test.yml\` (single Linux x64 caller,
smaller blast radius). If setup-soldr's log switches from "does not
already contain toolchain 1.94.1" to a positive detection, extend to
\`_bootstrap-e2e.yml\` and \`_ci-cross-build-linux.yml\` in a follow-up.

## Risk
If setup-soldr still uses its managed RUSTUP_HOME regardless of
~/.rustup contents, this adds ~2 s per lane for zero win. Easy to
revert — the change is isolated to two new steps.

## Test plan
- [ ] Lint stays green.
- [ ] First post-merge run: rustup_cache MISS, install runs, cache saves.
- [ ] Second post-merge run: rustup_cache HIT, setup-soldr's log shows
      it found 1.94.1 in ~/.rustup rather than "does not already contain".

🤖 Generated with [Claude Code](https://claude.com/claude-code)