### PR TITLE
ci(_ci-target-run.yml): fix mislabeled 'v6' comment on v4 download-artifact SHA (#1347)

### DIFF
--- a/.github/workflows/_ci-target-run.yml
+++ b/.github/workflows/_ci-target-run.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
 
       - name: Download cross-build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v6
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ inputs.artifact_name }}
           path: artifact


### PR DESCRIPTION
Fixes #1347.

## Summary
Update comment from \`# v6\` to \`# v4\`. SHA is unchanged (v4.3.0 of
actions/download-artifact); the comment was just wrong.

## Test plan
- [ ] Lint stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)