### PR TITLE
ci(bootstrap-e2e): pre-cache rustup 1.94.1 (#1340 extension)

### DIFF
--- a/.github/workflows/_bootstrap-e2e.yml
+++ b/.github/workflows/_bootstrap-e2e.yml
@@ -121,6 +121,23 @@ jobs:
       # repo. Cook rewrites workspace + per-crate source files in
       # ways incompatible with cross-compile lanes. Save cost no
       # longer offsets savings. Toolchain install only.
+      # soldr#1340 — pre-cache the 1.94.1 toolchain in ~/.rustup so
+      # setup-soldr uses it instead of installing to its managed
+      # RUSTUP_HOME (saves ~9 s per lane). Same pattern as #1341.
+      # #1341 verified setup-soldr's log flips from "does not already
+      # contain toolchain" to "Using runner rustup home /home/runner/
+      # .rustup for toolchain 1.94.1" — toolchain-snapshot: added=0.
+      - name: Cache rustup 1.94.1 in ~/.rustup
+        id: rustup_cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.rustup/toolchains/1.94.1-x86_64-unknown-linux-gnu
+          key: rustup-1.94.1-linux-x64-v1
+
+      - name: Install rustup 1.94.1 to ~/.rustup (if not cached)
+        if: steps.rustup_cache.outputs.cache-hit != 'true'
+        run: rustup toolchain install 1.94.1 --profile minimal --no-self-update
+
       - name: Setup soldr build cache
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         env:


### PR DESCRIPTION
Follow-up to #1341 which verified the pre-cache pattern on Linux x64.

## Summary
Add the same \`Cache rustup 1.94.1 in ~/.rustup\` + \`Install rustup 1.94.1
(if not cached)\` step pair to \`_bootstrap-e2e.yml\` before setup-soldr.

## Verification from #1341

Post-merge log on the Linux x64 lane:

\`\`\`
Using runner rustup home /home/runner/.rustup for toolchain 1.94.1;
setup cache stays binary-only without managed rustup
toolchain-snapshot: added=0 files (0.0KB) changed=0 removed=0
\`\`\`

vs pre-#1341:

\`\`\`
Runner rustup home /home/runner/.rustup does not already contain
toolchain 1.94.1; using managed RUSTUP_HOME under the setup cache root
toolchain-snapshot: added=165 files (597.6MB)
\`\`\`

setup-soldr found the pre-cached toolchain and skipped its install.

## Scope
\`_bootstrap-e2e.yml\` has a single caller (\`e2e-linux-x64\` on
x86_64-unknown-linux-gnu). Same shared cache key as #1341 so both
workflows populate/consume the same rustup cache.

Cross-build lanes deferred until this cycle validates.

## Test plan
- [ ] Lint stays green.
- [ ] Bootstrap-e2e log shows "Using runner rustup home" instead of
      "does not already contain toolchain".
- [ ] \`Build soldr and bootstrap third-party app\` shaves ~9 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)