### PR TITLE
perf(ci): bump rust-cache v3→v4 to save ci-release/ deps (#1357 followup)

### DIFF
--- a/.github/workflows/_ci-cross-build-linux.yml
+++ b/.github/workflows/_ci-cross-build-linux.yml
@@ -232,10 +232,15 @@ jobs:
           # subdir; soldr#1315 → v3 forces another fresh save because
           # the v2 primary key stuck with a cargo registry snapshot
           # where libz-ng-sys-1.1.29's src/zlib-ng was missing
-          # zlib-ng.map.in + test/. Every darwin run inherited that
-          # broken extraction (rust-cache only saves on primary-key
-          # miss). Bumping to v3 forces a clean re-fetch.
-          shared-key: cross-build-${{ inputs.target }}-v3
+          # zlib-ng.map.in + test/. soldr#1357 → v4 forces a fresh save
+          # after Stage B switched from --release to --profile ci-release:
+          # rust-cache's meta-hash doesn't include Cargo.toml profile
+          # additions, so the v3 primary key kept hitting with only
+          # target/<triple>/release/ deps cached — Stage B's cold
+          # ci-release/ subdir added ~5 min per lane in run 28750573776.
+          # Bumping to v4 forces one cache-miss cycle that saves the
+          # ci-release/ deps for every subsequent run.
+          shared-key: cross-build-${{ inputs.target }}-v4
 
       # Bootstrap soldr from the current checkout. Darwin uses it to
       # drive `soldr prepare --target ... --github-env`. Windows MSVC


### PR DESCRIPTION
## Summary

- Bump `_ci-cross-build-linux.yml` rust-cache `shared-key` from `cross-build-<target>-v3` to `-v4`.
- Forces one cache-miss cycle so `target/<triple>/ci-release/` deps land in the cache; subsequent runs go back to warm rebuilds.

## Motivation — regression from #1358

PR #1358 switched Stage B from `--release` to `--profile ci-release`. Empirically, Swatinem/rust-cache's meta-hash does NOT include Cargo.toml profile additions:

- Baseline (before #1358): [`28749046847`](https://github.com/zackees/soldr/actions/runs/28749046847) MSVC lane 6m 17s.
- Post-merge: [`28750573776`](https://github.com/zackees/soldr/actions/runs/28750573776) MSVC lane 11m 23s — **+5m regression**.
- Both runs hit **identical** rust-cache primary key `v0-rust-cross-build-x86_64-pc-windows-msvc-v3-Linux-x64-31b682bb-9697182d`.

Since the primary key HIT, rust-cache didn't save the fresh `ci-release/` subdir. Every future run would repeat the same cold `ci-release/` rebuild.

Bumping the shared-key to v4 forces one miss → save cycle. After that, all subsequent PRs get the promised 1-2 min speedup.

## Test plan

- [ ] First run after merge: MSVC lane is still 11+ min (cache-miss save).
- [ ] Next main-branch run: MSVC lane drops to ~5 min (warm ci-release/ deps).

Followup to #1358, closes the regression on #1357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)