### PR TITLE
ci(_ci-target-run.yml): drop unused submodules from checkout (#1350)

### DIFF
--- a/.github/workflows/_ci-target-run.yml
+++ b/.github/workflows/_ci-target-run.yml
@@ -59,10 +59,14 @@ jobs:
       # present (per the `--workspace-remap` docs) even when all binaries
       # come from the archive. Shallow checkout is enough; we don't run
       # cargo build here.
+      # soldr#1350 — dropped `submodules: recursive`. _vender/zccache is
+      # `exclude = ["_vender/zccache"]` in the workspace root Cargo.toml,
+      # so `cargo metadata` doesn't walk into the submodule. Nextest
+      # runs pre-built test binaries from the archive; no cargo build
+      # here. Saves ~4-5 s per target-run.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
-          submodules: recursive
 
       - name: Download cross-build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
Fixes #1350.

## Summary
Remove \`submodules: recursive\` from the \`_ci-target-run.yml\` checkout.

## Why
The comment already says \"we don't run cargo build here\". Since
\`_vender/zccache\` is excluded from the workspace root Cargo.toml and
target-run only executes pre-compiled test binaries via nextest, the
submodule content isn't needed.

Saves ~4-5 s per target-run × 6 target-run lanes = ~24-30 s aggregate
runner time per CI cycle.

## Test plan
- [ ] Lint stays green.
- [ ] Target-runs still pass (nextest doesn't complain about missing
      \`_vender/zccache/Cargo.toml\`).
- [ ] Revert is one-line if nextest actually needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)