### PR TITLE
ci: bump taiki-e/install-action v2.82.5 → v2.82.9 (#1352)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -168,14 +168,14 @@ jobs:
 
       - name: Install cargo-zigbuild
         if: contains(inputs.target, 'musl') || (contains(inputs.target, 'linux-gnu') && contains(inputs.target, 'aarch64'))
-        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
+        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
         with:
           tool: cargo-zigbuild@0.23.0
 
       # cargo-xwin — required for *-pc-windows-msvc.
       - name: Install cargo-xwin
         if: contains(inputs.target, 'pc-windows-msvc')
-        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
+        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
         with:
           tool: cargo-xwin@0.18.6
 
@@ -184,7 +184,7 @@ jobs:
       # skip the archive) don't install a tool they never invoke.
       - name: Install cargo-nextest
         if: (!contains(inputs.target, 'pc-windows-msvc')) && (!contains(inputs.target, 'apple-darwin'))
-        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
+        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/_ci-target-run.yml
+++ b/.github/workflows/_ci-target-run.yml
@@ -98,7 +98,7 @@ jobs:
           done
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
+        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -364,7 +364,7 @@ jobs:
 
       - name: Install cargo-zigbuild (zigbuild lanes)
         if: matrix.target == 'aarch64-unknown-linux-musl' || (contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04')
-        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
+        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
         with:
           tool: cargo-zigbuild@0.23.0
 


### PR DESCRIPTION
Fixes #1352.

## Summary
Bump \`taiki-e/install-action\` from v2.82.5 to v2.82.9 across three
workflow files (5 call sites total). Semver-safe patch bump.

## Test plan
- [ ] Lint stays green.
- [ ] cargo-zigbuild / cargo-xwin / cargo-nextest still install correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)