### PR TITLE
ci: pre-cache rustup 1.94.1 in ci.yml Lint job (#1340 extension)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,21 @@ jobs:
       # measurable speedups on the lint job. Drop both. Restore-from-
       # git workaround that paired with it is no longer needed
       # because the manifest is never overwritten.
+      # soldr#1340 — pre-cache the 1.94.1 toolchain in ~/.rustup so
+      # setup-soldr uses it (Setup soldr build cache drops from ~22 s
+      # to ~2 s). Same pattern as #1341/#1342/#1343. Shared cache key
+      # across all soldr workflows.
+      - name: Cache rustup 1.94.1 in ~/.rustup
+        id: rustup_cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.rustup/toolchains/1.94.1-x86_64-unknown-linux-gnu
+          key: rustup-1.94.1-linux-x64-v1
+
+      - name: Install rustup 1.94.1 to ~/.rustup (if not cached)
+        if: steps.rustup_cache.outputs.cache-hit != 'true'
+        run: rustup toolchain install 1.94.1 --profile minimal --no-self-update
+
       - name: Setup soldr build cache
         uses: zackees/setup-soldr@cca74625e75e70b56f1805fa6eeee9069f945d48
         with:


### PR DESCRIPTION
Follow-up to #1341 / #1342 / #1343.

## Summary
Add the \`Cache rustup 1.94.1 in ~/.rustup\` + \`Install rustup 1.94.1
(if not cached)\` step pair to the \`Lint\` job in \`ci.yml\`.

## Why
Lint runs on **every push AND every PR** — the highest-frequency
setup-soldr call site (~30+ runs/day). Empirical savings from #1342:
Setup soldr build cache drops from ~22 s to ~2 s on cache HIT.

Also on the merge critical path (branch protection requires Lint
green before merge), so wallclock savings translate directly to
merge latency reduction.

## Test plan
- [ ] Lint stays green.
- [ ] Post-merge run's Lint job shows Setup soldr build cache < 5 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)