### PR TITLE
Revert 'ci: bump taiki-e/install-action v2.82.5 → v2.82.9 (#1353)' — unblocks main

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -168,14 +168,14 @@ jobs:
 
       - name: Install cargo-zigbuild
         if: contains(inputs.target, 'musl') || (contains(inputs.target, 'linux-gnu') && contains(inputs.target, 'aarch64'))
-        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: cargo-zigbuild@0.23.0
 
       # cargo-xwin — required for *-pc-windows-msvc.
       - name: Install cargo-xwin
         if: contains(inputs.target, 'pc-windows-msvc')
-        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: cargo-xwin@0.18.6
 
@@ -184,7 +184,7 @@ jobs:
       # skip the archive) don't install a tool they never invoke.
       - name: Install cargo-nextest
         if: (!contains(inputs.target, 'pc-windows-msvc')) && (!contains(inputs.target, 'apple-darwin'))
-        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/_ci-target-run.yml
+++ b/.github/workflows/_ci-target-run.yml
@@ -98,7 +98,7 @@ jobs:
           done
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -364,7 +364,7 @@ jobs:
 
       - name: Install cargo-zigbuild (zigbuild lanes)
         if: matrix.target == 'aarch64-unknown-linux-musl' || (contains(matrix.target, 'apple-darwin') && matrix.runner == 'ubuntu-24.04')
-        uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.82.9
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: cargo-zigbuild@0.23.0
 


### PR DESCRIPTION
## Why

Main is red on all musl/gnu cross-build lanes after #1353 (my own PR).

Root cause: taiki-e/install-action v2.82.9 uses a newer cargo manifest
parser that rejects cargo-zigbuild's \`edition = \"2024\"\`:

    ERROR Fatal error:
      × For crate cargo-zigbuild: Failed to parse cargo manifest:
        TOML parse error at line 13, column 11
        13 | edition = "2024"
             |           ^^^^^^

## What

Roll SHA back to v2.82.5 which was installing cargo-zigbuild@=0.23.0
cleanly.

## Follow-up

Track upstream taiki-e/install-action for a version that handles
edition 2024, or migrate cargo-zigbuild pin to a version predating
edition 2024. Not urgent — v2.82.5 works fine.

## Test plan

- [ ] Lint stays green.
- [ ] cargo-zigbuild lane installs successfully.
- [ ] All 3 previously-failing musl/gnu cross-build lanes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)