### PR TITLE
perf(ci): add [profile.ci-release] for cross-build lanes (#1357)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -363,22 +363,26 @@ jobs:
         run: |
           set -euo pipefail
           target='${{ inputs.target }}'
+          # soldr#1357 — --profile ci-release drops LTO + codegen-units=1
+          # from CI-only cross-build artifacts (soldr-ci-e2e-*), saving
+          # 1-2 min per MSVC/darwin lane. Shipped release-soldr-* /
+          # pypi-soldr-* artifacts in release-auto.yml stay on --release.
           if [[ "$target" == *-pc-windows-msvc ]] \
              || [[ "$target" == *-apple-darwin ]]; then
-            soldr build --release --target "$target" \
+            soldr build --profile ci-release --target "$target" \
               --package soldr-cli --bin soldr
           elif [[ "$target" == *-unknown-linux-musl ]] \
                || [[ "$target" == aarch64-unknown-linux-gnu ]]; then
-            cargo zigbuild --release --target "$target" \
+            cargo zigbuild --profile ci-release --target "$target" \
               --package soldr-cli --bin soldr
           else
-            cargo build --release --target "$target" \
+            cargo build --profile ci-release --target "$target" \
               --package soldr-cli --bin soldr
           fi
           suffix=""
           case "$target" in *-pc-windows-msvc) suffix=".exe" ;; esac
-          ls -la "target/$target/release/soldr$suffix"
-          file "target/$target/release/soldr$suffix"
+          ls -la "target/$target/ci-release/soldr$suffix"
+          file "target/$target/ci-release/soldr$suffix"
 
       # Stage C — test binary archive (consumed by _ci-target-run.yml).
       # Skipped for windows-msvc: `cargo nextest archive` doesn't go
@@ -423,7 +427,7 @@ jobs:
           suffix=""
           case "$target" in *-pc-windows-msvc) suffix=".exe" ;; esac
           mkdir -p dist/package
-          cp "target/$target/release/soldr$suffix" "dist/package/soldr$suffix"
+          cp "target/$target/ci-release/soldr$suffix" "dist/package/soldr$suffix"
           chmod +x "dist/package/soldr$suffix" 2>/dev/null || true
           # Fixtures go alongside the binary so the target-run job can
           # set SOLDR_TEST_FIXTURES_DIR via the helper from #1040.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,22 @@ lto = false
 codegen-units = 16
 strip = "none"
 
+# soldr#1357 — fast-compile profile for CI cross-build lanes. Same
+# rationale as ci-bootstrap but applied to Stage B of
+# `_ci-cross-build-linux.yml` where `soldr build --release --target X`
+# spends 5+ min per lane, most of it in single-threaded LLVM codegen +
+# link for the soldr-cli monocrate. CI cross-build artifacts are
+# `soldr-ci-e2e-*` — consumed only by `_ci-target-run.yml` for
+# nextest smoke runs; NOT the shipped `release-soldr-*` /
+# `pypi-soldr-*` artifacts produced by `release-auto.yml` (which
+# stays on `--release` for shipped-binary quality). Keeps
+# `strip = "symbols"` so archive size stays comparable.
+[profile.ci-release]
+inherits = "release"
+lto = false
+codegen-units = 16
+strip = "symbols"
+
 [workspace.lints.rust]
 unused_mut = "deny"
 


### PR DESCRIPTION
## Summary

- Add `[profile.ci-release]` to workspace `Cargo.toml` (inherits release; `lto = false`, `codegen-units = 16`, `strip = "symbols"`).
- Change `_ci-cross-build-linux.yml` Stage B (Cross-build release binary) three arms from `--release` to `--profile ci-release`.
- Adjust `target/$target/release/soldr` → `target/$target/ci-release/soldr` in Stage B post-check and Stage D artifact bundle.

## Motivation

Latest main run [`28749046847`](https://github.com/zackees/soldr/actions/runs/28749046847) — MSVC lane spends **5m 25s** in Stage B. The last `Compiling …` line prints ~3m 41s before `Finished` — that's single-threaded LLVM codegen + link for the soldr-cli monocrate under `codegen-units = 1`.

The CI cross-build artifacts (`soldr-ci-e2e-*`) are consumed only by `_ci-target-run.yml` — they aren't the shipped `release-soldr-*` / `pypi-soldr-*` artifacts built by `release-auto.yml`. Same pattern as #1282's `ci-bootstrap` profile, applied one step downstream.

## Expected impact

1-2 min off MSVC + darwin cross-build lanes (single-threaded LLVM codegen wins the most). Linux musl/gnu lanes gain less (zigbuild parallelism is already better). Critical path: 6m 17s → ~4-5 min per PR.

## Test plan

- [x] Local Cargo.toml + workflow changes reviewed for consistency (`--release` → `--profile ci-release` in all three cross-build arms + both `target/*/release` path references).
- [ ] CI run on this PR verifies the artifact upload still finds `dist/package/soldr` after the profile change.
- [ ] Bench the wallclock delta on the first main-run after merge vs. `28749046847` baseline.

Fixes #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)