### PR TITLE
ci(cross-build): pre-cache rustup 1.94.1 across all 7 cross-build lanes (#1340 extension)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -86,6 +86,23 @@ jobs:
       # no longer offsets the savings. Pure toolchain install via
       # setup-soldr; no cook, no cache restore, no
       # `git restore --worktree` workaround needed.
+      # soldr#1340 — pre-cache the 1.94.1 toolchain in ~/.rustup so
+      # setup-soldr uses it (log switches to "Using runner rustup home")
+      # instead of installing to its managed RUSTUP_HOME. Empirically
+      # verified in #1341 / #1342: Setup soldr build cache drops from
+      # ~22 s to ~2 s on cache HIT. Shared cache key across all lanes
+      # + workflows.
+      - name: Cache rustup 1.94.1 in ~/.rustup
+        id: rustup_cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.rustup/toolchains/1.94.1-x86_64-unknown-linux-gnu
+          key: rustup-1.94.1-linux-x64-v1
+
+      - name: Install rustup 1.94.1 to ~/.rustup (if not cached)
+        if: steps.rustup_cache.outputs.cache-hit != 'true'
+        run: rustup toolchain install 1.94.1 --profile minimal --no-self-update
+
       - name: Setup soldr build cache (Rust toolchain only)
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:


### PR DESCRIPTION
Follow-up to #1341 (Linux x64) and #1342 (bootstrap-e2e).

## Summary
Add the \`Cache rustup 1.94.1 in ~/.rustup\` + \`Install rustup 1.94.1
(if not cached)\` step pair to \`_ci-cross-build-linux.yml\` before
setup-soldr. Applies to all 7 cross-build lanes.

## Empirical verification from #1342

Cache HIT scenario (bootstrap-e2e):
- Cache rustup: **2 s** restore
- Install rustup: **0 s** (skipped)
- Setup soldr build cache: **2 s** (down from ~22 s baseline)
- Post steps: unchanged

Setup-soldr log:
\`\`\`
Using runner rustup home /home/runner/.rustup for toolchain 1.94.1;
setup cache stays binary-only without managed rustup
toolchain-snapshot: added=0 files (0.0KB)
\`\`\`

## Expected impact
- ~9 s wallclock off CI critical path (parallel lanes, weakest link).
- Aggregate runner-time saved: ~18 s × 7 lanes = 126 s per CI run.

## Test plan
- [ ] Lint stays green.
- [ ] Post-merge run: cross-build lanes log "Using runner rustup home".
- [ ] Setup soldr build cache step drops to ~2 s from ~22 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)