### PR TITLE
perf(deps): #1356 Section B — unify prost on 0.14 (drop duplicate prost 0.13 + prost-derive)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
 dependencies = [
  "futures-core",
- "prost 0.14.4",
+ "prost",
  "prost-types",
  "tonic",
  "tonic-prost",
@@ -476,7 +476,7 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost 0.14.4",
+ "prost",
  "prost-types",
  "serde",
  "serde_json",
@@ -2020,22 +2020,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.4",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2050,24 +2040,11 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost 0.14.4",
+ "prost",
  "prost-types",
  "regex",
  "syn 2.0.118",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -2091,7 +2068,7 @@ checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
 dependencies = [
  "logos 0.16.1",
  "miette",
- "prost 0.14.4",
+ "prost",
  "prost-types",
 ]
 
@@ -2101,7 +2078,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.4",
+ "prost",
 ]
 
 [[package]]
@@ -2176,7 +2153,7 @@ checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
 dependencies = [
  "bytes",
  "miette",
- "prost 0.14.4",
+ "prost",
  "prost-reflect",
  "prost-types",
  "protox-parse",
@@ -2527,7 +2504,7 @@ dependencies = [
  "interprocess",
  "libc",
  "portable-pty",
- "prost 0.14.4",
+ "prost",
  "prost-build",
  "prost-types",
  "protox",
@@ -2915,8 +2892,7 @@ dependencies = [
  "hex",
  "jwalk",
  "libc",
- "prost 0.13.5",
- "prost 0.14.4",
+ "prost",
  "rayon",
  "redb 4.1.0",
  "reqwest",
@@ -3310,7 +3286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.4",
+ "prost",
  "tonic",
 ]
 
@@ -4007,7 +3983,7 @@ dependencies = [
  "memmap2",
  "mimalloc",
  "notify",
- "prost 0.14.4",
+ "prost",
  "prost-build",
  "protoc-bin-vendored",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ xz2 = "0.1"
 toml = "0.8"
 redb = "4.1.0"
 rayon = "1"
-prost = "0.13"
+prost = "0.14"
 # soldr#1356 A2 — walkdir workspace dep removed; jwalk is the sole
 # directory walker used in soldr-cli.
 jwalk = "0.8"

--- a/crates/soldr-cli/Cargo.toml
+++ b/crates/soldr-cli/Cargo.toml
@@ -18,7 +18,6 @@ fs2 = { workspace = true }
 hex = { workspace = true }
 jwalk = { workspace = true }
 prost = { workspace = true }
-prost14 = { package = "prost", version = "0.14" }
 rayon = { workspace = true }
 redb = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/soldr-cli/src/daemon/service_definition.rs
+++ b/crates/soldr-cli/src/daemon/service_definition.rs
@@ -7,7 +7,7 @@
 use crate::daemon::backend_handle_adoption::{
     SOLDR_DAEMON_SERVICE_NAME, SOLDR_DAEMON_SERVICE_VERSION,
 };
-use prost14::Message as _;
+use prost::Message as _;
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{
     ensure_service_definition_dir, service_definition_dir, service_definition_path,


### PR DESCRIPTION
## Summary

Section B of #1356. soldr-cli was the only consumer of prost 0.13.5, kept solely for `daemon/service_definition.rs` which needed running-process's prost-0.14-encoded ServiceDefinition. All other soldr code used prost 0.13 via the workspace dep.

- Bump workspace `prost = "0.13"` → `prost = "0.14"`.
- Delete `prost14 = { package = "prost", version = "0.14" }` alias from `crates/soldr-cli/Cargo.toml`.
- Change the single `use prost14::Message as _` reference in `daemon/service_definition.rs:10` to `use prost::Message as _`.

## Cargo.lock delta

**-2 packages**: `prost 0.13.5` + `prost-derive 0.13.5`. prost-derive is a proc-macro; removing it drops one proc-macro compilation pass on every fresh build.

## Test plan

- [x] `cargo check -p soldr-cli --locked --lib` passes end-to-end inside `rust:1.94.1` docker (same regen environment as #1363, which is what let Section A finally land).
- [ ] CI cross-build lanes pass.

Follow-up to #1363 (Section A). Section C (upstream zccache monocrate gating) remains a follow-up requiring a submodule PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)